### PR TITLE
Clarify shell integration docstrings

### DIFF
--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -43,14 +43,14 @@
 //! commands and adds `--internal`:
 //!
 //! 1. Shell wrapper calls: `wt switch --internal my-feature`
-//! 2. Binary outputs special directive protocol:
+//! 2. Binary outputs a NUL-delimited directive stream on **stdout** and user-facing messages on
+//!    **stderr**:
 //!    ```text
-//!    __WORKTRUNK_CD__/path/to/worktree
-//!    Created new branch and worktree for 'my-feature' at /path/to/worktree
+//!    __WORKTRUNK_CD__/path/to/worktree\0
 //!    ```
-//! 3. Shell wrapper parses output line-by-line
+//! 3. Shell wrapper splits stdout on `\0` bytes
 //! 4. When it sees `__WORKTRUNK_CD__<path>`, it executes `cd <path>` in the parent shell
-//! 5. Other lines are printed normally
+//! 5. Messages printed to stderr stream directly to the terminal for real-time feedback
 //!
 //! The binary **never changes directories itself** - it just communicates the desired path back
 //! to the shell wrapper via stdout using the `__WORKTRUNK_CD__` directive protocol.

--- a/tests/integration_tests/configure_shell.rs
+++ b/tests/integration_tests/configure_shell.rs
@@ -4,7 +4,7 @@ use insta_cmd::assert_cmd_snapshot;
 use std::fs;
 use tempfile::TempDir;
 
-/// Test configure-shell with --force flag (skips confirmation)
+/// Test `wt config shell` with --force flag (skips confirmation)
 #[test]
 fn test_configure_shell_with_yes() {
     let repo = TestRepo::new();
@@ -47,7 +47,7 @@ fn test_configure_shell_with_yes() {
     assert!(content.contains("eval \"$(command wt init zsh)\""));
 }
 
-/// Test configure-shell with specific shell
+/// Test `wt config shell` with specific shell
 #[test]
 fn test_configure_shell_specific_shell() {
     let repo = TestRepo::new();
@@ -92,7 +92,7 @@ fn test_configure_shell_specific_shell() {
     assert!(content.contains("eval \"$(command wt init zsh)\""));
 }
 
-/// Test configure-shell when line already exists
+/// Test `wt config shell` when line already exists
 #[test]
 fn test_configure_shell_already_exists() {
     let repo = TestRepo::new();
@@ -137,7 +137,7 @@ fn test_configure_shell_already_exists() {
     assert_eq!(count, 1, "Should only have one wt init line");
 }
 
-/// Test configure-shell for Fish (creates new file in conf.d/)
+/// Test `wt config shell` for Fish (creates new file in conf.d/)
 #[test]
 fn test_configure_shell_fish() {
     let repo = TestRepo::new();
@@ -185,7 +185,7 @@ fn test_configure_shell_fish() {
     );
 }
 
-/// Test configure-shell when no config files exist
+/// Test `wt config shell` when no config files exist
 #[test]
 fn test_configure_shell_no_files() {
     let repo = TestRepo::new();
@@ -220,8 +220,8 @@ fn test_configure_shell_no_files() {
     });
 }
 
-/// Test configure-shell for Fish with custom prefix
-/// Test configure-shell with multiple existing config files
+/// Test `wt config shell` for Fish with custom prefix
+/// Test `wt config shell` with multiple existing config files
 #[test]
 fn test_configure_shell_multiple_configs() {
     let repo = TestRepo::new();
@@ -277,7 +277,7 @@ fn test_configure_shell_multiple_configs() {
     );
 }
 
-/// Test configure-shell shows both shells needing updates and already configured shells
+/// Test `wt config shell` shows both shells needing updates and already configured shells
 #[test]
 fn test_configure_shell_mixed_states() {
     let repo = TestRepo::new();


### PR DESCRIPTION
## Summary
- Clarify how shell integration directives are emitted and consumed in worktree documentation comments
- Update configure shell integration test descriptions to reflect the `wt config shell` command name

## Testing
- Not run (documentation-only changes)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed5afec34832580c1ff4a75cb054f)