### PR TITLE
Fix typos in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ everything — standard `git worktree` commands continue working fine.
 
 ### LLM-Authored Commit Messages
 
-Worktrunk can invoke an external commands during merge operations to generate
+Worktrunk can invoke external commands during merge operations to generate
 commit messages. Simon Willison's [llm](https://llm.datasette.io/) tool reads
 the diff and a configurable prompt, then returns a formatted commit message.
 
@@ -841,7 +841,7 @@ When using Claude:
 - Changes to `💬` when Claude needs input (waiting for permission or idle)
 - Clears the status completely when the session ends
 
-**Status from other terminal:**
+**Status from another terminal:**
 
 <!-- Output from: tests/snapshots/integration__integration_tests__list__with_user_status.snap -->
 


### PR DESCRIPTION
## Summary
- correct wording around external command invocation for commit message generation
- clarify phrasing about checking status from another terminal

## Testing
- not run (documentation-only changes)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691ed9309c64832586759e6ac8d31c80)