### PR TITLE
Remove shared status note from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -862,7 +862,6 @@ dirty-with-status  ≡?🤖                  ./dirty-with-status           b8346
 - Status is stored as `worktrunk.status.<branch>` in `.git/config`
 - Each branch can have its own status emoji
 - The hooks automatically detect the current branch and set/clear its status
-- Status is shared across all worktrees on the same branch (by design)
 - Works with any git repository, no special configuration needed
 
 </details>


### PR DESCRIPTION
## Summary
- remove statement about status sharing across worktrees in README

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691eddec3f1c8325a4d07bc27d924a1c)