### PR TITLE
Add caching to MSRV and unused-deps jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,12 @@ jobs:
     - name: 📂 Checkout code
       uses: actions/checkout@v5
 
+    - name: 💰 Cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        prefix-key: msrv-${{ hashFiles('Cargo.lock') }}
+        save-if: ${{ github.ref == 'refs/heads/main' }}
+
     - uses: baptiste0928/cargo-install@v3
       with:
         crate: cargo-msrv
@@ -197,6 +203,12 @@ jobs:
 
     # cargo-udeps requires nightly; update date periodically
     - run: rustup override set nightly-2025-11-10
+
+    - name: 💰 Cache
+      uses: Swatinem/rust-cache@v2
+      with:
+        prefix-key: udeps-${{ hashFiles('Cargo.lock') }}
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - uses: baptiste0928/cargo-install@v3
       with:


### PR DESCRIPTION
## Summary
- Add Swatinem/rust-cache to MSRV and check-unused-dependencies jobs
- Uses separate prefix keys (msrv-, udeps-) to avoid cache conflicts
- Only saves cache on main branch pushes

## Test plan
- [ ] Jobs still pass
- [ ] Cache is populated on merge to main
- [ ] Subsequent runs use cached dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)