### PR TITLE
fix: Use static prefix-key in rust-cache configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,7 @@ jobs:
     - name: 💰 Cache
       uses: Swatinem/rust-cache@v2
       with:
-        prefix-key: ${{ hashFiles('Cargo.lock') }}
+        prefix-key: v0-rust
         save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Install shells (bash, zsh, fish) - Ubuntu
@@ -182,7 +182,7 @@ jobs:
     - name: 💰 Cache
       uses: Swatinem/rust-cache@v2
       with:
-        prefix-key: msrv-${{ hashFiles('Cargo.lock') }}
+        prefix-key: v0-msrv
         save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - uses: baptiste0928/cargo-install@v3
@@ -207,7 +207,7 @@ jobs:
     - name: 💰 Cache
       uses: Swatinem/rust-cache@v2
       with:
-        prefix-key: udeps-${{ hashFiles('Cargo.lock') }}
+        prefix-key: v0-udeps
         save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - uses: baptiste0928/cargo-install@v3
@@ -234,7 +234,7 @@ jobs:
     - name: 💰 Cache
       uses: Swatinem/rust-cache@v2
       with:
-        prefix-key: ${{ hashFiles('Cargo.lock') }}
+        prefix-key: v0-bench
         save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Install shells (zsh, fish)


### PR DESCRIPTION
## Summary
- Fix CI failure caused by incorrect use of `hashFiles('Cargo.lock')` as `prefix-key`
- `prefix-key` expects a static string; rust-cache already incorporates Cargo.lock automatically
- Changed all 4 cache configurations to use static prefixes: `v0-rust`, `v0-msrv`, `v0-udeps`, `v0-bench`

## Test plan
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)