### PR TITLE
fix: Make bash completion nosort option conditional for macOS

### DIFF
--- a/templates/bash.sh
+++ b/templates/bash.sh
@@ -73,5 +73,10 @@ if command -v {{ cmd_prefix }} >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]];
             _clap_complete_{{ cmd_prefix }}
         fi
     }
-    complete -o nospace -o bashdefault -o nosort -F _wt_lazy_complete {{ cmd_prefix }}
+    # nosort requires Bash 4.4+ (macOS ships with 3.2)
+    if [[ ${BASH_VERSINFO[0]} -gt 4 || (${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -ge 4) ]]; then
+        complete -o nospace -o bashdefault -o nosort -F _wt_lazy_complete {{ cmd_prefix }}
+    else
+        complete -o nospace -o bashdefault -F _wt_lazy_complete {{ cmd_prefix }}
+    fi
 fi

--- a/tests/snapshots/integration__integration_tests__init__init_bash.snap
+++ b/tests/snapshots/integration__integration_tests__init__init_bash.snap
@@ -185,7 +185,12 @@ wt_exec() {
             _clap_complete_wt
         fi
     }
-    complete -o nospace -o bashdefault -o nosort -F _wt_lazy_complete wt
+    # nosort requires Bash 4.4+ (macOS ships with 3.2)
+    if [[ ${BASH_VERSINFO[0]} -gt 4 || (${BASH_VERSINFO[0]} -eq 4 && ${BASH_VERSINFO[1]} -ge 4) ]]; then
+        complete -o nospace -o bashdefault -o nosort -F _wt_lazy_complete wt
+    else
+        complete -o nospace -o bashdefault -F _wt_lazy_complete wt
+    fi
 fi
 
 ----- stderr -----


### PR DESCRIPTION
## Summary
- Make the `nosort` option for bash's `complete` command conditional on Bash 4.4+
- Fixes CI failures on macOS which ships with Bash 3.2 due to licensing

## Test plan
- [x] Tests pass locally
- [ ] CI passes on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)