### PR TITLE
docs: Clarify pre-merge hooks as local CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,6 @@ Automate tasks at different points in the worktree lifecycle. Configure hooks in
 "lint" = "uv run ruff check"
 ```
 
-> **Note:** `pre-merge-command` acts as a local CI pipeline. Because it runs after squashing
-> but before pushing to main, and stops the merge on failure, it ensures tests pass before
-> code reaches the trunk. Post-merge hooks run after the merge completes and only log failures.
-
 <!-- README:snapshot:tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__readme_example_hooks_post_create.snap -->
 ```bash
 $ wt switch --create feature-x
@@ -281,9 +277,10 @@ setup, `post-start-command` for non-blocking tasks. For example, worktrunk uses
 eliminating cold compiles (see [worktrunk's config](.config/wt.toml)). See
 [Project Hooks](#project-hooks) for details.
 
-**Use `post-merge-command` as a "local CI"** — Running `wt merge` on a worktree
-and gating the merge on tests passing is very freeing — `main` is protected from
-one agent forgetting to run all tests, without you having to babysit it.
+**Use `pre-merge-command` as a "local CI"** — Running `wt merge` with pre-merge
+hooks is like having a local CI pipeline. Tests run after squashing but before
+pushing to main, and failures abort the merge. This protects `main` from one
+agent forgetting to run tests, without having to babysit it.
 
 **View Claude Code status from `wt list`** — The Claude Code integration shows
 which branches have active sessions in `wt list`. When the agent is working, the


### PR DESCRIPTION
- Fix incorrect tip: change post-merge to pre-merge (post-merge only warns, pre-merge blocks)
- Add note after hooks table explaining pre-merge acts as local CI pipeline
- Improve tip description to explain timing (after squash, before push)