### PR TITLE
Fix shell integration command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -818,7 +818,7 @@ For Claude:
 ```bash
 llm install llm-anthropic
 llm keys set anthropic
-llm models default claude-sonnet-4-5
+llm models default claude-haiku-4-5
 ```
 
 For OpenAI:


### PR DESCRIPTION
Change 'wt config shell' to 'wt config shell install' in Shell Integration section for consistency with the rest of the documentation.