### PR TITLE
fix(ci): Move `env` import inside unix-only block

### DIFF
--- a/src/bin/dev-detach.rs
+++ b/src/bin/dev-detach.rs
@@ -6,13 +6,13 @@
 //!
 //! Usage: dev-detach \<command\> [args...]
 
-use std::{env, process};
+use std::process;
 
 fn main() {
     #[cfg(unix)]
     {
         use nix::unistd::{execvp, setsid};
-        use std::ffi::CString;
+        use std::{env, ffi::CString};
 
         if let Err(e) = setsid() {
             eprintln!("dev-detach: setsid failed: {e}");


### PR DESCRIPTION
## Summary
- Moved `std::env` import inside the `#[cfg(unix)]` block in `dev-detach.rs`
- Fixes unused import warning on Windows that was failing CI

## Test plan
- [x] Clippy passes locally
- [x] All tests pass
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)