### PR TITLE
Fix: Exclude Reddit from link checker

### DIFF
--- a/.config/lychee.toml
+++ b/.config/lychee.toml
@@ -18,6 +18,7 @@ exclude = [
     # Social media (blocks GitHub Actions)
     "~twitter\\.com",
     "~x\\.com",
+    "~reddit\\.com",
 
     # Sites with reliability issues in CI
     "~stackoverflow\\.com",


### PR DESCRIPTION
## Summary
- Add reddit.com to lychee exclusion list (blocks GitHub Actions with 403)

## Test plan
- [x] Ran `pre-commit run lychee --all-files` locally - passes
- [ ] CI should pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)