### PR TITLE
ci: Remove lychee cache to avoid stale results

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -124,13 +124,6 @@ jobs:
     - name: Install pre-commit
       run: pip install pre-commit
 
-    - name: Cache lychee results
-      uses: actions/cache@v4
-      with:
-        path: .lycheecache
-        key: lychee-${{ hashFiles('.config/lychee.toml') }}-${{ github.sha }}
-        restore-keys: lychee-${{ hashFiles('.config/lychee.toml') }}-
-
     - name: Get modified markdown files
       if: github.event_name == 'pull_request'
       id: changed-files


### PR DESCRIPTION
## Summary
- Remove GitHub Actions cache for lychee link checker results
- Stale cache entries can cause false negatives when URLs move or get deleted
- Local caching remains enabled via `.config/lychee.toml` for faster local runs

## Test plan
- [ ] CI passes without the cache step
- [ ] Link checking still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)