### PR TITLE
Add workflow names for cleaner CI check display

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,3 +1,5 @@
+name: CI
+
 on:
   push:
     branches: [ main ]

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -37,6 +37,8 @@ permissions:
 #
 # If there's a prerelease-style suffix to the version, then the release(s)
 # will be marked as a prerelease.
+name: Release
+
 on:
   pull_request:
   push:


### PR DESCRIPTION
## Summary
- Add `name: CI` to ci.yaml workflow
- Add `name: Release` to release.yaml workflow

GitHub shows file paths when workflows lack names. This gives cleaner check names like "CI / test (macos-latest)" instead of ".github/workflows/ci.yaml / test (macos-latest)".

## Test plan
- [ ] Verify CI checks display with new names after PR is created

🤖 Generated with [Claude Code](https://claude.com/claude-code)