### PR TITLE
fix(fish): Handle empty WORKTRUNK_BIN in completions

### DIFF
--- a/src/commands/configure_shell.rs
+++ b/src/commands/configure_shell.rs
@@ -559,7 +559,7 @@ fn prompt_yes_no() -> Result<bool, String> {
 
 /// Fish completion content - finds wt in PATH, with WORKTRUNK_BIN as optional override
 const FISH_COMPLETION: &str = r#"# worktrunk completions for fish
-complete --keep-order --exclusive --command wt --arguments "(set -q WORKTRUNK_BIN; or set -l WORKTRUNK_BIN (type -P wt); COMPLETE=fish \$WORKTRUNK_BIN -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"
+complete --keep-order --exclusive --command wt --arguments "(test -n \"\$WORKTRUNK_BIN\"; or set -l WORKTRUNK_BIN (type -P wt); COMPLETE=fish \$WORKTRUNK_BIN -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"
 "#;
 
 /// Process shell completions - either preview or write based on dry_run flag

--- a/templates/fish.fish
+++ b/templates/fish.fish
@@ -1,11 +1,11 @@
 # worktrunk shell integration for fish
 
 # Only initialize if {{ cmd_prefix }} is available (in PATH or via WORKTRUNK_BIN)
-if type -q {{ cmd_prefix }}; or set -q WORKTRUNK_BIN
+if type -q {{ cmd_prefix }}; or test -n "$WORKTRUNK_BIN"
     # Capture stdout (shell script), eval in parent shell. stderr streams to terminal.
     # WORKTRUNK_BIN can override the binary path (for testing dev builds).
     function wt_exec
-        set -q WORKTRUNK_BIN; or set -l WORKTRUNK_BIN (type -P {{ cmd_prefix }})
+        test -n "$WORKTRUNK_BIN"; or set -l WORKTRUNK_BIN (type -P {{ cmd_prefix }})
         set -l script (command $WORKTRUNK_BIN $argv | string collect)
         set -l exit_code $pipestatus[1]
 

--- a/tests/integration_tests/configure_shell.rs
+++ b/tests/integration_tests/configure_shell.rs
@@ -236,8 +236,8 @@ fn test_configure_shell_fish_extension_exists() {
     );
     let contents = std::fs::read_to_string(&completions_file).unwrap();
     assert!(
-        contents.contains("set -q WORKTRUNK_BIN; or set -l WORKTRUNK_BIN"),
-        "Fish completions should use WORKTRUNK_BIN with fallback"
+        contents.contains(r#"test -n \"\$WORKTRUNK_BIN\""#),
+        "Fish completions should check WORKTRUNK_BIN is non-empty with fallback"
     );
 }
 

--- a/tests/snapshots/integration__integration_tests__init__init_fish.snap
+++ b/tests/snapshots/integration__integration_tests__init__init_fish.snap
@@ -26,11 +26,11 @@ exit_code: 0
 # worktrunk shell integration for fish
 
 # Only initialize if wt is available (in PATH or via WORKTRUNK_BIN)
-if type -q wt; or set -q WORKTRUNK_BIN
+if type -q wt; or test -n "$WORKTRUNK_BIN"
     # Capture stdout (shell script), eval in parent shell. stderr streams to terminal.
     # WORKTRUNK_BIN can override the binary path (for testing dev builds).
     function wt_exec
-        set -q WORKTRUNK_BIN; or set -l WORKTRUNK_BIN (type -P wt)
+        test -n "$WORKTRUNK_BIN"; or set -l WORKTRUNK_BIN (type -P wt)
         set -l script (command $WORKTRUNK_BIN $argv | string collect)
         set -l exit_code $pipestatus[1]
 


### PR DESCRIPTION
## Summary
- Fix fish completion failing with "The expanded command was empty" when `WORKTRUNK_BIN` is set but empty
- Simplify the check by using `test -n "$WORKTRUNK_BIN"` which handles both unset and empty cases
- Remove redundant `set -q` checks since `test -n` is sufficient

## Test plan
- [x] Unit tests pass
- [x] Integration tests pass (432 tests)
- [x] Shell wrapper tests pass (58 tests with shell-integration-tests feature)
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)