### PR TITLE
Move Path-First Lookup section to bottom of wt switch docs

### DIFF
--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -36,18 +36,6 @@ wt switch ^                      # Main worktree
 wt switch --create fix --base=@  # Branch from current HEAD
 ```
 
-## Path-First Lookup
-
-Arguments resolve by checking the filesystem before git branches:
-
-1. Compute expected path from argument (using configured path template)
-2. If worktree exists at that path, switch to it
-3. Otherwise, treat argument as branch name
-
-**Edge case**: If `repo.foo/` exists but tracks branch `bar`:
-- `wt switch foo` → switches to `repo.foo/` (the `bar` worktree)
-- `wt switch bar` → also works (branch lookup finds same worktree)
-
 ## Creating Worktrees
 
 With `--create`, worktrunk:
@@ -64,6 +52,18 @@ wt switch --create fix --base release-2.0
 wt switch --create docs --execute "code ."
 wt switch --create temp --no-verify      # Skip hooks
 ```
+
+## Path-First Lookup
+
+Arguments resolve by checking the filesystem before git branches:
+
+1. Compute expected path from argument (using configured path template)
+2. If worktree exists at that path, switch to it
+3. Otherwise, treat argument as branch name
+
+**Edge case**: If `repo.foo/` exists but tracks branch `bar`:
+- `wt switch foo` → switches to `repo.foo/` (the `bar` worktree)
+- `wt switch bar` → also works (branch lookup finds same worktree)
 
 ## See Also
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1007,18 +1007,6 @@ wt switch ^                      # Main worktree
 wt switch --create fix --base=@  # Branch from current HEAD
 ```
 
-## Path-First Lookup
-
-Arguments resolve by checking the filesystem before git branches:
-
-1. Compute expected path from argument (using configured path template)
-2. If worktree exists at that path, switch to it
-3. Otherwise, treat argument as branch name
-
-**Edge case**: If `repo.foo/` exists but tracks branch `bar`:
-- `wt switch foo` → switches to `repo.foo/` (the `bar` worktree)
-- `wt switch bar` → also works (branch lookup finds same worktree)
-
 ## Creating Worktrees
 
 With `--create`, worktrunk:
@@ -1035,6 +1023,18 @@ wt switch --create fix --base release-2.0
 wt switch --create docs --execute "code ."
 wt switch --create temp --no-verify      # Skip hooks
 ```
+
+## Path-First Lookup
+
+Arguments resolve by checking the filesystem before git branches:
+
+1. Compute expected path from argument (using configured path template)
+2. If worktree exists at that path, switch to it
+3. Otherwise, treat argument as branch name
+
+**Edge case**: If `repo.foo/` exists but tracks branch `bar`:
+- `wt switch foo` → switches to `repo.foo/` (the `bar` worktree)
+- `wt switch bar` → also works (branch lookup finds same worktree)
 
 ## See Also
 

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -83,18 +83,6 @@ For interactive selection, use [[2mwt select[0m](/select/).
   [2mwt switch ^                      # Main worktree[0m
   [2mwt switch --create fix --base=@  # Branch from current HEAD[0m
 
-[32mPath-First Lookup[0m
-
-Arguments resolve by checking the filesystem before git branches:
-
-1. Compute expected path from argument (using configured path template)
-2. If worktree exists at that path, switch to it
-3. Otherwise, treat argument as branch name
-
-[1mEdge case[0m: If [2mrepo.foo/[0m exists but tracks branch [2mbar[0m:
-- [2mwt switch foo[0m → switches to [2mrepo.foo/[0m (the [2mbar[0m worktree)
-- [2mwt switch bar[0m → also works (branch lookup finds same worktree)
-
 [32mCreating Worktrees[0m
 
 With [2m--create[0m, worktrunk:
@@ -109,6 +97,18 @@ With [2m--create[0m, worktrunk:
   [2mwt switch --create fix --base release-2.0[0m
   [2mwt switch --create docs --execute "code ."[0m
   [2mwt switch --create temp --no-verify      # Skip hooks[0m
+
+[32mPath-First Lookup[0m
+
+Arguments resolve by checking the filesystem before git branches:
+
+1. Compute expected path from argument (using configured path template)
+2. If worktree exists at that path, switch to it
+3. Otherwise, treat argument as branch name
+
+[1mEdge case[0m: If [2mrepo.foo/[0m exists but tracks branch [2mbar[0m:
+- [2mwt switch foo[0m → switches to [2mrepo.foo/[0m (the [2mbar[0m worktree)
+- [2mwt switch bar[0m → also works (branch lookup finds same worktree)
 
 [32mSee Also[0m
 


### PR DESCRIPTION
Reorder the documentation sections so Path-First Lookup appears
after Creating Worktrees and before See Also, making the more
commonly used information more prominent.