### PR TITLE
Fix lychee link checker failing on root-relative paths

### DIFF
--- a/.config/lychee.toml
+++ b/.config/lychee.toml
@@ -49,9 +49,14 @@ exclude = [
     # Local dev server URLs (not running during CI)
     "127\\.0\\.0\\.1",
     "localhost",
+
+    # Root-relative paths - validated by zola check during site build, not lychee
+    "^/",
 ]
 
 # Exclude files with relative paths intended for different locations
 exclude_path = [
     ".claude-plugin/skills/worktrunk/reference/README.md",
+    # Third-party theme - has its own linking conventions
+    "docs/themes/juice/README.md",
 ]


### PR DESCRIPTION
## Summary
- Exclude root-relative paths (`^/`) from lychee since they're validated by `zola check` during site build
- Exclude third-party juice theme README which has its own linking conventions

Fixes CI failures on main where lychee couldn't resolve paths like `/assets/wt-demo.gif`.

## Test plan
- [x] `pre-commit run lychee --all-files` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)