### PR TITLE
Fix lychee URL parsing failure on root-relative asset paths

### DIFF
--- a/.config/lychee.toml
+++ b/.config/lychee.toml
@@ -50,8 +50,6 @@ exclude = [
     "127\\.0\\.0\\.1",
     "localhost",
 
-    # Root-relative paths - validated by zola check during site build, not lychee
-    "^/",
 ]
 
 # Exclude files with relative paths intended for different locations
@@ -59,4 +57,8 @@ exclude_path = [
     ".claude-plugin/skills/worktrunk/reference/README.md",
     # Third-party theme - has its own linking conventions
     "docs/themes/juice/README.md",
+    # Root-relative asset paths (e.g., /assets/wt-demo.gif) fail lychee URL parsing.
+    # These are validated by zola check during site build instead.
+    "docs/content/select.md",
+    "docs/content/why-worktrunk.md",
 ]


### PR DESCRIPTION
## Summary

- Fixed CI failure caused by lychee link checker failing on root-relative asset paths
- The previous fix (#91) added `^/` to the exclude pattern, but lychee fails during URL building before exclude patterns are applied
- Instead, excluded the specific markdown files with root-relative asset paths (`docs/content/select.md`, `docs/content/why-worktrunk.md`)
- These paths are validated by zola check during site build anyway

## Test plan

- [x] `pre-commit run lychee --all-files` passes locally
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)