### PR TITLE
Use base URL instead of file exclusions for root-relative paths

### DIFF
--- a/.config/lychee.toml
+++ b/.config/lychee.toml
@@ -1,6 +1,10 @@
 # Lychee link checker configuration
 # See: https://lychee.cli.rs/
 
+# Base URL for resolving root-relative paths (e.g., /assets/wt-demo.gif)
+# This rewrites them to https://worktrunk.dev/assets/wt-demo.gif for validation
+base = "https://worktrunk.dev"
+
 # Network resilience - handles transient failures
 max_retries = 5
 timeout = 20
@@ -57,8 +61,4 @@ exclude_path = [
     ".claude-plugin/skills/worktrunk/reference/README.md",
     # Third-party theme - has its own linking conventions
     "docs/themes/juice/README.md",
-    # Root-relative asset paths (e.g., /assets/wt-demo.gif) fail lychee URL parsing.
-    # These are validated by zola check during site build instead.
-    "docs/content/select.md",
-    "docs/content/why-worktrunk.md",
 ]


### PR DESCRIPTION
## Summary

Improves on #92 by using lychee's `base` config option instead of excluding entire files.

- Added `base = "https://worktrunk.dev"` to rewrite root-relative paths
- Removed file exclusions for `docs/content/select.md` and `docs/content/why-worktrunk.md`

**Why this is better:**
- Still validates all other links in those files (the previous fix excluded ALL links)
- The rewritten URLs (e.g., `https://worktrunk.dev/assets/wt-demo.gif`) match our `--include` regex so they're checked
- More targeted solution that doesn't lose link coverage

## Test plan

- [x] `pre-commit run lychee --all-files` passes locally
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)