### PR TITLE
Add root_dir to lychee config for root-relative paths

### DIFF
--- a/.config/lychee.toml
+++ b/.config/lychee.toml
@@ -1,9 +1,9 @@
 # Lychee link checker configuration
 # See: https://lychee.cli.rs/
 
-# NOTE: base_url was removed because it converts ALL relative paths (including
-# docs/static/logo.png in README for GitHub display) to worktrunk.dev URLs.
-# Root-relative paths like /assets/foo.gif now need absolute URLs in source files.
+# Root directory for resolving root-relative paths (e.g., /assets/wt-demo.gif)
+# These resolve to docs/static/assets/wt-demo.gif for local validation
+root_dir = "docs/static"
 
 # Network resilience - handles transient failures
 max_retries = 5


### PR DESCRIPTION
## Summary
- Adds `root_dir = "docs/static"` to resolve root-relative paths like `/assets/wt-demo.gif`
- Fixes CI failure introduced by #94 which removed `base_url`

## Test plan
- [x] Pre-commit lychee passes locally
- [ ] CI check-links passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)