### PR TITLE
Pin lychee version to 0.18.0 via pre-commit rust language

### DIFF
--- a/.config/lychee.toml
+++ b/.config/lychee.toml
@@ -57,8 +57,4 @@ exclude_path = [
     ".claude-plugin/skills/worktrunk/reference/README.md",
     # Third-party theme - has its own linking conventions
     "docs/themes/juice/README.md",
-    # Files with root-relative GIF paths (assets stored in separate repo, fetched at deploy)
-    # Lychee 0.22+ requires base_url/root_dir to resolve these, but base_url breaks other links
-    "docs/content/select.md",
-    "docs/content/why-worktrunk.md",
 ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,26 +26,27 @@ repos:
     hooks:
       - id: clippy
         args: ["--all-targets", "--", "-D", "warnings"]
-  # Commit hash silences mutable ref warning; autoupdate reverts to nightly tag
-  # TODO: Update periodically
-  - repo: https://github.com/lycheeverse/lychee
-    rev: c513e7ee5d74d85aaaeaf2b4c67fb063f93e46e8
+  # Local hook with pinned version - lychee's script hook downloads latest, causing version drift
+  - repo: local
     hooks:
       # Fast PR mode - only check worktrunk domains (internal links validated by zola check)
       - id: lychee
         name: lychee (PR mode)
+        language: rust
+        entry: lychee --no-progress --config=.config/lychee.toml --include=^https://(github\.com/max-sixty/worktrunk|worktrunk\.dev)
         types: [markdown]
-        args:
-          - --config=.config/lychee.toml
-          - --include=^https://(github\.com/max-sixty/worktrunk|worktrunk\.dev)
+        require_serial: true
+        additional_dependencies: ["cli:lychee:0.18.0"]
       # Comprehensive mode - check all links with full config
       # Run manually: pre-commit run --hook-stage manual lychee-all --all-files
-      - id: lychee
+      - id: lychee-all
         name: lychee-all (comprehensive)
+        language: rust
+        entry: lychee --no-progress --config=.config/lychee.toml
         types: [markdown]
         stages: [manual]
-        args:
-          - --config=.config/lychee.toml
+        require_serial: true
+        additional_dependencies: ["cli:lychee:0.18.0"]
   - repo: local
     hooks:
       - id: no-dbg
@@ -66,5 +67,5 @@ repos:
 ci:
   # pre-commit.ci doesn't have Rust toolchain, so skip Rust-specific hooks.
   # Network access also isn't supported, so skip lychee.
-  skip: [fmt, clippy, lychee]
+  skip: [fmt, clippy, lychee, lychee-all]
   autoupdate_commit_msg: "chore: pre-commit autoupdate"


### PR DESCRIPTION
## Summary
- The lychee script hook downloads latest version, causing drift between local (0.20.1) and CI (0.22.0)
- Lychee 0.22+ requires `base_url`/`root_dir` for root-relative paths - breaking change
- Use pre-commit's `language: rust` with `cli:lychee:0.18.0` to pin via cargo install
- Reverts file exclusions since 0.18.0 handles root-relative paths correctly

## Test plan
- [x] Pre-commit passes locally with pinned version
- [x] Verified `lychee --version` shows 0.18.0 in pre-commit cache
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)