### PR TITLE
Upgrade lychee to 0.22.0, use root_dir for path resolution

### DIFF
--- a/.config/lychee.toml
+++ b/.config/lychee.toml
@@ -43,6 +43,9 @@ exclude = [
     "opensource\\.org",
     "llm\\.datasette\\.io",
 
+    # Asset GIFs stored in separate worktrunk-assets repo (gitignored, fetched at deploy)
+    "file://.*wt-.*\\.gif",
+
     # Local build artifacts (not checked into git)
     "wt-demo/out/wt-demo\\.gif",
 
@@ -51,6 +54,10 @@ exclude = [
     "localhost",
 
 ]
+
+# Root directory for resolving root-relative paths like /assets/wt-demo.gif
+# Assets are fetched from separate repo at deploy time (gitignored locally)
+root_dir = "docs/static"
 
 # Exclude source files from link checking
 exclude_path = [

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,7 @@ repos:
     hooks:
       - id: clippy
         args: ["--all-targets", "--", "-D", "warnings"]
-  # Local hook with pinned version - lychee's script hook downloads latest, causing version drift
+  # Local hook with pinned version - lychee's script hook uses system install if present
   - repo: local
     hooks:
       # Fast PR mode - only check worktrunk domains (internal links validated by zola check)
@@ -36,7 +36,7 @@ repos:
         entry: lychee --no-progress --config=.config/lychee.toml --include=^https://(github\.com/max-sixty/worktrunk|worktrunk\.dev)
         types: [markdown]
         require_serial: true
-        additional_dependencies: ["cli:lychee:0.18.0"]
+        additional_dependencies: ["cli:lychee:0.22.0"]
       # Comprehensive mode - check all links with full config
       # Run manually: pre-commit run --hook-stage manual lychee-all --all-files
       - id: lychee-all
@@ -46,7 +46,7 @@ repos:
         types: [markdown]
         stages: [manual]
         require_serial: true
-        additional_dependencies: ["cli:lychee:0.18.0"]
+        additional_dependencies: ["cli:lychee:0.22.0"]
   - repo: local
     hooks:
       - id: no-dbg


### PR DESCRIPTION
## Summary
- Upgrade pinned lychee from 0.18.0 to 0.22.0 (latest)
- Use `root_dir = "docs/static"` to resolve root-relative paths like `/assets/wt-demo.gif`
- Exclude `file://.*wt-.*\.gif` pattern (assets are gitignored, fetched at deploy)

This is cleaner than the previous approach of excluding entire files - only the specific GIF paths are skipped, other links in those files are still validated.

## Test plan
- [x] Pre-commit passes locally with assets present
- [x] Pre-commit passes locally with assets removed (simulating CI)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)