### PR TITLE
Use standard lychee pre-commit hook with v0.22.0

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -64,5 +64,5 @@ repos:
 ci:
   # pre-commit.ci doesn't have Rust toolchain, so skip Rust-specific hooks.
   # Network access also isn't supported, so skip lychee.
-  skip: [fmt, clippy, lychee, lychee-all]
+  skip: [fmt, clippy, lychee]
   autoupdate_commit_msg: "chore: pre-commit autoupdate"


### PR DESCRIPTION
## Summary
- Switch from local rust hook with pinned version to standard lychee pre-commit hook
- Update to latest lychee tag (lychee-v0.22.0)

Note: lychee's hook uses `language: script` which runs the system-installed lychee binary rather than pinning to the rev version. This is a known design limitation of lychee's pre-commit integration.

## Test plan
- [x] Pre-commit runs successfully locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)