### PR TITLE
Add --project flag to wt config create

### DIFF
--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -70,7 +70,7 @@ approved-commands = ["npm install"]
 
 # NOTE: For project-specific hooks (post-create, post-start, pre-merge, etc.),
 # use a separate PROJECT config file at <repo>/.config/wt.toml
-# See: dev/wt.example.toml for project configuration examples
+# Run `wt config create --project` to create one, or see https://worktrunk.dev/hooks/
 
 # ============================================================================
 # Custom Prompt Templates (Advanced)

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -31,6 +31,12 @@ Create user config file with documented examples:
 wt config create
 ```
 
+Create project config file (.config/wt.toml) for hooks:
+
+```bash
+wt config create --project
+```
+
 Show current configuration and file locations:
 
 ```bash
@@ -219,7 +225,7 @@ Usage: wt config [OPTIONS] <COMMAND>
 
 Commands:
   shell      Shell integration setup
-  create     Create user configuration file
+  create     Create configuration file
   show       Show configuration files & locations
   cache      Manage caches (CI status, default branch)
   var        Get or set runtime variables (stored in git config)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -269,15 +269,24 @@ pub enum ConfigCommand {
         action: ConfigShellCommand,
     },
 
-    /// Create user configuration file
+    /// Create configuration file
     #[command(
         after_long_help = concat!(
+            "## User config\n\n",
             "Creates `~/.config/worktrunk/config.toml` with the following content:\n\n```\n",
             include_str!("../dev/config.example.toml"),
+            "```\n\n",
+            "## Project config\n\n",
+            "With `--project`, creates `.config/wt.toml` in the current repository:\n\n```\n",
+            include_str!("../dev/wt.example.toml"),
             "```"
         )
     )]
-    Create,
+    Create {
+        /// Create project config (.config/wt.toml) instead of user config
+        #[arg(long)]
+        project: bool,
+    },
 
     /// Show configuration files & locations
     #[command(
@@ -691,6 +700,12 @@ Create user config file with documented examples:
 
 ```console
 wt config create
+```
+
+Create project config file (.config/wt.toml) for hooks:
+
+```console
+wt config create --project
 ```
 
 Show current configuration and file locations:

--- a/src/main.rs
+++ b/src/main.rs
@@ -732,7 +732,7 @@ fn main() {
                     }
                 }
             }
-            ConfigCommand::Create => handle_config_create(),
+            ConfigCommand::Create { project } => handle_config_create(project),
             ConfigCommand::Show { doctor } => handle_config_show(doctor),
             ConfigCommand::Cache { action } => match action {
                 CacheCommand::Show => handle_cache_show(),

--- a/tests/integration_tests/config_init.rs
+++ b/tests/integration_tests/config_init.rs
@@ -59,7 +59,7 @@ fn test_config_init_creates_file() {
         ----- stdout -----
 
         ----- stderr -----
-        ✅ [32mCreated config file: [1m~/.config/worktrunk/config.toml[22m[39m
+        ✅ [32mCreated user config: [1m~/.config/worktrunk/config.toml[22m[39m
 
         💡 [2mEdit this file to customize worktree paths and LLM settings[22m
         ");

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -18,10 +18,13 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-wt config create - Create user configuration file
+wt config create - Create configuration file
 Usage: [1m[36mwt config create[0m [36m[OPTIONS][0m
 
 [1m[32mOptions:[0m
+      [1m[36m--project[0m
+          Create project config (.config/wt.toml) instead of user config
+
   [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
@@ -34,6 +37,8 @@ Usage: [1m[36mwt config create[0m [36m[OPTIONS][0m
 
   [1m[36m-v[0m, [1m[36m--verbose[0m
           Show commands and debug info
+
+[32mUser config[0m
 
 Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 
@@ -109,7 +114,7 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
   [2m[0m
   [2m# NOTE: For project-specific hooks (post-create, post-start, pre-merge, etc.),[0m
   [2m# use a separate PROJECT config file at <repo>/.config/wt.toml[0m
-  [2m# See: dev/wt.example.toml for project configuration examples[0m
+  [2m# Run `wt config create --project` to create one, or see https://worktrunk.dev/hooks/[0m
   [2m[0m
   [2m# ============================================================================[0m
   [2m# Custom Prompt Templates (Advanced)[0m
@@ -227,3 +232,125 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
   [2m# Generate one cohesive commit message that captures the overall change.[0m
   [2m# Use conventional commit format (feat/fix/docs/refactor).[0m
   [2m# """[0m
+
+[32mProject config[0m
+
+With [2m--project[0m, creates [2m.config/wt.toml[0m in the current repository:
+
+  [2m# Worktrunk Project Configuration[0m
+  [2m# Copy to: <repo>/.config/wt.toml[0m
+  [2m#[0m
+  [2m# This file defines project-specific hooks that run automatically during[0m
+  [2m# worktree operations. It should be checked into git and shared across all[0m
+  [2m# developers working on the project.[0m
+  [2m[0m
+  [2m# Available template variables (all hooks):[0m
+  [2m#   {{ repo }}      - Repository name (e.g., "my-project")[0m
+  [2m#   {{ branch }}    - Branch name (slashes replaced with dashes)[0m
+  [2m#   {{ worktree }}  - Absolute path to the worktree[0m
+  [2m#   {{ repo_root }} - Absolute path to the repository root[0m
+  [2m#[0m
+  [2m# Merge-related hooks also support:[0m
+  [2m#   {{ target }}    - Target branch for the merge (e.g., "main")[0m
+  [2m[0m
+  [2m# Post-Create Hook[0m
+  [2m# Runs SEQUENTIALLY and BLOCKS until complete[0m
+  [2m# The worktree switch won't complete until these finish[0m
+  [2m# Commands run one after another in the worktree directory[0m
+  [2m#[0m
+  [2m# Format options:[0m
+  [2m# 1. Single string:[0m
+  [2m#    post-create = "npm install"[0m
+  [2m#[0m
+  [2m# 2. Named table (runs sequentially in declaration order):[0m
+  [2m# [post-create][0m
+  [2m# install = "npm install --frozen-lockfile"[0m
+  [2m# build = "npm run build"[0m
+  [2m[0m
+  [2m# Post-Start Hook[0m
+  [2m# Runs in BACKGROUND as detached processes (parallel)[0m
+  [2m# Use for: uv sync, npm install, bundle install, build, dev servers, file watchers,[0m
+  [2m# downloading assets too large for git (images, ML models, binaries), long-running tasks[0m
+  [2m# The worktree switch completes immediately, these run in parallel[0m
+  [2m# Output is logged to .git/wt-logs/{branch}-post-start-{name}.log[0m
+  [2m#[0m
+  [2m# Format options:[0m
+  [2m# 1. Single string:[0m
+  [2m#    post-start = "npm run dev"[0m
+  [2m#[0m
+  [2m# 2. Named table (runs in parallel):[0m
+  [2m# [post-start][0m
+  [2m# server = "npm run dev"[0m
+  [2m# watch = "npm run watch"[0m
+  [2m[0m
+  [2m# Pre-Commit Hook[0m
+  [2m# Runs SEQUENTIALLY before committing changes during merge (blocking, fail-fast)[0m
+  [2m# All commands must exit with code 0 for commit to proceed[0m
+  [2m# Runs for both squash and no-squash merge modes[0m
+  [2m# Use for: formatters, linters, quick validation[0m
+  [2m#[0m
+  [2m# Single command:[0m
+  [2m# pre-commit = "cargo fmt -- --check"[0m
+  [2m#[0m
+  [2m# Multiple commands:[0m
+  [2m# [pre-commit][0m
+  [2m# format = "cargo fmt -- --check"[0m
+  [2m# lint = "cargo clippy -- -D warnings"[0m
+  [2m[0m
+  [2m# Pre-Merge Hook[0m
+  [2m# Runs SEQUENTIALLY before merging to target branch (blocking, fail-fast)[0m
+  [2m# All commands must exit with code 0 for merge to proceed[0m
+  [2m# Use for: tests, linters, build verification before merging[0m
+  [2m#[0m
+  [2m# Single command:[0m
+  [2m# pre-merge = "cargo test"[0m
+  [2m#[0m
+  [2m# Multiple commands:[0m
+  [2m# [pre-merge][0m
+  [2m# test = "cargo test"[0m
+  [2m# build = "cargo build --release"[0m
+  [2m[0m
+  [2m# Post-Merge Hook[0m
+  [2m# Runs SEQUENTIALLY in the main worktree after successful merge (blocking)[0m
+  [2m# Runs after push succeeds but before cleanup[0m
+  [2m# Use for: updating production builds, notifications, cleanup[0m
+  [2m#[0m
+  [2m# Single command:[0m
+  [2m# post-merge = "cargo install --path ."[0m
+  [2m#[0m
+  [2m# Multiple commands:[0m
+  [2m# [post-merge][0m
+  [2m# install = "cargo install --path ."[0m
+  [2m# notify = "echo 'Merged!'"[0m
+  [2m[0m
+  [2m# Example: Node.js Project[0m
+  [2m# [post-create][0m
+  [2m# install = "npm ci"[0m
+  [2m#[0m
+  [2m# [post-start][0m
+  [2m# server = "npm run dev"[0m
+  [2m#[0m
+  [2m# [pre-merge][0m
+  [2m# lint = "npm run lint"[0m
+  [2m# test = "npm test"[0m
+  [2m[0m
+  [2m# Example: Rust Project[0m
+  [2m# [post-create][0m
+  [2m# build = "cargo build"[0m
+  [2m#[0m
+  [2m# [pre-merge][0m
+  [2m# format = "cargo fmt -- --check"[0m
+  [2m# clippy = "cargo clippy -- -D warnings"[0m
+  [2m# test = "cargo test"[0m
+  [2m#[0m
+  [2m# post-merge = "cargo install --path ."[0m
+  [2m[0m
+  [2m# Example: Python Project[0m
+  [2m# [post-create][0m
+  [2m# venv = "python -m venv .venv"[0m
+  [2m# install = ".venv/bin/pip install -r requirements.txt"[0m
+  [2m#[0m
+  [2m# [pre-merge][0m
+  [2m# format = ".venv/bin/black --check ."[0m
+  [2m# lint = ".venv/bin/ruff check ."[0m
+  [2m# test = ".venv/bin/pytest"[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -22,7 +22,7 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 
 [1m[32mCommands:[0m
   [1m[36mshell[0m      Shell integration setup
-  [1m[36mcreate[0m     Create user configuration file
+  [1m[36mcreate[0m     Create configuration file
   [1m[36mshow[0m       Show configuration files & locations
   [1m[36mcache[0m      Manage caches (CI status, default branch)
   [1m[36mvar[0m        Get or set runtime variables (stored in git config)
@@ -60,6 +60,10 @@ Install shell integration (required for directory switching):
 Create user config file with documented examples:
 
   [2mwt config create[0m
+
+Create project config file (.config/wt.toml) for hooks:
+
+  [2mwt config create --project[0m
 
 Show current configuration and file locations:
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_short.snap
@@ -22,7 +22,7 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 
 [1m[32mCommands:[0m
   [1m[36mshell[0m      Shell integration setup
-  [1m[36mcreate[0m     Create user configuration file
+  [1m[36mcreate[0m     Create configuration file
   [1m[36mshow[0m       Show configuration files & locations
   [1m[36mcache[0m      Manage caches (CI status, default branch)
   [1m[36mvar[0m        Get or set runtime variables (stored in git config)


### PR DESCRIPTION
## Summary
- Add `wt config create --project` to generate `.config/wt.toml` project config files
- Show both user and project config templates in `wt config create --help`
- Update stale `dev/wt.example.toml` reference to point to docs URL and new flag
- Add `wt config create --project` example to `wt config --help`

## Test plan
- [x] All 455 integration tests pass
- [x] All unit tests pass
- [x] Pre-commit hooks pass
- [ ] Manual verification: `wt config create --project` creates `.config/wt.toml`
- [ ] Manual verification: `wt config create --help` shows both config examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)