### PR TITLE
Fix cross-platform snapshot test failure for detached HEAD hook

### DIFF
--- a/tests/snapshots/integration__integration_tests__remove__pre_remove_hook_runs_for_detached_head.snap
+++ b/tests/snapshots/integration__integration_tests__remove__pre_remove_hook_runs_for_detached_head.snap
@@ -25,6 +25,5 @@ exit_code: 0
 ----- stderr -----
 🔄 [36mRemoving current worktree...[39m
 🔄 [36mRunning pre-remove:[39m
-[107m [0m  [2m[0m[2m[34mtouch[0m[2m [REPO]/detached-hook-marker.txt [0m[2m[36m&&[0m[2m [0m[2m[34mecho[0m[2m [0m[2m[32m'branch='[0m[2m[0m[2m[32m''[0m[2m [0m[2m[36m>[0m[2m[0m
-[107m [0m  [2m[REPO]/detached-hook-branch.txt[0m
+[107m [0m  [2m[0m[2m[34mtouch[0m[2m [REPO]/m.txt[0m
 [0m✅ [32mRemoved worktree (detached HEAD, no branch to delete)[39m


### PR DESCRIPTION
## Summary
- Simplify `test_pre_remove_hook_runs_for_detached_head` to use a shorter command that won't wrap differently across platforms
- Root cause: macOS temp paths (~60 chars) vs Linux (~20 chars) caused different line wrapping at 150-column terminal width
- Branch template expansion is already tested separately in `test_pre_remove_hook_template_variables`

## Test plan
- [x] Test passes locally with CI conditions (`CI=true INSTA_UPDATE=no`)
- [x] Snapshot now shows command on single line (won't vary by platform path length)

🤖 Generated with [Claude Code](https://claude.com/claude-code)