### PR TITLE
feat: allow running individual named hook commands

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -614,6 +614,10 @@ pub enum StepCommand {
 
     /// Run post-create hook
     PostCreate {
+        /// Run only this command from hook config
+        #[arg(add = crate::completion::hook_command_name_completer())]
+        name: Option<String>,
+
         /// Skip approval prompts
         #[arg(short, long)]
         force: bool,
@@ -621,6 +625,10 @@ pub enum StepCommand {
 
     /// Run post-start hook
     PostStart {
+        /// Run only this command from hook config
+        #[arg(add = crate::completion::hook_command_name_completer())]
+        name: Option<String>,
+
         /// Skip approval prompts
         #[arg(short, long)]
         force: bool,
@@ -628,6 +636,10 @@ pub enum StepCommand {
 
     /// Run pre-commit hook
     PreCommit {
+        /// Run only this command from hook config
+        #[arg(add = crate::completion::hook_command_name_completer())]
+        name: Option<String>,
+
         /// Skip approval prompts
         #[arg(short, long)]
         force: bool,
@@ -635,6 +647,10 @@ pub enum StepCommand {
 
     /// Run pre-merge hook
     PreMerge {
+        /// Run only this command from hook config
+        #[arg(add = crate::completion::hook_command_name_completer())]
+        name: Option<String>,
+
         /// Skip approval prompts
         #[arg(short, long)]
         force: bool,
@@ -642,6 +658,10 @@ pub enum StepCommand {
 
     /// Run post-merge hook
     PostMerge {
+        /// Run only this command from hook config
+        #[arg(add = crate::completion::hook_command_name_completer())]
+        name: Option<String>,
+
         /// Skip approval prompts
         #[arg(short, long)]
         force: bool,
@@ -649,6 +669,10 @@ pub enum StepCommand {
 
     /// Run pre-remove hook
     PreRemove {
+        /// Run only this command from hook config
+        #[arg(add = crate::completion::hook_command_name_completer())]
+        name: Option<String>,
+
         /// Skip approval prompts
         #[arg(short, long)]
         force: bool,

--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -150,7 +150,7 @@ impl CommitOptions<'_> {
             )))?;
         } else if let Some(ref config) = project_config {
             let pipeline = HookPipeline::new(*self.ctx);
-            pipeline.run_pre_commit(config, self.target_branch, self.auto_trust)?;
+            pipeline.run_pre_commit(config, self.target_branch, self.auto_trust, None)?;
         }
 
         if self.warn_about_untracked && self.stage_mode == StageMode::All {

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -621,6 +621,7 @@ impl<'a> CommandContext<'a> {
             "post-create",
             HookType::PostCreate,
             HookFailureStrategy::Warn,
+            None,
         )
     }
 
@@ -642,29 +643,7 @@ impl<'a> CommandContext<'a> {
             false,
             &[],
             "post-start",
-        )
-    }
-
-    /// Execute post-start commands sequentially (blocking) - for testing
-    pub fn execute_post_start_commands_sequential(&self) -> anyhow::Result<()> {
-        let project_config = match self.repo.load_project_config()? {
-            Some(cfg) => cfg,
-            None => return Ok(()),
-        };
-
-        let Some(post_start_config) = &project_config.post_start else {
-            return Ok(());
-        };
-
-        let pipeline = HookPipeline::new(*self);
-        pipeline.run_sequential(
-            post_start_config,
-            CommandPhase::PostStart,
-            false,
-            &[],
-            "post-start",
-            HookType::PostStart,
-            HookFailureStrategy::Warn,
+            None,
         )
     }
 }

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -111,6 +111,10 @@ pub enum GitError {
 
     // Validation/other errors
     NotInteractive,
+    HookCommandNotFound {
+        name: String,
+        available: Vec<String>,
+    },
     ParseError {
         message: String,
     },
@@ -414,6 +418,31 @@ impl std::fmt::Display for GitError {
                         "In CI/CD, use <bright-black>--force</> to skip prompts. To pre-approve commands, use <bright-black>wt config approvals add</>"
                     ))
                 )
+            }
+
+            GitError::HookCommandNotFound { name, available } => {
+                if available.is_empty() {
+                    write!(
+                        f,
+                        "{}",
+                        error_message(cformat!(
+                            "No command named <bold>{name}</> (hook has no named commands)"
+                        ))
+                    )
+                } else {
+                    let available_str = available
+                        .iter()
+                        .map(|s| cformat!("<bold>{s}</>"))
+                        .collect::<Vec<_>>()
+                        .join(", ");
+                    write!(
+                        f,
+                        "{}",
+                        error_message(cformat!(
+                            "No command named <bold>{name}</> (available: {available_str})"
+                        ))
+                    )
+                }
             }
 
             GitError::LlmCommandFailed { command, error } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -821,23 +821,23 @@ fn main() {
                     }
                 })
             }
-            StepCommand::PostCreate { force } => {
-                handle_standalone_run_hook(HookType::PostCreate, force)
+            StepCommand::PostCreate { name, force } => {
+                handle_standalone_run_hook(HookType::PostCreate, force, name.as_deref())
             }
-            StepCommand::PostStart { force } => {
-                handle_standalone_run_hook(HookType::PostStart, force)
+            StepCommand::PostStart { name, force } => {
+                handle_standalone_run_hook(HookType::PostStart, force, name.as_deref())
             }
-            StepCommand::PreCommit { force } => {
-                handle_standalone_run_hook(HookType::PreCommit, force)
+            StepCommand::PreCommit { name, force } => {
+                handle_standalone_run_hook(HookType::PreCommit, force, name.as_deref())
             }
-            StepCommand::PreMerge { force } => {
-                handle_standalone_run_hook(HookType::PreMerge, force)
+            StepCommand::PreMerge { name, force } => {
+                handle_standalone_run_hook(HookType::PreMerge, force, name.as_deref())
             }
-            StepCommand::PostMerge { force } => {
-                handle_standalone_run_hook(HookType::PostMerge, force)
+            StepCommand::PostMerge { name, force } => {
+                handle_standalone_run_hook(HookType::PostMerge, force, name.as_deref())
             }
-            StepCommand::PreRemove { force } => {
-                handle_standalone_run_hook(HookType::PreRemove, force)
+            StepCommand::PreRemove { name, force } => {
+                handle_standalone_run_hook(HookType::PreRemove, force, name.as_deref())
             }
         },
         #[cfg(unix)]

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -483,7 +483,7 @@ fn handle_removed_worktree_output(
             main_path,
             false, // force=false, prompt for approval
         );
-        execute_pre_remove_commands(&ctx, false)?;
+        execute_pre_remove_commands(&ctx, false, None)?;
     }
 
     // Handle detached HEAD case (no branch known)

--- a/tests/snapshots/integration__integration_tests__approval_ui__step_hook_name_filter_on_unnamed.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__step_hook_name_filter_on_unnamed.snap
@@ -1,0 +1,28 @@
+---
+source: tests/integration_tests/approval_ui.rs
+info:
+  program: wt
+  args:
+    - step
+    - pre-merge
+    - test
+    - "--force"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "150"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    LANG: C
+    LC_ALL: C
+    SOURCE_DATE_EPOCH: "1735776000"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+❌ [31mNo command named [1mtest[22m (hook has no named commands)[39m

--- a/tests/snapshots/integration__integration_tests__approval_ui__step_hook_unknown_name_error.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__step_hook_unknown_name_error.snap
@@ -1,0 +1,28 @@
+---
+source: tests/integration_tests/approval_ui.rs
+info:
+  program: wt
+  args:
+    - step
+    - pre-merge
+    - nonexistent
+    - "--force"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "150"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    LANG: C
+    LC_ALL: C
+    SOURCE_DATE_EPOCH: "1735776000"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+❌ [31mNo command named [1mnonexistent[22m (available: [1mtest[22m, [1mlint[22m)[39m


### PR DESCRIPTION
## Summary

- Add optional `name` argument to `wt step <hook-type>` commands to run a specific named command from hook config
- Add shell completion for hook command names from project config  
- Add `HookCommandNotFound` error with styled output showing available names
- Add 4 integration tests for name filtering behavior

Example usage:
```bash
wt step pre-merge test    # Run only the "test" command
wt step pre-merge         # Run all pre-merge commands (unchanged)
```

## Test plan

- [x] Unit tests pass (171 lib + 96 bin)
- [x] Integration tests pass (466 tests)
- [x] New tests verify name filtering, error messages, and shell completion
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)