### PR TITLE
Remove unnecessary dtolnay/rust-toolchain from CI workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,11 +24,6 @@ jobs:
     - name: 📂 Checkout code
       uses: actions/checkout@v6
 
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
-      with:
-        components: rustfmt, clippy
-
     - name: Install cargo-insta
       uses: baptiste0928/cargo-install@v3
       with:
@@ -216,9 +211,6 @@ jobs:
     steps:
     - name: 📂 Checkout code
       uses: actions/checkout@v6
-
-    - name: Install Rust
-      uses: dtolnay/rust-toolchain@stable
 
     - name: 💰 Cache
       uses: Swatinem/rust-cache@v2

--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -42,12 +42,6 @@ jobs:
           git config --global user.name "Claude Code"
           git config --global user.email "claude@anthropic.com"
 
-      # Rust is pre-installed on ubuntu-latest, but we ensure consistent toolchain
-      - name: Install Rust
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-
       - name: Install cargo-insta
         uses: baptiste0928/cargo-install@v3
         with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -286,7 +286,6 @@ jobs:
     if: ${{ needs.plan.outputs.publishing == 'true' }}
     steps:
       - uses: actions/checkout@v6
-      - uses: dtolnay/rust-toolchain@stable
       - name: Publish to crates.io
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

- Remove `dtolnay/rust-toolchain@stable` from all CI workflows
- GitHub runners have Rust stable pre-installed with rustfmt and clippy
- Matches prql's approach (they don't use dtolnay/rust-toolchain at all)

Removed from:
- `ci.yaml`: test job and benchmarks job
- `claude.yaml`: Claude Code action job  
- `release.yaml`: publish-cargo job

## Test plan

- [ ] CI passes on all platforms (ubuntu, macos, windows)
- [ ] Rust commands (cargo test, clippy, fmt) work without explicit toolchain install

🤖 Generated with [Claude Code](https://claude.com/claude-code)