### PR TITLE
Add black-box completion tests for zsh, bash, and fish

### DIFF
--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__bash_completion_subcommands.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__bash_completion_subcommands.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration_tests/shell_wrapper.rs
+expression: "String::from_utf8_lossy(&output.stdout)"
+---
+config
+step
+hook
+select
+list
+switch
+remove
+merge

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__fish_completion_subcommands.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__fish_completion_subcommands.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration_tests/shell_wrapper.rs
+expression: completions
+---
+config
+step
+hook
+select
+list
+switch
+remove
+merge

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__zsh_completion_subcommands.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__zsh_completion_subcommands.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration_tests/shell_wrapper.rs
+expression: "String::from_utf8_lossy(&output.stdout)"
+---
+config
+step
+hook
+select
+list
+switch
+remove
+merge


### PR DESCRIPTION
## Summary
- Add black-box snapshot tests that verify actual completion output for all three shells (zsh, bash, fish)
- Remove implementation-specific validation that was parsing sed patterns
- Each test sources the real shell integration script and triggers the completion pipeline

## Test plan
- [x] All 543 integration tests pass
- [x] Pre-commit checks pass
- [x] Snapshot tests capture correct subcommands (config, step, hook, select, list, switch, remove, merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)