### PR TITLE
Fix approvals and post-merge documentation

### DIFF
--- a/dev/wt.example.toml
+++ b/dev/wt.example.toml
@@ -73,7 +73,7 @@
 
 # Post-Merge Hook
 # Runs SEQUENTIALLY in the main worktree after successful merge (blocking)
-# Runs after push succeeds but before cleanup
+# Runs after push and cleanup complete
 # Use for: updating production builds, notifications, cleanup
 #
 # Single command:

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -127,7 +127,7 @@ approved-commands = [
 ]
 ```
 
-Manage approvals with `wt config approvals list` and `wt config approvals clear <repo>`.
+Manage approvals with `wt config approvals add` and `wt config approvals clear <repo>`.
 
 ## Project config
 
@@ -492,7 +492,7 @@ With `--project`, creates `.config/wt.toml` in the current repository:
 
 # Post-Merge Hook
 # Runs SEQUENTIALLY in the main worktree after successful merge (blocking)
-# Runs after push succeeds but before cleanup
+# Runs after push and cleanup complete
 # Use for: updating production builds, notifications, cleanup
 #
 # Single command:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -876,7 +876,7 @@ approved-commands = [
 ]
 ```
 
-Manage approvals with `wt config approvals list` and `wt config approvals clear <repo>`.
+Manage approvals with `wt config approvals add` and `wt config approvals clear <repo>`.
 
 ## Project config
 

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -64,7 +64,7 @@ pub struct ProjectConfig {
 
     /// Commands to execute after successful merge in the main worktree (blocking)
     /// Supports string (single command) or table (named, sequential)
-    /// Runs after push succeeds but before cleanup
+    /// Runs after push and cleanup complete
     ///
     /// Available template variables: `{{ repo }}`, `{{ branch }}`, `{{ worktree }}`, `{{ worktree_name }}`, `{{ repo_root }}`, `{{ default_branch }}`, `{{ commit }}`, `{{ short_commit }}`, `{{ remote }}`, `{{ upstream }}`, `{{ target }}`
     #[serde(default, rename = "post-merge")]

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -313,7 +313,7 @@ With [2m--project[0m, creates [2m.config/wt.toml[0m in the current repositor
   [2m[0m
   [2m# Post-Merge Hook[0m
   [2m# Runs SEQUENTIALLY in the main worktree after successful merge (blocking)[0m
-  [2m# Runs after push succeeds but before cleanup[0m
+  [2m# Runs after push and cleanup complete[0m
   [2m# Use for: updating production builds, notifications, cleanup[0m
   [2m#[0m
   [2m# Single command:[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -142,7 +142,7 @@ When project hooks run for the first time, Worktrunk prompts for approval. Appro
   [2m    "pre-merge.test = npm test",[0m
   [2m][0m
 
-Manage approvals with [2mwt config approvals list[0m and [2mwt config approvals clear <repo>[0m.
+Manage approvals with [2mwt config approvals add[0m and [2mwt config approvals clear <repo>[0m.
 
 [32mProject config[0m
 


### PR DESCRIPTION
## Summary
- update help text and docs to reference the existing `wt config approvals add` command instead of a missing list action
- clarify that post-merge hooks run after push and cleanup in examples, help output, and config comments

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6938d7d743548325859f9c973b9c8f9e)