### PR TITLE
Fix flaky tests by replacing fixed sleeps with polling

### DIFF
--- a/tests/integration_tests/remove.rs
+++ b/tests/integration_tests/remove.rs
@@ -1008,8 +1008,8 @@ approved-commands = ["echo 'hook ran' > {}"]
         None,
     );
 
-    // Wait a bit for any potential hook execution
-    thread::sleep(Duration::from_millis(100));
+    // Wait for any potential hook execution (absence check - can't poll, use 500ms per guidelines)
+    thread::sleep(Duration::from_millis(500));
 
     // Marker file should NOT exist - --no-verify skips the hook
     assert!(

--- a/tests/integration_tests/user_hooks.rs
+++ b/tests/integration_tests/user_hooks.rs
@@ -6,7 +6,9 @@
 //! - Don't require approval
 //! - Skipped together with project hooks via --no-verify
 
-use crate::common::{TestRepo, make_snapshot_cmd, setup_snapshot_settings, wait_for_file};
+use crate::common::{
+    TestRepo, make_snapshot_cmd, setup_snapshot_settings, wait_for_file, wait_for_file_content,
+};
 use insta_cmd::assert_cmd_snapshot;
 use std::fs;
 use std::process::Command;
@@ -212,10 +214,10 @@ bg = "echo 'USER_POST_START_RAN' > user_bg_marker.txt"
 
     snapshot_switch("user_post_start_executes", &repo, &["--create", "feature"]);
 
-    // Wait for background hook to complete
+    // Wait for background hook to complete and write content
     let worktree_path = repo.root_path().parent().unwrap().join("repo.feature");
     let marker_file = worktree_path.join("user_bg_marker.txt");
-    wait_for_file(&marker_file, Duration::from_secs(5));
+    wait_for_file_content(&marker_file, Duration::from_secs(5));
 
     let contents = fs::read_to_string(&marker_file).unwrap();
     assert!(


### PR DESCRIPTION
## Summary

- Fix `test_user_post_start_hook_executes` by using `wait_for_file_content()` instead of `wait_for_file()` to wait for content to be written, not just file existence
- Fix `test_post_start_json_stdin` by adding `wait_for_valid_json()` helper that polls until file contains valid JSON, replacing `wait_for_file()` + fixed 500ms sleep
- Fix `test_pre_remove_hook_skipped_with_no_verify` by increasing absence check sleep from 100ms to 500ms per project guidelines
- Fix `select.rs` by replacing fixed 100ms grace period with polling for process exit (fast polling, long timeout for CI)

## Test plan

- [x] All integration tests pass (`cargo test --test integration`)
- [x] Ran the originally flaky test 10+ times to verify it no longer fails
- [x] Clippy passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)