### PR TITLE
Build dev-detach before tests (fix for workspace package move)

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -41,5 +41,7 @@ pre-commit = "pre-commit run --all-files"
 # Note: This must come AFTER post-merge because [pre-merge] starts
 # a TOML table section, and everything after it would be inside that section
 [pre-merge]
+# Build test helpers first (dev-detach is a separate workspace member, not auto-built by cargo test)
+build = "cargo build -p dev-detach"
 insta = "NEXTEST_STATUS_LEVEL=fail NEXTEST_SUCCESS_OUTPUT=never cargo insta test --dnd --check --features shell-integration-tests"
 doc = "RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,6 +61,12 @@ jobs:
         echo "Using Git Bash for Windows tests"
       shell: pwsh
 
+    - name: 🔧 Build test helpers
+      uses: clechasseur/rs-cargo@v4
+      with:
+        command: build
+        args: -p dev-detach
+
     - name: 🏭 Compile
       uses: clechasseur/rs-cargo@v4
       with:


### PR DESCRIPTION
## Summary
- Add `cargo build -p dev-detach` step to CI before test compilation
- Add `build` pre-merge hook before insta tests

dev-detach is now a separate workspace member (not a binary in main crate), so `cargo test` doesn't automatically build it. The previous approach (PR #123) used `env!("CARGO_BIN_EXE_dev-detach")` which made it a compile-time dependency, but that broke cargo-dist releases.

## Test plan
- [x] Local pre-merge hook passes (889 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>