### PR TITLE
Document that default-members doesn't help with cargo test

### DIFF
--- a/tests/helpers/dev-detach/Cargo.toml
+++ b/tests/helpers/dev-detach/Cargo.toml
@@ -13,6 +13,8 @@
 #   find and package the binary, failing with "bin not found" during release
 # - `[package.metadata.dist] dist = false` in main package: excludes the entire
 #   package from distribution, not individual binaries
+# - `workspace.default-members`: makes `cargo build` include this package, but
+#   `cargo test` only builds test targets, not binaries (even for selected packages)
 #
 # BUILD REQUIREMENT:
 # Since this is a separate workspace member (not a dependency of the main package),


### PR DESCRIPTION
## Summary
Add note to dev-detach docs that `workspace.default-members` was tested but doesn't solve the problem because `cargo test` only builds test targets, not binaries.

Research via Codex suggested `default-members` would work, but testing showed:
- `cargo build` with default-members: ✅ builds dev-detach binary
- `cargo test` with default-members: ❌ only builds test executables, not binaries

The explicit `cargo build -p dev-detach` step remains necessary.

## Test plan
- [x] Documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>