### PR TITLE
Auto-build dev-detach binary via integration test trick

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -41,7 +41,5 @@ pre-commit = "pre-commit run --all-files"
 # Note: This must come AFTER post-merge because [pre-merge] starts
 # a TOML table section, and everything after it would be inside that section
 [pre-merge]
-# Build test helpers first (dev-detach is a separate workspace member, not auto-built by cargo test)
-build = "cargo build -p dev-detach"
 insta = "NEXTEST_STATUS_LEVEL=fail NEXTEST_SUCCESS_OUTPUT=never cargo insta test --dnd --check --features shell-integration-tests"
 doc = "RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -61,12 +61,6 @@ jobs:
         echo "Using Git Bash for Windows tests"
       shell: pwsh
 
-    - name: 🔧 Build test helpers
-      uses: clechasseur/rs-cargo@v4
-      with:
-        command: build
-        args: -p dev-detach
-
     - name: 🏭 Compile
       uses: clechasseur/rs-cargo@v4
       with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,7 @@
 [workspace]
 members = ["tests/helpers/setup-select-test", "tests/helpers/dev-detach"]
+# Include dev-detach so `cargo test` builds its binary (via its integration test)
+default-members = [".", "tests/helpers/dev-detach"]
 
 [package]
 name = "worktrunk"

--- a/tests/helpers/dev-detach/Cargo.toml
+++ b/tests/helpers/dev-detach/Cargo.toml
@@ -8,19 +8,17 @@
 # `publish = false` or `dist = false`. Moving test-only binaries to separate
 # packages with `publish = false` prevents them from being included in releases.
 #
-# Alternative approaches that DON'T work:
+# Alternative approaches that DON'T work for cargo-dist:
 # - `required-features = ["test-feature"]` on [[bin]]: cargo-dist still tries to
 #   find and package the binary, failing with "bin not found" during release
 # - `[package.metadata.dist] dist = false` in main package: excludes the entire
 #   package from distribution, not individual binaries
-# - `workspace.default-members`: makes `cargo build` include this package, but
-#   `cargo test` only builds test targets, not binaries (even for selected packages)
 #
-# BUILD REQUIREMENT:
-# Since this is a separate workspace member (not a dependency of the main package),
-# `cargo test` doesn't automatically build it. CI and pre-merge hooks must explicitly
-# run `cargo build -p dev-detach` before running tests. The test code uses
-# `insta_cmd::get_cargo_bin("dev-detach")` to locate the built binary at runtime.
+# HOW THE BINARY GETS BUILT:
+# `cargo test` only builds binaries for packages with integration tests (so tests
+# can run the binary). This package has a dummy integration test (tests/builds.rs)
+# that triggers binary compilation. Combined with `workspace.default-members`
+# including this package, `cargo test` automatically builds the binary.
 #
 # This is a workspace member (not a separate workspace) to share target/ and Cargo.lock.
 # Never published to crates.io (publish = false) - only used during testing.

--- a/tests/helpers/dev-detach/tests/builds.rs
+++ b/tests/helpers/dev-detach/tests/builds.rs
@@ -1,0 +1,5 @@
+#[test]
+fn builds() {
+    // Intentionally empty.
+    // This integration test forces cargo to build the package's binary when testing.
+}


### PR DESCRIPTION
## Summary
- Add dummy integration test to `dev-detach` package (`tests/builds.rs`)
- Add `workspace.default-members` to include dev-detach in test selection
- Remove explicit `cargo build -p dev-detach` from CI workflow and pre-merge hook

`cargo test` only builds binaries for packages with integration tests (so tests can run the binary). By adding a dummy test and including dev-detach in default-members, the binary is built automatically - no explicit build step needed.

## Test plan
- [x] `cargo test --features shell-integration-tests` builds dev-detach automatically
- [x] `cargo install --path .` only installs `wt` (not dev-detach)
- [x] Local pre-merge hook passes (890 tests)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>