### PR TITLE
Add `wt step for-each` command for multi-worktree operations

### DIFF
--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -34,6 +34,7 @@ wt step push
 - `squash` — Squash all branch commits into one with [LLM-generated message](@/llm-commits.md)
 - `rebase` — Rebase onto target branch
 - `push` — Push to target branch (default: main)
+- `for-each` — [experimental] Run a command in every worktree
 
 ## See also
 
@@ -50,10 +51,11 @@ wt step - Run individual workflow operations
 Usage: wt step [OPTIONS] <COMMAND>
 
 Commands:
-  commit  Commit changes with LLM commit message
-  squash  Squash commits down to target
-  push    Push changes to local target branch
-  rebase  Rebase onto target
+  commit    Commit changes with LLM commit message
+  squash    Squash commits down to target
+  push      Push changes to local target branch
+  rebase    Rebase onto target
+  for-each  [experimental] Run command in each worktree
 
 Options:
   -h, --help

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -615,6 +615,60 @@ pub enum StepCommand {
         #[arg(add = crate::completion::branch_value_completer())]
         target: Option<String>,
     },
+
+    /// \[experimental\] Run command in each worktree
+    ///
+    /// Executes a command sequentially in every worktree with real-time output.
+    /// Continues on failure and shows a summary at the end.
+    ///
+    /// Context JSON is piped to stdin for scripts that need structured data.
+    ///
+    /// Supports template variables (all shell-escaped):
+    ///
+    /// - `{{ branch }}` — branch name (slashes replaced with dashes)
+    /// - `{{ worktree }}` — absolute path to the worktree
+    /// - `{{ worktree_name }}` — worktree directory name
+    /// - `{{ repo }}` — repository name
+    /// - `{{ repo_root }}` — absolute path to the main repository root
+    /// - `{{ commit }}` — current HEAD commit SHA (full)
+    /// - `{{ short_commit }}` — current HEAD commit SHA (7 chars)
+    /// - `{{ default_branch }}` — default branch name (e.g., "main")
+    /// - `{{ remote }}` — primary remote name (e.g., "origin")
+    /// - `{{ remote_url }}` — primary remote URL
+    /// - `{{ upstream }}` — upstream tracking branch, if configured
+    ///
+    /// Note: This command is experimental and may change in future versions.
+    ///
+    /// # Examples
+    ///
+    /// Check status across all worktrees:
+    ///
+    /// ```text
+    /// wt step for-each -- git status --short
+    /// ```
+    ///
+    /// Run npm install in all worktrees:
+    ///
+    /// ```text
+    /// wt step for-each -- npm install
+    /// ```
+    ///
+    /// Use branch name in command:
+    ///
+    /// ```text
+    /// wt step for-each -- "echo Branch: {{ branch }}"
+    /// ```
+    ///
+    /// Pull updates in worktrees with upstreams (skips others):
+    ///
+    /// ```text
+    /// wt step for-each -- '[ "$(git rev-parse @{u} 2>/dev/null)" ] || exit 0; git pull --autostash'
+    /// ```
+    ForEach {
+        /// Command template (see --help for all variables)
+        #[arg(required = true, last = true, num_args = 1..)]
+        args: Vec<String>,
+    },
 }
 
 /// Run hooks independently
@@ -1038,6 +1092,7 @@ wt step push
 - `squash` — Squash all branch commits into one with [LLM-generated message](@/llm-commits.md)
 - `rebase` — Rebase onto target branch
 - `push` — Push to target branch (default: main)
+- `for-each` — [experimental] Run a command in every worktree
 
 ## See also
 

--- a/src/commands/for_each.rs
+++ b/src/commands/for_each.rs
@@ -1,0 +1,205 @@
+//! For-each command implementation
+//!
+//! Runs a command sequentially in each worktree with template expansion.
+//!
+//! # Design Notes
+//!
+//! The `step` subcommand grouping is not fully satisfying. Current state:
+//!
+//! - `commit`, `squash`, `rebase`, `push` — merge workflow steps (single-worktree)
+//! - `for-each` — utility to run commands across all worktrees (multi-worktree)
+//!
+//! These don't naturally belong together. Options considered:
+//!
+//! 1. **Top-level `wt for-each`** — more discoverable, but adds top-level commands
+//! 2. **Rename `step` to `ops`** — clearer grouping, but breaking change
+//! 3. **New `wt run` subcommand** — but unclear what stays in `step`
+//! 4. **Keep current structure** — document the awkwardness (this option)
+//!
+//! Historical note: `hook` subcommands (pre-commit, post-merge, etc.) were originally
+//! under `step` but were moved to their own `wt hook` subcommand for clarity.
+//!
+//! For now, we keep `for-each` under `step` as a pragmatic choice.
+
+use std::collections::HashMap;
+use std::io::Write;
+use std::process::Stdio;
+
+use color_print::cformat;
+use worktrunk::config::{WorktrunkConfig, expand_template};
+use worktrunk::git::Repository;
+use worktrunk::git::WorktrunkError;
+use worktrunk::shell_exec::ShellConfig;
+use worktrunk::styling::{
+    error_message, format_with_gutter, progress_message, success_message, warning_message,
+};
+
+use crate::commands::command_executor::{CommandContext, build_hook_context};
+use crate::output;
+
+/// Run a command in each worktree sequentially.
+///
+/// Executes the given command in every worktree, streaming output
+/// in real-time. Continues on errors and reports a summary at the end.
+///
+/// All template variables from hooks are available, and context JSON is piped to stdin.
+pub fn step_for_each(args: Vec<String>) -> anyhow::Result<()> {
+    let repo = Repository::current();
+    let worktrees = repo.list_worktrees()?;
+    let config = WorktrunkConfig::load()?;
+
+    let mut failed: Vec<String> = Vec::new();
+    let total = worktrees.worktrees.len();
+
+    // Join args into a template string (will be expanded per-worktree)
+    let command_template = args.join(" ");
+
+    // Get repo root for context
+    let repo_root = repo.worktree_base()?;
+
+    for wt in &worktrees.worktrees {
+        let branch = wt.branch.as_deref().unwrap_or("(detached)");
+        output::print(progress_message(cformat!(
+            "Running in <bold>{branch}</>..."
+        )))?;
+
+        // Open repository at worktree path to get worktree-specific context (commit, etc.)
+        let wt_repo = Repository::at(&wt.path);
+
+        // Build full hook context for this worktree
+        let ctx = CommandContext::new(&wt_repo, &config, branch, &wt.path, &repo_root, false);
+        let context_map = build_hook_context(&ctx, &[]);
+
+        // Convert to &str references for expand_template
+        let extras_ref: HashMap<&str, &str> = context_map
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+
+        let repo_name = repo_root
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("unknown");
+
+        // Expand template with full context
+        let command = expand_template(&command_template, repo_name, branch, &extras_ref)
+            .map_err(|e| anyhow::anyhow!("Template expansion failed: {e}"))?;
+
+        // Build JSON context for stdin
+        let context_json = serde_json::to_string(&context_map)
+            .expect("HashMap<String, String> serialization should never fail");
+
+        // Flush output before running command to ensure message ordering
+        output::flush()?;
+
+        // Execute command: stream both stdout and stderr in real-time
+        // Pipe context JSON to stdin for scripts that want structured data
+        match run_command_streaming(&command, &wt.path, Some(&context_json)) {
+            Ok(()) => {}
+            Err(CommandError::SpawnFailed(err)) => {
+                output::print(error_message(cformat!(
+                    "Failed in <bold>{branch}</> (spawn failed)"
+                )))?;
+                output::gutter(format_with_gutter(&err, "", None))?;
+                failed.push(branch.to_string());
+            }
+            Err(CommandError::ExitCode(exit_code)) => {
+                // stderr already streamed to terminal; just show failure message
+                let exit_info = exit_code
+                    .map(|code| format!(" (exit code {code})"))
+                    .unwrap_or_default();
+                output::print(error_message(cformat!(
+                    "Failed in <bold>{branch}</>{exit_info}"
+                )))?;
+                failed.push(branch.to_string());
+            }
+        }
+    }
+
+    // Summary
+    output::blank()?;
+    if failed.is_empty() {
+        output::print(success_message(format!(
+            "Completed in {total} worktree{}",
+            if total == 1 { "" } else { "s" }
+        )))?;
+        Ok(())
+    } else {
+        output::print(warning_message(format!(
+            "{} of {total} worktree{} failed",
+            failed.len(),
+            if total == 1 { "" } else { "s" }
+        )))?;
+        let failed_list = failed.join("\n");
+        output::gutter(format_with_gutter(&failed_list, "", None))?;
+        // Return silent error so main exits with code 1 without duplicate message
+        Err(WorktrunkError::AlreadyDisplayed { exit_code: 1 }.into())
+    }
+}
+
+/// Error from running a command in a worktree
+enum CommandError {
+    /// Command failed to spawn (e.g., command not found, permission denied)
+    SpawnFailed(String),
+    /// Command exited with non-zero status
+    ExitCode(Option<i32>),
+}
+
+/// Run a shell command, streaming both stdout and stderr in real-time.
+///
+/// Returns `Ok(())` on success, or `Err(CommandError)` on failure.
+/// Both stdout and stderr stream to the terminal (stderr) in real-time.
+/// If `stdin_content` is provided, it's piped to the command's stdin.
+///
+/// # TODO: Streaming vs Gutter Tradeoff
+///
+/// Currently stderr streams directly without gutter formatting, same as hooks.
+/// This means error output appears inline rather than in a visual gutter block.
+/// Options to consider:
+/// - Tee stderr (stream + capture) for gutter display on failure
+/// - Add `--gutter` flag to capture and format output
+/// - Accept current behavior as consistent with hooks
+fn run_command_streaming(
+    command: &str,
+    working_dir: &std::path::Path,
+    stdin_content: Option<&str>,
+) -> Result<(), CommandError> {
+    let shell = ShellConfig::get();
+
+    let stdin_mode = if stdin_content.is_some() {
+        Stdio::piped()
+    } else {
+        Stdio::inherit() // Allow interactive commands when no stdin content
+    };
+
+    let mut child = shell
+        .command(command)
+        .current_dir(working_dir)
+        .stdin(stdin_mode)
+        // Redirect stdout to stderr to keep stdout clean for directive scripts
+        // Note: Stdio::from(Stderr) works since Rust 1.74 (impl From<Stderr> for Stdio)
+        .stdout(Stdio::from(std::io::stderr()))
+        // Stream stderr to terminal in real-time
+        .stderr(Stdio::inherit())
+        .spawn()
+        .map_err(|e| CommandError::SpawnFailed(e.to_string()))?;
+
+    // Write stdin content if provided (JSON context for scripts)
+    if let Some(content) = stdin_content
+        && let Some(mut stdin) = child.stdin.take()
+    {
+        // Ignore write errors - command may not read stdin
+        let _ = stdin.write_all(content.as_bytes());
+        // stdin is dropped here, closing the pipe
+    }
+
+    let status = child
+        .wait()
+        .map_err(|e| CommandError::SpawnFailed(e.to_string()))?;
+
+    if status.success() {
+        Ok(())
+    } else {
+        Err(CommandError::ExitCode(status.code()))
+    }
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod commit;
 pub mod config;
 pub mod configure_shell;
 pub mod context;
+mod for_each;
 mod hooks;
 pub mod init;
 pub mod list;
@@ -25,6 +26,7 @@ pub use config::{
 pub use configure_shell::{
     ConfigAction, handle_configure_shell, handle_show_theme, handle_unconfigure_shell,
 };
+pub use for_each::step_for_each;
 pub use init::handle_init;
 pub use list::handle_list;
 pub use merge::{execute_pre_remove_commands, handle_merge};

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -498,6 +498,8 @@ pub enum WorktrunkError {
     },
     /// Command was not approved by user (silent error)
     CommandNotApproved,
+    /// Error already displayed, just exit with given code (silent error)
+    AlreadyDisplayed { exit_code: i32 },
 }
 
 impl std::fmt::Display for WorktrunkError {
@@ -531,6 +533,9 @@ impl std::fmt::Display for WorktrunkError {
             WorktrunkError::CommandNotApproved => {
                 Ok(()) // on_skip callback handles the printing
             }
+            WorktrunkError::AlreadyDisplayed { .. } => {
+                Ok(()) // error already shown via output functions
+            }
         }
     }
 }
@@ -543,6 +548,7 @@ pub fn exit_code(err: &anyhow::Error) -> Option<i32> {
         WorktrunkError::ChildProcessExited { code, .. } => Some(*code),
         WorktrunkError::HookCommandFailed { exit_code, .. } => *exit_code,
         WorktrunkError::CommandNotApproved => None,
+        WorktrunkError::AlreadyDisplayed { exit_code } => Some(*exit_code),
     })
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,7 @@ use commands::{
     handle_init, handle_list, handle_merge, handle_rebase, handle_remove, handle_remove_by_path,
     handle_remove_current, handle_show_theme, handle_squash, handle_switch,
     handle_unconfigure_shell, handle_var_clear, handle_var_get, handle_var_set,
-    resolve_worktree_path_first, run_hook, step_commit,
+    resolve_worktree_path_first, run_hook, step_commit, step_for_each,
 };
 use output::{execute_user_command, handle_remove_output, handle_switch_output};
 
@@ -964,6 +964,7 @@ fn main() {
                     }
                 })
             }
+            StepCommand::ForEach { args } => step_for_each(args),
         },
         Commands::Hook { action } => match action {
             HookCommand::Show {

--- a/tests/integration_tests/completion.rs
+++ b/tests/integration_tests/completion.rs
@@ -702,10 +702,11 @@ fn test_complete_step_subcommands() {
     assert!(subcommands.contains(&"squash"), "Missing squash");
     assert!(subcommands.contains(&"push"), "Missing push");
     assert!(subcommands.contains(&"rebase"), "Missing rebase");
+    assert!(subcommands.contains(&"for-each"), "Missing for-each");
     assert_eq!(
         subcommands.len(),
-        4,
-        "Should have exactly 4 step subcommands (git operations)"
+        5,
+        "Should have exactly 5 step subcommands"
     );
 }
 

--- a/tests/integration_tests/for_each.rs
+++ b/tests/integration_tests/for_each.rs
@@ -1,0 +1,96 @@
+//! Integration tests for `wt step for-each`
+
+use crate::common::{TestRepo, make_snapshot_cmd, setup_snapshot_settings};
+use insta_cmd::assert_cmd_snapshot;
+
+/// Helper to create snapshot for for-each command
+fn snapshot_for_each(test_name: &str, repo: &TestRepo, args: &[&str]) {
+    let settings = setup_snapshot_settings(repo);
+    settings.bind(|| {
+        let mut cmd = make_snapshot_cmd(repo, "step", args, None);
+        assert_cmd_snapshot!(test_name, cmd);
+    });
+}
+
+/// Common setup for for-each tests - creates repo with initial commit
+fn setup_repo() -> TestRepo {
+    let repo = TestRepo::new();
+    repo.commit("Initial commit");
+    repo
+}
+
+#[test]
+fn test_for_each_single_worktree() {
+    let repo = setup_repo();
+
+    // Only main worktree exists
+    snapshot_for_each(
+        "for_each_single_worktree",
+        &repo,
+        &["for-each", "--", "git", "status", "--short"],
+    );
+}
+
+#[test]
+fn test_for_each_multiple_worktrees() {
+    let mut repo = setup_repo();
+
+    // Create additional worktrees
+    repo.add_worktree("feature-a");
+    repo.add_worktree("feature-b");
+
+    snapshot_for_each(
+        "for_each_multiple_worktrees",
+        &repo,
+        &["for-each", "--", "git", "branch", "--show-current"],
+    );
+}
+
+#[test]
+fn test_for_each_command_fails_in_one() {
+    let mut repo = setup_repo();
+
+    repo.add_worktree("feature");
+
+    // Use a command that will fail: try to show a non-existent ref
+    snapshot_for_each(
+        "for_each_command_fails",
+        &repo,
+        &["for-each", "--", "git", "show", "nonexistent-ref"],
+    );
+}
+
+#[test]
+fn test_for_each_no_args_error() {
+    let repo = setup_repo();
+
+    // Missing arguments should show error
+    snapshot_for_each("for_each_no_args", &repo, &["for-each"]);
+}
+
+#[test]
+fn test_for_each_with_detached_head() {
+    let mut repo = setup_repo();
+
+    // Create a worktree and detach its HEAD
+    repo.add_worktree("detached-test");
+    repo.detach_head_in_worktree("detached-test");
+
+    snapshot_for_each(
+        "for_each_with_detached",
+        &repo,
+        &["for-each", "--", "git", "status", "--short"],
+    );
+}
+
+#[test]
+fn test_for_each_with_template() {
+    let repo = setup_repo();
+
+    // Test template expansion with {{ branch }}
+    snapshot_for_each(
+        "for_each_with_template",
+        &repo,
+        &["for-each", "--", "echo", "Branch: {{ branch }}"],
+    );
+}

--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -22,6 +22,7 @@ pub mod default_branch;
 pub mod directives;
 pub mod e2e_shell;
 pub mod e2e_shell_post_start;
+pub mod for_each;
 pub mod git_error_display;
 pub mod help;
 pub mod hook_show;

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__step_for_each.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__step_for_each.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration_tests/shell_wrapper.rs
+expression: output.normalized()
+---
+🔄 [36mRunning in [1mmain[22m...[39m
+Branch: main
+🔄 [36mRunning in [1mfeature-a[22m...[39m
+Branch: feature-a
+🔄 [36mRunning in [1mfeature-b[22m...[39m
+Branch: feature-b
+
+✅ [32mCompleted in 3 worktrees[39m

--- a/tests/snapshots/integration__integration_tests__for_each__for_each_command_fails.snap
+++ b/tests/snapshots/integration__integration_tests__for_each__for_each_command_fails.snap
@@ -1,0 +1,43 @@
+---
+source: tests/integration_tests/for_each.rs
+info:
+  program: wt
+  args:
+    - step
+    - for-each
+    - "--"
+    - git
+    - show
+    - nonexistent-ref
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "150"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    LANG: C
+    LC_ALL: C
+    SOURCE_DATE_EPOCH: "1735776000"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+🔄 [36mRunning in [1mmain[22m...[39m
+fatal: ambiguous argument 'nonexistent-ref': unknown revision or path not in the working tree.
+Use '--' to separate paths from revisions, like this:
+'git <command> [<revision>...] -- [<file>...]'
+❌ [31mFailed in [1mmain[22m (exit code 128)[39m
+🔄 [36mRunning in [1mfeature[22m...[39m
+fatal: ambiguous argument 'nonexistent-ref': unknown revision or path not in the working tree.
+Use '--' to separate paths from revisions, like this:
+'git <command> [<revision>...] -- [<file>...]'
+❌ [31mFailed in [1mfeature[22m (exit code 128)[39m
+
+🟡 [33m2 of 2 worktrees failed[39m
+[107m [0m  main
+[107m [0m  feature

--- a/tests/snapshots/integration__integration_tests__for_each__for_each_multiple_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__for_each__for_each_multiple_worktrees.snap
@@ -1,0 +1,37 @@
+---
+source: tests/integration_tests/for_each.rs
+info:
+  program: wt
+  args:
+    - step
+    - for-each
+    - "--"
+    - git
+    - branch
+    - "--show-current"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "150"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    LANG: C
+    LC_ALL: C
+    SOURCE_DATE_EPOCH: "1735776000"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+🔄 [36mRunning in [1mmain[22m...[39m
+main
+🔄 [36mRunning in [1mfeature-a[22m...[39m
+feature-a
+🔄 [36mRunning in [1mfeature-b[22m...[39m
+feature-b
+
+✅ [32mCompleted in 3 worktrees[39m

--- a/tests/snapshots/integration__integration_tests__for_each__for_each_no_args.snap
+++ b/tests/snapshots/integration__integration_tests__for_each__for_each_no_args.snap
@@ -1,0 +1,31 @@
+---
+source: tests/integration_tests/for_each.rs
+info:
+  program: wt
+  args:
+    - step
+    - for-each
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "150"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    LANG: C
+    LC_ALL: C
+    SOURCE_DATE_EPOCH: "1735776000"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+---
+success: false
+exit_code: 2
+----- stdout -----
+
+----- stderr -----
+[1m[31merror:[0m the following required arguments were not provided:
+  [1m[32m<ARGS>...
+
+[1m[32mUsage:[0m [1m[36mwt step for-each[0m [1m[36m--[0m [36m<ARGS>...
+
+For more information, try '[1m[36m--help[0m'.

--- a/tests/snapshots/integration__integration_tests__for_each__for_each_single_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__for_each__for_each_single_worktree.snap
@@ -1,0 +1,32 @@
+---
+source: tests/integration_tests/for_each.rs
+info:
+  program: wt
+  args:
+    - step
+    - for-each
+    - "--"
+    - git
+    - status
+    - "--short"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "150"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    LANG: C
+    LC_ALL: C
+    SOURCE_DATE_EPOCH: "1735776000"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+🔄 [36mRunning in [1mmain[22m...[39m
+
+✅ [32mCompleted in 1 worktree[39m

--- a/tests/snapshots/integration__integration_tests__for_each__for_each_with_detached.snap
+++ b/tests/snapshots/integration__integration_tests__for_each__for_each_with_detached.snap
@@ -1,0 +1,33 @@
+---
+source: tests/integration_tests/for_each.rs
+info:
+  program: wt
+  args:
+    - step
+    - for-each
+    - "--"
+    - git
+    - status
+    - "--short"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "150"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    LANG: C
+    LC_ALL: C
+    SOURCE_DATE_EPOCH: "1735776000"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+🔄 [36mRunning in [1mmain[22m...[39m
+🔄 [36mRunning in [1m(detached)[22m...[39m
+
+✅ [32mCompleted in 2 worktrees[39m

--- a/tests/snapshots/integration__integration_tests__for_each__for_each_with_template.snap
+++ b/tests/snapshots/integration__integration_tests__for_each__for_each_with_template.snap
@@ -1,0 +1,32 @@
+---
+source: tests/integration_tests/for_each.rs
+info:
+  program: wt
+  args:
+    - step
+    - for-each
+    - "--"
+    - echo
+    - "Branch: {{ branch }}"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "150"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    LANG: C
+    LC_ALL: C
+    SOURCE_DATE_EPOCH: "1735776000"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+🔄 [36mRunning in [1mmain[22m...[39m
+Branch: main
+
+✅ [32mCompleted in 1 worktree[39m

--- a/tests/snapshots/integration__integration_tests__help__help_step_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_long.snap
@@ -22,10 +22,11 @@ wt step - Run individual workflow operations
 Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
 
 [1m[32mCommands:
-  [1m[36mcommit[0m  Commit changes with LLM commit message
-  [1m[36msquash[0m  Squash commits down to target
-  [1m[36mpush[0m    Push changes to local target branch
-  [1m[36mrebase[0m  Rebase onto target
+  [1m[36mcommit[0m    Commit changes with LLM commit message
+  [1m[36msquash[0m    Squash commits down to target
+  [1m[36mpush[0m      Push changes to local target branch
+  [1m[36mrebase[0m    Rebase onto target
+  [1m[36mfor-each[0m  [experimental] Run command in each worktree
 
 [1m[32mOptions:
   [1m[36m-h[0m, [1m[36m--help
@@ -63,6 +64,7 @@ Manual merge workflow with review between steps:
 - [2msquash[0m — Squash all branch commits into one with LLM-generated message
 - [2mrebase[0m — Rebase onto target branch
 - [2mpush[0m — Push to target branch (default: main)
+- [2mfor-each[0m — [experimental] Run a command in every worktree
 
 [32mSee also
 

--- a/tests/snapshots/integration__integration_tests__help__help_step_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_short.snap
@@ -22,10 +22,11 @@ wt step - Run individual workflow operations
 Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
 
 [1m[32mCommands:
-  [1m[36mcommit[0m  Commit changes with LLM commit message
-  [1m[36msquash[0m  Squash commits down to target
-  [1m[36mpush[0m    Push changes to local target branch
-  [1m[36mrebase[0m  Rebase onto target
+  [1m[36mcommit[0m    Commit changes with LLM commit message
+  [1m[36msquash[0m    Squash commits down to target
+  [1m[36mpush[0m      Push changes to local target branch
+  [1m[36mrebase[0m    Rebase onto target
+  [1m[36mfor-each[0m  [experimental] Run command in each worktree
 
 [1m[32mOptions:
   [1m[36m-h[0m, [1m[36m--help[0m  Print help (see more with '--help')


### PR DESCRIPTION
## Summary

- Add experimental `wt step for-each` command that runs a command in each worktree sequentially
- Support template variables (`{{ branch }}`, `{{ worktree }}`, `{{ commit }}`, etc.) for per-worktree customization  
- Pipe JSON context to stdin for scripts that need structured data
- Continue on failure with summary report at end; exit code 1 when any worktree fails

Canonical use case: `wt step for-each -- git pull --autostash`

## Test plan

- [x] Unit tests for template expansion
- [x] Integration tests for single/multiple worktrees, failures, detached HEAD
- [x] PTY tests for shell wrapper integration (bash/zsh/fish)
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)