### PR TITLE
Fix unused import warning on Windows

### DIFF
--- a/tests/integration_tests/user_hooks.rs
+++ b/tests/integration_tests/user_hooks.rs
@@ -11,7 +11,7 @@ use crate::common::{
 };
 use insta_cmd::assert_cmd_snapshot;
 use std::fs;
-use std::process::{Command, Stdio};
+use std::process::Command;
 use std::thread;
 use std::time::Duration;
 
@@ -408,6 +408,7 @@ fn test_pre_merge_hook_receives_sigint() {
     use nix::sys::signal::{Signal, kill};
     use nix::unistd::Pid;
     use std::io::Read;
+    use std::process::Stdio;
 
     let repo = TestRepo::new();
     repo.commit("Initial commit");


### PR DESCRIPTION
## Summary
- Move `Stdio` import inside the cfg(unix) test function since it's only used there
- Fixes clippy warning on Windows CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)