### PR TITLE
Use Git Bash for pre-merge hooks on Windows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -59,6 +59,8 @@ jobs:
         # Fish and zsh are not commonly available on native Windows (require WSL/MSYS2)
         # CI will test with bash only on Windows (tests skip unavailable shells)
         echo "Using Git Bash for Windows tests"
+        # Add Git Bash to PATH for wt hook pre-merge
+        echo "C:\Program Files\Git\bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
       shell: pwsh
 
     - name: Setup Python for pre-commit
@@ -77,26 +79,13 @@ jobs:
     # This installs from crates.io, not from the PR code. Pre-merge hooks
     # run against the published version, testing the hook configuration.
     - name: Install wt
-      if: runner.os != 'Windows'
       uses: baptiste0928/cargo-install@v3
       with:
         crate: worktrunk
 
     - name: 🧪 Pre-merge hooks
-      if: runner.os != 'Windows'
       run: wt hook pre-merge --force
-
-    # Windows: Run tests directly (wt hook pre-merge uses bash syntax).
-    # Same test command as wt.toml pre-merge config.
-    - name: 🧪 Tests (Windows)
-      if: runner.os == 'Windows'
-      run: |
-        cargo insta test --dnd --check --features shell-integration-tests
-        cargo test --doc
-      env:
-        RUSTFLAGS: '-D warnings'
-        NEXTEST_STATUS_LEVEL: fail
-        NEXTEST_SUCCESS_OUTPUT: never
+      shell: bash
 
   check-links:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add Git Bash to PATH on Windows runner
- Use `shell: bash` for the pre-merge hooks step
- Removes the separate Windows-specific test step

This allows `wt hook pre-merge` to work on Windows using Git Bash, unifying the CI approach across all platforms.

## Test plan
- [ ] Verify Windows CI passes with `wt hook pre-merge --force`
- [ ] Verify Ubuntu and macOS CI still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)