### PR TITLE
Simplify CI: skip cargo-lock in pre-commit.ci, consolidate link checking

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,8 +71,8 @@ jobs:
         pip install pre-commit
         pre-commit run --all-files
       env:
-        # Skip lychee - the dedicated check-links job handles link checking
-        SKIP: lychee
+        # Skip lychee on Windows/macOS - it requires bash and we only need to run it once
+        SKIP: ${{ runner.os != 'Linux' && 'lychee' || '' }}
 
     # This installs from crates.io, not from the PR code. Pre-merge hooks
     # run against the published version, testing the hook configuration.
@@ -97,41 +97,6 @@ jobs:
         RUSTFLAGS: '-D warnings'
         NEXTEST_STATUS_LEVEL: fail
         NEXTEST_SUCCESS_OUTPUT: never
-
-  check-links:
-    runs-on: ubuntu-latest
-    steps:
-    - name: 📂 Checkout code
-      uses: actions/checkout@v6
-
-    - name: Install lychee
-      uses: baptiste0928/cargo-install@v3
-      with:
-        crate: lychee
-
-    - name: Setup Python
-      uses: actions/setup-python@v6
-      with:
-        python-version: "3.12"
-
-    - name: Install pre-commit
-      run: pip install pre-commit
-
-    - name: Get modified markdown files
-      if: github.event_name == 'pull_request'
-      id: changed-files
-      uses: tj-actions/changed-files@v47
-      with:
-        files: |
-          **/*.md
-
-    - name: Link checker (modified files - PRs)
-      if: github.event_name == 'pull_request' && steps.changed-files.outputs.any_modified == 'true'
-      run: pre-commit run lychee --files ${{ steps.changed-files.outputs.all_changed_files }}
-
-    - name: Link checker (all files - main branch)
-      if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-      run: pre-commit run lychee --all-files
 
   # Check if Cargo files changed (for conditional jobs below)
   changes:


### PR DESCRIPTION
## Summary
- Add `cargo-lock` to pre-commit.ci skip list (requires Rust toolchain not available in pre-commit.ci)
- Remove separate `check-links` job - lychee now runs as part of the main pre-commit step in the test job
- This simplifies CI by removing the extra job and its `tj-actions/changed-files` dependency

## Test plan
- [ ] pre-commit.ci should pass (skips Rust hooks + lychee)
- [ ] GitHub Actions CI should pass (runs all hooks including lychee)

🤖 Generated with [Claude Code](https://claude.com/claude-code)