### PR TITLE
Enable more Windows tests (internal_flag, for_each)

### DIFF
--- a/tests/integration_tests/for_each.rs
+++ b/tests/integration_tests/for_each.rs
@@ -13,7 +13,7 @@ fn snapshot_for_each(test_name: &str, repo: &TestRepo, args: &[&str]) {
     });
 }
 
-/// Skipped on Windows: snapshot output differs due to shell/path differences.
+/// Skipped on Windows: git status shows line-ending differences (CRLF vs LF).
 #[cfg_attr(windows, ignore)]
 #[rstest]
 fn test_for_each_single_worktree(repo: TestRepo) {
@@ -25,7 +25,7 @@ fn test_for_each_single_worktree(repo: TestRepo) {
     );
 }
 
-/// Skipped on Windows: snapshot output differs due to shell/path differences.
+/// Skipped on Windows: git status shows line-ending differences (CRLF vs LF).
 #[cfg_attr(windows, ignore)]
 #[rstest]
 fn test_for_each_multiple_worktrees(mut repo: TestRepo) {
@@ -40,7 +40,7 @@ fn test_for_each_multiple_worktrees(mut repo: TestRepo) {
     );
 }
 
-/// Skipped on Windows: snapshot output differs due to shell/path differences.
+/// Skipped on Windows: git show error messages may differ.
 #[cfg_attr(windows, ignore)]
 #[rstest]
 fn test_for_each_command_fails_in_one(mut repo: TestRepo) {
@@ -60,7 +60,7 @@ fn test_for_each_no_args_error(repo: TestRepo) {
     snapshot_for_each("for_each_no_args", &repo, &["for-each"]);
 }
 
-/// Skipped on Windows: snapshot output differs due to shell/path differences.
+/// Skipped on Windows: git status shows line-ending differences (CRLF vs LF).
 #[cfg_attr(windows, ignore)]
 #[rstest]
 fn test_for_each_with_detached_head(mut repo: TestRepo) {
@@ -75,7 +75,7 @@ fn test_for_each_with_detached_head(mut repo: TestRepo) {
     );
 }
 
-/// Skipped on Windows: snapshot output differs due to shell/path differences.
+/// Skipped on Windows: `echo` command has different quoting behavior.
 #[cfg_attr(windows, ignore)]
 #[rstest]
 fn test_for_each_with_template(repo: TestRepo) {

--- a/tests/integration_tests/internal_flag.rs
+++ b/tests/integration_tests/internal_flag.rs
@@ -42,7 +42,6 @@ fn test_list_with_internal_flag(repo: TestRepo) {
 ///
 /// Config show doesn't emit directives, but should work fine with --internal.
 #[rstest]
-#[cfg_attr(windows, ignore = "mock gh/glab batch files not found on Windows")]
 fn test_config_show_with_internal_flag(mut repo: TestRepo, temp_home: TempDir) {
     // Setup mock gh/glab for deterministic BINARIES output
     repo.setup_mock_ci_tools_unauthenticated();


### PR DESCRIPTION
## Summary

Enables `test_config_show_with_internal_flag` on Windows. The mock gh/glab batch files now work correctly with the goto-based structure from PR #150.

**Still ignored (with updated comments):**

- **for_each tests** - `git status` shows line-ending differences (CRLF vs LF) on Windows that cause snapshot mismatches
- **test_for_each_with_template** - `echo` command has different quoting behavior on Windows

## Test plan

- [ ] CI passes on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)