### PR TITLE
Test enabling merge tests on Windows

### DIFF
--- a/tests/integration_tests/merge.rs
+++ b/tests/integration_tests/merge.rs
@@ -609,8 +609,6 @@ fn test_merge_with_untracked_files(mut repo_with_main_worktree: TestRepo) {
     );
 }
 
-/// Skipped on Windows: snapshot output differs due to shell/path differences.
-#[cfg_attr(windows, ignore)]
 #[rstest]
 fn test_merge_pre_merge_command_success(mut repo: TestRepo) {
     // Create project config with pre-merge command


### PR DESCRIPTION
## Summary

Testing if merge tests can run on Windows now that we know Git Bash is available on Windows CI.

The shell_exec module shows that on Windows, commands use Git Bash if available, which is present on GitHub Actions. The `exit 0` command should work with bash.

This is an exploratory change to see what actually differs in the snapshot output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)