### PR TITLE
Enable more merge tests on Windows (exit-only commands)

### DIFF
--- a/tests/integration_tests/merge.rs
+++ b/tests/integration_tests/merge.rs
@@ -648,8 +648,6 @@ fn test_merge_pre_merge_command_success(mut repo: TestRepo) {
     );
 }
 
-/// Skipped on Windows: snapshot output differs due to shell/path differences.
-#[cfg_attr(windows, ignore)]
 #[rstest]
 fn test_merge_pre_merge_command_failure(mut repo: TestRepo) {
     // Create project config with failing pre-merge command
@@ -728,8 +726,6 @@ fn test_merge_pre_merge_command_no_hooks(mut repo: TestRepo) {
     );
 }
 
-/// Skipped on Windows: snapshot output differs due to shell/path differences.
-#[cfg_attr(windows, ignore)]
 #[rstest]
 fn test_merge_pre_merge_command_named(mut repo: TestRepo) {
     // Create project config with named pre-merge commands
@@ -886,8 +882,6 @@ fn test_merge_post_merge_command_skipped_with_no_verify(mut repo: TestRepo) {
     );
 }
 
-/// Skipped on Windows: snapshot output differs due to shell/path differences.
-#[cfg_attr(windows, ignore)]
 #[rstest]
 fn test_merge_post_merge_command_failure(mut repo: TestRepo) {
     // Create project config with failing post-merge command
@@ -1091,8 +1085,6 @@ fn test_merge_pre_commit_command_success(mut repo: TestRepo) {
     );
 }
 
-/// Skipped on Windows: snapshot output differs due to shell/path differences.
-#[cfg_attr(windows, ignore)]
 #[rstest]
 fn test_merge_pre_commit_command_failure(mut repo: TestRepo) {
     // Create project config with failing pre-commit command
@@ -1163,8 +1155,6 @@ fn test_merge_pre_squash_command_success(mut repo: TestRepo) {
     );
 }
 
-/// Skipped on Windows: snapshot output differs due to shell/path differences.
-#[cfg_attr(windows, ignore)]
 #[rstest]
 fn test_merge_pre_squash_command_failure(mut repo: TestRepo) {
     // Create project config with failing pre-commit command (used for both squash and no-squash)


### PR DESCRIPTION
## Summary

Enables additional merge tests on Windows that only use `exit 0` or `exit 1` commands:

- `test_merge_pre_merge_command_failure` - uses `exit 1`
- `test_merge_pre_merge_command_named` - uses `exit 0` (multiple times)
- `test_merge_post_merge_command_failure` - uses `exit 1`
- `test_merge_pre_commit_command_failure` - uses `exit 1`
- `test_merge_pre_squash_command_failure` - uses `exit 1`

These commands work reliably with Git Bash which is available on Windows CI runners.

Tests that use `echo ... > file.txt` shell redirection remain disabled as that syntax has more platform variability.

## Test plan

- [ ] CI passes on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)