### PR TITLE
Move pre-commit hook to pre-merge section

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -29,18 +29,14 @@ build = "cargo build --all-targets"
 install = "cargo install --path ."
 sync = 'if [ "{{ target }}" = "main" ]; then git pull && git push; fi'
 
-# Pre-commit hooks
-# These run sequentially before committing changes during merge (both squash and no-squash)
-# All commands must exit with code 0 for commit to proceed
-[pre-commit]
-pre-commit = "pre-commit run --all-files"
-
 # Pre-merge hooks
 # These run sequentially before merging to main
 # All commands must exit with code 0 for merge to proceed
 # Note: This must come AFTER post-merge because [pre-merge] starts
 # a TOML table section, and everything after it would be inside that section
 [pre-merge]
+# Skip if pre-commit not installed (Windows CI) - lint job handles this on Ubuntu
+pre-commit = "if which pre-commit > /dev/null 2>&1; then pre-commit run --all-files; fi"
 insta = "RUSTFLAGS='-D warnings' NEXTEST_STATUS_LEVEL=fail NEXTEST_SUCCESS_OUTPUT=never cargo insta test --dnd --check --features shell-integration-tests"
 doctest = "RUSTDOCFLAGS='-Dwarnings' cargo test --doc"
 doc = "RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,6 +68,16 @@ jobs:
         echo "Using Git Bash for Windows tests"
       shell: pwsh
 
+    - name: Install pre-commit
+      if: runner.os != 'Windows'
+      run: |
+        if command -v uv &> /dev/null; then
+          uv tool install pre-commit
+        else
+          pip install pre-commit
+        fi
+      shell: bash
+
     # On Linux/macOS: Install from crates.io (pre-merge hooks run against published version)
     # On Windows: Build from source (published version may not have Git Bash detection fixes)
     - name: Install wt (Linux/macOS)


### PR DESCRIPTION
## Summary
- Remove the `[pre-commit]` hooks section and relocate the pre-commit command to the `[pre-merge]` section
- Add pre-commit installation to CI test job (fixes CI failure from original commit)

## Test plan
- [x] Unit tests pass locally
- [x] Pre-commit lints pass locally  
- [ ] CI runs pre-merge hooks successfully with pre-commit installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)