### PR TITLE
Use lychee-system hook to fix Windows compatibility

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -35,8 +35,7 @@ sync = 'if [ "{{ target }}" = "main" ]; then git pull && git push; fi'
 # Note: This must come AFTER post-merge because [pre-merge] starts
 # a TOML table section, and everything after it would be inside that section
 [pre-merge]
-# Skip if pre-commit not installed (Windows CI) - lint job handles this on Ubuntu
-pre-commit = "if which pre-commit > /dev/null 2>&1; then pre-commit run --all-files; fi"
+pre-commit = "pre-commit run --all-files"
 insta = "RUSTFLAGS='-D warnings' NEXTEST_STATUS_LEVEL=fail NEXTEST_SUCCESS_OUTPUT=never cargo insta test --dnd --check --features shell-integration-tests"
 doctest = "RUSTDOCFLAGS='-Dwarnings' cargo test --doc"
 doc = "RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,15 +68,13 @@ jobs:
         echo "Using Git Bash for Windows tests"
       shell: pwsh
 
+    - name: Install lychee
+      uses: baptiste0928/cargo-install@v3
+      with:
+        crate: lychee
+
     - name: Install pre-commit
-      if: runner.os != 'Windows'
-      run: |
-        if command -v uv &> /dev/null; then
-          uv tool install pre-commit
-        else
-          pip install pre-commit
-        fi
-      shell: bash
+      run: pip install pre-commit
 
     # On Linux/macOS: Install from crates.io (pre-merge hooks run against published version)
     # On Windows: Build from source (published version may not have Git Bash detection fixes)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -30,9 +30,8 @@ repos:
     rev: lychee-v0.22.0
     hooks:
       # PR mode - check links using .config/lychee.toml exclusions
-      # TODO: Consider re-adding `--include=^https://(github\.com/max-sixty/worktrunk|worktrunk\.dev)`
-      # once /hook/ page is deployed (currently excluded in lychee.toml to allow landing page merge)
-      - id: lychee
+      # Uses lychee-system (requires `cargo install lychee`) to avoid /bin/bash on Windows
+      - id: lychee-system
         name: lychee (PR mode)
         types: [markdown]
         args:
@@ -42,7 +41,7 @@ repos:
           - -q
       # Comprehensive mode - check all links with full config
       # Run manually: pre-commit run --hook-stage manual lychee-all --all-files
-      - id: lychee
+      - id: lychee-system
         name: lychee-all (comprehensive)
         types: [markdown]
         stages: [manual]
@@ -76,5 +75,5 @@ repos:
 ci:
   # pre-commit.ci doesn't have Rust toolchain, so skip Rust-specific hooks.
   # Network access also isn't supported, so skip lychee.
-  skip: [fmt, clippy, lychee, cargo-lock]
+  skip: [fmt, clippy, lychee-system, cargo-lock]
   autoupdate_commit_msg: "chore: pre-commit autoupdate"


### PR DESCRIPTION
## Summary
- Switch from `lychee` to `lychee-system` pre-commit hook to fix Windows compatibility
- The default lychee hook uses `/bin/bash` which doesn't exist on Windows
- Install lychee via cargo in CI test job for all platforms
- Simplify pre-commit command (no longer needs conditional skip)

## Test plan
- [x] pre-commit hooks pass locally
- [ ] CI passes on all platforms including Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)