### PR TITLE
Update Zola to 0.21.0 for anchor link support

### DIFF
--- a/.github/workflows/build-docs.yaml
+++ b/.github/workflows/build-docs.yaml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup Zola
         uses: taiki-e/install-action@v2
         with:
-          tool: zola@0.19.2
+          tool: zola@0.21.0
 
       - name: Fetch demo assets
         env:


### PR DESCRIPTION
## Summary
- Updates Zola from 0.19.2 to 0.21.0 in CI
- Fixes anchor links not being generated on production

The `insert_anchor_links = "heading"` option doesn't work correctly in Zola 0.19.2 - the anchor links are only generated in 0.21.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)