### PR TITLE
Test: enable all modules on Windows

### DIFF
--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -1,11 +1,8 @@
 // Note: Some tests require Unix-specific features (PTY, shell integration).
-// Those are gated at the individual file level with #[cfg(unix)] or
-// #[cfg(all(unix, feature = "shell-integration-tests"))].
-
-// TODO: Re-enable Windows tests once snapshot path normalization is implemented.
-// Issue: Windows paths use backslashes which differ from Unix snapshots.
-// Fix: Either normalize paths in test output or create Windows-specific snapshots.
-// Modules below marked with #[cfg(not(windows))] fail due to path differences.
+// Those are gated at the individual test or file level with #[cfg(unix)],
+// #[cfg_attr(windows, ignore)], or #[cfg(all(unix, feature = "shell-integration-tests"))].
+//
+// Windows path differences are handled by snapshot filters in setup_snapshot_settings().
 
 // column_alignment merged into spacing_edge_cases
 pub mod approval_pty;
@@ -24,7 +21,6 @@ pub mod config_show_theme;
 pub mod config_var;
 pub mod configure_shell;
 pub mod default_branch;
-#[cfg(not(windows))]
 pub mod directives;
 pub mod e2e_shell;
 pub mod e2e_shell_post_start;
@@ -33,31 +29,21 @@ pub mod git_error_display;
 pub mod help;
 pub mod hook_show;
 pub mod init;
-#[cfg(not(windows))]
 pub mod internal_flag;
-#[cfg(not(windows))]
 pub mod list;
-#[cfg(not(windows))]
 pub mod list_column_alignment;
-#[cfg(not(windows))]
 pub mod list_config;
 pub mod list_progressive;
-#[cfg(not(windows))]
 pub mod merge;
 pub mod output_system_guard;
 pub mod post_start_commands;
-#[cfg(not(windows))]
 pub mod push;
 pub mod readme_sync;
 pub mod remove;
-#[cfg(not(windows))]
 pub mod security;
 pub mod select;
 pub mod shell_wrapper;
-#[cfg(not(windows))]
 pub mod spacing_edge_cases;
-#[cfg(not(windows))]
 pub mod statusline;
 pub mod switch;
-#[cfg(not(windows))]
 pub mod user_hooks;


### PR DESCRIPTION
## Summary
Enable all remaining test modules on Windows by removing mod.rs guards.
Individual tests that truly require Unix are marked with `#[cfg(unix)]` or
`#[cfg_attr(windows, ignore)]` at the test level:

- `internal_flag` (2 tests)
- `spacing_edge_cases` (7 tests)
- `push` (9 tests)
- `list` (49 tests)
- `list_column_alignment` (2 tests)
- `list_config` (5 tests)
- `directives` (9 tests)
- `statusline` (7 tests, 2 skipped on Windows due to timing)
- `user_hooks` (19 tests, 1 skipped on Windows due to /tmp path, 1 Unix-only)
- `merge` (66 tests, 3 skipped on Windows due to chmod)
- `security` (9 tests, 1 Unix-only)

Total: ~185 additional Windows tests.

## Test plan
- [x] Run tests locally on macOS
- [ ] CI passes on all platforms (Ubuntu, macOS, Windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)