### PR TITLE
Test: fix user_pre_remove test to be cross-platform

### DIFF
--- a/tests/snapshots/integration__integration_tests__user_hooks__user_pre_remove_executes.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_pre_remove_executes.snap
@@ -7,6 +7,7 @@ info:
     - feature
     - "--force-delete"
   env:
+    APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "150"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -14,10 +15,14 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    PATH: "[PATH]"
     SOURCE_DATE_EPOCH: "1735776000"
+    USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
 exit_code: 0
@@ -25,5 +30,5 @@ exit_code: 0
 
 ----- stderr -----
 🔄 [36mRunning user pre-remove [1mcleanup[22m:[39m
-[107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'USER_PRE_REMOVE_RAN'[0m[2m [0m[2m[36m>[0m[2m /tmp/user_preremove_marker.txt
+[107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'USER_PRE_REMOVE_RAN'[0m[2m [0m[2m[36m>[0m[2m ../user_preremove_marker.txt
 [0m🔄 [36m[36mRemoving [1mfeature[22m worktree & branch in background (--force-delete)[39m[39m


### PR DESCRIPTION
## Summary
Use relative path (`../`) instead of `/tmp` for the marker file in `test_user_pre_remove_hook_executes`.

The hook runs in the feature worktree, so `../` is the parent temp directory which persists after the worktree is removed. This makes the test work on Windows.

## Test plan
- [x] Test passes locally on macOS
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)