### PR TITLE
Increase stdin timeout for Windows compatibility

### DIFF
--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -70,8 +70,8 @@ impl ClaudeCodeContext {
             let _ = tx.send(input);
         });
 
-        // Wait up to 10ms for stdin
-        let input = rx.recv_timeout(Duration::from_millis(10)).ok()?;
+        // Wait up to 50ms for stdin (needs to be longer on Windows where process spawning is slower)
+        let input = rx.recv_timeout(Duration::from_millis(50)).ok()?;
 
         Self::parse(&input)
     }

--- a/tests/integration_tests/statusline.rs
+++ b/tests/integration_tests/statusline.rs
@@ -141,10 +141,7 @@ fn escape_path_for_json(path: &std::path::Path) -> String {
     path.display().to_string().replace('\\', "\\\\")
 }
 
-/// Skipped on Windows: stdin read has 10ms timeout, Windows process spawning is slower
-/// causing timing-sensitive race condition where model name is lost.
 #[rstest]
-#[cfg_attr(windows, ignore)]
 fn test_statusline_claude_code_full_context(repo: TestRepo) {
     add_uncommitted_changes(&repo);
 
@@ -182,10 +179,7 @@ fn test_statusline_claude_code_minimal(repo: TestRepo) {
     });
 }
 
-/// Skipped on Windows: stdin read has 10ms timeout, Windows process spawning is slower
-/// causing timing-sensitive race condition where model name is lost.
 #[rstest]
-#[cfg_attr(windows, ignore)]
 fn test_statusline_claude_code_with_model(repo: TestRepo) {
     let escaped_path = escape_path_for_json(repo.root_path());
     let json = format!(


### PR DESCRIPTION
## Summary
- Increased stdin read timeout from 10ms to 50ms in statusline command
- Fixes Windows race condition where process spawning delay caused stdin data to arrive late
- Enables 2 additional Windows tests that were previously skipped

## Test plan
- [x] Local statusline tests pass (all 7)
- [ ] CI passes on Windows

🤖 Generated with [Claude Code](https://claude.com/claude-code)