### PR TITLE
Make `wt config state show` comprehensive with JSON support

### DIFF
--- a/src/cli.rs
+++ b/src/cli.rs
@@ -465,10 +465,17 @@ pub enum StateCommand {
     #[command(after_long_help = r#"Shows all cached state including:
 
 - **Default branch**: Cached result of querying remote for default branch
+- **Switch history**: Previous branch for `wt switch -`
+- **Branch markers**: User-defined branch notes
 - **CI status**: Cached GitHub/GitLab CI status per branch (30s TTL)
+- **Log files**: Background operation logs
 
 CI cache entries show status, age, and the commit SHA they were fetched for."#)]
-    Show,
+    Show {
+        /// Output format (table, json)
+        #[arg(long, value_enum, default_value = "table", hide_possible_values = true)]
+        format: OutputFormat,
+    },
 }
 
 #[derive(Subcommand)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -929,7 +929,7 @@ fn main() {
                     LogsAction::Get => handle_state_get("logs", false, None),
                     LogsAction::Clear => handle_state_clear("logs", None, false),
                 },
-                StateCommand::Show => handle_state_show(),
+                StateCommand::Show { format } => handle_state_show(format),
             },
         },
         Commands::Step { action } => match action {

--- a/tests/integration_tests/snapshots/integration__integration_tests__config_state__state_show_comprehensive.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__config_state__state_show_comprehensive.snap
@@ -1,0 +1,26 @@
+---
+source: tests/integration_tests/config_state.rs
+expression: "String::from_utf8_lossy(&output.stderr)"
+---
+[36mDEFAULT BRANCH[39m
+[107m [0m  main
+
+[36mSWITCH HISTORY[39m
+[107m [0m  feature
+
+[36mBRANCH MARKERS[39m
+Branch   Marker        Age
+───────  ────────────  ───
+bugfix   🐛 debugging  now
+feature  🚧 WIP        now
+
+[36mCI STATUS CACHE[39m
+Branch   Status  Age  Head    
+───────  ──────  ───  ────────
+feature  passed  now  abc12345
+
+[36mLOG FILES[39m  @ .git/wt-logs
+File                        Size  Age   
+──────────────────────────  ────  ──────
+bugfix-remove.log           13B   future
+feature-post-start-npm.log  10B   future

--- a/tests/integration_tests/snapshots/integration__integration_tests__config_state__state_show_with_ci_entries.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__config_state__state_show_with_ci_entries.snap
@@ -2,12 +2,21 @@
 source: tests/integration_tests/config_state.rs
 expression: "String::from_utf8_lossy(&output.stderr)"
 ---
-⚪ Default branch:
+[36mDEFAULT BRANCH[39m
 [107m [0m  main
 
-⚪ CI status cache:
+[36mSWITCH HISTORY[39m
+[107m [0m  (none)
+
+[36mBRANCH MARKERS[39m
+[107m [0m  (none)
+
+[36mCI STATUS CACHE[39m
 Branch   Status  Age  Head    
 ───────  ──────  ───  ────────
-feature  passed  0s   abc12345
-bugfix   failed  0s   11122233
-main     none    0s   deadbeef
+bugfix   failed  now  11122233
+feature  passed  now  abc12345
+main     none    now  deadbeef
+
+[36mLOG FILES[39m  @ .git/wt-logs
+[107m [0m  (none)

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_show.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_show.snap
@@ -24,6 +24,11 @@ wt config state show - Show all cached state
 Usage: [1m[36mwt config state show[0m [36m[OPTIONS]
 
 [1m[32mOptions:
+      [1m[36m--format[0m[36m [0m[36m<FORMAT>
+          Output format (table, json)
+          
+          [default: table]
+
   [1m[36m-h[0m, [1m[36m--help
           Print help (see a summary with '-h')
 
@@ -40,6 +45,9 @@ Usage: [1m[36mwt config state show[0m [36m[OPTIONS]
 Shows all cached state including:
 
 - [1mDefault branch[0m: Cached result of querying remote for default branch
+- [1mSwitch history[0m: Previous branch for [2mwt switch -
+- [1mBranch markers[0m: User-defined branch notes
 - [1mCI status[0m: Cached GitHub/GitLab CI status per branch (30s TTL)
+- [1mLog files[0m: Background operation logs
 
 CI cache entries show status, age, and the commit SHA they were fetched for.


### PR DESCRIPTION
## Summary

- Show all state: default branch, switch history, markers, CI cache, log files
- Add `--format=json` for structured output
- Store markers as JSON with timestamps for age display
- Backward compatibility for legacy plain-text markers
- Use pager for long output (like `wt config show`)
- Consistent "Age" column and human-readable times across all sections

## Test plan

- [x] All 952 tests pass
- [x] Pre-commit hooks pass
- [x] Verified table output shows human-readable ages
- [x] Verified JSON output includes all state sections
- [x] Verified legacy plain-text markers still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)