### PR TITLE
Fix Zola version in publish-docs workflow

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -23,7 +23,7 @@ jobs:
       - name: Setup Zola
         uses: taiki-e/install-action@v2
         with:
-          tool: zola@0.19.2
+          tool: zola@0.21.0
 
       - name: Fetch demo assets
         env:


### PR DESCRIPTION
## Summary
- Restore Zola 0.21.0 in publish-docs workflow (was accidentally reverted to 0.19.2 during #165 merge)
- Fixes missing anchor links on worktrunk.dev headings

## Test plan
- [ ] CI passes
- [ ] After merge, verify anchor links appear on https://worktrunk.dev/switch/

🤖 Generated with [Claude Code](https://claude.com/claude-code)