### PR TITLE
Make state subcommands default to `get` action

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -571,7 +571,7 @@ Global Options:
 
 ## wt config state
 
-State is stored in git config, separate from configuration files.
+State is stored in `.git/` (config entries and log files), separate from configuration files.
 Use `wt config show` to view file-based configuration.
 
 ### Keys
@@ -586,7 +586,7 @@ Use `wt config show` to view file-based configuration.
 
 Get the default branch:
 ```bash
-wt config state default-branch get
+wt config state default-branch
 ```
 
 Set the default branch manually:
@@ -619,16 +619,16 @@ wt config state clear
 ### Command reference
 
 ```
-wt config state - Get, set, or clear stored state (git config)
+wt config state - Get, set, or clear stored state
 
 Usage: wt config state [OPTIONS] <COMMAND>
 
 Commands:
-  default-branch   Manage default branch setting
-  previous-branch  Manage previous branch (for wt switch -)
-  ci-status        Manage CI status cache
-  marker           Manage branch markers
-  logs             Manage background operation logs
+  default-branch   Default branch setting
+  previous-branch  Previous branch (for wt switch -)
+  ci-status        CI status cache
+  marker           Branch markers
+  logs             Background operation logs
   get              Get all stored state
   clear            Clear all stored state
 
@@ -660,7 +660,7 @@ Commands:
   shell   Shell integration setup
   create  Create configuration file
   show    Show configuration files & locations
-  state   Get, set, or clear stored state (git config)
+  state   Get, set, or clear stored state
 
 Options:
   -h, --help

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -388,9 +388,9 @@ commit messages."#
         full: bool,
     },
 
-    /// Get, set, or clear stored state (git config)
+    /// Get, set, or clear stored state
     #[command(
-        after_long_help = r#"State is stored in git config, separate from configuration files.
+        after_long_help = r#"State is stored in `.git/` (config entries and log files), separate from configuration files.
 Use `wt config show` to view file-based configuration.
 
 ## Keys
@@ -405,7 +405,7 @@ Use `wt config show` to view file-based configuration.
 
 Get the default branch:
 ```console
-wt config state default-branch get
+wt config state default-branch
 ```
 
 Set the default branch manually:
@@ -441,37 +441,46 @@ wt config state clear
 
 #[derive(Subcommand)]
 pub enum StateCommand {
-    /// Manage default branch setting
-    #[command(name = "default-branch")]
+    /// Default branch setting
+    #[command(
+        name = "default-branch",
+        after_long_help = "Without a subcommand, runs `get`. For `--refresh`, use `get --refresh`."
+    )]
     DefaultBranch {
         #[command(subcommand)]
-        action: DefaultBranchAction,
+        action: Option<DefaultBranchAction>,
     },
 
-    /// Manage previous branch (for `wt switch -`)
+    /// Previous branch (for `wt switch -`)
     #[command(name = "previous-branch")]
     PreviousBranch {
         #[command(subcommand)]
-        action: PreviousBranchAction,
+        action: Option<PreviousBranchAction>,
     },
 
-    /// Manage CI status cache
-    #[command(name = "ci-status")]
+    /// CI status cache
+    #[command(
+        name = "ci-status",
+        after_long_help = "Without a subcommand, runs `get` for the current branch. For `--branch` or `--refresh`, use `get --branch=NAME`."
+    )]
     CiStatus {
         #[command(subcommand)]
-        action: CiStatusAction,
+        action: Option<CiStatusAction>,
     },
 
-    /// Manage branch markers
+    /// Branch markers
+    #[command(
+        after_long_help = "Without a subcommand, runs `get` for the current branch. For `--branch`, use `get --branch=NAME`."
+    )]
     Marker {
         #[command(subcommand)]
-        action: MarkerAction,
+        action: Option<MarkerAction>,
     },
 
-    /// Manage background operation logs
+    /// Background operation logs
     Logs {
         #[command(subcommand)]
-        action: LogsAction,
+        action: Option<LogsAction>,
     },
 
     /// Get all stored state
@@ -511,7 +520,7 @@ pub enum DefaultBranchAction {
 
 Get the default branch:
 ```console
-wt config state default-branch get
+wt config state default-branch
 ```
 
 Force refresh from remote:
@@ -548,7 +557,7 @@ pub enum PreviousBranchAction {
 
 Get the previous branch (used by `wt switch -`):
 ```console
-wt config state previous-branch get
+wt config state previous-branch
 ```"#)]
     Get,
 
@@ -579,7 +588,7 @@ pub enum CiStatusAction {
 
 Get CI status for current branch:
 ```console
-wt config state ci-status get
+wt config state ci-status
 ```
 
 Force refresh from GitHub/GitLab:
@@ -637,7 +646,7 @@ pub enum MarkerAction {
 
 Get marker for current branch:
 ```console
-wt config state marker get
+wt config state marker
 ```
 
 Get marker for a specific branch:
@@ -709,7 +718,7 @@ pub enum LogsAction {
 
 List log files:
 ```console
-wt config state logs get
+wt config state logs
 ```"#
     )]
     Get,

--- a/src/main.rs
+++ b/src/main.rs
@@ -901,43 +901,50 @@ fn main() {
             ConfigCommand::Show { full } => handle_config_show(full),
             ConfigCommand::State { action } => match action {
                 StateCommand::DefaultBranch { action } => match action {
-                    DefaultBranchAction::Get { refresh } => {
+                    Some(DefaultBranchAction::Get { refresh }) => {
                         handle_state_get("default-branch", refresh, None)
                     }
-                    DefaultBranchAction::Set { branch } => {
+                    None => handle_state_get("default-branch", false, None),
+                    Some(DefaultBranchAction::Set { branch }) => {
                         handle_state_set("default-branch", branch, None)
                     }
-                    DefaultBranchAction::Clear => handle_state_clear("default-branch", None, false),
+                    Some(DefaultBranchAction::Clear) => {
+                        handle_state_clear("default-branch", None, false)
+                    }
                 },
                 StateCommand::PreviousBranch { action } => match action {
-                    PreviousBranchAction::Get => handle_state_get("previous-branch", false, None),
-                    PreviousBranchAction::Set { branch } => {
+                    Some(PreviousBranchAction::Get) | None => {
+                        handle_state_get("previous-branch", false, None)
+                    }
+                    Some(PreviousBranchAction::Set { branch }) => {
                         handle_state_set("previous-branch", branch, None)
                     }
-                    PreviousBranchAction::Clear => {
+                    Some(PreviousBranchAction::Clear) => {
                         handle_state_clear("previous-branch", None, false)
                     }
                 },
                 StateCommand::CiStatus { action } => match action {
-                    CiStatusAction::Get { refresh, branch } => {
+                    Some(CiStatusAction::Get { refresh, branch }) => {
                         handle_state_get("ci-status", refresh, branch)
                     }
-                    CiStatusAction::Clear { branch, all } => {
+                    None => handle_state_get("ci-status", false, None),
+                    Some(CiStatusAction::Clear { branch, all }) => {
                         handle_state_clear("ci-status", branch, all)
                     }
                 },
                 StateCommand::Marker { action } => match action {
-                    MarkerAction::Get { branch } => handle_state_get("marker", false, branch),
-                    MarkerAction::Set { value, branch } => {
+                    Some(MarkerAction::Get { branch }) => handle_state_get("marker", false, branch),
+                    None => handle_state_get("marker", false, None),
+                    Some(MarkerAction::Set { value, branch }) => {
                         handle_state_set("marker", value, branch)
                     }
-                    MarkerAction::Clear { branch, all } => {
+                    Some(MarkerAction::Clear { branch, all }) => {
                         handle_state_clear("marker", branch, all)
                     }
                 },
                 StateCommand::Logs { action } => match action {
-                    LogsAction::Get => handle_state_get("logs", false, None),
-                    LogsAction::Clear => handle_state_clear("logs", None, false),
+                    Some(LogsAction::Get) | None => handle_state_get("logs", false, None),
+                    Some(LogsAction::Clear) => handle_state_clear("logs", None, false),
                 },
                 StateCommand::Get { format } => handle_state_show(format),
                 StateCommand::Clear => handle_state_clear_all(),

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -25,7 +25,7 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>
   [1m[36mshell[0m   Shell integration setup
   [1m[36mcreate[0m  Create configuration file
   [1m[36mshow[0m    Show configuration files & locations
-  [1m[36mstate[0m   Get, set, or clear stored state (git config)
+  [1m[36mstate[0m   Get, set, or clear stored state
 
 [1m[32mOptions:
   [1m[36m-h[0m, [1m[36m--help

--- a/tests/snapshots/integration__integration_tests__help__help_config_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_short.snap
@@ -25,7 +25,7 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>
   [1m[36mshell[0m   Shell integration setup
   [1m[36mcreate[0m  Create configuration file
   [1m[36mshow[0m    Show configuration files & locations
-  [1m[36mstate[0m   Get, set, or clear stored state (git config)
+  [1m[36mstate[0m   Get, set, or clear stored state
 
 [1m[32mOptions:
   [1m[36m-h[0m, [1m[36m--help[0m  Print help (see more with '--help')

--- a/tests/snapshots/integration__integration_tests__help__help_config_state.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state.snap
@@ -18,16 +18,16 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-wt config state - Get, set, or clear stored state (git config)
+wt config state - Get, set, or clear stored state
 
 Usage: [1m[36mwt config state[0m [36m[OPTIONS][0m [36m<COMMAND>
 
 [1m[32mCommands:
-  [1m[36mdefault-branch[0m   Manage default branch setting
-  [1m[36mprevious-branch[0m  Manage previous branch (for [1mwt switch -[0m)
-  [1m[36mci-status[0m        Manage CI status cache
-  [1m[36mmarker[0m           Manage branch markers
-  [1m[36mlogs[0m             Manage background operation logs
+  [1m[36mdefault-branch[0m   Default branch setting
+  [1m[36mprevious-branch[0m  Previous branch (for [1mwt switch -[0m)
+  [1m[36mci-status[0m        CI status cache
+  [1m[36mmarker[0m           Branch markers
+  [1m[36mlogs[0m             Background operation logs
   [1m[36mget[0m              Get all stored state
   [1m[36mclear[0m            Clear all stored state
 
@@ -45,7 +45,7 @@ Usage: [1m[36mwt config state[0m [36m[OPTIONS][0m [36m<COMMAND>
   [1m[36m-v[0m, [1m[36m--verbose
           Show commands and debug info
 
-State is stored in git config, separate from configuration files.
+State is stored in [2m.git/[0m (config entries and log files), separate from configuration files.
 Use [2mwt config show[0m to view file-based configuration.
 
 [32mKeys
@@ -59,7 +59,7 @@ Use [2mwt config show[0m to view file-based configuration.
 [32mExamples
 
 Get the default branch:
-  [2mwt config state default-branch get
+  [2mwt config state default-branch
 
 Set the default branch manually:
   [2mwt config state default-branch set main

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
@@ -19,18 +19,26 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-wt config state ci-status - Manage CI status cache
+wt config state ci-status - CI status cache
 
-Usage: [1m[36mwt config state ci-status[0m [36m[OPTIONS][0m [36m<COMMAND>
+Usage: [1m[36mwt config state ci-status[0m [36m[OPTIONS][0m [36m[COMMAND]
 
 [1m[32mCommands:
   [1m[36mget[0m    Get CI status for a branch
   [1m[36mclear[0m  Clear CI status cache
 
 [1m[32mOptions:
-  [1m[36m-h[0m, [1m[36m--help[0m  Print help
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
 
 [1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
-      [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m        Show commands and debug info
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose
+          Show commands and debug info
+
+Without a subcommand, runs [2mget[0m for the current branch. For [2m--branch[0m or [2m--refresh[0m, use [2mget --branch=NAME[0m.

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
@@ -19,9 +19,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-wt config state default-branch - Manage default branch setting
+wt config state default-branch - Default branch setting
 
-Usage: [1m[36mwt config state default-branch[0m [36m[OPTIONS][0m [36m<COMMAND>
+Usage: [1m[36mwt config state default-branch[0m [36m[OPTIONS][0m [36m[COMMAND]
 
 [1m[32mCommands:
   [1m[36mget[0m    Get the default branch
@@ -29,9 +29,17 @@ Usage: [1m[36mwt config state default-branch[0m [36m[OPTIONS][0m [36m<COMM
   [1m[36mclear[0m  Clear the default branch cache
 
 [1m[32mOptions:
-  [1m[36m-h[0m, [1m[36m--help[0m  Print help
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
 
 [1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
-      [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m        Show commands and debug info
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose
+          Show commands and debug info
+
+Without a subcommand, runs [2mget[0m. For [2m--refresh[0m, use [2mget --refresh[0m.

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
@@ -19,9 +19,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-wt config state logs - Manage background operation logs
+wt config state logs - Background operation logs
 
-Usage: [1m[36mwt config state logs[0m [36m[OPTIONS][0m [36m<COMMAND>
+Usage: [1m[36mwt config state logs[0m [36m[OPTIONS][0m [36m[COMMAND]
 
 [1m[32mCommands:
   [1m[36mget[0m    List background operation log files

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
@@ -19,9 +19,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-wt config state marker - Manage branch markers
+wt config state marker - Branch markers
 
-Usage: [1m[36mwt config state marker[0m [36m[OPTIONS][0m [36m<COMMAND>
+Usage: [1m[36mwt config state marker[0m [36m[OPTIONS][0m [36m[COMMAND]
 
 [1m[32mCommands:
   [1m[36mget[0m    Get marker for a branch
@@ -29,9 +29,17 @@ Usage: [1m[36mwt config state marker[0m [36m[OPTIONS][0m [36m<COMMAND>
   [1m[36mclear[0m  Clear marker for a branch
 
 [1m[32mOptions:
-  [1m[36m-h[0m, [1m[36m--help[0m  Print help
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
 
 [1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
-      [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m        Show commands and debug info
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose
+          Show commands and debug info
+
+Without a subcommand, runs [2mget[0m for the current branch. For [2m--branch[0m, use [2mget --branch=NAME[0m.

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch.snap
@@ -19,9 +19,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-wt config state previous-branch - Manage previous branch (for [1mwt switch -[0m)
+wt config state previous-branch - Previous branch (for [1mwt switch -[0m)
 
-Usage: [1m[36mwt config state previous-branch[0m [36m[OPTIONS][0m [36m<COMMAND>
+Usage: [1m[36mwt config state previous-branch[0m [36m[OPTIONS][0m [36m[COMMAND]
 
 [1m[32mCommands:
   [1m[36mget[0m    Get the previous branch


### PR DESCRIPTION
## Summary

- Running `wt config state default-branch` now defaults to `get`, making commands shorter
- Added help text for subcommands with options explaining how to access them (e.g., `get --refresh`)
- Updated storage description from "(git config)" to ".git/ (config entries and log files)" for accuracy

## Test plan

- [x] Pre-merge hook passes
- [x] Verified `wt config state default-branch` returns the default branch
- [x] Help text shows correctly for commands with options

🤖 Generated with [Claude Code](https://claude.com/claude-code)