### PR TITLE
Add MainState::Empty to distinguish clean same-commit branches

### DIFF
--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -119,7 +119,8 @@ The Status column has multiple subcolumns. Within each, only the first matching 
 | | `⊞` | Locked worktree |
 | Main | `^` | Is the main branch |
 | | `✗` | Would conflict if merged to main |
-| | `_` | Same commit as main |
+| | `_` | Same commit as main, clean |
+| | `–` | Same commit as main, uncommitted changes |
 | | `⊂` | [Content integrated](@/remove.md#branch-cleanup) |
 | | `↕` | Diverged from main |
 | | `↑` | Ahead of main |
@@ -129,7 +130,7 @@ The Status column has multiple subcolumns. Within each, only the first matching 
 | | `⇡` | Ahead of remote |
 | | `⇣` | Behind remote |
 
-Rows are dimmed when the branch [content is already in main](@/remove.md#branch-cleanup) (`_` same commit or `⊂` content integrated).
+Rows are dimmed when [safe to delete](@/remove.md#branch-cleanup) (`_` same commit with clean working tree or `⊂` content integrated).
 
 ## JSON output
 
@@ -149,7 +150,7 @@ wt list --format=json | jq '.[] | select(.is_current)'
 wt list --format=json | jq '.[] | select(.main.ahead > 0)'
 
 # Integrated branches (ready to clean up)
-wt list --format=json | jq '.[] | select(.main_state == "integrated" or .main_state == "same_commit")'
+wt list --format=json | jq '.[] | select(.main_state == "integrated" or .main_state == "empty")'
 ```
 
 **Fields:**
@@ -161,7 +162,7 @@ wt list --format=json | jq '.[] | select(.main_state == "integrated" or .main_st
 | `kind` | `"worktree"` or `"branch"` |
 | `commit` | `{sha, short_sha, message, timestamp}` |
 | `working_tree` | `{staged, modified, untracked, renamed, deleted, diff, diff_vs_main}` |
-| `main_state` | `"is_main"` `"would_conflict"` `"same_commit"` `"integrated"` `"diverged"` `"ahead"` `"behind"` |
+| `main_state` | `"is_main"` `"would_conflict"` `"empty"` `"same_commit"` `"integrated"` `"diverged"` `"ahead"` `"behind"` |
 | `integration_reason` | `"ancestor"` `"trees_match"` `"no_added_changes"` `"merge_adds_nothing"` (when `main_state == "integrated"`) |
 | `operation_state` | `"conflicts"` `"rebase"` `"merge"` (absent when no operation in progress) |
 | `main` | `{ahead, behind, diff}` (absent when `is_main`) |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1752,7 +1752,8 @@ The Status column has multiple subcolumns. Within each, only the first matching 
 | | `⊞` | Locked worktree |
 | Main | `^` | Is the main branch |
 | | `✗` | Would conflict if merged to main |
-| | `_` | Same commit as main |
+| | `_` | Same commit as main, clean |
+| | `–` | Same commit as main, uncommitted changes |
 | | `⊂` | [Content integrated](@/remove.md#branch-cleanup) |
 | | `↕` | Diverged from main |
 | | `↑` | Ahead of main |
@@ -1762,7 +1763,7 @@ The Status column has multiple subcolumns. Within each, only the first matching 
 | | `⇡` | Ahead of remote |
 | | `⇣` | Behind remote |
 
-Rows are dimmed when the branch [content is already in main](@/remove.md#branch-cleanup) (`_` same commit or `⊂` content integrated).
+Rows are dimmed when [safe to delete](@/remove.md#branch-cleanup) (`_` same commit with clean working tree or `⊂` content integrated).
 
 ## JSON output
 
@@ -1782,7 +1783,7 @@ wt list --format=json | jq '.[] | select(.is_current)'
 wt list --format=json | jq '.[] | select(.main.ahead > 0)'
 
 # Integrated branches (ready to clean up)
-wt list --format=json | jq '.[] | select(.main_state == "integrated" or .main_state == "same_commit")'
+wt list --format=json | jq '.[] | select(.main_state == "integrated" or .main_state == "empty")'
 ```
 
 **Fields:**
@@ -1794,7 +1795,7 @@ wt list --format=json | jq '.[] | select(.main_state == "integrated" or .main_st
 | `kind` | `"worktree"` or `"branch"` |
 | `commit` | `{sha, short_sha, message, timestamp}` |
 | `working_tree` | `{staged, modified, untracked, renamed, deleted, diff, diff_vs_main}` |
-| `main_state` | `"is_main"` `"would_conflict"` `"same_commit"` `"integrated"` `"diverged"` `"ahead"` `"behind"` |
+| `main_state` | `"is_main"` `"would_conflict"` `"empty"` `"same_commit"` `"integrated"` `"diverged"` `"ahead"` `"behind"` |
 | `integration_reason` | `"ancestor"` `"trees_match"` `"no_added_changes"` `"merge_adds_nothing"` (when `main_state == "integrated"`) |
 | `operation_state` | `"conflicts"` `"rebase"` `"merge"` (absent when no operation in progress) |
 | `main` | `{ahead, behind, diff}` (absent when `is_main`) |

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -47,8 +47,9 @@ pub use repository::{Repository, ResolvedWorktree, set_base_path};
 ///
 /// Used by both `wt list` (for status symbols) and `wt remove` (for messages).
 /// Each variant corresponds to a specific integration check. In `wt list`,
-/// two symbols represent these checks:
-/// - `_` for [`SameCommit`](Self::SameCommit) (identical commit)
+/// three symbols represent these checks:
+/// - `_` for [`SameCommit`](Self::SameCommit) with clean working tree (empty)
+/// - `–` for [`SameCommit`](Self::SameCommit) with dirty working tree
 /// - `⊂` for all others (content integrated via different history)
 ///
 /// The checks are ordered by cost (cheapest first):
@@ -64,7 +65,8 @@ pub enum IntegrationReason {
     /// Branch HEAD is literally the same commit as target.
     ///
     /// Used by `wt remove` to determine if branch is safely deletable.
-    /// In `wt list`, same-commit state is shown via `MainState::SameCommit` (symbol `_`).
+    /// In `wt list`, same-commit state is shown via `MainState::Empty` (`_`) or
+    /// `MainState::SameCommit` (`–`) depending on working tree cleanliness.
     SameCommit,
 
     /// Branch HEAD is an ancestor of target (target has moved past this branch).

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -119,31 +119,32 @@ seconds; use [2mwt config state[0m to view or clear.
 
 The Status column has multiple subcolumns. Within each, only the first matching symbol is shown (listed in priority order):
 
-  Subcolumn         Symbol  Meaning                         
-  ────────────────  ──────  ────────────────────────────────
-  Working tree (1)  [36m+[0m       Staged files                    
-  Working tree (2)  [36m![0m       Modified files (unstaged)       
-  Working tree (3)  [36m?[0m       Untracked files                 
-  Worktree          [31m✘[0m       Merge conflicts                 
-                    [33m⤴[0m       Rebase in progress              
-                    [33m⤵[0m       Merge in progress               
-                    [2m/[0m       Branch without worktree         
-                    [31m⚑[0m       Path doesn't match template     
-                    [33m⊟[0m       Prunable (directory missing)    
-                    [33m⊞[0m       Locked worktree                 
-  Main              [2m^[0m       Is the main branch              
-                    [33m✗[0m       Would conflict if merged to main
-                    [2m_[0m       Same commit as main             
-                    [2m⊂[0m       Content integrated              
-                    [2m↕[0m       Diverged from main              
-                    [2m↑[0m       Ahead of main                   
-                    [2m↓[0m       Behind main                     
-  Remote            [2m|[0m       In sync with remote             
-                    [2m⇅[0m       Diverged from remote            
-                    [2m⇡[0m       Ahead of remote                 
-                    [2m⇣[0m       Behind remote                   
+  Subcolumn         Symbol  Meaning                                 
+  ────────────────  ──────  ────────────────────────────────────────
+  Working tree (1)  [36m+[0m       Staged files                            
+  Working tree (2)  [36m![0m       Modified files (unstaged)               
+  Working tree (3)  [36m?[0m       Untracked files                         
+  Worktree          [31m✘[0m       Merge conflicts                         
+                    [33m⤴[0m       Rebase in progress                      
+                    [33m⤵[0m       Merge in progress                       
+                    [2m/[0m       Branch without worktree                 
+                    [31m⚑[0m       Path doesn't match template             
+                    [33m⊟[0m       Prunable (directory missing)            
+                    [33m⊞[0m       Locked worktree                         
+  Main              [2m^[0m       Is the main branch                      
+                    [33m✗[0m       Would conflict if merged to main        
+                    [2m_[0m       Same commit as main, clean              
+                    [2m–[0m       Same commit as main, uncommitted changes
+                    [2m⊂[0m       Content integrated                      
+                    [2m↕[0m       Diverged from main                      
+                    [2m↑[0m       Ahead of main                           
+                    [2m↓[0m       Behind main                             
+  Remote            [2m|[0m       In sync with remote                     
+                    [2m⇅[0m       Diverged from remote                    
+                    [2m⇡[0m       Ahead of remote                         
+                    [2m⇣[0m       Behind remote                           
 
-Rows are dimmed when the branch content is already in main ([2m_[0m same commit or [2m⊂[0m content integrated).
+Rows are dimmed when safe to delete ([2m_[0m same commit with clean working tree or [2m⊂[0m content integrated).
 
 [32mJSON output
 
@@ -162,7 +163,7 @@ Query structured data with [2m--format=json[0m:
   [2mwt list --format=json | jq '.[] | select(.main.ahead > 0)'
   [2m
   [2m# Integrated branches (ready to clean up)
-  [2mwt list --format=json | jq '.[] | select(.main_state == "integrated" or .main_state == "same_commit")'
+  [2mwt list --format=json | jq '.[] | select(.main_state == "integrated" or .main_state == "empty")'
 
 [1mFields:
 
@@ -173,7 +174,7 @@ Query structured data with [2m--format=json[0m:
   [2mkind[0m                [2m"worktree"[0m or [2m"branch"[0m                                                                            
   [2mcommit[0m              [2m{sha, short_sha, message, timestamp}[0m                                                              
   [2mworking_tree[0m        [2m{staged, modified, untracked, renamed, deleted, diff, diff_vs_main}[0m                               
-  [2mmain_state[0m          [2m"is_main"[0m [2m"would_conflict"[0m [2m"same_commit"[0m [2m"integrated"[0m [2m"diverged"[0m [2m"ahead"[0m [2m"behind"[0m                 
+  [2mmain_state[0m          [2m"is_main"[0m [2m"would_conflict"[0m [2m"empty"[0m [2m"same_commit"[0m [2m"integrated"[0m [2m"diverged"[0m [2m"ahead"[0m [2m"behind"[0m         
   [2mintegration_reason[0m  [2m"ancestor"[0m [2m"trees_match"[0m [2m"no_added_changes"[0m [2m"merge_adds_nothing"[0m (when [2mmain_state == "integrated"[0m)
   [2moperation_state[0m     [2m"conflicts"[0m [2m"rebase"[0m [2m"merge"[0m (absent when no operation in progress)                               
   [2mmain[0m                [2m{ahead, behind, diff}[0m (absent when [2mis_main[0m)                                                       

--- a/tests/snapshots/integration__integration_tests__list__json_with_git_operation.snap
+++ b/tests/snapshots/integration__integration_tests__list__json_with_git_operation.snap
@@ -87,7 +87,7 @@ exit_code: 0
         "deleted": 0
       }
     },
-    "main_state": "same_commit",
+    "main_state": "empty",
     "operation_state": "conflicts",
     "main": {
       "ahead": 0,

--- a/tests/snapshots/integration__integration_tests__list__json_with_metadata.snap
+++ b/tests/snapshots/integration__integration_tests__list__json_with_metadata.snap
@@ -87,7 +87,7 @@ exit_code: 0
         "deleted": 0
       }
     },
-    "main_state": "same_commit",
+    "main_state": "empty",
     "main": {
       "ahead": 0,
       "behind": 0
@@ -125,7 +125,7 @@ exit_code: 0
         "deleted": 0
       }
     },
-    "main_state": "same_commit",
+    "main_state": "empty",
     "main": {
       "ahead": 0,
       "behind": 0

--- a/tests/snapshots/integration__integration_tests__list__json_with_user_marker.snap
+++ b/tests/snapshots/integration__integration_tests__list__json_with_user_marker.snap
@@ -87,7 +87,7 @@ exit_code: 0
         "deleted": 0
       }
     },
-    "main_state": "same_commit",
+    "main_state": "empty",
     "main": {
       "ahead": 0,
       "behind": 0
@@ -125,7 +125,7 @@ exit_code: 0
         "deleted": 0
       }
     },
-    "main_state": "same_commit",
+    "main_state": "empty",
     "main": {
       "ahead": 0,
       "behind": 0

--- a/tests/snapshots/integration__integration_tests__list__maximum_status_with_git_operation.snap
+++ b/tests/snapshots/integration__integration_tests__list__maximum_status_with_git_operation.snap
@@ -30,6 +30,6 @@ exit_code: 0
 ----- stderr -----
   [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
 @ [1mmain[0m         [2m^[22m                                    [1m./repo[0m                       [2m1c3b3fec[0m  [2m1d[0m    [2mMain conflicting changes
-+ feature  [36m+[39m[36m![39m[36m?[39m[31m✘[39m  🤖    [32m+7[0m                           ./repo.feature               [2m1c3b3fec[0m  [2m1d[0m    [2mMain conflicting changes
++ feature  [36m+[39m[36m![39m[36m?[39m[31m✘[39m[2m–[22m 🤖    [32m+7[0m                           ./repo.feature               [2m1c3b3fec[0m  [2m1d[0m    [2mMain conflicting changes
 
 ⚪ [2mShowing 2 worktrees, 1 with changes

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_empty_diffs.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_empty_diffs.snap
@@ -31,6 +31,6 @@ exit_code: 0
 @ [1mmain[0m                 [2m^[22m                         [1m./repo[0m                           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 + [2malso-no-changes[0m      [2m_[22m                         [2m./repo.also-no-changes[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 + [2mno-changes[0m           [2m_[22m                         [2m./repo.no-changes[0m                [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ with-changes      [36m![39m          [32m+1[0m   [31m-1[0m           ./repo.with-changes              [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ with-changes      [36m![39m  [2m–[22m       [32m+1[0m   [31m-1[0m           ./repo.with-changes              [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 4 worktrees, 1 with changes

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_extreme_diffs.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_extreme_diffs.snap
@@ -30,6 +30,6 @@ exit_code: 0
   [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m         [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
 @ [1mmain[0m        [2m^[22m                         [1m./repo[0m                [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 + [2mhuge[0m      [36m?[39m [2m_[22m                         [2m./repo.huge[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ tiny     [36m![39m          [32m+1[0m   [31m-1[0m           ./repo.tiny           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ tiny     [36m![39m  [2m–[22m       [32m+1[0m   [31m-1[0m           ./repo.tiny           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 3 worktrees, 1 with changes


### PR DESCRIPTION
## Summary

- Adds `MainState::Empty` (`_`) for branches at same commit as main with clean working tree (safe to delete, dimmed)
- Changes `MainState::SameCommit` (`–` en-dash) for branches at same commit as main with uncommitted changes (NOT safe to delete, NOT dimmed)
- Refactors `determine_integration_state()` to `check_integration_state()` - only returns true integration states
- `SameCommit` detected separately in caller since it's not an integration state

## Test plan

- [x] Unit tests updated for new `Empty` variant and `is_same_commit_dirty` parameter
- [x] Integration test snapshots updated to show new `–` symbol
- [x] All 530 integration tests pass
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)