### PR TITLE
Add diff size limits and diffstat for LLM commit generation

### DIFF
--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -96,6 +96,10 @@ approved-commands = ["npm install"]
 # - Describe the change, not the intent or benefit
 # </style>
 #
+# <diffstat>
+# {{ git_diff_stat }}
+# </diffstat>
+#
 # <diff>
 # {{ git_diff }}
 # </diff>
@@ -154,6 +158,10 @@ approved-commands = ["npm install"]
 # <commits branch="{{ branch }}" target="{{ target_branch }}">
 # {% for commit in commits %}- {{ commit }}
 # {% endfor %}</commits>
+#
+# <diffstat>
+# {{ git_diff_stat }}
+# </diffstat>
 #
 # <diff>
 # {{ git_diff }}

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -334,6 +334,10 @@ approved-commands = ["npm install"]
 # - Describe the change, not the intent or benefit
 # </style>
 #
+# <diffstat>
+# {{ git_diff_stat }}
+# </diffstat>
+#
 # <diff>
 # {{ git_diff }}
 # </diff>
@@ -392,6 +396,10 @@ approved-commands = ["npm install"]
 # <commits branch="{{ branch }}" target="{{ target_branch }}">
 # {% for commit in commits %}- {{ commit }}
 # {% endfor %}</commits>
+#
+# <diffstat>
+# {{ git_diff_stat }}
+# </diffstat>
 #
 # <diff>
 # {{ git_diff }}

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -141,6 +141,10 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
   [2m# - Describe the change, not the intent or benefit
   [2m# </style>
   [2m#
+  [2m# <diffstat>
+  [2m# {{ git_diff_stat }}
+  [2m# </diffstat>
+  [2m#
   [2m# <diff>
   [2m# {{ git_diff }}
   [2m# </diff>
@@ -199,6 +203,10 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
   [2m# <commits branch="{{ branch }}" target="{{ target_branch }}">
   [2m# {% for commit in commits %}- {{ commit }}
   [2m# {% endfor %}</commits>
+  [2m#
+  [2m# <diffstat>
+  [2m# {{ git_diff_stat }}
+  [2m# </diffstat>
   [2m#
   [2m# <diff>
   [2m# {{ git_diff }}


### PR DESCRIPTION
## Summary

- Add `git_diff_stat` template variable (always included in prompts)
- Implement progressive diff filtering when diff exceeds 400K characters:
  - First filter out lock files (`*.lock`, `*-lock.json`, `*-lock.yaml`, `.lock.hcl`)
  - If still too large, truncate to 50 lines per file, max 50 files
- Update default templates to include `<diffstat>` section before `<diff>`
- Use `-c` flags to ensure consistent git diff format regardless of user's git config

## Test plan

- [x] Unit tests for lock file detection, diff parsing, truncation, and two-stage filtering
- [x] Existing template tests pass with new `git_diff_stat` variable
- [x] Integration tests pass
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)