### PR TITLE
Unify Windows CI to install wt from crates.io

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -81,17 +81,10 @@ jobs:
       with:
         crate: lychee
 
-    # On Linux/macOS: Install from crates.io (pre-merge hooks run against published version)
-    # On Windows: Build from source (published version may not have Git Bash detection fixes)
-    - name: Install wt (Linux/macOS)
-      if: runner.os != 'Windows'
+    - name: Install wt
       uses: baptiste0928/cargo-install@v3
       with:
         crate: worktrunk
-
-    - name: Install wt (Windows - from source)
-      if: runner.os == 'Windows'
-      run: cargo install --path .
 
     - name: 🧪 Pre-merge hooks
       run: wt hook pre-merge --force


### PR DESCRIPTION
## Summary
- Switch Windows CI from building from source to installing from crates.io
- Now all platforms (Linux, macOS, Windows) use `baptiste0928/cargo-install@v3` with `crate: worktrunk`

## Test plan
- [ ] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)