### PR TITLE
Fix branch names with slashes breaking git config markers

### DIFF
--- a/.claude-plugin/hooks/hooks.json
+++ b/.claude-plugin/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "git branch --show-current 2>/dev/null | sed 's|/|--|g' | xargs -I {} git config worktrunk.marker.{} 🤖"
+            "command": "wt config state marker set 🤖 || true"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "git branch --show-current 2>/dev/null | sed 's|/|--|g' | xargs -I {} git config worktrunk.marker.{} 💬"
+            "command": "wt config state marker set 💬 || true"
           }
         ]
       }
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "git branch --show-current 2>/dev/null | sed 's|/|--|g' | xargs -I {} git config --unset worktrunk.marker.{} 2>/dev/null || true"
+            "command": "wt config state marker clear || true"
           }
         ]
       }

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -277,7 +277,8 @@ impl Repository {
     /// Markers are stored as JSON: `{"marker": "text", "set_at": unix_timestamp}`.
     /// Falls back to plain text for legacy markers without timestamps.
     pub fn branch_keyed_marker(&self, branch: &str) -> Option<String> {
-        let config_key = format!("worktrunk.marker.{}", branch);
+        let escaped = super::escape_branch_for_config(branch);
+        let config_key = format!("worktrunk.marker.{}", escaped);
         let raw = self
             .run_command(&["config", "--get", &config_key])
             .ok()

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1541,6 +1541,18 @@ exit /b 1
             cmd.env("PATH", new_path);
         }
     }
+
+    /// Set a marker for a branch with proper escaping for git config keys.
+    ///
+    /// This handles the branch name escaping required for git config keys,
+    /// which only allow alphanumeric, `-`, and `.` characters.
+    pub fn set_marker(&self, branch: &str, marker: &str) {
+        let escaped = worktrunk::git::escape_branch_for_config(branch);
+        let config_key = format!("worktrunk.marker.{}", escaped);
+        self.git_command(&["config", &config_key, marker])
+            .output()
+            .unwrap();
+    }
 }
 
 /// Add standard env var redactions to insta settings


### PR DESCRIPTION
## Summary

- Fix `invalid key` error when branch names contain `/` (e.g., `fix/feature-name`)
- Use `sed 's|/|--|g'` to replace `/` with `--` (double hyphen)

## Problem

When working on a branch with `/` in the name (common convention like `fix/...`, `feature/...`), every prompt submission shows an error in Claude Code:

```
⎿  UserPromptSubmit says: Plugin hook error: error: invalid key: worktrunk.marker.fix/some-feature-branch
```

<details>
<summary>Full error from ~/.claude/debug/latest</summary>

```
[ERROR] Error: Error: Plugin hook "git branch --show-current 2>/dev/null | xargs -I {} git config worktrunk.marker.{} 🤖" failed with exit code 1
stderr: error: invalid key: worktrunk.marker.fix/some-feature-branch
```
</details>

Git config interprets `/` as a key path separator, making `worktrunk.marker.fix/some-feature-branch` invalid.

## Solution

Sanitize branch names by replacing `/` with `--` (double hyphen) before using them as git config keys.

**Why double hyphen?**

Git config keys have strict character restrictions:
- **Invalid:** `_` (underscore), `/`, `:`, `~`, `@`
- **Valid:** alphanumeric, `-` (hyphen), `.` (period)

Double underscore (`__`) doesn't work because **underscores are not allowed in git config keys at all**.

**Collision prevention:**

| Branch | Git Config Key |
|--------|----------------|
| `fix/bug-123` | `fix--bug-123` |
| `fix-bug-123` | `fix-bug-123` (unchanged) |
| `feature/auth/oauth` | `feature--auth--oauth` |

Branches like `fix/x` and `fix-x` map to different keys, preventing collisions.

## Test plan

- [x] Verified `sed 's|/|--|g'` correctly transforms branch names
- [x] **Marker set**: On branch `fix/sanitize-branch-names-in-hooks`, hook sets `worktrunk.marker.fix--sanitize-branch-names-in-hooks` (exit code 0)
- [x] **Marker unset**: SessionEnd hook correctly unsets the sanitized key
- [x] **Collision prevention**: `fix/test-branch` → `fix--test-branch` and `fix-test-branch` → `fix-test-branch` stored separately

<details>
<summary>Test execution log</summary>

```
TEST 1: Marker Set (UserPromptSubmit hook)
  Command: git branch --show-current | sed 's|/|--|g' | xargs -I {} git config worktrunk.marker.{} 🤖
  Exit code: 0
  Marker value: 🤖
  RESULT: ✅ PASS

TEST 2: Marker Unset (SessionEnd hook)
  Command: git branch --show-current | sed 's|/|--|g' | xargs -I {} git config --unset worktrunk.marker.{}
  Marker after unset: '<empty>'
  RESULT: ✅ PASS

TEST 3: No Collision (fix/x vs fix-x)
  Branch 'fix/test-branch' → key 'fix--test-branch' = 🔵
  Branch 'fix-test-branch' → key 'fix-test-branch'  = 🔴
  RESULT: ✅ PASS (no collision, stored separately)
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)