### PR TITLE
Fix stdin inheritance for --execute on non-Unix platforms

### DIFF
--- a/src/output/interactive.rs
+++ b/src/output/interactive.rs
@@ -93,8 +93,9 @@ impl OutputHandler for InteractiveOutput {
 
         // On non-Unix platforms, fall back to spawn-and-wait.
         // This uses the shell abstraction (Git Bash if available).
+        // inherit_stdin=true enables interactive programs (like `claude`, `vim`, `python -i`)
         let exec_dir = self.target_dir.as_deref().unwrap_or_else(|| Path::new("."));
-        if let Err(err) = execute_streaming(&command, exec_dir, false, None) {
+        if let Err(err) = execute_streaming(&command, exec_dir, false, None, true) {
             // If the command failed with an exit code, just exit with that code.
             // This matches Unix behavior where exec() replaces the process and
             // the shell's exit code becomes the process exit code (no error message).


### PR DESCRIPTION
## Summary
- Fix bug where `--execute` commands on non-Unix platforms (Windows) couldn't read from stdin
- Interactive programs like `vim`, `python -i`, or `claude` would fail immediately with EOF
- Root cause: `execute_streaming()` used `Stdio::null()` instead of `Stdio::inherit()` when no stdin content was provided

## Changes
- Add `inherit_stdin` parameter to `execute_streaming()` function
- Non-Unix `InteractiveOutput::execute()` now passes `true` for interactive use
- `execute_command_in_worktree()` passes `false` for non-interactive hooks
- Added integration test that verifies stdin inheritance works

## Test plan
- [x] Unit tests pass
- [x] Integration tests pass (536 tests)
- [x] Pre-commit hooks pass
- [ ] **Windows CI should verify the fix works on non-Unix platforms** ← key validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)