### PR TITLE
Improve wt switch help text clarity

### DIFF
--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -8,17 +8,16 @@ group = "Commands"
 
 <!-- ⚠️ AUTO-GENERATED from `wt switch --help-page` — edit cli.rs to update -->
 
-Two distinct operations:
+Switches to a worktree, creating one if needed.
 
-- **Switch to existing worktree** — Changes directory, nothing else
-- **Create new worktree** (`--create`) — Creates branch and worktree, runs [hooks](@/hook.md)
+With `--create`, creates a new branch based off `--base` (defaults to default branch) and runs [hooks](@/hook.md).
 
 ## Examples
 
 ```bash
-wt switch feature-auth           # Switch to existing worktree
+wt switch feature-auth           # Switch to worktree
 wt switch -                      # Previous worktree (like cd -)
-wt switch --create new-feature   # Create branch and worktree
+wt switch --create new-feature   # Create new branch and worktree
 wt switch --create hotfix --base production
 ```
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2009,17 +2009,16 @@ wt list --format=json | jq '.[] | select(.main_state == "integrated" or .main_st
     },
 
     /// Switch to a worktree
-    #[command(after_long_help = r#"Two distinct operations:
+    #[command(after_long_help = r#"Switches to a worktree, creating one if needed.
 
-- **Switch to existing worktree** — Changes directory, nothing else
-- **Create new worktree** (`--create`) — Creates branch and worktree, runs [hooks](@/hook.md)
+With `--create`, creates a new branch based off `--base` (defaults to default branch) and runs [hooks](@/hook.md).
 
 ## Examples
 
 ```console
-wt switch feature-auth           # Switch to existing worktree
+wt switch feature-auth           # Switch to worktree
 wt switch -                      # Previous worktree (like cd -)
-wt switch --create new-feature   # Create branch and worktree
+wt switch --create new-feature   # Create new branch and worktree
 wt switch --create hotfix --base production
 ```
 

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -67,16 +67,15 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m<BRANCH>
   [1m[36m-v[0m, [1m[36m--verbose
           Show commands and debug info
 
-Two distinct operations:
+Switches to a worktree, creating one if needed.
 
-- [1mSwitch to existing worktree[0m — Changes directory, nothing else
-- [1mCreate new worktree[0m ([2m--create[0m) — Creates branch and worktree, runs hooks
+With [2m--create[0m, creates a new branch based off [2m--base[0m (defaults to default branch) and runs hooks.
 
 [32mExamples
 
-  [2mwt switch feature-auth           # Switch to existing worktree
+  [2mwt switch feature-auth           # Switch to worktree
   [2mwt switch -                      # Previous worktree (like cd -)
-  [2mwt switch --create new-feature   # Create branch and worktree
+  [2mwt switch --create new-feature   # Create new branch and worktree
   [2mwt switch --create hotfix --base production
 
 For interactive selection, use `wt select`.


### PR DESCRIPTION
## Summary

- Rewrote the intro section to better explain the command's behavior
- "Switches to a worktree, creating one if needed" — clarifies that worktrees are created automatically for existing branches
- With `--create`, explains it creates a new branch based off `--base` (defaults to default branch)
- Updated example comments for consistency

Previously the help text implied you could only switch to existing worktrees without `--create`, but actually a worktree is created automatically for existing branches that don't have one yet.

## Test plan

- [x] `cargo test --test integration -- help` passes
- [x] `pre-commit run --all-files` passes
- [x] Verified help output renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)