### PR TITLE
Route statusline output via output::data_raw()

### DIFF
--- a/src/output/global.rs
+++ b/src/output/global.rs
@@ -151,6 +151,28 @@ pub fn data(content: impl Into<String>) -> io::Result<()> {
     }
 }
 
+/// Emit raw data output, bypassing anstream color detection
+///
+/// Like `data()` but writes directly to stdout/stderr without anstream processing.
+/// Use when ANSI codes must be preserved regardless of TTY detection (e.g., statusline
+/// output for Claude Code which always expects ANSI).
+///
+/// - **Interactive**: writes to stdout
+/// - **Directive**: writes to stderr (stdout reserved for shell script)
+pub fn data_raw(content: impl Into<String>) -> io::Result<()> {
+    let content = content.into();
+    match get_mode() {
+        OutputMode::Interactive => {
+            writeln!(io::stdout(), "{content}")?;
+            io::stdout().flush()
+        }
+        OutputMode::Directive(_) => {
+            writeln!(io::stderr(), "{content}")?;
+            io::stderr().flush()
+        }
+    }
+}
+
 /// Emit table/UI output to stderr
 ///
 /// Used for table rows and progress indicators that should appear on the same

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -54,8 +54,8 @@ pub mod handlers;
 
 // Re-export the public API
 pub use global::{
-    OutputMode, blank, change_directory, data, execute, flush, flush_for_stderr_prompt, gutter,
-    initialize, print, shell_integration_hint, table, terminate_output,
+    OutputMode, blank, change_directory, data, data_raw, execute, flush, flush_for_stderr_prompt,
+    gutter, initialize, print, shell_integration_hint, table, terminate_output,
 };
 // Re-export output handlers
 pub use handlers::{

--- a/tests/integration_tests/statusline.rs
+++ b/tests/integration_tests/statusline.rs
@@ -99,14 +99,14 @@ fn add_commits_ahead(repo: &mut TestRepo) {
 #[rstest]
 fn test_statusline_basic(repo: TestRepo) {
     let output = run_statusline(&repo, &[], None);
-    assert_snapshot!(output, @"main  [2m^[22m");
+    assert_snapshot!(output, @"[0m main  [2m^[22m");
 }
 
 #[rstest]
 fn test_statusline_with_changes(repo: TestRepo) {
     add_uncommitted_changes(&repo);
     let output = run_statusline(&repo, &[], None);
-    assert_snapshot!(output, @"main  [36m?[39m[2m^[22m");
+    assert_snapshot!(output, @"[0m main  [36m?[0m[2m^[22m");
 }
 
 #[rstest]
@@ -115,7 +115,7 @@ fn test_statusline_commits_ahead(mut repo: TestRepo) {
     // Run from the feature worktree to see commits ahead
     let feature_path = repo.worktree_path("feature");
     let output = run_statusline_from_dir(&repo, &[], None, feature_path);
-    assert_snapshot!(output, @"feature  [2m↑[22m  [32m↑2[0m  ^[32m+2[0m");
+    assert_snapshot!(output, @"[0m feature  [2m↑[22m  [32m↑2[0m  ^[32m+2[0m");
 }
 
 // --- Claude Code Mode Tests ---


### PR DESCRIPTION
## Summary

- Add `output::data_raw()` function for raw ANSI output with mode-based routing
- Update statusline to use output system instead of direct writes
- Interactive mode → stdout (for shell prompts)
- Directive mode → stderr (stdout reserved for shell script)

This allows statusline to work correctly with Claude Code's statusLine hook while preserving raw ANSI codes including OSC 8 hyperlinks.

## Test plan

- [x] Statusline tests pass
- [x] Interactive mode outputs to stdout
- [x] Directive mode outputs to stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)