### PR TITLE
Improve path-occupied error message structure

### DIFF
--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -225,10 +225,12 @@ impl std::fmt::Display for GitError {
                 occupant,
             } => {
                 let path_display = format_path_for_display(path);
-                let error_suffix = if let Some(occupant_branch) = occupant {
-                    cformat!("existing worktree, on <bold>{occupant_branch}</>")
+                let error_detail = if let Some(occupant_branch) = occupant {
+                    cformat!(
+                        "existing worktree at <bold>{path_display}</> on <bold>{occupant_branch}</>"
+                    )
                 } else {
-                    "existing worktree, detached".to_string()
+                    cformat!("existing worktree at <bold>{path_display}</>, detached")
                 };
                 // Hint is self-contained (includes both path and branch)
                 let hint = hint_message(cformat!(
@@ -239,7 +241,7 @@ impl std::fmt::Display for GitError {
                     f,
                     "{}\n\n{}\n{}",
                     error_message(cformat!(
-                        "Cannot create worktree for <bold>{branch}</> at <bold>{path_display}</>: {error_suffix}"
+                        "Cannot create worktree for <bold>{branch}</>: {error_detail}"
                     )),
                     hint,
                     format_with_gutter(&command, "", None)

--- a/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__worktree_path_occupied.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__worktree_path_occupied.snap
@@ -2,7 +2,7 @@
 source: tests/integration_tests/git_error_display.rs
 expression: err.to_string()
 ---
-❌ [31mCannot create worktree for [1mfeature-z[22m at [1m/tmp/repo.feature-z[22m: existing worktree, on [1mother-branch[22m[39m
+❌ [31mCannot create worktree for [1mfeature-z[22m: existing worktree at [1m/tmp/repo.feature-z[22m on [1mother-branch[22m[39m
 
 💡 [2mSwitch the worktree at [90m/tmp/repo.feature-z[39m to [90mfeature-z[39m[22m
 [107m [0m  cd /tmp/repo.feature-z && git switch feature-z

--- a/tests/snapshots/integration__integration_tests__switch__switch_error_main_worktree_on_different_branch.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_error_main_worktree_on_different_branch.snap
@@ -29,7 +29,7 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[0m❌ [31mCannot create worktree for [1mmain[22m at [1m[REPO][22m: existing worktree, on [1mfeature[22m[39m
+[0m❌ [31mCannot create worktree for [1mmain[22m: existing worktree at [1m[REPO][22m on [1mfeature[22m[39m
 
 💡 [2mSwitch the worktree at [90m[REPO][39m to [90mmain[39m[22m
 [107m [0m  cd [REPO] && git switch main

--- a/tests/snapshots/integration__integration_tests__switch__switch_error_path_occupied_detached.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_error_path_occupied_detached.snap
@@ -29,7 +29,7 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[0m❌ [31mCannot create worktree for [1mfeature[22m at [1m[REPO].feature[22m: existing worktree, detached[39m
+[0m❌ [31mCannot create worktree for [1mfeature[22m: existing worktree at [1m[REPO].feature[22m, detached[39m
 
 💡 [2mSwitch the worktree at [90m[REPO].feature[39m to [90mfeature[39m[22m
 [107m [0m  cd [REPO].feature && git switch feature

--- a/tests/snapshots/integration__integration_tests__switch__switch_error_path_occupied_different_branch.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_error_path_occupied_different_branch.snap
@@ -29,7 +29,7 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[0m❌ [31mCannot create worktree for [1mfeature[22m at [1m[REPO].feature[22m: existing worktree, on [1mbugfix[22m[39m
+[0m❌ [31mCannot create worktree for [1mfeature[22m: existing worktree at [1m[REPO].feature[22m on [1mbugfix[22m[39m
 
 💡 [2mSwitch the worktree at [90m[REPO].feature[39m to [90mfeature[39m[22m
 [107m [0m  cd [REPO].feature && git switch feature


### PR DESCRIPTION
Move the path from after the branch name to after "existing worktree"
for better readability:

Before: Cannot create worktree for main at [path]: existing worktree, on feature
After:  Cannot create worktree for main: existing worktree at [path] on feature

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>
