### PR TITLE
CI: install lychee in lint job

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,11 @@ jobs:
     - name: 💰 Cache
       uses: Swatinem/rust-cache@v2
 
+    - name: Install lychee
+      uses: baptiste0928/cargo-install@v3
+      with:
+        crate: lychee
+
     - name: 🔍 Pre-commit hooks
       uses: pre-commit/action@v3.0.1
 


### PR DESCRIPTION
## Summary
- Fixed CI lint job failure by installing lychee before running pre-commit hooks

The lint job runs pre-commit hooks which include the lychee-system hook for link checking. However, lychee was only installed in the test job, not the lint job, causing pre-commit to fail with "Executable `lychee` not found".

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)