### PR TITLE
Fix lint CI job to install lychee & remove duplicate hook

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,6 +20,11 @@ jobs:
     - name: 💰 Cache
       uses: Swatinem/rust-cache@v2
 
+    - name: Install lychee
+      uses: baptiste0928/cargo-install@v3
+      with:
+        crate: lychee
+
     - name: 🔍 Pre-commit hooks
       uses: pre-commit/action@v3.0.1
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,24 +29,14 @@ repos:
   - repo: https://github.com/lycheeverse/lychee
     rev: lychee-v0.22.0
     hooks:
-      # PR mode - check links using .config/lychee.toml exclusions
+      # Check links using .config/lychee.toml exclusions
       # Uses lychee-system (requires `cargo install lychee`) to avoid /bin/bash dependency on Windows
       - id: lychee-system
-        name: lychee (PR mode)
         types: [markdown]
         args:
           - --config=.config/lychee.toml
           # Suppress warnings about root-relative paths (e.g., /assets/wt-demo.gif)
           # These are valid web paths validated by zola, not lychee
-          - -q
-      # Comprehensive mode - check all links with full config
-      # Run manually: pre-commit run --hook-stage manual lychee-all --all-files
-      - id: lychee-system
-        name: lychee-all (comprehensive)
-        types: [markdown]
-        stages: [manual]
-        args:
-          - --config=.config/lychee.toml
           - -q
   - repo: local
     hooks:


### PR DESCRIPTION
## Summary
- Add missing lychee install step to lint CI job (was causing intermittent failures)
- Remove redundant `lychee-all (comprehensive)` hook that had identical args to PR mode hook

The lint job intermittently failed with "Executable `lychee` not found" because it relied on cache hits from the test job rather than installing lychee directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)