### PR TITLE
Improve wording for flag documentation

### DIFF
--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -30,7 +30,7 @@ When the target branch has no worktree, worktrunk:
 3. Switches to new directory
 4. Spawns [post-start hooks](@/hook.md#post-start) (background)
 
-The `--create` flag creates a new branch from `--base` (defaults to default branch). Without `--create`, the branch must already exist.
+The `--create` flag creates a new branch from the `--base` branch (defaults to default branch). Without `--create`, the branch must already exist.
 
 ```bash
 wt switch feature                        # Existing branch → creates worktree

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2032,7 +2032,7 @@ When the target branch has no worktree, worktrunk:
 3. Switches to new directory
 4. Spawns [post-start hooks](@/hook.md#post-start) (background)
 
-The `--create` flag creates a new branch from `--base` (defaults to default branch). Without `--create`, the branch must already exist.
+The `--create` flag creates a new branch from the `--base` branch (defaults to default branch). Without `--create`, the branch must already exist.
 
 ```console
 wt switch feature                        # Existing branch → creates worktree

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -9,6 +9,7 @@ info:
     CLICOLOR_FORCE: "1"
     COLUMNS: "150"
     GIT_EDITOR: ""
+    GIT_FETCH_ARGS: ""
     SOURCE_DATE_EPOCH: "1735776000"
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
 ---
@@ -87,7 +88,7 @@ When the target branch has no worktree, worktrunk:
 3. Switches to new directory
 4. Spawns post-start hooks (background)
 
-The [2m--create[0m flag creates a new branch from [2m--base[0m (defaults to default branch). Without [2m--create[0m, the branch must already exist.
+The [2m--create[0m flag creates a new branch from the [2m--base[0m branch (defaults to default branch). Without [2m--create[0m, the branch must already exist.
 
   [2mwt switch feature                        # Existing branch → creates worktree
   [2mwt switch --create feature               # New branch and worktree


### PR DESCRIPTION
Change "from --base" to "from the --base branch" to make it clearer that we're referring to the branch value, not the flag itself.