### PR TITLE
Fix worktree creation and hook ordering

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/project-config.md
+++ b/.claude-plugin/skills/worktrunk/reference/project-config.md
@@ -254,7 +254,7 @@ Five hook types with different timing and behavior:
 
 ### post-create
 
-**When**: After creating new worktree, before switching to it
+**When**: After creating new worktree (blocking, before user switches)
 **Blocking**: Yes (user waits)
 **Fail-fast**: No (shows error but continues)
 **Execution**: Sequential
@@ -276,7 +276,7 @@ migrate = "npm run db:migrate"
 
 ### post-start
 
-**When**: After switching to existing worktree
+**When**: After creating new worktree (background, after user switches)
 **Blocking**: No (runs in background)
 **Fail-fast**: No
 **Execution**: Parallel

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -683,11 +683,13 @@ pub fn handle_state_get(key: &str, refresh: bool, branch: Option<String>) -> any
                 return Ok(());
             }
 
-            // Sort by modification time (newest first)
+            // Sort by modification time (newest first), then by name for stability
             entries.sort_by(|a, b| {
                 let a_time = a.metadata().and_then(|m| m.modified()).ok();
                 let b_time = b.metadata().and_then(|m| m.modified()).ok();
-                b_time.cmp(&a_time)
+                b_time
+                    .cmp(&a_time)
+                    .then_with(|| a.file_name().cmp(&b.file_name()))
             });
 
             // Build table
@@ -1157,11 +1159,13 @@ fn handle_state_show_table(repo: &Repository) -> anyhow::Result<()> {
         if entries.is_empty() {
             write!(out, "{}", format_with_gutter("(none)", "", None))?;
         } else {
-            // Sort by modification time (newest first)
+            // Sort by modification time (newest first), then by name for stability
             entries.sort_by(|a, b| {
                 let a_time = a.metadata().and_then(|m| m.modified()).ok();
                 let b_time = b.metadata().and_then(|m| m.modified()).ok();
-                b_time.cmp(&a_time)
+                b_time
+                    .cmp(&a_time)
+                    .then_with(|| a.file_name().cmp(&b.file_name()))
             });
 
             // Build table


### PR DESCRIPTION
- post-create: clarify it runs "before user switches" (blocking)
- post-start: fix incorrect claim it runs on "existing worktree" - it actually runs when creating NEW worktrees, after user switches