### PR TITLE
Reorganize CLAUDE.md: lead with pre-merge, move docs to subdirs

### DIFF
--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -93,6 +93,21 @@ branch: Option<String>,
 
 **Pattern:** All branch arguments should use `branch_value_completer()` for consistency with commands like `wt merge`, `wt switch --base`, `wt rebase`.
 
+## CLI Flag Descriptions
+
+Keep the first line of flag and argument descriptions brief—aim for 3-6 words. Use parenthetical defaults sparingly, only when the default isn't obvious from context.
+
+**Good examples:**
+- `/// Skip approval prompts`
+- `/// Show CI and \`main\` diffstat`
+- `/// Target branch (defaults to default branch)`
+
+**Bad examples (too verbose):**
+- `/// Auto-approve project commands without saving approvals.`
+- `/// Show CI status, conflict detection, and complete diff statistics`
+
+The help text should be scannable. Users reading `wt switch --help` need to quickly understand what each flag does without parsing long sentences.
+
 ## CLI Help Text Placement
 
 Help text has three levels:

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -1,5 +1,56 @@
 # Testing Guidelines
 
+## Timing Tests: Long Timeouts with Fast Polling
+
+**Core principle:** Use long timeouts (5+ seconds) for reliability on slow CI, but poll frequently (10-50ms) so tests complete quickly when things work.
+
+This achieves both goals:
+- **No flaky failures** on slow machines - generous timeout accommodates worst-case
+- **Fast tests** on normal machines - frequent polling means no unnecessary waiting
+
+```rust
+// ✅ GOOD: Long timeout, fast polling
+let timeout = Duration::from_secs(5);
+let poll_interval = Duration::from_millis(10);
+let start = Instant::now();
+while start.elapsed() < timeout {
+    if condition_met() { break; }
+    thread::sleep(poll_interval);
+}
+
+// ❌ BAD: Fixed sleep (always slow, might still fail)
+thread::sleep(Duration::from_millis(500));
+assert!(condition_met());
+
+// ❌ BAD: Short timeout (flaky on slow CI)
+let timeout = Duration::from_millis(100);
+```
+
+Use the helpers in `tests/common/mod.rs`:
+
+```rust
+use crate::common::{wait_for_file, wait_for_file_count};
+
+// ✅ Poll for file existence with 5+ second timeout
+wait_for_file(&log_file, Duration::from_secs(5));
+
+// ✅ Poll for multiple files
+wait_for_file_count(&log_dir, "log", 3, Duration::from_secs(5));
+```
+
+These use exponential backoff (10ms → 500ms cap) for fast initial checks that back off on slow CI.
+
+**Exception - testing absence:** When verifying something did NOT happen, polling doesn't work. Use a fixed 500ms+ sleep:
+
+```rust
+thread::sleep(Duration::from_millis(500));
+assert!(!marker_file.exists(), "Command should NOT have run");
+```
+
+## Testing with --execute Commands
+
+Use `--force` to skip interactive prompts in tests. Don't pipe input to stdin.
+
 ## README Examples and Snapshot Testing
 
 ### Problem: Separated stdout/stderr in Standard Snapshots


### PR DESCRIPTION
## Summary

- Restructures Testing section to lead with `wt hook pre-merge --force` as the primary "run all tests + lints" command, reducing cases where Claude runs only `cargo test` and CI fails on lints
- Adds `pre-commit run --all-files` as a lints-only option for faster iteration
- Moves CLI Flag Descriptions to `src/commands/CLAUDE.md` (alongside related CLI Help Text Placement)
- Moves Timing Tests and `--execute` testing guidance to `tests/CLAUDE.md`

## Test plan

- [ ] Verify CLAUDE.md structure is cleaner and more hierarchical
- [ ] Verify moved sections appear in appropriate subdirectory CLAUDE.md files

🤖 Generated with [Claude Code](https://claude.com/claude-code)