### PR TITLE
Silence uv cache warning in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -75,6 +75,9 @@ jobs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7
+      with:
+        # Silence "no file matched" warning; uv is only used to install pre-commit
+        cache-dependency-glob: ".pre-commit-config.yaml"
 
     - name: Install pre-commit
       run: uv tool install pre-commit


### PR DESCRIPTION
## Summary
- Set `cache-dependency-glob` to `.pre-commit-config.yaml` in the `setup-uv` action
- Silences the "no file matched" warning since uv is only used to install pre-commit as a tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)