### PR TITLE
Use <pre> tags for Worktrunk column to prevent wrapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,33 +44,33 @@ worktree requires typing the branch name three times: `git worktree add -b feat
   <thead>
     <tr>
       <th>Task</th>
-      <th style="white-space: nowrap">Worktrunk</th>
+      <th>Worktrunk</th>
       <th>Plain git</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>Switch worktrees</td>
-      <td style="white-space: nowrap"><code>wt switch feat</code></td>
+      <td><pre>wt switch feat</pre></td>
       <td><pre>cd ../repo.feat</pre></td>
     </tr>
     <tr>
       <td>Create + start Claude</td>
-      <td style="white-space: nowrap"><code>wt switch -c -x claude feat</code></td>
+      <td><pre>wt switch -c -x claude feat</pre></td>
       <td><pre>git worktree add -b feat ../repo.feat && \
 cd ../repo.feat && \
 claude</pre></td>
     </tr>
     <tr>
       <td>Clean up</td>
-      <td style="white-space: nowrap"><code>wt remove</code></td>
+      <td><pre>wt remove</pre></td>
       <td><pre>cd ../repo && \
 git worktree remove ../repo.feat && \
 git branch -d feat</pre></td>
     </tr>
     <tr>
       <td>List with status</td>
-      <td style="white-space: nowrap"><code>wt list</code></td>
+      <td><pre>wt list</pre></td>
       <td><pre>git worktree list</pre> (paths only)</td>
     </tr>
   </tbody>

--- a/docs/content/worktrunk.md
+++ b/docs/content/worktrunk.md
@@ -45,26 +45,26 @@ worktree requires typing the branch name three times: `git worktree add -b feat
   <tbody>
     <tr>
       <td>Switch worktrees</td>
-      <td><code>wt switch feat</code></td>
+      <td>{% rawcode() %}wt switch feat{% end %}</td>
       <td>{% rawcode() %}cd ../repo.feat{% end %}</td>
     </tr>
     <tr>
       <td>Create + start Claude</td>
-      <td><code>wt switch -c -x claude feat</code></td>
+      <td>{% rawcode() %}wt switch -c -x claude feat{% end %}</td>
       <td>{% rawcode() %}git worktree add -b feat ../repo.feat && \
 cd ../repo.feat && \
 claude{% end %}</td>
     </tr>
     <tr>
       <td>Clean up</td>
-      <td><code>wt remove</code></td>
+      <td>{% rawcode() %}wt remove{% end %}</td>
       <td>{% rawcode() %}cd ../repo && \
 git worktree remove ../repo.feat && \
 git branch -d feat{% end %}</td>
     </tr>
     <tr>
       <td>List with status</td>
-      <td><code>wt list</code></td>
+      <td>{% rawcode() %}wt list{% end %}</td>
       <td>{% rawcode() %}git worktree list{% end %} (paths only)</td>
     </tr>
   </tbody>


### PR DESCRIPTION
## Summary
- Changed Worktrunk column in README table from `<code>` to `<pre>` tags
- GitHub's table rendering gives `<pre>` blocks width priority, preventing the column from wrapping
- Updated source in `docs/content/worktrunk.md` to use `{% rawcode() %}` shortcode consistently

## Test plan
- [x] Verified via Playwright that commands no longer wrap on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)