### PR TITLE
Separate stats_base and integration_base for branch status

### DIFF
--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -117,11 +117,11 @@ The Status column has multiple subcolumns. Within each, only the first matching 
 | | `⚑` | Path doesn't match template |
 | | `⊟` | Prunable (directory missing) |
 | | `⊞` | Locked worktree |
-| Main | `^` | Is the main branch |
+| Main | `^` | Is the default branch |
 | | `✗` | Would conflict if merged to main |
 | | `_` | Same commit as main, clean |
 | | `–` | Same commit as main, uncommitted changes |
-| | `⊂` | [Content integrated](@/remove.md#branch-cleanup) |
+| | `⊂` | Content [integrated](@/remove.md#branch-cleanup) into main or target |
 | | `↕` | Diverged from main |
 | | `↑` | Ahead of main |
 | | `↓` | Behind main |

--- a/docs/content/remove.md
+++ b/docs/content/remove.md
@@ -39,16 +39,19 @@ wt remove -D experimental
 
 ## Branch cleanup
 
-Branches delete automatically when their content is already in the target branch (typically main). This works with squash-merge and rebase workflows where commit history differs but file changes match.
+Branches delete automatically when merging them would add nothing. This works with squash-merge and rebase workflows where commit history differs but file changes match.
 
-A branch is safe to delete when its content is already reflected in the target. Worktrunk checks four conditions (in order of cost):
+Worktrunk checks five conditions (in order of cost):
 
-1. **Same commit** — Branch HEAD is literally the same commit as target.
-2. **No added changes** — Three-dot diff (`main...branch`) shows no files. The branch has no file changes beyond the merge-base (includes "branch is ancestor" case).
-3. **Tree contents match** — Branch tree SHA equals main tree SHA. Commit history differs but file contents are identical (e.g., after a revert or merge commit pulling in main).
-4. **Merge adds nothing** — Simulated merge (`git merge-tree`) produces the same tree as main. Handles squash-merged branches where main has since advanced.
+1. **Same commit** — Branch HEAD equals main. Shows `_` in `wt list`.
+2. **Ancestor** — Branch is in target's history (fast-forward or rebase case). Shows `⊂`.
+3. **No added changes** — Three-dot diff (`target...branch`) is empty. Shows `⊂`.
+4. **Trees match** — Branch tree SHA equals target tree SHA. Shows `⊂`.
+5. **Merge adds nothing** — Simulated merge produces the same tree as target. Handles squash-merged branches where target has advanced. Shows `⊂`.
 
-In `wt list`, `_` indicates same commit, and `⊂` indicates content is integrated. Branches showing either are dimmed as safe to delete.
+Check 1 compares against main. Checks 2-5 compare against **target** — main, or origin/main when it's strictly ahead (catching branches merged remotely before pulling).
+
+Branches showing `_` or `⊂` are dimmed as safe to delete.
 
 Use `-D` to force-delete branches with unmerged changes. Use `--no-delete-branch` to keep the branch regardless of status.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1908,11 +1908,11 @@ The Status column has multiple subcolumns. Within each, only the first matching 
 | | `⚑` | Path doesn't match template |
 | | `⊟` | Prunable (directory missing) |
 | | `⊞` | Locked worktree |
-| Main | `^` | Is the main branch |
+| Main | `^` | Is the default branch |
 | | `✗` | Would conflict if merged to main |
 | | `_` | Same commit as main, clean |
 | | `–` | Same commit as main, uncommitted changes |
-| | `⊂` | [Content integrated](@/remove.md#branch-cleanup) |
+| | `⊂` | Content [integrated](@/remove.md#branch-cleanup) into main or target |
 | | `↕` | Diverged from main |
 | | `↑` | Ahead of main |
 | | `↓` | Behind main |
@@ -2145,16 +2145,19 @@ wt remove -D experimental
 
 ## Branch cleanup
 
-Branches delete automatically when their content is already in the target branch (typically main). This works with squash-merge and rebase workflows where commit history differs but file changes match.
+Branches delete automatically when merging them would add nothing. This works with squash-merge and rebase workflows where commit history differs but file changes match.
 
-A branch is safe to delete when its content is already reflected in the target. Worktrunk checks four conditions (in order of cost):
+Worktrunk checks five conditions (in order of cost):
 
-1. **Same commit** — Branch HEAD is literally the same commit as target.
-2. **No added changes** — Three-dot diff (`main...branch`) shows no files. The branch has no file changes beyond the merge-base (includes "branch is ancestor" case).
-3. **Tree contents match** — Branch tree SHA equals main tree SHA. Commit history differs but file contents are identical (e.g., after a revert or merge commit pulling in main).
-4. **Merge adds nothing** — Simulated merge (`git merge-tree`) produces the same tree as main. Handles squash-merged branches where main has since advanced.
+1. **Same commit** — Branch HEAD equals main. Shows `_` in `wt list`.
+2. **Ancestor** — Branch is in target's history (fast-forward or rebase case). Shows `⊂`.
+3. **No added changes** — Three-dot diff (`target...branch`) is empty. Shows `⊂`.
+4. **Trees match** — Branch tree SHA equals target tree SHA. Shows `⊂`.
+5. **Merge adds nothing** — Simulated merge produces the same tree as target. Handles squash-merged branches where target has advanced. Shows `⊂`.
 
-In `wt list`, `_` indicates same commit, and `⊂` indicates content is integrated. Branches showing either are dimmed as safe to delete.
+Check 1 compares against main. Checks 2-5 compare against **target** — main, or origin/main when it's strictly ahead (catching branches merged remotely before pulling).
+
+Branches showing `_` or `⊂` are dimmed as safe to delete.
 
 Use `-D` to force-delete branches with unmerged changes. Use `--no-delete-branch` to keep the branch regardless of status.
 

--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -245,7 +245,14 @@ fn get_git_status(repo: &Repository, cwd: &Path) -> Result<Option<String>> {
 
     // Populate computed fields (parallel git operations) and format status_line
     // Compute everything (same as --full) for complete status symbols
-    list::populate_items(&mut items, &integration_target, CollectOptions::default())?;
+    // Pass default_branch for stable informational stats,
+    // and integration_target for integration status checks.
+    list::populate_items(
+        &mut items,
+        &default_branch,
+        &integration_target,
+        CollectOptions::default(),
+    )?;
 
     // Return the pre-formatted statusline
     if let Some(ref statusline) = items[0].display.statusline {

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -131,11 +131,11 @@ The Status column has multiple subcolumns. Within each, only the first matching 
                     [31m⚑[0m       Path doesn't match template             
                     [33m⊟[0m       Prunable (directory missing)            
                     [33m⊞[0m       Locked worktree                         
-  Main              [2m^[0m       Is the main branch                      
+  Main              [2m^[0m       Is the default branch                   
                     [33m✗[0m       Would conflict if merged to main        
                     [2m_[0m       Same commit as main, clean              
                     [2m–[0m       Same commit as main, uncommitted changes
-                    [2m⊂[0m       Content integrated                      
+                    [2m⊂[0m       Content integrated into main or target  
                     [2m↕[0m       Diverged from main                      
                     [2m↑[0m       Ahead of main                           
                     [2m↓[0m       Behind main                             

--- a/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
@@ -77,20 +77,21 @@ Force-delete an unmerged branch:
 
 [32mBranch cleanup
 
-Branches delete automatically when their content is already in the target branch (typically main). This works with squash-merge and rebase workflows
-where commit history differs but file changes match.
+Branches delete automatically when merging them would add nothing. This works with squash-merge and rebase workflows where commit history differs but
+file changes match.
 
-A branch is safe to delete when its content is already reflected in the target. Worktrunk checks four conditions (in order of cost):
+Worktrunk checks five conditions (in order of cost):
 
-1. [1mSame commit[0m — Branch HEAD is literally the same commit as target.
-2. [1mNo added changes[0m — Three-dot diff ([2mmain...branch[0m) shows no files. The branch has no file changes beyond the merge-base (includes "branch is
-ancestor" case).
-3. [1mTree contents match[0m — Branch tree SHA equals main tree SHA. Commit history differs but file contents are identical (e.g., after a revert or
-merge commit pulling in main).
-4. [1mMerge adds nothing[0m — Simulated merge ([2mgit merge-tree[0m) produces the same tree as main. Handles squash-merged branches where main has since
-advanced.
+1. [1mSame commit[0m — Branch HEAD equals main. Shows [2m_[0m in [2mwt list[0m.
+2. [1mAncestor[0m — Branch is in target's history (fast-forward or rebase case). Shows [2m⊂[0m.
+3. [1mNo added changes[0m — Three-dot diff ([2mtarget...branch[0m) is empty. Shows [2m⊂[0m.
+4. [1mTrees match[0m — Branch tree SHA equals target tree SHA. Shows [2m⊂[0m.
+5. [1mMerge adds nothing[0m — Simulated merge produces the same tree as target. Handles squash-merged branches where target has advanced. Shows [2m⊂[0m.
 
-In [2mwt list[0m, [2m_[0m indicates same commit, and [2m⊂[0m indicates content is integrated. Branches showing either are dimmed as safe to delete.
+Check 1 compares against main. Checks 2-5 compare against [1mtarget[0m — main, or origin/main when it's strictly ahead (catching branches merged
+remotely before pulling).
+
+Branches showing [2m_[0m or [2m⊂[0m are dimmed as safe to delete.
 
 Use [2m-D[0m to force-delete branches with unmerged changes. Use [2m--no-delete-branch[0m to keep the branch regardless of status.
 


### PR DESCRIPTION
## Summary

- Clarifies which git ref is used for different status checks in `wt list`
- `stats_base` (local main): Used for informational stats (ahead/behind, branch diff, conflict detection `✗`)
- `integration_base` (effective target): Used for integration checks (`⊂`) - may be origin/main when ahead

## Status symbol mapping

| Symbol | Meaning | Base used |
|--------|---------|-----------|
| `_` | Same commit as main | stats_base (via counts) |
| `⊂` | Content integrated | integration_base |
| `✗` | Would conflict | stats_base |

## Documentation updates

- Lists all 5 integration conditions (added Ancestor between Same commit and No added changes)
- Clarifies "Check 1 compares against main. Checks 2-5 compare against target"

## Test plan

- [x] All unit tests pass
- [x] All integration tests pass (585 tests)
- [x] Pre-commit checks pass
- [x] Docs sync test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)