### PR TITLE
Unify command execution through shell_exec::run()

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -67,6 +67,16 @@ repos:
         language: pygrep
         entry: '\.canonicalize\(\)'
         files: '^tests/'
+      - id: no-direct-cmd-output
+        name: no-direct-cmd-output
+        description: Use shell_exec::run() instead of cmd.output() for consistent logging
+        language: pygrep
+        types: ["rust"]
+        entry: '\.output\(\)'
+        # shell_exec.rs: defines run() which legitimately calls .output()
+        # select.rs: skim API's selected.output() is not Command::output()
+        # tests/benches: test utilities run commands directly
+        exclude: '^(src/shell_exec\.rs|src/commands/select\.rs|tests/|benches/)'
 
 ci:
   # pre-commit.ci doesn't have Rust toolchain, so skip Rust-specific hooks.

--- a/src/commands/select.rs
+++ b/src/commands/select.rs
@@ -9,6 +9,7 @@ use std::sync::{Arc, OnceLock};
 use std::time::{Duration, Instant};
 use worktrunk::config::WorktrunkConfig;
 use worktrunk::git::Repository;
+use worktrunk::shell_exec::run;
 
 use super::list::collect;
 use super::list::layout::{DiffDisplayConfig, DiffVariant};
@@ -38,19 +39,17 @@ fn get_diff_pager() -> Option<&'static String> {
             }
 
             // Fall back to core.pager config
-            Command::new("git")
-                .args(["config", "--get", "core.pager"])
-                .output()
-                .ok()
-                .and_then(|output| {
-                    if output.status.success() {
-                        String::from_utf8(output.stdout)
-                            .ok()
-                            .and_then(|s| parse_pager(&s))
-                    } else {
-                        None
-                    }
-                })
+            let mut cmd = Command::new("git");
+            cmd.args(["config", "--get", "core.pager"]);
+            run(&mut cmd, None).ok().and_then(|output| {
+                if output.status.success() {
+                    String::from_utf8(output.stdout)
+                        .ok()
+                        .and_then(|s| parse_pager(&s))
+                } else {
+                    None
+                }
+            })
         })
         .as_ref()
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,6 +1,8 @@
 use std::path::{Path, PathBuf};
 
 #[cfg(windows)]
+use crate::shell_exec::run;
+#[cfg(windows)]
 use std::process::Command;
 
 /// Convert a path to POSIX format for Git Bash compatibility.
@@ -26,7 +28,9 @@ pub fn to_posix_path(path: &str) -> String {
         return path.to_string();
     };
 
-    let Ok(output) = Command::new(&cygpath).arg("-u").arg(path).output() else {
+    let mut cmd = Command::new(&cygpath);
+    cmd.arg("-u").arg(path);
+    let Ok(output) = run(&mut cmd, None) else {
         return path.to_string();
     };
 


### PR DESCRIPTION
## Summary

- All external command execution now routes through `shell_exec::run()` for consistent logging and tracing
- Skip redundant CI tools detection after table render (fixes 100-500ms post-table delay in `wt list --full`)
- Add pre-commit lint to catch direct `.output()` calls in source code

## Changes

- Add `run()` function to `shell_exec.rs` with timing and debug logging
- Update `Repository::run_command()` to wrap `shell_exec::run()`  
- Convert CI tool calls (gh, glab), pager detection, and cygpath to use `run()`
- Document the pattern in CLAUDE.md

The unified logging format:
```
$ git status [worktree-name]
[wt-trace] cmd="..." dur=12.3ms ok=true
```

## Test plan

- [x] `cargo test --lib --bins` passes
- [x] `cargo test --test integration` passes
- [x] `pre-commit run --all-files` passes
- [x] Verified logging format with `RUST_LOG=debug cargo run -- list`

🤖 Generated with [Claude Code](https://claude.com/claude-code)