### PR TITLE
Refactor wt list task error handling to collect and display errors

### DIFF
--- a/src/commands/list/mod.rs
+++ b/src/commands/list/mod.rs
@@ -183,7 +183,7 @@ pub fn handle_list(
         config,
     )?;
 
-    let Some(ListData { items }) = list_data else {
+    let Some(ListData { items, .. }) = list_data else {
         return Ok(());
     };
 


### PR DESCRIPTION
## Summary

- Replace silent error swallowing (`.unwrap_or()`, `.ok()`, `log::warn!()`) with proper `Result` semantics
- Add `TaskError` struct and change `Task::compute()` to return `Result<TaskResult, TaskError>`
- Add `apply_default()` to centralize conservative fallback values when tasks fail
- Display collected errors as warnings after the table renders
- For detached HEAD, tasks return success with conservative defaults (expected behavior, not an error)
- Add `debug_assert!` for impossible cases (worktree-only tasks receiving branch items)

## Test plan

- [x] All 604 integration tests pass
- [x] Pre-commit lints pass
- [x] Detached HEAD cases handled correctly (no spurious warnings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)