### PR TITLE
Enable automatic winget package publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -291,34 +291,32 @@ jobs:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: cargo publish --package worktrunk
 
-  # TODO: Enable after initial manual submission to winget-pkgs repository
-  # See: https://github.com/microsoft/winget-pkgs/blob/master/CONTRIBUTING.md
-  # publish-winget:
-  #   needs:
-  #     - plan
-  #     - host
-  #   runs-on: ubuntu-latest
-  #   if: ${{ needs.plan.outputs.publishing == 'true' }}
-  #   steps:
-  #     - name: Publish to winget
-  #       uses: vedantmgoyal9/winget-releaser@v2
-  #       with:
-  #         identifier: max-sixty.worktrunk
-  #         version: ${{ needs.plan.outputs.tag }}
-  #         installers-regex: '^worktrunk-.*-windows-.*\.zip$'
-  #         token: ${{ secrets.WINGET_TOKEN }}
-  #         fork-user: max-sixty
+  publish-winget:
+    needs:
+      - plan
+      - host
+    runs-on: ubuntu-latest
+    if: ${{ needs.plan.outputs.publishing == 'true' }}
+    steps:
+      - name: Publish to winget
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: max-sixty.worktrunk
+          version: ${{ needs.plan.outputs.tag }}
+          installers-regex: '^worktrunk-.*-windows-.*\.zip$'
+          token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
+          fork-user: max-sixty
 
   announce:
     needs:
       - plan
       - host
       - publish-cargo
-      # - publish-winget
+      - publish-winget
     # use "always() && ..." to allow us to wait for all publish jobs while
     # still allowing individual publish jobs to skip themselves (for prereleases).
     # "host" however must run to completion, no skipping allowed!
-    if: ${{ always() && needs.host.result == 'success' && (needs.publish-cargo.result == 'success' || needs.publish-cargo.result == 'skipped') }}
+    if: ${{ always() && needs.host.result == 'success' && (needs.publish-cargo.result == 'success' || needs.publish-cargo.result == 'skipped') && (needs.publish-winget.result == 'success' || needs.publish-winget.result == 'skipped') }}
     runs-on: "ubuntu-22.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Enable the `publish-winget` job in release workflow
- Automatically submit PRs to winget-pkgs on new releases using vedantmgoyal9/winget-releaser
- Use `WORKTRUNK_BOT_TOKEN` secret for authentication

## Test plan
- [x] Workflow file syntax is valid
- [ ] Next release will test the winget publishing

🤖 Generated with [Claude Code](https://claude.com/claude-code)