### PR TITLE
Use info_message for switching to existing worktrees

### DIFF
--- a/.claude/rules/cli-output-formatting.md
+++ b/.claude/rules/cli-output-formatting.md
@@ -146,12 +146,21 @@ spawn_background(build_command_that_checks_merge_again());  // Duplicate check!
 Seven canonical message patterns with their emojis:
 
 1. **Progress**: 🔄 (operations in progress)
-2. **Success**: ✅ (successful completion)
+2. **Success**: ✅ (something was created or changed)
 3. **Errors**: ❌ (failures, invalid states)
 4. **Warnings**: 🟡 (non-blocking issues)
 5. **Hints**: 💡 (actionable — user could/should do something)
 6. **Info**: ⚪ (status — acknowledging state or user choices, no action needed)
 7. **Prompts**: ❓ (questions requiring user input)
+
+**Success vs Info decision:** Success (✅) means something was created or
+changed. Info (⚪) means acknowledging state without creating/changing anything.
+
+| Success ✅                              | Info ⚪                               |
+| --------------------------------------- | ------------------------------------- |
+| "Created worktree for feature"          | "Switched to worktree for feature"    |
+| "Created new worktree for feature"      | "Already on worktree for feature"     |
+| "Commands approved & saved"             | "All commands already approved"       |
 
 **Hint vs Info decision:** If the message suggests the user take an action, it's
 a hint. If it's acknowledging what happened (including flag effects), it's info.

--- a/tests/integration_tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_accept.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_accept.snap
@@ -12,5 +12,5 @@ y
 🔄 [36mRunning project post-create:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m[0m
 [0mtest command
-✅ [32m[32mCreated new worktree for [1mtest-approve[22m from [1mmain[22m @ [1m[REPO]/repo.test-approve[39m[22m[39m
+✅ [32mCreated new worktree for [1mtest-approve[22m from [1mmain[22m @ [1m[REPO]/repo.test-approve[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_decline.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_decline.snap
@@ -10,5 +10,5 @@ n
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m[0m
 ❓ Allow and remember? [1m[y/N][22m 
 ⚪ Commands declined, continuing worktree creation
-✅ [32m[32mCreated new worktree for [1mtest-decline[22m from [1mmain[22m @ [1m[REPO]/repo.test-decline[39m[22m[39m
+✅ [32mCreated new worktree for [1mtest-decline[22m from [1mmain[22m @ [1m[REPO]/repo.test-decline[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_mixed_approved_unapproved_accept.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_mixed_approved_unapproved_accept.snap
@@ -20,5 +20,5 @@ y
 🔄 [36mRunning project post-create [1mthird[22m:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Third command'[0m[2m[0m
 [0mThird command
-✅ [32m[32mCreated new worktree for [1mtest-mixed-accept[22m from [1mmain[22m @ [1m[REPO]/repo.test-mixed-accept[39m[22m[39m
+✅ [32mCreated new worktree for [1mtest-mixed-accept[22m from [1mmain[22m @ [1m[REPO]/repo.test-mixed-accept[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_mixed_approved_unapproved_decline.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_mixed_approved_unapproved_decline.snap
@@ -12,5 +12,5 @@ n
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Third command'[0m[2m[0m
 ❓ Allow and remember? [1m[y/N][22m 
 ⚪ Commands declined, continuing worktree creation
-✅ [32m[32mCreated new worktree for [1mtest-mixed-decline[22m from [1mmain[22m @ [1m[REPO]/repo.test-mixed-decline[39m[22m[39m
+✅ [32mCreated new worktree for [1mtest-mixed-decline[22m from [1mmain[22m @ [1m[REPO]/repo.test-mixed-decline[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_multiple_commands.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_multiple_commands.snap
@@ -22,5 +22,5 @@ y
 🔄 [36mRunning project post-create [1mthird[22m:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Third command'[0m[2m[0m
 [0mThird command
-✅ [32m[32mCreated new worktree for [1mtest-multi[22m from [1mmain[22m @ [1m[REPO]/repo.test-multi[39m[22m[39m
+✅ [32mCreated new worktree for [1mtest-multi[22m from [1mmain[22m @ [1m[REPO]/repo.test-multi[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_named_commands.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_named_commands.snap
@@ -22,5 +22,5 @@ y
 🔄 [36mRunning project post-create [1mtest[22m:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Running tests...'[0m[2m[0m
 [0mRunning tests...
-✅ [32m[32mCreated new worktree for [1mtest-named[22m from [1mmain[22m @ [1m[REPO]/repo.test-named[39m[22m[39m
+✅ [32mCreated new worktree for [1mtest-named[22m from [1mmain[22m @ [1m[REPO]/repo.test-named[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_permission_error.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_permission_error.snap
@@ -14,5 +14,5 @@ y
 🔄 [36mRunning project post-create:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m[0m
 [0mtest command
-✅ [32m[32mCreated new worktree for [1mtest-permission[22m from [1mmain[22m @ [1m[REPO]/repo.test-permission[39m[22m[39m
+✅ [32mCreated new worktree for [1mtest-permission[22m from [1mmain[22m @ [1m[REPO]/repo.test-permission[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__bash_shell_integration_hint_suppressed.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__bash_shell_integration_hint_suppressed.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-✅ [32m[32mCreated new worktree for [1mbash-test[22m from [1mmain[22m @ [1m[TMPDIR]/repo.bash-test[39m[22m[39m
+✅ [32mCreated new worktree for [1mbash-test[22m from [1mmain[22m @ [1m[TMPDIR]/repo.bash-test[22m[39m

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__fish_multiline_command_execution.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__fish_multiline_command_execution.snap
@@ -2,7 +2,7 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-✅ [32m[32mCreated new worktree for [1mfish-multiline[22m from [1mmain[22m @ [1m[TMPDIR]/repo.fish-multiline[39m[22m[39m
+✅ [32mCreated new worktree for [1mfish-multiline[22m from [1mmain[22m @ [1m[TMPDIR]/repo.fish-multiline[22m[39m
 🔄 [36mExecuting (--execute):[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'line 1'[0m[2m; [0m[2m[34mecho[0m[2m [0m[2m[32m'line 2'[0m[2m; [0m[2m[34mecho[0m[2m [0m[2m[32m'line 3'[0m[2m[0m
 line 1

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__fish_wrapper_handles_empty_chunks.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__fish_wrapper_handles_empty_chunks.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-✅ [32m[32mCreated new worktree for [1mfish-minimal[22m from [1mmain[22m @ [1m[TMPDIR]/repo.fish-minimal[39m[22m[39m
+✅ [32mCreated new worktree for [1mfish-minimal[22m from [1mmain[22m @ [1m[TMPDIR]/repo.fish-minimal[22m[39m

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__fish_wrapper_preserves_progress_messages.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__fish_wrapper_preserves_progress_messages.snap
@@ -2,6 +2,6 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-✅ [32m[32mCreated new worktree for [1mfish-bg[22m from [1mmain[22m @ [1m[TMPDIR]/repo.fish-bg[39m[22m[39m
+✅ [32mCreated new worktree for [1mfish-bg[22m from [1mmain[22m @ [1m[TMPDIR]/repo.fish-bg[22m[39m
 🔄 [36mRunning project post-start:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'fish background task'[0m[2m[0m

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__readme_example_hooks_post_create.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__readme_example_hooks_post_create.snap
@@ -7,6 +7,6 @@ expression: output.normalized()
 
   Resolved 24 packages in 145ms
   Installed 24 packages in 1.2s
-✅ [32m[32mCreated new worktree for [1mfeature-x[22m from [1mmain[22m @ [1m[TMPDIR]/repo.feature-x[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature-x[22m from [1mmain[22m @ [1m[TMPDIR]/repo.feature-x[22m[39m
 🔄 [36mRunning project post-start [1mdev[22m:[39m
 [107m [0m  [2m[0m[2m[34muv[0m[2m run dev[0m

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__readme_example_simple_switch.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__readme_example_simple_switch.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-✅ [32m[32mCreated new worktree for [1mfix-auth[22m from [1mmain[22m @ [1m[TMPDIR]/repo.fix-auth[39m[22m[39m
+✅ [32mCreated new worktree for [1mfix-auth[22m from [1mmain[22m @ [1m[TMPDIR]/repo.fix-auth[22m[39m

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__readme_example_switch_back.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__readme_example_switch_back.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-✅ [32m[32mSwitched to worktree for [1mfeature-api[22m @ [1m[TMPDIR]/repo.feature-api[39m[22m[39m
+⚪ Switched to worktree for [1mfeature-api[22m @ [1m[TMPDIR]/repo.feature-api[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_create.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_create.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[TMPDIR]/repo.feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[TMPDIR]/repo.feature[22m[39m

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_with_execute.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_with_execute.snap
@@ -2,7 +2,7 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-✅ [32m[32mCreated new worktree for [1mtest-exec[22m from [1mmain[22m @ [1m[TMPDIR]/repo.test-exec[39m[22m[39m
+✅ [32mCreated new worktree for [1mtest-exec[22m from [1mmain[22m @ [1m[TMPDIR]/repo.test-exec[22m[39m
 🔄 [36mExecuting (--execute):[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m executed[0m
 executed

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_with_execute_through_wrapper.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_with_execute_through_wrapper.snap
@@ -2,7 +2,7 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-✅ [32m[32mCreated new worktree for [1mtest-exec[22m from [1mmain[22m @ [1m[TMPDIR]/repo.test-exec[39m[22m[39m
+✅ [32mCreated new worktree for [1mtest-exec[22m from [1mmain[22m @ [1m[TMPDIR]/repo.test-exec[22m[39m
 🔄 [36mExecuting (--execute):[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m executed[0m
 executed

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_with_hooks_zsh.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_with_hooks_zsh.snap
@@ -8,7 +8,7 @@ Installing dependencies...
 🔄 [36mRunning project post-create [1mbuild[22m:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Building project...'[0m[2m[0m
 Building project...
-✅ [32m[32mCreated new worktree for [1mfeature-hooks[22m from [1mmain[22m @ [1m[TMPDIR]/repo.feature-hooks[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature-hooks[22m from [1mmain[22m @ [1m[TMPDIR]/repo.feature-hooks[22m[39m
 🔄 [36mRunning project post-start [1mserver[22m:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Starting dev server on port 3000'[0m[2m[0m
 🔄 [36mRunning project post-start [1mwatch[22m:[39m

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_with_post_start_command_no_directive_leak.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_with_post_start_command_no_directive_leak.snap
@@ -2,6 +2,6 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-✅ [32m[32mCreated new worktree for [1mfeature-with-hooks[22m from [1mmain[22m @ [1m[TMPDIR]/repo.feature-with-hooks[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature-with-hooks[22m from [1mmain[22m @ [1m[TMPDIR]/repo.feature-with-hooks[22m[39m
 🔄 [36mRunning project post-start:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command executed'[0m[2m[0m

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__wrapper_preserves_progress_messages.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__wrapper_preserves_progress_messages.snap
@@ -2,6 +2,6 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-✅ [32m[32mCreated new worktree for [1mfeature-bg[22m from [1mmain[22m @ [1m[TMPDIR]/repo.feature-bg[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature-bg[22m from [1mmain[22m @ [1m[TMPDIR]/repo.feature-bg[22m[39m
 🔄 [36mRunning project post-start:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'background task'[0m[2m[0m

--- a/tests/snapshots/integration__integration_tests__approval_ui__already_approved_skip_prompt.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__already_approved_skip_prompt.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -31,5 +32,5 @@ exit_code: 0
 ----- stderr -----
 🔄 [36mRunning project post-create:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'approved'[0m[2m [0m[2m[36m>[0m[2m output.txt
-[0m✅ [32m[32mCreated new worktree for [1mtest-approved[22m from [1mmain[22m @ [1m[REPO].test-approved[39m[22m[39m
+[0m✅ [32mCreated new worktree for [1mtest-approved[22m from [1mmain[22m @ [1m[REPO].test-approved[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__force_bypasses_tty_check.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__force_bypasses_tty_check.snap
@@ -16,6 +16,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -33,5 +34,5 @@ exit_code: 0
 🔄 [36mRunning project post-create:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m
 [0mtest command
-✅ [32m[32mCreated new worktree for [1mtest-force-tty[22m from [1mmain[22m @ [1m[REPO].test-force-tty[39m[22m[39m
+✅ [32mCreated new worktree for [1mtest-force-tty[22m from [1mmain[22m @ [1m[REPO].test-force-tty[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__force_does_not_save_approvals_first_run.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__force_does_not_save_approvals_first_run.snap
@@ -16,6 +16,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -32,5 +33,5 @@ exit_code: 0
 ----- stderr -----
 🔄 [36mRunning project post-create:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m [0m[2m[36m>[0m[2m output.txt
-[0m✅ [32m[32mCreated new worktree for [1mtest-force[22m from [1mmain[22m @ [1m[REPO].test-force[39m[22m[39m
+[0m✅ [32mCreated new worktree for [1mtest-force[22m from [1mmain[22m @ [1m[REPO].test-force[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__directives__switch_internal_powershell_directive.snap
+++ b/tests/snapshots/integration__integration_tests__directives__switch_internal_powershell_directive.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -30,4 +31,4 @@ exit_code: 0
 Set-Location '[PATH]'
 
 ----- stderr -----
-✅ [32m[32mSwitched to worktree for [1mfeature[22m @ [1m[REPO].feature[39m[22m[39m
+⚪ Switched to worktree for [1mfeature[22m @ [1m[REPO].feature[22m

--- a/tests/snapshots/integration__integration_tests__merge__readme_example_hooks_post_create.snap
+++ b/tests/snapshots/integration__integration_tests__merge__readme_example_hooks_post_create.snap
@@ -16,6 +16,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -35,7 +36,7 @@ exit_code: 0
 
   Resolved 24 packages in 145ms
   Installed 24 packages in 1.2s
-✅ [32m[32mCreated new worktree for [1mfeature-x[22m from [1mmain[22m @ [1m[REPO].feature-x[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature-x[22m from [1mmain[22m @ [1m[REPO].feature-x[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m
 🔄 [36mRunning project post-start [1mdev[22m:[39m
 [107m [0m  [2m[0m[2m[34muv[0m[2m run dev

--- a/tests/snapshots/integration__integration_tests__merge__readme_example_simple_switch.snap
+++ b/tests/snapshots/integration__integration_tests__merge__readme_example_simple_switch.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,5 +30,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfix-auth[22m from [1mmain[22m @ [1m[REPO].fix-auth[39m[22m[39m
+✅ [32mCreated new worktree for [1mfix-auth[22m from [1mmain[22m @ [1m[REPO].fix-auth[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__both_create_and_start.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__both_create_and_start.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -31,7 +32,7 @@ exit_code: 0
 ----- stderr -----
 🔄 [36mRunning project post-create:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setup done'[0m[2m [0m[2m[36m>[0m[2m setup.txt
-[0m✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+[0m✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m
 🔄 [36mRunning project post-start [1mserver[22m:[39m
 [107m [0m  [2m[0m[2m[34msleep[0m[2m 0.05 [0m[2m[36m&&[0m[2m [0m[2m[34mecho[0m[2m [0m[2m[32m'Server running'[0m[2m [0m[2m[36m>[0m[2m server.txt

--- a/tests/snapshots/integration__integration_tests__post_start_commands__execute_with_post_start.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__execute_with_post_start.snap
@@ -17,6 +17,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -31,7 +32,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 🔄 [36mRunning project post-start:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Background task'[0m[2m [0m[2m[36m>[0m[2m background.txt
 🔄 [36mExecuting (--execute):[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_default_branch_template.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_default_branch_template.snap
@@ -16,6 +16,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -32,5 +33,5 @@ exit_code: 0
 ----- stderr -----
 🔄 [36mRunning project post-create:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Default: main'[0m[2m [0m[2m[36m>[0m[2m default.txt
-[0m✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+[0m✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_failing_command.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_failing_command.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -32,5 +33,5 @@ exit_code: 0
 🔄 [36mRunning project post-create:[39m
 [107m [0m  [2m[0m[2m[34mexit[0m[2m 1
 [0m🟡 [33mCommand failed: exit status: 1[39m
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_git_variables_template.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_git_variables_template.snap
@@ -16,6 +16,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -38,5 +39,5 @@ exit_code: 0
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Remote: origin'[0m[2m [0m[2m[36m>>[0m[2m git_vars.txt
 [0m🔄 [36mRunning project post-create [1mworktree_name[22m:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Worktree Name: repo.feature'[0m[2m [0m[2m[36m>>[0m[2m git_vars.txt
-[0m✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+[0m✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_multiline_control_structure.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_multiline_control_structure.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -35,5 +36,5 @@ exit_code: 0
 [107m [0m  [2m[0m[2m[34melse[0m[2m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'File exists'[0m[2m [0m[2m[36m>[0m[2m result.txt
 [107m [0m  [2m[0m[2m[34mfi[0m[2m
-[0m✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+[0m✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_named_commands.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_named_commands.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -35,5 +36,5 @@ exit_code: 0
 🔄 [36mRunning project post-create [1msetup[22m:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Running setup'[0m[2m
 [0mRunning setup
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_no_config.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_no_config.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,5 +30,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_single_command.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_single_command.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -32,5 +33,5 @@ exit_code: 0
 🔄 [36mRunning project post-create:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setup complete'[0m[2m
 [0mSetup complete
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_template_expansion.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_template_expansion.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -37,5 +38,5 @@ exit_code: 0
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Worktree: [REPO].feature-test'[0m[2m [0m[2m[36m>>[0m[2m info.txt
 [0m🔄 [36mRunning project post-create [1mroot[22m:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Root: [REPO]'[0m[2m [0m[2m[36m>>[0m[2m info.txt
-[0m✅ [32m[32mCreated new worktree for [1mfeature/test[22m from [1mmain[22m @ [1m[REPO].feature-test[39m[22m[39m
+[0m✅ [32mCreated new worktree for [1mfeature/test[22m from [1mmain[22m @ [1m[REPO].feature-test[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_upstream_template.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_upstream_template.snap
@@ -16,6 +16,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -32,5 +33,5 @@ exit_code: 0
 ----- stderr -----
 🔄 [36mRunning project post-create:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Upstream: '[0m[2m [0m[2m[36m>[0m[2m upstream.txt
-[0m✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+[0m✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_complex_shell.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_complex_shell.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,7 +30,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m
 🔄 [36mRunning project post-start:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m 'line1

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_create_with_command.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_create_with_command.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,7 +30,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m
 🔄 [36mRunning project post-start:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'POST-START-RAN'[0m[2m [0m[2m[36m>[0m[2m post_start_marker.txt

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_invalid_command.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_invalid_command.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,7 +30,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m
 🔄 [36mRunning project post-start:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m 'unclosed quote

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_log_captures_output.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_log_captures_output.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,7 +30,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m
 🔄 [36mRunning project post-start:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'stdout output'[0m[2m [0m[2m[36m&&[0m[2m [0m[2m[34mecho[0m[2m [0m[2m[32m'stderr output'[0m[2m >&2

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_multiline_with_newlines.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_multiline_with_newlines.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,7 +30,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m
 🔄 [36mRunning project post-start:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'first line'[0m[2m [0m[2m[36m>[0m[2m multiline.txt

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_multiple_background.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_multiple_background.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,7 +30,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m
 🔄 [36mRunning project post-start [1mtask1[22m:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Task 1 running'[0m[2m [0m[2m[36m>[0m[2m task1.txt

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_separate_logs.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_separate_logs.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,7 +30,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m
 🔄 [36mRunning project post-start [1mtask1[22m:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'TASK1_OUTPUT'[0m[2m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_single_background.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_single_background.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,7 +30,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m
 🔄 [36mRunning project post-start:[39m
 [107m [0m  [2m[0m[2m[34msleep[0m[2m 0.1 [0m[2m[36m&&[0m[2m [0m[2m[34mecho[0m[2m [0m[2m[32m'Background task done'[0m[2m [0m[2m[36m>[0m[2m background.txt

--- a/tests/snapshots/integration__integration_tests__switch__create_with_base_main.snap
+++ b/tests/snapshots/integration__integration_tests__switch__create_with_base_main.snap
@@ -17,6 +17,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -31,5 +32,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mnew-feature[22m from [1mmain[22m @ [1m[REPO].new-feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mnew-feature[22m from [1mmain[22m @ [1m[REPO].new-feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__switch__ping_pong_1_main_to_feature_a.snap
+++ b/tests/snapshots/integration__integration_tests__switch__ping_pong_1_main_to_feature_a.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,5 +29,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mSwitched to worktree for [1mfeature-a[22m @ [1m[REPO].feature-a[39m[22m[39m
+✅ [32mSwitched to worktree for [1mfeature-a[22m @ [1m[REPO].feature-a[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_clobber_path_with_extension.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_clobber_path_with_extension.snap
@@ -32,5 +32,5 @@ exit_code: 0
 
 ----- stderr -----
 🟡 [33mMoving [1m[REPO].clobber-ext.txt[22m to [1m[REPO].clobber-ext.txt.bak.20250102-000000[22m ([90m--clobber[39m)[39m
-✅ [32m[32mCreated new worktree for [1mclobber-ext.txt[22m from [1mmain[22m @ [1m[REPO].clobber-ext.txt[39m[22m[39m
+✅ [32mCreated new worktree for [1mclobber-ext.txt[22m from [1mmain[22m @ [1m[REPO].clobber-ext.txt[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_clobber_removes_stale_dir.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_clobber_removes_stale_dir.snap
@@ -32,5 +32,5 @@ exit_code: 0
 
 ----- stderr -----
 🟡 [33mMoving [1m[REPO].clobber-dir-test[22m to [1m[REPO].clobber-dir-test.bak.20250102-000000[22m ([90m--clobber[39m)[39m
-✅ [32m[32mCreated new worktree for [1mclobber-dir-test[22m from [1mmain[22m @ [1m[REPO].clobber-dir-test[39m[22m[39m
+✅ [32mCreated new worktree for [1mclobber-dir-test[22m from [1mmain[22m @ [1m[REPO].clobber-dir-test[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_clobber_removes_stale_file.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_clobber_removes_stale_file.snap
@@ -32,5 +32,5 @@ exit_code: 0
 
 ----- stderr -----
 🟡 [33mMoving [1m[REPO].clobber-file-test[22m to [1m[REPO].clobber-file-test.bak.20250102-000000[22m ([90m--clobber[39m)[39m
-✅ [32m[32mCreated new worktree for [1mclobber-file-test[22m from [1mmain[22m @ [1m[REPO].clobber-file-test[39m[22m[39m
+✅ [32mCreated new worktree for [1mclobber-file-test[22m from [1mmain[22m @ [1m[REPO].clobber-file-test[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_create_new.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_create_new.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,5 +30,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfeature-x[22m from [1mmain[22m @ [1m[REPO].feature-x[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature-x[22m from [1mmain[22m @ [1m[REPO].feature-x[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_create_no_remote.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_create_no_remote.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,5 +30,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_create_remote_only.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_create_remote_only.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -31,5 +32,5 @@ exit_code: 0
 ----- stderr -----
 🟡 [33mBranch [1mremote-feature[22m exists on remote (origin/remote-feature); creating new branch from base instead[39m
 💡 [2mUse [90mwt switch remote-feature[39m (without [90m--create[39m) to switch to the remote branch[22m
-✅ [32m[32mCreated new worktree for [1mremote-feature[22m from [1mmain[22m @ [1m[REPO].remote-feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mremote-feature[22m from [1mmain[22m @ [1m[REPO].remote-feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_creates_file.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_creates_file.snap
@@ -17,6 +17,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -31,6 +32,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfile-test[22m from [1mmain[22m @ [1m[REPO].file-test[39m[22m[39m
+✅ [32mCreated new worktree for [1mfile-test[22m from [1mmain[22m @ [1m[REPO].file-test[22m[39m
 🔄 [36mExecuting (--execute):[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test content'[0m[2m [0m[2m[36m>[0m[2m test.txt

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_existing.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_existing.snap
@@ -16,6 +16,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -30,6 +31,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mSwitched to worktree for [1mexisting-exec[22m @ [1m[REPO].existing-exec[39m[22m[39m
+⚪ Switched to worktree for [1mexisting-exec[22m @ [1m[REPO].existing-exec[22m
 🔄 [36mExecuting (--execute):[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'existing worktree'[0m[2m [0m[2m[36m>[0m[2m existing.txt

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_failure.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_failure.snap
@@ -17,6 +17,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -31,6 +32,6 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfail-test[22m from [1mmain[22m @ [1m[REPO].fail-test[39m[22m[39m
+✅ [32mCreated new worktree for [1mfail-test[22m from [1mmain[22m @ [1m[REPO].fail-test[22m[39m
 🔄 [36mExecuting (--execute):[39m
 [107m [0m  [2m[0m[2m[34mexit[0m[2m 1

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_multiline.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_multiline.snap
@@ -17,6 +17,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -34,7 +35,7 @@ line2
 line3
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mmultiline-test[22m from [1mmain[22m @ [1m[REPO].multiline-test[39m[22m[39m
+✅ [32mCreated new worktree for [1mmultiline-test[22m from [1mmain[22m @ [1m[REPO].multiline-test[22m[39m
 🔄 [36mExecuting (--execute):[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'line1'[0m[2m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'line2'[0m[2m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_success.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_success.snap
@@ -17,6 +17,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -32,6 +33,6 @@ exit_code: 0
 test output
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mexec-test[22m from [1mmain[22m @ [1m[REPO].exec-test[39m[22m[39m
+✅ [32mCreated new worktree for [1mexec-test[22m from [1mmain[22m @ [1m[REPO].exec-test[22m[39m
 🔄 [36mExecuting (--execute):[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test output'[0m[2m

--- a/tests/snapshots/integration__integration_tests__switch__switch_existing_internal.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_existing_internal.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -30,4 +31,4 @@ exit_code: 0
 cd '[REPO].existing-wt'
 
 ----- stderr -----
-✅ [32m[32mSwitched to worktree for [1mexisting-wt[22m @ [1m[REPO].existing-wt[39m[22m[39m
+⚪ Switched to worktree for [1mexisting-wt[22m @ [1m[REPO].existing-wt[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_internal_execute_exit_code.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_internal_execute_exit_code.snap
@@ -18,6 +18,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -34,6 +35,6 @@ cd '[REPO].exit-code-test'
 exit 42
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mexit-code-test[22m from [1mmain[22m @ [1m[REPO].exit-code-test[39m[22m[39m
+✅ [32mCreated new worktree for [1mexit-code-test[22m from [1mmain[22m @ [1m[REPO].exit-code-test[22m[39m
 🔄 [36mExecuting (--execute):[39m
 [107m [0m  [2m[0m[2m[34mexit[0m[2m 42

--- a/tests/snapshots/integration__integration_tests__switch__switch_internal_execute_output_then_exit.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_internal_execute_output_then_exit.snap
@@ -18,6 +18,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -35,7 +36,7 @@ echo 'doing work'
 exit 7
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1moutput-exit-test[22m from [1mmain[22m @ [1m[REPO].output-exit-test[39m[22m[39m
+✅ [32mCreated new worktree for [1moutput-exit-test[22m from [1mmain[22m @ [1m[REPO].output-exit-test[22m[39m
 🔄 [36mExecuting (--execute):[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'doing work'[0m[2m
 [107m [0m  [2m[0m[2m[34mexit[0m[2m 7

--- a/tests/snapshots/integration__integration_tests__switch__switch_internal_mode.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_internal_mode.snap
@@ -16,6 +16,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -31,4 +32,4 @@ exit_code: 0
 cd '[REPO].internal-test'
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1minternal-test[22m from [1mmain[22m @ [1m[REPO].internal-test[39m[22m[39m
+✅ [32mCreated new worktree for [1minternal-test[22m from [1mmain[22m @ [1m[REPO].internal-test[22m[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_internal_with_execute.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_internal_with_execute.snap
@@ -18,6 +18,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -35,7 +36,7 @@ echo 'line1'
 echo 'line2'
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mexec-internal[22m from [1mmain[22m @ [1m[REPO].exec-internal[39m[22m[39m
+✅ [32mCreated new worktree for [1mexec-internal[22m from [1mmain[22m @ [1m[REPO].exec-internal[22m[39m
 🔄 [36mExecuting (--execute):[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'line1'[0m[2m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'line2'[0m[2m

--- a/tests/snapshots/integration__integration_tests__switch__switch_main_branch_to_feature.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_main_branch_to_feature.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,5 +29,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mSwitched to worktree for [1mfeature-a[22m @ [1m[REPO].feature-a[39m[22m[39m
+✅ [32mSwitched to worktree for [1mfeature-a[22m @ [1m[REPO].feature-a[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_execute_still_runs.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_execute_still_runs.snap
@@ -18,6 +18,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -33,6 +34,6 @@ exit_code: 0
 execute command runs
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mno-hooks-test[22m from [1mmain[22m @ [1m[REPO].no-hooks-test[39m[22m[39m
+✅ [32mCreated new worktree for [1mno-hooks-test[22m from [1mmain[22m @ [1m[REPO].no-hooks-test[22m[39m
 🔄 [36mExecuting (--execute):[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'execute command runs'[0m[2m

--- a/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_existing.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_existing.snap
@@ -17,6 +17,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -32,6 +33,6 @@ exit_code: 0
 execute still runs
 
 ----- stderr -----
-✅ [32m[32mSwitched to worktree for [1mexisting-no-hooks[22m @ [1m[REPO].existing-no-hooks[39m[22m[39m
+⚪ Switched to worktree for [1mexisting-no-hooks[22m @ [1m[REPO].existing-no-hooks[22m
 🔄 [36mExecuting (--execute):[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'execute still runs'[0m[2m

--- a/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_skips_post_start.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_skips_post_start.snap
@@ -16,6 +16,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -30,5 +31,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mno-post-start[22m from [1mmain[22m @ [1m[REPO].no-post-start[39m[22m[39m
+✅ [32mCreated new worktree for [1mno-post-start[22m from [1mmain[22m @ [1m[REPO].no-post-start[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_with_force.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_with_force.snap
@@ -17,6 +17,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -31,5 +32,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mforce-no-hooks[22m from [1mmain[22m @ [1m[REPO].force-no-hooks[39m[22m[39m
+✅ [32mCreated new worktree for [1mforce-no-hooks[22m from [1mmain[22m @ [1m[REPO].force-no-hooks[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_no_warning_when_branch_matches.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_no_warning_when_branch_matches.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -30,4 +31,4 @@ exit_code: 0
 cd '[REPO].feature'
 
 ----- stderr -----
-✅ [32m[32mSwitched to worktree for [1mfeature[22m @ [1m[REPO].feature[39m[22m[39m
+⚪ Switched to worktree for [1mfeature[22m @ [1m[REPO].feature[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_path_mismatch_shows_hint.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_path_mismatch_shows_hint.snap
@@ -31,5 +31,5 @@ exit_code: 0
 cd '[PROJECT_ID]'
 
 ----- stderr -----
-✅ [32m[32mSwitched to worktree for [1mfeature[22m @ [1m[PROJECT_ID][39m[22m[39m
+⚪ Switched to worktree for [1mfeature[22m @ [1m[PROJECT_ID][22m
 🟡 [33mWorktree path doesn't match branch name; expected [1m[REPO].feature[22m [31m⚑[39m[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_primary_on_different_branch.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_primary_on_different_branch.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,5 +30,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfeature-from-main[22m from [1mmain[22m @ [1m[REPO].feature-from-main[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature-from-main[22m from [1mmain[22m @ [1m[REPO].feature-from-main[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_stale_history_to_a.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_stale_history_to_a.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,5 +29,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mSwitched to worktree for [1mbranch-a[22m @ [1m[REPO].branch-a[39m[22m[39m
+✅ [32mSwitched to worktree for [1mbranch-a[22m @ [1m[REPO].branch-a[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_stale_history_to_b.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_stale_history_to_b.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,5 +29,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mSwitched to worktree for [1mbranch-b[22m @ [1m[REPO].branch-b[39m[22m[39m
+✅ [32mSwitched to worktree for [1mbranch-b[22m @ [1m[REPO].branch-b[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_with_base.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_with_base.snap
@@ -17,6 +17,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -31,5 +32,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfeature-with-base[22m from [1mmain[22m @ [1m[REPO].feature-with-base[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature-with-base[22m from [1mmain[22m @ [1m[REPO].feature-with-base[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__user_hooks__no_verify_skips_all_hooks.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__no_verify_skips_all_hooks.snap
@@ -16,6 +16,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -30,5 +31,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_and_project_post_start.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_and_project_post_start.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,7 +30,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m
 🔄 [36mRunning user post-start [1mbg[22m:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'USER_POST_START'[0m[2m [0m[2m[36m>[0m[2m user_bg.txt

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_hook_template_vars.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_hook_template_vars.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -31,5 +32,5 @@ exit_code: 0
 ----- stderr -----
 🔄 [36mRunning user post-create [1mvars[22m:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'repo=repo branch=feature'[0m[2m [0m[2m[36m>[0m[2m template_vars.txt
-[0m✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+[0m✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_before_project.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_before_project.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -33,5 +34,5 @@ exit_code: 0
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'USER_HOOK'[0m[2m [0m[2m[36m>>[0m[2m hook_order.txt
 [0m🔄 [36mRunning project post-create:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'PROJECT_HOOK'[0m[2m [0m[2m[36m>>[0m[2m hook_order.txt
-[0m✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+[0m✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_no_approval.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_no_approval.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -31,5 +32,5 @@ exit_code: 0
 ----- stderr -----
 🔄 [36mRunning user post-create [1msetup[22m:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'NO_APPROVAL_NEEDED'[0m[2m [0m[2m[36m>[0m[2m no_approval.txt
-[0m✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+[0m✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_post_create_executes.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_post_create_executes.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -31,5 +32,5 @@ exit_code: 0
 ----- stderr -----
 🔄 [36mRunning user post-create [1mlog[22m:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'USER_POST_CREATE_RAN'[0m[2m [0m[2m[36m>[0m[2m user_hook_marker.txt
-[0m✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+[0m✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_post_create_failure.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_post_create_failure.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -32,5 +33,5 @@ exit_code: 0
 🔄 [36mRunning user post-create [1mfailing[22m:[39m
 [107m [0m  [2m[0m[2m[34mexit[0m[2m 1
 [0m🟡 [33mCommand [1mfailing[22m failed: exit status: 1[39m
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_post_start_executes.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_post_start_executes.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,7 +30,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m
 🔄 [36mRunning user post-start [1mbg[22m:[39m
 [107m [0m  [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'USER_POST_START_RAN'[0m[2m [0m[2m[36m>[0m[2m user_bg_marker.txt

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_post_start_skipped_no_verify.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_post_start_skipped_no_verify.snap
@@ -16,6 +16,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -30,5 +31,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-✅ [32m[32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[39m[22m[39m
+✅ [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO].feature[22m[39m
 💡 [2mRun [90mwt config shell install[39m to enable automatic cd[22m


### PR DESCRIPTION
## Summary
- Change `wt switch` messaging so that switching to an existing worktree uses `info_message` (⚪) instead of `success_message` (✅)
- The semantic distinction: success = something was created or changed; info = acknowledging state without creating anything
- Updated CLI output guidelines with "Success vs Info decision" table

**Before:**
```
✅ Switched to worktree for help-intro @ ~/workspace/worktrunk.help-intro
```

**After:**
```
⚪ Switched to worktree for help-intro @ ~/workspace/worktrunk.help-intro
```

## Test plan
- [x] All snapshot tests updated (85 files)
- [x] `cargo run -- hook pre-merge --force` passes
- [x] Demo GIFs regenerated and published

🤖 Generated with [Claude Code](https://claude.com/claude-code)