### PR TITLE
Fix flaky CI tests

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,17 @@
 [profile.default]
 slow-timeout = { period = "60s", terminate-after = 1 }
+
+# The ci_status tests spawn many parallel threads and processes (~30 threads, ~34
+# child processes each). Mark them as "heavy" so nextest limits how many run
+# concurrently. threads-required=4 means on an 8-core machine, only 2 of these
+# tests run at once instead of 8.
+[[profile.default.overrides]]
+filter = 'test(/integration_tests::ci_status::test_list_full/)'
+threads-required = 4
+
+# Windows has stricter file locking than macOS/Linux. The list tests run many parallel
+# git operations that can race for .git/config access, causing transient "Permission
+# denied" errors. Retry flaky list tests.
+[[profile.default.overrides]]
+filter = 'test(/integration_tests::list::/)'
+retries = { backoff = "exponential", count = 2, delay = "100ms" }


### PR DESCRIPTION
## Summary
- Limit parallelism for heavy ci_status tests using `threads-required = 4`
- Add retries for Windows list tests that hit file locking race conditions

## Background

**ci_status tests**: These tests spawn ~30 threads and ~34 child processes each.
When nextest runs multiple in parallel, the CI runner gets overwhelmed, causing
60s timeouts on macOS. Using `threads-required = 4` limits concurrent heavy tests.

**Windows list tests**: Windows has stricter file locking than macOS/Linux. The
parallel git operations in `wt list` can race for `.git/config` access, causing
transient "Permission denied" errors. Retries handle these rare race conditions.

## Test plan
- [x] CI passes on all platforms

🤖 Generated with [Claude Code](https://claude.com/claude-code)