### PR TITLE
Fix switch docs: show directory change before hooks

### DIFF
--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -26,8 +26,8 @@ For interactive selection, use [`wt select`](@/select.md).
 When the target branch has no worktree, worktrunk:
 
 1. Creates worktree at configured path
-2. Runs [post-create hooks](@/hook.md#post-create) (blocking)
-3. Switches to new directory
+2. Switches to new directory
+3. Runs [post-create hooks](@/hook.md#post-create) (blocking)
 4. Spawns [post-start hooks](@/hook.md#post-start) (background)
 
 The `--create` flag creates a new branch from the `--base` branch (defaults to default branch). Without `--create`, the branch must already exist.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2030,8 +2030,8 @@ For interactive selection, use [`wt select`](@/select.md).
 When the target branch has no worktree, worktrunk:
 
 1. Creates worktree at configured path
-2. Runs [post-create hooks](@/hook.md#post-create) (blocking)
-3. Switches to new directory
+2. Switches to new directory
+3. Runs [post-create hooks](@/hook.md#post-create) (blocking)
 4. Spawns [post-start hooks](@/hook.md#post-start) (background)
 
 The `--create` flag creates a new branch from the `--base` branch (defaults to default branch). Without `--create`, the branch must already exist.

--- a/tests/snapshots/integration__integration_tests__help__help_page_switch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_page_switch.snap
@@ -35,8 +35,8 @@ For interactive selection, use [`wt select`](@/select.md).
 When the target branch has no worktree, worktrunk:
 
 1. Creates worktree at configured path
-2. Runs [post-create hooks](@/hook.md#post-create) (blocking)
-3. Switches to new directory
+2. Switches to new directory
+3. Runs [post-create hooks](@/hook.md#post-create) (blocking)
 4. Spawns [post-start hooks](@/hook.md#post-start) (background)
 
 The `--create` flag creates a new branch from the `--base` branch (defaults to default branch). Without `--create`, the branch must already exist.

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -86,8 +86,8 @@ For interactive selection, use `wt select`.
 When the target branch has no worktree, worktrunk:
 
 1. Creates worktree at configured path
-2. Runs post-create hooks (blocking)
-3. Switches to new directory
+2. Switches to new directory
+3. Runs post-create hooks (blocking)
 4. Spawns post-start hooks (background)
 
 The [2m--create[0m flag creates a new branch from the [2m--base[0m branch (defaults to default branch). Without [2m--create[0m, the branch must already exist.


### PR DESCRIPTION
## Summary

- Reorder worktree creation steps to show "Switches to new directory" before hooks run
- Both post-create and post-start hooks run with the new worktree as their working directory
- The previous order implied post-create runs in the old directory

## Test plan

- [x] `cargo test` passes
- [x] Docs sync test passes
- [x] Help snapshots updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)