### PR TITLE
Show paths relative to main worktree in wt list

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3084,6 +3084,7 @@ dependencies = [
  "nix 0.30.1",
  "normalize-path",
  "osc8",
+ "pathdiff",
  "portable-pty",
  "rayon",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -97,6 +97,7 @@ osc8 = "0.1.0"
 home = "0.5.12"
 dirs = "6.0"
 normalize-path = "0.2.1"
+pathdiff = "0.2"
 which = "8.0"
 # Cross-platform path canonicalization that avoids Windows verbatim paths (\\?\)
 # which external tools like git cannot handle. On Unix, it's a no-op wrapper.

--- a/docs/content/claude-code.md
+++ b/docs/content/claude-code.md
@@ -16,11 +16,11 @@ The plugin adds status indicators to `wt list`:
 
 {% terminal() %}
 <span class="prompt">$</span> <span class="cmd">wt list</span>
-  <b>Branch</b>       <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>  <b>Path</b>                <b>Remote⇅</b>  <b>Commit</b>    <b>Age</b>   <b>Message</b>
-@ <b>main</b>             <span class=d>^</span>                         <b>./repo</b>                       <span class=d>a058e792</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
-+ feature-api      <span class=d>↑</span> 🤖              <span class=g>↑1</span>      ./repo.feature-api           <span class=d>95e48b49</span>  <span class=d>1d</span>    <span class=d>Add REST API endpoints</span>
-+ review-ui      <span class=c>?</span> <span class=d>↑</span> 💬              <span class=g>↑1</span>      ./repo.review-ui             <span class=d>46b6a187</span>  <span class=d>1d</span>    <span class=d>Add dashboard component</span>
-+ wip-docs       <span class=c>?</span> <span class=d>–</span>                         ./repo.wip-docs              <span class=d>a058e792</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
+  <b>Branch</b>       <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>  <b>Path</b>                 <b>Remote⇅</b>  <b>Commit</b>    <b>Age</b>   <b>Message</b>
+@ <b>main</b>             <span class=d>^</span>                         <b>.</b>                             <span class=d>a058e792</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
++ feature-api      <span class=d>↑</span> 🤖              <span class=g>↑1</span>      ../repo.feature-api           <span class=d>95e48b49</span>  <span class=d>1d</span>    <span class=d>Add REST API endpoints</span>
++ review-ui      <span class=c>?</span> <span class=d>↑</span> 💬              <span class=g>↑1</span>      ../repo.review-ui             <span class=d>46b6a187</span>  <span class=d>1d</span>    <span class=d>Add dashboard component</span>
++ wip-docs       <span class=c>?</span> <span class=d>–</span>                         ../repo.wip-docs              <span class=d>a058e792</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
 
 ⚪ <span class=d>Showing 4 worktrees, 2 with changes, 2 ahead</span>
 {% end %}

--- a/src/commands/list/collect.rs
+++ b/src/commands/list/collect.rs
@@ -702,7 +702,8 @@ pub fn collect(
     );
 
     // Calculate layout from items (worktrees, local branches, and remote branches)
-    let layout = super::layout::calculate_layout_from_basics(&all_items, skip_tasks);
+    let layout =
+        super::layout::calculate_layout_from_basics(&all_items, skip_tasks, &main_worktree.path);
 
     // Single-line invariant: use safe width to prevent line wrapping
     let max_width = super::layout::get_safe_list_width();
@@ -1029,7 +1030,10 @@ pub fn collect(
     // - Buffered: rendered final table (no progress bars)
     // JSON mode (render_table=false): no rendering, data returned for serialization
 
-    Ok(Some(super::model::ListData { items }))
+    Ok(Some(super::model::ListData {
+        items,
+        main_worktree_path: main_worktree.path.clone(),
+    }))
 }
 
 /// Sort items by timestamp descending (most recent first).

--- a/src/commands/list/model.rs
+++ b/src/commands/list/model.rs
@@ -250,6 +250,10 @@ pub struct ListItem {
 
 pub struct ListData {
     pub items: Vec<ListItem>,
+    /// Path to the main worktree, used for computing relative paths in display.
+    /// Currently only read by `select` command (unix-only).
+    #[cfg_attr(windows, allow(dead_code))]
+    pub main_worktree_path: std::path::PathBuf,
 }
 
 impl ListItem {

--- a/src/commands/list/render.rs
+++ b/src/commands/list/render.rs
@@ -397,7 +397,7 @@ impl LayoutConfig {
             column.render_cell(
                 &ctx,
                 &self.status_position_mask,
-                &self.common_prefix,
+                &self.main_worktree_path,
                 self.max_message_len,
             )
         })
@@ -416,7 +416,7 @@ impl LayoutConfig {
         let is_previous = wt_data.is_some_and(|d| d.is_previous);
         let shortened_path = item
             .worktree_path()
-            .map(|p| shorten_path(p, &self.common_prefix))
+            .map(|p| shorten_path(p, &self.main_worktree_path))
             .unwrap_or_default();
 
         let dim = Style::new().dimmed();
@@ -556,7 +556,7 @@ impl ColumnLayout {
         &self,
         ctx: &ListRowContext,
         status_mask: &PositionMask,
-        common_prefix: &Path,
+        main_worktree_path: &Path,
         max_message_len: usize,
     ) -> StyledLine {
         match self.kind {
@@ -636,7 +636,7 @@ impl ColumnLayout {
                     return StyledLine::new();
                 };
                 let mut cell = StyledLine::new();
-                let path_str = shorten_path(&data.path, common_prefix);
+                let path_str = shorten_path(&data.path, main_worktree_path);
                 if let Some(style) = ctx.text_style {
                     cell.push_styled(path_str, style);
                 } else {

--- a/src/commands/select.rs
+++ b/src/commands/select.rs
@@ -847,6 +847,7 @@ pub fn handle_select(is_directive_mode: bool) -> anyhow::Result<()> {
         &list_data.items,
         &skip_tasks,
         skim_list_width,
+        &list_data.main_worktree_path,
     );
 
     // Render header using layout system (need both plain and styled text for skim)

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_list_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_list_worktrees.snap
@@ -21,8 +21,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  Branch   Status        HEAD±    main↕  Path       Remote⇅  Commit    Age   Message
-@ main         ^                         ./main              6c3da842  1d    Initial commit on main
-+ feature      ↑                 ↑1      ./feature           72413a3b  1d    Work on feature
+  Branch   Status        HEAD±    main↕  Path        Remote⇅  Commit    Age   Message
+@ main         ^                         .                    6c3da842  1d    Initial commit on main
++ feature      ↑                 ↑1      ../feature           72413a3b  1d    Work on feature
 
 ⚪ Showing 2 worktrees, 1 ahead

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_filters_by_repo_owner.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_filters_by_repo_owner.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,8 +29,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m                                    [1m./repo[0m                   [4m[32m]8;;https://github.com/my-org/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature[0m      [2m_[22m                                    [2m./repo.feature[0m           [4m[32m]8;;https://github.com/my-org/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m                                    [1m.[0m                         [4m[32m]8;;https://github.com/my-org/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature[0m      [2m_[22m                                    [2m../repo.feature[0m           [4m[32m]8;;https://github.com/my-org/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_github_pr_conflicts.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_github_pr_conflicts.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,8 +29,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m                                    [1m./repo[0m                   [4m[33m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature[0m      [2m_[22m                                    [2m./repo.feature[0m           [4m[33m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m                                    [1m.[0m                         [4m[33m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature[0m      [2m_[22m                                    [2m../repo.feature[0m           [4m[33m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_github_pr_failed.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_github_pr_failed.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,8 +29,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m                                    [1m./repo[0m                   [4m[31m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature[0m      [2m_[22m                                    [2m./repo.feature[0m           [4m[31m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m                                    [1m.[0m                         [4m[31m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature[0m      [2m_[22m                                    [2m../repo.feature[0m           [4m[31m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_github_pr_passed.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_github_pr_passed.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,8 +29,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m                                    [1m./repo[0m                   [4m[32m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature[0m      [2m_[22m                                    [2m./repo.feature[0m           [4m[32m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m                                    [1m.[0m                         [4m[32m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature[0m      [2m_[22m                                    [2m../repo.feature[0m           [4m[32m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_github_pr_running.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_github_pr_running.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,8 +29,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m                                    [1m./repo[0m                   [4m[34m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature[0m      [2m_[22m                                    [2m./repo.feature[0m           [4m[34m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m                                    [1m.[0m                         [4m[34m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature[0m      [2m_[22m                                    [2m../repo.feature[0m           [4m[34m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_github_workflow_run.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_github_workflow_run.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,8 +29,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m                                    [1m./repo[0m                       [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature[0m      [2m_[22m                                    [2m./repo.feature[0m               [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m                                    [1m.[0m                             [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature[0m      [2m_[22m                                    [2m../repo.feature[0m               [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_github_workflow_running.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_github_workflow_running.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,8 +29,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m                                    [1m./repo[0m                       [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature[0m      [2m_[22m                                    [2m./repo.feature[0m               [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m                                    [1m.[0m                             [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature[0m      [2m_[22m                                    [2m../repo.feature[0m               [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_mixed_check_types.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_mixed_check_types.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,8 +29,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m                                    [1m./repo[0m                   [4m[34m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature[0m      [2m_[22m                                    [2m./repo.feature[0m           [4m[34m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m                                    [1m.[0m                         [4m[34m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature[0m      [2m_[22m                                    [2m../repo.feature[0m           [4m[34m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_no_ci_checks.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_no_ci_checks.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,8 +29,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m                                    [1m./repo[0m                   [4m[90m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature[0m      [2m_[22m                                    [2m./repo.feature[0m           [4m[90m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m                                    [1m.[0m                         [4m[90m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature[0m      [2m_[22m                                    [2m../repo.feature[0m           [4m[90m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_stale_pr.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_stale_pr.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,8 +29,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m                                    [1m./repo[0m                   [2m[4m[32m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ feature      [2m↑[22m                 [32m↑1[0m        [32m+1[0m       ./repo.feature           [2m[4m[32m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2m1b2eaadd[0m  [2m1d[0m    [2mLocal commit
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m                                    [1m.[0m                         [2m[4m[32m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ feature      [2m↑[22m                 [32m↑1[0m        [32m+1[0m       ../repo.feature           [2m[4m[32m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2m1b2eaadd[0m  [2m1d[0m    [2mLocal commit
 
 ⚪ [2mShowing 2 worktrees, 1 ahead

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_status_context_failure.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_status_context_failure.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,8 +29,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m                                    [1m./repo[0m                   [4m[31m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature[0m      [2m_[22m                                    [2m./repo.feature[0m           [4m[31m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m                                    [1m.[0m                         [4m[31m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature[0m      [2m_[22m                                    [2m../repo.feature[0m           [4m[31m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_status_context_pending.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_status_context_pending.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,8 +29,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m                                    [1m./repo[0m                   [4m[34m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature[0m      [2m_[22m                                    [2m./repo.feature[0m           [4m[34m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m                                    [1m.[0m                         [4m[34m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature[0m      [2m_[22m                                    [2m../repo.feature[0m           [4m[34m]8;;https://github.com/test-owner/test-repo/pull/1/●]8;;/[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__list__detached_head_in_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__list__detached_head_in_worktree.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,8 +28,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m        [2m^[22m                         [1m./repo[0m                   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2m-[0m          [31m⚑[39m[2m_[22m                         [2m./repo.feature[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m        [2m^[22m                         [1m.[0m                         [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2m-[0m          [31m⚑[39m[2m_[22m                         [2m../repo.feature[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__list__git_error_warning.snap
+++ b/tests/snapshots/integration__integration_tests__list__git_error_warning.snap
@@ -28,9 +28,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m                         [1m./repo[0m                   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ feature      [33m✗[39m                         ./repo.feature           [2m00000000[0m  [2m55y[0m   [2m
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m                         [1m.[0m                         [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ feature      [33m✗[39m                         ../repo.feature           [2m00000000[0m  [2m55y[0m   [2m
 
 ⚪ [2mShowing 2 worktrees
 🟡 [33mSome git operations failed:

--- a/tests/snapshots/integration__integration_tests__list__large_diffs_alignment.snap
+++ b/tests/snapshots/integration__integration_tests__list__large_diffs_alignment.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,10 +28,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m           [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                    [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m                 [2m^[22m                         [1m./repo[0m                           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ diverged          [36m![39m  [2m↑[22m 💬   [32m+40[0m  [31m-60[0m   [32m↑1[0m      ./repo.diverged                  [2ma86ce3fb[0m  [2m1d[0m    [2mDiverged commit
-+ feature-changes   [36m![39m[36m?[39m [2m↑[22m 🤖   [32m+50[0m [31m-100[0m   [32m↑1[0m      ./repo.feature-changes           [2m38944dae[0m  [2m1d[0m    [2mAdd 100 lines
-+ fix                [36m?[39m [2m–[22m 💬                      ./repo.fix                       [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m           [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                     [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m                 [2m^[22m                         [1m.[0m                                 [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ diverged          [36m![39m  [2m↑[22m 💬   [32m+40[0m  [31m-60[0m   [32m↑1[0m      ../repo.diverged                  [2ma86ce3fb[0m  [2m1d[0m    [2mDiverged commit
++ feature-changes   [36m![39m[36m?[39m [2m↑[22m 🤖   [32m+50[0m [31m-100[0m   [32m↑1[0m      ../repo.feature-changes           [2m38944dae[0m  [2m1d[0m    [2mAdd 100 lines
++ fix                [36m?[39m [2m–[22m 💬                      ../repo.fix                       [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 4 worktrees, 3 with changes, 2 ahead

--- a/tests/snapshots/integration__integration_tests__list__list_ordering_rules.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_ordering_rules.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,11 +28,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m           [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                    [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mfeature-current[0m      [2m↑[22m                 [32m↑1[0m      [1m./repo.feature-current[0m           [2m431987e2[0m  [2m23h[0m   [2mCommit at 01:00
-^ main                 [2m^[22m                         ./repo                           [2mb8b9f445[0m  [2m1d[0m    [2mInitial commit on main
-+ feature-newest       [2m↑[22m                 [32m↑1[0m      ./repo.feature-newest            [2m721211d9[0m  [2m21h[0m   [2mCommit at 03:00
-+ feature-middle       [2m↑[22m                 [32m↑1[0m      ./repo.feature-middle            [2ma84219ce[0m  [2m22h[0m   [2mCommit at 02:00
-+ feature-oldest       [2m↑[22m                 [32m↑1[0m      ./repo.feature-oldest            [2m9777b5e4[0m  [2m23h[0m   [2mCommit at 00:30
+  [1mBranch[0m           [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                     [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mfeature-current[0m      [2m↑[22m                 [32m↑1[0m      [1m../repo.feature-current[0m           [2m431987e2[0m  [2m23h[0m   [2mCommit at 01:00
+^ main                 [2m^[22m                         .                                 [2mb8b9f445[0m  [2m1d[0m    [2mInitial commit on main
++ feature-newest       [2m↑[22m                 [32m↑1[0m      ../repo.feature-newest            [2m721211d9[0m  [2m21h[0m   [2mCommit at 03:00
++ feature-middle       [2m↑[22m                 [32m↑1[0m      ../repo.feature-middle            [2ma84219ce[0m  [2m22h[0m   [2mCommit at 02:00
++ feature-oldest       [2m↑[22m                 [32m↑1[0m      ../repo.feature-oldest            [2m9777b5e4[0m  [2m23h[0m   [2mCommit at 00:30
 
 ⚪ [2mShowing 5 worktrees, 4 ahead

--- a/tests/snapshots/integration__integration_tests__list__list_primary_on_different_branch.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_primary_on_different_branch.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,9 +28,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m              [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mdevelop[0m       [31m⚑[39m[2m^[22m                         [1m./repo[0m                     [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-a[0m      [2m_[22m                         [2m./repo.feature-a[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-b[0m      [2m_[22m                         [2m./repo.feature-b[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m               [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mdevelop[0m       [31m⚑[39m[2m^[22m                         [1m.[0m                           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-a[0m      [2m_[22m                         [2m../repo.feature-a[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-b[0m      [2m_[22m                         [2m../repo.feature-b[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 3 worktrees

--- a/tests/snapshots/integration__integration_tests__list__list_with_c_flag.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_c_flag.snap
@@ -18,9 +18,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m              [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m           [2m^[22m                         [1m./repo[0m                     [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-a[0m      [2m_[22m                         [2m./repo.feature-a[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-b[0m      [2m_[22m                         [2m./repo.feature-b[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m               [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m           [2m^[22m                         [1m.[0m                           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-a[0m      [2m_[22m                         [2m../repo.feature-a[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-b[0m      [2m_[22m                         [2m../repo.feature-b[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 3 worktrees

--- a/tests/snapshots/integration__integration_tests__list__locked_no_reason.snap
+++ b/tests/snapshots/integration__integration_tests__list__locked_no_reason.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,8 +28,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m            [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                     [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m                  [2m^[22m                         [1m./repo[0m                            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mlocked-no-reason[0m     [33m⊞[39m[2m_[22m                         [2m./repo.locked-no-reason[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m            [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                      [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m                  [2m^[22m                         [1m.[0m                                  [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mlocked-no-reason[0m     [33m⊞[39m[2m_[22m                         [2m../repo.locked-no-reason[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__list__locked_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__list__locked_worktree.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,8 +28,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m          [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                   [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m                [2m^[22m                         [1m./repo[0m                          [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mlocked-feature[0m     [33m⊞[39m[2m_[22m                         [2m./repo.locked-feature[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m          [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                    [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m                [2m^[22m                         [1m.[0m                                [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mlocked-feature[0m     [33m⊞[39m[2m_[22m                         [2m../repo.locked-feature[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__list__long_commit_message.snap
+++ b/tests/snapshots/integration__integration_tests__list__long_commit_message.snap
@@ -28,8 +28,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m              [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m           [2m^[22m                         [1m./repo[0m                     [2mc80da958[0m  [2m1d[0m    [2mShort message
-+ [2mfeature-a[0m      [2m⊂[22m                     [2m[31m↓1[0m  [2m./repo.feature-a[0m           [2m0fcd1a46[0m  [2m1d[0m    [2mThis is a very long commit message that should test how the mes…
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m               [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m           [2m^[22m                         [1m.[0m                           [2mc80da958[0m  [2m1d[0m    [2mShort message
++ [2mfeature-a[0m      [2m⊂[22m                     [2m[31m↓1[0m  [2m../repo.feature-a[0m           [2m0fcd1a46[0m  [2m1d[0m    [2mThis is a very long commit message that should test how the me…
 
 ⚪ [2mShowing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__list__many_worktrees_varied.snap
+++ b/tests/snapshots/integration__integration_tests__list__many_worktrees_varied.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,11 +28,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m                      [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                               [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m                            [2m^[22m                         [1m./repo[0m                                      [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mmedium-name[0m                     [2m_[22m                         [2m./repo.medium-name[0m                          [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mshort[0m                           [2m_[22m                         [2m./repo.short[0m                                [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mvery-long-branch-name-here[0m      [2m_[22m                         [2m./repo.very-long-branch-name-here[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mwith-changes[0m                    [2m_[22m                         [2m./repo.with-changes[0m                         [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m                      [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                                [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m                            [2m^[22m                         [1m.[0m                                            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mmedium-name[0m                     [2m_[22m                         [2m../repo.medium-name[0m                          [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mshort[0m                           [2m_[22m                         [2m../repo.short[0m                                [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mvery-long-branch-name-here[0m      [2m_[22m                         [2m../repo.very-long-branch-name-here[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mwith-changes[0m                    [2m_[22m                         [2m../repo.with-changes[0m                         [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 5 worktrees

--- a/tests/snapshots/integration__integration_tests__list__maximum_status_symbols.snap
+++ b/tests/snapshots/integration__integration_tests__list__maximum_status_symbols.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,8 +29,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m[2m⇡[22m                                   [1m./repo[0m           [32m⇡1[0m          [2m9dd6c628[0m  [2m1d[0m    [2mMain advances
-+ feature  [36m+[39m[36m![39m[36m?[39m[33m⊞[39m[33m✗[39m[2m⇅[22m🤖    [32m+2[0m   [31m-2[0m   [32m↑2[0m  [2m[31m↓1[0m    [32m+3[0m   [31m-1[0m  ./repo.feature   [32m⇡1[0m  [2m[31m⇣1[0m      [2m88205002[0m  [2m1d[0m    [2mLocal commit
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m[2m⇡[22m                                   [1m.[0m                 [32m⇡1[0m          [2m9dd6c628[0m  [2m1d[0m    [2mMain advances
++ feature  [36m+[39m[36m![39m[36m?[39m[33m⊞[39m[33m✗[39m[2m⇅[22m🤖    [32m+2[0m   [31m-2[0m   [32m↑2[0m  [2m[31m↓1[0m    [32m+3[0m   [31m-1[0m  ../repo.feature   [32m⇡1[0m  [2m[31m⇣1[0m      [2m88205002[0m  [2m1d[0m    [2mLocal commit
 
 ⚪ [2mShowing 2 worktrees, 1 with changes, 1 ahead

--- a/tests/snapshots/integration__integration_tests__list__maximum_status_with_git_operation.snap
+++ b/tests/snapshots/integration__integration_tests__list__maximum_status_with_git_operation.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,8 +29,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m                                    [1m./repo[0m                       [2m1c3b3fec[0m  [2m1d[0m    [2mMain conflicting changes
-+ feature  [36m+[39m[36m![39m[36m?[39m[31m✘[39m[2m–[22m 🤖    [32m+7[0m                           ./repo.feature               [2m1c3b3fec[0m  [2m1d[0m    [2mMain conflicting changes
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m                                    [1m.[0m                             [2m1c3b3fec[0m  [2m1d[0m    [2mMain conflicting changes
++ feature  [36m+[39m[36m![39m[36m?[39m[31m✘[39m[2m–[22m 🤖    [32m+7[0m                           ../repo.feature               [2m1c3b3fec[0m  [2m1d[0m    [2mMain conflicting changes
 
 ⚪ [2mShowing 2 worktrees, 1 with changes

--- a/tests/snapshots/integration__integration_tests__list__maximum_working_tree_symbols.snap
+++ b/tests/snapshots/integration__integration_tests__list__maximum_working_tree_symbols.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,8 +28,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m                         [1m./repo[0m                   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ feature  [36m+[39m[36m![39m[36m?[39m [2m↑[22m       [32m+2[0m   [31m-3[0m   [32m↑1[0m      ./repo.feature           [2m095602ce[0m  [2m1d[0m    [2mAdd files
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m                         [1m.[0m                         [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ feature  [36m+[39m[36m![39m[36m?[39m [2m↑[22m       [32m+2[0m   [31m-3[0m   [32m↑1[0m      ../repo.feature           [2m095602ce[0m  [2m1d[0m    [2mAdd files
 
 ⚪ [2mShowing 2 worktrees, 1 with changes, 1 ahead

--- a/tests/snapshots/integration__integration_tests__list__multiple_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__list__multiple_worktrees.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,9 +28,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m              [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m           [2m^[22m                         [1m./repo[0m                     [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-a[0m      [2m_[22m                         [2m./repo.feature-a[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-b[0m      [2m_[22m                         [2m./repo.feature-b[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m               [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m           [2m^[22m                         [1m.[0m                           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-a[0m      [2m_[22m                         [2m../repo.feature-a[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-b[0m      [2m_[22m                         [2m../repo.feature-b[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 3 worktrees

--- a/tests/snapshots/integration__integration_tests__list__no_progressive_flag.snap
+++ b/tests/snapshots/integration__integration_tests__list__no_progressive_flag.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,8 +29,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m                         [1m./repo[0m                   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature[0m      [2m_[22m                         [2m./repo.feature[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m                         [1m.[0m                         [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature[0m      [2m_[22m                         [2m../repo.feature[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__list__previous_worktree_gutter.snap
+++ b/tests/snapshots/integration__integration_tests__list__previous_worktree_gutter.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,8 +28,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m                         [1m./repo[0m                   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-- [2mfeature[0m      [2m_[22m                         [2m./repo.feature[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m                         [1m.[0m                         [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+- [2mfeature[0m      [2m_[22m                         [2m../repo.feature[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__list__progressive_flag.snap
+++ b/tests/snapshots/integration__integration_tests__list__progressive_flag.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,9 +29,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m              [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m           [2m^[22m                         [1m./repo[0m                     [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-a[0m      [2m_[22m                         [2m./repo.feature-a[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-b[0m      [2m_[22m                         [2m./repo.feature-b[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m               [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m           [2m^[22m                         [1m.[0m                           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-a[0m      [2m_[22m                         [2m../repo.feature-a[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-b[0m      [2m_[22m                         [2m../repo.feature-b[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 3 worktrees

--- a/tests/snapshots/integration__integration_tests__list__progressive_with_branches.snap
+++ b/tests/snapshots/integration__integration_tests__list__progressive_with_branches.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,10 +30,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m              [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m           [2m^[22m                         [1m./repo[0m                     [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-a[0m      [2m_[22m                         [2m./repo.feature-a[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-  [2morphan-1[0m      [2m/[22m[2m_[22m                                                    [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-  [2morphan-2[0m      [2m/[22m[2m_[22m                                                    [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m               [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m           [2m^[22m                         [1m.[0m                           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-a[0m      [2m_[22m                         [2m../repo.feature-a[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [2morphan-1[0m      [2m/[22m[2m_[22m                                                     [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [2morphan-2[0m      [2m/[22m[2m_[22m                                                     [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 2 worktrees, 2 branches

--- a/tests/snapshots/integration__integration_tests__list__status_column_padding_emoji.snap
+++ b/tests/snapshots/integration__integration_tests__list__status_column_padding_emoji.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,10 +28,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m        [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                 [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m              [2m^[22m                         [1m./repo[0m                        [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ main-symbol       [2m↑[22m 💬              [32m↑1[0m      ./repo.main-symbol            [2mb69fe20d[0m  [2m1d[0m    [2mSymbol commit
-+ pr-link           [2m↑[22m 🤖              [32m↑1[0m      ./repo.pr-link                [2mf42f2185[0m  [2m1d[0m    [2mPR commit
-+ wli-sequence   [36m![39m[36m?[39m [2m↑[22m 🤖    [32m+1[0m [31m-112[0m   [32m↑1[0m      ./repo.wli-sequence           [2mc73070d4[0m  [2m1d[0m    [2mInitial content
+  [1mBranch[0m        [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m              [2m^[22m                         [1m.[0m                              [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ main-symbol       [2m↑[22m 💬              [32m↑1[0m      ../repo.main-symbol            [2mb69fe20d[0m  [2m1d[0m    [2mSymbol commit
++ pr-link           [2m↑[22m 🤖              [32m↑1[0m      ../repo.pr-link                [2mf42f2185[0m  [2m1d[0m    [2mPR commit
++ wli-sequence   [36m![39m[36m?[39m [2m↑[22m 🤖    [32m+1[0m [31m-112[0m   [32m↑1[0m      ../repo.wli-sequence           [2mc73070d4[0m  [2m1d[0m    [2mInitial content
 
 ⚪ [2mShowing 4 worktrees, 1 with changes, 3 ahead

--- a/tests/snapshots/integration__integration_tests__list__task_dag_full_with_diffs.snap
+++ b/tests/snapshots/integration__integration_tests__list__task_dag_full_with_diffs.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,9 +30,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m              [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m           [2m^[22m                                    [1m./repo[0m                         [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ feature-a    [36m?[39m [2m–[22m                                    ./repo.feature-a               [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m   [31m-1[0m  ./repo.feature-b               [2m86bdffd3[0m  [2m1d[0m    [2mTest commit
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m               [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m           [2m^[22m                                    [1m.[0m                               [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ feature-a    [36m?[39m [2m–[22m                                    ../repo.feature-a               [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m   [31m-1[0m  ../repo.feature-b               [2m86bdffd3[0m  [2m1d[0m    [2mTest commit
 
 ⚪ [2mShowing 3 worktrees, 1 with changes, 1 ahead

--- a/tests/snapshots/integration__integration_tests__list__task_dag_many_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__list__task_dag_many_worktrees.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,17 +29,17 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m      [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m               [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m            [2m^[22m                         [1m./repo[0m                      [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-1[0m       [2m_[22m                         [2m./repo.feature-1[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-10[0m      [2m_[22m                         [2m./repo.feature-10[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-2[0m       [2m_[22m                         [2m./repo.feature-2[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-3[0m       [2m_[22m                         [2m./repo.feature-3[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-4[0m       [2m_[22m                         [2m./repo.feature-4[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-5[0m       [2m_[22m                         [2m./repo.feature-5[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-6[0m       [2m_[22m                         [2m./repo.feature-6[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-7[0m       [2m_[22m                         [2m./repo.feature-7[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-8[0m       [2m_[22m                         [2m./repo.feature-8[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-9[0m       [2m_[22m                         [2m./repo.feature-9[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m      [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m            [2m^[22m                         [1m.[0m                            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-1[0m       [2m_[22m                         [2m../repo.feature-1[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-10[0m      [2m_[22m                         [2m../repo.feature-10[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-2[0m       [2m_[22m                         [2m../repo.feature-2[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-3[0m       [2m_[22m                         [2m../repo.feature-3[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-4[0m       [2m_[22m                         [2m../repo.feature-4[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-5[0m       [2m_[22m                         [2m../repo.feature-5[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-6[0m       [2m_[22m                         [2m../repo.feature-6[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-7[0m       [2m_[22m                         [2m../repo.feature-7[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-8[0m       [2m_[22m                         [2m../repo.feature-8[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-9[0m       [2m_[22m                         [2m../repo.feature-9[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 11 worktrees

--- a/tests/snapshots/integration__integration_tests__list__task_dag_multiple_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__list__task_dag_multiple_worktrees.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,10 +29,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m              [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m           [2m^[22m                         [1m./repo[0m                     [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-a[0m      [2m_[22m                         [2m./repo.feature-a[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-b[0m      [2m_[22m                         [2m./repo.feature-b[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-c[0m      [2m_[22m                         [2m./repo.feature-c[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m               [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m           [2m^[22m                         [1m.[0m                           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-a[0m      [2m_[22m                         [2m../repo.feature-a[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-b[0m      [2m_[22m                         [2m../repo.feature-b[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-c[0m      [2m_[22m                         [2m../repo.feature-c[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 4 worktrees

--- a/tests/snapshots/integration__integration_tests__list__task_dag_ordering_stability.snap
+++ b/tests/snapshots/integration__integration_tests__list__task_dag_ordering_stability.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,11 +29,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m           [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                    [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mfeature-current[0m      [2m↑[22m                 [32m↑1[0m      [1m./repo.feature-current[0m           [2m431987e2[0m  [2m23h[0m   [2mCommit at 01:00
-^ main                 [2m^[22m                         ./repo                           [2mb8b9f445[0m  [2m1d[0m    [2mInitial commit on main
-+ feature-newest       [2m↑[22m                 [32m↑1[0m      ./repo.feature-newest            [2m721211d9[0m  [2m21h[0m   [2mCommit at 03:00
-+ feature-middle       [2m↑[22m                 [32m↑1[0m      ./repo.feature-middle            [2ma84219ce[0m  [2m22h[0m   [2mCommit at 02:00
-+ feature-oldest       [2m↑[22m                 [32m↑1[0m      ./repo.feature-oldest            [2m9777b5e4[0m  [2m23h[0m   [2mCommit at 00:30
+  [1mBranch[0m           [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                     [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mfeature-current[0m      [2m↑[22m                 [32m↑1[0m      [1m../repo.feature-current[0m           [2m431987e2[0m  [2m23h[0m   [2mCommit at 01:00
+^ main                 [2m^[22m                         .                                 [2mb8b9f445[0m  [2m1d[0m    [2mInitial commit on main
++ feature-newest       [2m↑[22m                 [32m↑1[0m      ../repo.feature-newest            [2m721211d9[0m  [2m21h[0m   [2mCommit at 03:00
++ feature-middle       [2m↑[22m                 [32m↑1[0m      ../repo.feature-middle            [2ma84219ce[0m  [2m22h[0m   [2mCommit at 02:00
++ feature-oldest       [2m↑[22m                 [32m↑1[0m      ../repo.feature-oldest            [2m9777b5e4[0m  [2m23h[0m   [2mCommit at 00:30
 
 ⚪ [2mShowing 5 worktrees, 4 ahead

--- a/tests/snapshots/integration__integration_tests__list__task_dag_with_locked.snap
+++ b/tests/snapshots/integration__integration_tests__list__task_dag_with_locked.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,9 +29,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m           [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m        [2m^[22m                         [1m./repo[0m                  [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mlocked[0m     [33m⊞[39m[2m_[22m                         [2m./repo.locked[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mnormal[0m      [2m_[22m                         [2m./repo.normal[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m        [2m^[22m                         [1m.[0m                        [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mlocked[0m     [33m⊞[39m[2m_[22m                         [2m../repo.locked[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mnormal[0m      [2m_[22m                         [2m../repo.normal[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 3 worktrees

--- a/tests/snapshots/integration__integration_tests__list__task_dag_with_upstream.snap
+++ b/tests/snapshots/integration__integration_tests__list__task_dag_with_upstream.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,9 +30,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m[2m|[22m                                   [1m./repo[0m             [2m|[0m         [2mb8b9f445[0m  [2m1d[0m    [2mInitial commit on main
-+ ahead        [2m↑[22m[2m⇡[22m                [32m↑1[0m        [32m+1[0m       ./repo.ahead     [32m⇡1[0m          [2ma66d3071[0m  [2m1d[0m    [2mAhead commit
-+ [2min-sync[0m      [2m_[22m[2m|[22m                                   [2m./repo.in-sync[0m     [2m|[0m         [2mb8b9f445[0m  [2m1d[0m    [2mInitial commit on main
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m[2m|[22m                                   [1m.[0m                   [2m|[0m         [2mb8b9f445[0m  [2m1d[0m    [2mInitial commit on main
++ ahead        [2m↑[22m[2m⇡[22m                [32m↑1[0m        [32m+1[0m       ../repo.ahead     [32m⇡1[0m          [2ma66d3071[0m  [2m1d[0m    [2mAhead commit
++ [2min-sync[0m      [2m_[22m[2m|[22m                                   [2m../repo.in-sync[0m     [2m|[0m         [2mb8b9f445[0m  [2m1d[0m    [2mInitial commit on main
 
 ⚪ [2mShowing 3 worktrees, 1 ahead

--- a/tests/snapshots/integration__integration_tests__list__unicode_commit_message.snap
+++ b/tests/snapshots/integration__integration_tests__list__unicode_commit_message.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,8 +28,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m        [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                 [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m              [2m^[22m                         [1m./repo[0m                        [2md167d3cc[0m  [2m1d[0m    [2mFix bug with café ☕ handling
-+ [2mfeature-test[0m      [2m⊂[22m                     [2m[31m↓1[0m  [2m./repo.feature-test[0m           [2m96b95eab[0m  [2m1d[0m    [2mAdd support for 日本語 and émoji 🎉
+  [1mBranch[0m        [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m              [2m^[22m                         [1m.[0m                              [2md167d3cc[0m  [2m1d[0m    [2mFix bug with café ☕ handling
++ [2mfeature-test[0m      [2m⊂[22m                     [2m[31m↓1[0m  [2m../repo.feature-test[0m           [2m96b95eab[0m  [2m1d[0m    [2mAdd support for 日本語 and émoji 🎉
 
 ⚪ [2mShowing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__list__user_marker_special_chars.snap
+++ b/tests/snapshots/integration__integration_tests__list__user_marker_special_chars.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,9 +28,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m          [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m        [2m^[22m                         [1m./repo[0m                 [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2memoji[0m       [2m_[22m 🔄                      [2m./repo.emoji[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mmulti[0m       [2m_[22m 👨‍💻                      [2m./repo.multi[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m           [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m        [2m^[22m                         [1m.[0m                       [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2memoji[0m       [2m_[22m 🔄                      [2m../repo.emoji[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mmulti[0m       [2m_[22m 👨‍💻                      [2m../repo.multi[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 3 worktrees

--- a/tests/snapshots/integration__integration_tests__list__with_branches_flag.snap
+++ b/tests/snapshots/integration__integration_tests__list__with_branches_flag.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,11 +29,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m                    [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                          [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m                          [2m^[22m                         [1m./repo[0m                                 [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-with-worktree[0m         [2m_[22m                         [2m./repo.feature-with-worktree[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-  [2manother-branch[0m               [2m/[22m[2m_[22m                                                                [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-  [2mfeature-without-worktree[0m     [2m/[22m[2m_[22m                                                                [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-  [2mfix-bug[0m                      [2m/[22m[2m_[22m                                                                [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m                    [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                           [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m                          [2m^[22m                         [1m.[0m                                       [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-with-worktree[0m         [2m_[22m                         [2m../repo.feature-with-worktree[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [2manother-branch[0m               [2m/[22m[2m_[22m                                                                 [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [2mfeature-without-worktree[0m     [2m/[22m[2m_[22m                                                                 [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [2mfix-bug[0m                      [2m/[22m[2m_[22m                                                                 [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 2 worktrees, 3 branches

--- a/tests/snapshots/integration__integration_tests__list__with_branches_flag_none_available.snap
+++ b/tests/snapshots/integration__integration_tests__list__with_branches_flag_none_available.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,9 +29,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m              [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m           [2m^[22m                         [1m./repo[0m                     [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-a[0m      [2m_[22m                         [2m./repo.feature-a[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-b[0m      [2m_[22m                         [2m./repo.feature-b[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m               [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m           [2m^[22m                         [1m.[0m                           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-a[0m      [2m_[22m                         [2m../repo.feature-a[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-b[0m      [2m_[22m                         [2m../repo.feature-b[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 3 worktrees

--- a/tests/snapshots/integration__integration_tests__list__with_remotes_filters_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__list__with_remotes_filters_worktrees.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -28,9 +29,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m                 [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                          [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m                       [2m^[22m[2m|[22m                        [1m./repo[0m                           [2m|[0m     [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mfeature-with-worktree[0m      [2m_[22m                         [2m./repo.feature-with-worktree[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-  [2morigin/remote-only[0m        [2m/[22m[2m_[22m                                                                [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m                 [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                           [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m                       [2m^[22m[2m|[22m                        [1m.[0m                                 [2m|[0m     [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature-with-worktree[0m      [2m_[22m                         [2m../repo.feature-with-worktree[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [2morigin/remote-only[0m        [2m/[22m[2m_[22m                                                                 [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 2 worktrees, 1 remote branches

--- a/tests/snapshots/integration__integration_tests__list__with_upstream_tracking.snap
+++ b/tests/snapshots/integration__integration_tests__list__with_upstream_tracking.snap
@@ -15,6 +15,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,12 +30,12 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m       [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m                [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m             [2m^[22m[2m|[22m                                   [1m./repo[0m                 [2m|[0m         [2mb8b9f445[0m  [2m1d[0m    [2mInitial commit on main
-+ ahead            [2m↑[22m[2m⇡[22m                [32m↑2[0m        [32m+2[0m       ./repo.ahead         [32m⇡2[0m          [2m9c8b56b3[0m  [2m1d[0m    [2mAhead commit 2
-+ [2mbehind[0m           [2m_[22m[2m⇣[22m                                   [2m./repo.behind[0m            [2m[31m⇣1[0m      [2mb8b9f445[0m  [2m1d[0m    [2mInitial commit on main
-+ diverged         [2m↑[22m[2m⇅[22m                [32m↑1[0m        [32m+1[0m       ./repo.diverged      [32m⇡1[0m  [2m[31m⇣1[0m      [2m3b16f5c5[0m  [2m1d[0m    [2mDiverged local commit
-+ [2min-sync[0m          [2m_[22m[2m|[22m                                   [2m./repo.in-sync[0m         [2m|[0m         [2mb8b9f445[0m  [2m1d[0m    [2mInitial commit on main
-+ [2mno-upstream[0m      [2m_[22m                                    [2m./repo.no-upstream[0m               [2mb8b9f445[0m  [2m1d[0m    [2mInitial commit on main
+  [1mBranch[0m       [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m                 [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m             [2m^[22m[2m|[22m                                   [1m.[0m                       [2m|[0m         [2mb8b9f445[0m  [2m1d[0m    [2mInitial commit on main
++ ahead            [2m↑[22m[2m⇡[22m                [32m↑2[0m        [32m+2[0m       ../repo.ahead         [32m⇡2[0m          [2m9c8b56b3[0m  [2m1d[0m    [2mAhead commit 2
++ [2mbehind[0m           [2m_[22m[2m⇣[22m                                   [2m../repo.behind[0m            [2m[31m⇣1[0m      [2mb8b9f445[0m  [2m1d[0m    [2mInitial commit on main
++ diverged         [2m↑[22m[2m⇅[22m                [32m↑1[0m        [32m+1[0m       ../repo.diverged      [32m⇡1[0m  [2m[31m⇣1[0m      [2m3b16f5c5[0m  [2m1d[0m    [2mDiverged local commit
++ [2min-sync[0m          [2m_[22m[2m|[22m                                   [2m../repo.in-sync[0m         [2m|[0m         [2mb8b9f445[0m  [2m1d[0m    [2mInitial commit on main
++ [2mno-upstream[0m      [2m_[22m                                    [2m../repo.no-upstream[0m               [2mb8b9f445[0m  [2m1d[0m    [2mInitial commit on main
 
 ⚪ [2mShowing 6 worktrees, 2 ahead

--- a/tests/snapshots/integration__integration_tests__list__with_user_marker.snap
+++ b/tests/snapshots/integration__integration_tests__list__with_user_marker.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,10 +28,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m       [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m             [2m^[22m                         [1m./repo[0m                       [2ma058e792[0m  [2m1d[0m    [2mInitial commit
-+ feature-api      [2m↑[22m 🤖              [32m↑1[0m      ./repo.feature-api           [2m95e48b49[0m  [2m1d[0m    [2mAdd REST API endpoints
-+ review-ui      [36m?[39m [2m↑[22m 💬              [32m↑1[0m      ./repo.review-ui             [2m46b6a187[0m  [2m1d[0m    [2mAdd dashboard component
-+ wip-docs       [36m?[39m [2m–[22m                         ./repo.wip-docs              [2ma058e792[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m       [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                 [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m             [2m^[22m                         [1m.[0m                             [2ma058e792[0m  [2m1d[0m    [2mInitial commit
++ feature-api      [2m↑[22m 🤖              [32m↑1[0m      ../repo.feature-api           [2m95e48b49[0m  [2m1d[0m    [2mAdd REST API endpoints
++ review-ui      [36m?[39m [2m↑[22m 💬              [32m↑1[0m      ../repo.review-ui             [2m46b6a187[0m  [2m1d[0m    [2mAdd dashboard component
++ wip-docs       [36m?[39m [2m–[22m                         ../repo.wip-docs              [2ma058e792[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 4 worktrees, 2 with changes, 2 ahead

--- a/tests/snapshots/integration__integration_tests__list_column_alignment__status_column_alignment_check.snap
+++ b/tests/snapshots/integration__integration_tests__list_column_alignment__status_column_alignment_check.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,8 +28,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m         [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m        [2m^[22m                         [1m./repo[0m                [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ test     [36m![39m[36m?[39m [2m↑[22m       [32m+1[0m   [31m-1[0m   [32m↑1[0m      ./repo.test           [2m689d5d16[0m  [2m1d[0m    [2mTest
+  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m          [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m        [2m^[22m                         [1m.[0m                      [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ test     [36m![39m[36m?[39m [2m↑[22m       [32m+1[0m   [31m-1[0m   [32m↑1[0m      ../repo.test           [2m689d5d16[0m  [2m1d[0m    [2mTest
 
 ⚪ [2mShowing 2 worktrees, 1 with changes, 1 ahead

--- a/tests/snapshots/integration__integration_tests__list_column_alignment__status_column_width_consistency.snap
+++ b/tests/snapshots/integration__integration_tests__list_column_alignment__status_column_width_consistency.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,9 +28,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m                         [1m./repo[0m                   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ complex  [36m+[39m [36m?[39m [2m↑[22m       [32m+1[0m   [31m-1[0m   [32m↑1[0m      ./repo.complex           [2m42162296[0m  [2m1d[0m    [2mComplex
-+ simple     [36m?[39m [2m↑[22m                 [32m↑1[0m      ./repo.simple            [2m63ee5cb5[0m  [2m1d[0m    [2mSimple
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m                         [1m.[0m                         [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ complex  [36m+[39m [36m?[39m [2m↑[22m       [32m+1[0m   [31m-1[0m   [32m↑1[0m      ../repo.complex           [2m42162296[0m  [2m1d[0m    [2mComplex
++ simple     [36m?[39m [2m↑[22m                 [32m↑1[0m      ../repo.simple            [2m63ee5cb5[0m  [2m1d[0m    [2mSimple
 
 ⚪ [2mShowing 3 worktrees, 2 with changes, 2 ahead

--- a/tests/snapshots/integration__integration_tests__security__commit_message_with_directive_not_executed.snap
+++ b/tests/snapshots/integration__integration_tests__security__commit_message_with_directive_not_executed.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,8 +28,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m         [2m^[22m                         [1m./repo[0m                   [2m85d55864[0m  [2m1d[0m    [2mFix bug __WORKTRUNK_EXEC__echo PWNED > /tmp/hacked4
-+ [2mfeature[0m      [2m_[22m                         [2m./repo.feature[0m           [2m85d55864[0m  [2m1d[0m    [2mFix bug __WORKTRUNK_EXEC__echo PWNED > /tmp/hacked4
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m         [2m^[22m                         [1m.[0m                         [2m85d55864[0m  [2m1d[0m    [2mFix bug __WORKTRUNK_EXEC__echo PWNED > /tmp/hacked4
++ [2mfeature[0m      [2m_[22m                         [2m../repo.feature[0m           [2m85d55864[0m  [2m1d[0m    [2mFix bug __WORKTRUNK_EXEC__echo PWNED > /tmp/hacked4
 
 ⚪ [2mShowing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_empty_diffs.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_empty_diffs.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,10 +28,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m           [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                    [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m                 [2m^[22m                         [1m./repo[0m                           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2malso-no-changes[0m      [2m_[22m                         [2m./repo.also-no-changes[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mno-changes[0m           [2m_[22m                         [2m./repo.no-changes[0m                [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ with-changes      [36m![39m  [2m–[22m       [32m+1[0m   [31m-1[0m           ./repo.with-changes              [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m           [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                     [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m                 [2m^[22m                         [1m.[0m                                 [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2malso-no-changes[0m      [2m_[22m                         [2m../repo.also-no-changes[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mno-changes[0m           [2m_[22m                         [2m../repo.no-changes[0m                [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ with-changes      [36m![39m  [2m–[22m       [32m+1[0m   [31m-1[0m           ../repo.with-changes              [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 4 worktrees, 1 with changes

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_extreme_diffs.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_extreme_diffs.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,9 +28,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m         [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m        [2m^[22m                         [1m./repo[0m                [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ huge      [36m?[39m [2m–[22m                         ./repo.huge           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ tiny     [36m![39m  [2m–[22m       [32m+1[0m   [31m-1[0m           ./repo.tiny           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m          [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m        [2m^[22m                         [1m.[0m                      [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ huge      [36m?[39m [2m–[22m                         ../repo.huge           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ tiny     [36m![39m  [2m–[22m       [32m+1[0m   [31m-1[0m           ../repo.tiny           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 3 worktrees, 2 with changes

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_varying_diffs.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_varying_diffs.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,10 +28,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m          [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                   [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m                [2m^[22m                         [1m./repo[0m                          [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ feature-large     [36m?[39m [2m–[22m                         ./repo.feature-large            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ feature-medium    [36m?[39m [2m–[22m                         ./repo.feature-medium           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ feature-small     [36m?[39m [2m–[22m                         ./repo.feature-small            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m          [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                    [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m                [2m^[22m                         [1m.[0m                                [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ feature-large     [36m?[39m [2m–[22m                         ../repo.feature-large            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ feature-medium    [36m?[39m [2m–[22m                         ../repo.feature-medium           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ feature-small     [36m?[39m [2m–[22m                         ../repo.feature-small            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 4 worktrees, 3 with changes

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__long_branch_names.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__long_branch_names.snap
@@ -28,10 +28,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m                            [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                                     [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m                                  [2m^[22m                         [1m./repo[0m                                            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2manother-extremely-long-name-here[0m      [2m_[22m                         [2m./repo.another-extremely-long-name-here[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mshort[0m                                 [2m_[22m                         [2m./repo.short[0m                                      [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mvery-long-feature-branch-name[0m         [2m_[22m                         [2m./repo.very-long-feature-branch-name[0m              [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m                            [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                                      [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m                                  [2m^[22m                         [1m.[0m                                                  [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2manother-extremely-long-name-here[0m      [2m_[22m                         [2m../repo.another-extremely-long-name-here[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mshort[0m                                 [2m_[22m                         [2m../repo.short[0m                                      [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mvery-long-feature-branch-name[0m         [2m_[22m                         [2m../repo.very-long-feature-branch-name[0m              [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 4 worktrees

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__short_branch_names.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__short_branch_names.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,10 +28,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m        [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m        [2m^[22m                         [1m./repo[0m               [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2ma[0m           [2m_[22m                         [2m./repo.a[0m             [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mbb[0m          [2m_[22m                         [2m./repo.bb[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mccc[0m         [2m_[22m                         [2m./repo.ccc[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m         [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m        [2m^[22m                         [1m.[0m                     [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2ma[0m           [2m_[22m                         [2m../repo.a[0m             [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mbb[0m          [2m_[22m                         [2m../repo.bb[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mccc[0m         [2m_[22m                         [2m../repo.ccc[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 4 worktrees

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__unicode_branch_names.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__unicode_branch_names.snap
@@ -13,6 +13,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -27,10 +28,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m           [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ [1mmain[0m        [2m^[22m                         [1m./repo[0m                  [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mcafe[0m        [2m_[22m                         [2m./repo.cafe[0m             [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mnaive[0m       [2m_[22m                         [2m./repo.naive[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
-+ [2mresume[0m      [2m_[22m                         [2m./repo.resume[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m            [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [1mmain[0m        [2m^[22m                         [1m.[0m                        [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mcafe[0m        [2m_[22m                         [2m../repo.cafe[0m             [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mnaive[0m       [2m_[22m                         [2m../repo.naive[0m            [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mresume[0m      [2m_[22m                         [2m../repo.resume[0m           [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
 
 ⚪ [2mShowing 4 worktrees


### PR DESCRIPTION
## Summary

- Paths in `wt list` are now shown relative to the main worktree instead of a computed common prefix
- Main worktree shows as `.`, children as `./subdir`, siblings as `../project.feature`
- Fixes confusing output when worktrees are in unrelated locations (common prefix degenerating to `/`)

## Test plan

- [x] Unit tests updated for new `shorten_path` behavior
- [x] All integration test snapshots updated
- [x] Pre-commit lints pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)