### PR TITLE
Fix broken anchor link in remove.md docs

### DIFF
--- a/docs/content/remove.md
+++ b/docs/content/remove.md
@@ -61,7 +61,7 @@ Removal runs in the background by default (returns immediately). Logs are writte
 
 ## Shortcuts
 
-`@` (current), `-` (previous), `^` (main worktree). See [wt switch](@/switch.md#argument-resolution) for argument resolution.
+`@` (current), `-` (previous), `^` (main worktree). See [wt switch](@/switch.md#shortcuts).
 
 ## See also
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2236,7 +2236,7 @@ Removal runs in the background by default (returns immediately). Logs are writte
 
 ## Shortcuts
 
-`@` (current), `-` (previous), `^` (main worktree). See [wt switch](@/switch.md#argument-resolution) for argument resolution.
+`@` (current), `-` (previous), `^` (main worktree). See [wt switch](@/switch.md#shortcuts).
 
 ## See also
 

--- a/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
@@ -9,6 +9,7 @@ info:
     CLICOLOR_FORCE: "1"
     COLUMNS: "150"
     GIT_EDITOR: ""
+    RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
 ---
@@ -102,7 +103,7 @@ in the foreground.
 
 [32mShortcuts
 
-[2m@[0m (current), [2m-[0m (previous), [2m^[0m (main worktree). See wt switch for argument resolution.
+[2m@[0m (current), [2m-[0m (previous), [2m^[0m (main worktree). See wt switch.
 
 [32mSee also
 


### PR DESCRIPTION
## Summary
- Fix broken anchor link: `@/switch.md#argument-resolution` → `@/switch.md#shortcuts`

The docs linked to a non-existent `#argument-resolution` anchor. The correct section in switch.md is named "Shortcuts".

This fixes the `publish-docs` workflow that has been failing since commit bb86da25.

🤖 Generated with [Claude Code](https://claude.com/claude-code)