### PR TITLE
Fix piped output routing for shell wrapper

### DIFF
--- a/.claude/rules/cli-output-formatting.md
+++ b/.claude/rules/cli-output-formatting.md
@@ -239,15 +239,18 @@ messages. Currently being trialed — expand to other commands if it works well.
 **Both modes write all messages to stderr.** stdout is reserved for structured
 data:
 
-- **stdout**: JSON output (`--format=json`), shell scripts (directive mode)
+- **stdout**: Data output (`--format=json`, `--show-prompt`, `--claude-code`),
+  shell scripts (directive mode)
 - **stderr**: All user-facing messages (progress, success, errors, hints,
   gutter, etc.)
 
 **Directive mode** additionally emits a shell script to stdout at the end.
 
-Use the output system (`output::print()` with message formatting functions) to
-handle both modes automatically. Never write directly to stdout/stderr in
-command code.
+Use the output system (`output::print()`, `output::data()`) to handle both modes
+automatically. Never write directly to stdout/stderr in command code.
+
+For the full architecture (piped output bypass, mode selection), see
+`output-system-architecture.md`.
 
 ```rust
 // GOOD - use output system (handles both modes)

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -141,6 +141,25 @@ $ cargo install worktrunk --no-default-features
 
 This disables bash syntax highlighting in command output but keeps all core functionality. The syntax highlighting feature requires C99 compiler support and can fail on older systems or minimal Docker images.
 
+## Why does JSON output go to stderr?
+
+When run interactively (not piped), JSON appears on stderr rather than stdout. The shell wrapper captures stdout to enable directory changing (`wt switch` runs `cd` in the caller's shell). With stdout captured for eval, data output goes to stderr.
+
+When piping or redirecting, the wrapper detects this and runs the binary directly:
+
+```bash
+wt list --format=json | jq .           # Works - JSON flows to jq
+wt list --format=json > worktrees.json # Works - JSON goes to file
+```
+
+To force stdout interactively, bypass the wrapper with `command`:
+
+```bash
+command wt list --format=json          # Outputs to stdout
+```
+
+This applies to all data-producing flags (`--format=json`, `--show-prompt`, etc.). We're open to better ideas — [let us know](https://github.com/max-sixty/worktrunk/issues) if you have one.
+
 ## Running tests (for contributors)
 
 ### Quick tests

--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -123,7 +123,7 @@ fn format_directory_fish_style(path: &Path) -> String {
 
 /// Run the statusline command.
 ///
-/// Output uses `output::data_raw()` which routes based on mode:
+/// Output uses `output::data()` which routes based on mode:
 /// - Interactive: stdout (for shell prompts)
 /// - Directive: stderr (stdout reserved for shell script)
 pub fn run(claude_code: bool) -> Result<()> {
@@ -201,7 +201,7 @@ pub fn run(claude_code: bool) -> Result<()> {
         use worktrunk::styling::fix_dim_after_color_reset;
         let reset = anstyle::Reset;
         let output = fix_dim_after_color_reset(&output);
-        output::data_raw(format!("{reset} {output}"))?;
+        output::data(format!("{reset} {output}"))?;
     }
 
     Ok(())

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -54,8 +54,8 @@ pub mod handlers;
 
 // Re-export the public API
 pub use global::{
-    OutputMode, blank, change_directory, data, data_raw, execute, flush, flush_for_stderr_prompt,
-    gutter, initialize, print, shell_integration_hint, table, terminate_output,
+    OutputMode, blank, change_directory, data, execute, flush, flush_for_stderr_prompt, gutter,
+    initialize, print, shell_integration_hint, table, terminate_output,
 };
 // Re-export output handlers
 pub use handlers::{

--- a/templates/bash.sh
+++ b/templates/bash.sh
@@ -36,6 +36,14 @@ if command -v {{ cmd }} >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
             return "$exit_code"
         fi
 
+        # If stdout is not a terminal (piped/redirected), run directly.
+        # This allows `wt list --format=json | jq` to work - the output flows
+        # through instead of being captured and eval'd as shell script.
+        if [[ ! -t 1 ]]; then
+            command "${WORKTRUNK_BIN:-{{ cmd }}}" "${args[@]}"
+            return
+        fi
+
         wt_exec --internal "${args[@]}"
     }
 

--- a/templates/fish.fish
+++ b/templates/fish.fish
@@ -49,6 +49,15 @@ if type -q {{ cmd }}; or test -n "$WORKTRUNK_BIN"
             return $exit_code
         end
 
+        # If stdout is not a terminal (piped/redirected), run directly.
+        # This allows `wt list --format=json | jq` to work - the output flows
+        # through instead of being captured and eval'd as shell script.
+        if not isatty stdout
+            test -n "$WORKTRUNK_BIN"; or set -l WORKTRUNK_BIN (type -P {{ cmd }})
+            command $WORKTRUNK_BIN $args
+            return $status
+        end
+
         wt_exec --internal $args
     end
 

--- a/templates/powershell.ps1
+++ b/templates/powershell.ps1
@@ -17,6 +17,14 @@ if (Get-Command {{ cmd }} -ErrorAction SilentlyContinue) {
 
         $wtBin = (Get-Command {{ cmd }} -CommandType Application).Source
 
+        # If output is redirected (piped), run directly without wrapper.
+        # This allows `wt list --format=json | ConvertFrom-Json` to work - the output
+        # flows through instead of being captured and Invoke-Expression'd.
+        if ([Console]::IsOutputRedirected) {
+            & $wtBin @Arguments
+            return $LASTEXITCODE
+        }
+
         # Run wt with --internal=powershell
         # stdout is captured for Invoke-Expression (contains Set-Location directives)
         # stderr passes through to console in real-time (user messages, progress, errors)

--- a/templates/zsh.zsh
+++ b/templates/zsh.zsh
@@ -39,6 +39,14 @@ if command -v {{ cmd }} >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
             return "$exit_code"
         fi
 
+        # If stdout is not a terminal (piped/redirected), run directly.
+        # This allows `wt list --format=json | jq` to work - the output flows
+        # through instead of being captured and eval'd as shell script.
+        if [[ ! -t 1 ]]; then
+            command "${WORKTRUNK_BIN:-{{ cmd }}}" "${args[@]}"
+            return
+        fi
+
         wt_exec --internal "${args[@]}"
     }
 

--- a/tests/snapshots/integration__integration_tests__init__init_bash.snap
+++ b/tests/snapshots/integration__integration_tests__init__init_bash.snap
@@ -16,10 +16,12 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
     PATH: "[PATH]"
+    RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
@@ -78,6 +80,14 @@ wt_exec() {
                 fi
             fi
             return "$exit_code"
+        fi
+
+        # If stdout is not a terminal (piped/redirected), run directly.
+        # This allows `wt list --format=json | jq` to work - the output flows
+        # through instead of being captured and eval'd as shell script.
+        if [[ ! -t 1 ]]; then
+            command "${WORKTRUNK_BIN:-wt}" "${args[@]}"
+            return
         fi
 
         wt_exec --internal "${args[@]}"

--- a/tests/snapshots/integration__integration_tests__init__init_fish.snap
+++ b/tests/snapshots/integration__integration_tests__init__init_fish.snap
@@ -16,10 +16,12 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
     PATH: "[PATH]"
+    RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
@@ -77,6 +79,15 @@ if type -q wt; or test -n "$WORKTRUNK_BIN"
                 end
             end
             return $exit_code
+        end
+
+        # If stdout is not a terminal (piped/redirected), run directly.
+        # This allows `wt list --format=json | jq` to work - the output flows
+        # through instead of being captured and eval'd as shell script.
+        if not isatty stdout
+            test -n "$WORKTRUNK_BIN"; or set -l WORKTRUNK_BIN (type -P wt)
+            command $WORKTRUNK_BIN $args
+            return $status
         end
 
         wt_exec --internal $args

--- a/tests/snapshots/integration__integration_tests__init__init_zsh.snap
+++ b/tests/snapshots/integration__integration_tests__init__init_zsh.snap
@@ -16,10 +16,12 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
     PATH: "[PATH]"
+    RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
@@ -81,6 +83,14 @@ wt_exec() {
                 fi
             fi
             return "$exit_code"
+        fi
+
+        # If stdout is not a terminal (piped/redirected), run directly.
+        # This allows `wt list --format=json | jq` to work - the output flows
+        # through instead of being captured and eval'd as shell script.
+        if [[ ! -t 1 ]]; then
+            command "${WORKTRUNK_BIN:-wt}" "${args[@]}"
+            return
         fi
 
         wt_exec --internal "${args[@]}"


### PR DESCRIPTION
## Summary

- Shell wrappers now detect when stdout is piped/redirected and run the binary directly (without `--internal`)
- Enables `wt list --format=json | jq`, `wt step commit --show-prompt | llm`, and file redirection
- Consolidates `output::data()` and `output::data_raw()` into a single function
- Adds FAQ entry explaining the stdout/stderr trade-off
- Updates documentation for output system architecture

## Test plan

- [ ] Verify `wt list --format=json | jq .` works (JSON flows to jq)
- [ ] Verify `wt list --format=json > file.json` works (JSON goes to file)
- [ ] Verify interactive `wt list --format=json` still shows output (on stderr, visible to user)
- [ ] Verify Claude Code statusline still works (`wt list statusline --claude-code`)
- [ ] All integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)