### PR TITLE
Fix piped output routing for shell wrapper

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -138,6 +138,25 @@ $ cargo install worktrunk --no-default-features
 
 This disables bash syntax highlighting in command output but keeps all core functionality. The syntax highlighting feature requires C99 compiler support and can fail on older systems or minimal Docker images.
 
+## Why does JSON output go to stderr?
+
+The `wt` shell function captures stdout so it can eval the output as shell script — this is how `wt switch` runs `cd` in the caller's shell. With stdout reserved for shell directives, data output (JSON, tables) goes to stderr during interactive use.
+
+When stdout isn't a terminal (piped or redirected), the wrapper runs the binary directly instead:
+
+```bash
+wt list --format=json | jq .           # Binary runs directly, JSON flows to jq
+wt list --format=json > worktrees.json # Binary runs directly, JSON goes to file
+```
+
+This direct-binary mode applies to all commands, not just data-producing flags. Shell-side effects like directory changing require the wrapper, so `wt switch branch | cat` won't change directories. In practice this is fine — piped output is typically for data processing, not interactive use.
+
+To force direct-binary mode interactively, bypass the wrapper:
+
+```bash
+command wt list --format=json          # Outputs to stdout
+```
+
 ## Running tests (for contributors)
 
 ### Quick tests

--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -123,7 +123,7 @@ fn format_directory_fish_style(path: &Path) -> String {
 
 /// Run the statusline command.
 ///
-/// Output uses `output::data_raw()` which routes based on mode:
+/// Output uses `output::data()` which routes based on mode:
 /// - Interactive: stdout (for shell prompts)
 /// - Directive: stderr (stdout reserved for shell script)
 pub fn run(claude_code: bool) -> Result<()> {
@@ -201,7 +201,7 @@ pub fn run(claude_code: bool) -> Result<()> {
         use worktrunk::styling::fix_dim_after_color_reset;
         let reset = anstyle::Reset;
         let output = fix_dim_after_color_reset(&output);
-        output::data_raw(format!("{reset} {output}"))?;
+        output::data(format!("{reset} {output}"))?;
     }
 
     Ok(())

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -54,8 +54,8 @@ pub mod handlers;
 
 // Re-export the public API
 pub use global::{
-    OutputMode, blank, change_directory, data, data_raw, execute, flush, flush_for_stderr_prompt,
-    gutter, initialize, print, shell_integration_hint, table, terminate_output,
+    OutputMode, blank, change_directory, data, execute, flush, flush_for_stderr_prompt, gutter,
+    initialize, print, shell_integration_hint, table, terminate_output,
 };
 // Re-export output handlers
 pub use handlers::{

--- a/templates/bash.sh
+++ b/templates/bash.sh
@@ -25,6 +25,10 @@ if command -v {{ cmd }} >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
 
         # --source: use cargo run (builds from source)
         if [[ "$use_source" == true ]]; then
+            if [[ ! -t 1 ]]; then
+                cargo run --bin {{ cmd }} --quiet -- "${args[@]}"
+                return
+            fi
             local script exit_code=0
             script="$(cargo run --bin {{ cmd }} --quiet -- --internal "${args[@]}")" || exit_code=$?
             if [[ -n "$script" ]]; then
@@ -34,6 +38,13 @@ if command -v {{ cmd }} >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
                 fi
             fi
             return "$exit_code"
+        fi
+
+        # If stdout is not a terminal (piped/redirected), run directly.
+        # This allows `wt list --format=json | jq` to work.
+        if [[ ! -t 1 ]]; then
+            command "${WORKTRUNK_BIN:-{{ cmd }}}" "${args[@]}"
+            return
         fi
 
         wt_exec --internal "${args[@]}"

--- a/templates/powershell.ps1
+++ b/templates/powershell.ps1
@@ -17,6 +17,14 @@ if (Get-Command {{ cmd }} -ErrorAction SilentlyContinue) {
 
         $wtBin = (Get-Command {{ cmd }} -CommandType Application).Source
 
+        # If output is redirected (piped), run directly without wrapper.
+        # This allows `wt list --format=json | ConvertFrom-Json` to work - the output
+        # flows through instead of being captured and Invoke-Expression'd.
+        if ([Console]::IsOutputRedirected) {
+            & $wtBin @Arguments
+            return $LASTEXITCODE
+        }
+
         # Run wt with --internal=powershell
         # stdout is captured for Invoke-Expression (contains Set-Location directives)
         # stderr passes through to console in real-time (user messages, progress, errors)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1933,6 +1933,17 @@ pub fn setup_snapshot_settings(repo: &TestRepo) -> insta::Settings {
     settings.add_filter(r"\x1b\[0m$", "");
     settings.add_filter(r"\x1b\[0m\n", "\n");
 
+    // Normalize tree-sitter bash syntax highlighting differences between platforms.
+    // On Linux, tree-sitter-bash may parse paths as "string" tokens (green: [32m),
+    // while on macOS the same paths are just dimmed (no color). This causes snapshot
+    // mismatches when the same code produces different ANSI sequences.
+    // Strip green color from _REPO_ placeholders and normalize the surrounding sequences.
+    // Pattern: [2m [0m[2m[32m_REPO_...[0m[2m [0m[2m  ->  [2m _REPO_... [0m[2m
+    settings.add_filter(
+        r"\x1b\[2m \x1b\[0m\x1b\[2m\x1b\[32m(_REPO_[^\x1b]*)\x1b\[0m\x1b\[2m \x1b\[0m\x1b\[2m",
+        "\x1b[2m $1 \x1b[0m\x1b[2m",
+    );
+
     settings
 }
 

--- a/tests/snapshots/integration__integration_tests__init__init_bash.snap
+++ b/tests/snapshots/integration__integration_tests__init__init_bash.snap
@@ -16,10 +16,12 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
     PATH: "[PATH]"
+    RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
@@ -69,6 +71,10 @@ wt_exec() {
 
         # --source: use cargo run (builds from source)
         if [[ "$use_source" == true ]]; then
+            if [[ ! -t 1 ]]; then
+                cargo run --bin wt --quiet -- "${args[@]}"
+                return
+            fi
             local script exit_code=0
             script="$(cargo run --bin wt --quiet -- --internal "${args[@]}")" || exit_code=$?
             if [[ -n "$script" ]]; then
@@ -78,6 +84,13 @@ wt_exec() {
                 fi
             fi
             return "$exit_code"
+        fi
+
+        # If stdout is not a terminal (piped/redirected), run directly.
+        # This allows `wt list --format=json | jq` to work.
+        if [[ ! -t 1 ]]; then
+            command "${WORKTRUNK_BIN:-wt}" "${args[@]}"
+            return
         fi
 
         wt_exec --internal "${args[@]}"

--- a/tests/snapshots/integration__integration_tests__init__init_fish.snap
+++ b/tests/snapshots/integration__integration_tests__init__init_fish.snap
@@ -16,10 +16,12 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
     PATH: "[PATH]"
+    RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
@@ -68,6 +70,10 @@ if type -q wt; or test -n "$WORKTRUNK_BIN"
 
         # --source: use cargo run (builds from source)
         if test $use_source = true
+            if not isatty stdout
+                cargo run --bin wt --quiet -- $args
+                return $status
+            end
             cargo run --bin wt --quiet -- --internal $args | string collect --allow-empty | read --local -z script
             set -l exit_code $pipestatus[1]
             if test -n "$script"
@@ -77,6 +83,14 @@ if type -q wt; or test -n "$WORKTRUNK_BIN"
                 end
             end
             return $exit_code
+        end
+
+        # If stdout is not a terminal (piped/redirected), run directly.
+        # This allows `wt list --format=json | jq` to work.
+        if not isatty stdout
+            test -n "$WORKTRUNK_BIN"; or set -l WORKTRUNK_BIN (type -P wt)
+            command $WORKTRUNK_BIN $args
+            return $status
         end
 
         wt_exec --internal $args

--- a/tests/snapshots/integration__integration_tests__init__init_zsh.snap
+++ b/tests/snapshots/integration__integration_tests__init__init_zsh.snap
@@ -16,10 +16,12 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
     PATH: "[PATH]"
+    RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
@@ -72,6 +74,10 @@ wt_exec() {
 
         # --source: use cargo run (builds from source)
         if [[ "$use_source" == true ]]; then
+            if [[ ! -t 1 ]]; then
+                cargo run --bin wt --quiet -- "${args[@]}"
+                return
+            fi
             local script exit_code=0
             script="$(cargo run --bin wt --quiet -- --internal "${args[@]}")" || exit_code=$?
             if [[ -n "$script" ]]; then
@@ -81,6 +87,13 @@ wt_exec() {
                 fi
             fi
             return "$exit_code"
+        fi
+
+        # If stdout is not a terminal (piped/redirected), run directly.
+        # This allows `wt list --format=json | jq` to work.
+        if [[ ! -t 1 ]]; then
+            command "${WORKTRUNK_BIN:-wt}" "${args[@]}"
+            return
         fi
 
         wt_exec --internal "${args[@]}"


### PR DESCRIPTION
## Summary
- Shell wrappers now detect when stdout is piped/redirected and run the binary directly
- This enables piping to work: `wt list --format=json | jq .` and `wt step commit --show-prompt | llm`
- Consolidated `data()` and `data_raw()` into a single function
- Added FAQ entry explaining the stdout/stderr trade-off
- Updated documentation in cli-output-formatting.md and output-system-architecture.md

## Test plan
- [x] All 610 integration tests pass
- [ ] Verify `wt list --format=json | jq .` works in bash, zsh, fish
- [ ] Verify `wt list --format=json > file.json` works
- [ ] Verify interactive use still works (shell wrapper cd functionality)

🤖 Generated with [Claude Code](https://claude.com/claude-code)