### PR TITLE
Add {{ branch | sanitize }} filter for explicit branch sanitization

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/hook-types-reference.md
+++ b/.claude-plugin/skills/worktrunk/reference/hook-types-reference.md
@@ -12,8 +12,9 @@ Detailed behavior and use cases for all five Worktrunk hook types.
 | `pre-merge` | Before merging to target | Yes | Yes | Basic + Merge | Sequential |
 | `post-merge` | After successful merge | Yes | No | Basic + Merge | Sequential |
 
-**Basic variables**: `{{ repo }}`, `{{ branch }}`, `{{ worktree }}`, `{{ repo_root }}`
+**Basic variables**: `{{ repo }}`, `{{ branch }}` (raw), `{{ worktree }}`, `{{ repo_root }}`
 **Merge variables**: Basic + `{{ target }}`
+**Filter**: `{{ branch | sanitize }}` replaces `/` and `\` with `-`
 
 ## Detailed Behavior
 

--- a/.claude-plugin/skills/worktrunk/reference/project-config.md
+++ b/.claude-plugin/skills/worktrunk/reference/project-config.md
@@ -186,7 +186,8 @@ All hooks support template variables for dynamic behavior.
 
 Available in all hook types:
 - `{{ repo }}` - Repository name (e.g., "my-project")
-- `{{ branch }}` - Branch name (e.g., "feature-auth")
+- `{{ branch }}` - Raw branch name (e.g., "feature/auth")
+- `{{ branch | sanitize }}` - Branch name with `/` and `\` replaced by `-`
 - `{{ worktree }}` - Absolute path to worktree
 - `{{ repo_root }}` - Absolute path to repository root
 

--- a/.claude-plugin/skills/worktrunk/reference/user-config.md
+++ b/.claude-plugin/skills/worktrunk/reference/user-config.md
@@ -107,13 +107,13 @@ Users may want different worktree organization patterns.
 
 Default (parent siblings):
 ```toml
-worktree-path = "../{{ main_worktree }}.{{ branch }}"
+worktree-path = "../{{ main_worktree }}.{{ branch | sanitize }}"
 ```
 Result: `~/code/myproject` → `~/code/myproject.feature-auth`
 
 Inside repo:
 ```toml
-worktree-path = ".worktrees/{{ branch }}"
+worktree-path = ".worktrees/{{ branch | sanitize }}"
 ```
 Result: `~/code/myproject/.worktrees/feature-auth`
 
@@ -130,7 +130,8 @@ Result: `~/code/myproject/.worktrees/feature-auth`
 ### Available Variables
 
 - `{{ main_worktree }}` - Main worktree directory name
-- `{{ branch }}` - Branch name (slashes replaced with dashes)
+- `{{ branch }}` - Raw branch name (e.g., `feature/foo`)
+- `{{ branch | sanitize }}` - Branch name with `/` and `\` replaced by `-`
 
 ### Validation Rules
 
@@ -200,7 +201,7 @@ Complete reference:
 
 ```toml
 # Worktree Path Template
-worktree-path = "../{{ main_worktree }}.{{ branch }}"
+worktree-path = "../{{ main_worktree }}.{{ branch | sanitize }}"
 
 # LLM Commit Generation (Optional)
 [commit-generation]

--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -30,18 +30,19 @@ args = ["-m", "claude-haiku-4.5"]
 
 # Worktree Path Template
 # Variables:
-#   {{ main_worktree }} - Main worktree directory name (e.g., "myproject")
-#   {{ branch }}        - Branch name with slashes replaced by dashes (feature/auth → feature-auth)
+#   {{ main_worktree }}     - Main worktree directory name (e.g., "myproject")
+#   {{ branch }}            - Raw branch name (e.g., "feature/auth")
+#   {{ branch | sanitize }} - Branch name with / and \ replaced by - (e.g., "feature-auth")
 #
 # Paths are relative to the main worktree root (original repository directory).
 #
 # Example paths created (main worktree at /Users/dev/myproject, branch feature/auth):
-#   "../{{ main_worktree }}.{{ branch }}" → /Users/dev/myproject.feature-auth
-#   ".worktrees/{{ branch }}"             → /Users/dev/myproject/.worktrees/feature-auth
-worktree-path = "../{{ main_worktree }}.{{ branch }}"
+#   "../{{ main_worktree }}.{{ branch | sanitize }}" → /Users/dev/myproject.feature-auth
+#   ".worktrees/{{ branch | sanitize }}"             → /Users/dev/myproject/.worktrees/feature-auth
+worktree-path = "../{{ main_worktree }}.{{ branch | sanitize }}"
 
 # Alternative: Inside repo (useful for bare repos)
-# worktree-path = ".worktrees/{{ branch }}"
+# worktree-path = ".worktrees/{{ branch | sanitize }}"
 
 # List Command Defaults
 # Configure default behavior for `wt list`

--- a/dev/wt.example.toml
+++ b/dev/wt.example.toml
@@ -6,10 +6,11 @@
 # developers working on the project.
 
 # Available template variables (all hooks):
-#   {{ repo }}      - Repository name (e.g., "my-project")
-#   {{ branch }}    - Branch name (slashes replaced with dashes)
-#   {{ worktree }}  - Absolute path to the worktree
-#   {{ repo_root }} - Absolute path to the repository root
+#   {{ repo }}              - Repository name (e.g., "my-project")
+#   {{ branch }}            - Raw branch name (e.g., "feature/foo")
+#   {{ branch | sanitize }} - Branch name with / and \ replaced by -
+#   {{ worktree }}          - Absolute path to the worktree
+#   {{ repo_root }}         - Absolute path to the repository root
 #
 # Merge-related hooks also support:
 #   {{ target }}    - Target branch for the merge (e.g., "main")

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -53,22 +53,23 @@ Controls where new worktrees are created. The template is relative to the reposi
 
 **Available variables:**
 - `{{ main_worktree }}` — main worktree directory name
-- `{{ branch }}` — branch name (slashes replaced with dashes)
+- `{{ branch }}` — raw branch name (e.g., `feature/foo`)
+- `{{ branch | sanitize }}` — branch name with `/` and `\` replaced by `-`
 
 **Examples** for a repo at `~/code/myproject` creating branch `feature/login`:
 
 ```toml
 # Default — siblings in parent directory
 # Creates: ~/code/myproject.feature-login
-worktree-path = "../{{ main_worktree }}.{{ branch }}"
+worktree-path = "../{{ main_worktree }}.{{ branch | sanitize }}"
 
 # Inside the repository
 # Creates: ~/code/myproject/.worktrees/feature-login
-worktree-path = ".worktrees/{{ branch }}"
+worktree-path = ".worktrees/{{ branch | sanitize }}"
 
 # Namespaced (useful when multiple repos share a parent directory)
 # Creates: ~/code/worktrees/myproject/feature-login
-worktree-path = "../worktrees/{{ main_worktree }}/{{ branch }}"
+worktree-path = "../worktrees/{{ main_worktree }}/{{ branch | sanitize }}"
 ```
 
 ### Command settings
@@ -297,18 +298,19 @@ args = ["-m", "claude-haiku-4.5"]
 
 # Worktree Path Template
 # Variables:
-#   {{ main_worktree }} - Main worktree directory name (e.g., "myproject")
-#   {{ branch }}        - Branch name with slashes replaced by dashes (feature/auth → feature-auth)
+#   {{ main_worktree }}     - Main worktree directory name (e.g., "myproject")
+#   {{ branch }}            - Raw branch name (e.g., "feature/auth")
+#   {{ branch | sanitize }} - Branch name with / and \ replaced by - (e.g., "feature-auth")
 #
 # Paths are relative to the main worktree root (original repository directory).
 #
 # Example paths created (main worktree at /Users/dev/myproject, branch feature/auth):
-#   "../{{ main_worktree }}.{{ branch }}" → /Users/dev/myproject.feature-auth
-#   ".worktrees/{{ branch }}"             → /Users/dev/myproject/.worktrees/feature-auth
-worktree-path = "../{{ main_worktree }}.{{ branch }}"
+#   "../{{ main_worktree }}.{{ branch | sanitize }}" → /Users/dev/myproject.feature-auth
+#   ".worktrees/{{ branch | sanitize }}"             → /Users/dev/myproject/.worktrees/feature-auth
+worktree-path = "../{{ main_worktree }}.{{ branch | sanitize }}"
 
 # Alternative: Inside repo (useful for bare repos)
-# worktree-path = ".worktrees/{{ branch }}"
+# worktree-path = ".worktrees/{{ branch | sanitize }}"
 
 # List Command Defaults
 # Configure default behavior for `wt list`
@@ -467,10 +469,11 @@ With `--project`, creates `.config/wt.toml` in the current repository:
 # developers working on the project.
 
 # Available template variables (all hooks):
-#   {{ repo }}      - Repository name (e.g., "my-project")
-#   {{ branch }}    - Branch name (slashes replaced with dashes)
-#   {{ worktree }}  - Absolute path to the worktree
-#   {{ repo_root }} - Absolute path to the repository root
+#   {{ repo }}              - Repository name (e.g., "my-project")
+#   {{ branch }}            - Raw branch name (e.g., "feature/foo")
+#   {{ branch | sanitize }} - Branch name with / and \ replaced by -
+#   {{ worktree }}          - Absolute path to the worktree
+#   {{ repo_root }}         - Absolute path to the repository root
 #
 # Merge-related hooks also support:
 #   {{ target }}    - Target branch for the merge (e.g., "main")

--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -82,7 +82,8 @@ All variables are shell-escaped:
 
 | Variable | Description |
 |----------|-------------|
-| `{{ branch }}` | Branch name (slashes replaced with dashes) |
+| `{{ branch }}` | Branch name (raw, e.g., `feature/foo`) |
+| `{{ branch \| sanitize }}` | Branch name with `/` and `\` replaced by `-` |
 | `{{ worktree }}` | Absolute path to the worktree |
 | `{{ worktree_name }}` | Worktree directory name |
 | `{{ repo }}` | Repository name |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -960,7 +960,8 @@ All variables are shell-escaped:
 
 | Variable | Description |
 |----------|-------------|
-| `{{ branch }}` | Branch name (slashes replaced with dashes) |
+| `{{ branch }}` | Branch name (raw, e.g., `feature/foo`) |
+| `{{ branch \| sanitize }}` | Branch name with `/` and `\` replaced by `-` |
 | `{{ worktree }}` | Absolute path to the worktree |
 | `{{ worktree_name }}` | Worktree directory name |
 | `{{ repo }}` | Repository name |
@@ -1203,22 +1204,23 @@ Controls where new worktrees are created. The template is relative to the reposi
 
 **Available variables:**
 - `{{ main_worktree }}` — main worktree directory name
-- `{{ branch }}` — branch name (slashes replaced with dashes)
+- `{{ branch }}` — raw branch name (e.g., `feature/foo`)
+- `{{ branch | sanitize }}` — branch name with `/` and `\` replaced by `-`
 
 **Examples** for a repo at `~/code/myproject` creating branch `feature/login`:
 
 ```toml
 # Default — siblings in parent directory
 # Creates: ~/code/myproject.feature-login
-worktree-path = "../{{ main_worktree }}.{{ branch }}"
+worktree-path = "../{{ main_worktree }}.{{ branch | sanitize }}"
 
 # Inside the repository
 # Creates: ~/code/myproject/.worktrees/feature-login
-worktree-path = ".worktrees/{{ branch }}"
+worktree-path = ".worktrees/{{ branch | sanitize }}"
 
 # Namespaced (useful when multiple repos share a parent directory)
 # Creates: ~/code/worktrees/myproject/feature-login
-worktree-path = "../worktrees/{{ main_worktree }}/{{ branch }}"
+worktree-path = "../worktrees/{{ main_worktree }}/{{ branch | sanitize }}"
 ```
 
 ### Command settings

--- a/src/commands/command_executor.rs
+++ b/src/commands/command_executor.rs
@@ -1,9 +1,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 use worktrunk::HookType;
-use worktrunk::config::{
-    Command, CommandConfig, WorktrunkConfig, expand_template, sanitize_branch_name,
-};
+use worktrunk::config::{Command, CommandConfig, WorktrunkConfig, expand_template};
 use worktrunk::git::Repository;
 use worktrunk::path::to_posix_path;
 
@@ -76,7 +74,7 @@ pub fn build_hook_context(
     let mut map = HashMap::new();
     map.insert("repo".into(), repo_name.into());
     map.insert("main_worktree".into(), repo_name.into()); // Alias for repo
-    map.insert("branch".into(), sanitize_branch_name(ctx.branch_or_head()));
+    map.insert("branch".into(), ctx.branch_or_head().into());
     map.insert("worktree".into(), worktree);
     map.insert("worktree_name".into(), worktree_name.into());
     map.insert(

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -255,8 +255,7 @@ fn render_user_config(out: &mut String) -> anyhow::Result<()> {
             ))
         )?;
         writeln!(out)?;
-        let default_config =
-            "# Default configuration:\nworktree-path = \"../{{ main_worktree }}.{{ branch }}\"";
+        let default_config = "# Default configuration:\nworktree-path = \"../{{ main_worktree }}.{{ branch | sanitize }}\"";
         write!(out, "{}", format_toml(default_config, ""))?;
         return Ok(());
     }

--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -6,7 +6,7 @@
 //!
 //! All templates support Jinja2 syntax including filters, conditionals, and loops.
 
-use minijinja::Environment;
+use minijinja::{Environment, Value};
 use std::collections::HashMap;
 
 /// Sanitize a branch name for use in filesystem paths.
@@ -30,30 +30,32 @@ pub fn sanitize_branch_name(branch: &str) -> String {
 ///
 /// # Arguments
 /// * `template` - Template string using Jinja2 syntax (e.g., `{{ branch }}`)
-/// * `vars` - Variables to substitute. Callers should sanitize branch names with
-///   [`sanitize_branch_name`] before inserting.
+/// * `vars` - Variables to substitute
 /// * `shell_escape` - If true, shell-escape all values for safe command execution.
 ///   If false, substitute values literally (for filesystem paths).
 ///
+/// # Filters
+/// The `sanitize` filter is available for branch names, replacing `/` and `\` with `-`:
+/// - `{{ branch }}` — raw branch name (e.g., `feature/foo`)
+/// - `{{ branch | sanitize }}` — sanitized for paths (e.g., `feature-foo`)
+///
 /// # Examples
 /// ```
-/// use worktrunk::config::{expand_template, sanitize_branch_name};
+/// use worktrunk::config::expand_template;
 /// use std::collections::HashMap;
 ///
-/// // For shell commands (escaped)
-/// let branch = sanitize_branch_name("feature/foo");
+/// // Raw branch name
 /// let mut vars = HashMap::new();
-/// vars.insert("branch", branch.as_str());
+/// vars.insert("branch", "feature/foo");
 /// vars.insert("repo", "myrepo");
 /// let cmd = expand_template("echo {{ branch }} in {{ repo }}", &vars, true).unwrap();
-/// assert_eq!(cmd, "echo feature-foo in myrepo");
+/// assert_eq!(cmd, "echo feature/foo in myrepo");
 ///
-/// // For filesystem paths (literal)
-/// let branch = sanitize_branch_name("feature/foo");
+/// // Sanitized branch name for filesystem paths
 /// let mut vars = HashMap::new();
-/// vars.insert("branch", branch.as_str());
+/// vars.insert("branch", "feature/foo");
 /// vars.insert("main_worktree", "myrepo");
-/// let path = expand_template("{{ main_worktree }}.{{ branch }}", &vars, false).unwrap();
+/// let path = expand_template("{{ main_worktree }}.{{ branch | sanitize }}", &vars, false).unwrap();
 /// assert_eq!(path, "myrepo.feature-foo");
 /// ```
 pub fn expand_template(
@@ -81,6 +83,12 @@ pub fn expand_template(
         // Preserve trailing newlines in templates (important for multiline shell commands)
         env.set_keep_trailing_newline(true);
     }
+
+    // Register the `sanitize` filter for branch names (replaces / and \ with -)
+    env.add_filter("sanitize", |value: Value| -> String {
+        sanitize_branch_name(value.as_str().unwrap_or_default())
+    });
+
     let tmpl = env
         .template_from_str(template)
         .map_err(|e| format!("Template syntax error: {}", e))?;
@@ -197,6 +205,37 @@ mod tests {
         assert_eq!(
             expand_template("{{ name | upper }}", &vars, false).unwrap(),
             "HELLO"
+        );
+    }
+
+    #[test]
+    fn test_expand_template_sanitize_filter() {
+        let mut vars = HashMap::new();
+        vars.insert("branch", "feature/foo");
+        assert_eq!(
+            expand_template("{{ branch | sanitize }}", &vars, false).unwrap(),
+            "feature-foo"
+        );
+
+        // Backslashes are also sanitized
+        vars.insert("branch", "feature\\bar");
+        assert_eq!(
+            expand_template("{{ branch | sanitize }}", &vars, false).unwrap(),
+            "feature-bar"
+        );
+
+        // Multiple slashes
+        vars.insert("branch", "user/feature/task");
+        assert_eq!(
+            expand_template("{{ branch | sanitize }}", &vars, false).unwrap(),
+            "user-feature-task"
+        );
+
+        // Raw branch is unchanged
+        vars.insert("branch", "feature/foo");
+        assert_eq!(
+            expand_template("{{ branch }}", &vars, false).unwrap(),
+            "feature/foo"
         );
     }
 

--- a/src/config/snapshots/worktrunk__config__test__snapshot_complex_templates.snap
+++ b/src/config/snapshots/worktrunk__config__test__snapshot_complex_templates.snap
@@ -7,7 +7,7 @@ expression: results
   - feature branch
   - "cd '/path with spaces/wt' && git merge 'main; rm -rf /'"
 - - npm_install
-  - "cd {{ main_worktree }}/{{ branch }} && npm install"
+  - "cd {{ main_worktree }}/{{ branch | sanitize }} && npm install"
   - feature/new-ui
   - cd /repo/path/feature-new-ui && npm install
 - - echo_vars

--- a/src/config/snapshots/worktrunk__config__test__snapshot_shell_escaping_special_chars.snap
+++ b/src/config/snapshots/worktrunk__config__test__snapshot_shell_escaping_special_chars.snap
@@ -16,7 +16,7 @@ expression: results
   - "echo 'feature`id`'"
 - - semicolon
   - feature;rm -rf /
-  - "echo 'feature;rm -rf -'"
+  - "echo 'feature;rm -rf /'"
 - - pipe
   - feature|grep foo
   - "echo 'feature|grep foo'"

--- a/tests/integration_tests/approval_save.rs
+++ b/tests/integration_tests/approval_save.rs
@@ -33,7 +33,7 @@ fn test_approval_saves_to_disk() {
     // Verify TOML structure
     let toml_content = fs::read_to_string(&config_path).unwrap();
     assert_snapshot!(toml_content, @r#"
-    worktree-path = "../{{ main_worktree }}.{{ branch }}"
+    worktree-path = "../{{ main_worktree }}.{{ branch | sanitize }}"
 
     [commit-generation]
     args = []
@@ -89,7 +89,7 @@ fn test_duplicate_approvals_not_saved_twice() {
     // Verify file contains only one entry
     let toml_content = fs::read_to_string(&config_path).unwrap();
     assert_snapshot!(toml_content, @r#"
-    worktree-path = "../{{ main_worktree }}.{{ branch }}"
+    worktree-path = "../{{ main_worktree }}.{{ branch | sanitize }}"
 
     [commit-generation]
     args = []
@@ -141,7 +141,7 @@ fn test_multiple_project_approvals() {
     // Verify file structure
     let toml_content = fs::read_to_string(&config_path).unwrap();
     assert_snapshot!(toml_content, @r#"
-    worktree-path = "../{{ main_worktree }}.{{ branch }}"
+    worktree-path = "../{{ main_worktree }}.{{ branch | sanitize }}"
 
     [commit-generation]
     args = []
@@ -230,7 +230,7 @@ fn test_force_flag_does_not_save_approval() {
     // Load the config and verify it's still empty (no approvals added)
     let saved_config = fs::read_to_string(&config_path).unwrap();
     assert_snapshot!(saved_config, @r#"
-    worktree-path = "../{{ main_worktree }}.{{ branch }}"
+    worktree-path = "../{{ main_worktree }}.{{ branch | sanitize }}"
 
     [commit-generation]
     args = []
@@ -264,7 +264,7 @@ fn test_force_flag_saves_to_new_config_file() {
     // Verify content
     let content = fs::read_to_string(&config_path).unwrap();
     assert_snapshot!(content, @r#"
-    worktree-path = "../{{ main_worktree }}.{{ branch }}"
+    worktree-path = "../{{ main_worktree }}.{{ branch | sanitize }}"
 
     [commit-generation]
     args = []

--- a/tests/integration_tests/post_start_commands.rs
+++ b/tests/integration_tests/post_start_commands.rs
@@ -141,7 +141,7 @@ root = "echo 'Root: {{ repo_root }}' >> info.txt"
     // Pre-approve all commands in isolated test config
     let repo_name = "repo";
     repo.write_test_config(
-        r#"worktree-path = "../{{ main_worktree }}.{{ branch }}"
+        r#"worktree-path = "../{{ main_worktree }}.{{ branch | sanitize }}"
 
 [projects."repo"]
 approved-commands = [
@@ -182,8 +182,8 @@ approved-commands = [
         contents
     );
     assert!(
-        contents.contains("Branch: feature-test"),
-        "Should contain expanded branch name (sanitized), got: {}",
+        contents.contains("Branch: feature/test"),
+        "Should contain raw branch name, got: {}",
         contents
     );
 }

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -10,6 +10,7 @@ info:
     CLICOLOR_FORCE: "1"
     COLUMNS: "150"
     GIT_EDITOR: ""
+    RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
 ---
@@ -75,18 +76,19 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
   [2m
   [2m# Worktree Path Template
   [2m# Variables:
-  [2m#   {{ main_worktree }} - Main worktree directory name (e.g., "myproject")
-  [2m#   {{ branch }}        - Branch name with slashes replaced by dashes (feature/auth → feature-auth)
+  [2m#   {{ main_worktree }}     - Main worktree directory name (e.g., "myproject")
+  [2m#   {{ branch }}            - Raw branch name (e.g., "feature/auth")
+  [2m#   {{ branch | sanitize }} - Branch name with / and \ replaced by - (e.g., "feature-auth")
   [2m#
   [2m# Paths are relative to the main worktree root (original repository directory).
   [2m#
   [2m# Example paths created (main worktree at /Users/dev/myproject, branch feature/auth):
-  [2m#   "../{{ main_worktree }}.{{ branch }}" → /Users/dev/myproject.feature-auth
-  [2m#   ".worktrees/{{ branch }}"             → /Users/dev/myproject/.worktrees/feature-auth
-  [2mworktree-path = "../{{ main_worktree }}.{{ branch }}"
+  [2m#   "../{{ main_worktree }}.{{ branch | sanitize }}" → /Users/dev/myproject.feature-auth
+  [2m#   ".worktrees/{{ branch | sanitize }}"             → /Users/dev/myproject/.worktrees/feature-auth
+  [2mworktree-path = "../{{ main_worktree }}.{{ branch | sanitize }}"
   [2m
   [2m# Alternative: Inside repo (useful for bare repos)
-  [2m# worktree-path = ".worktrees/{{ branch }}"
+  [2m# worktree-path = ".worktrees/{{ branch | sanitize }}"
   [2m
   [2m# List Command Defaults
   [2m# Configure default behavior for `wt list`
@@ -243,10 +245,11 @@ With [2m--project[0m, creates [2m.config/wt.toml[0m in the current repositor
   [2m# developers working on the project.
   [2m
   [2m# Available template variables (all hooks):
-  [2m#   {{ repo }}      - Repository name (e.g., "my-project")
-  [2m#   {{ branch }}    - Branch name (slashes replaced with dashes)
-  [2m#   {{ worktree }}  - Absolute path to the worktree
-  [2m#   {{ repo_root }} - Absolute path to the repository root
+  [2m#   {{ repo }}              - Repository name (e.g., "my-project")
+  [2m#   {{ branch }}            - Raw branch name (e.g., "feature/foo")
+  [2m#   {{ branch | sanitize }} - Branch name with / and \ replaced by -
+  [2m#   {{ worktree }}          - Absolute path to the worktree
+  [2m#   {{ repo_root }}         - Absolute path to the repository root
   [2m#
   [2m# Merge-related hooks also support:
   [2m#   {{ target }}    - Target branch for the merge (e.g., "main")

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -9,6 +9,7 @@ info:
     CLICOLOR_FORCE: "1"
     COLUMNS: "150"
     GIT_EDITOR: ""
+    RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
 ---
@@ -78,21 +79,22 @@ Controls where new worktrees are created. The template is relative to the reposi
 
 [1mAvailable variables:
 - [2m{{ main_worktree }}[0m — main worktree directory name
-- [2m{{ branch }}[0m — branch name (slashes replaced with dashes)
+- [2m{{ branch }}[0m — raw branch name (e.g., [2mfeature/foo[0m)
+- [2m{{ branch | sanitize }}[0m — branch name with [2m/[0m and [2m\[0m replaced by [2m-
 
 [1mExamples[0m for a repo at [2m~/code/myproject[0m creating branch [2mfeature/login[0m:
 
   [2m# Default — siblings in parent directory
   [2m# Creates: ~/code/myproject.feature-login
-  [2mworktree-path = "../{{ main_worktree }}.{{ branch }}"
+  [2mworktree-path = "../{{ main_worktree }}.{{ branch | sanitize }}"
   [2m
   [2m# Inside the repository
   [2m# Creates: ~/code/myproject/.worktrees/feature-login
-  [2mworktree-path = ".worktrees/{{ branch }}"
+  [2mworktree-path = ".worktrees/{{ branch | sanitize }}"
   [2m
   [2m# Namespaced (useful when multiple repos share a parent directory)
   [2m# Creates: ~/code/worktrees/myproject/feature-login
-  [2mworktree-path = "../worktrees/{{ main_worktree }}/{{ branch }}"
+  [2mworktree-path = "../worktrees/{{ main_worktree }}/{{ branch | sanitize }}"
 
 [1mCommand settings
 

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_template_expansion.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_template_expansion.snap
@@ -34,7 +34,7 @@ exit_code: 0
 [36m◎[39m [36mRunning project post-create [1mrepo[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Repo: repo'[0m[2m [0m[2m[36m>[0m[2m info.txt
 [0m[36m◎[39m [36mRunning project post-create [1mbranch[22m:[39m
-[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Branch: feature-test'[0m[2m [0m[2m[36m>>[0m[2m info.txt
+[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Branch: feature/test'[0m[2m [0m[2m[36m>>[0m[2m info.txt
 [0m[36m◎[39m [36mRunning project post-create [1mworktree[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Worktree: _REPO_.feature-test'[0m[2m [0m[2m[36m>>[0m[2m info.txt
 [0m[36m◎[39m [36mRunning project post-create [1mroot[22m:[39m


### PR DESCRIPTION
## Summary

- Changes `{{ branch }}` to provide raw branch names (e.g., `feature/auth`)
- Adds a `sanitize` filter for filesystem-safe paths (`{{ branch | sanitize }}` → `feature-auth`)
- Updates default worktree-path template to `../{{ main_worktree }}.{{ branch | sanitize }}`
- Sanitization is now explicit in templates rather than implicit

This is a breaking change for custom templates that relied on implicit sanitization, but the default behavior remains the same.

## Test plan

- [x] All unit tests pass (449 tests)
- [x] All integration tests pass (610 tests)
- [x] Pre-commit lints pass
- [x] Documentation updated consistently across all files

🤖 Generated with [Claude Code](https://claude.com/claude-code)