### PR TITLE
Fix step rebase incorrectly reporting up-to-date for merge commits

### DIFF
--- a/tests/snapshots/integration__integration_tests__merge__step_rebase_with_merge_commit.snap
+++ b/tests/snapshots/integration__integration_tests__merge__step_rebase_with_merge_commit.snap
@@ -1,0 +1,35 @@
+---
+source: tests/integration_tests/merge.rs
+info:
+  program: wt
+  args:
+    - step
+    - rebase
+    - main
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "150"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mRebasing onto [1mmain[22m...[39m
+[32m✓[39m [32mRebased onto [1mmain[22m[39m


### PR DESCRIPTION
## Summary

- Fix `wt step rebase` incorrectly reporting "Already up-to-date" when a branch contains merge commits
- Fix `wt merge --no-rebase` incorrectly passing validation for branches with merge commits
- Consolidate the check into `is_rebased_onto()` as the canonical implementation

## Problem

When a branch has merged the target (e.g., main) into itself:
- The merge-base equals target's SHA (because the merge commit includes target)
- But there are still commits that need rebasing to linearize history

The old check only compared `merge_base == target_sha`, which incorrectly returned "Already up-to-date".

## Solution

Check for merge commits in `target..HEAD` using `git rev-list --merges`. If merge commits exist, the branch needs rebasing to linearize history even though merge-base equals target.

## Test plan

- [x] Added `test_step_rebase_with_merge_commit` that reproduces the exact bug scenario
- [x] All existing tests pass
- [x] Pre-merge hooks pass (lints, tests, docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)