### PR TITLE
Add trailing argument support to `wt switch --execute`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3093,6 +3093,7 @@ dependencies = [
  "serde_json",
  "shell-escape",
  "shellexpand",
+ "shlex",
  "skim",
  "strum",
  "synoptic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shell-escape = "0.1"
 shellexpand = "3.1"
+shlex = "1.3"
 strum = { version = "0.27", features = ["derive"] }
 synoptic = "2"
 terminal_size = "0.4"

--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -67,13 +67,19 @@ wt switch --create fix --base=@  # Branch from current HEAD
 ```
 wt switch - Switch to a worktree
 
-Usage: wt switch [OPTIONS] <BRANCH>
+Usage: wt switch [OPTIONS] <BRANCH> [-- <EXECUTE_ARGS>...]
 
 Arguments:
   <BRANCH>
           Branch or worktree name
 
           Shortcuts: '^' (main), '-' (previous), '@' (current)
+
+  [EXECUTE_ARGS]...
+          Additional arguments for --execute command (after --)
+
+          Arguments after -- are appended to the execute command. Each argument
+          is POSIX shell-escaped before appending.
 
 Options:
   -c, --create
@@ -91,12 +97,14 @@ Options:
           full terminal control. Useful for launching editors, AI agents, or
           other interactive tools.
 
-          Especially useful in shell aliases to create a worktree and start
-          working in one command:
+          Especially useful with shell aliases:
 
-            alias wsc='wt switch --create --execute=claude'
+            alias wsc='wt switch --create -x claude'
+            wsc feature-branch -- 'implement the login flow'
 
           Then wsc feature-branch creates the worktree and launches Claude Code.
+          Arguments after -- are passed to the command, so wsc feature --
+          'implement login' works.
 
   -f, --force
           Skip approval prompts

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2182,16 +2182,25 @@ wt switch --create fix --base=@  # Branch from current HEAD
         /// it full terminal control. Useful for launching editors, AI agents,
         /// or other interactive tools.
         ///
-        /// Especially useful in shell aliases to create a worktree and start
-        /// working in one command:
+        /// Especially useful with shell aliases:
         ///
         /// ```sh
-        /// alias wsc='wt switch --create --execute=claude'
+        /// alias wsc='wt switch --create -x claude'
+        /// wsc feature-branch -- 'implement the login flow'
         /// ```
         ///
-        /// Then `wsc feature-branch` creates the worktree and launches Claude Code.
+        /// Then `wsc feature-branch` creates the worktree and launches Claude
+        /// Code. Arguments after `--` are passed to the command, so
+        /// `wsc feature -- 'implement login'` works.
         #[arg(short = 'x', long)]
         execute: Option<String>,
+
+        /// Additional arguments for --execute command (after --)
+        ///
+        /// Arguments after `--` are appended to the execute command.
+        /// Each argument is POSIX shell-escaped before appending.
+        #[arg(last = true, requires = "execute")]
+        execute_args: Vec<String>,
 
         /// Skip approval prompts
         #[arg(short = 'f', long)]

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -372,7 +372,6 @@ thread_local! {
 
 fn completion_command() -> Command {
     let cmd = cli::build_command();
-    let cmd = adjust_completion_command(cmd);
     hide_non_positional_options_for_completion(cmd)
 }
 
@@ -420,39 +419,4 @@ fn hide_non_positional_options_for_completion(cmd: Command) -> Command {
     }
 
     process_command(cmd, true)
-}
-
-// Mark positional args as `.last(true)` to allow them after all flags.
-// This enables flexible argument ordering like:
-// - `wt switch --create --execute=cmd --base=main feature` instead of `wt switch feature --create --execute=cmd --base=main`
-// - `wt merge --no-squash main` instead of `wt merge main --no-squash`
-// - `wt remove --no-delete-branch feature` instead of `wt remove feature --no-delete-branch`
-fn adjust_completion_command(cmd: Command) -> Command {
-    cmd.mut_subcommand("switch", |switch| {
-        switch.mut_arg("branch", |arg| arg.last(true))
-    })
-    .mut_subcommand("remove", |remove| {
-        remove.mut_arg("worktrees", |arg| arg.last(true))
-    })
-    .mut_subcommand("merge", |merge| {
-        merge.mut_arg("target", |arg| arg.last(true))
-    })
-    .mut_subcommand("step", |step| {
-        step.mut_subcommand("push", |push| push.mut_arg("target", |arg| arg.last(true)))
-            .mut_subcommand("squash", |squash| {
-                squash.mut_arg("target", |arg| arg.last(true))
-            })
-            .mut_subcommand("rebase", |rebase| {
-                rebase.mut_arg("target", |arg| arg.last(true))
-            })
-    })
-    .mut_subcommand("hook", |hook| {
-        // Hook subcommands - allow name after --force
-        hook.mut_subcommand("post-create", |c| c.mut_arg("name", |arg| arg.last(true)))
-            .mut_subcommand("post-start", |c| c.mut_arg("name", |arg| arg.last(true)))
-            .mut_subcommand("pre-commit", |c| c.mut_arg("name", |arg| arg.last(true)))
-            .mut_subcommand("pre-merge", |c| c.mut_arg("name", |arg| arg.last(true)))
-            .mut_subcommand("post-merge", |c| c.mut_arg("name", |arg| arg.last(true)))
-            .mut_subcommand("pre-remove", |c| c.mut_arg("name", |arg| arg.last(true)))
-    })
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1191,6 +1191,7 @@ fn main() {
             create,
             base,
             execute,
+            execute_args,
             force,
             clobber,
             verify,
@@ -1266,8 +1267,19 @@ fn main() {
                 }
 
                 // Execute user command after post-start hooks have been spawned
+                // Note: execute_args requires execute via clap's `requires` attribute
                 if let Some(cmd) = execute {
-                    execute_user_command(&cmd)?;
+                    // Append any trailing args (after --) to the execute command
+                    let full_cmd = if execute_args.is_empty() {
+                        cmd
+                    } else {
+                        let escaped_args: Vec<_> = execute_args
+                            .iter()
+                            .map(|arg| shlex::try_quote(arg).unwrap_or(arg.into()).into_owned())
+                            .collect();
+                        format!("{} {}", cmd, escaped_args.join(" "))
+                    };
+                    execute_user_command(&full_cmd)?;
                 }
 
                 Ok(())

--- a/tests/snapshots/integration__integration_tests__help__help_page_switch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_page_switch.snap
@@ -9,6 +9,7 @@ info:
     CLICOLOR_FORCE: "1"
     COLUMNS: "150"
     GIT_EDITOR: ""
+    RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
 ---
@@ -76,13 +77,19 @@ wt switch --create fix --base=@  # Branch from current HEAD
 ```
 wt switch - Switch to a worktree
 
-Usage: wt switch [OPTIONS] <BRANCH>
+Usage: wt switch [OPTIONS] <BRANCH> [-- <EXECUTE_ARGS>...]
 
 Arguments:
   <BRANCH>
           Branch or worktree name
           
           Shortcuts: '^' (main), '-' (previous), '@' (current)
+
+  [EXECUTE_ARGS]...
+          Additional arguments for --execute command (after --)
+          
+          Arguments after -- are appended to the execute command. Each argument
+          is POSIX shell-escaped before appending.
 
 Options:
   -c, --create
@@ -100,12 +107,14 @@ Options:
           full terminal control. Useful for launching editors, AI agents, or
           other interactive tools.
           
-          Especially useful in shell aliases to create a worktree and start
-          working in one command:
+          Especially useful with shell aliases:
           
-            alias wsc='wt switch --create --execute=claude'
+            alias wsc='wt switch --create -x claude'
+            wsc feature-branch -- 'implement the login flow'
           
           Then wsc feature-branch creates the worktree and launches Claude Code.
+          Arguments after -- are passed to the command, so wsc feature --
+          'implement login' works.
 
   -f, --force
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -9,6 +9,7 @@ info:
     CLICOLOR_FORCE: "1"
     COLUMNS: "150"
     GIT_EDITOR: ""
+    RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
 ---
@@ -19,13 +20,18 @@ exit_code: 0
 ----- stderr -----
 wt switch - Switch to a worktree
 
-Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m<BRANCH>
+Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m<BRANCH>[0m [1m[36m[--[0m [36m<EXECUTE_ARGS>...[0m[1m[36m]
 
 [1m[32mArguments:
   [36m<BRANCH>
           Branch or worktree name
           
           Shortcuts: '^' (main), '-' (previous), '@' (current)
+
+  [36m[EXECUTE_ARGS]...
+          Additional arguments for --execute command (after --)
+          
+          Arguments after [1m--[0m are appended to the execute command. Each argument is POSIX shell-escaped before appending.
 
 [1m[32mOptions:
   [1m[36m-c[0m, [1m[36m--create
@@ -42,11 +48,13 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m<BRANCH>
           Replaces the wt process with the command after switching, giving it full terminal control. Useful for launching editors, AI agents, or other
           interactive tools.
           
-          Especially useful in shell aliases to create a worktree and start working in one command:
+          Especially useful with shell aliases:
           
-            [1m[1malias wsc='wt switch --create --execute=claude'
+            [1m[1malias wsc='wt switch --create -x claude'
+            [1mwsc feature-branch -- 'implement the login flow'
           [0m
-          Then [1mwsc feature-branch[0m creates the worktree and launches Claude Code.
+          Then [1mwsc feature-branch[0m creates the worktree and launches Claude Code. Arguments after [1m--[0m are passed to the command, so [1mwsc feature --
+          'implement login'[0m works.
 
   [1m[36m-f[0m, [1m[36m--force
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
@@ -9,6 +9,7 @@ info:
     CLICOLOR_FORCE: "1"
     COLUMNS: "150"
     GIT_EDITOR: ""
+    RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
 ---
@@ -19,10 +20,11 @@ exit_code: 0
 ----- stderr -----
 wt switch - Switch to a worktree
 
-Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m<BRANCH>
+Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m<BRANCH>[0m [1m[36m[--[0m [36m<EXECUTE_ARGS>...[0m[1m[36m]
 
 [1m[32mArguments:
-  [36m<BRANCH>[0m  Branch or worktree name
+  [36m<BRANCH>[0m           Branch or worktree name
+  [36m[EXECUTE_ARGS]...[0m  Additional arguments for --execute command (after --)
 
 [1m[32mOptions:
   [1m[36m-c[0m, [1m[36m--create[0m             Create a new branch

--- a/tests/snapshots/integration__integration_tests__switch__switch_missing_argument_hints.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_missing_argument_hints.snap
@@ -5,6 +5,7 @@ info:
   args:
     - switch
   env:
+    APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "150"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -12,12 +13,16 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: false
 exit_code: 2
@@ -27,7 +32,7 @@ exit_code: 2
 [1m[31merror:[0m the following required arguments were not provided:
   [1m[32m<BRANCH>
 
-[1m[32mUsage:[0m [1m[36mwt switch[0m [36m<BRANCH>
+[1m[32mUsage:[0m [1m[36mwt switch[0m [36m<BRANCH>[0m [1m[36m[--[0m [36m<EXECUTE_ARGS>...[0m[1m[36m]
 
 For more information, try '[1m[36m--help[0m'.
 [32m[1mQuick switches:[39m[22m


### PR DESCRIPTION
## Summary

- Arguments after `--` are now appended to the execute command
- Enables shell aliases: `alias wsc='wt switch --create -x claude'` then `wsc feature -- 'implement login'`
- Uses `shlex::try_quote()` for POSIX shell escaping (platform-independent)
- Removes vestigial `adjust_completion_command` function (tests pass without it)
- Removes custom `shell_escape` in favor of standard `shlex` crate

## Test plan

- [x] All 1434 tests pass
- [x] Pre-commit lints pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)