### PR TITLE
Unify directory change output between remove and switch commands

### DIFF
--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__merge_with_mixed_stdout_stderr_bash.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__merge_with_mixed_stdout_stderr_bash.snap
@@ -27,4 +27,5 @@ expression: output.normalized()
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m[TMPDIR]/repo[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m[TMPDIR]/repo[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__merge_with_mixed_stdout_stderr_zsh.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__merge_with_mixed_stdout_stderr_zsh.snap
@@ -27,4 +27,5 @@ expression: output.normalized()
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m[TMPDIR]/repo[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m[TMPDIR]/repo[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__merge_with_pre_merge_success_bash.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__merge_with_pre_merge_success_bash.snap
@@ -16,4 +16,5 @@ expression: output.normalized()
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m[TMPDIR]/repo[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m[TMPDIR]/repo[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__merge_with_pre_merge_success_zsh.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__merge_with_pre_merge_success_zsh.snap
@@ -16,4 +16,5 @@ expression: output.normalized()
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m[TMPDIR]/repo[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m[TMPDIR]/repo[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__readme_example_hooks_pre_merge.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__readme_example_hooks_pre_merge.snap
@@ -32,4 +32,5 @@ All checks passed!
 [107m [0m  tests/test_auth.py | 14 [32m++++++++++++++[m
 [107m [0m  2 files changed, 45 insertions(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 2 files, [32m+45[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature-auth[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m[TMPDIR]/repo[39m[22m
+[36m◎ Removing [1mfeature-auth[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m[TMPDIR]/repo[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__readme_example_remove.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__tests__readme_example_remove.snap
@@ -2,4 +2,5 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-[36m◎ Removing [1mfeature-api[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m[TMPDIR]/repo[39m[22m
+[36m◎ Removing [1mfeature-api[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m[TMPDIR]/repo[22m

--- a/tests/snapshots/integration__integration_tests__directives__merge_directive_file.snap
+++ b/tests/snapshots/integration__integration_tests__directives__merge_directive_file.snap
@@ -36,4 +36,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__directives__merge_directive_remove.snap
+++ b/tests/snapshots/integration__integration_tests__directives__merge_directive_remove.snap
@@ -36,4 +36,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__directives__remove_directive_file.snap
+++ b/tests/snapshots/integration__integration_tests__directives__remove_directive_file.snap
@@ -30,4 +30,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_auto_commit_and_squash.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_auto_commit_and_squash.snap
@@ -41,4 +41,5 @@ exit_code: 0
 [107m [0m  file2.txt | 1 [32m+[m
 [107m [0m  2 files changed, 2 insertions(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 2 files, [32m+2[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_auto_commit_deterministic.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_auto_commit_deterministic.snap
@@ -44,4 +44,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_auto_commit_with_llm.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_auto_commit_with_llm.snap
@@ -40,4 +40,5 @@ exit_code: 0
 [107m [0m  auth.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_dirty_working_tree.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_dirty_working_tree.snap
@@ -41,4 +41,5 @@ exit_code: 0
 [107m [0m  dirty.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_fast_forward.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_fast_forward.snap
@@ -35,4 +35,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_no_commits.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_no_commits.snap
@@ -31,4 +31,5 @@ exit_code: 0
 
 ----- stderr -----
 [2m○[22m Already up to date with [1mmain[22m (no new commits, no rebase needed)
-[36m◎ Removing [1mno-commits[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mno-commits[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_no_commits_with_changes.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_no_commits_with_changes.snap
@@ -41,4 +41,5 @@ exit_code: 0
 [107m [0m  newfile.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mno-commits-dirty[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mno-commits-dirty[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_no_rebase_already_rebased.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_no_rebase_already_rebased.snap
@@ -36,4 +36,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_no_remote.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_no_remote.snap
@@ -34,4 +34,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_no_squash.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_no_squash.snap
@@ -38,4 +38,5 @@ exit_code: 0
 [107m [0m  file2.txt | 1 [32m+[m
 [107m [0m  2 files changed, 2 insertions(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(2 commits, 2 files, [32m+2[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_not_fast_forward.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_not_fast_forward.snap
@@ -35,4 +35,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_post_merge_command_failure.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_post_merge_command_failure.snap
@@ -36,7 +36,8 @@ exit_code: 1
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m
 [36m◎[39m [36mRunning project post-merge:[39m
 [107m [0m [2m[0m[2m[34mexit[0m[2m 1
 [0m[33m▲[39m [33mCommand failed: exit status: 1[39m

--- a/tests/snapshots/integration__integration_tests__merge__merge_post_merge_command_named.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_post_merge_command_named.snap
@@ -36,7 +36,8 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m
 [36m◎[39m [36mRunning project post-merge [1mnotify[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Merge to main complete'[0m[2m [0m[2m[36m>[0m[2m notify.txt
 [0m[36m◎[39m [36mRunning project post-merge [1mdeploy[22m:[39m

--- a/tests/snapshots/integration__integration_tests__merge__merge_post_merge_command_no_verify.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_post_merge_command_no_verify.snap
@@ -37,4 +37,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_post_merge_command_success.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_post_merge_command_success.snap
@@ -36,6 +36,7 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m
 [36m◎[39m [36mRunning project post-merge:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'merged feature to main'[0m[2m [0m[2m[36m>[0m[2m post-merge-ran.txt

--- a/tests/snapshots/integration__integration_tests__merge__merge_post_merge_runs_with_nothing_to_merge.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_post_merge_runs_with_nothing_to_merge.snap
@@ -32,6 +32,7 @@ exit_code: 0
 
 ----- stderr -----
 [2m○[22m Already up to date with [1mmain[22m (no new commits, no rebase needed)
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m
 [36m◎[39m [36mRunning project post-merge:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'post-merge ran'[0m[2m [0m[2m[36m>[0m[2m post-merge-ran.txt

--- a/tests/snapshots/integration__integration_tests__merge__merge_pre_commit_command_success.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_pre_commit_command_success.snap
@@ -45,4 +45,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_pre_merge_command_named.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_pre_merge_command_named.snap
@@ -42,4 +42,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_pre_merge_command_no_hooks.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_pre_merge_command_no_hooks.snap
@@ -36,4 +36,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_pre_merge_command_success.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_pre_merge_command_success.snap
@@ -38,4 +38,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_pre_squash_command_success.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_pre_squash_command_success.snap
@@ -39,4 +39,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_primary_on_different_branch.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_primary_on_different_branch.snap
@@ -35,4 +35,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature-from-develop[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature-from-develop[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mdevelop[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_primary_on_different_branch_dirty.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_primary_on_different_branch_dirty.snap
@@ -37,4 +37,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature-dirty-primary[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature-dirty-primary[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mdevelop[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_rebase_fast_forward.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_rebase_fast_forward.snap
@@ -32,4 +32,5 @@ exit_code: 0
 ----- stderr -----
 [32m✓[39m [32mFast-forwarded to [1mmain[22m[39m
 [2m○[22m Already up to date with [1mmain[22m (no new commits)
-[36m◎ Removing [1mfast-forward-test[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfast-forward-test[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_rebase_true_rebase.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_rebase_true_rebase.snap
@@ -37,4 +37,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mtrue-rebase-test[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mtrue-rebase-test[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_squash_deterministic.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_squash_deterministic.snap
@@ -47,4 +47,5 @@ exit_code: 0
 [107m [0m  file3.txt | 1 [32m+[m
 [107m [0m  3 files changed, 3 insertions(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 3 files, [32m+3[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_squash_empty_changes.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_squash_empty_changes.snap
@@ -41,4 +41,5 @@ exit_code: 0
 [107m [0m - Revert to initial
 [2m○[22m No changes after squashing 3 commits
 [2m○[22m Already up to date with [1mmain[22m (no new commits, no rebase needed)
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_squash_single_commit.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_squash_single_commit.snap
@@ -35,4 +35,5 @@ exit_code: 0
 [107m [0m  file1.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_squash_with_llm.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_squash_with_llm.snap
@@ -39,4 +39,5 @@ exit_code: 0
 [107m [0m  auth.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_squash_with_working_tree_creates_backup.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_squash_with_working_tree_creates_backup.snap
@@ -43,4 +43,5 @@ exit_code: 0
 [107m [0m  file2.txt | 1 [32m+[m
 [107m [0m  2 files changed, 2 insertions(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 2 files, [32m+2[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_to_default.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_to_default.snap
@@ -34,4 +34,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_to_non_default_target.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_to_non_default_target.snap
@@ -37,4 +37,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mstaging[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature-for-staging[22m worktree & branch in background (same commit as [1mstaging[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature-for-staging[22m worktree & branch in background (same commit as [1mstaging[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mstaging[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_when_primary_not_on_default_but_default_has_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_when_primary_not_on_default_but_default_has_worktree.snap
@@ -35,4 +35,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_.main-wt[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_.main-wt[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_with_caret.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_with_caret.snap
@@ -35,4 +35,5 @@ exit_code: 0
 [107m [0m  feature.txt | 1 [32m+[m
 [107m [0m  1 file changed, 1 insertion(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_with_untracked_files.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_with_untracked_files.snap
@@ -47,4 +47,5 @@ exit_code: 0
 [107m [0m  untracked2.txt | 1 [32m+[m
 [107m [0m  3 files changed, 3 insertions(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 3 files, [32m+3[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__readme_example_complex.snap
+++ b/tests/snapshots/integration__integration_tests__merge__readme_example_complex.snap
@@ -66,7 +66,8 @@ test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fin
 [107m [0m  jwt.rs       |  8 [32m++++++++[m
 [107m [0m  3 files changed, 33 insertions(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 3 files, [32m+33[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature-auth[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature-auth[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m
 [36m◎[39m [36mRunning project post-merge [1minstall[22m:[39m
 [107m [0m [2m[0m[2m[34mcargo[0m[2m install [0m[2m[36m--path[0m[2m .
 [0m  Installing worktrunk v0.1.0

--- a/tests/snapshots/integration__integration_tests__merge__readme_example_hooks_pre_merge.snap
+++ b/tests/snapshots/integration__integration_tests__merge__readme_example_hooks_pre_merge.snap
@@ -61,4 +61,5 @@ All checks passed!
 [107m [0m  tests/test_auth.py | 14 [32m++++++++++++++[m
 [107m [0m  2 files changed, 45 insertions(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 2 files, [32m+45[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfeature-auth[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature-auth[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__merge__readme_example_simple.snap
+++ b/tests/snapshots/integration__integration_tests__merge__readme_example_simple.snap
@@ -35,4 +35,5 @@ exit_code: 0
 [107m [0m  auth.rs | 13 [32m+++++++++++++[m
 [107m [0m  1 file changed, 13 insertions(+)
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+13[39m[39m[90m)[39m[39m
-[36m◎ Removing [1mfix-auth[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfix-auth[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__remove__remove_current_by_name.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_current_by_name.snap
@@ -30,4 +30,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎ Removing [1mfeature-current[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature-current[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__remove__remove_from_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_from_worktree.snap
@@ -29,4 +29,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎ Removing [1mfeature-wt[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature-wt[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__remove__remove_internal_mode.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_internal_mode.snap
@@ -30,4 +30,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎ Removing [1mfeature-internal[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature-internal[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__remove__remove_main_vs_linked__from_linked_succeeds.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_main_vs_linked__from_linked_succeeds.snap
@@ -31,4 +31,5 @@ exit_code: 0
 
 ----- stderr -----
 [36m◎[39m [36mRemoving current worktree...[39m
-[32m✓ Removed [1mfeature[22m worktree & branch; changed directory to [1m_REPO_[22m (same commit as [1mmain[22m,[39m [2m_[22m[32m)[39m
+[32m✓ Removed [1mfeature[22m worktree & branch (same commit as [1mmain[22m,[39m [2m_[22m[32m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m

--- a/tests/snapshots/integration__integration_tests__remove__remove_multiple_including_current.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_multiple_including_current.snap
@@ -34,4 +34,5 @@ exit_code: 0
 ----- stderr -----
 [36m◎ Removing [1mfeature-b[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
 [36m◎ Removing [1mfeature-c[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
-[36m◎ Removing [1mfeature-a[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m[36m. Changing directory to [1m_REPO_[39m[22m
+[36m◎ Removing [1mfeature-a[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m


### PR DESCRIPTION
## Summary

- Replace inline "Changing directory to" suffix with separate "Switched to worktree for {branch} @ {path}" message
- Output now matches the format used by `wt switch`
- Handler looks up branch at destination path when `changed_directory` is true

Before:
```
◎ Removing feature worktree & branch in background (same commit as main, _). Changing directory to ~/repo
```

After:
```
◎ Removing feature worktree & branch in background (same commit as main, _)
○ Switched to worktree for main @ ~/repo
```

## Test plan

- [x] All tests pass
- [x] Snapshot tests updated to reflect new output format
- [x] Lints pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)