### PR TITLE
Standardize 'already up to date' message formatting

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1124,8 +1124,8 @@ fn main() {
                 handle_rebase(target.as_deref()).and_then(|result| match result {
                     RebaseResult::Rebased => Ok(()),
                     RebaseResult::UpToDate(branch) => {
-                        crate::output::print(info_message(format!(
-                            "Already up-to-date with {branch}"
+                        crate::output::print(info_message(cformat!(
+                            "Already up to date with <bold>{branch}</>"
                         )))?;
                         Ok(())
                     }


### PR DESCRIPTION
## Summary

- Remove hyphen from "up-to-date" → "up to date" (matches git convention and the existing push message)
- Add bold styling to branch name (matches other branch references per CLI output rules)

This unifies the rebase "already up to date" message (`wt step rebase`) with the push equivalent (`wt step push`).

## Test plan

- [x] All tests pass (1530 tests)
- [x] Pre-commit lints pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)