### PR TITLE
Remove unnecessary piped stdout bypass from shell wrappers

### DIFF
--- a/templates/bash.sh
+++ b/templates/bash.sh
@@ -25,12 +25,6 @@ if command -v {{ cmd }} >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
 
         # --source: use cargo run (builds from source)
         if [[ "$use_source" == true ]]; then
-            # If stdout is not a terminal (piped/redirected), run directly.
-            # This allows `wt list --format=json | jq` to work.
-            if [[ ! -t 1 ]]; then
-                cargo run --bin {{ cmd }} --quiet -- "${args[@]}"
-                return
-            fi
             local directive_file exit_code=0
             directive_file="$(mktemp)"
             WORKTRUNK_DIRECTIVE_FILE="$directive_file" cargo run --bin {{ cmd }} --quiet -- "${args[@]}" || exit_code=$?
@@ -42,13 +36,6 @@ if command -v {{ cmd }} >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
             fi
             rm -f "$directive_file"
             return "$exit_code"
-        fi
-
-        # If stdout is not a terminal (piped/redirected), run directly.
-        # This allows `wt list --format=json | jq` to work.
-        if [[ ! -t 1 ]]; then
-            command "${WORKTRUNK_BIN:-{{ cmd }}}" "${args[@]}"
-            return
         fi
 
         _{{ cmd|safe_fn }}_exec "${args[@]}"

--- a/templates/fish.fish
+++ b/templates/fish.fish
@@ -40,12 +40,6 @@ if type -q {{ cmd }}; or test -n "$WORKTRUNK_BIN"
 
         # --source: use cargo run (builds from source)
         if test $use_source = true
-            # If stdout is not a terminal (piped/redirected), run directly.
-            # This allows `wt list --format=json | jq` to work.
-            if not isatty stdout
-                cargo run --bin {{ cmd }} --quiet -- $args
-                return $status
-            end
             set -l directive_file (mktemp)
             WORKTRUNK_DIRECTIVE_FILE=$directive_file cargo run --bin {{ cmd }} --quiet -- $args
             set -l exit_code $status
@@ -57,14 +51,6 @@ if type -q {{ cmd }}; or test -n "$WORKTRUNK_BIN"
             end
             rm -f "$directive_file"
             return $exit_code
-        end
-
-        # If stdout is not a terminal (piped/redirected), run directly.
-        # This allows `wt list --format=json | jq` to work.
-        if not isatty stdout
-            test -n "$WORKTRUNK_BIN"; or set -l WORKTRUNK_BIN (type -P {{ cmd }})
-            command $WORKTRUNK_BIN $args
-            return $status
         end
 
         _{{ cmd|safe_fn }}_exec $args

--- a/templates/powershell.ps1
+++ b/templates/powershell.ps1
@@ -16,15 +16,6 @@ if (Get-Command {{ cmd }} -ErrorAction SilentlyContinue) {
         )
 
         $wtBin = (Get-Command {{ cmd }} -CommandType Application).Source
-
-        # If output is redirected (piped), run directly without wrapper.
-        # This allows `wt list --format=json | ConvertFrom-Json` to work - the output
-        # flows through instead of being captured and Invoke-Expression'd.
-        if ([Console]::IsOutputRedirected) {
-            & $wtBin @Arguments
-            return $LASTEXITCODE
-        }
-
         $directiveFile = [System.IO.Path]::GetTempFileName()
 
         try {

--- a/templates/zsh.zsh
+++ b/templates/zsh.zsh
@@ -28,12 +28,6 @@ if command -v {{ cmd }} >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
 
         # --source: use cargo run (builds from source)
         if [[ "$use_source" == true ]]; then
-            # If stdout is not a terminal (piped/redirected), run directly.
-            # This allows `wt list --format=json | jq` to work.
-            if [[ ! -t 1 ]]; then
-                cargo run --bin {{ cmd }} --quiet -- "${args[@]}"
-                return
-            fi
             local directive_file exit_code=0
             directive_file="$(mktemp)"
             WORKTRUNK_DIRECTIVE_FILE="$directive_file" cargo run --bin {{ cmd }} --quiet -- "${args[@]}" || exit_code=$?
@@ -45,13 +39,6 @@ if command -v {{ cmd }} >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
             fi
             rm -f "$directive_file"
             return "$exit_code"
-        fi
-
-        # If stdout is not a terminal (piped/redirected), run directly.
-        # This allows `wt list --format=json | jq` to work.
-        if [[ ! -t 1 ]]; then
-            command "${WORKTRUNK_BIN:-{{ cmd }}}" "${args[@]}"
-            return
         fi
 
         _{{ cmd|safe_fn }}_exec "${args[@]}"

--- a/tests/common/shell.rs
+++ b/tests/common/shell.rs
@@ -59,8 +59,8 @@ pub fn get_shell_binary(shell: &str) -> &str {
 
 /// Execute a script in the given shell with the repo's isolated environment.
 ///
-/// Uses a PTY so that stdout appears as a terminal to the shell. This is required
-/// for shell wrapper tests since the wrapper uses `[[ ! -t 1 ]]` to detect piping.
+/// Uses a PTY so that stdout appears as a terminal to the shell. This simulates
+/// real terminal behavior for shell wrapper tests (combined stdout/stderr, ANSI codes).
 #[cfg(unix)]
 pub fn execute_shell_script(repo: &TestRepo, shell: &str, script: &str) -> String {
     use portable_pty::CommandBuilder;

--- a/tests/snapshots/integration__integration_tests__init__init_bash.snap
+++ b/tests/snapshots/integration__integration_tests__init__init_bash.snap
@@ -76,12 +76,6 @@ _wt_exec() {
 
         # --source: use cargo run (builds from source)
         if [[ "$use_source" == true ]]; then
-            # If stdout is not a terminal (piped/redirected), run directly.
-            # This allows `wt list --format=json | jq` to work.
-            if [[ ! -t 1 ]]; then
-                cargo run --bin wt --quiet -- "${args[@]}"
-                return
-            fi
             local directive_file exit_code=0
             directive_file="$(mktemp)"
             WORKTRUNK_DIRECTIVE_FILE="$directive_file" cargo run --bin wt --quiet -- "${args[@]}" || exit_code=$?
@@ -93,13 +87,6 @@ _wt_exec() {
             fi
             rm -f "$directive_file"
             return "$exit_code"
-        fi
-
-        # If stdout is not a terminal (piped/redirected), run directly.
-        # This allows `wt list --format=json | jq` to work.
-        if [[ ! -t 1 ]]; then
-            command "${WORKTRUNK_BIN:-wt}" "${args[@]}"
-            return
         fi
 
         _wt_exec "${args[@]}"

--- a/tests/snapshots/integration__integration_tests__init__init_fish.snap
+++ b/tests/snapshots/integration__integration_tests__init__init_fish.snap
@@ -72,12 +72,6 @@ if type -q wt; or test -n "$WORKTRUNK_BIN"
 
         # --source: use cargo run (builds from source)
         if test $use_source = true
-            # If stdout is not a terminal (piped/redirected), run directly.
-            # This allows `wt list --format=json | jq` to work.
-            if not isatty stdout
-                cargo run --bin wt --quiet -- $args
-                return $status
-            end
             set -l directive_file (mktemp)
             WORKTRUNK_DIRECTIVE_FILE=$directive_file cargo run --bin wt --quiet -- $args
             set -l exit_code $status
@@ -89,14 +83,6 @@ if type -q wt; or test -n "$WORKTRUNK_BIN"
             end
             rm -f "$directive_file"
             return $exit_code
-        end
-
-        # If stdout is not a terminal (piped/redirected), run directly.
-        # This allows `wt list --format=json | jq` to work.
-        if not isatty stdout
-            test -n "$WORKTRUNK_BIN"; or set -l WORKTRUNK_BIN (type -P wt)
-            command $WORKTRUNK_BIN $args
-            return $status
         end
 
         _wt_exec $args

--- a/tests/snapshots/integration__integration_tests__init__init_zsh.snap
+++ b/tests/snapshots/integration__integration_tests__init__init_zsh.snap
@@ -79,12 +79,6 @@ _wt_exec() {
 
         # --source: use cargo run (builds from source)
         if [[ "$use_source" == true ]]; then
-            # If stdout is not a terminal (piped/redirected), run directly.
-            # This allows `wt list --format=json | jq` to work.
-            if [[ ! -t 1 ]]; then
-                cargo run --bin wt --quiet -- "${args[@]}"
-                return
-            fi
             local directive_file exit_code=0
             directive_file="$(mktemp)"
             WORKTRUNK_DIRECTIVE_FILE="$directive_file" cargo run --bin wt --quiet -- "${args[@]}" || exit_code=$?
@@ -96,13 +90,6 @@ _wt_exec() {
             fi
             rm -f "$directive_file"
             return "$exit_code"
-        fi
-
-        # If stdout is not a terminal (piped/redirected), run directly.
-        # This allows `wt list --format=json | jq` to work.
-        if [[ ! -t 1 ]]; then
-            command "${WORKTRUNK_BIN:-wt}" "${args[@]}"
-            return
         fi
 
         _wt_exec "${args[@]}"


### PR DESCRIPTION
## Summary

- Removed the `[[ ! -t 1 ]]` (piped stdout) bypass check from all shell wrappers (bash, zsh, fish, powershell)
- This check was needed for an older output system that didn't cleanly separate stdout from stderr
- With the current output system (data→stdout, status→stderr, directives→file), piping works correctly with shell integration active
- Removing the bypass actually improves behavior for cases like `wt switch feature | tee log.txt` where you want both piped output AND shell effects

## Test plan

- [x] All 605 integration tests pass
- [x] Pre-commit lints pass
- [x] Snapshot tests updated for new wrapper output

🤖 Generated with [Claude Code](https://claude.com/claude-code)