### PR TITLE
Add "Run in Smithery" badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Here's a quick demo:
 
 ## Context: git worktrees
 
+[![Run in Smithery](https://smithery.ai/badge/skills/max-sixty)](https://smithery.ai/skills?ns=max-sixty&utm_source=github&utm_medium=badge)
+
+
 AI agents like Claude Code and Codex can handle longer tasks without
 supervision, such that it's possible to manage 5-10+ in parallel. Git worktrees
 give each agent its own working directory; no stepping on each other's changes.


### PR DESCRIPTION
## Add skill discoverability badge

Your 1 Claude skill is already indexed on [Smithery](https://smithery.ai), a directory of Agent Skills and MCP servers. This badge links users directly to your skills.

### Badge Preview
[![Run in Smithery](https://smithery.ai/badge/skills/max-sixty)](https://smithery.ai/skills?ns=max-sixty&utm_source=github&utm_medium=badge)

### Why add this?
- Users browsing your repo can discover and install your skills with one click
- No additional setup required - your skills are already listed

---

This is optional. Feel free to close if you prefer not to add external badges.