### PR TITLE
Add post-switch hook for background execution after every switch

### DIFF
--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -25,6 +25,7 @@ wt hook pre-merge --force   # Skip approval prompts (for CI)
 |------|------|----------|-----------|
 | `post-create` | After worktree created | Yes | No |
 | `post-start` | After worktree created | No (background) | No |
+| `post-switch` | After every switch | No (background) | No |
 | `pre-commit` | Before commit during merge | Yes | Yes |
 | `pre-merge` | Before merging to target | Yes | Yes |
 | `post-merge` | After successful merge | Yes | No |
@@ -59,6 +60,18 @@ server = "npm run dev"
 ```
 
 Output logged to `.git/wt-logs/{branch}-{source}-post-start-{name}.log` (source is `user` or `project`).
+
+### post-switch
+
+Runs after **every** switch operation, **in background**. Triggers on all switch results: creating new worktrees, switching to existing ones, or switching to the current worktree.
+
+**Use cases**: Renaming terminal tabs, updating tmux window names, IDE notifications.
+
+```toml
+post-switch = "echo 'Switched to {{ branch }}'"
+```
+
+Output logged to `.git/wt-logs/{branch}-{source}-post-switch-{name}.log` (source is `user` or `project`).
 
 ### pre-commit
 
@@ -377,6 +390,7 @@ Usage: <b><span class=c>wt hook</span></b> <span class=c>[OPTIONS]</span> <span 
   <b><span class=c>show</span></b>         Show configured hooks
   <b><span class=c>post-create</span></b>  Run post-create hooks
   <b><span class=c>post-start</span></b>   Run post-start hooks
+  <b><span class=c>post-switch</span></b>  Run post-switch hooks
   <b><span class=c>pre-commit</span></b>   Run pre-commit hooks
   <b><span class=c>pre-merge</span></b>    Run pre-merge hooks
   <b><span class=c>post-merge</span></b>   Run post-merge hooks

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1003,7 +1003,7 @@ pub enum HookCommand {
     /// Lists user and project hooks. Project hooks show approval status (❓ = needs approval).
     Show {
         /// Hook type to show (default: all)
-        #[arg(value_parser = ["post-create", "post-start", "pre-commit", "pre-merge", "post-merge", "pre-remove"])]
+        #[arg(value_parser = ["post-create", "post-start", "post-switch", "pre-commit", "pre-merge", "post-merge", "pre-remove"])]
         hook_type: Option<String>,
 
         /// Show expanded commands with current variables
@@ -1028,6 +1028,19 @@ pub enum HookCommand {
     ///
     /// Background — runs without blocking.
     PostStart {
+        /// Run only this command from hook config
+        #[arg(add = crate::completion::hook_command_name_completer())]
+        name: Option<String>,
+
+        /// Skip approval prompts
+        #[arg(short, long)]
+        force: bool,
+    },
+
+    /// Run post-switch hooks
+    ///
+    /// Background — runs without blocking.
+    PostSwitch {
         /// Run only this command from hook config
         #[arg(add = crate::completion::hook_command_name_completer())]
         name: Option<String>,
@@ -1445,6 +1458,7 @@ wt hook pre-merge --force   # Skip approval prompts (for CI)
 |------|------|----------|-----------|
 | `post-create` | After worktree created | Yes | No |
 | `post-start` | After worktree created | No (background) | No |
+| `post-switch` | After every switch | No (background) | No |
 | `pre-commit` | Before commit during merge | Yes | Yes |
 | `pre-merge` | Before merging to target | Yes | Yes |
 | `post-merge` | After successful merge | Yes | No |
@@ -1479,6 +1493,18 @@ server = "npm run dev"
 ```
 
 Output logged to `.git/wt-logs/{branch}-{source}-post-start-{name}.log` (source is `user` or `project`).
+
+### post-switch
+
+Runs after **every** switch operation, **in background**. Triggers on all switch results: creating new worktrees, switching to existing ones, or switching to the current worktree.
+
+**Use cases**: Renaming terminal tabs, updating tmux window names, IDE notifications.
+
+```toml
+post-switch = "echo 'Switched to {{ branch }}'"
+```
+
+Output logged to `.git/wt-logs/{branch}-{source}-post-switch-{name}.log` (source is `user` or `project`).
 
 ### pre-commit
 

--- a/src/commands/project_config.rs
+++ b/src/commands/project_config.rs
@@ -11,6 +11,7 @@ pub fn collect_commands_for_hooks(
         let cfg = match hook {
             HookType::PostCreate => &project_config.post_create,
             HookType::PostStart => &project_config.post_start,
+            HookType::PostSwitch => &project_config.post_switch,
             HookType::PreCommit => &project_config.pre_commit,
             HookType::PreMerge => &project_config.pre_merge,
             HookType::PostMerge => &project_config.post_merge,

--- a/src/commands/standalone.rs
+++ b/src/commands/standalone.rs
@@ -101,6 +101,20 @@ pub fn run_hook(hook_type: HookType, force: bool, name_filter: Option<&str>) -> 
                 name_filter,
             )
         }
+        HookType::PostSwitch => {
+            let user_config = user_hook!(post_switch);
+            let project_config = project_config.as_ref().and_then(|c| c.post_switch.as_ref());
+            require_hooks(user_config, project_config, hook_type)?;
+            run_hook_with_filter(
+                &ctx,
+                user_config,
+                project_config,
+                hook_type,
+                &[],
+                HookFailureStrategy::FailFast,
+                name_filter,
+            )
+        }
         HookType::PreCommit => {
             let user_config = user_hook!(pre_commit);
             let project_config = project_config.as_ref().and_then(|c| c.pre_commit.as_ref());
@@ -656,6 +670,7 @@ pub fn handle_hook_show(hook_type_filter: Option<&str>, expanded: bool) -> anyho
     let filter: Option<HookType> = hook_type_filter.map(|s| match s {
         "post-create" => HookType::PostCreate,
         "post-start" => HookType::PostStart,
+        "post-switch" => HookType::PostSwitch,
         "pre-commit" => HookType::PreCommit,
         "pre-merge" => HookType::PreMerge,
         "post-merge" => HookType::PostMerge,
@@ -725,6 +740,7 @@ fn render_user_hooks(
     let hooks = [
         (HookType::PostCreate, &config.post_create),
         (HookType::PostStart, &config.post_start),
+        (HookType::PostSwitch, &config.post_switch),
         (HookType::PreCommit, &config.pre_commit),
         (HookType::PreMerge, &config.pre_merge),
         (HookType::PostMerge, &config.post_merge),
@@ -784,6 +800,7 @@ fn render_project_hooks(
     let hooks = [
         (HookType::PostCreate, &config.post_create),
         (HookType::PostStart, &config.post_start),
+        (HookType::PostSwitch, &config.post_switch),
         (HookType::PreCommit, &config.pre_commit),
         (HookType::PreMerge, &config.pre_merge),
         (HookType::PostMerge, &config.post_merge),

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -50,6 +50,14 @@ pub struct ProjectConfig {
     #[serde(default, rename = "post-start")]
     pub post_start: Option<CommandConfig>,
 
+    /// Commands to execute after switching to a worktree (non-blocking, background)
+    /// Runs on every switch, including to existing worktrees and newly created ones
+    /// Supports string (single command) or table (named, parallel)
+    ///
+    /// Available template variables: `{{ repo }}`, `{{ branch }}`, `{{ worktree }}`, `{{ worktree_name }}`, `{{ repo_root }}`, `{{ default_branch }}`, `{{ commit }}`, `{{ short_commit }}`, `{{ remote }}`, `{{ upstream }}`
+    #[serde(default, rename = "post-switch")]
+    pub post_switch: Option<CommandConfig>,
+
     /// Commands to execute before committing changes during merge (blocking, fail-fast validation)
     /// Supports string (single command) or table (named, sequential)
     /// All commands must exit with code 0 for commit to proceed
@@ -134,6 +142,7 @@ mod tests {
         let config = ProjectConfig::default();
         assert!(config.post_create.is_none());
         assert!(config.post_start.is_none());
+        assert!(config.post_switch.is_none());
         assert!(config.pre_commit.is_none());
         assert!(config.pre_merge.is_none());
         assert!(config.post_merge.is_none());
@@ -203,6 +212,7 @@ test = "cargo test"
         let contents = r#"
 post-create = "npm install"
 post-start = "npm run watch"
+post-switch = "rename-tab"
 pre-commit = "cargo fmt --check"
 pre-merge = "cargo test"
 post-merge = "git push"
@@ -211,6 +221,7 @@ pre-remove = "echo bye"
         let config: ProjectConfig = toml::from_str(contents).unwrap();
         assert!(config.post_create.is_some());
         assert!(config.post_start.is_some());
+        assert!(config.post_switch.is_some());
         assert!(config.pre_commit.is_some());
         assert!(config.pre_merge.is_some());
         assert!(config.post_merge.is_some());

--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -168,6 +168,14 @@ pub struct WorktrunkConfig {
     )]
     pub post_start: Option<CommandConfig>,
 
+    /// Commands to execute after switching to a worktree (background)
+    #[serde(
+        default,
+        rename = "post-switch",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub post_switch: Option<CommandConfig>,
+
     /// Commands to execute before committing during merge (blocking, fail-fast)
     #[serde(
         default,
@@ -342,6 +350,7 @@ impl Default for WorktrunkConfig {
             merge: None,
             post_create: None,
             post_start: None,
+            post_switch: None,
             pre_commit: None,
             pre_merge: None,
             post_merge: None,
@@ -805,6 +814,9 @@ run = "npm install"
 
 [post-start]
 run = "npm run build"
+
+[post-switch]
+rename-tab = "echo 'switched'"
 "#;
         let keys = find_unknown_keys(content);
         assert!(keys.is_empty());

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -286,6 +286,7 @@ pub(crate) use parse::DefaultBranchName;
 pub enum HookType {
     PostCreate,
     PostStart,
+    PostSwitch,
     PreCommit,
     PreMerge,
     PostMerge,

--- a/tests/integration_tests/completion.rs
+++ b/tests/integration_tests/completion.rs
@@ -707,6 +707,7 @@ fn test_complete_hook_subcommands(repo: TestRepo) {
     assert!(subcommands.contains(&"show"), "Missing show");
     assert!(subcommands.contains(&"post-create"), "Missing post-create");
     assert!(subcommands.contains(&"post-start"), "Missing post-start");
+    assert!(subcommands.contains(&"post-switch"), "Missing post-switch");
     assert!(subcommands.contains(&"pre-commit"), "Missing pre-commit");
     assert!(subcommands.contains(&"pre-merge"), "Missing pre-merge");
     assert!(subcommands.contains(&"post-merge"), "Missing post-merge");
@@ -714,8 +715,8 @@ fn test_complete_hook_subcommands(repo: TestRepo) {
     assert!(subcommands.contains(&"approvals"), "Missing approvals");
     assert_eq!(
         subcommands.len(),
-        8,
-        "Should have exactly 8 hook subcommands"
+        9,
+        "Should have exactly 9 hook subcommands"
     );
 
     // Test 2: Partial input "po" - filters to post-* subcommands
@@ -725,6 +726,7 @@ fn test_complete_hook_subcommands(repo: TestRepo) {
     let subcommands = value_suggestions(&stdout);
     assert!(subcommands.contains(&"post-create"));
     assert!(subcommands.contains(&"post-start"));
+    assert!(subcommands.contains(&"post-switch"));
     assert!(subcommands.contains(&"post-merge"));
     assert!(!subcommands.contains(&"pre-commit"));
     assert!(!subcommands.contains(&"pre-merge"));


### PR DESCRIPTION
## Summary

- Add a new `post-switch` hook that runs in the background after every `wt switch` operation
- Unlike `post-start` (which only runs on creation), `post-switch` runs on all switch results: Created, Existing, and AlreadyAt
- Useful for tasks like renaming terminal tabs, updating tmux window names, and IDE notifications

## Changes

- Added `PostSwitch` variant to `HookType` enum
- Added `post_switch` field to both user and project config
- Added `wt hook post-switch` CLI subcommand
- Added `spawn_post_switch_commands()` method following the `post-start` pattern
- Updated approval logic to request approval for `post-switch` on all switches
- Added hook types table entry and documentation section

## Execution order on `wt switch --create`

1. Create worktree
2. Run post-create hooks (blocking)
3. Show success message
4. Spawn post-switch hooks (background)
5. Spawn post-start hooks (background)

## Test plan

- [x] All 1428 tests pass
- [x] Pre-commit lints pass
- [x] Docs auto-synced via readme_sync test

🤖 Generated with [Claude Code](https://claude.com/claude-code)