### PR TITLE
Optimize wt list skeleton display speed

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -697,16 +697,17 @@ Usage: <b><span class=c>wt config state</span></b> <span class=c>[OPTIONS]</span
 
 Worktrunk detects the default branch automatically:
 
-1. **Local cache** — Checks `git rev-parse origin/HEAD` (fast, no network)
-2. **Remote query** — If not cached, queries `git ls-remote` (100ms–2s)
-3. **Cache result** — Stores via `git remote set-head` for future calls
+1. **Worktrunk cache** — Checks `git config worktrunk.default-branch` (single command)
+2. **Git cache** — Detects primary remote and checks its HEAD (e.g., `origin/HEAD`)
+3. **Remote query** — If not cached, queries `git ls-remote` (100ms–2s)
 4. **Local inference** — If no remote, infers from local branches
+
+Once detected, the result is cached in `worktrunk.default-branch` for fast access.
 
 The local inference fallback uses these heuristics in order:
 - If only one local branch exists, uses it
-- Checks what HEAD points to in main worktree
 - Checks `git config init.defaultBranch`
-- Looks for common names: main, master, develop
+- Looks for common names: main, master, develop, trunk
 
 ### When to use
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -441,16 +441,17 @@ pub enum StateCommand {
 
 Worktrunk detects the default branch automatically:
 
-1. **Local cache** — Checks `git rev-parse origin/HEAD` (fast, no network)
-2. **Remote query** — If not cached, queries `git ls-remote` (100ms–2s)
-3. **Cache result** — Stores via `git remote set-head` for future calls
+1. **Worktrunk cache** — Checks `git config worktrunk.default-branch` (single command)
+2. **Git cache** — Detects primary remote and checks its HEAD (e.g., `origin/HEAD`)
+3. **Remote query** — If not cached, queries `git ls-remote` (100ms–2s)
 4. **Local inference** — If no remote, infers from local branches
+
+Once detected, the result is cached in `worktrunk.default-branch` for fast access.
 
 The local inference fallback uses these heuristics in order:
 - If only one local branch exists, uses it
-- Checks what HEAD points to in main worktree
 - Checks `git config init.defaultBranch`
-- Looks for common names: main, master, develop
+- Looks for common names: main, master, develop, trunk
 
 ## When to use
 

--- a/src/commands/list/model.rs
+++ b/src/commands/list/model.rs
@@ -312,6 +312,13 @@ impl ListItem {
         }
     }
 
+    pub fn worktree_data_mut(&mut self) -> Option<&mut WorktreeData> {
+        match &mut self.kind {
+            ItemKind::Worktree(data) => Some(data),
+            ItemKind::Branch => None,
+        }
+    }
+
     pub fn worktree_path(&self) -> Option<&PathBuf> {
         self.worktree_data().map(|data| &data.path)
     }

--- a/src/commands/list/render.rs
+++ b/src/commands/list/render.rs
@@ -399,9 +399,6 @@ impl LayoutConfig {
 
         let branch = item.branch_name();
         let wt_data = item.worktree_data();
-        let is_main = item.is_main();
-        let is_current = wt_data.is_some_and(|d| d.is_current);
-        let is_previous = wt_data.is_some_and(|d| d.is_previous);
         let shortened_path = item
             .worktree_path()
             .map(|p| shorten_path(p, &self.main_worktree_path))
@@ -415,20 +412,14 @@ impl LayoutConfig {
 
             match col.kind {
                 ColumnKind::Gutter => {
-                    // Show actual gutter symbol even in skeleton
-                    // Priority: @ (current) > ^ (main) > - (previous) > + (regular worktree) > space (branch)
-                    let symbol = if is_current {
-                        "@ "
-                    } else if is_main {
-                        "^ "
-                    } else if is_previous {
-                        "- "
-                    } else if wt_data.is_some() {
-                        "+ " // Regular worktree
+                    // Skeleton shows placeholder gutter - actual symbols appear when data loads.
+                    // This allows deferring previous_branch lookup until after skeleton.
+                    let symbol = if wt_data.is_some() {
+                        "· " // Placeholder for worktrees
                     } else {
                         "  " // Branch without worktree (two spaces to match width)
                     };
-                    cell.push_raw(symbol.to_string());
+                    cell.push_styled(symbol, dim);
                 }
                 ColumnKind::Branch => {
                     // Show actual branch name (no dim - start normal, gray out later if removable)

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -38,7 +38,7 @@ pub use standalone::{
 };
 pub use worktree::{
     ResolutionContext, compute_worktree_path, handle_remove, handle_remove_by_path,
-    handle_remove_current, handle_switch, is_worktree_at_expected_path, resolve_worktree_arg,
+    handle_remove_current, handle_switch, is_worktree_at_expected_path_with, resolve_worktree_arg,
     worktree_display_name,
 };
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
@@ -11,6 +11,7 @@ info:
     CLICOLOR_FORCE: "1"
     COLUMNS: "150"
     GIT_EDITOR: ""
+    RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
 ---
@@ -46,16 +47,17 @@ Usage: [1m[36mwt config state default-branch[0m [36m[OPTIONS][0m [36m[COMM
 
 Worktrunk detects the default branch automatically:
 
-1. [1mLocal cache[0m — Checks [2mgit rev-parse origin/HEAD[0m (fast, no network)
-2. [1mRemote query[0m — If not cached, queries [2mgit ls-remote[0m (100ms–2s)
-3. [1mCache result[0m — Stores via [2mgit remote set-head[0m for future calls
+1. [1mWorktrunk cache[0m — Checks [2mgit config worktrunk.default-branch[0m (single command)
+2. [1mGit cache[0m — Detects primary remote and checks its HEAD (e.g., [2morigin/HEAD[0m)
+3. [1mRemote query[0m — If not cached, queries [2mgit ls-remote[0m (100ms–2s)
 4. [1mLocal inference[0m — If no remote, infers from local branches
+
+Once detected, the result is cached in [2mworktrunk.default-branch[0m for fast access.
 
 The local inference fallback uses these heuristics in order:
 - If only one local branch exists, uses it
-- Checks what HEAD points to in main worktree
 - Checks [2mgit config init.defaultBranch
-- Looks for common names: main, master, develop
+- Looks for common names: main, master, develop, trunk
 
 [32mWhen to use
 


### PR DESCRIPTION
## Summary

- Add `worktrunk.default-branch` cache for O(1) default branch lookup (single git config read vs 3+ commands)
- Batch timestamp fetching in single git command for sorting efficiency
- Detect current worktree via path comparison instead of `git rev-parse --show-toplevel`
- Defer `previous_branch` and `effective_integration_target` lookups until after skeleton
- Pre-compute `is_bare` and `default_branch` values to avoid redundant git calls in hot paths
- Skeleton shows `·` placeholder for gutter symbols, filled in when data loads
- Add documentation explaining skeleton performance requirements

## Test plan

- [x] All 606 integration tests pass
- [x] All lints pass
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)