### PR TITLE
Fix syntax highlighting being stripped by 1Password extension

### DIFF
--- a/docs/sass/custom.scss
+++ b/docs/sass/custom.scss
@@ -442,12 +442,17 @@ main {
         font-family: var(--wt-font-mono);
         font-size: 0.875rem;
         line-height: 1.6;
-        color: var(--wt-color-text);
+        // Note: color is NOT set here to allow syntax highlighting themes to apply
     }
 }
 
 .content pre {
     @extend %code-block-base;
+
+    // Override .content code color to allow syntax highlighting
+    code {
+        color: inherit;
+    }
 }
 
 // Copy button for code blocks
@@ -485,6 +490,7 @@ main {
     font-family: var(--wt-font-mono);
     font-size: 0.875rem;
     line-height: 1.5;
+    color: var(--wt-color-text);  // Default text color for terminal (not syntax-highlighted)
 
     .prompt {
         color: var(--wt-color-text-soft);

--- a/docs/templates/base.html
+++ b/docs/templates/base.html
@@ -85,6 +85,26 @@
     <script src="/code-copy.js" defer></script>
     <script src="/mobile-menu.js" defer></script>
     <script src="//instant.page/5.2.0" type="module" integrity="sha384-jnZyxPjiipYXnSU0ygqeac2q7CVYMbh84q0uHVRRxEtvFPiQYbXWUorga2aqZJ0z"></script>
+    <script>
+    // 1Password extension bug workaround: it strips syntax highlighting spans from
+    // code blocks with language-* classes. Adding data-1p-ignore prevents this.
+    // https://1password.community/discussion/165597
+    (function() {
+        var mark = function(el) { el.setAttribute('data-1p-ignore', ''); };
+        new MutationObserver(function(mutations) {
+            mutations.forEach(function(m) {
+                m.addedNodes.forEach(function(n) {
+                    if (n.nodeType === 1) {
+                        if (n.matches && n.matches('code[class*="language-"]')) mark(n);
+                        if (n.querySelectorAll) {
+                            n.querySelectorAll('code[class*="language-"]').forEach(mark);
+                        }
+                    }
+                });
+            });
+        }).observe(document.documentElement, { childList: true, subtree: true });
+    })();
+    </script>
 </head>
 
 <body>


### PR DESCRIPTION
## Summary

- Fix 1Password browser extension stripping syntax highlighting spans from code blocks with `language-*` classes
- Add `data-1p-ignore` attribute via MutationObserver to prevent 1Password from processing code blocks
- Fix CSS to let syntax highlighting colors apply by using `color: inherit` for `.content pre code`

## Context

The 1Password extension rewrites code blocks that have `language-*` classes, replacing Zola's syntect-generated `.z-*` spans with its own Prism-style tokens. This breaks all syntax highlighting.

Known bug: https://1password.community/discussion/165597

The workaround uses `data-1p-ignore` which tells 1Password to skip processing these elements.

## Test plan

- [x] Verified in Chrome with 1Password enabled - syntax highlighting now works
- [x] DOM shows 46+ `.z-comment` spans preserved (was 0 before fix)
- [x] `data-1p-ignore` attribute present on code elements

🤖 Generated with [Claude Code](https://claude.com/claude-code)