### PR TITLE
Add working tree conflict detection to --full flag

### DIFF
--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -122,7 +122,7 @@ The Status column has multiple subcolumns. Within each, only the first matching 
 | | `⊟` | Prunable (directory missing) |
 | | `⊞` | Locked worktree |
 | Default branch | `^` | Is the default branch |
-| | `✗` | Would conflict if merged to the default branch |
+| | `✗` | Would conflict if merged to the default branch (with `--full`, includes uncommitted changes) |
 | | `_` | Same commit as the default branch, clean |
 | | `–` | Same commit as the default branch, uncommitted changes |
 | | `⊂` | Content [integrated](@/remove.md#branch-cleanup) into the default branch or target |
@@ -278,7 +278,7 @@ Usage: <b><span class=c>wt list</span></b> <span class=c>[OPTIONS]</span>
           Include remote branches
 
       <b><span class=c>--full</span></b>
-          Show CI and default-branch merge-base diffstat (<b>main…±</b> column)
+          Show CI, merge-base diffstat, and working tree conflict check
 
       <b><span class=c>--progressive</span></b>
           Show fast info immediately, update with slow info

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1966,7 +1966,7 @@ The Status column has multiple subcolumns. Within each, only the first matching 
 | | `⊟` | Prunable (directory missing) |
 | | `⊞` | Locked worktree |
 | Default branch | `^` | Is the default branch |
-| | `✗` | Would conflict if merged to the default branch |
+| | `✗` | Would conflict if merged to the default branch (with `--full`, includes uncommitted changes) |
 | | `_` | Same commit as the default branch, clean |
 | | `–` | Same commit as the default branch, uncommitted changes |
 | | `⊂` | Content [integrated](@/remove.md#branch-cleanup) into the default branch or target |
@@ -2120,7 +2120,7 @@ When `main_state == "integrated"`: `"ancestor"` `"trees_match"` `"no_added_chang
         #[arg(long)]
         remotes: bool,
 
-        /// Show CI and default-branch merge-base diffstat (`main…±` column)
+        /// Show CI, merge-base diffstat, and working tree conflict check
         #[arg(long)]
         full: bool,
 

--- a/src/commands/list/mod.rs
+++ b/src/commands/list/mod.rs
@@ -152,16 +152,20 @@ pub fn handle_list(
     let repo = Repository::current();
 
     // Build skip set based on flags
-    // Without --full: skip expensive operations (BranchDiff, CiStatus)
+    // Without --full: skip expensive operations (BranchDiff, CiStatus, WorkingTreeConflicts)
     // TODO: WouldMergeAdd (~500ms-2s per worktree) is currently enabled for ⊂ detection.
     // If this causes performance issues, consider adding it back to skip_tasks or
     // implementing a timeout for the merge simulation.
     let skip_tasks: std::collections::HashSet<TaskKind> = if show_full {
         std::collections::HashSet::new() // Compute everything
     } else {
-        [TaskKind::BranchDiff, TaskKind::CiStatus]
-            .into_iter()
-            .collect()
+        [
+            TaskKind::BranchDiff,
+            TaskKind::CiStatus,
+            TaskKind::WorkingTreeConflicts,
+        ]
+        .into_iter()
+        .collect()
     };
 
     // Progressive rendering only for table format with Progressive mode

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -39,7 +39,7 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS]
           Include remote branches
 
       [1m[36m--full
-          Show CI and default-branch merge-base diffstat ([1mmain…±[0m column)
+          Show CI, merge-base diffstat, and working tree conflict check
 
       [1m[36m--progressive
           Show fast info immediately, update with slow info
@@ -124,30 +124,30 @@ seconds; use [2mwt config state[0m to view or clear.
 
 The Status column has multiple subcolumns. Within each, only the first matching symbol is shown (listed in priority order):
 
-      Subcolumn     Symbol                        Meaning                         
-   ──────────────── ────── ────────────────────────────────────────────────────── 
-   Working tree (1) +      Staged files                                           
-   Working tree (2) !      Modified files (unstaged)                              
-   Working tree (3) ?      Untracked files                                        
-   Worktree         ✘      Merge conflicts                                        
-                    ⤴      Rebase in progress                                     
-                    ⤵      Merge in progress                                      
-                    /      Branch without worktree                                
-                    ⚑      Worktree path doesn't match branch name                
-                    ⊟      Prunable (directory missing)                           
-                    ⊞      Locked worktree                                        
-   Default branch   ^      Is the default branch                                  
-                    ✗      Would conflict if merged to the default branch         
-                    _      Same commit as the default branch, clean               
-                    –      Same commit as the default branch, uncommitted changes 
-                    ⊂      Content integrated into the default branch or target   
-                    ↕      Diverged from the default branch                       
-                    ↑      Ahead of the default branch                            
-                    ↓      Behind the default branch                              
-   Remote           \|     In sync with remote                                    
-                    ⇅      Diverged from remote                                   
-                    ⇡      Ahead of remote                                        
-                    ⇣      Behind remote                                          
+      Subcolumn     Symbol                                          Meaning                                           
+   ──────────────── ────── ────────────────────────────────────────────────────────────────────────────────────────── 
+   Working tree (1) +      Staged files                                                                               
+   Working tree (2) !      Modified files (unstaged)                                                                  
+   Working tree (3) ?      Untracked files                                                                            
+   Worktree         ✘      Merge conflicts                                                                            
+                    ⤴      Rebase in progress                                                                         
+                    ⤵      Merge in progress                                                                          
+                    /      Branch without worktree                                                                    
+                    ⚑      Worktree path doesn't match branch name                                                    
+                    ⊟      Prunable (directory missing)                                                               
+                    ⊞      Locked worktree                                                                            
+   Default branch   ^      Is the default branch                                                                      
+                    ✗      Would conflict if merged to the default branch (with --full, includes uncommitted changes) 
+                    _      Same commit as the default branch, clean                                                   
+                    –      Same commit as the default branch, uncommitted changes                                     
+                    ⊂      Content integrated into the default branch or target                                       
+                    ↕      Diverged from the default branch                                                           
+                    ↑      Ahead of the default branch                                                                
+                    ↓      Behind the default branch                                                                  
+   Remote           \|     In sync with remote                                                                        
+                    ⇅      Diverged from remote                                                                       
+                    ⇡      Ahead of remote                                                                            
+                    ⇣      Behind remote                                                                              
 
 Rows are dimmed when safe to delete ([2m_[0m same commit with clean working tree or [2m⊂[0m content integrated).
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -39,7 +39,7 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS]
           Include remote branches
 
       [1m[36m--full
-          Show CI and default-branch merge-base diffstat ([1mmain…±[0m column)
+          Show CI, merge-base diffstat, and working tree conflict check
 
       [1m[36m--progressive
           Show fast info immediately, update with slow info
@@ -131,23 +131,23 @@ to view or clear.
 The Status column has multiple subcolumns. Within each, only the first matching
 symbol is shown (listed in priority order):
 
-      Subcolumn     Symbol                       Meaning                        
-   ──────────────── ────── ──────────────────────────────────────────────────── 
-   Working tree (1) +      Staged files                                         
-   Working tree (2) !      Modified files (unstaged)                            
-   Working tree (3) ?      Untracked files                                      
-   Worktree         ✘      Merge conflicts                                      
-                    ⤴      Rebase in progress                                   
-                    ⤵      Merge in progress                                    
-                    /      Branch without worktree                              
-                    ⚑      Worktree path doesn't match branch name              
-                    ⊟      Prunable (directory missing)                         
-                    ⊞      Locked worktree                                      
-   Default branch   ^      Is the default branch                                
-                    ✗      Would conflict if merged to the default branch       
-                    _      Same commit as the default branch, clean             
-                    –      Same commit as the default branch, uncommitted       
-                           changes                                              
+      Subcolumn     Symbol                 Meaning                 
+   ──────────────── ────── ─────────────────────────────────────── 
+   Working tree (1) +      Staged files                            
+   Working tree (2) !      Modified files (unstaged)               
+   Working tree (3) ?      Untracked files                         
+   Worktree         ✘      Merge conflicts                         
+                    ⤴      Rebase in progress                      
+                    ⤵      Merge in progress                       
+                    /      Branch without worktree                 
+                    ⚑      Worktree path doesn't match branch name 
+                    ⊟      Prunable (directory missing)            
+                    ⊞      Locked worktree                         
+   Default branch   ^      Is the default branch                   
+| | [33m✗[0m | Would conflict if merged to the default branch (with [2m--full[0m,
+includes uncommitted changes) |
+        _         Same commit as the default branch, clean        
+        –  Same commit as the default branch, uncommitted changes 
 | | [2m⊂[0m | Content integrated into the default
 branch or target |
            ↕  Diverged from the default branch 

--- a/tests/snapshots/integration__integration_tests__help__help_list_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_short.snap
@@ -8,7 +8,7 @@ info:
   env:
     CLICOLOR_FORCE: "1"
     COLUMNS: "150"
-    GIT_CONFIG_GLOBAL: ""
+    GIT_EDITOR: ""
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -30,7 +30,7 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS]
       [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m  Output format (table, json) [default: table]
       [1m[36m--branches[0m         Include branches without worktrees
       [1m[36m--remotes[0m          Include remote branches
-      [1m[36m--full[0m             Show CI and default-branch merge-base diffstat ([1mmain…±[0m column)
+      [1m[36m--full[0m             Show CI, merge-base diffstat, and working tree conflict check
       [1m[36m--progressive[0m      Show fast info immediately, update with slow info
   [1m[36m-h[0m, [1m[36m--help[0m             Print help (see more with '--help')
 

--- a/tests/snapshots/integration__integration_tests__list__commit_conflicts_with_full.snap
+++ b/tests/snapshots/integration__integration_tests__list__commit_conflicts_with_full.snap
@@ -1,0 +1,37 @@
+---
+source: tests/integration_tests/list.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "150"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main         [2m^[22m                                    .                             [2mf31b5717[0m  [2m1d[0m    [2mMain changes shared.txt
++ feature      [33m✗[39m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m   [31m-1[0m  ../repo.feature               [2m70300b03[0m  [2m1d[0m    [2mFeature changes shared.txt
+
+[2m○[22m [2mShowing 2 worktrees, 1 ahead
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__list__commit_conflicts_without_full.snap
+++ b/tests/snapshots/integration__integration_tests__list__commit_conflicts_without_full.snap
@@ -1,0 +1,36 @@
+---
+source: tests/integration_tests/list.rs
+info:
+  program: wt
+  args:
+    - list
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "150"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main         [2m^[22m                         .                         [2mf31b5717[0m  [2m1d[0m    [2mMain changes shared.txt
++ feature      [33m✗[39m                 [32m↑1[0m  [2m[31m↓1[0m  ../repo.feature           [2m70300b03[0m  [2m1d[0m    [2mFeature changes shared.txt
+
+[2m○[22m [2mShowing 2 worktrees, 1 ahead
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__list__working_tree_conflicts_with_full.snap
+++ b/tests/snapshots/integration__integration_tests__list__working_tree_conflicts_with_full.snap
@@ -1,0 +1,37 @@
+---
+source: tests/integration_tests/list.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "150"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main         [2m^[22m                                    .                             [2mf31b5717[0m  [2m1d[0m    [2mMain changes shared.txt
++ feature   [36m![39m  [33m✗[39m       [32m+1[0m   [31m-1[0m       [2m[31m↓1[0m             ../repo.feature               [2m523c1c09[0m  [2m1d[0m    [2mInitial commit
+
+[2m○[22m [2mShowing 2 worktrees, 1 with changes
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__list__working_tree_conflicts_without_full.snap
+++ b/tests/snapshots/integration__integration_tests__list__working_tree_conflicts_without_full.snap
@@ -1,0 +1,36 @@
+---
+source: tests/integration_tests/list.rs
+info:
+  program: wt
+  args:
+    - list
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "150"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main         [2m^[22m                         .                         [2mf31b5717[0m  [2m1d[0m    [2mMain changes shared.txt
++ feature   [36m![39m  [2m↓[22m       [32m+1[0m   [31m-1[0m       [2m[31m↓1[0m  ../repo.feature           [2m523c1c09[0m  [2m1d[0m    [2mInitial commit
+
+[2m○[22m [2mShowing 2 worktrees, 1 with changes
+
+----- stderr -----


### PR DESCRIPTION
## Summary
- `wt list --full` now detects conflicts from uncommitted working tree changes
- Uses `git stash create` + `merge-tree` to check if uncommitted changes would conflict with main
- Falls back to commit-based check when working tree is clean or during active merge/rebase

## Test plan
- [x] New tests: `test_list_full_working_tree_conflicts`, `test_list_full_clean_working_tree_uses_commit_conflicts`
- [x] All 614 integration tests pass
- [x] Pre-commit lints pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)