### PR TITLE
Use extended timeout instead of ignoring source_flag test

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -23,3 +23,9 @@ slow-timeout = { period = "60s", terminate-after = 1 }
 [[profile.default.overrides]]
 filter = 'test(/integration_tests::ci_status::test_list_full/)'
 threads-required = 4
+
+# The source_flag test runs `cargo run` inside a PTY, which can take longer than
+# 60s when cargo needs to check/compile dependencies on slow CI runners.
+[[profile.default.overrides]]
+filter = 'test(/test_source_flag_forwards_errors/)'
+slow-timeout = { period = "180s", terminate-after = 1 }

--- a/tests/integration_tests/shell_wrapper.rs
+++ b/tests/integration_tests/shell_wrapper.rs
@@ -1505,14 +1505,13 @@ approved-commands = ["echo 'fish background task'"]
     // when using the --source flag (instead of being hidden with generic
     // wrapper error messages like "Error: cargo build failed").
 
-    // This test runs `cargo run` inside a PTY which can exceed the 60s nextest
-    // timeout when cargo needs to check/compile dependencies. Run with --ignored:
-    //   cargo test --test integration test_source_flag -- --ignored
+    // This test runs `cargo run` inside a PTY which can take longer than the
+    // default 60s timeout when cargo checks/compiles dependencies. Extended
+    // timeout configured in .config/nextest.toml.
     #[rstest]
     #[case("bash")]
     #[case("zsh")]
     #[case("fish")]
-    #[ignore = "cargo run inside PTY can timeout - run with --ignored"]
     fn test_source_flag_forwards_errors(#[case] shell: &str, repo: TestRepo) {
         use std::env;
 


### PR DESCRIPTION
## Summary
- Configure 180s timeout in nextest for `test_source_flag_forwards_errors` instead of ignoring the test

This allows the test to run in CI while accommodating the longer runtime when cargo needs to check/compile dependencies inside the PTY.

## Test plan
- [x] All tests pass locally
- [x] Test runs (not ignored) with the extended timeout
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)