### PR TITLE
Add --force flag to wt remove for worktrees with untracked files

### DIFF
--- a/docs/content/remove.md
+++ b/docs/content/remove.md
@@ -92,8 +92,11 @@ Usage: <b><span class=c>wt remove</span></b> <span class=c>[OPTIONS]</span> <spa
       <b><span class=c>--no-verify</span></b>
           Skip hooks
 
-      <b><span class=c>--force</span></b>
-          Skip approval prompts
+  <b><span class=c>-f</span></b>, <b><span class=c>--force</span></b>
+          Force removal
+
+          Skip approval prompts, and remove worktrees even if they contain
+          untracked files (like build artifacts).
 
   <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
           Print help (see a summary with &#39;-h&#39;)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2330,8 +2330,11 @@ Removal runs in the background by default (returns immediately). Logs are writte
         #[arg(long = "no-verify", action = clap::ArgAction::SetFalse, default_value_t = true)]
         verify: bool,
 
-        /// Skip approval prompts
-        #[arg(long)]
+        /// Force removal
+        ///
+        /// Skip approval prompts, and remove worktrees even if they contain
+        /// untracked files (like build artifacts).
+        #[arg(short = 'f', long)]
         force: bool,
     },
 

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -246,6 +246,9 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
             deletion_mode: BranchDeletionMode::SafeDelete,
             target_branch: Some(target_branch.clone()),
             integration_reason,
+            // After a successful merge, force removal since any untracked files
+            // (build artifacts) are no longer needed
+            force_worktree: true,
         };
         // Run hooks during merge removal (pass through verify flag)
         // Approval was handled at the gate (MergeCommandCollector)

--- a/src/commands/repository_ext.rs
+++ b/src/commands/repository_ext.rs
@@ -27,6 +27,7 @@ pub trait RepositoryCliExt {
         &self,
         branch_name: &str,
         deletion_mode: BranchDeletionMode,
+        force_worktree: bool,
     ) -> anyhow::Result<RemoveResult>;
 
     /// Remove the current worktree (handles detached HEAD state).
@@ -38,6 +39,7 @@ pub trait RepositoryCliExt {
     fn remove_current_worktree(
         &self,
         deletion_mode: BranchDeletionMode,
+        force_worktree: bool,
     ) -> anyhow::Result<RemoveResult>;
 
     /// Prepare the target worktree for push by auto-stashing non-overlapping changes when safe.
@@ -86,6 +88,7 @@ impl RepositoryCliExt for Repository {
         &self,
         branch_name: &str,
         deletion_mode: BranchDeletionMode,
+        force_worktree: bool,
     ) -> anyhow::Result<RemoveResult> {
         let worktree_path = match self.worktree_for_branch(branch_name)? {
             Some(path) => path,
@@ -165,12 +168,14 @@ impl RepositoryCliExt for Repository {
             deletion_mode,
             target_branch,
             integration_reason,
+            force_worktree,
         })
     }
 
     fn remove_current_worktree(
         &self,
         deletion_mode: BranchDeletionMode,
+        force_worktree: bool,
     ) -> anyhow::Result<RemoveResult> {
         // Cannot remove the main working tree (only linked worktrees can be removed)
         if !self.is_in_worktree()? {
@@ -220,6 +225,7 @@ impl RepositoryCliExt for Repository {
             deletion_mode,
             target_branch,
             integration_reason,
+            force_worktree,
         })
     }
 

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -1425,13 +1425,22 @@ impl Repository {
     }
 
     /// Remove a worktree at the specified path.
-    pub fn remove_worktree(&self, path: &std::path::Path) -> anyhow::Result<()> {
+    ///
+    /// When `force` is true, passes `--force` to `git worktree remove`,
+    /// allowing removal even when the worktree contains untracked files
+    /// (like build artifacts such as `.vite/` or `node_modules/`).
+    pub fn remove_worktree(&self, path: &std::path::Path, force: bool) -> anyhow::Result<()> {
         let path_str = path.to_str().ok_or_else(|| {
             anyhow::Error::from(GitError::Other {
                 message: format!("Worktree path contains invalid UTF-8: {}", path.display()),
             })
         })?;
-        self.run_command(&["worktree", "remove", path_str])?;
+        let mut args = vec!["worktree", "remove"];
+        if force {
+            args.push("--force");
+        }
+        args.push(path_str);
+        self.run_command(&args)?;
         Ok(())
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1380,8 +1380,9 @@ fn main() {
                 if worktrees.is_empty() {
                     // No worktrees specified, remove current worktree
                     // Uses path-based removal to handle detached HEAD state
-                    let result = handle_remove_current(!delete_branch, force_delete, background)
-                        .context("Failed to remove worktree")?;
+                    let result =
+                        handle_remove_current(!delete_branch, force_delete, force, background)
+                            .context("Failed to remove worktree")?;
                     // Approval was handled at the gate
                     // Post-switch hooks are spawned internally by handle_remove_output
                     handle_remove_output(&result, background, verify)
@@ -1430,6 +1431,7 @@ fn main() {
                                 branch_name,
                                 !delete_branch,
                                 force_delete,
+                                force,
                                 background,
                             ) {
                                 Ok(result) => {
@@ -1442,7 +1444,7 @@ fn main() {
                             }
                         } else {
                             // Non-current worktree is detached - remove by path (no branch to delete)
-                            match handle_remove_by_path(path, None, background) {
+                            match handle_remove_by_path(path, None, force, background) {
                                 Ok(result) => {
                                     handle_remove_output(&result, background, verify)?;
                                 }
@@ -1456,7 +1458,8 @@ fn main() {
 
                     // Handle branch-only cases (no worktree)
                     for branch in &branch_only {
-                        match handle_remove(branch, !delete_branch, force_delete, background) {
+                        match handle_remove(branch, !delete_branch, force_delete, force, background)
+                        {
                             Ok(result) => {
                                 handle_remove_output(&result, background, verify)?;
                             }
@@ -1470,7 +1473,8 @@ fn main() {
                     // Remove current worktree last (if it was in the list)
                     // Post-switch hooks are spawned internally by handle_remove_output
                     if let Some((_path, _branch)) = current {
-                        match handle_remove_current(!delete_branch, force_delete, background) {
+                        match handle_remove_current(!delete_branch, force_delete, force, background)
+                        {
                             Ok(result) => {
                                 handle_remove_output(&result, background, verify)?;
                             }

--- a/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
@@ -39,8 +39,10 @@ Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[WORKTREES]...
       [1m[36m--no-verify
           Skip hooks
 
-      [1m[36m--force
-          Skip approval prompts
+  [1m[36m-f[0m, [1m[36m--force
+          Force removal
+          
+          Skip approval prompts, and remove worktrees even if they contain untracked files (like build artifacts).
 
   [1m[36m-h[0m, [1m[36m--help
           Print help (see a summary with '-h')

--- a/tests/snapshots/integration__integration_tests__help__help_remove_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_short.snap
@@ -30,7 +30,7 @@ Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[WORKTREES]...
   [1m[36m-D[0m, [1m[36m--force-delete[0m      Delete unmerged branches
       [1m[36m--no-background[0m     Run removal in foreground
       [1m[36m--no-verify[0m         Skip hooks
-      [1m[36m--force[0m             Skip approval prompts
+  [1m[36m-f[0m, [1m[36m--force[0m             Force removal
   [1m[36m-h[0m, [1m[36m--help[0m              Print help (see more with '--help')
 
 [1m[32mGlobal Options:


### PR DESCRIPTION
## Summary

- Extended `--force` flag on `wt remove` to also pass `--force` to `git worktree remove`, allowing removal of worktrees containing untracked files like build artifacts (`.vite/`, `node_modules/`, etc.)
- Added `-f` short form for convenience
- `wt merge` now always forces worktree removal since build artifacts aren't needed post-merge

Fixes #301

## Test plan

- [x] All 635 integration tests pass
- [x] Pre-commit lints pass
- [x] Help text snapshots updated
- [x] Docs auto-updated from CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)