### PR TITLE
Simplify worktree API and bare repository support

### DIFF
--- a/docs/content/tips-patterns.md
+++ b/docs/content/tips-patterns.md
@@ -149,3 +149,37 @@ wt switch --create feature-part2 --base=@
 ```
 
 Creates a worktree that builds on the current branch's changes.
+
+## Bare repository layout
+
+An alternative to the default sibling layout (`myproject.feature/`) uses a bare repository with worktrees as subdirectories:
+
+```
+myproject/
+├── .git/       # bare repository
+├── main/       # main branch
+├── feature/    # feature branch
+└── bugfix/     # bugfix branch
+```
+
+Setup:
+
+```bash
+git clone --bare <url> myproject/.git
+cd myproject
+```
+
+Configure worktrunk to create worktrees as subdirectories:
+
+```toml
+# ~/.config/worktrunk/config.toml
+worktree-path = "{{ branch | sanitize }}"
+```
+
+Create the first worktree:
+
+```bash
+wt switch --create main
+```
+
+Now `wt switch --create feature` creates `myproject/feature/`.

--- a/src/commands/for_each.rs
+++ b/src/commands/for_each.rs
@@ -50,7 +50,7 @@ pub fn step_for_each(args: Vec<String>) -> anyhow::Result<()> {
     let config = WorktrunkConfig::load()?;
 
     let mut failed: Vec<String> = Vec::new();
-    let total = worktrees.worktrees.len();
+    let total = worktrees.len();
 
     // Join args into a template string (will be expanded per-worktree)
     let command_template = args.join(" ");
@@ -58,7 +58,7 @@ pub fn step_for_each(args: Vec<String>) -> anyhow::Result<()> {
     // Get repo root for context
     let repo_root = repo.worktree_base()?;
 
-    for wt in &worktrees.worktrees {
+    for wt in &worktrees {
         let display_name = worktree_display_name(wt, &repo, &config);
         output::print(progress_message(format!("Running in {display_name}...")))?;
 

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -222,7 +222,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
     // Destination: prefer the target branch's worktree; fall back to main when absent
     let destination_path = target_worktree_path
         .clone()
-        .unwrap_or_else(|| worktrees.main().path.clone());
+        .unwrap_or_else(|| worktrees[0].path.clone());
 
     // Finish worktree unless --no-remove was specified
     if remove_effective {

--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -210,10 +210,7 @@ pub fn run(claude_code: bool) -> Result<()> {
 fn get_git_status(repo: &Repository, cwd: &Path) -> Result<Option<String>> {
     // Get current worktree info
     let worktrees = repo.list_worktrees()?;
-    let current_worktree = worktrees
-        .worktrees
-        .iter()
-        .find(|wt| cwd.starts_with(&wt.path));
+    let current_worktree = worktrees.iter().find(|wt| cwd.starts_with(&wt.path));
 
     let Some(wt) = current_worktree else {
         // Not in a worktree - just show branch name
@@ -236,10 +233,9 @@ fn get_git_status(repo: &Repository, cwd: &Path) -> Result<Option<String>> {
 
     // Determine if this is the main worktree
     let main_worktree = worktrees
-        .worktrees
         .iter()
         .find(|w| w.branch.as_deref() == Some(default_branch.as_str()))
-        .unwrap_or_else(|| worktrees.main());
+        .unwrap_or(&worktrees[0]);
     let is_main = wt.path == main_worktree.path;
 
     // Build item with identity fields

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -278,8 +278,8 @@ pub struct CompletionBranch {
 // Re-export parsing helpers for internal use
 pub(crate) use parse::DefaultBranchName;
 
-// Note: HookType, Worktree, and WorktreeList are defined in this module and are already public.
-// They're accessible as git::HookType, git::Worktree, and git::WorktreeList without needing re-export.
+// Note: HookType and Worktree are defined in this module and are already public.
+// They're accessible as git::HookType and git::Worktree without needing re-export.
 
 /// Hook types for git operations
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum, strum::Display, strum::EnumString)]
@@ -324,57 +324,6 @@ impl Worktree {
     /// use `worktree_display_name()` from the commands module instead.
     pub fn dir_name(&self) -> &str {
         path_dir_name(&self.path)
-    }
-}
-
-/// A list of worktrees with automatic bare worktree filtering.
-///
-/// This type ensures:
-/// - Bare worktrees are filtered out (only worktrees with working trees are included)
-/// - The main worktree is at index 0 (accessible via `.main()`) for non-bare repos
-/// - Construction fails if no valid worktrees exist
-///
-/// Git guarantees that the main worktree is listed first in `git worktree list` output,
-/// so index 0 is always the main worktree after filtering. For bare repositories where
-/// the main worktree is filtered out, index 0 will be the first linked worktree.
-#[derive(Debug, Clone)]
-pub struct WorktreeList {
-    pub worktrees: Vec<Worktree>,
-}
-
-impl WorktreeList {
-    /// Create from raw worktrees, filtering bare entries.
-    ///
-    /// Preserves git's ordering where the main worktree is first.
-    pub(crate) fn from_raw(raw_worktrees: Vec<Worktree>) -> anyhow::Result<Self> {
-        let worktrees: Vec<_> = raw_worktrees.into_iter().filter(|wt| !wt.bare).collect();
-
-        if worktrees.is_empty() {
-            return Err(GitError::Other {
-                message: "No worktrees found".into(),
-            }
-            .into());
-        }
-
-        Ok(Self { worktrees })
-    }
-
-    /// Returns the main worktree (at index 0).
-    ///
-    /// For non-bare repositories, this is the original working tree created by
-    /// `git init` or `git clone`. For bare repositories, this returns the first
-    /// linked worktree (since bare worktrees are filtered out).
-    pub fn main(&self) -> &Worktree {
-        &self.worktrees[0]
-    }
-}
-
-impl IntoIterator for WorktreeList {
-    type Item = Worktree;
-    type IntoIter = std::vec::IntoIter<Worktree>;
-
-    fn into_iter(self) -> Self::IntoIter {
-        self.worktrees.into_iter()
     }
 }
 
@@ -425,137 +374,6 @@ pub(crate) fn finalize_worktree(mut wt: Worktree) -> Worktree {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_worktree_list_filters_bare() {
-        let worktrees = vec![
-            Worktree {
-                path: PathBuf::from("/repo"),
-                head: String::new(),
-                branch: None,
-                bare: true,
-                detached: false,
-                locked: None,
-                prunable: None,
-            },
-            Worktree {
-                path: PathBuf::from("/repo/main"),
-                head: "abc123".to_string(),
-                branch: Some("main".to_string()),
-                bare: false,
-                detached: false,
-                locked: None,
-                prunable: None,
-            },
-            Worktree {
-                path: PathBuf::from("/repo/feature"),
-                head: "def456".to_string(),
-                branch: Some("feature".to_string()),
-                bare: false,
-                detached: false,
-                locked: None,
-                prunable: None,
-            },
-        ];
-
-        let list = WorktreeList::from_raw(worktrees).unwrap();
-
-        assert_eq!(list.worktrees.len(), 2);
-        assert_eq!(list.worktrees[0].branch, Some("main".to_string()));
-        assert_eq!(list.worktrees[1].branch, Some("feature".to_string()));
-    }
-
-    #[test]
-    fn test_worktree_list_main() {
-        let worktrees = vec![
-            Worktree {
-                path: PathBuf::from("/repo"),
-                head: String::new(),
-                branch: None,
-                bare: true,
-                detached: false,
-                locked: None,
-                prunable: None,
-            },
-            Worktree {
-                path: PathBuf::from("/repo/main"),
-                head: "abc123".to_string(),
-                branch: Some("main".to_string()),
-                bare: false,
-                detached: false,
-                locked: None,
-                prunable: None,
-            },
-        ];
-
-        let list = WorktreeList::from_raw(worktrees).unwrap();
-
-        let main = list.main();
-        assert_eq!(main.branch, Some("main".to_string()));
-        assert_eq!(main.path, PathBuf::from("/repo/main"));
-    }
-
-    #[test]
-    fn test_worktree_list_all_bare_error() {
-        let worktrees = vec![Worktree {
-            path: PathBuf::from("/repo"),
-            head: String::new(),
-            branch: None,
-            bare: true,
-            detached: false,
-            locked: None,
-            prunable: None,
-        }];
-
-        let result = WorktreeList::from_raw(worktrees);
-
-        assert!(result.is_err());
-        assert!(
-            result
-                .unwrap_err()
-                .to_string()
-                .contains("No worktrees found")
-        );
-    }
-
-    #[test]
-    fn test_worktree_list_iteration() {
-        let worktrees = vec![
-            Worktree {
-                path: PathBuf::from("/repo/main"),
-                head: "abc123".to_string(),
-                branch: Some("main".to_string()),
-                bare: false,
-                detached: false,
-                locked: None,
-                prunable: None,
-            },
-            Worktree {
-                path: PathBuf::from("/repo/feature"),
-                head: "def456".to_string(),
-                branch: Some("feature".to_string()),
-                bare: false,
-                detached: false,
-                locked: None,
-                prunable: None,
-            },
-        ];
-
-        let list = WorktreeList::from_raw(worktrees).unwrap();
-
-        let branches: Vec<_> = list
-            .worktrees
-            .iter()
-            .filter_map(|wt| wt.branch.as_ref())
-            .collect();
-        assert_eq!(branches, vec!["main", "feature"]);
-
-        let branches_owned: Vec<_> = list.into_iter().filter_map(|wt| wt.branch).collect();
-        assert_eq!(
-            branches_owned,
-            vec!["main".to_string(), "feature".to_string()]
-        );
-    }
 
     #[test]
     fn test_check_integration() {


### PR DESCRIPTION
## Summary

- Remove `WorktreeList` wrapper type, `list_worktrees()` now returns `Vec<Worktree>` directly
- Add `current_worktree()` method to Repository for the common "find my worktree" pattern
- Simplify `load_project_config()` - returns `None` when not in a worktree (bare repo bootstrap case)
- Remove `require_project_config()` - inline the error handling at the single call site
- Simplify `remove_current_worktree()` - use `current_branch()` directly instead of searching worktree list
- Add integration tests for bare repository bootstrap workflow

Fixes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)