### PR TITLE
Fix test isolation for wt commands and improve test API

### DIFF
--- a/tests/common/list_snapshots.rs
+++ b/tests/common/list_snapshots.rs
@@ -21,7 +21,7 @@ pub fn json_settings(repo: &TestRepo) -> Settings {
 
 pub fn command(repo: &TestRepo, cwd: &Path) -> Command {
     let mut cmd = wt_command();
-    repo.clean_cli_env(&mut cmd);
+    repo.configure_wt_cmd(&mut cmd);
     cmd.arg("list").current_dir(cwd);
     cmd
 }
@@ -100,7 +100,7 @@ pub fn command_progressive_full(repo: &TestRepo) -> Command {
 
 pub fn command_progressive_from_dir(repo: &TestRepo, cwd: &Path) -> Command {
     let mut cmd = wt_command();
-    repo.clean_cli_env(&mut cmd);
+    repo.configure_wt_cmd(&mut cmd);
     cmd.args(["list", "--progressive"]).current_dir(cwd);
     cmd
 }

--- a/tests/common/shell.rs
+++ b/tests/common/shell.rs
@@ -158,7 +158,7 @@ pub fn execute_shell_script(repo: &TestRepo, shell: &str, script: &str) -> Strin
 /// Generate `wt config shell init <shell>` output for the repo.
 pub fn generate_init_code(repo: &TestRepo, shell: &str) -> String {
     let mut cmd = wt_command();
-    repo.clean_cli_env(&mut cmd);
+    repo.configure_wt_cmd(&mut cmd);
 
     let output = cmd
         .args(["config", "shell", "init", shell])

--- a/tests/integration_tests/bare_repository.rs
+++ b/tests/integration_tests/bare_repository.rs
@@ -424,7 +424,7 @@ worktree-path = "{{ branch }}"
     bare_list.arg("list").current_dir(&bare_main);
 
     let mut normal_list = wt_command();
-    repo.clean_cli_env(&mut normal_list);
+    repo.configure_wt_cmd(&mut normal_list);
     normal_list.arg("list").current_dir(repo.root_path());
 
     let bare_output = bare_list.output().unwrap();

--- a/tests/integration_tests/ci_status.rs
+++ b/tests/integration_tests/ci_status.rs
@@ -19,7 +19,8 @@ use std::process::Command;
 /// Get the HEAD commit SHA for a branch
 fn get_branch_sha(repo: &TestRepo, branch: &str) -> String {
     let output = repo
-        .git_command(&["rev-parse", branch])
+        .git_command()
+        .args(["rev-parse", branch])
         .output()
         .expect("Failed to get commit SHA");
     String::from_utf8_lossy(&output.stdout).trim().to_string()
@@ -29,14 +30,15 @@ fn get_branch_sha(repo: &TestRepo, branch: &str) -> String {
 #[rstest]
 fn test_list_full_with_github_pr_passed(mut repo: TestRepo) {
     // Add GitHub remote
-    repo.git_command(&[
-        "remote",
-        "add",
-        "origin",
-        "https://github.com/test-owner/test-repo.git",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/test-owner/test-repo.git",
+        ])
+        .output()
+        .unwrap();
 
     // Create a feature branch and push it
     repo.add_worktree("feature");
@@ -73,14 +75,15 @@ fn test_list_full_with_github_pr_passed(mut repo: TestRepo) {
 #[rstest]
 fn test_list_full_with_github_pr_failed(mut repo: TestRepo) {
     // Add GitHub remote
-    repo.git_command(&[
-        "remote",
-        "add",
-        "origin",
-        "https://github.com/test-owner/test-repo.git",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/test-owner/test-repo.git",
+        ])
+        .output()
+        .unwrap();
 
     // Create a feature branch and push it
     repo.add_worktree("feature");
@@ -117,14 +120,15 @@ fn test_list_full_with_github_pr_failed(mut repo: TestRepo) {
 #[rstest]
 fn test_list_full_with_github_pr_running(mut repo: TestRepo) {
     // Add GitHub remote
-    repo.git_command(&[
-        "remote",
-        "add",
-        "origin",
-        "https://github.com/test-owner/test-repo.git",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/test-owner/test-repo.git",
+        ])
+        .output()
+        .unwrap();
 
     // Create a feature branch and push it
     repo.add_worktree("feature");
@@ -161,14 +165,15 @@ fn test_list_full_with_github_pr_running(mut repo: TestRepo) {
 #[rstest]
 fn test_list_full_with_github_pr_conflicts(mut repo: TestRepo) {
     // Add GitHub remote
-    repo.git_command(&[
-        "remote",
-        "add",
-        "origin",
-        "https://github.com/test-owner/test-repo.git",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/test-owner/test-repo.git",
+        ])
+        .output()
+        .unwrap();
 
     // Create a feature branch and push it
     repo.add_worktree("feature");
@@ -205,14 +210,15 @@ fn test_list_full_with_github_pr_conflicts(mut repo: TestRepo) {
 #[rstest]
 fn test_list_full_with_status_context_pending(mut repo: TestRepo) {
     // Add GitHub remote
-    repo.git_command(&[
-        "remote",
-        "add",
-        "origin",
-        "https://github.com/test-owner/test-repo.git",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/test-owner/test-repo.git",
+        ])
+        .output()
+        .unwrap();
 
     // Create a feature branch and push it
     repo.add_worktree("feature");
@@ -249,14 +255,15 @@ fn test_list_full_with_status_context_pending(mut repo: TestRepo) {
 #[rstest]
 fn test_list_full_with_status_context_failure(mut repo: TestRepo) {
     // Add GitHub remote
-    repo.git_command(&[
-        "remote",
-        "add",
-        "origin",
-        "https://github.com/test-owner/test-repo.git",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/test-owner/test-repo.git",
+        ])
+        .output()
+        .unwrap();
 
     // Create a feature branch and push it
     repo.add_worktree("feature");
@@ -293,14 +300,15 @@ fn test_list_full_with_status_context_failure(mut repo: TestRepo) {
 #[rstest]
 fn test_list_full_with_github_workflow_run(mut repo: TestRepo) {
     // Add GitHub remote
-    repo.git_command(&[
-        "remote",
-        "add",
-        "origin",
-        "https://github.com/test-owner/test-repo.git",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/test-owner/test-repo.git",
+        ])
+        .output()
+        .unwrap();
 
     // Create a feature branch and push it (so has_upstream is true)
     repo.add_worktree("feature");
@@ -333,14 +341,15 @@ fn test_list_full_with_github_workflow_run(mut repo: TestRepo) {
 #[rstest]
 fn test_list_full_with_github_workflow_running(mut repo: TestRepo) {
     // Add GitHub remote
-    repo.git_command(&[
-        "remote",
-        "add",
-        "origin",
-        "https://github.com/test-owner/test-repo.git",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/test-owner/test-repo.git",
+        ])
+        .output()
+        .unwrap();
 
     // Create a feature branch and push it
     repo.add_worktree("feature");
@@ -373,14 +382,15 @@ fn test_list_full_with_github_workflow_running(mut repo: TestRepo) {
 #[rstest]
 fn test_list_full_with_stale_pr(mut repo: TestRepo) {
     // Add GitHub remote
-    repo.git_command(&[
-        "remote",
-        "add",
-        "origin",
-        "https://github.com/test-owner/test-repo.git",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/test-owner/test-repo.git",
+        ])
+        .output()
+        .unwrap();
 
     // Create a feature branch and push it
     repo.add_worktree("feature");
@@ -428,14 +438,15 @@ fn test_list_full_with_stale_pr(mut repo: TestRepo) {
 #[rstest]
 fn test_list_full_with_mixed_check_types(mut repo: TestRepo) {
     // Add GitHub remote
-    repo.git_command(&[
-        "remote",
-        "add",
-        "origin",
-        "https://github.com/test-owner/test-repo.git",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/test-owner/test-repo.git",
+        ])
+        .output()
+        .unwrap();
 
     // Create a feature branch and push it
     repo.add_worktree("feature");
@@ -474,14 +485,15 @@ fn test_list_full_with_mixed_check_types(mut repo: TestRepo) {
 #[rstest]
 fn test_list_full_with_no_ci_checks(mut repo: TestRepo) {
     // Add GitHub remote
-    repo.git_command(&[
-        "remote",
-        "add",
-        "origin",
-        "https://github.com/test-owner/test-repo.git",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/test-owner/test-repo.git",
+        ])
+        .output()
+        .unwrap();
 
     // Create a feature branch and push it
     repo.add_worktree("feature");
@@ -516,14 +528,15 @@ fn test_list_full_with_no_ci_checks(mut repo: TestRepo) {
 #[rstest]
 fn test_list_full_filters_by_repo_owner(mut repo: TestRepo) {
     // Add GitHub remote with specific owner
-    repo.git_command(&[
-        "remote",
-        "add",
-        "origin",
-        "https://github.com/my-org/test-repo.git",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/my-org/test-repo.git",
+        ])
+        .output()
+        .unwrap();
 
     // Create a feature branch and push it
     repo.add_worktree("feature");

--- a/tests/integration_tests/column_alignment_verification.rs
+++ b/tests/integration_tests/column_alignment_verification.rs
@@ -327,7 +327,7 @@ fn test_alignment_verification_with_varying_content(mut repo: TestRepo) {
 
     // Run wt list and capture output
     let mut cmd = wt_command();
-    repo.clean_cli_env(&mut cmd);
+    repo.configure_wt_cmd(&mut cmd);
     cmd.arg("list").current_dir(repo.root_path());
 
     let output = cmd.output().unwrap();
@@ -355,7 +355,7 @@ fn test_alignment_with_unicode_content(mut repo: TestRepo) {
 
     // Run wt list
     let mut cmd = wt_command();
-    repo.clean_cli_env(&mut cmd);
+    repo.configure_wt_cmd(&mut cmd);
     cmd.arg("list").current_dir(repo.root_path());
 
     let output = cmd.output().unwrap();
@@ -391,7 +391,7 @@ fn test_alignment_with_sparse_columns(mut repo: TestRepo) {
 
     // Run wt list
     let mut cmd = wt_command();
-    repo.clean_cli_env(&mut cmd);
+    repo.configure_wt_cmd(&mut cmd);
     cmd.arg("list").current_dir(repo.root_path());
 
     let output = cmd.output().unwrap();
@@ -439,7 +439,7 @@ fn test_alignment_real_world_scenario(mut repo: TestRepo) {
 
     // Run wt list at a width where Dirty column is visible
     let mut cmd = wt_command();
-    repo.clean_cli_env(&mut cmd);
+    repo.configure_wt_cmd(&mut cmd);
     cmd.arg("list").current_dir(repo.root_path());
 
     let output = cmd.output().unwrap();
@@ -469,7 +469,7 @@ fn test_alignment_at_different_terminal_widths(mut repo: TestRepo) {
         println!("\n### Testing at width {} ###", width);
 
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         cmd.arg("list")
             .current_dir(repo.root_path())
             .env("COLUMNS", width.to_string());

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -41,7 +41,7 @@ server = "npm run dev"
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         repo.configure_mock_commands(&mut cmd);
         cmd.arg("config").arg("show").current_dir(repo.root_path());
         set_temp_home_env(&mut cmd, temp_home.path());
@@ -69,7 +69,7 @@ fn test_config_show_no_project_config(mut repo: TestRepo, temp_home: TempDir) {
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         repo.configure_mock_commands(&mut cmd);
         cmd.arg("config").arg("show").current_dir(repo.root_path());
         set_temp_home_env(&mut cmd, temp_home.path());
@@ -130,7 +130,7 @@ if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         repo.configure_mock_commands(&mut cmd);
         // Force compinit warning for deterministic tests across environments
         cmd.env("WORKTRUNK_TEST_COMPINIT_MISSING", "1");
@@ -173,7 +173,7 @@ if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         repo.configure_mock_commands(&mut cmd);
         cmd.arg("config").arg("show").current_dir(repo.root_path());
         set_temp_home_env(&mut cmd, temp_home.path());
@@ -209,7 +209,7 @@ if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         repo.configure_mock_commands(&mut cmd);
         cmd.arg("config").arg("show").current_dir(repo.root_path());
         set_temp_home_env(&mut cmd, temp_home.path());
@@ -249,7 +249,7 @@ if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         // Keep PATH minimal so the probe zsh doesn't find a globally-installed `wt`.
         cmd.env("PATH", "/usr/bin:/bin");
         cmd.env("ZDOTDIR", temp_home.path());
@@ -296,7 +296,7 @@ if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         // Keep PATH minimal so the probe zsh doesn't find a globally-installed `wt`.
         cmd.env("PATH", "/usr/bin:/bin");
         cmd.env("ZDOTDIR", temp_home.path());
@@ -340,7 +340,7 @@ fn test_config_show_warns_unknown_project_keys(mut repo: TestRepo, temp_home: Te
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         repo.configure_mock_commands(&mut cmd);
         cmd.arg("config").arg("show").current_dir(repo.root_path());
         set_temp_home_env(&mut cmd, temp_home.path());
@@ -367,7 +367,7 @@ fn test_config_show_warns_unknown_user_keys(mut repo: TestRepo, temp_home: TempD
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         repo.configure_mock_commands(&mut cmd);
         cmd.arg("config").arg("show").current_dir(repo.root_path());
         set_temp_home_env(&mut cmd, temp_home.path());
@@ -395,7 +395,7 @@ fn test_config_show_full_not_configured(mut repo: TestRepo, temp_home: TempDir) 
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         repo.configure_mock_commands(&mut cmd);
         // Override WORKTRUNK_CONFIG_PATH to point to our test config
         cmd.env("WORKTRUNK_CONFIG_PATH", &config_path);
@@ -433,7 +433,7 @@ args = ["-m", "test-model"]
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         repo.configure_mock_commands(&mut cmd);
         // Override WORKTRUNK_CONFIG_PATH to point to our test config
         cmd.env("WORKTRUNK_CONFIG_PATH", &config_path);
@@ -454,14 +454,15 @@ fn test_config_show_github_remote(mut repo: TestRepo, temp_home: TempDir) {
     repo.setup_mock_ci_tools_unauthenticated();
 
     // Add GitHub remote
-    repo.git_command(&[
-        "remote",
-        "add",
-        "origin",
-        "https://github.com/example/repo.git",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/example/repo.git",
+        ])
+        .output()
+        .unwrap();
 
     // Create fake global config
     let global_config_dir = temp_home.path().join(".config").join("worktrunk");
@@ -476,7 +477,7 @@ fn test_config_show_github_remote(mut repo: TestRepo, temp_home: TempDir) {
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         repo.configure_mock_commands(&mut cmd);
         cmd.arg("config").arg("show").current_dir(repo.root_path());
         set_temp_home_env(&mut cmd, temp_home.path());
@@ -492,14 +493,15 @@ fn test_config_show_gitlab_remote(mut repo: TestRepo, temp_home: TempDir) {
     repo.setup_mock_ci_tools_unauthenticated();
 
     // Add GitLab remote
-    repo.git_command(&[
-        "remote",
-        "add",
-        "origin",
-        "https://gitlab.com/example/repo.git",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "remote",
+            "add",
+            "origin",
+            "https://gitlab.com/example/repo.git",
+        ])
+        .output()
+        .unwrap();
 
     // Create fake global config
     let global_config_dir = temp_home.path().join(".config").join("worktrunk");
@@ -514,7 +516,7 @@ fn test_config_show_gitlab_remote(mut repo: TestRepo, temp_home: TempDir) {
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         repo.configure_mock_commands(&mut cmd);
         cmd.arg("config").arg("show").current_dir(repo.root_path());
         set_temp_home_env(&mut cmd, temp_home.path());
@@ -547,7 +549,7 @@ fn test_config_show_empty_project_config(mut repo: TestRepo, temp_home: TempDir)
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         repo.configure_mock_commands(&mut cmd);
         cmd.arg("config").arg("show").current_dir(repo.root_path());
         set_temp_home_env(&mut cmd, temp_home.path());
@@ -580,7 +582,7 @@ fn test_config_show_whitespace_only_project_config(mut repo: TestRepo, temp_home
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         repo.configure_mock_commands(&mut cmd);
         cmd.arg("config").arg("show").current_dir(repo.root_path());
         set_temp_home_env(&mut cmd, temp_home.path());

--- a/tests/integration_tests/configure_shell.rs
+++ b/tests/integration_tests/configure_shell.rs
@@ -16,7 +16,7 @@ fn test_configure_shell_with_yes(repo: TestRepo, temp_home: TempDir) {
     let settings = setup_home_snapshot_settings(&temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/zsh");
         // Force compinit warning for deterministic tests across environments
@@ -59,7 +59,7 @@ fn test_configure_shell_specific_shell(repo: TestRepo, temp_home: TempDir) {
     let settings = setup_home_snapshot_settings(&temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/zsh");
         // Force compinit warning for deterministic tests across environments
@@ -105,7 +105,7 @@ fn test_configure_shell_already_exists(repo: TestRepo, temp_home: TempDir) {
     let settings = setup_home_snapshot_settings(&temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/zsh");
         cmd.arg("config")
@@ -138,7 +138,7 @@ fn test_configure_shell_fish(repo: TestRepo, temp_home: TempDir) {
     let settings = setup_home_snapshot_settings(&temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/fish");
         cmd.arg("config")
@@ -191,7 +191,7 @@ fn test_configure_shell_fish_extension_exists(repo: TestRepo, temp_home: TempDir
     let settings = setup_home_snapshot_settings(&temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/fish");
         cmd.arg("config")
@@ -251,7 +251,7 @@ fn test_configure_shell_fish_all_already_configured(repo: TestRepo, temp_home: T
     let settings = setup_home_snapshot_settings(&temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/fish");
         cmd.arg("config")
@@ -272,7 +272,7 @@ fn test_configure_shell_no_files(repo: TestRepo, temp_home: TempDir) {
     let settings = setup_home_snapshot_settings(&temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/zsh");
         cmd.arg("config")
@@ -307,7 +307,7 @@ fn test_configure_shell_multiple_configs(repo: TestRepo, temp_home: TempDir) {
     let settings = setup_home_snapshot_settings(&temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/zsh");
         // Force compinit warning for deterministic tests across environments
@@ -367,7 +367,7 @@ fn test_configure_shell_mixed_states(repo: TestRepo, temp_home: TempDir) {
     let settings = setup_home_snapshot_settings(&temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/zsh");
         // Force compinit warning for deterministic tests across environments
@@ -425,7 +425,7 @@ fn test_uninstall_shell(repo: TestRepo, temp_home: TempDir) {
     let settings = setup_home_snapshot_settings(&temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/zsh");
         cmd.arg("config")
@@ -482,7 +482,7 @@ fn test_uninstall_shell_multiple(repo: TestRepo, temp_home: TempDir) {
     let settings = setup_home_snapshot_settings(&temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/zsh");
         cmd.arg("config")
@@ -531,7 +531,7 @@ fn test_uninstall_shell_not_found(repo: TestRepo, temp_home: TempDir) {
     let settings = setup_home_snapshot_settings(&temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/zsh");
         cmd.arg("config")
@@ -568,7 +568,7 @@ fn test_uninstall_shell_fish(repo: TestRepo, temp_home: TempDir) {
     let settings = setup_home_snapshot_settings(&temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/fish");
         cmd.arg("config")
@@ -609,7 +609,7 @@ fn test_install_uninstall_roundtrip(repo: TestRepo, temp_home: TempDir) {
     // First install
     {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/zsh");
         cmd.arg("config")
@@ -630,7 +630,7 @@ fn test_install_uninstall_roundtrip(repo: TestRepo, temp_home: TempDir) {
     // Then uninstall
     {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/zsh");
         cmd.arg("config")
@@ -672,7 +672,7 @@ fn test_install_uninstall_no_blank_line_accumulation(repo: TestRepo, temp_home: 
     // Install
     {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/zsh");
         cmd.args(["config", "shell", "install", "zsh", "--yes"]);
@@ -690,7 +690,7 @@ fn test_install_uninstall_no_blank_line_accumulation(repo: TestRepo, temp_home: 
     // Uninstall
     {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/zsh");
         cmd.args(["config", "shell", "uninstall", "zsh", "--yes"]);
@@ -708,7 +708,7 @@ fn test_install_uninstall_no_blank_line_accumulation(repo: TestRepo, temp_home: 
     // Re-install
     {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/zsh");
         cmd.args(["config", "shell", "install", "zsh", "--yes"]);
@@ -744,7 +744,7 @@ fn test_configure_shell_no_warning_when_compinit_enabled(repo: TestRepo, temp_ho
     let settings = setup_home_snapshot_settings(&temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/zsh");
         cmd.env("ZDOTDIR", temp_home.path()); // Point zsh to our test home for config
@@ -783,7 +783,7 @@ fn test_configure_shell_no_warning_for_bash_user(repo: TestRepo, temp_home: Temp
     let settings = setup_home_snapshot_settings(&temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/bash"); // User's primary shell is bash
         cmd.arg("config")
@@ -820,7 +820,7 @@ fn test_configure_shell_no_warning_for_fish_install(repo: TestRepo, temp_home: T
     let settings = setup_home_snapshot_settings(&temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/zsh"); // User is zsh user, but installing fish
         cmd.arg("config")
@@ -859,7 +859,7 @@ fn test_configure_shell_no_warning_when_already_configured(repo: TestRepo, temp_
     let settings = setup_home_snapshot_settings(&temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("SHELL", "/bin/zsh");
         cmd.arg("config")
@@ -894,7 +894,7 @@ fn test_configure_shell_no_warning_when_shell_unset(repo: TestRepo, temp_home: T
     let settings = setup_home_snapshot_settings(&temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env_remove("SHELL"); // Explicitly unset SHELL
         cmd.arg("config")

--- a/tests/integration_tests/default_branch.rs
+++ b/tests/integration_tests/default_branch.rs
@@ -24,7 +24,8 @@ fn test_get_default_branch_without_origin_head(#[from(repo_with_remote)] repo: T
 
     // Verify that worktrunk's cache is now set
     let cached = repo
-        .git_command(&["config", "--get", "worktrunk.default-branch"])
+        .git_command()
+        .args(["config", "--get", "worktrunk.default-branch"])
         .output()
         .unwrap();
     assert_eq!(String::from_utf8_lossy(&cached.stdout).trim(), "main");
@@ -35,13 +36,15 @@ fn test_get_default_branch_caches_result(#[from(repo_with_remote)] repo: TestRep
     // Clear both caches to force remote query
     repo.clear_origin_head();
     let _ = repo
-        .git_command(&["config", "--unset", "worktrunk.default-branch"])
+        .git_command()
+        .args(["config", "--unset", "worktrunk.default-branch"])
         .output();
 
     // First call queries remote and caches to worktrunk config
     Repository::at(repo.root_path()).default_branch().unwrap();
     let cached = repo
-        .git_command(&["config", "--get", "worktrunk.default-branch"])
+        .git_command()
+        .args(["config", "--get", "worktrunk.default-branch"])
         .output()
         .unwrap();
     assert!(cached.status.success());
@@ -100,8 +103,14 @@ fn test_branch_exists_with_custom_remote(mut repo: TestRepo) {
 #[rstest]
 fn test_get_default_branch_no_remote_common_names_fallback(repo: TestRepo) {
     // Create additional branches (no remote configured)
-    repo.git_command(&["branch", "feature"]).status().unwrap();
-    repo.git_command(&["branch", "bugfix"]).status().unwrap();
+    repo.git_command()
+        .args(["branch", "feature"])
+        .status()
+        .unwrap();
+    repo.git_command()
+        .args(["branch", "bugfix"])
+        .status()
+        .unwrap();
 
     // Now we have multiple branches: main, feature, bugfix
     // Should detect "main" from the common names list
@@ -112,11 +121,18 @@ fn test_get_default_branch_no_remote_common_names_fallback(repo: TestRepo) {
 #[rstest]
 fn test_get_default_branch_no_remote_master_fallback(repo: TestRepo) {
     // Rename main to master, then create other branches
-    repo.git_command(&["branch", "-m", "main", "master"])
+    repo.git_command()
+        .args(["branch", "-m", "main", "master"])
         .status()
         .unwrap();
-    repo.git_command(&["branch", "feature"]).status().unwrap();
-    repo.git_command(&["branch", "bugfix"]).status().unwrap();
+    repo.git_command()
+        .args(["branch", "feature"])
+        .status()
+        .unwrap();
+    repo.git_command()
+        .args(["branch", "bugfix"])
+        .status()
+        .unwrap();
 
     // Now we have: master, feature, bugfix (no "main")
     // Should detect "master" from the common names list
@@ -127,13 +143,18 @@ fn test_get_default_branch_no_remote_master_fallback(repo: TestRepo) {
 #[rstest]
 fn test_get_default_branch_no_remote_init_default_branch_config(repo: TestRepo) {
     // Rename main to something non-standard, create the configured default
-    repo.git_command(&["branch", "-m", "main", "primary"])
+    repo.git_command()
+        .args(["branch", "-m", "main", "primary"])
         .status()
         .unwrap();
-    repo.git_command(&["branch", "feature"]).status().unwrap();
+    repo.git_command()
+        .args(["branch", "feature"])
+        .status()
+        .unwrap();
 
     // Set init.defaultBranch - this should be checked before common names
-    repo.git_command(&["config", "init.defaultBranch", "primary"])
+    repo.git_command()
+        .args(["config", "init.defaultBranch", "primary"])
         .status()
         .unwrap();
 
@@ -146,11 +167,12 @@ fn test_get_default_branch_no_remote_init_default_branch_config(repo: TestRepo) 
 #[rstest]
 fn test_get_default_branch_no_remote_fails_when_no_match(repo: TestRepo) {
     // Rename main to something non-standard
-    repo.git_command(&["branch", "-m", "main", "xyz"])
+    repo.git_command()
+        .args(["branch", "-m", "main", "xyz"])
         .status()
         .unwrap();
-    repo.git_command(&["branch", "abc"]).status().unwrap();
-    repo.git_command(&["branch", "def"]).status().unwrap();
+    repo.git_command().args(["branch", "abc"]).status().unwrap();
+    repo.git_command().args(["branch", "def"]).status().unwrap();
 
     // Now we have: xyz, abc, def - no common names, no init.defaultBranch
     // Should fail with an error

--- a/tests/integration_tests/directives.rs
+++ b/tests/integration_tests/directives.rs
@@ -23,7 +23,7 @@ fn test_switch_directive_file(#[from(repo_with_remote)] mut repo: TestRepo) {
 
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         configure_directive_file(&mut cmd, &directive_path);
         cmd.arg("switch")
             .arg("feature")
@@ -53,7 +53,7 @@ fn test_merge_directive_file(mut repo_with_remote_and_feature: TestRepo) {
 
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         configure_directive_file(&mut cmd, &directive_path);
         cmd.arg("merge").arg("main").current_dir(feature_wt);
 
@@ -80,7 +80,7 @@ fn test_remove_directive_file(#[from(repo_with_remote)] mut repo: TestRepo) {
 
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         configure_directive_file(&mut cmd, &directive_path);
         cmd.arg("remove").current_dir(&feature_wt);
 
@@ -107,7 +107,7 @@ fn test_switch_without_directive_file(repo: TestRepo) {
 
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         cmd.arg("switch")
             .arg("my-feature")
             .current_dir(repo.root_path());
@@ -123,7 +123,7 @@ fn test_remove_without_directive_file(repo: TestRepo) {
 
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         cmd.arg("remove").current_dir(repo.root_path());
 
         assert_cmd_snapshot!(cmd);
@@ -141,7 +141,7 @@ fn test_merge_directive_no_remove(mut repo_with_feature_worktree: TestRepo) {
 
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         configure_directive_file(&mut cmd, &directive_path);
         cmd.arg("merge")
             .arg("main")
@@ -164,7 +164,7 @@ fn test_merge_directive_remove(mut repo_with_feature_worktree: TestRepo) {
 
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         configure_directive_file(&mut cmd, &directive_path);
         cmd.arg("merge").arg("main").current_dir(feature_wt);
 

--- a/tests/integration_tests/hook_show.rs
+++ b/tests/integration_tests/hook_show.rs
@@ -40,7 +40,7 @@ test = "cargo test"
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         cmd.arg("hook").arg("show").current_dir(repo.root_path());
         set_temp_home_env(&mut cmd, temp_home.path());
 
@@ -64,7 +64,7 @@ fn test_hook_show_no_hooks(repo: TestRepo, temp_home: TempDir) {
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         cmd.arg("hook").arg("show").current_dir(repo.root_path());
         set_temp_home_env(&mut cmd, temp_home.path());
 
@@ -103,7 +103,7 @@ deploy = "scripts/deploy.sh"
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         cmd.arg("hook")
             .arg("show")
             .arg("pre-merge")
@@ -143,7 +143,7 @@ test = "cargo test"
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         // Override config path to point to our test config with approval
         cmd.env("WORKTRUNK_CONFIG_PATH", &config_path);
         cmd.arg("hook").arg("show").current_dir(repo.root_path());
@@ -193,7 +193,7 @@ worktree-path = "../project.{{ branch }}"
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         cmd.arg("hook").arg("show").current_dir(repo.root_path());
         set_temp_home_env(&mut cmd, temp_home.path());
 

--- a/tests/integration_tests/init.rs
+++ b/tests/integration_tests/init.rs
@@ -21,7 +21,7 @@ fn snapshot_init(test_name: &str, repo: &TestRepo, shell: &str, extra_args: &[&s
 
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         cmd.arg("config").arg("shell").arg("init").arg(shell);
 
         for arg in extra_args {
@@ -52,7 +52,7 @@ fn test_init_invalid_shell(repo: TestRepo) {
 
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         cmd.arg("config")
             .arg("shell")
             .arg("init")

--- a/tests/integration_tests/list_config.rs
+++ b/tests/integration_tests/list_config.rs
@@ -27,7 +27,7 @@ full = true
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.arg("list").current_dir(repo.root_path());
 
@@ -62,7 +62,7 @@ branches = true
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.arg("list").current_dir(repo.root_path());
 
@@ -97,7 +97,7 @@ branches = false
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         // CLI flag --branches should override config
         cmd.arg("list")
@@ -136,7 +136,7 @@ branches = true
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.arg("list").current_dir(repo.root_path());
 
@@ -168,7 +168,7 @@ fn test_list_no_config(repo: TestRepo, temp_home: TempDir) {
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.arg("list").current_dir(repo.root_path());
 
@@ -199,7 +199,7 @@ url = "http://localhost:{{ branch | hash_port }}"
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.arg("list").current_dir(repo.root_path());
 
@@ -228,7 +228,7 @@ url = "http://localhost:{{ branch | hash_port }}"
     .unwrap();
 
     let mut cmd = wt_command();
-    repo.clean_cli_env(&mut cmd);
+    repo.configure_wt_cmd(&mut cmd);
     set_temp_home_env(&mut cmd, temp_home.path());
     cmd.args(["list", "--format=json"])
         .current_dir(repo.root_path());
@@ -269,7 +269,7 @@ fn test_list_json_no_url_without_template(repo: TestRepo, temp_home: TempDir) {
     .unwrap();
 
     let mut cmd = wt_command();
-    repo.clean_cli_env(&mut cmd);
+    repo.configure_wt_cmd(&mut cmd);
     set_temp_home_env(&mut cmd, temp_home.path());
     cmd.args(["list", "--format=json"])
         .current_dir(repo.root_path());
@@ -317,7 +317,7 @@ url = "http://localhost:{{ branch | hash_port }}"
     .unwrap();
 
     let mut cmd = wt_command();
-    repo.clean_cli_env(&mut cmd);
+    repo.configure_wt_cmd(&mut cmd);
     set_temp_home_env(&mut cmd, temp_home.path());
     cmd.args(["list", "--branches", "--format=json"])
         .current_dir(repo.root_path());
@@ -358,7 +358,7 @@ url = "http://localhost:8080/{{ branch }}"
     .unwrap();
 
     let mut cmd = wt_command();
-    repo.clean_cli_env(&mut cmd);
+    repo.configure_wt_cmd(&mut cmd);
     set_temp_home_env(&mut cmd, temp_home.path());
     cmd.args(["list", "--format=json"])
         .current_dir(repo.root_path());

--- a/tests/integration_tests/merge.rs
+++ b/tests/integration_tests/merge.rs
@@ -2663,7 +2663,7 @@ fn test_merge_error_conflicting_changes_in_target(mut repo_with_alternate_primar
 fn test_step_commit_show_prompt(repo: TestRepo) {
     // Create some staged changes so there's a diff to include in the prompt
     fs::write(repo.root_path().join("new_file.txt"), "new content").expect("Failed to write file");
-    repo.git_command(&["add", "new_file.txt"]);
+    repo.git_command().args(["add", "new_file.txt"]);
 
     // The prompt should be written to stdout
     snapshot_step_commit_with_env(

--- a/tests/integration_tests/post_start_commands.rs
+++ b/tests/integration_tests/post_start_commands.rs
@@ -251,7 +251,8 @@ approved-commands = ["echo 'Default: {{ default_branch }}' > default.txt"]
 #[rstest]
 fn test_post_create_git_variables_template(#[from(repo_with_remote)] repo: TestRepo) {
     // Set up an upstream tracking branch
-    repo.git_command(&["push", "-u", "origin", "main"])
+    repo.git_command()
+        .args(["push", "-u", "origin", "main"])
         .output()
         .expect("failed to push");
 
@@ -323,7 +324,8 @@ worktree_name = "echo 'Worktree Name: {{ worktree_name }}' >> git_vars.txt"
 #[rstest]
 fn test_post_create_upstream_template(#[from(repo_with_remote)] repo: TestRepo) {
     // Push main to set up tracking
-    repo.git_command(&["push", "-u", "origin", "main"])
+    repo.git_command()
+        .args(["push", "-u", "origin", "main"])
         .output()
         .expect("failed to push main");
 

--- a/tests/integration_tests/readme_sync.rs
+++ b/tests/integration_tests/readme_sync.rs
@@ -19,11 +19,11 @@
 //! 4. **Updating**: `update_section()` finds markers and replaces content
 #![cfg(not(windows))]
 
+use crate::common::wt_command;
 use ansi_to_html::convert as ansi_to_html;
 use regex::Regex;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
 use std::sync::LazyLock;
 
 /// Unified pattern for all AUTO-GENERATED markers (README and docs)
@@ -558,8 +558,8 @@ fn get_help_output(id: &str, project_root: &Path) -> Result<String, String> {
         return Err(format!("Command must end with '--help-md': {}", command));
     }
 
-    // Use the already-built binary from cargo test
-    let output = Command::new(env!("CARGO_BIN_EXE_wt"))
+    // Use the already-built binary from cargo test (wt_command provides isolation)
+    let output = wt_command()
         .args(&args[1..]) // Skip "wt" prefix
         .current_dir(project_root)
         .output()
@@ -1175,7 +1175,7 @@ fn test_command_pages_are_in_sync() {
         }
 
         // Run wt <cmd> --help-page (outputs START marker + content + END marker)
-        let output = Command::new(env!("CARGO_BIN_EXE_wt"))
+        let output = wt_command()
             .args([cmd, "--help-page"])
             .current_dir(project_root)
             .output()

--- a/tests/integration_tests/remove.rs
+++ b/tests/integration_tests/remove.rs
@@ -149,7 +149,7 @@ fn test_remove_nonexistent_worktree(repo: TestRepo) {
 #[rstest]
 fn test_remove_branch_no_worktree_path_occupied(mut repo: TestRepo) {
     // Create branch `npm` without a worktree
-    repo.git_command(&["branch", "npm"]).output().unwrap();
+    repo.git_command().args(["branch", "npm"]).output().unwrap();
 
     // Create a worktree for a different branch at the path where `npm` worktree would be
     // (the path template puts worktrees at ../repo.branch, so ../repo.npm would be npm's path)
@@ -167,24 +167,26 @@ fn test_remove_branch_no_worktree_path_occupied(mut repo: TestRepo) {
     ));
 
     // Remove the worktree metadata and move the directory
-    repo.git_command(&[
-        "worktree",
-        "remove",
-        "--force",
-        other_path.to_str().unwrap(),
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "worktree",
+            "remove",
+            "--force",
+            other_path.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
 
     // Create worktree at npm's expected path but for the "other" branch
-    repo.git_command(&[
-        "worktree",
-        "add",
-        npm_expected_path.to_str().unwrap(),
-        "other",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "worktree",
+            "add",
+            npm_expected_path.to_str().unwrap(),
+            "other",
+        ])
+        .output()
+        .unwrap();
 
     // Now: branch `npm` exists, no worktree for it, but npm's expected path has `other` branch
     // Running `wt remove npm` should show "No worktree found" NOT "Cannot create worktree"
@@ -326,11 +328,13 @@ fn test_remove_branch_not_fully_merged(mut repo: TestRepo) {
 
     // Add a commit to the feature branch that's not in main
     std::fs::write(worktree_path.join("feature.txt"), "new feature").unwrap();
-    repo.git_command(&["add", "feature.txt"])
+    repo.git_command()
+        .args(["add", "feature.txt"])
         .current_dir(&worktree_path)
         .output()
         .unwrap();
-    repo.git_command(&["commit", "-m", "Add feature"])
+    repo.git_command()
+        .args(["commit", "-m", "Add feature"])
         .current_dir(&worktree_path)
         .output()
         .unwrap();
@@ -366,11 +370,13 @@ fn test_remove_foreground_unmerged(mut repo: TestRepo) {
 
     // Add a commit to the feature branch that's not in main
     std::fs::write(worktree_path.join("feature.txt"), "new feature").unwrap();
-    repo.git_command(&["add", "feature.txt"])
+    repo.git_command()
+        .args(["add", "feature.txt"])
         .current_dir(&worktree_path)
         .output()
         .unwrap();
-    repo.git_command(&["commit", "-m", "Add feature"])
+    repo.git_command()
+        .args(["commit", "-m", "Add feature"])
         .current_dir(&worktree_path)
         .output()
         .unwrap();
@@ -410,17 +416,22 @@ fn test_remove_foreground_no_delete_branch_unmerged(mut repo: TestRepo) {
 
     // Add a commit to the feature branch that's not in main
     std::fs::write(worktree_path.join("feature.txt"), "new feature").unwrap();
-    repo.git_command(&["add", "feature.txt"])
+    repo.git_command()
+        .args(["add", "feature.txt"])
         .current_dir(&worktree_path)
         .output()
         .unwrap();
-    repo.git_command(&["commit", "-m", "Add feature"])
+    repo.git_command()
+        .args(["commit", "-m", "Add feature"])
         .current_dir(&worktree_path)
         .output()
         .unwrap();
 
     // Go back to main
-    repo.git_command(&["checkout", "main"]).output().unwrap();
+    repo.git_command()
+        .args(["checkout", "main"])
+        .output()
+        .unwrap();
 
     // Remove with both --no-background and --no-delete-branch
     // No hint because:
@@ -460,17 +471,22 @@ fn test_remove_no_delete_branch_unmerged(mut repo: TestRepo) {
 
     // Add a commit to the feature branch that's not in main
     std::fs::write(worktree_path.join("feature.txt"), "new feature").unwrap();
-    repo.git_command(&["add", "feature.txt"])
+    repo.git_command()
+        .args(["add", "feature.txt"])
         .current_dir(&worktree_path)
         .output()
         .unwrap();
-    repo.git_command(&["commit", "-m", "Add feature"])
+    repo.git_command()
+        .args(["commit", "-m", "Add feature"])
         .current_dir(&worktree_path)
         .output()
         .unwrap();
 
     // Go back to main before removing
-    repo.git_command(&["checkout", "main"]).output().unwrap();
+    repo.git_command()
+        .args(["checkout", "main"])
+        .output()
+        .unwrap();
 
     // Remove worktree with --no-delete-branch flag
     // Since branch is unmerged, the flag has no effect - no hint shown
@@ -485,7 +501,8 @@ fn test_remove_no_delete_branch_unmerged(mut repo: TestRepo) {
 #[rstest]
 fn test_remove_branch_only_merged(repo: TestRepo) {
     // Create a branch from main without a worktree (already merged)
-    repo.git_command(&["branch", "feature-merged"])
+    repo.git_command()
+        .args(["branch", "feature-merged"])
         .output()
         .unwrap();
 
@@ -501,20 +518,29 @@ fn test_remove_branch_only_merged(repo: TestRepo) {
 #[rstest]
 fn test_remove_branch_only_unmerged(repo: TestRepo) {
     // Create a branch with a unique commit (not in main)
-    repo.git_command(&["branch", "feature-unmerged"])
+    repo.git_command()
+        .args(["branch", "feature-unmerged"])
         .output()
         .unwrap();
 
     // Add a commit to the branch that's not in main
-    repo.git_command(&["checkout", "feature-unmerged"])
+    repo.git_command()
+        .args(["checkout", "feature-unmerged"])
         .output()
         .unwrap();
     std::fs::write(repo.root_path().join("feature.txt"), "new feature").unwrap();
-    repo.git_command(&["add", "feature.txt"]).output().unwrap();
-    repo.git_command(&["commit", "-m", "Add feature"])
+    repo.git_command()
+        .args(["add", "feature.txt"])
         .output()
         .unwrap();
-    repo.git_command(&["checkout", "main"]).output().unwrap();
+    repo.git_command()
+        .args(["commit", "-m", "Add feature"])
+        .output()
+        .unwrap();
+    repo.git_command()
+        .args(["checkout", "main"])
+        .output()
+        .unwrap();
 
     // Try to remove the branch (no worktree exists, branch not merged)
     // Branch deletion should fail but not error
@@ -529,20 +555,29 @@ fn test_remove_branch_only_unmerged(repo: TestRepo) {
 #[rstest]
 fn test_remove_branch_only_force_delete(repo: TestRepo) {
     // Create a branch with a unique commit (not in main)
-    repo.git_command(&["branch", "feature-force"])
+    repo.git_command()
+        .args(["branch", "feature-force"])
         .output()
         .unwrap();
 
     // Add a commit to the branch that's not in main
-    repo.git_command(&["checkout", "feature-force"])
+    repo.git_command()
+        .args(["checkout", "feature-force"])
         .output()
         .unwrap();
     std::fs::write(repo.root_path().join("feature.txt"), "new feature").unwrap();
-    repo.git_command(&["add", "feature.txt"]).output().unwrap();
-    repo.git_command(&["commit", "-m", "Add feature"])
+    repo.git_command()
+        .args(["add", "feature.txt"])
         .output()
         .unwrap();
-    repo.git_command(&["checkout", "main"]).output().unwrap();
+    repo.git_command()
+        .args(["commit", "-m", "Add feature"])
+        .output()
+        .unwrap();
+    repo.git_command()
+        .args(["checkout", "main"])
+        .output()
+        .unwrap();
 
     // Force delete the branch (no worktree exists)
     snapshot_remove(
@@ -626,31 +661,45 @@ fn test_remove_at_from_detached_head_in_worktree(mut repo: TestRepo) {
 #[rstest]
 fn test_remove_branch_matching_tree_content(repo: TestRepo) {
     // Create a feature branch from main
-    repo.git_command(&["branch", "feature-squashed"])
+    repo.git_command()
+        .args(["branch", "feature-squashed"])
         .output()
         .unwrap();
 
     // On feature branch: add a file
-    repo.git_command(&["checkout", "feature-squashed"])
+    repo.git_command()
+        .args(["checkout", "feature-squashed"])
         .output()
         .unwrap();
     std::fs::write(repo.root_path().join("feature.txt"), "squash content").unwrap();
-    repo.git_command(&["add", "feature.txt"]).output().unwrap();
-    repo.git_command(&["commit", "-m", "Add feature (on feature branch)"])
+    repo.git_command()
+        .args(["add", "feature.txt"])
+        .output()
+        .unwrap();
+    repo.git_command()
+        .args(["commit", "-m", "Add feature (on feature branch)"])
         .output()
         .unwrap();
 
     // On main: add the same file with same content (simulates squash merge result)
-    repo.git_command(&["checkout", "main"]).output().unwrap();
+    repo.git_command()
+        .args(["checkout", "main"])
+        .output()
+        .unwrap();
     std::fs::write(repo.root_path().join("feature.txt"), "squash content").unwrap();
-    repo.git_command(&["add", "feature.txt"]).output().unwrap();
-    repo.git_command(&["commit", "-m", "Add feature (squash merged)"])
+    repo.git_command()
+        .args(["add", "feature.txt"])
+        .output()
+        .unwrap();
+    repo.git_command()
+        .args(["commit", "-m", "Add feature (squash merged)"])
         .output()
         .unwrap();
 
     // Verify the setup: feature-squashed is NOT an ancestor of main (different commits)
     let is_ancestor = repo
-        .git_command(&["merge-base", "--is-ancestor", "feature-squashed", "main"])
+        .git_command()
+        .args(["merge-base", "--is-ancestor", "feature-squashed", "main"])
         .output()
         .unwrap();
     assert!(
@@ -660,14 +709,16 @@ fn test_remove_branch_matching_tree_content(repo: TestRepo) {
 
     // Verify: tree SHAs should match
     let feature_tree = String::from_utf8(
-        repo.git_command(&["rev-parse", "feature-squashed^{tree}"])
+        repo.git_command()
+            .args(["rev-parse", "feature-squashed^{tree}"])
             .output()
             .unwrap()
             .stdout,
     )
     .unwrap();
     let main_tree = String::from_utf8(
-        repo.git_command(&["rev-parse", "main^{tree}"])
+        repo.git_command()
+            .args(["rev-parse", "main^{tree}"])
             .output()
             .unwrap()
             .stdout,
@@ -878,42 +929,55 @@ fn test_remove_default_branch_no_tautology() {
 #[rstest]
 fn test_remove_squash_merged_then_main_advanced(repo: TestRepo) {
     // Create feature branch
-    repo.git_command(&["checkout", "-b", "feature-squash"])
+    repo.git_command()
+        .args(["checkout", "-b", "feature-squash"])
         .output()
         .unwrap();
 
     // Make changes on feature branch (file A)
     std::fs::write(repo.root_path().join("feature-a.txt"), "feature content").unwrap();
-    repo.git_command(&["add", "feature-a.txt"])
+    repo.git_command()
+        .args(["add", "feature-a.txt"])
         .output()
         .unwrap();
-    repo.git_command(&["commit", "-m", "Add feature A"])
+    repo.git_command()
+        .args(["commit", "-m", "Add feature A"])
         .output()
         .unwrap();
 
     // Go back to main
-    repo.git_command(&["checkout", "main"]).output().unwrap();
+    repo.git_command()
+        .args(["checkout", "main"])
+        .output()
+        .unwrap();
 
     // Squash merge feature into main (simulating GitHub squash merge)
     // This creates a NEW commit on main with the same content changes
     std::fs::write(repo.root_path().join("feature-a.txt"), "feature content").unwrap();
-    repo.git_command(&["add", "feature-a.txt"])
+    repo.git_command()
+        .args(["add", "feature-a.txt"])
         .output()
         .unwrap();
-    repo.git_command(&["commit", "-m", "Add feature A (squash merged)"])
+    repo.git_command()
+        .args(["commit", "-m", "Add feature A (squash merged)"])
         .output()
         .unwrap();
 
     // Main advances with another commit (file B)
     std::fs::write(repo.root_path().join("main-b.txt"), "main content").unwrap();
-    repo.git_command(&["add", "main-b.txt"]).output().unwrap();
-    repo.git_command(&["commit", "-m", "Main advances with B"])
+    repo.git_command()
+        .args(["add", "main-b.txt"])
+        .output()
+        .unwrap();
+    repo.git_command()
+        .args(["commit", "-m", "Main advances with B"])
         .output()
         .unwrap();
 
     // Verify setup: feature-squash is NOT an ancestor of main (squash creates different SHAs)
     let is_ancestor = repo
-        .git_command(&["merge-base", "--is-ancestor", "feature-squash", "main"])
+        .git_command()
+        .args(["merge-base", "--is-ancestor", "feature-squash", "main"])
         .output()
         .unwrap();
     assert!(
@@ -923,14 +987,16 @@ fn test_remove_squash_merged_then_main_advanced(repo: TestRepo) {
 
     // Verify setup: trees don't match (main has file B that feature doesn't)
     let feature_tree = String::from_utf8(
-        repo.git_command(&["rev-parse", "feature-squash^{tree}"])
+        repo.git_command()
+            .args(["rev-parse", "feature-squash^{tree}"])
             .output()
             .unwrap()
             .stdout,
     )
     .unwrap();
     let main_tree = String::from_utf8(
-        repo.git_command(&["rev-parse", "main^{tree}"])
+        repo.git_command()
+            .args(["rev-parse", "main^{tree}"])
             .output()
             .unwrap()
             .stdout,
@@ -1052,7 +1118,7 @@ approved-commands = ["echo 'hook ran' > {}"]
 
     // Remove in background mode (default)
     let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_wt"));
-    repo.clean_cli_env(&mut cmd);
+    repo.configure_wt_cmd(&mut cmd);
     cmd.current_dir(repo.root_path())
         .args(["remove", "feature-bg"])
         .output()
@@ -1126,13 +1192,14 @@ approved-commands = ["echo 'hook ran' > {}"]
     ));
 
     // Create a branch without a worktree
-    repo.git_command(&["branch", "branch-only"])
+    repo.git_command()
+        .args(["branch", "branch-only"])
         .output()
         .unwrap();
 
     // Remove the branch (no worktree)
     let mut cmd = std::process::Command::new(env!("CARGO_BIN_EXE_wt"));
-    repo.clean_cli_env(&mut cmd);
+    repo.configure_wt_cmd(&mut cmd);
     cmd.current_dir(repo.root_path())
         .args(["remove", "branch-only"])
         .output()

--- a/tests/integration_tests/repository.rs
+++ b/tests/integration_tests/repository.rs
@@ -141,7 +141,8 @@ fn test_available_branches_all_have_worktrees() {
 fn test_available_branches_some_without_worktrees() {
     let repo = TestRepo::new();
     // Create a branch without a worktree
-    repo.git_command(&["branch", "orphan-branch"])
+    repo.git_command()
+        .args(["branch", "orphan-branch"])
         .output()
         .unwrap();
 
@@ -162,8 +163,14 @@ fn test_available_branches_some_without_worktrees() {
 fn test_all_branches() {
     let repo = TestRepo::new();
     // Create some branches
-    repo.git_command(&["branch", "alpha"]).output().unwrap();
-    repo.git_command(&["branch", "beta"]).output().unwrap();
+    repo.git_command()
+        .args(["branch", "alpha"])
+        .output()
+        .unwrap();
+    repo.git_command()
+        .args(["branch", "beta"])
+        .output()
+        .unwrap();
 
     let repository = Repository::at(repo.root_path().to_path_buf());
     let branches = repository.all_branches().unwrap();
@@ -182,14 +189,15 @@ fn test_project_identifier_https() {
     let mut repo = TestRepo::new();
     repo.setup_remote("main");
     // Override the remote URL to https format
-    repo.git_command(&[
-        "remote",
-        "set-url",
-        "origin",
-        "https://github.com/user/repo.git",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            "https://github.com/user/repo.git",
+        ])
+        .output()
+        .unwrap();
 
     let repository = Repository::at(repo.root_path().to_path_buf());
     let id = repository.project_identifier().unwrap();
@@ -201,14 +209,15 @@ fn test_project_identifier_http() {
     let mut repo = TestRepo::new();
     repo.setup_remote("main");
     // Override the remote URL to http format (no SSL)
-    repo.git_command(&[
-        "remote",
-        "set-url",
-        "origin",
-        "http://gitlab.example.com/team/project.git",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            "http://gitlab.example.com/team/project.git",
+        ])
+        .output()
+        .unwrap();
 
     let repository = Repository::at(repo.root_path().to_path_buf());
     let id = repository.project_identifier().unwrap();
@@ -220,14 +229,15 @@ fn test_project_identifier_ssh_colon() {
     let mut repo = TestRepo::new();
     repo.setup_remote("main");
     // Override the remote URL to SSH format with colon
-    repo.git_command(&[
-        "remote",
-        "set-url",
-        "origin",
-        "git@github.com:user/repo.git",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            "git@github.com:user/repo.git",
+        ])
+        .output()
+        .unwrap();
 
     let repository = Repository::at(repo.root_path().to_path_buf());
     let id = repository.project_identifier().unwrap();
@@ -239,14 +249,15 @@ fn test_project_identifier_ssh_protocol() {
     let mut repo = TestRepo::new();
     repo.setup_remote("main");
     // Override the remote URL to ssh:// format
-    repo.git_command(&[
-        "remote",
-        "set-url",
-        "origin",
-        "ssh://git@github.com/user/repo.git",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            "ssh://git@github.com/user/repo.git",
+        ])
+        .output()
+        .unwrap();
 
     let repository = Repository::at(repo.root_path().to_path_buf());
     let id = repository.project_identifier().unwrap();
@@ -259,14 +270,15 @@ fn test_project_identifier_ssh_protocol_with_port() {
     let mut repo = TestRepo::new();
     repo.setup_remote("main");
     // Override the remote URL to ssh:// format with port
-    repo.git_command(&[
-        "remote",
-        "set-url",
-        "origin",
-        "ssh://git@gitlab.example.com:2222/team/project.git",
-    ])
-    .output()
-    .unwrap();
+    repo.git_command()
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            "ssh://git@gitlab.example.com:2222/team/project.git",
+        ])
+        .output()
+        .unwrap();
 
     let repository = Repository::at(repo.root_path().to_path_buf());
     let id = repository.project_identifier().unwrap();
@@ -292,7 +304,8 @@ fn test_project_identifier_no_remote_fallback() {
 #[test]
 fn test_get_config_exists() {
     let repo = TestRepo::new();
-    repo.git_command(&["config", "test.key", "test-value"])
+    repo.git_command()
+        .args(["config", "test.key", "test-value"])
         .output()
         .unwrap();
 

--- a/tests/integration_tests/security.rs
+++ b/tests/integration_tests/security.rs
@@ -221,7 +221,7 @@ fn test_branch_name_is_directive_not_executed(repo: TestRepo) {
     settings.bind(|| {
         let (directive_path, _guard) = directive_file();
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         configure_directive_file(&mut cmd, &directive_path);
         cmd.arg("switch")
             .arg("--create")
@@ -260,7 +260,7 @@ fn test_branch_name_with_newline_directive_not_executed(repo: TestRepo) {
     settings.bind(|| {
         let (directive_path, _guard) = directive_file();
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         configure_directive_file(&mut cmd, &directive_path);
         cmd.arg("switch")
             .arg("--create")
@@ -295,7 +295,7 @@ fn test_commit_message_with_directive_not_executed(mut repo: TestRepo) {
     // Run 'wt list' which might show commit messages
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         cmd.arg("list").current_dir(repo.root_path());
 
         // Verify output - commit message should be escaped/sanitized
@@ -326,7 +326,7 @@ fn test_path_with_directive_not_executed(repo: TestRepo) {
     // Run a command that might display this path
     settings.bind(|| {
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         cmd.arg("list").current_dir(repo.root_path());
 
         assert_cmd_snapshot!(cmd);
@@ -363,7 +363,7 @@ fn test_branch_name_with_cd_directive_not_executed(repo: TestRepo) {
     settings.bind(|| {
         let (directive_path, _guard) = directive_file();
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         configure_directive_file(&mut cmd, &directive_path);
         cmd.arg("switch")
             .arg("--create")
@@ -388,7 +388,7 @@ fn test_error_message_with_directive_not_executed(repo: TestRepo) {
     settings.bind(|| {
         let (directive_path, _guard) = directive_file();
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         configure_directive_file(&mut cmd, &directive_path);
         cmd.arg("switch")
             .arg(malicious_branch)
@@ -432,7 +432,7 @@ fn test_execute_flag_with_directive_like_branch_name(repo: TestRepo) {
     settings.bind(|| {
         let (directive_path, _guard) = directive_file();
         let mut cmd = wt_command();
-        repo.clean_cli_env(&mut cmd);
+        repo.configure_wt_cmd(&mut cmd);
         configure_directive_file(&mut cmd, &directive_path);
         cmd.arg("switch")
             .arg("--create")

--- a/tests/integration_tests/select.rs
+++ b/tests/integration_tests/select.rs
@@ -369,7 +369,8 @@ fn test_select_with_branches(mut repo: TestRepo) {
     repo.add_worktree("active-worktree");
     // Create a branch without a worktree
     let output = repo
-        .git_command(&["branch", "orphan-branch"])
+        .git_command()
+        .args(["branch", "orphan-branch"])
         .output()
         .unwrap();
     assert!(output.status.success(), "Failed to create branch");
@@ -398,12 +399,14 @@ fn test_select_preview_panel_uncommitted(mut repo: TestRepo) {
     // First, create and commit a file so we have something to modify
     std::fs::write(feature_path.join("tracked.txt"), "Original content\n").unwrap();
     let output = repo
-        .git_command(&["-C", feature_path.to_str().unwrap(), "add", "tracked.txt"])
+        .git_command()
+        .args(["-C", feature_path.to_str().unwrap(), "add", "tracked.txt"])
         .output()
         .unwrap();
     assert!(output.status.success(), "Failed to add file");
     let output = repo
-        .git_command(&[
+        .git_command()
+        .args([
             "-C",
             feature_path.to_str().unwrap(),
             "commit",
@@ -456,12 +459,14 @@ fn test_select_preview_panel_log(mut repo: TestRepo) {
         )
         .unwrap();
         let output = repo
-            .git_command(&["-C", feature_path.to_str().unwrap(), "add", "."])
+            .git_command()
+            .args(["-C", feature_path.to_str().unwrap(), "add", "."])
             .output()
             .unwrap();
         assert!(output.status.success(), "Failed to add files");
         let output = repo
-            .git_command(&[
+            .git_command()
+            .args([
                 "-C",
                 feature_path.to_str().unwrap(),
                 "commit",
@@ -513,12 +518,14 @@ fn test_select_preview_panel_main_diff(mut repo: TestRepo) {
     )
     .unwrap();
     let output = repo
-        .git_command(&["-C", feature_path.to_str().unwrap(), "add", "."])
+        .git_command()
+        .args(["-C", feature_path.to_str().unwrap(), "add", "."])
         .output()
         .unwrap();
     assert!(output.status.success(), "Failed to add files");
     let output = repo
-        .git_command(&[
+        .git_command()
+        .args([
             "-C",
             feature_path.to_str().unwrap(),
             "commit",
@@ -540,12 +547,14 @@ fn test_new_feature() {
     )
     .unwrap();
     let output = repo
-        .git_command(&["-C", feature_path.to_str().unwrap(), "add", "."])
+        .git_command()
+        .args(["-C", feature_path.to_str().unwrap(), "add", "."])
         .output()
         .unwrap();
     assert!(output.status.success(), "Failed to add files");
     let output = repo
-        .git_command(&[
+        .git_command()
+        .args([
             "-C",
             feature_path.to_str().unwrap(),
             "commit",

--- a/tests/integration_tests/shell_wrapper.rs
+++ b/tests/integration_tests/shell_wrapper.rs
@@ -170,7 +170,7 @@ fn generate_wrapper(repo: &TestRepo, shell: &str) -> String {
     cmd.arg("config").arg("shell").arg("init").arg(shell);
 
     // Configure environment
-    repo.clean_cli_env(&mut cmd);
+    repo.configure_wt_cmd(&mut cmd);
 
     let output = cmd.output().unwrap_or_else(|e| {
         panic!(

--- a/tests/integration_tests/statusline.rs
+++ b/tests/integration_tests/statusline.rs
@@ -21,7 +21,7 @@ fn run_statusline_from_dir(
     cmd.args(args);
 
     // Apply repo's git environment
-    repo.clean_cli_env(&mut cmd);
+    repo.configure_wt_cmd(&mut cmd);
 
     if stdin_json.is_some() {
         cmd.stdin(Stdio::piped());
@@ -73,21 +73,25 @@ fn add_commits_ahead(repo: &mut TestRepo) {
 
     // Add commits in the feature worktree
     std::fs::write(feature_path.join("feature.txt"), "feature content").unwrap();
-    repo.git_command(&["add", "."])
+    repo.git_command()
+        .args(["add", "."])
         .current_dir(&feature_path)
         .output()
         .unwrap();
-    repo.git_command(&["commit", "-m", "Feature commit 1"])
+    repo.git_command()
+        .args(["commit", "-m", "Feature commit 1"])
         .current_dir(&feature_path)
         .output()
         .unwrap();
 
     std::fs::write(feature_path.join("feature2.txt"), "more content").unwrap();
-    repo.git_command(&["add", "."])
+    repo.git_command()
+        .args(["add", "."])
         .current_dir(&feature_path)
         .output()
         .unwrap();
-    repo.git_command(&["commit", "-m", "Feature commit 2"])
+    repo.git_command()
+        .args(["commit", "-m", "Feature commit 2"])
         .current_dir(&feature_path)
         .output()
         .unwrap();
@@ -220,9 +224,13 @@ fn test_statusline_reflects_checked_out_branch(mut repo: TestRepo) {
     );
 
     // Create and checkout a different branch "other" in the feature worktree
-    repo.git_command(&["branch", "other"]).output().unwrap();
+    repo.git_command()
+        .args(["branch", "other"])
+        .output()
+        .unwrap();
     let checkout_output = repo
-        .git_command(&["checkout", "other"])
+        .git_command()
+        .args(["checkout", "other"])
         .current_dir(&feature_path)
         .output()
         .unwrap();
@@ -251,7 +259,8 @@ fn test_statusline_detached_head(mut repo: TestRepo) {
     let feature_path = repo.add_worktree("feature");
 
     // Detach HEAD
-    repo.git_command(&["checkout", "--detach"])
+    repo.git_command()
+        .args(["checkout", "--detach"])
         .current_dir(&feature_path)
         .output()
         .unwrap();

--- a/tests/integration_tests/switch.rs
+++ b/tests/integration_tests/switch.rs
@@ -122,7 +122,7 @@ fn test_switch_existing_with_shell_integration_configured(mut repo: TestRepo) {
     repo.add_worktree("shell-configured");
 
     // Simulate shell integration configured in user's shell rc files
-    // (repo.home_path() is automatically set as HOME by clean_cli_env)
+    // (repo.home_path() is automatically set as HOME by configure_wt_cmd)
     let zshrc_path = repo.home_path().join(".zshrc");
     fs::write(
         &zshrc_path,
@@ -368,7 +368,7 @@ fn test_switch_no_config_commands_with_yes(repo: TestRepo) {
     repo.commit("Add config");
 
     // With --no-verify, even --yes shouldn't execute config commands
-    // (HOME is automatically set to repo.home_path() by clean_cli_env)
+    // (HOME is automatically set to repo.home_path() by configure_wt_cmd)
     snapshot_switch(
         "switch_no_hooks_with_yes",
         &repo,
@@ -737,14 +737,12 @@ fn test_switch_missing_argument_shows_hints(repo: TestRepo) {
 #[rstest]
 fn test_switch_execute_stdin_inheritance(repo: TestRepo) {
     use std::io::Write;
-    use std::process::{Command, Stdio};
+    use std::process::Stdio;
 
     let test_input = "stdin_inheritance_test_content\n";
 
-    let mut cmd = Command::new(env!("CARGO_BIN_EXE_wt"));
-    repo.configure_git_cmd(&mut cmd);
+    let mut cmd = repo.wt_command();
     cmd.args(["switch", "--create", "stdin-test", "--execute", "cat"])
-        .current_dir(repo.root_path())
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());


### PR DESCRIPTION
## Summary

- Fix test isolation bug where `wt switch` tests could write to the user's shell directive file when running tests from a `wt` shell
- Add `TestRepo::wt_command()` convenience method for cleaner test code
- Rename `clean_cli_env` → `configure_wt_cmd` for consistency with `configure_git_cmd`
- Make `git_command()` API consistent (no args parameter, chain `.args()`)
- Document the pattern in `tests/CLAUDE.md`

## Test plan

- [x] All 637 integration tests pass
- [x] Pre-commit hooks pass (clippy, fmt)
- [x] Verified the stdin inheritance test now uses proper isolation

🤖 Generated with [Claude Code](https://claude.com/claude-code)