### PR TITLE
dist: enable shell and powershell installers

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -8,7 +8,7 @@ cargo-dist-version = "0.30.2"
 # CI backends to support
 ci = "github"
 # The installers to generate for each app
-installers = []
+installers = ["shell", "powershell"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "aarch64-unknown-linux-musl", "x86_64-unknown-linux-musl", "x86_64-pc-windows-msvc"]
 # Whether to install an updater program


### PR DESCRIPTION
## Summary

- Enable cargo-dist shell and powershell installers for easier installation
- Users can now install with a single curl/irm command instead of manual steps

After release, install commands will be:

```bash
# Linux/macOS
curl --proto '=https' --tlsv1.2 -LsSf https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.sh | sh

# Windows PowerShell
irm https://github.com/max-sixty/worktrunk/releases/latest/download/worktrunk-installer.ps1 | iex
```

Closes #317

## Test plan

- [x] `dist plan` shows `worktrunk-installer.sh` and `worktrunk-installer.ps1` in output
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)