### PR TITLE
Add nested bare repo documentation and test helpers

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -70,6 +70,10 @@ worktree-path = ".worktrees/{{ branch | sanitize }}"
 # Namespaced (useful when multiple repos share a parent directory)
 # Creates: ~/code/worktrees/myproject/feature-login
 worktree-path = "../worktrees/{{ main_worktree }}/{{ branch | sanitize }}"
+
+# Nested bare repo (git clone --bare <url> project/.git)
+# Creates: ~/code/project/feature-login (sibling to .git)
+worktree-path = "../{{ branch | sanitize }}"
 ```
 
 ### Command settings

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1217,6 +1217,10 @@ worktree-path = ".worktrees/{{ branch | sanitize }}"
 # Namespaced (useful when multiple repos share a parent directory)
 # Creates: ~/code/worktrees/myproject/feature-login
 worktree-path = "../worktrees/{{ main_worktree }}/{{ branch | sanitize }}"
+
+# Nested bare repo (git clone --bare <url> project/.git)
+# Creates: ~/code/project/feature-login (sibling to .git)
+worktree-path = "../{{ branch | sanitize }}"
 ```
 
 ### Command settings

--- a/tests/snapshots/integration__integration_tests__bare_repository__nested_bare_repo_list_snapshot.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__nested_bare_repo_list_snapshot.snap
@@ -1,0 +1,32 @@
+---
+source: tests/integration_tests/bare_repository.rs
+info:
+  program: wt
+  args:
+    - list
+  env:
+    CLICOLOR_FORCE: ""
+    COLUMNS: "150"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    LANG: C
+    LC_ALL: C
+    NO_COLOR: ""
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m        [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main         [2m^[22m                         .                    [2ma6c13b13[0m  [2m1d[0m    [2mInitial[0m
++ [2mfeature[0m      [2m_[22m                         [2m../feature[0m           [2ma6c13b13[0m  [2m1d[0m    [2mInitial[0m
+
+[2m○[22m [2mShowing 2 worktrees[0m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -95,6 +95,10 @@ Controls where new worktrees are created. The template is relative to the reposi
   [2m# Namespaced (useful when multiple repos share a parent directory)
   [2m# Creates: ~/code/worktrees/myproject/feature-login
   [2mworktree-path = "../worktrees/{{ main_worktree }}/{{ branch | sanitize }}"
+  [2m
+  [2m# Nested bare repo (git clone --bare <url> project/.git)
+  [2m# Creates: ~/code/project/feature-login (sibling to .git)
+  [2mworktree-path = "../{{ branch | sanitize }}"
 
 [1mCommand settings
 


### PR DESCRIPTION
## Summary

- Add documentation example for nested bare repo layout (`project/.git` pattern from #313)
- Users can use relative paths like `../{{ branch | sanitize }}` in worktree-path template
- Extract `configure_git_cmd()` as standalone helper in tests/common for reuse

Closes #313

## Test plan

- [x] Run nested bare repo tests: `cargo test --test integration test_nested_bare_repo`
- [x] Verify worktrees are created as siblings to `.git` directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)