### PR TITLE
fix(docs): use sparse checkout for nested demo assets

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -29,11 +29,13 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          mkdir -p docs/static/assets
-          for file in $(gh api repos/max-sixty/worktrunk-assets/contents/demos --jq '.[].name'); do
-            curl -fsSL -o "docs/static/assets/$file" \
-              "https://raw.githubusercontent.com/max-sixty/worktrunk-assets/main/demos/$file"
-          done
+          # Clone just the demos directory from worktrunk-assets
+          gh repo clone max-sixty/worktrunk-assets /tmp/worktrunk-assets -- --depth 1 --filter=blob:none --sparse
+          cd /tmp/worktrunk-assets
+          git sparse-checkout set demos
+          # Copy assets to docs/static/assets
+          mkdir -p $GITHUB_WORKSPACE/docs/static/assets
+          cp -r demos/* $GITHUB_WORKSPACE/docs/static/assets/
 
       - name: 🕷️ Build docs
         run: zola build


### PR DESCRIPTION
## Summary
- Fix publish-docs workflow which fails because the `demos` directory now contains subdirectories instead of flat files

The demos directory structure changed from:
```
demos/
  wt-core.gif
  wt-switch.gif
  ...
```

To:
```
demos/
  docs/
    dark/
      wt-core.gif
      ...
    light/
      wt-core.gif
      ...
  social/
    dark/
      ...
    light/
      ...
```

The previous curl-based approach tried to download directories as files, which returned 404. This fix uses git sparse checkout to properly handle the nested structure.

## Test plan
- [ ] Merge to main triggers publish-docs workflow
- [ ] Docs site builds successfully with demo GIFs

🤖 Generated with [Claude Code](https://claude.com/claude-code)