### PR TITLE
refactor(docs): simplify demo asset fetch with shallow clone

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -29,13 +29,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          # Clone just the demos directory from worktrunk-assets
-          gh repo clone max-sixty/worktrunk-assets /tmp/worktrunk-assets -- --depth 1 --filter=blob:none --sparse
-          cd /tmp/worktrunk-assets
-          git sparse-checkout set demos
-          # Copy assets to docs/static/assets
-          mkdir -p $GITHUB_WORKSPACE/docs/static/assets
-          cp -r demos/* $GITHUB_WORKSPACE/docs/static/assets/
+          gh repo clone max-sixty/worktrunk-assets /tmp/worktrunk-assets -- --depth 1
+          cp -r /tmp/worktrunk-assets/demos/* docs/static/assets/
 
       - name: 🕷️ Build docs
         run: zola build


### PR DESCRIPTION
## Summary
- Replace sparse checkout with simple shallow clone for fetching demo assets

The assets repo is small enough that a full shallow clone is simpler and just as fast.

## Test plan
- [ ] publish-docs workflow passes after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)