### PR TITLE
fix(docs): create assets directory before copying

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -30,6 +30,7 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh repo clone max-sixty/worktrunk-assets /tmp/worktrunk-assets -- --depth 1
+          mkdir -p docs/static/assets
           cp -r /tmp/worktrunk-assets/demos/* docs/static/assets/
 
       - name: 🕷️ Build docs


### PR DESCRIPTION
## Summary
- Add missing `mkdir -p docs/static/assets` before copying demo assets

Fixes the publish-docs workflow after #322 simplified the asset fetch.

## Test plan
- [ ] publish-docs workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)