### PR TITLE
Add restart hint when shell integration is configured but not active

### DIFF
--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -355,7 +355,7 @@ pub fn handle_switch_output(
             {
                 // Shell wrapper is configured but user ran binary directly
                 super::print(warning_message(cformat!(
-                    "Worktree for <bold>{branch}</> @ <bold>{path_display}</>, but cannot change directory — shell integration not active"
+                    "Worktree for <bold>{branch}</> @ <bold>{path_display}</>, but cannot change directory — restart your shell to activate"
                 )))?;
                 if let Some(warning) = path_mismatch_warning {
                     super::print(warning)?;

--- a/tests/snapshots/integration__integration_tests__help__version.snap
+++ b/tests/snapshots/integration__integration_tests__help__version.snap
@@ -8,6 +8,8 @@ info:
     CLICOLOR_FORCE: "1"
     COLUMNS: "150"
     GIT_EDITOR: ""
+    GIT_FETCH_ARGS: ""
+    RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
 ---

--- a/tests/snapshots/integration__integration_tests__switch__switch_existing_with_shell_configured.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_existing_with_shell_configured.snap
@@ -14,6 +14,7 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
+    GIT_FETCH_ARGS: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -30,4 +31,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mWorktree for [1mshell-configured[22m @ [1m_REPO_.shell-configured[22m, but cannot change directory — shell integration not active[39m
+[33m▲[39m [33mWorktree for [1mshell-configured[22m @ [1m_REPO_.shell-configured[22m, but cannot change directory — restart your shell to activate[39m


### PR DESCRIPTION
When a user runs `wt config shell install` but hasn't restarted their
shell yet, the warning message now includes actionable guidance:

  "cannot change directory — restart your shell to activate"

Instead of just "shell integration not active" with no context.