### PR TITLE
Remove 2nd person pronouns from user-facing messages

### DIFF
--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -66,7 +66,7 @@ verify = true          # Run project hooks
 
 # Approved Commands
 # Commands approved for project hooks in this repo
-# Auto-populated when you approve hooks (prompt on first run) or run: wt hook approvals add
+# Auto-populated when approving hooks (prompt on first run) or via `wt hook approvals add`
 [projects."github.com/user/repo"]
 approved-commands = ["npm install"]
 

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -353,7 +353,7 @@ verify = true          # Run project hooks
 
 # Approved Commands
 # Commands approved for project hooks in this repo
-# Auto-populated when you approve hooks (prompt on first run) or run: wt hook approvals add
+# Auto-populated when approving hooks (prompt on first run) or via `wt hook approvals add`
 [projects."github.com/user/repo"]
 approved-commands = ["npm install"]
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -12,7 +12,7 @@ Worktrunk executes commands in three contexts:
 
 1. **Project hooks** (`.config/wt.toml`) — Automation for worktree lifecycle
 2. **LLM commands** (`~/.config/worktrunk/config.toml`) — Commit message generation
-3. **--execute flag** — Commands you provide explicitly
+3. **--execute flag** — Explicitly provided commands
 
 Commands from project hooks require approval on first run. Approved commands are saved to user config. If a command changes, Worktrunk requires new approval.
 

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -176,7 +176,7 @@ The `sanitize` filter makes branch names safe for filesystem paths. The `hash_po
 dev = "npm run dev -- --host {{ branch }}.lvh.me --port {{ branch | hash_port }}"
 ```
 
-You can hash any string, including concatenations:
+Hash any string, including concatenations:
 
 ```toml
 # Unique port per repo+branch combination

--- a/docs/content/merge.md
+++ b/docs/content/merge.md
@@ -61,7 +61,7 @@ wt merge --no-commit
 6. **Cleanup** — Removes the worktree and branch. Use `--no-remove` to keep the worktree. When already on the target branch or in the main worktree, the worktree is preserved.
 7. **Post-merge hooks** — Project commands run after cleanup. Failures are logged but don't abort.
 
-Use `--no-commit` to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless you pass `--no-rebase`. Useful after preparing commits manually with `wt step`. Requires a clean working tree.
+Use `--no-commit` to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless `--no-rebase` is passed. Useful after preparing commits manually with `wt step`. Requires a clean working tree.
 
 ## Local CI
 

--- a/docs/content/select.md
+++ b/docs/content/select.md
@@ -50,7 +50,7 @@ Branches without worktrees are included — selecting one creates a worktree. (`
 ## See also
 
 - [wt list](@/list.md) — Static table view with all worktree metadata
-- [wt switch](@/switch.md) — Direct switching when you know the target branch
+- [wt switch](@/switch.md) — Direct switching to a known target branch
 
 ## Command reference
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1622,7 +1622,7 @@ The `sanitize` filter makes branch names safe for filesystem paths. The `hash_po
 dev = "npm run dev -- --host {{ branch }}.lvh.me --port {{ branch | hash_port }}"
 ```
 
-You can hash any string, including concatenations:
+Hash any string, including concatenations:
 
 ```toml
 # Unique port per repo+branch combination
@@ -1875,7 +1875,7 @@ Branches without worktrees are included — selecting one creates a worktree. (`
 ## See also
 
 - [wt list](@/list.md) — Static table view with all worktree metadata
-- [wt switch](@/switch.md) — Direct switching when you know the target branch
+- [wt switch](@/switch.md) — Direct switching to a known target branch
 "#
     )]
     Select,
@@ -2404,7 +2404,7 @@ wt merge --no-commit
 6. **Cleanup** — Removes the worktree and branch. Use `--no-remove` to keep the worktree. When already on the target branch or in the main worktree, the worktree is preserved.
 7. **Post-merge hooks** — Project commands run after cleanup. Failures are logged but don't abort.
 
-Use `--no-commit` to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless you pass `--no-rebase`. Useful after preparing commits manually with `wt step`. Requires a clean working tree.
+Use `--no-commit` to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless `--no-rebase` is passed. Useful after preparing commits manually with `wt step`. Requires a clean working tree.
 
 ## Local CI
 

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -633,7 +633,7 @@ pub fn test_commit_generation(
 ) -> anyhow::Result<String> {
     if !commit_generation_config.is_configured() {
         anyhow::bail!(
-            "Commit generation is not configured. Add [commit-generation] to your config."
+            "Commit generation is not configured. Add [commit-generation] to the config."
         );
     }
 

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -355,7 +355,7 @@ pub fn handle_switch_output(
             {
                 // Shell wrapper is configured but user ran binary directly
                 super::print(warning_message(cformat!(
-                    "Worktree for <bold>{branch}</> @ <bold>{path_display}</>, but cannot change directory — restart your shell to activate"
+                    "Worktree for <bold>{branch}</> @ <bold>{path_display}</>, but cannot change directory — restart the shell to activate"
                 )))?;
                 if let Some(warning) = path_mismatch_warning {
                     super::print(warning)?;

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -9,7 +9,7 @@ info:
   env:
     CLICOLOR_FORCE: "1"
     COLUMNS: "150"
-    GIT_CONFIG_GLOBAL: ""
+    GIT_EDITOR: ""
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -112,7 +112,7 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
   [2m
   [2m# Approved Commands
   [2m# Commands approved for project hooks in this repo
-  [2m# Auto-populated when you approve hooks (prompt on first run) or run: wt hook approvals add
+  [2m# Auto-populated when approving hooks (prompt on first run) or via `wt hook approvals add`
   [2m[projects."github.com/user/repo"]
   [2mapproved-commands = ["npm install"]
   [2m

--- a/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
@@ -119,8 +119,8 @@ changes become a separate commit and individual commits are preserved.
 the worktree is preserved.
 7. **Post-merge hooks** — Project commands run after cleanup. Failures are logged but don't abort.
 
-Use `--no-commit` to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless you pass
-`--no-rebase`. Useful after preparing commits manually with `wt step`. Requires a clean working tree.
+Use `--no-commit` to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless `--no-rebase` is
+passed. Useful after preparing commits manually with `wt step`. Requires a clean working tree.
 
 ## Local CI
 

--- a/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
@@ -110,8 +110,8 @@ changes become a separate commit and individual commits are preserved.
 the worktree is preserved.
 7. [1mPost-merge hooks[0m — Project commands run after cleanup. Failures are logged but don't abort.
 
-Use [2m--no-commit[0m to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless you pass
-[2m--no-rebase[0m. Useful after preparing commits manually with [2mwt step[0m. Requires a clean working tree.
+Use [2m--no-commit[0m to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless [2m--no-rebase[0m is
+passed. Useful after preparing commits manually with [2mwt step[0m. Requires a clean working tree.
 
 [32mLocal CI
 

--- a/tests/snapshots/integration__integration_tests__help__help_page_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_page_merge.snap
@@ -71,7 +71,7 @@ wt merge --no-commit
 6. **Cleanup** — Removes the worktree and branch. Use `--no-remove` to keep the worktree. When already on the target branch or in the main worktree, the worktree is preserved.
 7. **Post-merge hooks** — Project commands run after cleanup. Failures are logged but don't abort.
 
-Use `--no-commit` to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless you pass `--no-rebase`. Useful after preparing commits manually with `wt step`. Requires a clean working tree.
+Use `--no-commit` to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless `--no-rebase` is passed. Useful after preparing commits manually with `wt step`. Requires a clean working tree.
 
 ## Local CI
 

--- a/tests/snapshots/integration__integration_tests__switch__switch_existing_with_shell_configured.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_existing_with_shell_configured.snap
@@ -14,7 +14,6 @@ info:
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
     GIT_EDITOR: ""
-    GIT_FETCH_ARGS: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -31,4 +30,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mWorktree for [1mshell-configured[22m @ [1m_REPO_.shell-configured[22m, but cannot change directory — restart your shell to activate[39m
+[33m▲[39m [33mWorktree for [1mshell-configured[22m @ [1m_REPO_.shell-configured[22m, but cannot change directory — restart the shell to activate[39m


### PR DESCRIPTION
## Summary

Replace "you/your" with direct references following CLI output formatting guidelines:

- `"your config"` → `"the config"`
- `"your shell"` → `"the shell"`
- `"You can hash"` → `"Hash"`
- `"when you know"` → `"to a known"`
- `"unless you pass"` → `"unless ... is passed"`
- `"Commands you provide"` → `"Explicitly provided commands"`
- `"when you approve"` → `"when approving"`

## Test plan

- [x] All 646 integration tests pass
- [x] Pre-commit lints pass
- [x] Snapshots updated and reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)