### PR TITLE
fix: `wt hook post-start` spawns in background instead of blocking

### DIFF
--- a/src/commands/standalone.rs
+++ b/src/commands/standalone.rs
@@ -13,7 +13,10 @@ use worktrunk::styling::{
 use super::command_executor::CommandContext;
 use super::commit::{CommitGenerator, CommitOptions};
 use super::context::CommandEnv;
-use super::hooks::{HookFailureStrategy, run_hook_concurrent_with_filter, run_hook_with_filter};
+use super::hooks::{
+    HookFailureStrategy, check_name_filter_matched, prepare_hook_commands, run_hook_with_filter,
+    spawn_hook_commands_background,
+};
 use super::merge::{
     execute_post_merge_commands, execute_pre_remove_commands, run_pre_merge_commands,
 };
@@ -90,36 +93,40 @@ pub fn run_hook(hook_type: HookType, yes: bool, name_filter: Option<&str>) -> an
             )
         }
         HookType::PostStart => {
-            // post-start hooks run concurrently (matching their normal background behavior)
+            // post-start hooks spawn in background (matching their normal behavior during switch)
             let user_config = user_hook!(post_start);
             let project_config = project_config
                 .as_ref()
                 .and_then(|c| c.hooks.post_start.as_ref());
             require_hooks(user_config, project_config, hook_type)?;
-            run_hook_concurrent_with_filter(
+            let commands = prepare_hook_commands(
                 &ctx,
                 user_config,
                 project_config,
                 hook_type,
                 &[],
                 name_filter,
-            )
+            )?;
+            check_name_filter_matched(name_filter, commands.len(), user_config, project_config)?;
+            spawn_hook_commands_background(&ctx, commands, hook_type)
         }
         HookType::PostSwitch => {
-            // post-switch hooks run concurrently (matching their normal background behavior)
+            // post-switch hooks spawn in background (matching their normal behavior during switch)
             let user_config = user_hook!(post_switch);
             let project_config = project_config
                 .as_ref()
                 .and_then(|c| c.hooks.post_switch.as_ref());
             require_hooks(user_config, project_config, hook_type)?;
-            run_hook_concurrent_with_filter(
+            let commands = prepare_hook_commands(
                 &ctx,
                 user_config,
                 project_config,
                 hook_type,
                 &[],
                 name_filter,
-            )
+            )?;
+            check_name_filter_matched(name_filter, commands.len(), user_config, project_config)?;
+            spawn_hook_commands_background(&ctx, commands, hook_type)
         }
         HookType::PreCommit => {
             let user_config = user_hook!(pre_commit);


### PR DESCRIPTION
## Summary

- Fix `wt hook post-start` and `wt hook post-switch` to spawn commands in background instead of blocking
- The help text says "Background — runs without blocking" but the command was blocking on `child.wait()`
- A dev server that never exits would hang `wt hook post-start` forever
- Now matches behavior when triggered via `wt switch --create`

## Changes

- `PostStart` and `PostSwitch` handlers now use `spawn_hook_commands_background()` 
- Deleted unused `run_hook_concurrent_with_filter()` function (~130 lines)
- Deleted unused `HookFailure` struct
- Changed `check_name_filter_matched` to `pub(crate)` for use in standalone.rs
- Tests updated to poll for marker files and verify log contents

## Test plan

- [x] All 649 tests pass
- [x] Pre-commit lints pass
- [x] `wt hook post-start` now returns immediately when spawning long-running commands
- [x] Log files created in `.git/wt-logs/` with expected content

🤖 Generated with [Claude Code](https://claude.com/claude-code)