### PR TITLE
fix: use --root-dir for lychee instead of version pin

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -24,8 +24,6 @@ jobs:
       uses: baptiste0928/cargo-install@v3
       with:
         crate: lychee
-        # Pin to 0.20.x - 0.22.0 has a regression with exclude patterns for root-relative paths
-        version: ^0.20
 
     - name: 🔍 Pre-commit hooks
       uses: pre-commit/action@v3.0.1
@@ -91,8 +89,6 @@ jobs:
       uses: baptiste0928/cargo-install@v3
       with:
         crate: lychee
-        # Pin to 0.20.x - 0.22.0 has a regression with exclude patterns for root-relative paths
-        version: ^0.20
 
     - name: Install wt
       uses: baptiste0928/cargo-install@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,8 +35,8 @@ repos:
         types: [markdown]
         args:
           - --config=.config/lychee.toml
-          # Suppress warnings about root-relative paths (e.g., /assets/wt-demo.gif)
-          # These are valid web paths validated by zola, not lychee
+          # Root dir for resolving absolute paths like /assets/...
+          - --root-dir=docs/static
           - -q
   - repo: local
     hooks:


### PR DESCRIPTION
Lychee needs `--root-dir` to resolve root-relative paths like `/assets/...`. Without it, paths can't be parsed as URIs and exclude patterns don't apply.

This is the proper fix for the lychee issue - the version pin was a workaround based on incorrect assumption of a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)