### PR TITLE
Move lychee root_dir to config file

### DIFF
--- a/.config/lychee.toml
+++ b/.config/lychee.toml
@@ -1,6 +1,9 @@
 # Lychee link checker configuration
 # See: https://lychee.cli.rs/
 
+# Root directory for resolving absolute paths (e.g., /assets/...)
+root_dir = "docs/static"
+
 # Network resilience - handles transient failures
 max_retries = 5
 timeout = 20

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -34,8 +34,6 @@ repos:
         types: [markdown]
         args:
           - --config=.config/lychee.toml
-          # Root dir for resolving absolute paths like /assets/...
-          - --root-dir=docs/static
   - repo: local
     hooks:
       - id: cargo-lock


### PR DESCRIPTION
## Summary
- Move `--root-dir=docs/static` from pre-commit hook args to `.config/lychee.toml`
- Centralizes lychee configuration in one place

## Test plan
- [ ] Pre-commit lychee hook still resolves absolute paths correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)