### PR TITLE
Exclude git-scm.com and worktrunk.dev from lychee link checks

### DIFF
--- a/.config/lychee.toml
+++ b/.config/lychee.toml
@@ -38,6 +38,8 @@ exclude = [
     "stackoverflow\\.com",
     "npmjs\\.com",
     "incident\\.io",
+    "git-scm\\.com",
+    "worktrunk\\.dev",
 
     # Package registries and badges (frequently return 429 or block CI)
     "crates\\.io",


### PR DESCRIPTION
These sites have transient 503 availability issues that cause CI to fail
spuriously. Both are known-good URLs that don't need validation.