### PR TITLE
Ignore flaky shell install preview test on CI

### DIFF
--- a/tests/integration_tests/configure_shell.rs
+++ b/tests/integration_tests/configure_shell.rs
@@ -984,6 +984,7 @@ mod pty_tests {
 
     /// Test that `wt config shell install` shows preview with gutter-formatted config lines
     #[rstest]
+    #[ignore = "flaky on CI due to zsh compinit warnings about insecure directories"]
     fn test_install_preview_with_gutter(repo: TestRepo, temp_home: TempDir) {
         // Create zsh config file
         let zshrc_path = temp_home.path().join(".zshrc");


### PR DESCRIPTION
## Summary
- Marks `test_install_preview_with_gutter` as ignored due to zsh "compinit: insecure directories" warnings that leak into PTY output on GitHub Actions

## Test plan
- [x] Verified test is now ignored when running locally
- [ ] CI should pass with this test ignored

🤖 Generated with [Claude Code](https://claude.com/claude-code)