### PR TITLE
Fix dim attribute not preserved on wrapped continuation lines

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -170,9 +170,26 @@ Users can clean up old logs manually or use a git hook. No automatic cleanup is 
 
 ## Coverage
 
+We maintain high code coverage. The `codecov/patch` CI check enforces coverage on changed lines — respond to failures by writing tests, not by ignoring them.
+
+### Running Coverage Locally
+
 - Install once: `cargo install cargo-llvm-cov`.
-- Run: `./dev/coverage.sh` — runs tests once, then generates HTML (`target/llvm-cov/html/index.html`) and LCOV (`target/llvm-cov/lcov.info`). Set `COVERAGE_OPEN=0` to skip opening the HTML report.
+- Run: `./dev/coverage.sh` — runs tests once, then generates HTML (`target/llvm-cov/html/index.html`) and LCOV (`target/llvm-cov/lcov.info`).
 - Pass extra args to the test run (for example to filter tests): `./dev/coverage.sh -- --test test_name`.
+
+### Investigating codecov/patch Failures
+
+When `codecov/patch` fails, find which changed lines lack coverage:
+
+```bash
+# 1. Run coverage and show uncovered lines
+./dev/coverage.sh
+cargo llvm-cov report --show-missing-lines | grep <file>
+
+# 2. Compare against your diff (use three-dot diff for PR changes)
+git diff main...HEAD -- path/to/file.rs
+```
 
 ## Benchmarks
 

--- a/dev/coverage.sh
+++ b/dev/coverage.sh
@@ -32,13 +32,8 @@ export NEXTEST_NO_INPUT_HANDLER=1
 # Run tests once with instrumentation, without generating a report yet.
 "${CARGO_BIN[@]}" llvm-cov --locked --workspace --no-report --features shell-integration-tests "$@"
 
-# Generate HTML (optionally open) and LCOV reports from the recorded data without rerunning tests.
-OPEN_FLAG=()
-if [ "${COVERAGE_OPEN:-1}" != "0" ]; then
-  OPEN_FLAG=(--open)
-fi
-
-"${CARGO_BIN[@]}" llvm-cov report --html --output-dir "${COVERAGE_DIR}/html" "${OPEN_FLAG[@]}"
+# Generate HTML and LCOV reports from the recorded data without rerunning tests.
+"${CARGO_BIN[@]}" llvm-cov report --html --output-dir "${COVERAGE_DIR}/html"
 "${CARGO_BIN[@]}" llvm-cov report --lcov --output-path "${LCOV_PATH}"
 
 echo "HTML report: ${COVERAGE_DIR}/html/index.html"

--- a/src/styling/format.rs
+++ b/src/styling/format.rs
@@ -514,32 +514,16 @@ mod tests {
             "{dim}{green}This is a very long string that definitely needs to wrap across multiple lines{reset}"
         );
 
-        // Force wrapping
+        // Force wrapping at 30 chars - should produce multiple lines
         let result = wrap_styled_text(&styled, 30);
-
-        assert!(
-            result.len() > 1,
-            "Should wrap into multiple lines, got {} lines",
-            result.len()
-        );
+        assert!(result.len() > 1);
 
         // First line should have dim+green (as input)
-        assert!(
-            result[0].starts_with("\x1b[2m\x1b[32m"),
-            "First line should start with dim+green, got: {:?}",
-            &result[0][..result[0].len().min(20)]
-        );
+        assert!(result[0].starts_with("\x1b[2m\x1b[32m"));
 
-        // Continuation lines should ALSO have dim before the color
-        for (i, line) in result.iter().enumerate().skip(1) {
-            // Each continuation line should start with dim (restored by our fix)
-            // followed by the color (restored by wrap_ansi)
-            assert!(
-                line.starts_with("\x1b[2m\x1b[32m") || line.starts_with("\x1b[2m"),
-                "Continuation line {} should start with dim, got: {:?}",
-                i + 1,
-                &line[..line.len().min(20)]
-            );
+        // Continuation lines should ALSO have dim before the color (restored by our fix)
+        for line in result.iter().skip(1) {
+            assert!(line.starts_with("\x1b[2m\x1b[32m") || line.starts_with("\x1b[2m"));
         }
     }
 


### PR DESCRIPTION
## Summary

- Fix wrapped text appearing brighter than first line due to missing dim attribute

When `wrap_ansi` wraps styled text, it restores foreground colors on continuation lines but not text attributes like dim (SGR 2). This caused the `--execute` command output to display wrapped text without the dim styling, making it appear "bold" relative to the first line.

**Before**: Wrapped continuation lines had green color but no dim
**After**: Wrapped continuation lines have dim+green, matching the first line

## Root Cause

This is a limitation in the `wrap-ansi` crate. Its `AnsiState` struct only tracks:
- `foreground_code: Option<u8>`
- `background_code: Option<u8>`
- `hyperlink_url: Option<String>`

It does NOT track text attributes (bold, dim, italic, etc.). The `AnsiCodeType::Other` variant captures these codes but they're never restored in `apply_after_newline()`.

I'll file an issue upstream with a link to this PR.

## Test plan

- [x] Added `test_wrap_styled_text_restores_dim_on_continuation` unit test
- [x] All existing tests pass
- [x] Lints pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)