### PR TITLE
Fix WorktreePathOccupied hint: tilde expansion and formatting

### DIFF
--- a/.claude/rules/cli-output-formatting.md
+++ b/.claude/rules/cli-output-formatting.md
@@ -334,8 +334,9 @@ cformat!("{ERROR_SYMBOL} <red>Branch <bold>{branch}</> not found</>")
 Never quote commands or branch names. Use styling to make them stand out:
 
 - **In normal font context**: Use `<bold>` for commands and branches
-- **In hints**: Use `<bright-black>` for commands (hint() already applies
-  dimming — no explicit `<dim>` needed)
+- **In hints**: Use `<bright-black>` for commands and data values (paths,
+  branches). Avoid `<bold>` inside hints — the closing `[22m` resets both bold
+  AND dim, so text after `</bold>` loses dim styling.
 
 ```rust
 // GOOD - bold in normal context
@@ -376,13 +377,18 @@ See `src/commands/list/render.rs` for advanced usage.
 
 ## Gutter Formatting
 
-Use gutter for **quoted content** (git output, commit messages, shell commands):
+Use gutter for **quoted content** (git output, commit messages, config to copy,
+hook commands being displayed):
 
 - `format_bash_with_gutter()` — shell commands (dimmed + syntax highlighting)
 - `format_with_gutter()` — other content
 
 **Gutter vs Table:** Tables for structured app data; gutter for quoting external
 content.
+
+**Gutter vs Hints:** Command suggestions in hints use inline `<bright-black>`,
+not gutter. Gutter is for displaying content (what will execute, config to
+copy); hints suggest what the user should run.
 
 ## Newline Convention
 

--- a/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__worktree_path_occupied.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__worktree_path_occupied.snap
@@ -3,5 +3,4 @@ source: tests/integration_tests/git_error_display.rs
 expression: err.to_string()
 ---
 [31m✗[39m [31mCannot switch to [1mfeature-z[22m — there's a worktree at the expected path [1m/tmp/repo.feature-z[22m on branch [1mother-branch[22m[39m
-[2m↳[22m [2mTo switch the worktree at [1m/tmp/repo.feature-z[22m to branch [1mfeature-z[22m:[22m
-[107m [0m [2m[0m[2m[34mcd[0m[2m /tmp/repo.feature-z [0m[2m[36m&&[0m[2m [0m[2m[34mgit[0m[2m switch feature-z[0m
+[2m↳[22m [2mTo switch the worktree at [90m/tmp/repo.feature-z[39m to [90mfeature-z[39m, run [90mcd /tmp/repo.feature-z && git switch feature-z[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_default_branch_from_feature_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_default_branch_from_feature_worktree.snap
@@ -23,6 +23,7 @@ info:
     SOURCE_DATE_EPOCH: "1735776000"
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: false
@@ -31,5 +32,4 @@ exit_code: 1
 
 ----- stderr -----
 [31m✗[39m [31mCannot switch to [1mmain[22m — there's a worktree at the expected path [1m_REPO_[22m on branch [1mfeature-rpa[22m[39m
-[2m↳[22m [2mTo switch the worktree at [1m_REPO_[22m to branch [1mmain[22m:[22m
-[107m [0m [2m[0m[2m[34mcd[0m[2m _REPO_ [0m[2m[36m&&[0m[2m [0m[2m[34mgit[0m[2m switch main
+[2m↳[22m [2mTo switch the worktree at [90m_REPO_[39m to [90mmain[39m, run [90mcd _REPO_ && git switch main[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_error_path_occupied_detached.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_error_path_occupied_detached.snap
@@ -24,6 +24,7 @@ info:
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_DIRECTIVE_FILE: "[DIRECTIVE_FILE]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: false
@@ -32,5 +33,4 @@ exit_code: 1
 
 ----- stderr -----
 [31m✗[39m [31mCannot switch to [1mfeature[22m — there's a detached worktree at the expected path [1m_REPO_.feature[22m[39m
-[2m↳[22m [2mTo switch the worktree at [1m_REPO_.feature[22m to branch [1mfeature[22m:[22m
-[107m [0m [2m[0m[2m[34mcd[0m[2m _REPO_.feature [0m[2m[36m&&[0m[2m [0m[2m[34mgit[0m[2m switch feature
+[2m↳[22m [2mTo switch the worktree at [90m_REPO_.feature[39m to [90mfeature[39m, run [90mcd _REPO_.feature && git switch feature[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_error_path_occupied_different_branch.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_error_path_occupied_different_branch.snap
@@ -24,6 +24,7 @@ info:
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_DIRECTIVE_FILE: "[DIRECTIVE_FILE]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: false
@@ -32,5 +33,4 @@ exit_code: 1
 
 ----- stderr -----
 [31m✗[39m [31mCannot switch to [1mfeature[22m — there's a worktree at the expected path [1m_REPO_.feature[22m on branch [1mbugfix[22m[39m
-[2m↳[22m [2mTo switch the worktree at [1m_REPO_.feature[22m to branch [1mfeature[22m:[22m
-[107m [0m [2m[0m[2m[34mcd[0m[2m _REPO_.feature [0m[2m[36m&&[0m[2m [0m[2m[34mgit[0m[2m switch feature
+[2m↳[22m [2mTo switch the worktree at [90m_REPO_.feature[39m to [90mfeature[39m, run [90mcd _REPO_.feature && git switch feature[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_main_worktree_on_different_branch.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_main_worktree_on_different_branch.snap
@@ -24,6 +24,7 @@ info:
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_DIRECTIVE_FILE: "[DIRECTIVE_FILE]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: false
@@ -32,5 +33,4 @@ exit_code: 1
 
 ----- stderr -----
 [31m✗[39m [31mCannot switch to [1mmain[22m — there's a worktree at the expected path [1m_REPO_[22m on branch [1mfeature[22m[39m
-[2m↳[22m [2mTo switch the worktree at [1m_REPO_[22m to branch [1mmain[22m:[22m
-[107m [0m [2m[0m[2m[34mcd[0m[2m _REPO_ [0m[2m[36m&&[0m[2m [0m[2m[34mgit[0m[2m switch main
+[2m↳[22m [2mTo switch the worktree at [90m_REPO_[39m to [90mmain[39m, run [90mcd _REPO_ && git switch main[39m[22m


### PR DESCRIPTION
## Summary

- Fix tilde expansion bug: `cd '~/path'` doesn't work because tilde doesn't expand inside single quotes. Now uses actual path for shell command.
- Change from gutter block format to inline hint following the "To X, run Y" pattern used by other hints
- Use `<bright-black>` for all data values in hints (paths, branches, commands) for consistency

## Test plan

- [x] All tests pass (`cargo run -- hook pre-merge --yes`)
- [x] Snapshot tests updated to reflect new format

🤖 Generated with [Claude Code](https://claude.com/claude-code)