### PR TITLE
docs: add wt config show to command docs

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -630,6 +630,51 @@ Usage: <b><span class=c>wt config create</span></b> <span class=c>[OPTIONS]</spa
 {% end %}
 
 
+## wt config show
+
+Shows location and contents of user config (`~/.config/worktrunk/config.toml`)
+and project config (`.config/wt.toml`).
+
+If a config file doesn't exist, shows defaults that would be used.
+
+### Full diagnostics
+
+Use `--full` to run diagnostic checks:
+
+```bash
+wt config show --full
+```
+
+This tests:
+- **CI tool status** — Whether `gh` (GitHub) or `glab` (GitLab) is installed and authenticated
+- **Commit generation** — Whether the LLM command can generate commit messages
+
+### Command reference
+
+{% terminal() %}
+wt config show - Show configuration files &amp; locations
+
+Usage: <b><span class=c>wt config show</span></b> <span class=c>[OPTIONS]</span>
+
+<b><span class=g>Options:</span></b>
+      <b><span class=c>--full</span></b>
+          Run diagnostic checks (CI tools, commit generation)
+
+  <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
+          Print help (see a summary with &#39;-h&#39;)
+
+<b><span class=g>Global Options:</span></b>
+  <b><span class=c>-C</span></b><span class=c> &lt;path&gt;</span>
+          Working directory for this command
+
+      <b><span class=c>--config</span></b><span class=c> &lt;path&gt;</span>
+          User config file path
+
+  <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b>
+          Show commands and debug info
+{% end %}
+
+
 ## wt config state
 
 State is stored in `.git/` (config entries and log files), separate from configuration files.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -359,17 +359,18 @@ If a config file doesn't exist, shows defaults that would be used.
 
 ## Full diagnostics
 
-Use `--full` to test commit generation with a synthetic diff:
+Use `--full` to run diagnostic checks:
 
 ```console
 wt config show --full
 ```
 
-This verifies that the LLM command is configured correctly and can generate
-commit messages."#
+This tests:
+- **CI tool status** — Whether `gh` (GitHub) or `glab` (GitLab) is installed and authenticated
+- **Commit generation** — Whether the LLM command can generate commit messages"#
     )]
     Show {
-        /// Test commit generation pipeline
+        /// Run diagnostic checks (CI tools, commit generation)
         #[arg(long)]
         full: bool,
     },
@@ -1398,6 +1399,8 @@ WORKTRUNK_COMMIT_GENERATION__ARGS="test: automated commit" \
 | `CLICOLOR_FORCE` | Force colored output even when not a TTY |
 
 <!-- subdoc: create -->
+
+<!-- subdoc: show -->
 
 <!-- subdoc: state -->
 "#

--- a/tests/snapshots/integration__integration_tests__help__help_config_show.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_show.snap
@@ -10,8 +10,10 @@ info:
     CLICOLOR_FORCE: "1"
     COLUMNS: "150"
     GIT_EDITOR: ""
+    RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
 ---
 success: true
 exit_code: 0
@@ -24,7 +26,7 @@ Usage: [1m[36mwt config show[0m [36m[OPTIONS]
 
 [1m[32mOptions:
       [1m[36m--full
-          Test commit generation pipeline
+          Run diagnostic checks (CI tools, commit generation)
 
   [1m[36m-h[0m, [1m[36m--help
           Print help (see a summary with '-h')
@@ -46,9 +48,10 @@ If a config file doesn't exist, shows defaults that would be used.
 
 [32mFull diagnostics
 
-Use [2m--full[0m to test commit generation with a synthetic diff:
+Use [2m--full[0m to run diagnostic checks:
 
   [2mwt config show --full
 
-This verifies that the LLM command is configured correctly and can generate
-commit messages.
+This tests:
+- [1mCI tool status[0m — Whether [2mgh[0m (GitHub) or [2mglab[0m (GitLab) is installed and authenticated
+- [1mCommit generation[0m — Whether the LLM command can generate commit messages


### PR DESCRIPTION
## Summary
- Add `wt config show` subdoc to the config command docs page
- Fix `--full` flag documentation to accurately describe both diagnostic checks (CI tool status + commit generation)

## Test plan
- [x] All 1579 tests pass
- [x] pre-commit lints pass
- [x] Docs sync test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)