### PR TITLE
Fix escaped pipe characters in markdown table help output

### DIFF
--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -159,8 +159,8 @@ Templates support Jinja2 filters for transforming values:
 
 | Filter | Example | Description |
 |--------|---------|-------------|
-| `sanitize` | `{{ branch \| sanitize }}` → feature-foo | Replace `/` and `\` with `-` |
-| `hash_port` | `{{ branch \| hash_port }}` → 12472 | Hash string to port (10000-19999) |
+| `sanitize` | `{{ branch \| sanitize }}` | Replace `/` and `\` with `-` |
+| `hash_port` | `{{ branch \| hash_port }}` | Hash to port 10000-19999 |
 
 The `sanitize` filter makes branch names safe for filesystem paths. The `hash_port` filter is useful for running dev servers on unique ports per worktree:
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1629,8 +1629,8 @@ Templates support Jinja2 filters for transforming values:
 
 | Filter | Example | Description |
 |--------|---------|-------------|
-| `sanitize` | `{{ branch \| sanitize }}` → feature-foo | Replace `/` and `\` with `-` |
-| `hash_port` | `{{ branch \| hash_port }}` → 12472 | Hash string to port (10000-19999) |
+| `sanitize` | `{{ branch \| sanitize }}` | Replace `/` and `\` with `-` |
+| `hash_port` | `{{ branch \| hash_port }}` | Hash to port 10000-19999 |
 
 The `sanitize` filter makes branch names safe for filesystem paths. The `hash_port` filter is useful for running dev servers on unique ports per worktree:
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -12,6 +12,7 @@ info:
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
 ---
 success: true
 exit_code: 0
@@ -144,7 +145,7 @@ The Status column has multiple subcolumns. Within each, only the first matching 
                     ↕      Diverged from the default branch                                                           
                     ↑      Ahead of the default branch                                                                
                     ↓      Behind the default branch                                                                  
-   Remote           \|     In sync with remote                                                                        
+   Remote           |      In sync with remote                                                                        
                     ⇅      Diverged from remote                                                                       
                     ⇡      Ahead of remote                                                                            
                     ⇣      Behind remote                                                                              

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -12,6 +12,7 @@ info:
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
 ---
 success: true
 exit_code: 0
@@ -153,7 +154,7 @@ branch or target |
            ↕  Diverged from the default branch 
            ↑    Ahead of the default branch    
            ↓     Behind the default branch     
-   Remote \|        In sync with remote        
+   Remote  |        In sync with remote        
            ⇅        Diverged from remote       
            ⇡          Ahead of remote          
            ⇣           Behind remote           


### PR DESCRIPTION
## Summary
- Add `unescape_table_pipes()` to convert `\|` to `|` before termimad rendering
- Shorten Filters table in hook help to fit 80-column terminals
- Update test to verify escaped pipe handling

The `\|` escape sequence is used in markdown tables to include literal pipe characters (since `|` is the column delimiter), but termimad doesn't handle it. This adds preprocessing to convert `\|` to `|` for all tables in help output.

**Before:** `{{ branch \| sanitize }}`
**After:** `{{ branch | sanitize }}`

## Test plan
- [x] `cargo test --test integration test_help` passes
- [x] `pre-commit run --all-files` passes
- [x] Verified output at 80 and 150 column widths

🤖 Generated with [Claude Code](https://claude.com/claude-code)