### PR TITLE
Don't force nextest as default test runner

### DIFF
--- a/.config/insta.yaml
+++ b/.config/insta.yaml
@@ -2,7 +2,6 @@
 # https://insta.rs/docs/settings/
 
 test:
-  # Use nextest as the test runner
-  runner: "nextest"
-  # Fall back to cargo-test if nextest is not available
+  # Don't force nextest — its InputHandler can cause SIGTTOU in background process groups.
+  # See tests/common/mod.rs for details. Auto-detection with fallback handles this gracefully.
   test_runner_fallback: true

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -16,7 +16,7 @@ sync = 'if [ "{{ target }}" = "main" ]; then git pull && git push; fi'
 
 [pre-merge]
 pre-commit = "if [ -n \"$MSYSTEM\" ]; then SKIP=lychee-system pre-commit run --all-files; else pre-commit run --all-files; fi"
-insta = "RUSTFLAGS='-D warnings' NEXTEST_STATUS_LEVEL=fail NEXTEST_SUCCESS_OUTPUT=never NEXTEST_NO_INPUT_HANDLER=1 cargo insta test --dnd --check --features shell-integration-tests"
+insta = "RUSTFLAGS='-D warnings' NEXTEST_STATUS_LEVEL=fail NEXTEST_SUCCESS_OUTPUT=never NEXTEST_NO_INPUT_HANDLER=1 cargo insta test --test-runner nextest --dnd --check --features shell-integration-tests"
 doctest = "RUSTDOCFLAGS='-Dwarnings' cargo test --doc"
 doc = "RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps"
 

--- a/dev/coverage.sh
+++ b/dev/coverage.sh
@@ -26,8 +26,6 @@ LCOV_PATH="${COVERAGE_DIR}/lcov.info"
 mkdir -p "${COVERAGE_DIR}"
 
 # Include shell-integration-tests feature for comprehensive coverage of TUI/PTY code.
-# Set NEXTEST_NO_INPUT_HANDLER to prevent nextest terminal cleanup issues with PTY tests.
-export NEXTEST_NO_INPUT_HANDLER=1
 
 # Run tests once with instrumentation, without generating a report yet.
 "${CARGO_BIN[@]}" llvm-cov --locked --workspace --no-report --features shell-integration-tests "$@"


### PR DESCRIPTION
## Summary
- Remove `runner: "nextest"` from insta config; use auto-detection with fallback instead (avoids SIGTTOU issues in background process groups)
- Explicitly use `--test-runner nextest` in pre-merge hook where we control the environment with `NEXTEST_NO_INPUT_HANDLER=1`
- Remove unused `NEXTEST_NO_INPUT_HANDLER` from coverage.sh (llvm-cov uses cargo test, not nextest)

## Test plan
- [x] Pre-commit lints pass
- [x] Unit tests pass with `cargo test --lib`

🤖 Generated with [Claude Code](https://claude.com/claude-code)