### PR TITLE
Add pre-remove hook to clean up background processes

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -22,3 +22,6 @@ doc = "RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps"
 
 [list]
 url = "http://127.0.0.1:{{ branch | hash_port }}"
+
+[pre-remove]
+docs = "lsof -ti :{{ branch | hash_port }} | xargs kill 2>/dev/null || true"

--- a/docs/content/tips-patterns.md
+++ b/docs/content/tips-patterns.md
@@ -41,6 +41,9 @@ server = "npm run dev -- --port {{ branch | hash_port }}"
 
 [list]
 url = "http://localhost:{{ branch | hash_port }}"
+
+[pre-remove]
+server = "lsof -ti :{{ branch | hash_port }} | xargs kill 2>/dev/null || true"
 ```
 
 The URL column in `wt list` shows each worktree's dev server:

--- a/docs/demos/tapes/wt-zellij-omnibus.tape
+++ b/docs/demos/tapes/wt-zellij-omnibus.tape
@@ -198,3 +198,10 @@ Sleep 3s
 # Done!
 Type "done!"
 Sleep 1.5s
+
+Hide
+# Clean up zellij after recording stops
+Ctrl+Space
+Sleep 200ms
+Type "q"
+Sleep 500ms


### PR DESCRIPTION
## Summary

- Add `pre-remove` hook to `.config/wt.toml` that kills the zola dev server when a worktree is removed (prevents orphaned processes accumulating)
- Add zellij quit command to demo tape after recording stops (cleanup after VHS finishes)
- Document the `pre-remove` cleanup pattern in the "Dev server per worktree" section of tips-patterns.md

The zola dev servers started by `post-start` hooks were accumulating as orphaned processes (202 at one point). The `pre-remove` hook uses `lsof -ti :PORT | xargs kill` to precisely kill only the process on that worktree's hashed port.

## Test plan

- [ ] Verify `wt remove` on a worktree with a running zola server kills the process
- [ ] Verify docs build and the new example renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)