### PR TITLE
fix: show hook path when shell integration inactive

### DIFF
--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -282,13 +282,16 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
             &destination_repo_root,
             yes,
         );
-        // Show path when user's shell stays in a different directory than where hooks run.
-        // This happens only with --no-remove on a feature branch (not in_main, not on_target).
-        // When in_main or on_target, user is already in the destination directory.
-        let display_path = if !remove_effective && !in_main && !on_target {
+        // Show path when user's shell won't be in the destination directory where hooks run.
+        let display_path = if in_main || on_target {
+            // User is already in the destination directory
+            None
+        } else if !remove_effective {
+            // Worktree preserved — user's shell stays in feature worktree
             Some(destination_path.as_path())
         } else {
-            None
+            // Worktree removed — show path only if shell integration won't cd there
+            crate::output::hooks_display_path(&destination_path)
         };
         execute_post_merge_commands(&ctx, &target_branch, None, display_path)?;
     }

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -832,7 +832,13 @@ impl<'a> CommandContext<'a> {
     }
 
     /// Spawn post-start commands in parallel as background processes (non-blocking)
-    pub fn spawn_post_start_commands(&self) -> anyhow::Result<()> {
+    ///
+    /// `display_path`: When `Some`, shows the path in hook announcements. Pass this when
+    /// the user's shell won't be in the worktree (shell integration not active).
+    pub fn spawn_post_start_commands(
+        &self,
+        display_path: Option<&std::path::Path>,
+    ) -> anyhow::Result<()> {
         let project_config = self.repo.load_project_config()?;
 
         let commands = prepare_hook_commands(
@@ -844,7 +850,7 @@ impl<'a> CommandContext<'a> {
             HookType::PostStart,
             &[],
             None,
-            None, // No path display - running in expected directory
+            display_path,
         )?;
 
         spawn_hook_commands_background(self, commands, HookType::PostStart)

--- a/src/main.rs
+++ b/src/main.rs
@@ -1279,7 +1279,7 @@ fn main() {
 
                     // Post-start runs only on creation (setup tasks)
                     if matches!(&result, SwitchResult::Created { .. }) {
-                        ctx.spawn_post_start_commands()?;
+                        ctx.spawn_post_start_commands(hooks_display_path.as_deref())?;
                     }
                 }
 

--- a/src/output/global.rs
+++ b/src/output/global.rs
@@ -276,6 +276,20 @@ pub fn is_shell_integration_active() -> bool {
     has_directive_file()
 }
 
+/// Returns `Some(path)` when shell integration isn't active, `None` otherwise.
+///
+/// Use this to decide whether hook announcements should show "@ path".
+/// When shell integration is active, the user's shell will cd to the path automatically,
+/// so no annotation is needed. When inactive, showing the path helps users understand
+/// where hooks are running.
+pub fn hooks_display_path(path: &std::path::Path) -> Option<&std::path::Path> {
+    if is_shell_integration_active() {
+        None
+    } else {
+        Some(path)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -912,8 +912,8 @@ fn spawn_post_switch_after_remove(
         &repo_root,
         false, // force=false for CommandContext
     );
-    // No display_path needed - changed_directory is true, so user's shell IS going there
-    ctx.spawn_post_switch_commands(None)
+    // Show path when shell integration isn't active — the cd directive won't take effect
+    ctx.spawn_post_switch_commands(super::hooks_display_path(main_path))
 }
 
 /// Handle output for RemovedWorktree removal

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -31,8 +31,8 @@ pub mod handlers;
 
 // Re-export the public API
 pub use global::{
-    blank, change_directory, execute, flush, is_shell_integration_active, print, stdout,
-    terminate_output,
+    blank, change_directory, execute, flush, hooks_display_path, is_shell_integration_active,
+    print, stdout, terminate_output,
 };
 // Re-export output handlers
 pub use handlers::{

--- a/tests/snapshots/integration__integration_tests__merge__merge_post_merge_command_failure.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_post_merge_command_failure.snap
@@ -24,6 +24,7 @@ info:
     SOURCE_DATE_EPOCH: "1735776000"
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: false
@@ -38,7 +39,7 @@ exit_code: 1
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
 [36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
 [2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m
-[36m◎[39m [36mRunning post-merge project hook:[39m
+[36m◎[39m [36mRunning post-merge project hook @ [1m_REPO_[22m:[39m
 [107m [0m [2m[0m[2m[34mexit[0m[2m 1
 [0m[33m▲[39m [33mCommand failed: exit status: 1[39m
 [31m✗[39m [31mpost-merge command failed: exit status: 1[39m

--- a/tests/snapshots/integration__integration_tests__merge__merge_post_merge_command_named.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_post_merge_command_named.snap
@@ -24,6 +24,7 @@ info:
     SOURCE_DATE_EPOCH: "1735776000"
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
@@ -38,7 +39,7 @@ exit_code: 0
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
 [36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
 [2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m
-[36m◎[39m [36mRunning post-merge [1mproject:notify[22m:[39m
+[36m◎[39m [36mRunning post-merge [1mproject:notify[22m @ [1m_REPO_[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Merge to main complete'[0m[2m [0m[2m[36m>[0m[2m notify.txt
-[0m[36m◎[39m [36mRunning post-merge [1mproject:deploy[22m:[39m
+[0m[36m◎[39m [36mRunning post-merge [1mproject:deploy[22m @ [1m_REPO_[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Deploying branch feature'[0m[2m [0m[2m[36m>[0m[2m deploy.txt

--- a/tests/snapshots/integration__integration_tests__merge__merge_post_merge_command_success.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_post_merge_command_success.snap
@@ -24,6 +24,7 @@ info:
     SOURCE_DATE_EPOCH: "1735776000"
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
@@ -38,5 +39,5 @@ exit_code: 0
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
 [36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
 [2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m
-[36m◎[39m [36mRunning post-merge project hook:[39m
+[36m◎[39m [36mRunning post-merge project hook @ [1m_REPO_[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'merged feature to main'[0m[2m [0m[2m[36m>[0m[2m post-merge-ran.txt

--- a/tests/snapshots/integration__integration_tests__merge__merge_post_merge_runs_with_nothing_to_merge.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_post_merge_runs_with_nothing_to_merge.snap
@@ -24,6 +24,7 @@ info:
     SOURCE_DATE_EPOCH: "1735776000"
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
@@ -34,5 +35,5 @@ exit_code: 0
 [2m○[22m Already up to date with [1mmain[22m (no new commits, no rebase needed)
 [36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
 [2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m
-[36m◎[39m [36mRunning post-merge project hook:[39m
+[36m◎[39m [36mRunning post-merge project hook @ [1m_REPO_[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'post-merge ran'[0m[2m [0m[2m[36m>[0m[2m post-merge-ran.txt

--- a/tests/snapshots/integration__integration_tests__merge__readme_example_complex.snap
+++ b/tests/snapshots/integration__integration_tests__merge__readme_example_complex.snap
@@ -24,6 +24,7 @@ info:
     SOURCE_DATE_EPOCH: "1735776000"
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
@@ -68,7 +69,7 @@ test result: ok. 18 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; fin
 [32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 3 files, [32m+33[39m[39m[90m)[39m[39m
 [36m◎ Removing [1mfeature-auth[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
 [2m○[22m Switched to worktree for [1mmain[22m @ [1m_REPO_[22m
-[36m◎[39m [36mRunning post-merge [1mproject:install[22m:[39m
+[36m◎[39m [36mRunning post-merge [1mproject:install[22m @ [1m_REPO_[22m:[39m
 [107m [0m [2m[0m[2m[34mcargo[0m[2m install [0m[2m[36m--path[0m[2m .
 [0m  Installing worktrunk v0.1.0
    Compiling worktrunk v0.1.0

--- a/tests/snapshots/integration__integration_tests__merge__readme_example_hooks_post_create.snap
+++ b/tests/snapshots/integration__integration_tests__merge__readme_example_hooks_post_create.snap
@@ -41,5 +41,5 @@ exit_code: 0
 [32m✓[39m [32mCreated new worktree for [1mfeature-x[22m from [1mmain[22m @ [1m_REPO_.feature-x[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mRunning post-start [1mproject:dev[22m:[39m
+[36m◎[39m [36mRunning post-start [1mproject:dev[22m @ [1m_REPO_.feature-x[22m:[39m
 [107m [0m [2m[0m[2m[34muv[0m[2m run dev

--- a/tests/snapshots/integration__integration_tests__post_start_commands__both_create_and_start.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__both_create_and_start.snap
@@ -37,5 +37,5 @@ exit_code: 0
 [0m[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mRunning post-start [1mproject:server[22m:[39m
+[36m◎[39m [36mRunning post-start [1mproject:server[22m @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34msleep[0m[2m 0.05 [0m[2m[36m&&[0m[2m [0m[2m[34mecho[0m[2m [0m[2m[32m'Server running'[0m[2m [0m[2m[36m>[0m[2m server.txt

--- a/tests/snapshots/integration__integration_tests__post_start_commands__execute_with_post_start.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__execute_with_post_start.snap
@@ -37,7 +37,7 @@ exit_code: 0
 [32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mExecuting [1mecho 'Execute flag' > execute.txt[22m @ [1m_REPO_.feature[22m, but shell directory unchanged — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mRunning post-start project hook:[39m
+[36m◎[39m [36mRunning post-start project hook @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Background task'[0m[2m [0m[2m[36m>[0m[2m background.txt
 [36m◎[39m [36mExecuting (--execute):[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Execute flag'[0m[2m [0m[2m[36m>[0m[2m execute.txt

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_complex_shell.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_complex_shell.snap
@@ -35,7 +35,7 @@ exit_code: 0
 [32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mRunning post-start project hook:[39m
+[36m◎[39m [36mRunning post-start project hook @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m 'line1
 [107m [0m [2m[0m[2m[34mline2[0m[2m
 [107m [0m [2m[0m[2m[34mline3[0m[2m' | grep line2 > filtered.txt

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_create_with_command.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_create_with_command.snap
@@ -35,5 +35,5 @@ exit_code: 0
 [32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mRunning post-start project hook:[39m
+[36m◎[39m [36mRunning post-start project hook @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'POST-START-RAN'[0m[2m [0m[2m[36m>[0m[2m post_start_marker.txt

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_invalid_command.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_invalid_command.snap
@@ -35,5 +35,5 @@ exit_code: 0
 [32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mRunning post-start project hook:[39m
+[36m◎[39m [36mRunning post-start project hook @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m 'unclosed quote

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_log_captures_output.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_log_captures_output.snap
@@ -35,5 +35,5 @@ exit_code: 0
 [32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mRunning post-start project hook:[39m
+[36m◎[39m [36mRunning post-start project hook @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'stdout output'[0m[2m [0m[2m[36m&&[0m[2m [0m[2m[34mecho[0m[2m [0m[2m[32m'stderr output'[0m[2m >&2

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_multiline_with_newlines.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_multiline_with_newlines.snap
@@ -35,7 +35,7 @@ exit_code: 0
 [32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mRunning post-start project hook:[39m
+[36m◎[39m [36mRunning post-start project hook @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'first line'[0m[2m [0m[2m[36m>[0m[2m multiline.txt
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'second line'[0m[2m [0m[2m[36m>>[0m[2m multiline.txt
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'third line'[0m[2m [0m[2m[36m>>[0m[2m multiline.txt

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_multiple_background.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_multiple_background.snap
@@ -35,7 +35,7 @@ exit_code: 0
 [32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mRunning post-start [1mproject:task1[22m:[39m
+[36m◎[39m [36mRunning post-start [1mproject:task1[22m @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Task 1 running'[0m[2m [0m[2m[36m>[0m[2m task1.txt
-[36m◎[39m [36mRunning post-start [1mproject:task2[22m:[39m
+[36m◎[39m [36mRunning post-start [1mproject:task2[22m @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Task 2 running'[0m[2m [0m[2m[36m>[0m[2m task2.txt

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_separate_logs.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_separate_logs.snap
@@ -35,9 +35,9 @@ exit_code: 0
 [32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mRunning post-start [1mproject:task1[22m:[39m
+[36m◎[39m [36mRunning post-start [1mproject:task1[22m @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'TASK1_OUTPUT'[0m[2m
-[36m◎[39m [36mRunning post-start [1mproject:task2[22m:[39m
+[36m◎[39m [36mRunning post-start [1mproject:task2[22m @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'TASK2_OUTPUT'[0m[2m
-[36m◎[39m [36mRunning post-start [1mproject:task3[22m:[39m
+[36m◎[39m [36mRunning post-start [1mproject:task3[22m @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'TASK3_OUTPUT'[0m[2m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_single_background.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_single_background.snap
@@ -35,5 +35,5 @@ exit_code: 0
 [32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mRunning post-start project hook:[39m
+[36m◎[39m [36mRunning post-start project hook @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34msleep[0m[2m 0.1 [0m[2m[36m&&[0m[2m [0m[2m[34mecho[0m[2m [0m[2m[32m'Background task done'[0m[2m [0m[2m[36m>[0m[2m background.txt

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_and_project_post_start.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_and_project_post_start.snap
@@ -35,7 +35,7 @@ exit_code: 0
 [32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mRunning post-start [1muser:bg[22m:[39m
+[36m◎[39m [36mRunning post-start [1muser:bg[22m @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'USER_POST_START'[0m[2m [0m[2m[36m>[0m[2m user_bg.txt
-[36m◎[39m [36mRunning post-start project hook:[39m
+[36m◎[39m [36mRunning post-start project hook @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'PROJECT_POST_START'[0m[2m [0m[2m[36m>[0m[2m project_bg.txt

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_post_start_executes.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_post_start_executes.snap
@@ -35,5 +35,5 @@ exit_code: 0
 [32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mRunning post-start [1muser:bg[22m:[39m
+[36m◎[39m [36mRunning post-start [1muser:bg[22m @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'USER_POST_START_RAN'[0m[2m [0m[2m[36m>[0m[2m user_bg_marker.txt


### PR DESCRIPTION
## Summary

When shell integration isn't active, hook announcements now show `@ path` so users know where hooks are running.

Previously:
- **post-start hooks** never showed the path
- **post-merge/post-switch hooks** after remove operations incorrectly assumed the shell would cd automatically

Now all hooks correctly show `@ ~/path/to/worktree` when the user's shell won't be in that directory.

### Changes

- Add `hooks_display_path()` helper to centralize the shell integration check
- Pass display path to `spawn_post_start_commands()` (now accepts parameter like `spawn_post_switch_commands()`)
- Fix `spawn_post_switch_after_remove()` to check shell integration status
- Fix `wt merge` display_path logic to consider shell integration

## Test plan

- [x] All integration tests pass
- [x] 18 snapshots updated to show new `@ path` suffix in hook announcements

🤖 Generated with [Claude Code](https://claude.com/claude-code)