### PR TITLE
fix: normalize deprecated template vars in approval matching

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -27,6 +27,7 @@ mod user;
 // Re-export public types
 pub use commands::{Command, CommandConfig};
 pub use deprecation::check_and_migrate as check_deprecated_vars;
+pub use deprecation::normalize_template_vars;
 pub use expansion::{expand_template, sanitize_branch_name};
 pub use hooks::HooksConfig;
 pub use project::{


### PR DESCRIPTION
## Summary

- Normalizes both stored approvals and incoming commands to canonical variable names before comparing
- Fixes issue where approvals wouldn't match after migrating project config from deprecated variable names
- Adds `normalize_template_vars()` function for single template strings

## Problem

When switching between branches with different config versions:
1. Branch A (old): command uses `{{ repo_root }}` → user approves, saved with `repo_root`
2. Branch B (migrated): command uses `{{ repo_path }}` → approval check fails, user re-prompted

## Solution

Normalize both sides to canonical form before comparison. `{{ repo_root }}` and `{{ repo_path }}` both normalize to `{{ repo_path }}`, so they match.

## Test plan

- [x] Unit tests for `normalize_template_vars()` function
- [x] Unit tests for normalized approval matching (old→new, new→old, mixed)
- [x] Tests for deprecated vars in `approved-commands` arrays
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)