### PR TITLE
fix: allow dead code for main_worktree_path on Windows

### DIFF
--- a/src/commands/list/model.rs
+++ b/src/commands/list/model.rs
@@ -259,6 +259,7 @@ pub struct ListItem {
 pub struct ListData {
     pub items: Vec<ListItem>,
     /// Path to the main worktree, used for computing relative paths in display.
+    #[cfg_attr(windows, allow(dead_code))] // Used only by select module (unix-only)
     pub main_worktree_path: std::path::PathBuf,
 }
 


### PR DESCRIPTION
## Summary

- Adds `#[cfg_attr(windows, allow(dead_code))]` to `main_worktree_path` field in `ListData`

The `main_worktree_path` field is used by the `select` module, which is conditionally compiled for Unix only (`#[cfg(unix)]`). On Windows builds, this field appears unused, causing a `dead_code` lint error with `-D warnings`.

## Context

This fixes the CI failure on main from commit b534f8f (Refactor: consolidate parsing and utility functions into shared modules).

Failed run: https://github.com/max-sixty/worktrunk/actions/runs/20670743038

> _This was written by Claude Code on behalf of Maximilian_