### PR TITLE
fix: prevent test output leakage in ProgressiveTable

### DIFF
--- a/src/commands/list/collect.rs
+++ b/src/commands/list/collect.rs
@@ -866,13 +866,13 @@ pub fn collect(
 
         let initial_footer = format!("{INFO_SYMBOL} {dim}{footer_base} (loading...){dim:#}");
 
-        let table = ProgressiveTable::new(
+        let mut table = ProgressiveTable::new(
             layout.format_header_line(),
             skeletons,
             initial_footer,
             max_width,
         );
-        table.render_initial()?;
+        table.render_skeleton()?;
         Some(table)
     } else {
         None
@@ -1100,7 +1100,7 @@ pub fn collect(
                 let rendered = layout.format_list_item_line(item, previous_branch.as_deref());
                 table.update_row(item_idx, rendered);
             }
-            table.finalize_tty(final_msg)?;
+            table.finalize(final_msg)?;
         } else {
             // Non-TTY: output to stdout (same as buffered mode)
             // Progressive skeleton was suppressed; now output the final table


### PR DESCRIPTION
## Summary

- Fix test output leaking strings ("Complete!", "updated", "new footer") to stdout in TTY environments
- Add `rendered` field to track skeleton print state
- Gate dirty list updates on `rendered` flag so flush() is a no-op before render
- Add defense-in-depth debug_assert in flush()
- Make render_skeleton() idempotent
- Rename finalize_tty() → finalize() (no longer TTY-specific)
- Rename render_initial() → render_skeleton() for terminology consistency

## Test plan

- [x] Run `cargo test --bin wt progressive_table` in tmux to verify no leakage
- [x] All tests pass
- [x] pre-commit lints pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)