### PR TITLE
feat(config): improve RUNTIME section display and add debug info

### DIFF
--- a/tests/snapshots/integration__integration_tests__config_show__config_show_empty_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_empty_project_config.snap
@@ -42,6 +42,7 @@ exit_code: 0
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m
 [2m○[22m [2mSkipped fish; ~/.config/fish/conf.d not found[22m
 
-[36mRUNTIME[39m
-[107m [0m [1mwt[22m [2m[VERSION][22m
-[2m↳[22m [2mShell integration not active[22m
+[36mRUNTIME[39m  wt [VERSION]
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Explicit path: yes (contains path separator)

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_command_not_found.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_command_not_found.snap
@@ -55,6 +55,7 @@ exit_code: 0
 [107m [0m [2m○[22m Ran command:
 [107m [0m [107m [0m nonexistent-llm-command-12345 -m test-model
 
-[36mRUNTIME[39m
-[107m [0m [1mwt[22m [2m[VERSION][22m
-[2m↳[22m [2mShell integration not active[22m
+[36mRUNTIME[39m  wt [VERSION]
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Explicit path: yes (contains path separator)

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_not_configured.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_not_configured.snap
@@ -47,6 +47,7 @@ exit_code: 0
 [2m↳[22m [2mCI status requires GitHub or GitLab remote[22m
 [2m↳[22m [2mCommit generation not configured[22m
 
-[36mRUNTIME[39m
-[107m [0m [1mwt[22m [2m[VERSION][22m
-[2m↳[22m [2mShell integration not active[22m
+[36mRUNTIME[39m  wt [VERSION]
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Explicit path: yes (contains path separator)

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_github_remote.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_github_remote.snap
@@ -42,6 +42,7 @@ exit_code: 0
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m
 [2m○[22m [2mSkipped fish; ~/.config/fish/conf.d not found[22m
 
-[36mRUNTIME[39m
-[107m [0m [1mwt[22m [2m[VERSION][22m
-[2m↳[22m [2mShell integration not active[22m
+[36mRUNTIME[39m  wt [VERSION]
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Explicit path: yes (contains path separator)

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_gitlab_remote.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_gitlab_remote.snap
@@ -42,6 +42,7 @@ exit_code: 0
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m
 [2m○[22m [2mSkipped fish; ~/.config/fish/conf.d not found[22m
 
-[36mRUNTIME[39m
-[107m [0m [1mwt[22m [2m[VERSION][22m
-[2m↳[22m [2mShell integration not active[22m
+[36mRUNTIME[39m  wt [VERSION]
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Explicit path: yes (contains path separator)

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_no_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_no_project_config.snap
@@ -42,6 +42,7 @@ exit_code: 0
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m
 [2m○[22m [2mSkipped fish; ~/.config/fish/conf.d not found[22m
 
-[36mRUNTIME[39m
-[107m [0m [1mwt[22m [2m[VERSION][22m
-[2m↳[22m [2mShell integration not active[22m
+[36mRUNTIME[39m  wt [VERSION]
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Explicit path: yes (contains path separator)

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_no_user_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_no_user_config.snap
@@ -42,6 +42,7 @@ exit_code: 0
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m
 [2m○[22m [2mSkipped fish; ~/.config/fish/conf.d not found[22m
 
-[36mRUNTIME[39m
-[107m [0m [1mwt[22m [2m[VERSION][22m
-[2m↳[22m [2mShell integration not active[22m
+[36mRUNTIME[39m  wt [VERSION]
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Explicit path: yes (contains path separator)

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_outside_git_repo.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_outside_git_repo.snap
@@ -34,6 +34,7 @@ exit_code: 0
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m
 [2m○[22m [2mSkipped fish; ~/.config/fish/conf.d not found[22m
 
-[36mRUNTIME[39m
-[107m [0m [1mwt[22m [2m[VERSION][22m
-[2m↳[22m [2mShell integration not active[22m
+[36mRUNTIME[39m  wt [VERSION]
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Explicit path: yes (contains path separator)

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_partial_shell_config_shows_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_partial_shell_config_shows_hint.snap
@@ -46,6 +46,7 @@ exit_code: 0
 
 [2m↳[22m [2mTo enable shell integration, run [90mwt config shell install[39m[22m
 
-[36mRUNTIME[39m
-[107m [0m [1mwt[22m [2m[VERSION][22m
-[2m↳[22m [2mShell integration not active[22m
+[36mRUNTIME[39m  wt [VERSION]
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Explicit path: yes (contains path separator)

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_shell_integration_active.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_shell_integration_active.snap
@@ -43,6 +43,7 @@ exit_code: 0
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m
 [2m○[22m [2mSkipped fish; ~/.config/fish/conf.d not found[22m
 
-[36mRUNTIME[39m
-[107m [0m [1mwt[22m [2m[VERSION][22m
+[36mRUNTIME[39m  wt [VERSION]
 [2m○[22m Shell integration active
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Explicit path: yes (contains path separator)

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_warning.snap
@@ -49,6 +49,7 @@ exit_code: 0
 
 [2m↳[22m [2mIf this is shell integration, report a false negative: https://github.com/max-sixty/worktrunk/issues/new?title=Shell%20integration%20detection%20false%20negative&body=Shell%20integration%20not%20detected%20despite%20config%20containing%20%60wt%60.%0A%0A%2A%2AUnmatched%20lines%3A%2A%2A%0A%60%60%60%0Aalias%20wt%3D%22git%20worktree%22%0A%60%60%60%0A%0A%2A%2AExpected%20behavior%3A%2A%2A%20These%20lines%20should%20be%20detected%20as%20shell%20integration.[22m
 
-[36mRUNTIME[39m
-[107m [0m [1mwt[22m [2m[VERSION][22m
-[2m↳[22m [2mShell integration not active[22m
+[36mRUNTIME[39m  wt [VERSION]
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Explicit path: yes (contains path separator)

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_project_keys.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_project_keys.snap
@@ -44,6 +44,7 @@ exit_code: 0
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m
 [2m○[22m [2mSkipped fish; ~/.config/fish/conf.d not found[22m
 
-[36mRUNTIME[39m
-[107m [0m [1mwt[22m [2m[VERSION][22m
-[2m↳[22m [2mShell integration not active[22m
+[36mRUNTIME[39m  wt [VERSION]
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Explicit path: yes (contains path separator)

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_user_keys.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_user_keys.snap
@@ -46,6 +46,7 @@ exit_code: 0
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m
 [2m○[22m [2mSkipped fish; ~/.config/fish/conf.d not found[22m
 
-[36mRUNTIME[39m
-[107m [0m [1mwt[22m [2m[VERSION][22m
-[2m↳[22m [2mShell integration not active[22m
+[36mRUNTIME[39m  wt [VERSION]
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Explicit path: yes (contains path separator)

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_whitespace_only_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_whitespace_only_project_config.snap
@@ -42,6 +42,7 @@ exit_code: 0
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m
 [2m○[22m [2mSkipped fish; ~/.config/fish/conf.d not found[22m
 
-[36mRUNTIME[39m
-[107m [0m [1mwt[22m [2m[VERSION][22m
-[2m↳[22m [2mShell integration not active[22m
+[36mRUNTIME[39m  wt [VERSION]
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Explicit path: yes (contains path separator)

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_with_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_with_project_config.snap
@@ -48,6 +48,7 @@ exit_code: 0
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m
 [2m○[22m [2mSkipped fish; ~/.config/fish/conf.d not found[22m
 
-[36mRUNTIME[39m
-[107m [0m [1mwt[22m [2m[VERSION][22m
-[2m↳[22m [2mShell integration not active[22m
+[36mRUNTIME[39m  wt [VERSION]
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Explicit path: yes (contains path separator)

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_correct_order.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_correct_order.snap
@@ -44,6 +44,7 @@ exit_code: 0
 [2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
 [2m○[22m [2mSkipped fish; ~/.config/fish/conf.d not found[22m
 
-[36mRUNTIME[39m
-[107m [0m [1mwt[22m [2m[VERSION][22m
-[2m↳[22m [2mShell integration not active[22m
+[36mRUNTIME[39m  wt [VERSION]
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Explicit path: yes (contains path separator)

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_warning.snap
@@ -46,6 +46,7 @@ exit_code: 0
 [2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
 [2m○[22m [2mSkipped fish; ~/.config/fish/conf.d not found[22m
 
-[36mRUNTIME[39m
-[107m [0m [1mwt[22m [2m[VERSION][22m
-[2m↳[22m [2mShell integration not active[22m
+[36mRUNTIME[39m  wt [VERSION]
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Explicit path: yes (contains path separator)


### PR DESCRIPTION
## Summary

- Display version as heading suffix to avoid lonely gutter
- Add shell integration debug info (invocation path, detection flags)
- Change "Shell integration not active" from hint to warning

The debug info helps diagnose shell integration issues by showing:
- How wt was invoked (the actual argv[0] path)
- Whether GIT_EXEC_PATH was set (git subcommand mode)
- Whether an explicit path was used (contains path separator)

**Before:**
```
RUNTIME
   ┃ wt v0.9.0
↳ Shell integration not active
```

**After:**
```
RUNTIME  wt v0.9.0
▲ Shell integration not active
   ┃ Invoked as: /usr/local/bin/wt
   ┃ Explicit path: yes (contains path separator)
```

Related: helps debug issues like #387

## Test plan

- [x] All integration tests pass
- [x] Snapshot tests updated with new format

🤖 Generated with [Claude Code](https://claude.com/claude-code)