### PR TITLE
ci: fail on unreferenced insta snapshots

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -16,7 +16,7 @@ sync = 'if [ "{{ target }}" = "main" ]; then git pull && git push; fi'
 
 [pre-merge]
 pre-commit = "if [ -n \"$MSYSTEM\" ]; then SKIP=lychee-system pre-commit run --all-files; else pre-commit run --all-files; fi"
-insta = "RUSTFLAGS='-D warnings' NEXTEST_STATUS_LEVEL=fail NEXTEST_SUCCESS_OUTPUT=never NEXTEST_NO_INPUT_HANDLER=1 cargo insta test --test-runner nextest --dnd --check --features shell-integration-tests"
+insta = "RUSTFLAGS='-D warnings' NEXTEST_STATUS_LEVEL=fail NEXTEST_SUCCESS_OUTPUT=never NEXTEST_NO_INPUT_HANDLER=1 cargo insta test --test-runner nextest --dnd --check $([ \"$(uname)\" = 'Linux' ] && echo '--unreferenced reject') --features shell-integration-tests"
 doctest = "RUSTDOCFLAGS='-Dwarnings' cargo test --doc"
 doc = "RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps"
 


### PR DESCRIPTION
## Summary
- Add `--unreferenced reject` flag to `cargo insta test` in pre-merge hook
- CI now fails if orphaned `.snap` files exist (snapshots no longer referenced by tests)

## Test plan
- [x] Verified locally with `cargo run -- hook pre-merge insta --yes`
- [x] Pre-commit lints pass

> _This was written by Claude Code on behalf of max-sixty_

🤖 Generated with [Claude Code](https://claude.com/claude-code)