### PR TITLE
fix: Windows Git Bash shell integration path handling

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use std::process;
 use worktrunk::config::{WorktrunkConfig, set_config_path};
 use worktrunk::git::{Repository, exit_code, set_base_path};
 use worktrunk::path::format_path_for_display;
+use worktrunk::shell::extract_filename_from_path;
 use worktrunk::styling::{
     error_message, format_with_gutter, hint_message, info_message, println, success_message,
     warning_message,
@@ -935,7 +936,7 @@ fn main() {
                                 // Hint about restarting shell (only if current shell was affected)
                                 let current_shell = std::env::var("SHELL")
                                     .ok()
-                                    .and_then(|s| s.rsplit('/').next().map(String::from));
+                                    .and_then(|s| extract_filename_from_path(&s).map(String::from));
 
                                 let current_shell_affected =
                                     current_shell.as_ref().is_some_and(|shell_name| {

--- a/src/output/shell_integration.rs
+++ b/src/output/shell_integration.rs
@@ -60,7 +60,7 @@ use color_print::cformat;
 
 use worktrunk::config::WorktrunkConfig;
 use worktrunk::path::format_path_for_display;
-use worktrunk::shell::Shell;
+use worktrunk::shell::{Shell, extract_filename_from_path};
 use worktrunk::styling::hint_message;
 
 /// Shell integration install hint message.
@@ -75,8 +75,9 @@ pub(crate) fn shell_restart_hint() -> &'static str {
 
 /// Shell integration hint for unknown/unsupported shell.
 fn shell_integration_unsupported_shell(shell_path: &str) -> String {
-    // Extract shell name from path (e.g., "/bin/tcsh" -> "tcsh")
-    let shell_name = shell_path.rsplit('/').next().unwrap_or(shell_path);
+    // Extract shell name from path, handling both Unix and Windows paths
+    // e.g., "/bin/tcsh" -> "tcsh", "C:\...\tcsh.exe" -> "tcsh"
+    let shell_name = extract_filename_from_path(shell_path).unwrap_or(shell_path);
     format!(
         "Shell integration not yet supported for {shell_name} (supports bash, zsh, fish, PowerShell)"
     )
@@ -252,7 +253,7 @@ pub fn print_shell_install_result(
     if shells_configured_count > 0 {
         let current_shell = std::env::var("SHELL")
             .ok()
-            .and_then(|s| s.rsplit('/').next().map(String::from));
+            .and_then(|s| extract_filename_from_path(&s).map(String::from));
 
         let current_shell_result = current_shell.as_ref().and_then(|shell_name| {
             scan_result


### PR DESCRIPTION
## Summary

- Fix Windows Git Bash shell integration not recognizing `$SHELL` paths like `C:\Program Files\Git\usr\bin\bash.exe`
- Use `std::path::Path::file_name()` for platform-native path handling instead of `rsplit('/')`
- Add case-insensitive `.exe` stripping for Windows executables
- Make pager detection (`delta`, `bat`) case-insensitive for Windows command names

Fixes #348

## Test plan

- [x] All existing tests pass (565 lib + 376 bin + 681 integration)
- [x] New tests for mixed-case `.exe` variants (`.Exe`, `.EXE`, `.eXe`)
- [x] Platform-specific path tests (Unix on Unix, Windows on Windows)
- [x] Case-insensitive pager detection tests
- [ ] Windows CI validates the fix on actual Windows platform

> _This was written by Claude Code on behalf of @max-sixty_

🤖 Generated with [Claude Code](https://claude.com/claude-code)