### PR TITLE
refactor: cache load_project_config() in Repository with OnceCell

### DIFF
--- a/src/commands/command_approval.rs
+++ b/src/commands/command_approval.rs
@@ -19,7 +19,6 @@
 
 use super::hooks::{HookSource, ParsedFilter};
 use super::project_config::{HookCommand, collect_commands_for_hooks};
-use super::repository_ext::RepositoryCliExt;
 use crate::output;
 use anyhow::Context;
 use color_print::cformat;

--- a/src/commands/hook_commands.rs
+++ b/src/commands/hook_commands.rs
@@ -28,7 +28,6 @@ use super::merge::{
     execute_post_merge_commands, execute_pre_remove_commands, run_pre_merge_commands,
 };
 use super::project_config::collect_commands_for_hooks;
-use super::repository_ext::RepositoryCliExt;
 
 /// Handle `wt hook` command
 ///

--- a/src/commands/repository_ext.rs
+++ b/src/commands/repository_ext.rs
@@ -5,7 +5,6 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use super::worktree::{BranchDeletionMode, RemoveResult};
 use anyhow::Context;
 use color_print::cformat;
-use worktrunk::config::ProjectConfig;
 use worktrunk::git::{
     GitError, IntegrationReason, Repository, parse_porcelain_z, parse_untracked_files,
 };
@@ -24,9 +23,6 @@ pub enum RemoveTarget<'a> {
 /// CLI-only helpers implemented on [`Repository`] via an extension trait so we can keep orphan
 /// implementations inside the binary crate.
 pub trait RepositoryCliExt {
-    /// Load the project configuration if it exists.
-    fn load_project_config(&self) -> anyhow::Result<Option<ProjectConfig>>;
-
     /// Warn about untracked files being auto-staged.
     fn warn_if_auto_staging_untracked(&self) -> anyhow::Result<()>;
 
@@ -60,13 +56,6 @@ pub trait RepositoryCliExt {
 }
 
 impl RepositoryCliExt for Repository {
-    fn load_project_config(&self) -> anyhow::Result<Option<ProjectConfig>> {
-        match self.worktree_root() {
-            Ok(root) => ProjectConfig::load(root).context("Failed to load project config"),
-            Err(_) => Ok(None), // Not in a worktree, no project config
-        }
-    }
-
     fn warn_if_auto_staging_untracked(&self) -> anyhow::Result<()> {
         // Use -z for NUL-separated output to handle filenames with spaces/newlines
         let status = self


### PR DESCRIPTION
## Summary

- Move `load_project_config()` from `RepositoryCliExt` extension trait to `Repository` struct with `OnceCell` caching
- Follows established caching pattern used for other expensive git queries (`project_identifier()`, `worktree_base()`)
- Remove unused `RepositoryCliExt` imports from `command_approval.rs` and `hook_commands.rs`

## Test plan

- [x] All 376 unit tests pass
- [x] Integration tests pass
- [x] No change in behavior — only caching optimization

🤖 Generated with [Claude Code](https://claude.com/claude-code)