### PR TITLE
refactor: multi-dimensional simplifications (hooks, caching, sorting)

### DIFF
--- a/.claude/rules/caching-strategy.md
+++ b/.claude/rules/caching-strategy.md
@@ -22,6 +22,7 @@ Everything else (remote URLs, project config, branch metadata) is read-only.
 - `current_branch()` — we don't switch branches within a worktree
 - `project_identifier()` — derived from remote URL
 - `primary_remote()` — git config, doesn't change
+- `default_branch()` — from git config or detection, doesn't change
 
 **Not cached (intentionally):**
 - `is_dirty()` — changes as we stage/commit


### PR DESCRIPTION
## Summary

- Extract hook filter iteration: Replace duplicated User/Project blocks with iterator over `(source, config)` pairs in `prepare_hook_commands` and `check_name_filter_matched`
- Add `default_branch` OnceCell cache: Follow existing pattern for caching expensive git operations, avoiding repeated git config reads within same Repository instance  
- Simplify sorting functions: Embed timestamp/priority directly in tuple instead of parallel Vec with index lookups

## Test plan

- [x] All 681 integration tests pass
- [x] All 378 unit tests pass
- [x] Lints pass (pre-commit run --all-files)
- [x] Code reviewed via subagent with clean design verdict

🤖 Generated with [Claude Code](https://claude.com/claude-code)