### PR TITLE
Fix git worktree unlock hint to use path instead of branch

### DIFF
--- a/src/commands/repository_ext.rs
+++ b/src/commands/repository_ext.rs
@@ -93,6 +93,7 @@ impl RepositoryCliExt for Repository {
                         if wt.locked.is_some() {
                             return Err(GitError::WorktreeLocked {
                                 branch: branch.into(),
+                                path: wt.path.clone(),
                                 reason: wt.locked.clone(),
                             }
                             .into());
@@ -139,6 +140,7 @@ impl RepositoryCliExt for Repository {
                         .unwrap_or_else(|| wt.dir_name().to_string());
                     return Err(GitError::WorktreeLocked {
                         branch: name,
+                        path: wt.path.clone(),
                         reason: wt.locked.clone(),
                     }
                     .into());

--- a/tests/snapshots/integration__integration_tests__remove__remove_locked_current_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_locked_current_worktree.snap
@@ -31,4 +31,4 @@ exit_code: 1
 
 ----- stderr -----
 [31m✗[39m [31mCannot remove [1mlocked-current[22m, worktree is locked (Do not remove)[39m
-[2m↳[22m [2mTo unlock, run [90mgit worktree unlock locked-current[39m[22m
+[2m↳[22m [2mTo unlock, run [90mgit worktree unlock _REPO_.locked-current[39m[22m

--- a/tests/snapshots/integration__integration_tests__remove__remove_locked_detached_multi.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_locked_detached_multi.snap
@@ -34,4 +34,4 @@ exit_code: 1
 ----- stderr -----
 [36m◎ Removing [1mother[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
 [31m✗[39m [31mCannot remove [1mrepo.locked-detached[22m, worktree is locked (Locked detached)[39m
-[2m↳[22m [2mTo unlock, run [90mgit worktree unlock repo.locked-detached[39m[22m
+[2m↳[22m [2mTo unlock, run [90mgit worktree unlock _REPO_.locked-detached[39m[22m

--- a/tests/snapshots/integration__integration_tests__remove__remove_locked_detached_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_locked_detached_worktree.snap
@@ -31,4 +31,4 @@ exit_code: 1
 
 ----- stderr -----
 [31m✗[39m [31mCannot remove [1mrepo.locked-detached[22m, worktree is locked (Detached and locked)[39m
-[2m↳[22m [2mTo unlock, run [90mgit worktree unlock repo.locked-detached[39m[22m
+[2m↳[22m [2mTo unlock, run [90mgit worktree unlock _REPO_.locked-detached[39m[22m

--- a/tests/snapshots/integration__integration_tests__remove__remove_locked_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_locked_worktree.snap
@@ -32,4 +32,4 @@ exit_code: 1
 
 ----- stderr -----
 [31m✗[39m [31mCannot remove [1mlocked-feature[22m, worktree is locked (Testing lock)[39m
-[2m↳[22m [2mTo unlock, run [90mgit worktree unlock locked-feature[39m[22m
+[2m↳[22m [2mTo unlock, run [90mgit worktree unlock _REPO_.locked-feature[39m[22m

--- a/tests/snapshots/integration__integration_tests__remove__remove_locked_worktree_no_reason.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_locked_worktree_no_reason.snap
@@ -32,4 +32,4 @@ exit_code: 1
 
 ----- stderr -----
 [31m✗[39m [31mCannot remove [1mlocked-no-reason[22m, worktree is locked[39m
-[2m↳[22m [2mTo unlock, run [90mgit worktree unlock locked-no-reason[39m[22m
+[2m↳[22m [2mTo unlock, run [90mgit worktree unlock _REPO_.locked-no-reason[39m[22m


### PR DESCRIPTION
## Summary

- The `git worktree unlock` command takes a worktree path, not a branch name
- Updated the `WorktreeLocked` error to include the worktree path
- Hint now shows the correct command: `git worktree unlock <path>`

## Test plan

- [x] Unit tests updated
- [x] Integration test snapshots updated
- [x] Verified `git worktree unlock` accepts paths but not branch names

🤖 Generated with [Claude Code](https://claude.com/claude-code)