### PR TITLE
docs: improve help text for select, squash, and merge

### DIFF
--- a/docs/content/merge.md
+++ b/docs/content/merge.md
@@ -88,8 +88,7 @@ lint = "cargo clippy"
 {% terminal() %}
 wt merge - Merge worktree into target branch
 
-Squashes commits, rebases, runs hooks, merges to target, and removes the
-worktree.
+Squash &amp; rebase, fast-forward target, remove the worktree.
 
 Usage: <b><span class=c>wt merge</span></b> <span class=c>[OPTIONS]</span> <span class=c>[TARGET]</span>
 

--- a/docs/content/select.md
+++ b/docs/content/select.md
@@ -57,7 +57,7 @@ Branches without worktrees are included — selecting one creates a worktree. (`
 {% terminal() %}
 wt select - Interactive worktree selector
 
-Toggle preview tabs with 1/2/3 keys. Toggle preview visibility with alt-p.
+Browse and switch worktrees with live preview.
 
 Usage: <b><span class=c>wt select</span></b> <span class=c>[OPTIONS]</span>
 

--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -50,7 +50,7 @@ Usage: <b><span class=c>wt step</span></b> <span class=c>[OPTIONS]</span> <span 
 
 <b><span class=g>Commands:</span></b>
   <b><span class=c>commit</span></b>    Commit changes with LLM commit message
-  <b><span class=c>squash</span></b>    Squash commits since target
+  <b><span class=c>squash</span></b>    Squash commits since branching
   <b><span class=c>push</span></b>      Fast-forward target to current branch
   <b><span class=c>rebase</span></b>    Rebase onto target
   <b><span class=c>for-each</span></b>  [experimental] Run command in each worktree

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -888,7 +888,7 @@ pub enum StepCommand {
         show_prompt: bool,
     },
 
-    /// Squash commits since target
+    /// Squash commits since branching
     ///
     /// Stages working tree changes, squashes all commits since diverging from target into one, generates message with LLM.
     Squash {
@@ -1962,7 +1962,7 @@ fi
 
     /// Interactive worktree selector
     ///
-    /// Toggle preview tabs with 1/2/3 keys. Toggle preview visibility with alt-p.
+    /// Browse and switch worktrees with live preview.
     #[cfg_attr(not(unix), command(hide = true))]
     #[command(
         after_long_help = r#"Interactive worktree picker with live preview. Navigate worktrees with keyboard shortcuts and press Enter to switch.
@@ -2489,7 +2489,7 @@ Removal runs in the background by default (returns immediately). Logs are writte
 
     /// Merge worktree into target branch
     ///
-    /// Squashes commits, rebases, runs hooks, merges to target, and removes the worktree.
+    /// Squash & rebase, fast-forward target, remove the worktree.
     #[command(
         after_long_help = r#"Run from a feature worktree to merge into the default branch — like clicking "Merge pull request" on GitHub.
 <!-- demo: wt-merge.gif 1600x900 -->

--- a/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
@@ -12,13 +12,14 @@ info:
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
 ---
 success: true
 exit_code: 0
 ----- stdout -----
 wt merge - Merge worktree into target branch
 
-Squashes commits, rebases, runs hooks, merges to target, and removes the worktree.
+Squash & rebase, fast-forward target, remove the worktree.
 
 Usage: wt merge [OPTIONS] [TARGET]
 

--- a/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
@@ -12,6 +12,7 @@ info:
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
 ---
 success: true
 exit_code: 0
@@ -20,7 +21,7 @@ exit_code: 0
 ----- stderr -----
 wt merge - Merge worktree into target branch
 
-Squashes commits, rebases, runs hooks, merges to target, and removes the worktree.
+Squash & rebase, fast-forward target, remove the worktree.
 
 Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET]
 

--- a/tests/snapshots/integration__integration_tests__help__help_page_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_page_merge.snap
@@ -99,8 +99,7 @@ lint = "cargo clippy"
 ```
 wt merge - Merge worktree into target branch[0m
 [0m
-Squashes commits, rebases, runs hooks, merges to target, and removes the
-worktree.[0m
+Squash & rebase, fast-forward target, remove the worktree.[0m
 
 Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET][0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_step_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_long.snap
@@ -25,7 +25,7 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
 
 [1m[32mCommands:
   [1m[36mcommit[0m    Commit changes with LLM commit message
-  [1m[36msquash[0m    Squash commits since target
+  [1m[36msquash[0m    Squash commits since branching
   [1m[36mpush[0m      Fast-forward target to current branch
   [1m[36mrebase[0m    Rebase onto target
   [1m[36mfor-each[0m  [experimental] Run command in each worktree

--- a/tests/snapshots/integration__integration_tests__help__help_step_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_short.snap
@@ -25,7 +25,7 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
 
 [1m[32mCommands:
   [1m[36mcommit[0m    Commit changes with LLM commit message
-  [1m[36msquash[0m    Squash commits since target
+  [1m[36msquash[0m    Squash commits since branching
   [1m[36mpush[0m      Fast-forward target to current branch
   [1m[36mrebase[0m    Rebase onto target
   [1m[36mfor-each[0m  [experimental] Run command in each worktree


### PR DESCRIPTION
## Summary

- `wt select` subtitle: Replace keybinding instructions with purpose description
- `wt step squash`: Clarify ambiguous "since target" to "since branching"
- `wt merge` subtitle: Condense verbose 5-item list to concise summary

## Test plan

- [x] `cargo test` passes
- [x] `pre-commit run --all-files` passes
- [x] Verified rendered output in docs dev server

> _This was written by Claude Code on behalf of max-sixty_