### PR TITLE
feat: add URL to statusline output

### DIFF
--- a/src/commands/list/model.rs
+++ b/src/commands/list/model.rs
@@ -436,6 +436,11 @@ impl ListItem {
             parts.push(pr_status.format_indicator_with_options(include_links));
         }
 
+        // 8. URL (from project config template)
+        if let Some(ref url) = self.url {
+            parts.push(url.clone());
+        }
+
         parts.join("  ")
     }
 


### PR DESCRIPTION
## Summary

- Add URL support to the statusline command
- When a project has a `[list] url` template configured, the expanded URL now appears in the statusline

## Test plan

- [x] `test_statusline_with_url` - URL appears in main worktree statusline
- [x] `test_statusline_url_in_feature_worktree` - URL appears with branch name in feature worktrees
- [x] All existing statusline tests pass
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)