### PR TITLE
docs: fix copy button position during horizontal scroll

### DIFF
--- a/docs/sass/custom.scss
+++ b/docs/sass/custom.scss
@@ -464,7 +464,13 @@ main {
     }
 }
 
+// Wrapper for code blocks - enables fixed copy button during horizontal scroll
+.code-block-wrapper {
+    position: relative;
+}
+
 // Copy button for code blocks
+// Positioned on the wrapper (not the pre) so it stays fixed when code scrolls horizontally
 .code-copy-btn {
     position: absolute;
     top: 0.5rem;
@@ -478,6 +484,7 @@ main {
     opacity: 0;
     transition: opacity 150ms, background 150ms, color 150ms;
     line-height: 0;
+    z-index: 1;
 
     &:hover {
         background: var(--wt-color-bg);
@@ -489,7 +496,7 @@ main {
     }
 }
 
-.content pre:hover .code-copy-btn {
+.code-block-wrapper:hover .code-copy-btn {
     opacity: 1;
 }
 

--- a/docs/static/code-copy.js
+++ b/docs/static/code-copy.js
@@ -1,10 +1,17 @@
 // Copy-to-clipboard for code blocks
 // Strips leading `$ ` from terminal blocks
+// Wraps pre in a container so copy button stays fixed during horizontal scroll
 
 document.addEventListener('DOMContentLoaded', function() {
   const codeBlocks = document.querySelectorAll('.content pre');
 
   codeBlocks.forEach(function(block) {
+    // Wrap pre in a container for proper button positioning
+    const wrapper = document.createElement('div');
+    wrapper.className = 'code-block-wrapper';
+    block.parentNode.insertBefore(wrapper, block);
+    wrapper.appendChild(block);
+
     const button = document.createElement('button');
     button.className = 'code-copy-btn';
     button.setAttribute('aria-label', 'Copy code');
@@ -36,6 +43,7 @@ document.addEventListener('DOMContentLoaded', function() {
       });
     });
 
-    block.appendChild(button);
+    // Add button to wrapper (outside the scrollable pre)
+    wrapper.appendChild(button);
   });
 });


### PR DESCRIPTION
## Summary

- Fix copy button staying fixed when scrolling code blocks horizontally
- Wrap code blocks in a container div so the button is positioned outside the scrollable area

Previously when a code block required horizontal scrolling and the user scrolled right, the copy button would move with the content. Now it stays fixed at the top-right corner.

## Test plan

- [ ] Visit docs site with code blocks that have horizontal overflow
- [ ] Scroll horizontally within a code block
- [ ] Verify copy button stays at top-right corner
- [ ] Verify copy functionality still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)