### PR TITLE
feat: improve bare repo support with symbolic-ref HEAD heuristic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,6 +38,23 @@ Example of escalating instead of suppressing:
 fn parse_config() { ... }
 ```
 
+## Documentation
+
+**Behavior changes require documentation updates.** This is not optional.
+
+When changing:
+- Detection logic
+- CLI flags or their defaults
+- Error conditions or messages
+
+Ask: "Does `--help` still describe what the code does?" If not, update `src/cli.rs` first.
+
+After modifying `cli.rs`, sync the doc pages:
+
+```bash
+cargo test --test integration test_command_pages_are_in_sync
+```
+
 ## Data Safety
 
 Never risk data loss without explicit user consent. Err on the side of failing safely.

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -766,6 +766,7 @@ Once detected, the result is cached in `worktrunk.default-branch` for fast acces
 
 The local inference fallback uses these heuristics in order:
 - If only one local branch exists, uses it
+- For bare repos or empty repos, checks `symbolic-ref HEAD`
 - Checks `git config init.defaultBranch`
 - Looks for common names: main, master, develop, trunk
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -456,6 +456,7 @@ Once detected, the result is cached in `worktrunk.default-branch` for fast acces
 
 The local inference fallback uses these heuristics in order:
 - If only one local branch exists, uses it
+- For bare repos or empty repos, checks `symbolic-ref HEAD`
 - Checks `git config init.defaultBranch`
 - Looks for common names: main, master, develop, trunk
 

--- a/src/commands/list/collect.rs
+++ b/src/commands/list/collect.rs
@@ -685,6 +685,16 @@ pub fn collect(
             }
         }
     );
+    // TODO: Make default_branch optional so wt list can gracefully degrade when detection fails.
+    // Currently, ambiguous repos (multiple non-standard branches, no remote) fail entirely.
+    // With symbolic-ref HEAD heuristic added, this is less common but still possible.
+    // Required changes:
+    // 1. Make default_branch Option<String> here
+    // 2. find_home() already handles empty default_branch (falls back to first)
+    // 3. Make main_worktree optional or use first worktree when default_branch is None
+    // 4. Update TaskContext.require_default_branch() callers to handle None gracefully
+    //    (skip ahead/behind, integration status, etc. instead of failing)
+    // 5. Show warning when default_branch couldn't be determined
     let default_branch = default_branch?;
     let branches_without_worktrees = branches_without_worktrees?;
     let remote_branches = remote_branches?;

--- a/tests/integration_tests/default_branch.rs
+++ b/tests/integration_tests/default_branch.rs
@@ -176,6 +176,8 @@ fn test_get_default_branch_no_remote_fails_when_no_match(repo: TestRepo) {
     repo.git_command().args(["branch", "def"]).status().unwrap();
 
     // Now we have: xyz, abc, def - no common names, no init.defaultBranch
+    // In normal repos (not bare), symbolic-ref HEAD isn't used because HEAD
+    // points to the current branch, not the default branch.
     // Should fail with an error
     let result = Repository::at(repo.root_path()).default_branch();
     assert!(result.is_err());

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
@@ -14,6 +14,7 @@ info:
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
 ---
 success: true
 exit_code: 0
@@ -56,6 +57,7 @@ Once detected, the result is cached in [2mworktrunk.default-branch[0m for fast
 
 The local inference fallback uses these heuristics in order:
 - If only one local branch exists, uses it
+- For bare repos or empty repos, checks [2msymbolic-ref HEAD
 - Checks [2mgit config init.defaultBranch
 - Looks for common names: main, master, develop, trunk
 

--- a/tests/snapshots/integration__integration_tests__remove__remove_default_branch_no_tautology.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_default_branch_no_tautology.snap
@@ -21,6 +21,7 @@ info:
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
 ---
 success: true
 exit_code: 0


### PR DESCRIPTION
## Summary

- Add symbolic-ref HEAD heuristic for default branch detection in bare repos and empty repos
- Fix bootstrap case where `wt switch --create main` failed in empty bare repos
- Add `NotInWorktree` error type for clear error when `@` is used from bare repo directory
- Add TODO for graceful degradation of `wt list` when default_branch fails
- Update documentation for detection algorithm in `--help` and web docs
- Add CLAUDE.md guidelines for documentation updates

## Test plan

- [x] All 688 tests pass
- [x] Bare repo tests pass including bootstrap case
- [x] Default branch detection tests pass
- [x] Snapshot tests updated for new output format

🤖 Generated with [Claude Code](https://claude.com/claude-code)