### PR TITLE
Rename "path mismatch" to "branch-worktree mismatch"

### DIFF
--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -125,7 +125,7 @@ The Status column has multiple subcolumns. Within each, only the first matching 
 | | `⤴` | Rebase in progress |
 | | `⤵` | Merge in progress |
 | | `/` | Branch without worktree |
-| | `⚑` | Worktree path doesn't match branch name |
+| | `⚑` | Branch-worktree mismatch (branch name doesn't match worktree path) |
 | | `⊟` | Prunable (directory missing) |
 | | `⊞` | Locked worktree |
 | Default branch | `^` | Is the default branch |
@@ -230,7 +230,7 @@ wt list --format=json | jq '.[] | select(.main_state == "integrated" or .main_st
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `state` | string | `"path_mismatch"`, `"prunable"`, `"locked"` (absent when normal) |
+| `state` | string | `"branch_worktree_mismatch"`, `"prunable"`, `"locked"` (absent when normal) |
 | `reason` | string | Reason for locked/prunable state |
 | `detached` | boolean | HEAD is detached |
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2090,7 +2090,7 @@ The Status column has multiple subcolumns. Within each, only the first matching 
 | | `⤴` | Rebase in progress |
 | | `⤵` | Merge in progress |
 | | `/` | Branch without worktree |
-| | `⚑` | Worktree path doesn't match branch name |
+| | `⚑` | Branch-worktree mismatch (branch name doesn't match worktree path) |
 | | `⊟` | Prunable (directory missing) |
 | | `⊞` | Locked worktree |
 | Default branch | `^` | Is the default branch |
@@ -2195,7 +2195,7 @@ wt list --format=json | jq '.[] | select(.main_state == "integrated" or .main_st
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `state` | string | `"path_mismatch"`, `"prunable"`, `"locked"` (absent when normal) |
+| `state` | string | `"branch_worktree_mismatch"`, `"prunable"`, `"locked"` (absent when normal) |
 | `reason` | string | Reason for locked/prunable state |
 | `detached` | boolean | HEAD is detached |
 

--- a/src/commands/list/collect.rs
+++ b/src/commands/list/collect.rs
@@ -759,12 +759,12 @@ pub fn collect(
 
             // Check if worktree is at its expected path based on config template
             // Use optimized variant with pre-computed default_branch and is_bare
-            let path_mismatch =
+            let branch_worktree_mismatch =
                 !is_worktree_at_expected_path_with(wt, repo, config, &default_branch, is_bare);
 
             let mut worktree_data =
                 WorktreeData::from_worktree(wt, is_main, is_current, is_previous);
-            worktree_data.path_mismatch = path_mismatch;
+            worktree_data.branch_worktree_mismatch = branch_worktree_mismatch;
 
             // URL expanded post-skeleton to minimize time-to-skeleton
             ListItem {

--- a/src/commands/list/json_output.rs
+++ b/src/commands/list/json_output.rs
@@ -191,7 +191,7 @@ pub struct JsonRemote {
 /// Worktree-specific state
 #[derive(Debug, Clone, Serialize)]
 pub struct JsonWorktree {
-    /// Worktree state: "no_worktree", "path_mismatch", "prunable", "locked" (absent when normal)
+    /// Worktree state: "no_worktree", "branch_worktree_mismatch", "prunable", "locked" (absent when normal)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<&'static str>,
 
@@ -384,7 +384,9 @@ fn worktree_state_to_json(
         match symbols.worktree_state {
             WorktreeState::None => {}
             WorktreeState::Branch => return (Some("no_worktree"), None),
-            WorktreeState::PathMismatch => return (Some("path_mismatch"), None),
+            WorktreeState::BranchWorktreeMismatch => {
+                return (Some("branch_worktree_mismatch"), None);
+            }
             WorktreeState::Prunable => return (Some("prunable"), data.prunable.clone()),
             WorktreeState::Locked => return (Some("locked"), data.locked.clone()),
         }
@@ -631,7 +633,7 @@ mod tests {
             working_tree_diff: None,
             working_tree_diff_with_main: None,
             git_operation: GitOperationState::None,
-            path_mismatch: false,
+            branch_worktree_mismatch: false,
             working_diff_display: None,
         }
     }
@@ -666,11 +668,12 @@ mod tests {
     }
 
     #[test]
-    fn test_worktree_state_to_json_path_mismatch() {
+    fn test_worktree_state_to_json_branch_worktree_mismatch() {
         let data = make_worktree_data();
-        let symbols = make_status_symbols_with_worktree_state(WorktreeState::PathMismatch);
+        let symbols =
+            make_status_symbols_with_worktree_state(WorktreeState::BranchWorktreeMismatch);
         let (state, reason) = worktree_state_to_json(&data, Some(&symbols));
-        assert_eq!(state, Some("path_mismatch"));
+        assert_eq!(state, Some("branch_worktree_mismatch"));
         assert!(reason.is_none());
     }
 

--- a/src/commands/list/model.rs
+++ b/src/commands/list/model.rs
@@ -90,10 +90,10 @@ pub struct WorktreeData {
     /// Whether this was the previous worktree (from WT_PREVIOUS_BRANCH)
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub is_previous: bool,
-    /// Whether the worktree path doesn't match what the template would generate.
+    /// Whether the worktree is at an unexpected location (branch-worktree mismatch).
     /// Only true when: has branch name, not main worktree, and path differs from template.
     #[serde(skip_serializing_if = "std::ops::Not::not")]
-    pub path_mismatch: bool,
+    pub branch_worktree_mismatch: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub working_diff_display: Option<String>,
 }
@@ -489,9 +489,9 @@ impl ListItem {
             ItemKind::Worktree(data) => {
                 // Full status computation for worktrees
 
-                // Worktree location state - priority: path_mismatch > prunable > locked
-                let worktree_state = if data.path_mismatch {
-                    WorktreeState::PathMismatch
+                // Worktree location state - priority: branch_worktree_mismatch > prunable > locked
+                let worktree_state = if data.branch_worktree_mismatch {
+                    WorktreeState::BranchWorktreeMismatch
                 } else if data.prunable.is_some() {
                     WorktreeState::Prunable
                 } else if data.locked.is_some() {
@@ -722,15 +722,15 @@ impl Divergence {
 /// - For worktrees: whether the path matches the template, or has issues
 /// - For branches (without worktree): shows / to distinguish from worktrees
 ///
-/// Priority order for worktrees: PathMismatch > Prunable > Locked
+/// Priority order for worktrees: BranchWorktreeMismatch > Prunable > Locked
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, strum::IntoStaticStr)]
 pub enum WorktreeState {
     #[strum(serialize = "")]
     /// Normal worktree (path matches template, not locked or prunable)
     #[default]
     None,
-    /// Path doesn't match what the template would generate (red flag = "not at home")
-    PathMismatch,
+    /// Branch-worktree mismatch: path doesn't match what the template would generate
+    BranchWorktreeMismatch,
     /// Prunable (worktree directory missing)
     Prunable,
     /// Locked (protected from removal)
@@ -743,7 +743,7 @@ impl std::fmt::Display for WorktreeState {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
         match self {
             Self::None => Ok(()),
-            Self::PathMismatch => write!(f, "⚑"),
+            Self::BranchWorktreeMismatch => write!(f, "⚑"),
             Self::Prunable => write!(f, "⊟"),
             Self::Locked => write!(f, "⊞"),
             Self::Branch => write!(f, "/"),
@@ -1016,7 +1016,7 @@ impl PositionMask {
             1, // STAGED: + (1 char)
             1, // MODIFIED: ! (1 char)
             1, // UNTRACKED: ? (1 char)
-            1, // WORKTREE_STATE: ✘⤴⤵/⚑⊟⊞ (1 char, priority: conflicts > rebase > merge > path_mismatch > prunable > locked > branch)
+            1, // WORKTREE_STATE: ✘⤴⤵/⚑⊟⊞ (1 char, priority: conflicts > rebase > merge > branch_worktree_mismatch > prunable > locked > branch)
             1, // MAIN_STATE: ^✗_–⊂↕↑↓ (1 char, priority: is_main > would_conflict > empty > same_commit > integrated > diverged > ahead > behind)
             1, // UPSTREAM_DIVERGENCE: |⇡⇣⇅ (1 char)
             2, // USER_MARKER: single emoji or two chars (allocate 2)
@@ -1046,7 +1046,7 @@ impl PositionMask {
 /// - ✘: Actual conflicts (must resolve)
 /// - ⤴: Rebase in progress
 /// - ⤵: Merge in progress
-/// - ⚑: Worktree path doesn't match branch name
+/// - ⚑: Branch-worktree mismatch
 /// - ⊟: Prunable (directory missing)
 /// - ⊞: Locked worktree
 /// - /: Branch without worktree
@@ -1202,8 +1202,10 @@ impl StatusSymbols {
                 WorktreeState::None => (String::new(), false),
                 // Branch indicator (/) is informational (dimmed)
                 WorktreeState::Branch => (cformat!("<dim>{}</>", self.worktree_state), true),
-                // Path mismatch (⚑) is a stronger warning (red)
-                WorktreeState::PathMismatch => (cformat!("<red>{}</>", self.worktree_state), true),
+                // Branch-worktree mismatch (⚑) is a stronger warning (red)
+                WorktreeState::BranchWorktreeMismatch => {
+                    (cformat!("<red>{}</>", self.worktree_state), true)
+                }
                 // Other worktree attrs (⊟⊞) are warnings (yellow)
                 _ => (cformat!("<yellow>{}</>", self.worktree_state), true),
             }
@@ -1629,7 +1631,7 @@ mod tests {
     #[test]
     fn test_worktree_state_display() {
         assert_eq!(format!("{}", WorktreeState::None), "");
-        assert_eq!(format!("{}", WorktreeState::PathMismatch), "⚑");
+        assert_eq!(format!("{}", WorktreeState::BranchWorktreeMismatch), "⚑");
         assert_eq!(format!("{}", WorktreeState::Prunable), "⊟");
         assert_eq!(format!("{}", WorktreeState::Locked), "⊞");
         assert_eq!(format!("{}", WorktreeState::Branch), "/");
@@ -1641,7 +1643,7 @@ mod tests {
         let json = serde_json::to_string(&WorktreeState::None).unwrap();
         assert_eq!(json, "\"\"");
 
-        let json = serde_json::to_string(&WorktreeState::PathMismatch).unwrap();
+        let json = serde_json::to_string(&WorktreeState::BranchWorktreeMismatch).unwrap();
         assert_eq!(json, "\"⚑\"");
 
         let json = serde_json::to_string(&WorktreeState::Branch).unwrap();

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -363,7 +363,7 @@ impl SwitchResult {
 pub struct SwitchBranchInfo {
     /// The branch being switched to
     pub branch: String,
-    /// Expected path when there's a path mismatch (None = path matches template)
+    /// Expected path when there's a branch-worktree mismatch (None = path matches template)
     pub expected_path: Option<PathBuf>,
 }
 
@@ -506,9 +506,9 @@ pub fn handle_switch(
             .map(|cur| cur == &canonical_path)
             .unwrap_or(false);
 
-        // Check if the actual path matches the expected path.
+        // Check if the actual path matches the expected path (branch-worktree mismatch detection).
         let canonical_expected = canonicalize(&expected_path).unwrap_or(expected_path.clone());
-        let path_mismatch = if canonical_path != canonical_expected {
+        let mismatch_path = if canonical_path != canonical_expected {
             Some(expected_path.clone())
         } else {
             None
@@ -521,7 +521,7 @@ pub fn handle_switch(
         };
         let branch_info = SwitchBranchInfo {
             branch: resolved_branch.clone(),
-            expected_path: path_mismatch,
+            expected_path: mismatch_path,
         };
         (result, branch_info)
     };

--- a/src/md_help.rs
+++ b/src/md_help.rs
@@ -328,7 +328,7 @@ fn colorize_status_symbols(text: &str) -> String {
     result = replace_dim(result, "⤵", warning);
     result = replace_dim(result, "✗", warning);
 
-    // Worktree state: PathMismatch (red), Prunable/Locked (yellow)
+    // Worktree state: BranchWorktreeMismatch (red), Prunable/Locked (yellow)
     result = replace_dim(result, "⚑", error);
     result = replace_dim(result, "⊟", warning);
     result = replace_dim(result, "⊞", warning);

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -297,11 +297,12 @@ pub fn handle_switch_output(
         Some(compute_shell_warning_reason())
     };
 
-    // Show path mismatch warning after the main message
-    let path_mismatch_warning = branch_info.expected_path.as_ref().map(|expected| {
+    // Show branch-worktree mismatch warning after the main message
+    let branch_worktree_mismatch_warning = branch_info.expected_path.as_ref().map(|expected| {
         let expected_display = format_path_for_display(expected);
+        let branch = &branch_info.branch;
         warning_message(cformat!(
-            "Worktree path doesn't match branch name; expected <bold>{expected_display}</> <red>⚑</>"
+            "Branch-worktree mismatch; expected <bold>{branch}</> @ <bold>{expected_display}</> <red>⚑</>"
         ))
     });
 
@@ -311,7 +312,7 @@ pub fn handle_switch_output(
             super::print(info_message(cformat!(
                 "Already on worktree for <bold>{branch}</> @ <bold>{path_display}</>"
             )))?;
-            if let Some(warning) = path_mismatch_warning {
+            if let Some(warning) = branch_worktree_mismatch_warning {
                 super::print(warning)?;
             }
             // User is already there - no path annotation needed
@@ -320,7 +321,7 @@ pub fn handle_switch_output(
         SwitchResult::Existing(_) => {
             if let Some(reason) = &shell_warning_reason {
                 // Shell integration not active — single warning with context
-                if let Some(warning) = path_mismatch_warning {
+                if let Some(warning) = branch_worktree_mismatch_warning {
                     super::print(warning)?;
                 }
                 if let Some(cmd) = execute_command {
@@ -345,7 +346,7 @@ pub fn handle_switch_output(
                 super::print(info_message(format_switch_message(
                     branch, path, false, None, None,
                 )))?;
-                if let Some(warning) = path_mismatch_warning {
+                if let Some(warning) = branch_worktree_mismatch_warning {
                     super::print(warning)?;
                 }
                 // cd will happen - no path annotation needed
@@ -389,7 +390,7 @@ pub fn handle_switch_output(
                 // cd will happen - no path annotation needed
                 None
             }
-            // Note: No path_mismatch_warning — created worktrees are always at
+            // Note: No branch_worktree_mismatch_warning — created worktrees are always at
             // the expected path (SwitchBranchInfo::expected_path is None)
         }
     };

--- a/tests/integration_tests/switch.rs
+++ b/tests/integration_tests/switch.rs
@@ -464,7 +464,7 @@ fn test_switch_no_warning_when_branch_matches(mut repo: TestRepo) {
 
 /// Test switching to a worktree at an unexpected path shows a hint
 #[rstest]
-fn test_switch_path_mismatch_shows_hint(repo: TestRepo) {
+fn test_switch_branch_worktree_mismatch_shows_hint(repo: TestRepo) {
     // Create a worktree at a non-standard path (sibling to repo, not following template)
     let wrong_path = repo.root_path().parent().unwrap().join("wrong-path");
     repo.run_git(&[
@@ -475,16 +475,20 @@ fn test_switch_path_mismatch_shows_hint(repo: TestRepo) {
         "feature",
     ]);
 
-    // Switch to feature - should show hint about path mismatch
-    snapshot_switch_with_directive_file("switch_path_mismatch_shows_hint", &repo, &["feature"]);
+    // Switch to feature - should show hint about branch-worktree mismatch
+    snapshot_switch_with_directive_file(
+        "switch_branch_worktree_mismatch_shows_hint",
+        &repo,
+        &["feature"],
+    );
 }
 
-/// Test path mismatch warning without shell integration.
+/// Test branch-worktree mismatch warning without shell integration.
 ///
-/// When shell integration is not active, the path mismatch warning should appear
+/// When shell integration is not active, the branch-worktree mismatch warning should appear
 /// alongside the "cannot change directory" warning.
 #[rstest]
-fn test_switch_path_mismatch_without_shell_integration(repo: TestRepo) {
+fn test_switch_branch_worktree_mismatch_without_shell_integration(repo: TestRepo) {
     // Create a worktree at a non-standard path
     let wrong_path = repo
         .root_path()
@@ -501,18 +505,18 @@ fn test_switch_path_mismatch_without_shell_integration(repo: TestRepo) {
 
     // Switch without directive file (no shell integration) - should show both warnings
     snapshot_switch(
-        "switch_path_mismatch_no_shell",
+        "switch_branch_worktree_mismatch_no_shell",
         &repo,
         &["feature-mismatch"],
     );
 }
 
-/// Test AlreadyAt with path mismatch.
+/// Test AlreadyAt with branch-worktree mismatch.
 ///
 /// When already in a worktree whose path doesn't match the branch name,
-/// switching to that branch should show the path mismatch warning.
+/// switching to that branch should show the branch-worktree mismatch warning.
 #[rstest]
-fn test_switch_already_at_with_path_mismatch(repo: TestRepo) {
+fn test_switch_already_at_with_branch_worktree_mismatch(repo: TestRepo) {
     // Create a worktree at a non-standard path
     let wrong_path = repo
         .root_path()
@@ -527,9 +531,9 @@ fn test_switch_already_at_with_path_mismatch(repo: TestRepo) {
         "feature-already",
     ]);
 
-    // Switch from within the worktree with mismatched path (AlreadyAt case)
+    // Switch from within the worktree with branch-worktree mismatch (AlreadyAt case)
     snapshot_switch_from_dir(
-        "switch_already_at_path_mismatch",
+        "switch_already_at_branch_worktree_mismatch",
         &repo,
         &["feature-already"],
         &wrong_path,

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -134,7 +134,7 @@ The Status column has multiple subcolumns. Within each, only the first matching 
                     ⤴      Rebase in progress                                                                         
                     ⤵      Merge in progress                                                                          
                     /      Branch without worktree                                                                    
-                    ⚑      Worktree path doesn't match branch name                                                    
+                    ⚑      Branch-worktree mismatch (branch name doesn't match worktree path)                         
                     ⊟      Prunable (directory missing)                                                               
                     ⊞      Locked worktree                                                                            
    Default branch   ^      Is the default branch                                                                      
@@ -235,11 +235,11 @@ Query structured data with [2m--format=json[0m:
 
 [1mworktree object
 
-    Field    Type                          Description                         
-   ──────── ─────── ────────────────────────────────────────────────────────── 
-   state    string  "path_mismatch", "prunable", "locked" (absent when normal) 
-   reason   string  Reason for locked/prunable state                           
-   detached boolean HEAD is detached                                           
+    Field    Type                                Description                              
+   ──────── ─────── ───────────────────────────────────────────────────────────────────── 
+   state    string  "branch_worktree_mismatch", "prunable", "locked" (absent when normal) 
+   reason   string  Reason for locked/prunable state                                      
+   detached boolean HEAD is detached                                                      
 
 [1mci object
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -132,19 +132,20 @@ to view or clear.
 The Status column has multiple subcolumns. Within each, only the first matching
 symbol is shown (listed in priority order):
 
-      Subcolumn     Symbol                 Meaning                 
-   ──────────────── ────── ─────────────────────────────────────── 
-   Working tree (1) +      Staged files                            
-   Working tree (2) !      Modified files (unstaged)               
-   Working tree (3) ?      Untracked files                         
-   Worktree         ✘      Merge conflicts                         
-                    ⤴      Rebase in progress                      
-                    ⤵      Merge in progress                       
-                    /      Branch without worktree                 
-                    ⚑      Worktree path doesn't match branch name 
-                    ⊟      Prunable (directory missing)            
-                    ⊞      Locked worktree                         
-   Default branch   ^      Is the default branch                   
+      Subcolumn     Symbol                       Meaning                        
+   ──────────────── ────── ──────────────────────────────────────────────────── 
+   Working tree (1) +      Staged files                                         
+   Working tree (2) !      Modified files (unstaged)                            
+   Working tree (3) ?      Untracked files                                      
+   Worktree         ✘      Merge conflicts                                      
+                    ⤴      Rebase in progress                                   
+                    ⤵      Merge in progress                                    
+                    /      Branch without worktree                              
+                    ⚑      Branch-worktree mismatch (branch name doesn't match  
+                           worktree path)                                       
+                    ⊟      Prunable (directory missing)                         
+                    ⊞      Locked worktree                                      
+   Default branch   ^      Is the default branch                                
 | | [33m✗[0m | Would conflict if merged to the default branch (with [2m--full[0m,
 includes uncommitted changes) |
         _         Same commit as the default branch, clean        
@@ -255,8 +256,8 @@ deleted}[2m |
 
    Field Type Description 
    ───── ──── ─────────── 
-| [2mstate[0m | string | [2m"path_mismatch"[0m, [2m"prunable"[0m, [2m"locked"[0m (absent when
-normal) |
+| [2mstate[0m | string | [2m"branch_worktree_mismatch"[0m, [2m"prunable"[0m, [2m"locked"
+(absent when normal) |
     reason  string  Reason for locked/prunable state 
    detached boolean         HEAD is detached         
 

--- a/tests/snapshots/integration__integration_tests__switch__switch_already_at_branch_worktree_mismatch.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_already_at_branch_worktree_mismatch.snap
@@ -4,7 +4,7 @@ info:
   program: wt
   args:
     - switch
-    - feature
+    - feature-already
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -23,7 +23,6 @@ info:
     SOURCE_DATE_EPOCH: "1735776000"
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
-    WORKTRUNK_DIRECTIVE_FILE: "[DIRECTIVE_FILE]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
@@ -32,5 +31,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m Switched to worktree for [1mfeature[22m @ [1m[PROJECT_ID][22m
-[33m▲[39m [33mWorktree path doesn't match branch name; expected [1m_REPO_.feature[22m [31m⚑[39m[39m
+[2m○[22m Already on worktree for [1mfeature-already[22m @ [1m[PROJECT_ID][22m
+[33m▲[39m [33mBranch-worktree mismatch; expected [1mfeature-already[22m @ [1m_REPO_.feature-already[22m [31m⚑[39m[39m
+[2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_branch_worktree_mismatch_no_shell.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_branch_worktree_mismatch_no_shell.snap
@@ -4,7 +4,7 @@ info:
   program: wt
   args:
     - switch
-    - feature-already
+    - feature-mismatch
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -31,6 +31,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m Already on worktree for [1mfeature-already[22m @ [1m[PROJECT_ID][22m
-[33m▲[39m [33mWorktree path doesn't match branch name; expected [1m_REPO_.feature-already[22m [31m⚑[39m[39m
+[33m▲[39m [33mBranch-worktree mismatch; expected [1mfeature-mismatch[22m @ [1m_REPO_.feature-mismatch[22m [31m⚑[39m[39m
+[33m▲[39m [33mWorktree for [1mfeature-mismatch[22m @ [1m[PROJECT_ID][22m, but cannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_branch_worktree_mismatch_shows_hint.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_branch_worktree_mismatch_shows_hint.snap
@@ -4,7 +4,7 @@ info:
   program: wt
   args:
     - switch
-    - feature-mismatch
+    - feature
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -23,6 +23,7 @@ info:
     SOURCE_DATE_EPOCH: "1735776000"
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_DIRECTIVE_FILE: "[DIRECTIVE_FILE]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
@@ -31,6 +32,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mWorktree path doesn't match branch name; expected [1m_REPO_.feature-mismatch[22m [31m⚑[39m[39m
-[33m▲[39m [33mWorktree for [1mfeature-mismatch[22m @ [1m[PROJECT_ID][22m, but cannot change directory — shell integration not installed[39m
-[2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
+[2m○[22m Switched to worktree for [1mfeature[22m @ [1m[PROJECT_ID][22m
+[33m▲[39m [33mBranch-worktree mismatch; expected [1mfeature[22m @ [1m_REPO_.feature[22m [31m⚑[39m[39m


### PR DESCRIPTION
## Summary

- Rename the concept of "path mismatch" to "branch-worktree mismatch" throughout the codebase
- Update user-facing message to: `Branch-worktree mismatch; expected {branch} @ {path}`
- Add explanation in help text: "(branch name doesn't match worktree path)"
- JSON API breaking change: `"path_mismatch"` → `"branch_worktree_mismatch"`

## Rationale

The old terminology "path mismatch" was ambiguous about what was mismatched. The new terminology better describes the relationship problem without prescribing a fix. This matters because:
- Branches have primacy in worktrunk's model
- The fix is always branch-side (rename, recreate), not worktree-side (relocate)

## Test plan

- [x] All tests pass (688 integration + 568 unit)
- [x] Snapshots updated for renamed tests
- [x] Pre-commit passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)