### PR TITLE
refactor: use strum derives for enum string conversions

### DIFF
--- a/src/commands/list/ci_status.rs
+++ b/src/commands/list/ci_status.rs
@@ -10,7 +10,8 @@ use worktrunk::utils::get_now;
 /// CI platform detected from remote URL
 // TODO: Add a `[ci] platform = "github" | "gitlab"` override in project config
 // for cases where URL detection fails or users want to force a specific platform.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::EnumString)]
+#[strum(serialize_all = "lowercase")]
 pub enum CiPlatform {
     GitHub,
     GitLab,

--- a/src/commands/list/model.rs
+++ b/src/commands/list/model.rs
@@ -782,10 +782,12 @@ impl serde::Serialize for WorktreeState {
 ///
 /// The `Integrated` variant carries an [`IntegrationReason`] explaining how the
 /// content was integrated (ancestor, trees match, no added changes, or merge adds nothing).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
 pub enum MainState {
     /// Normal working branch (up-to-date with main, no special state)
     #[default]
+    #[strum(serialize = "")]
     None,
     /// This IS the main branch
     IsMain,
@@ -796,6 +798,7 @@ pub enum MainState {
     /// Branch HEAD is same commit as main but has uncommitted changes
     SameCommit,
     /// Content is integrated into main via different history
+    #[strum(serialize = "integrated")]
     Integrated(IntegrationReason),
     /// Both ahead and behind main
     Diverged,
@@ -847,17 +850,8 @@ impl MainState {
 
     /// Returns the JSON string representation for main_state field.
     pub fn as_json_str(self) -> Option<&'static str> {
-        match self {
-            Self::None => None,
-            Self::IsMain => Some("is_main"),
-            Self::WouldConflict => Some("would_conflict"),
-            Self::Empty => Some("empty"),
-            Self::SameCommit => Some("same_commit"),
-            Self::Integrated(_) => Some("integrated"),
-            Self::Diverged => Some("diverged"),
-            Self::Ahead => Some("ahead"),
-            Self::Behind => Some("behind"),
-        }
+        let s: &'static str = self.into();
+        if s.is_empty() { None } else { Some(s) }
     }
 
     /// Compute from divergence counts, integration state, and same-commit-dirty flag.
@@ -905,10 +899,12 @@ impl serde::Serialize for MainState {
 /// These take priority over all other states in the Worktree column.
 ///
 /// Priority: Conflicts (✘) > Rebase (⤴) > Merge (⤵)
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, strum::IntoStaticStr)]
+#[strum(serialize_all = "snake_case")]
 pub enum OperationState {
     /// No operation in progress
     #[default]
+    #[strum(serialize = "")]
     None,
     /// Actual merge conflicts (unmerged paths in working tree)
     Conflicts,
@@ -946,12 +942,8 @@ impl OperationState {
 
     /// Returns the JSON string representation.
     pub fn as_json_str(self) -> Option<&'static str> {
-        match self {
-            Self::None => None,
-            Self::Conflicts => Some("conflicts"),
-            Self::Rebase => Some("rebase"),
-            Self::Merge => Some("merge"),
-        }
+        let s: &'static str = self.into();
+        if s.is_empty() { None } else { Some(s) }
     }
 }
 


### PR DESCRIPTION
## Summary

- Add `strum::IntoStaticStr` to `MainState` and `OperationState` enums, simplifying `as_json_str()` from manual match statements to 2-line strum conversions
- Add `strum::Display` and `strum::EnumString` to `CiPlatform` for future config parsing support

## Test plan

- [x] Existing `test_main_state_as_json_str` and `test_operation_state_as_json_str` tests pass
- [x] JSON list integration tests pass
- [x] All 379 unit tests pass
- [x] All lints pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)