### PR TITLE
feat: show path mismatch warning when removing worktrees at unexpected paths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1373,9 +1373,14 @@ fn main() {
                 if branches.is_empty() {
                     // No branches specified, remove current worktree
                     // Uses path-based removal to handle detached HEAD state
-                    let result =
-                        handle_remove_current(!delete_branch, force_delete, force, background)
-                            .context("Failed to remove worktree")?;
+                    let result = handle_remove_current(
+                        !delete_branch,
+                        force_delete,
+                        force,
+                        background,
+                        &config,
+                    )
+                    .context("Failed to remove worktree")?;
                     // Approval was handled at the gate
                     // Post-switch hooks are spawned internally by handle_remove_output
                     handle_remove_output(&result, background, verify)
@@ -1430,6 +1435,7 @@ fn main() {
                             force_delete,
                             force,
                             background,
+                            &config,
                         ) {
                             Ok(result) => {
                                 handle_remove_output(&result, background, verify)?;
@@ -1443,8 +1449,14 @@ fn main() {
 
                     // Handle branch-only cases (no worktree)
                     for branch in &branch_only {
-                        match handle_remove(branch, !delete_branch, force_delete, force, background)
-                        {
+                        match handle_remove(
+                            branch,
+                            !delete_branch,
+                            force_delete,
+                            force,
+                            background,
+                            &config,
+                        ) {
                             Ok(result) => {
                                 handle_remove_output(&result, background, verify)?;
                             }
@@ -1458,8 +1470,13 @@ fn main() {
                     // Remove current worktree last (if it was in the list)
                     // Post-switch hooks are spawned internally by handle_remove_output
                     if let Some((_path, _branch)) = current {
-                        match handle_remove_current(!delete_branch, force_delete, force, background)
-                        {
+                        match handle_remove_current(
+                            !delete_branch,
+                            force_delete,
+                            force,
+                            background,
+                            &config,
+                        ) {
                             Ok(result) => {
                                 handle_remove_output(&result, background, verify)?;
                             }

--- a/tests/snapshots/integration__integration_tests__remove__remove_path_mismatch_warning.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_path_mismatch_warning.snap
@@ -1,0 +1,36 @@
+---
+source: tests/integration_tests/remove.rs
+info:
+  program: wt
+  args:
+    - remove
+    - feature
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "150"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[33m▲[39m [33mBranch-worktree mismatch; expected [1mfeature[22m @ [1m_REPO_.feature[22m [31m⚑[39m[39m

--- a/tests/snapshots/integration__integration_tests__remove__remove_path_mismatch_warning_foreground.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_path_mismatch_warning_foreground.snap
@@ -1,0 +1,38 @@
+---
+source: tests/integration_tests/remove.rs
+info:
+  program: wt
+  args:
+    - remove
+    - "--no-background"
+    - feature-fg
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "150"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mRemoving [1mfeature-fg[22m worktree...[39m
+[32m✓ Removed [1mfeature-fg[22m worktree & branch (same commit as [1mmain[22m,[39m [2m_[22m[32m)[39m
+[33m▲[39m [33mBranch-worktree mismatch; expected [1mfeature-fg[22m @ [1m_REPO_.feature-fg[22m [31m⚑[39m[39m


### PR DESCRIPTION
## Summary

- When a worktree is at a path that doesn't match the config template, `wt remove` and `wt merge` now show a warning
- Follows the existing pattern from `wt switch` for consistency
- Helps clarify what's happening when users create worktrees via raw git commands

Example output:
```
◎ Removing feature worktree & branch in background (same commit as main, _)
▲ Branch-worktree mismatch; expected feature @ /repo.feature ⚑
```

## Changes

- Add `expected_path` field to `RemoveResult::RemovedWorktree`
- Add `paths_match()` helper to consolidate canonicalized path comparison (used by 3 places)
- Add `format_path_mismatch_warning()` to consolidate warning message format (used by 3 places)
- Add `get_path_mismatch()` to detect mismatches for remove/merge operations
- Update `prepare_worktree_removal` to compute expected path
- Add integration tests for background and foreground removal modes

## Test plan

- [x] All 696 integration tests pass
- [x] New tests verify warning appears for mismatched worktrees in both modes
- [x] Pre-commit lints pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)