### PR TITLE
refactor: improve wt switch message clarity

### DIFF
--- a/tests/integration_tests/approval_pty.rs
+++ b/tests/integration_tests/approval_pty.rs
@@ -442,7 +442,7 @@ approved-commands = ["echo 'Second command'"]
         "Should NOT execute any commands when declined"
     );
     assert!(
-        normalized.contains("Created new worktree"),
+        normalized.contains("Created branch") && normalized.contains("and worktree"),
         "Should still create worktree even when commands declined"
     );
     assert_snapshot!(

--- a/tests/integration_tests/shell_integration_prompt.rs
+++ b/tests/integration_tests/shell_integration_prompt.rs
@@ -109,7 +109,7 @@ fn test_switch_non_tty_shows_hint(repo: TestRepo) {
     // Verify the switch succeeded without prompting
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("Created new worktree for"),
+        stderr.contains("Created branch") && stderr.contains("and worktree"),
         "Should create worktree: {stderr}"
     );
 
@@ -334,7 +334,7 @@ mod pty_tests {
 
         // Should have created the worktree
         assert!(
-            output.contains("Created new worktree for"),
+            output.contains("Created branch") && output.contains("and worktree"),
             "Should create worktree: {output}"
         );
 
@@ -381,7 +381,7 @@ mod pty_tests {
 
         // Should have created the worktree
         assert!(
-            normalized.contains("Created new worktree for"),
+            normalized.contains("Created branch") && normalized.contains("and worktree"),
             "Should create worktree: {normalized}"
         );
 

--- a/tests/integration_tests/shell_wrapper.rs
+++ b/tests/integration_tests/shell_wrapper.rs
@@ -742,7 +742,7 @@ mod tests {
         output.assert_no_job_control_messages();
 
         assert!(
-            output.combined.contains("Created new worktree"),
+            output.combined.contains("Created branch") && output.combined.contains("and worktree"),
             "{}: Should show success message",
             shell
         );
@@ -928,7 +928,7 @@ mod tests {
 
         // Should still show wt's success message (worktree was created)
         assert!(
-            output.combined.contains("Created new worktree"),
+            output.combined.contains("Created branch") && output.combined.contains("and worktree"),
             "{}: Should show wt's success message even though execute command failed",
             shell
         );
@@ -1266,7 +1266,7 @@ approved-commands = ["echo 'test command executed'"]
 
         // Should still have the success message
         assert!(
-            output.combined.contains("Created new worktree"),
+            output.combined.contains("Created branch") && output.combined.contains("and worktree"),
             "Success message missing"
         );
 
@@ -1455,7 +1455,7 @@ approved-commands = ["echo 'fish background task'"]
 
         // Should still show success message
         assert!(
-            output.combined.contains("Created new worktree"),
+            output.combined.contains("Created branch") && output.combined.contains("and worktree"),
             "Success message missing from minimal output"
         );
 
@@ -1694,7 +1694,7 @@ approved-commands = ["echo 'bash background'"]
 
         // Verify the command completed successfully
         assert!(
-            output.contains("Created new worktree"),
+            output.contains("Created branch") && output.contains("and worktree"),
             "Should show success message.\nOutput:\n{}",
             output
         );
@@ -1856,7 +1856,7 @@ approved-commands = ["echo 'bash background'"]
         output.assert_no_directive_leaks();
 
         assert!(
-            output.combined.contains("Created new worktree"),
+            output.combined.contains("Created branch") && output.combined.contains("and worktree"),
             "{}: Should create worktree for branch with slashes",
             shell
         );
@@ -1874,7 +1874,7 @@ approved-commands = ["echo 'bash background'"]
         output.assert_no_directive_leaks();
 
         assert!(
-            output.combined.contains("Created new worktree"),
+            output.combined.contains("Created branch") && output.combined.contains("and worktree"),
             "{}: Should create worktree for branch with dashes/underscores",
             shell
         );
@@ -1965,7 +1965,7 @@ approved-commands = ["echo 'bash background'"]
         output.assert_no_directive_leaks();
 
         assert!(
-            output.combined.contains("Created new worktree"),
+            output.combined.contains("Created branch") && output.combined.contains("and worktree"),
             "{}: Should create worktree using WORKTRUNK_BIN fallback.\nOutput:\n{}",
             shell,
             output.combined
@@ -2026,7 +2026,7 @@ approved-commands = ["echo 'cleanup test'"]
         output.assert_no_directive_leaks();
 
         assert!(
-            output.combined.contains("Created new worktree"),
+            output.combined.contains("Created branch") && output.combined.contains("and worktree"),
             "{}: Should complete successfully",
             shell
         );

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_accept.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_accept.snap
@@ -12,5 +12,5 @@ y
 [36m◎[39m [36mRunning post-create project hook @ [1m_REPO_/repo.BRANCH[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m
 [0mtest command
-[32m✓[39m [32mCreated new worktree for [1mtest-approve[22m from [1mmain[22m @ [1m_REPO_/repo.BRANCH[22m[39m
+[32m✓[39m [32mCreated branch [1mtest-approve[22m and worktree from [1mmain[22m @ [1m_REPO_/repo.BRANCH[22m[39m
 [33m▲[39m [33mCannot change directory — ran [BIN][22m; shell integration wraps [1mwt[22m[39m

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_decline.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_decline.snap
@@ -10,5 +10,5 @@ n
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m
 [36m❯[39m Allow and remember? [1m[y/N][22m 
 [2m○[22m Commands declined, continuing worktree creation
-[32m✓[39m [32mCreated new worktree for [1mtest-decline[22m from [1mmain[22m @ [1m_REPO_/repo.BRANCH[22m[39m
+[32m✓[39m [32mCreated branch [1mtest-decline[22m and worktree from [1mmain[22m @ [1m_REPO_/repo.BRANCH[22m[39m
 [33m▲[39m [33mCannot change directory — ran [BIN][22m; shell integration wraps [1mwt[22m[39m

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_mixed_approved_unapproved_accept.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_mixed_approved_unapproved_accept.snap
@@ -20,5 +20,5 @@ y
 [36m◎[39m [36mRunning post-create [1mproject:third[22m @ [1m_REPO_/repo.BRANCH[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Third command'[0m[2m
 [0mThird command
-[32m✓[39m [32mCreated new worktree for [1mtest-mixed-accept[22m from [1mmain[22m @ [1m_REPO_/repo.BRANCH[22m[39m
+[32m✓[39m [32mCreated branch [1mtest-mixed-accept[22m and worktree from [1mmain[22m @ [1m_REPO_/repo.BRANCH[22m[39m
 [33m▲[39m [33mCannot change directory — ran [BIN][22m; shell integration wraps [1mwt[22m[39m

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_mixed_approved_unapproved_decline.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_mixed_approved_unapproved_decline.snap
@@ -12,5 +12,5 @@ n
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Third command'[0m[2m
 [36m❯[39m Allow and remember? [1m[y/N][22m 
 [2m○[22m Commands declined, continuing worktree creation
-[32m✓[39m [32mCreated new worktree for [1mtest-mixed-decline[22m from [1mmain[22m @ [1m_REPO_/repo.BRANCH[22m[39m
+[32m✓[39m [32mCreated branch [1mtest-mixed-decline[22m and worktree from [1mmain[22m @ [1m_REPO_/repo.BRANCH[22m[39m
 [33m▲[39m [33mCannot change directory — ran [BIN][22m; shell integration wraps [1mwt[22m[39m

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_multiple_commands.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_multiple_commands.snap
@@ -22,5 +22,5 @@ y
 [36m◎[39m [36mRunning post-create [1mproject:third[22m @ [1m_REPO_/repo.BRANCH[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Third command'[0m[2m
 [0mThird command
-[32m✓[39m [32mCreated new worktree for [1mtest-multi[22m from [1mmain[22m @ [1m_REPO_/repo.BRANCH[22m[39m
+[32m✓[39m [32mCreated branch [1mtest-multi[22m and worktree from [1mmain[22m @ [1m_REPO_/repo.BRANCH[22m[39m
 [33m▲[39m [33mCannot change directory — ran [BIN][22m; shell integration wraps [1mwt[22m[39m

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_named_commands.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_named_commands.snap
@@ -22,5 +22,5 @@ y
 [36m◎[39m [36mRunning post-create [1mproject:test[22m @ [1m_REPO_/repo.BRANCH[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Running tests...'[0m[2m
 [0mRunning tests...
-[32m✓[39m [32mCreated new worktree for [1mtest-named[22m from [1mmain[22m @ [1m_REPO_/repo.BRANCH[22m[39m
+[32m✓[39m [32mCreated branch [1mtest-named[22m and worktree from [1mmain[22m @ [1m_REPO_/repo.BRANCH[22m[39m
 [33m▲[39m [33mCannot change directory — ran [BIN][22m; shell integration wraps [1mwt[22m[39m

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_permission_error.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_permission_error.snap
@@ -14,5 +14,5 @@ y
 [36m◎[39m [36mRunning post-create project hook @ [1m_REPO_/repo.BRANCH[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m
 [0mtest command
-[32m✓[39m [32mCreated new worktree for [1mtest-permission[22m from [1mmain[22m @ [1m_REPO_/repo.BRANCH[22m[39m
+[32m✓[39m [32mCreated branch [1mtest-permission[22m and worktree from [1mmain[22m @ [1m_REPO_/repo.BRANCH[22m[39m
 [33m▲[39m [33mCannot change directory — ran [BIN][22m; shell integration wraps [1mwt[22m[39m

--- a/tests/snapshots/integration__integration_tests__approval_ui__already_approved_skip_prompt.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__already_approved_skip_prompt.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -34,6 +35,6 @@ exit_code: 0
 ----- stderr -----
 [36m◎[39m [36mRunning post-create project hook @ [1m_REPO_.test-approved[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'approved'[0m[2m [0m[2m[36m>[0m[2m output.txt
-[0m[32m✓[39m [32mCreated new worktree for [1mtest-approved[22m from [1mmain[22m @ [1m_REPO_.test-approved[22m[39m
+[0m[32m✓[39m [32mCreated branch [1mtest-approved[22m and worktree from [1mmain[22m @ [1m_REPO_.test-approved[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__yes_bypasses_tty_check.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__yes_bypasses_tty_check.snap
@@ -23,6 +23,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -36,6 +37,6 @@ exit_code: 0
 [36m◎[39m [36mRunning post-create project hook @ [1m_REPO_.test-yes-tty[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m
 [0mtest command
-[32m✓[39m [32mCreated new worktree for [1mtest-yes-tty[22m from [1mmain[22m @ [1m_REPO_.test-yes-tty[22m[39m
+[32m✓[39m [32mCreated branch [1mtest-yes-tty[22m and worktree from [1mmain[22m @ [1m_REPO_.test-yes-tty[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__yes_does_not_save_approvals_first_run.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__yes_does_not_save_approvals_first_run.snap
@@ -23,6 +23,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -35,6 +36,6 @@ exit_code: 0
 ----- stderr -----
 [36m◎[39m [36mRunning post-create project hook @ [1m_REPO_.test-yes[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m [0m[2m[36m>[0m[2m output.txt
-[0m[32m✓[39m [32mCreated new worktree for [1mtest-yes[22m from [1mmain[22m @ [1m_REPO_.test-yes[22m[39m
+[0m[32m✓[39m [32mCreated branch [1mtest-yes[22m and worktree from [1mmain[22m @ [1m_REPO_.test-yes[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__merge__readme_example_hooks_post_create.snap
+++ b/tests/snapshots/integration__integration_tests__merge__readme_example_hooks_post_create.snap
@@ -23,6 +23,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -38,7 +39,7 @@ exit_code: 0
 
   Resolved 24 packages in 145ms
   Installed 24 packages in 1.2s
-[32m✓[39m [32mCreated new worktree for [1mfeature-x[22m from [1mmain[22m @ [1m_REPO_.feature-x[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature-x[22m and worktree from [1mmain[22m @ [1m_REPO_.feature-x[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mRunning post-start [1mproject:dev[22m @ [1m_REPO_.feature-x[22m:[39m

--- a/tests/snapshots/integration__integration_tests__merge__readme_example_simple_switch.snap
+++ b/tests/snapshots/integration__integration_tests__merge__readme_example_simple_switch.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -32,6 +33,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfix-auth[22m from [1mmain[22m @ [1m_REPO_.fix-auth[22m[39m
+[32m✓[39m [32mCreated branch [1mfix-auth[22m and worktree from [1mmain[22m @ [1m_REPO_.fix-auth[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__both_create_and_start.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__both_create_and_start.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -34,7 +35,7 @@ exit_code: 0
 ----- stderr -----
 [36m◎[39m [36mRunning post-create project hook @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setup done'[0m[2m [0m[2m[36m>[0m[2m setup.txt
-[0m[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[0m[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mRunning post-start [1mproject:server[22m @ [1m_REPO_.feature[22m:[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__execute_with_post_start.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__execute_with_post_start.snap
@@ -24,6 +24,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -34,7 +35,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mExecuting [1mecho 'Execute flag' > execute.txt[22m @ [1m_REPO_.feature[22m, but shell directory unchanged — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mRunning post-start project hook @ [1m_REPO_.feature[22m:[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_default_branch_template.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_default_branch_template.snap
@@ -23,6 +23,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -35,6 +36,6 @@ exit_code: 0
 ----- stderr -----
 [36m◎[39m [36mRunning post-create project hook @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Default: main'[0m[2m [0m[2m[36m>[0m[2m default.txt
-[0m[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[0m[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_failing_command.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_failing_command.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -35,6 +36,6 @@ exit_code: 0
 [36m◎[39m [36mRunning post-create project hook @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mexit[0m[2m 1
 [0m[33m▲[39m [33mCommand failed: exit status: 1[39m
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_git_variables_template.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_git_variables_template.snap
@@ -23,6 +23,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -41,6 +42,6 @@ exit_code: 0
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Remote: origin'[0m[2m [0m[2m[36m>>[0m[2m git_vars.txt
 [0m[36m◎[39m [36mRunning post-create [1mproject:worktree_name[22m @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Worktree Name: repo.feature'[0m[2m [0m[2m[36m>>[0m[2m git_vars.txt
-[0m[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[0m[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_multiline_control_structure.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_multiline_control_structure.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -38,6 +39,6 @@ exit_code: 0
 [107m [0m [2m[0m[2m[34melse[0m[2m
 [107m [0m [2m  [0m[2m[34mecho[0m[2m [0m[2m[32m'File exists'[0m[2m [0m[2m[36m>[0m[2m result.txt
 [107m [0m [2m[0m[2m[34mfi[0m[2m
-[0m[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[0m[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_named_commands.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_named_commands.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -38,6 +39,6 @@ exit_code: 0
 [36m◎[39m [36mRunning post-create [1mproject:setup[22m @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Running setup'[0m[2m
 [0mRunning setup
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_no_config.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_no_config.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -32,6 +33,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_single_command.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_single_command.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -35,6 +36,6 @@ exit_code: 0
 [36m◎[39m [36mRunning post-create project hook @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setup complete'[0m[2m
 [0mSetup complete
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_template_expansion.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_template_expansion.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -42,6 +43,6 @@ exit_code: 0
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Worktree: _REPO_.feature-test'[0m[2m [0m[2m[36m>>[0m[2m info.txt
 [0m[36m◎[39m [36mRunning post-create [1mproject:root[22m @ [1m_REPO_.feature-test[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Root: _REPO_'[0m[2m [0m[2m[36m>>[0m[2m info.txt
-[0m[32m✓[39m [32mCreated new worktree for [1mfeature/test[22m from [1mmain[22m @ [1m_REPO_.feature-test[22m[39m
+[0m[32m✓[39m [32mCreated branch [1mfeature/test[22m and worktree from [1mmain[22m @ [1m_REPO_.feature-test[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_upstream_template.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_upstream_template.snap
@@ -23,6 +23,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -35,6 +36,6 @@ exit_code: 0
 ----- stderr -----
 [36m◎[39m [36mRunning post-create project hook @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Upstream: '[0m[2m [0m[2m[36m>[0m[2m upstream.txt
-[0m[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[0m[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_complex_shell.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_complex_shell.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -32,7 +33,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mRunning post-start project hook @ [1m_REPO_.feature[22m:[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_create_with_command.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_create_with_command.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -32,7 +33,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mRunning post-start project hook @ [1m_REPO_.feature[22m:[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_invalid_command.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_invalid_command.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -32,7 +33,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mRunning post-start project hook @ [1m_REPO_.feature[22m:[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_log_captures_output.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_log_captures_output.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -32,7 +33,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mRunning post-start project hook @ [1m_REPO_.feature[22m:[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_multiline_with_newlines.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_multiline_with_newlines.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -32,7 +33,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mRunning post-start project hook @ [1m_REPO_.feature[22m:[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_multiple_background.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_multiple_background.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -32,7 +33,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mRunning post-start [1mproject:task1[22m @ [1m_REPO_.feature[22m:[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_separate_logs.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_separate_logs.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -32,7 +33,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mRunning post-start [1mproject:task1[22m @ [1m_REPO_.feature[22m:[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_single_background.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_single_background.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -32,7 +33,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mRunning post-start project hook @ [1m_REPO_.feature[22m:[39m

--- a/tests/snapshots/integration__integration_tests__shell_integration_prompt__pty_tests__prompt_accept.snap
+++ b/tests/snapshots/integration__integration_tests__shell_integration_prompt__pty_tests__prompt_accept.snap
@@ -1,11 +1,10 @@
 ---
 source: tests/integration_tests/shell_integration_prompt.rs
-assertion_line: 465
 expression: normalized
 ---
 y
 
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO]/repo.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m[REPO]/repo.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 
 [36m❯[39m Install shell integration? [1m[y/N/?][22m 

--- a/tests/snapshots/integration__integration_tests__shell_integration_prompt__pty_tests__prompt_decline.snap
+++ b/tests/snapshots/integration__integration_tests__shell_integration_prompt__pty_tests__prompt_decline.snap
@@ -4,7 +4,7 @@ expression: normalized
 ---
 n
 
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO]/repo.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m[REPO]/repo.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 
 [36m❯[39m Install shell integration? [1m[y/N/?][22m 

--- a/tests/snapshots/integration__integration_tests__shell_integration_prompt__pty_tests__prompt_preview_decline.snap
+++ b/tests/snapshots/integration__integration_tests__shell_integration_prompt__pty_tests__prompt_preview_decline.snap
@@ -5,7 +5,7 @@ expression: normalized
 ?
 n
 
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[REPO]/repo.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m[REPO]/repo.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 
 [36m❯[39m Install shell integration? [1m[y/N/?][22m 

--- a/tests/snapshots/integration__integration_tests__shell_wrapper__tests__bash_shell_integration_hint_suppressed.snap
+++ b/tests/snapshots/integration__integration_tests__shell_wrapper__tests__bash_shell_integration_hint_suppressed.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-[32m✓[39m [32mCreated new worktree for [1mbash-test[22m from [1mmain[22m @ [1m[TMPDIR]/repo.bash-test[22m[39m
+[32m✓[39m [32mCreated branch [1mbash-test[22m and worktree from [1mmain[22m @ [1m[TMPDIR]/repo.bash-test[22m[39m

--- a/tests/snapshots/integration__integration_tests__shell_wrapper__tests__fish_multiline_command_execution.snap
+++ b/tests/snapshots/integration__integration_tests__shell_wrapper__tests__fish_multiline_command_execution.snap
@@ -2,7 +2,7 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-[32m✓[39m [32mCreated new worktree for [1mfish-multiline[22m from [1mmain[22m @ [1m[TMPDIR]/repo.fish-multiline[22m[39m
+[32m✓[39m [32mCreated branch [1mfish-multiline[22m and worktree from [1mmain[22m @ [1m[TMPDIR]/repo.fish-multiline[22m[39m
 [36m◎[39m [36mExecuting (--execute):[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'line 1'[0m[2m; [0m[2m[34mecho[0m[2m [0m[2m[32m'line 2'[0m[2m; [0m[2m[34mecho[0m[2m [0m[2m[32m'line 3'[0m[2m
 line 1

--- a/tests/snapshots/integration__integration_tests__shell_wrapper__tests__fish_wrapper_handles_empty_chunks.snap
+++ b/tests/snapshots/integration__integration_tests__shell_wrapper__tests__fish_wrapper_handles_empty_chunks.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-[32m✓[39m [32mCreated new worktree for [1mfish-minimal[22m from [1mmain[22m @ [1m[TMPDIR]/repo.fish-minimal[22m[39m
+[32m✓[39m [32mCreated branch [1mfish-minimal[22m and worktree from [1mmain[22m @ [1m[TMPDIR]/repo.fish-minimal[22m[39m

--- a/tests/snapshots/integration__integration_tests__shell_wrapper__tests__fish_wrapper_preserves_progress_messages.snap
+++ b/tests/snapshots/integration__integration_tests__shell_wrapper__tests__fish_wrapper_preserves_progress_messages.snap
@@ -2,6 +2,6 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-[32m✓[39m [32mCreated new worktree for [1mfish-bg[22m from [1mmain[22m @ [1m[TMPDIR]/repo.fish-bg[22m[39m
+[32m✓[39m [32mCreated branch [1mfish-bg[22m and worktree from [1mmain[22m @ [1m[TMPDIR]/repo.fish-bg[22m[39m
 [36m◎[39m [36mRunning post-start project hook:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'fish background task'[0m[2m

--- a/tests/snapshots/integration__integration_tests__shell_wrapper__tests__readme_example_hooks_post_create.snap
+++ b/tests/snapshots/integration__integration_tests__shell_wrapper__tests__readme_example_hooks_post_create.snap
@@ -7,6 +7,6 @@ expression: output.normalized()
 
   Resolved 24 packages in 145ms
   Installed 24 packages in 1.2s
-[32m✓[39m [32mCreated new worktree for [1mfeature-x[22m from [1mmain[22m @ [1m[TMPDIR]/repo.feature-x[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature-x[22m and worktree from [1mmain[22m @ [1m[TMPDIR]/repo.feature-x[22m[39m
 [36m◎[39m [36mRunning post-start [1mproject:dev[22m:[39m
 [107m [0m [2m[0m[2m[34muv[0m[2m run dev

--- a/tests/snapshots/integration__integration_tests__shell_wrapper__tests__readme_example_simple_switch.snap
+++ b/tests/snapshots/integration__integration_tests__shell_wrapper__tests__readme_example_simple_switch.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-[32m✓[39m [32mCreated new worktree for [1mfix-auth[22m from [1mmain[22m @ [1m[TMPDIR]/repo.fix-auth[22m[39m
+[32m✓[39m [32mCreated branch [1mfix-auth[22m and worktree from [1mmain[22m @ [1m[TMPDIR]/repo.fix-auth[22m[39m

--- a/tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_create.snap
+++ b/tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_create.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m[TMPDIR]/repo.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m[TMPDIR]/repo.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_with_execute.snap
+++ b/tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_with_execute.snap
@@ -2,7 +2,7 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-[32m✓[39m [32mCreated new worktree for [1mtest-exec[22m from [1mmain[22m @ [1m[TMPDIR]/repo.test-exec[22m[39m
+[32m✓[39m [32mCreated branch [1mtest-exec[22m and worktree from [1mmain[22m @ [1m[TMPDIR]/repo.test-exec[22m[39m
 [36m◎[39m [36mExecuting (--execute):[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m executed
 executed

--- a/tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_with_execute_through_wrapper.snap
+++ b/tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_with_execute_through_wrapper.snap
@@ -2,7 +2,7 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-[32m✓[39m [32mCreated new worktree for [1mtest-exec[22m from [1mmain[22m @ [1m[TMPDIR]/repo.test-exec[22m[39m
+[32m✓[39m [32mCreated branch [1mtest-exec[22m and worktree from [1mmain[22m @ [1m[TMPDIR]/repo.test-exec[22m[39m
 [36m◎[39m [36mExecuting (--execute):[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m executed
 executed

--- a/tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_with_hooks_zsh.snap
+++ b/tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_with_hooks_zsh.snap
@@ -8,7 +8,7 @@ Installing dependencies...
 [36m◎[39m [36mRunning post-create [1mproject:build[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Building project...'[0m[2m
 Building project...
-[32m✓[39m [32mCreated new worktree for [1mfeature-hooks[22m from [1mmain[22m @ [1m[TMPDIR]/repo.feature-hooks[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature-hooks[22m and worktree from [1mmain[22m @ [1m[TMPDIR]/repo.feature-hooks[22m[39m
 [36m◎[39m [36mRunning post-start [1mproject:server[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Starting dev server on port 3000'[0m[2m
 [36m◎[39m [36mRunning post-start [1mproject:watch[22m:[39m

--- a/tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_with_post_start_command_no_directive_leak.snap
+++ b/tests/snapshots/integration__integration_tests__shell_wrapper__tests__switch_with_post_start_command_no_directive_leak.snap
@@ -2,6 +2,6 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-[32m✓[39m [32mCreated new worktree for [1mfeature-with-hooks[22m from [1mmain[22m @ [1m[TMPDIR]/repo.feature-with-hooks[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature-with-hooks[22m and worktree from [1mmain[22m @ [1m[TMPDIR]/repo.feature-with-hooks[22m[39m
 [36m◎[39m [36mRunning post-start project hook:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command executed'[0m[2m

--- a/tests/snapshots/integration__integration_tests__shell_wrapper__tests__wrapper_preserves_progress_messages.snap
+++ b/tests/snapshots/integration__integration_tests__shell_wrapper__tests__wrapper_preserves_progress_messages.snap
@@ -2,6 +2,6 @@
 source: tests/integration_tests/shell_wrapper.rs
 expression: output.normalized()
 ---
-[32m✓[39m [32mCreated new worktree for [1mfeature-bg[22m from [1mmain[22m @ [1m[TMPDIR]/repo.feature-bg[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature-bg[22m and worktree from [1mmain[22m @ [1m[TMPDIR]/repo.feature-bg[22m[39m
 [36m◎[39m [36mRunning post-start project hook:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'background task'[0m[2m

--- a/tests/snapshots/integration__integration_tests__switch__create_with_base_main.snap
+++ b/tests/snapshots/integration__integration_tests__switch__create_with_base_main.snap
@@ -24,6 +24,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -34,6 +35,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mnew-feature[22m from [1mmain[22m @ [1m_REPO_.new-feature[22m[39m
+[32m✓[39m [32mCreated branch [1mnew-feature[22m and worktree from [1mmain[22m @ [1m_REPO_.new-feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__ping_pong_1_main_to_feature_a.snap
+++ b/tests/snapshots/integration__integration_tests__switch__ping_pong_1_main_to_feature_a.snap
@@ -21,6 +21,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -31,6 +32,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mSwitched to worktree for [1mfeature-a[22m @ [1m_REPO_.feature-a[22m[39m
+[32m✓[39m [32mCreated worktree for [1mfeature-a[22m @ [1m_REPO_.feature-a[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_clobber_path_with_extension.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_clobber_path_with_extension.snap
@@ -23,6 +23,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -34,6 +35,6 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mMoving [1m_REPO_.clobber-ext.txt[22m to [1m_REPO_.clobber-ext.txt.bak.20250102-000000[22m ([90m--clobber[39m)[39m
-[32m✓[39m [32mCreated new worktree for [1mclobber-ext.txt[22m from [1mmain[22m @ [1m_REPO_.clobber-ext.txt[22m[39m
+[32m✓[39m [32mCreated branch [1mclobber-ext.txt[22m and worktree from [1mmain[22m @ [1m_REPO_.clobber-ext.txt[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_clobber_removes_stale_dir.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_clobber_removes_stale_dir.snap
@@ -23,6 +23,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -34,6 +35,6 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mMoving [1m_REPO_.clobber-dir-test[22m to [1m_REPO_.clobber-dir-test.bak.20250102-000000[22m ([90m--clobber[39m)[39m
-[32m✓[39m [32mCreated new worktree for [1mclobber-dir-test[22m from [1mmain[22m @ [1m_REPO_.clobber-dir-test[22m[39m
+[32m✓[39m [32mCreated branch [1mclobber-dir-test[22m and worktree from [1mmain[22m @ [1m_REPO_.clobber-dir-test[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_clobber_removes_stale_file.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_clobber_removes_stale_file.snap
@@ -23,6 +23,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -34,6 +35,6 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mMoving [1m_REPO_.clobber-file-test[22m to [1m_REPO_.clobber-file-test.bak.20250102-000000[22m ([90m--clobber[39m)[39m
-[32m✓[39m [32mCreated new worktree for [1mclobber-file-test[22m from [1mmain[22m @ [1m_REPO_.clobber-file-test[22m[39m
+[32m✓[39m [32mCreated branch [1mclobber-file-test[22m and worktree from [1mmain[22m @ [1m_REPO_.clobber-file-test[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_create_new.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_create_new.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -32,6 +33,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfeature-x[22m from [1mmain[22m @ [1m_REPO_.feature-x[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature-x[22m and worktree from [1mmain[22m @ [1m_REPO_.feature-x[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_create_no_remote.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_create_no_remote.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -32,6 +33,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_create_remote_only.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_create_remote_only.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -34,6 +35,6 @@ exit_code: 0
 ----- stderr -----
 [33m▲[39m [33mBranch [1mremote-feature[22m exists on remote (origin/remote-feature); creating new branch from base instead[39m
 [2m↳[22m [2mTo switch to the remote branch, remove [90m--create[39m; run [90mwt switch remote-feature[39m[22m
-[32m✓[39m [32mCreated new worktree for [1mremote-feature[22m from [1mmain[22m @ [1m_REPO_.remote-feature[22m[39m
+[32m✓[39m [32mCreated branch [1mremote-feature[22m and worktree from [1mmain[22m @ [1m_REPO_.remote-feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_creates_file.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_creates_file.snap
@@ -24,6 +24,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -34,7 +35,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfile-test[22m from [1mmain[22m @ [1m_REPO_.file-test[22m[39m
+[32m✓[39m [32mCreated branch [1mfile-test[22m and worktree from [1mmain[22m @ [1m_REPO_.file-test[22m[39m
 [33m▲[39m [33mExecuting [1mecho 'test content' > test.txt[22m @ [1m_REPO_.file-test[22m, but shell directory unchanged — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mExecuting (--execute):[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_failure.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_failure.snap
@@ -24,6 +24,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -34,7 +35,7 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfail-test[22m from [1mmain[22m @ [1m_REPO_.fail-test[22m[39m
+[32m✓[39m [32mCreated branch [1mfail-test[22m and worktree from [1mmain[22m @ [1m_REPO_.fail-test[22m[39m
 [33m▲[39m [33mExecuting [1mexit 1[22m @ [1m_REPO_.fail-test[22m, but shell directory unchanged — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mExecuting (--execute):[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_multiline.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_multiline.snap
@@ -24,6 +24,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -37,7 +38,7 @@ line2
 line3
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mmultiline-test[22m from [1mmain[22m @ [1m_REPO_.multiline-test[22m[39m
+[32m✓[39m [32mCreated branch [1mmultiline-test[22m and worktree from [1mmain[22m @ [1m_REPO_.multiline-test[22m[39m
 [33m▲[39m [33mExecuting [1mecho 'line1'
 echo 'line2'
 echo 'line3'[22m @ [1m_REPO_.multiline-test[22m, but shell directory unchanged — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_success.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_success.snap
@@ -24,6 +24,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -35,7 +36,7 @@ exit_code: 0
 test output
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mexec-test[22m from [1mmain[22m @ [1m_REPO_.exec-test[22m[39m
+[32m✓[39m [32mCreated branch [1mexec-test[22m and worktree from [1mmain[22m @ [1m_REPO_.exec-test[22m[39m
 [33m▲[39m [33mExecuting [1mecho 'test output'[22m @ [1m_REPO_.exec-test[22m, but shell directory unchanged — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mExecuting (--execute):[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_internal_execute_exit_code.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_internal_execute_exit_code.snap
@@ -24,6 +24,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_DIRECTIVE_FILE: "[DIRECTIVE_FILE]"
@@ -35,6 +36,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mexit-code-test[22m from [1mmain[22m @ [1m_REPO_.exit-code-test[22m[39m
+[32m✓[39m [32mCreated branch [1mexit-code-test[22m and worktree from [1mmain[22m @ [1m_REPO_.exit-code-test[22m[39m
 [36m◎[39m [36mExecuting (--execute):[39m
 [107m [0m [2m[0m[2m[34mexit[0m[2m 42

--- a/tests/snapshots/integration__integration_tests__switch__switch_internal_execute_output_then_exit.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_internal_execute_output_then_exit.snap
@@ -24,6 +24,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_DIRECTIVE_FILE: "[DIRECTIVE_FILE]"
@@ -35,7 +36,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1moutput-exit-test[22m from [1mmain[22m @ [1m_REPO_.output-exit-test[22m[39m
+[32m✓[39m [32mCreated branch [1moutput-exit-test[22m and worktree from [1mmain[22m @ [1m_REPO_.output-exit-test[22m[39m
 [36m◎[39m [36mExecuting (--execute):[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'doing work'[0m[2m
 [107m [0m [2m[0m[2m[34mexit[0m[2m 7

--- a/tests/snapshots/integration__integration_tests__switch__switch_internal_mode.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_internal_mode.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_DIRECTIVE_FILE: "[DIRECTIVE_FILE]"
@@ -33,4 +34,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1minternal-test[22m from [1mmain[22m @ [1m_REPO_.internal-test[22m[39m
+[32m✓[39m [32mCreated branch [1minternal-test[22m and worktree from [1mmain[22m @ [1m_REPO_.internal-test[22m[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_internal_with_execute.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_internal_with_execute.snap
@@ -24,6 +24,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_DIRECTIVE_FILE: "[DIRECTIVE_FILE]"
@@ -35,7 +36,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mexec-internal[22m from [1mmain[22m @ [1m_REPO_.exec-internal[22m[39m
+[32m✓[39m [32mCreated branch [1mexec-internal[22m and worktree from [1mmain[22m @ [1m_REPO_.exec-internal[22m[39m
 [36m◎[39m [36mExecuting (--execute):[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'line1'[0m[2m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'line2'[0m[2m

--- a/tests/snapshots/integration__integration_tests__switch__switch_main_branch_to_feature.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_main_branch_to_feature.snap
@@ -21,6 +21,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -31,6 +32,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mSwitched to worktree for [1mfeature-a[22m @ [1m_REPO_.feature-a[22m[39m
+[32m✓[39m [32mCreated worktree for [1mfeature-a[22m @ [1m_REPO_.feature-a[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_execute_still_runs.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_execute_still_runs.snap
@@ -25,6 +25,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -36,7 +37,7 @@ exit_code: 0
 execute command runs
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mno-hooks-test[22m from [1mmain[22m @ [1m_REPO_.no-hooks-test[22m[39m
+[32m✓[39m [32mCreated branch [1mno-hooks-test[22m and worktree from [1mmain[22m @ [1m_REPO_.no-hooks-test[22m[39m
 [33m▲[39m [33mExecuting [1mecho 'execute command runs'[22m @ [1m_REPO_.no-hooks-test[22m, but shell directory unchanged — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mExecuting (--execute):[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_skips_post_start.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_skips_post_start.snap
@@ -23,6 +23,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -33,6 +34,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mno-post-start[22m from [1mmain[22m @ [1m_REPO_.no-post-start[22m[39m
+[32m✓[39m [32mCreated branch [1mno-post-start[22m and worktree from [1mmain[22m @ [1m_REPO_.no-post-start[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_with_yes.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_with_yes.snap
@@ -24,6 +24,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -34,6 +35,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1myes-no-hooks[22m from [1mmain[22m @ [1m_REPO_.yes-no-hooks[22m[39m
+[32m✓[39m [32mCreated branch [1myes-no-hooks[22m and worktree from [1mmain[22m @ [1m_REPO_.yes-no-hooks[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_post_hook_no_path_with_shell_integration.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_post_hook_no_path_with_shell_integration.snap
@@ -23,6 +23,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_DIRECTIVE_FILE: "[DIRECTIVE_FILE]"
@@ -34,6 +35,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mpost-hook-shell-test[22m from [1mmain[22m @ [1m_REPO_.post-hook-shell-test[22m[39m
+[32m✓[39m [32mCreated branch [1mpost-hook-shell-test[22m and worktree from [1mmain[22m @ [1m_REPO_.post-hook-shell-test[22m[39m
 [36m◎[39m [36mRunning post-switch project hook:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m switched

--- a/tests/snapshots/integration__integration_tests__switch__switch_post_hook_path_annotation.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_post_hook_path_annotation.snap
@@ -23,6 +23,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -33,7 +34,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mpost-hook-test[22m from [1mmain[22m @ [1m_REPO_.post-hook-test[22m[39m
+[32m✓[39m [32mCreated branch [1mpost-hook-test[22m and worktree from [1mmain[22m @ [1m_REPO_.post-hook-test[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mRunning post-switch project hook @ [1m_REPO_.post-hook-test[22m:[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_primary_on_different_branch.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_primary_on_different_branch.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -32,6 +33,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfeature-from-main[22m from [1mmain[22m @ [1m_REPO_.feature-from-main[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature-from-main[22m and worktree from [1mmain[22m @ [1m_REPO_.feature-from-main[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_stale_history_to_a.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_stale_history_to_a.snap
@@ -21,6 +21,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -31,6 +32,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mSwitched to worktree for [1mbranch-a[22m @ [1m_REPO_.branch-a[22m[39m
+[32m✓[39m [32mCreated worktree for [1mbranch-a[22m @ [1m_REPO_.branch-a[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_stale_history_to_b.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_stale_history_to_b.snap
@@ -21,6 +21,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -31,6 +32,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mSwitched to worktree for [1mbranch-b[22m @ [1m_REPO_.branch-b[22m[39m
+[32m✓[39m [32mCreated worktree for [1mbranch-b[22m @ [1m_REPO_.branch-b[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_with_base.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_with_base.snap
@@ -24,6 +24,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -34,6 +35,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfeature-with-base[22m from [1mmain[22m @ [1m_REPO_.feature-with-base[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature-with-base[22m and worktree from [1mmain[22m @ [1m_REPO_.feature-with-base[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__user_hooks__no_verify_skips_all_hooks.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__no_verify_skips_all_hooks.snap
@@ -23,6 +23,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -33,6 +34,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_and_project_post_start.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_and_project_post_start.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -32,7 +33,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mRunning post-start [1muser:bg[22m @ [1m_REPO_.feature[22m:[39m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_hook_template_vars.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_hook_template_vars.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -34,6 +35,6 @@ exit_code: 0
 ----- stderr -----
 [36m◎[39m [36mRunning post-create [1muser:vars[22m @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'repo=repo branch=feature'[0m[2m [0m[2m[36m>[0m[2m template_vars.txt
-[0m[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[0m[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_before_project.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_before_project.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -36,6 +37,6 @@ exit_code: 0
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'USER_HOOK'[0m[2m [0m[2m[36m>>[0m[2m hook_order.txt
 [0m[36m◎[39m [36mRunning post-create project hook @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'PROJECT_HOOK'[0m[2m [0m[2m[36m>>[0m[2m hook_order.txt
-[0m[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[0m[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_no_approval.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_no_approval.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -34,6 +35,6 @@ exit_code: 0
 ----- stderr -----
 [36m◎[39m [36mRunning post-create [1muser:setup[22m @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'NO_APPROVAL_NEEDED'[0m[2m [0m[2m[36m>[0m[2m no_approval.txt
-[0m[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[0m[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_post_create_executes.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_post_create_executes.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -34,6 +35,6 @@ exit_code: 0
 ----- stderr -----
 [36m◎[39m [36mRunning post-create [1muser:log[22m @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'USER_POST_CREATE_RAN'[0m[2m [0m[2m[36m>[0m[2m user_hook_marker.txt
-[0m[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[0m[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_post_create_failure.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_post_create_failure.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -35,6 +36,6 @@ exit_code: 0
 [36m◎[39m [36mRunning post-create [1muser:failing[22m @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mexit[0m[2m 1
 [0m[33m▲[39m [33mCommand [1mfailing[22m failed: exit status: 1[39m
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_post_start_executes.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_post_start_executes.snap
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -32,7 +33,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mRunning post-start [1muser:bg[22m @ [1m_REPO_.feature[22m:[39m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_post_start_skipped_no_verify.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_post_start_skipped_no_verify.snap
@@ -23,6 +23,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -33,6 +34,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[32m✓[39m [32mCreated new worktree for [1mfeature[22m from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m


### PR DESCRIPTION
## Summary

- Update switch messages to explicitly state what was created
- `--create`: "Created branch X and worktree from Y @ path"
- DWIM from remote: "Created branch X (tracking origin/X) and worktree @ path"  
- Worktree only: "Created worktree for X @ path"
- Switch to existing: "Switched to worktree for X @ path"

Previously, creating a worktree for an existing local branch showed "Switched to worktree" which was misleading since a worktree was actually created.

## Test plan

- [x] All 1772 integration tests pass
- [x] Pre-merge hooks pass (pre-commit, clippy, tests, doctests)
- [x] Snapshot tests updated to reflect new messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)