### PR TITLE
Refactor hint messages to avoid multi-line coverage gaps

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -1196,26 +1196,22 @@ pub fn handle_hints_clear(name: Option<String>) -> anyhow::Result<()> {
 
     match name {
         Some(hint_name) => {
-            if repo.clear_hint(&hint_name)? {
-                crate::output::print(success_message(cformat!(
-                    "Cleared hint <bold>{hint_name}</>"
-                )))?;
+            let msg = if repo.clear_hint(&hint_name)? {
+                success_message(cformat!("Cleared hint <bold>{hint_name}</>"))
             } else {
-                crate::output::print(info_message(cformat!(
-                    "Hint <bold>{hint_name}</> was not set"
-                )))?;
-            }
+                info_message(cformat!("Hint <bold>{hint_name}</> was not set"))
+            };
+            crate::output::print(msg)?;
         }
         None => {
             let cleared = repo.clear_all_hints()?;
-            if cleared == 0 {
-                crate::output::print(info_message("No hints to clear"))?;
+            let msg = if cleared == 0 {
+                info_message("No hints to clear")
             } else {
-                crate::output::print(success_message(cformat!(
-                    "Cleared <bold>{cleared}</> hint{}",
-                    if cleared == 1 { "" } else { "s" }
-                )))?;
-            }
+                let suffix = if cleared == 1 { "" } else { "s" };
+                success_message(cformat!("Cleared <bold>{cleared}</> hint{suffix}"))
+            };
+            crate::output::print(msg)?;
         }
     }
 

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -390,9 +390,10 @@ pub fn handle_switch_output(
                     .map(|c| c.has_custom_worktree_path())
                     .unwrap_or(false);
                 if !has_custom_config && !repo.has_shown_hint("worktree-path") {
-                    super::print(hint_message(cformat!(
+                    let hint = hint_message(cformat!(
                         "Customize worktree locations: <bright-black>wt config create</>"
-                    )))?;
+                    ));
+                    super::print(hint)?;
                     let _ = repo.mark_hint_shown("worktree-path");
                 }
             }


### PR DESCRIPTION
## Summary

- Refactor `handle_hints_clear()` and hint display in `handle_switch_output()` to use intermediate variables
- Fixes false uncovered line reports in codecov/patch check

LLVM coverage counts multi-line macro call endings (`))?;`) as separate regions. By extracting the message to an intermediate variable, all coverage is attributed to single expressions.

## Test plan

- [x] All 814 tests pass
- [x] Pre-commit hooks pass
- [x] Coverage improved on changed lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)