### PR TITLE
test: remove runtime shell availability skipping

### DIFF
--- a/tests/common/shell.rs
+++ b/tests/common/shell.rs
@@ -1,51 +1,5 @@
 use super::{TestRepo, wt_command};
 use insta_cmd::get_cargo_bin;
-use std::{
-    collections::HashSet,
-    process::{Command, Stdio},
-    sync::LazyLock,
-};
-
-/// Check if a shell binary is available (non-interactive)
-fn check_shell_available(binary: &str, arg: &str) -> bool {
-    Command::new(binary)
-        .arg(arg)
-        .stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status()
-        .map(|s| s.success())
-        .unwrap_or(false)
-}
-
-/// Set of shells available on this system (cached at first access)
-static AVAILABLE_SHELLS: LazyLock<HashSet<&'static str>> = LazyLock::new(|| {
-    let mut shells = HashSet::new();
-
-    if check_shell_available("bash", "--version") {
-        shells.insert("bash");
-    }
-
-    if check_shell_available("zsh", "--version") {
-        shells.insert("zsh");
-    }
-
-    if check_shell_available("fish", "--version") {
-        shells.insert("fish");
-    }
-
-    if check_shell_available("pwsh", "-Version") {
-        shells.insert("pwsh");
-        shells.insert("powershell");
-    }
-
-    shells
-});
-
-/// Check if a shell is available on the current system.
-pub fn shell_available(shell: &str) -> bool {
-    AVAILABLE_SHELLS.contains(shell)
-}
 
 /// Map shell display names to actual binaries.
 pub fn get_shell_binary(shell: &str) -> &str {

--- a/tests/integration_tests/e2e_shell.rs
+++ b/tests/integration_tests/e2e_shell.rs
@@ -3,21 +3,9 @@
 
 use crate::common::{
     TestRepo, repo,
-    shell::{
-        execute_shell_script, generate_init_code, path_export_syntax, shell_available, wt_bin_dir,
-    },
+    shell::{execute_shell_script, generate_init_code, path_export_syntax, wt_bin_dir},
 };
 use rstest::rstest;
-
-/// Skip test if the shell is not available on this system.
-macro_rules! skip_if_shell_unavailable {
-    ($shell:expr) => {
-        if !shell_available($shell) {
-            eprintln!("Skipping test: {} not available on this system", $shell);
-            return;
-        }
-    };
-}
 
 #[rstest]
 // Test with bash (baseline) and fish (alternate syntax)
@@ -25,8 +13,6 @@ macro_rules! skip_if_shell_unavailable {
 #[case("fish")]
 #[case("zsh")]
 fn test_shell_integration_switch_and_remove(#[case] shell: &str, repo: TestRepo) {
-    skip_if_shell_unavailable!(shell);
-
     let init_code = generate_init_code(&repo, shell);
     let bin_path = wt_bin_dir();
 
@@ -79,8 +65,6 @@ fn test_shell_integration_switch_and_remove(#[case] shell: &str, repo: TestRepo)
 
 #[rstest]
 fn test_bash_shell_integration_error_handling(repo: TestRepo) {
-    skip_if_shell_unavailable!("bash");
-
     let init_code = generate_init_code(&repo, "bash");
     let bin_path = wt_bin_dir();
 
@@ -119,8 +103,6 @@ fn test_bash_shell_integration_error_handling(repo: TestRepo) {
 
 #[rstest]
 fn test_bash_shell_integration_switch_existing_worktree(repo: TestRepo) {
-    skip_if_shell_unavailable!("bash");
-
     let init_code = generate_init_code(&repo, "bash");
     let bin_path = wt_bin_dir();
     let repo_root = repo.root_path().display();

--- a/tests/integration_tests/e2e_shell_post_start.rs
+++ b/tests/integration_tests/e2e_shell_post_start.rs
@@ -3,24 +3,12 @@
 
 use crate::common::{
     TestRepo, repo, resolve_git_common_dir,
-    shell::{
-        execute_shell_script, generate_init_code, path_export_syntax, shell_available, wt_bin_dir,
-    },
+    shell::{execute_shell_script, generate_init_code, path_export_syntax, wt_bin_dir},
     wait_for_file, wait_for_file_content,
 };
 use rstest::rstest;
 use std::fs;
 use std::time::Duration;
-
-/// Skip test if the shell is not available on this system.
-macro_rules! skip_if_shell_unavailable {
-    ($shell:expr) => {
-        if !shell_available($shell) {
-            eprintln!("Skipping test: {} not available on this system", $shell);
-            return;
-        }
-    };
-}
 
 /// Test that post-start background commands work with shell integration
 #[rstest]
@@ -28,8 +16,6 @@ macro_rules! skip_if_shell_unavailable {
 #[case("bash")]
 #[case("fish")]
 fn test_shell_integration_post_start_background(#[case] shell: &str, repo: TestRepo) {
-    skip_if_shell_unavailable!(shell);
-
     // Create project config with background command
     let config_dir = repo.root_path().join(".config");
     fs::create_dir_all(&config_dir).unwrap();

--- a/tests/integration_tests/shell_wrapper.rs
+++ b/tests/integration_tests/shell_wrapper.rs
@@ -37,24 +37,12 @@
 
 use crate::common::TestRepo;
 use crate::common::canonicalize;
-use crate::common::shell::shell_available;
 use insta::assert_snapshot;
 use insta_cmd::get_cargo_bin;
 use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 use std::sync::LazyLock;
-
-/// Skip test if the shell is not available.
-/// Returns early from the test with a message.
-macro_rules! skip_if_shell_unavailable {
-    ($shell:expr) => {
-        if !shell_available($shell) {
-            eprintln!("Skipping test: {} not available on this system", $shell);
-            return;
-        }
-    };
-}
 
 /// Regex for normalizing temporary directory paths in test snapshots
 static TMPDIR_REGEX: LazyLock<regex::Regex> = LazyLock::new(|| {
@@ -699,8 +687,6 @@ mod tests {
     #[case("zsh")]
     #[case("fish")]
     fn test_wrapper_handles_command_failure(#[case] shell: &str, mut repo: TestRepo) {
-        skip_if_shell_unavailable!(shell);
-
         // Create a worktree that already exists
         repo.add_worktree("existing");
 
@@ -732,8 +718,6 @@ mod tests {
     #[case("zsh")]
     #[case("fish")]
     fn test_wrapper_switch_create(#[case] shell: &str, repo: TestRepo) {
-        skip_if_shell_unavailable!(shell);
-
         let output = exec_through_wrapper(shell, &repo, "switch", &["--create", "feature"]);
 
         // Shell-agnostic assertions
@@ -758,8 +742,6 @@ mod tests {
     #[case("zsh")]
     #[case("fish")]
     fn test_wrapper_remove(#[case] shell: &str, mut repo: TestRepo) {
-        skip_if_shell_unavailable!(shell);
-
         // Create a worktree to remove
         repo.add_worktree("to-remove");
 
@@ -780,7 +762,6 @@ mod tests {
     #[case("zsh")]
     #[case("fish")]
     fn test_wrapper_step_for_each(#[case] shell: &str, mut repo: TestRepo) {
-        skip_if_shell_unavailable!(shell);
         repo.commit("Initial commit");
 
         // Create additional worktrees
@@ -839,8 +820,6 @@ mod tests {
     #[case("zsh")]
     #[case("fish")]
     fn test_wrapper_merge(#[case] shell: &str, mut repo: TestRepo) {
-        skip_if_shell_unavailable!(shell);
-
         // Create a feature branch
         repo.add_worktree("feature");
 
@@ -861,8 +840,6 @@ mod tests {
     #[case("zsh")]
     #[case("fish")]
     fn test_wrapper_switch_with_execute(#[case] shell: &str, repo: TestRepo) {
-        skip_if_shell_unavailable!(shell);
-
         // Use --yes to skip approval prompt in tests
         let output = exec_through_wrapper(
             shell,
@@ -901,8 +878,6 @@ mod tests {
     #[case("zsh")]
     #[case("fish")]
     fn test_wrapper_execute_exit_code_propagation(#[case] shell: &str, repo: TestRepo) {
-        skip_if_shell_unavailable!(shell);
-
         // Use --yes to skip approval prompt in tests
         // wt should succeed (creates worktree), but the execute command should fail with exit 42
         let output = exec_through_wrapper(
@@ -945,8 +920,6 @@ mod tests {
     #[case("zsh")]
     // #[case("fish")] // TODO: Fish shell has non-deterministic PTY output ordering
     fn test_wrapper_switch_with_hooks(#[case] shell: &str, repo: TestRepo) {
-        skip_if_shell_unavailable!(shell);
-
         // Create project config with both post-create and post-start hooks
         let config_dir = repo.root_path().join(".config");
         fs::create_dir_all(&config_dir).unwrap();
@@ -998,8 +971,6 @@ approved-commands = [
     #[case("zsh")]
     // #[case("fish")] // TODO: Fish shell has non-deterministic PTY output ordering
     fn test_wrapper_merge_with_pre_merge_success(#[case] shell: &str, mut repo: TestRepo) {
-        skip_if_shell_unavailable!(shell);
-
         // Create project config with pre-merge validation
         let config_dir = repo.root_path().join(".config");
         fs::create_dir_all(&config_dir).unwrap();
@@ -1050,8 +1021,6 @@ approved-commands = [
     #[case("zsh")]
     // #[case("fish")] // TODO: Fish shell has non-deterministic PTY output ordering
     fn test_wrapper_merge_with_pre_merge_failure(#[case] shell: &str, mut repo: TestRepo) {
-        skip_if_shell_unavailable!(shell);
-
         // Create project config with failing pre-merge validation
         let config_dir = repo.root_path().join(".config");
         fs::create_dir_all(&config_dir).unwrap();
@@ -1107,8 +1076,6 @@ approved-commands = [
     #[case("zsh")]
     // #[case("fish")] // TODO: Fish shell has non-deterministic PTY output ordering
     fn test_wrapper_merge_with_mixed_stdout_stderr(#[case] shell: &str, mut repo: TestRepo) {
-        skip_if_shell_unavailable!(shell);
-
         // Copy the fixture script to the test repo to avoid path issues with special characters
         // (CARGO_MANIFEST_DIR may contain single quotes like worktrunk.'∅' which break shell parsing)
         let fixtures_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures");
@@ -2825,7 +2792,6 @@ for c in "${{COMPREPLY[@]}}"; do echo "${{c%%	*}}"; done
     #[case("zsh")]
     #[case("fish")]
     fn test_wrapper_help_redirect_captures_all_output(#[case] shell: &str, repo: TestRepo) {
-        skip_if_shell_unavailable!(shell);
         use std::io::Read;
 
         let wt_bin = get_cargo_bin("wt");
@@ -2976,7 +2942,6 @@ echo "SCRIPT_COMPLETED"
     #[case("zsh")]
     #[case("fish")]
     fn test_wrapper_help_interactive_uses_pager(#[case] shell: &str, repo: TestRepo) {
-        skip_if_shell_unavailable!(shell);
         use std::io::Read;
 
         let wt_bin = get_cargo_bin("wt");


### PR DESCRIPTION
## Summary

- Remove `skip_if_shell_unavailable!` macro from shell integration tests
- Tests are already gated by `shell-integration-tests` feature flag, making runtime skipping redundant
- If CI fails to install shells, tests now fail loudly instead of silently passing
- Aligns with testing guidelines in `tests/CLAUDE.md`: "Never skip tests based on runtime availability checks"

## Test plan

- [x] All 830 tests pass with `--features shell-integration-tests`
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)