### PR TITLE
deprecate template-file and squash-template-file config options

### DIFF
--- a/docs/content/llm-commits.md
+++ b/docs/content/llm-commits.md
@@ -147,16 +147,6 @@ Diff:
 """
 ```
 
-Or load templates from files (supports `~` expansion):
-
-```toml
-[commit-generation]
-command = "llm"
-args = ["-m", "claude-haiku-4.5"]
-template-file = "~/.config/worktrunk/commit-template.txt"
-squash-template-file = "~/.config/worktrunk/squash-template.txt"
-```
-
 ### Template syntax
 
 Templates use [minijinja](https://docs.rs/minijinja/latest/minijinja/syntax/index.html), which supports:


### PR DESCRIPTION
Remove from docs and add deprecation warning when used.
The inline template/squash-template options cover the same use case.

Tracking issue: https://github.com/max-sixty/worktrunk/issues/444