### PR TITLE
Replace path string manipulation with Path/PathBuf methods

### DIFF
--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -611,7 +611,8 @@ pub fn handle_switch(
 
     // Create the worktree
     // Build git worktree add command
-    let mut args = vec!["worktree", "add", worktree_path.to_str().unwrap()];
+    let worktree_path_str = worktree_path.to_string_lossy();
+    let mut args = vec!["worktree", "add", worktree_path_str.as_ref()];
 
     // Use the resolved base, or default to default branch if creating without a base.
     // For bare repos with no branches yet (bootstrap case), allow None to create orphan branch.
@@ -975,6 +976,7 @@ pub fn handle_push(
 
     // Get git common dir for the push
     let git_common_dir = repo.git_common_dir()?;
+    let git_common_dir_str = git_common_dir.to_string_lossy();
 
     // Perform the push - stash guard will auto-restore on any exit path
     // Use --receive-pack to pass config to the receiving end without permanently mutating repo config
@@ -982,7 +984,7 @@ pub fn handle_push(
     repo.run_command(&[
         "push",
         "--receive-pack=git -c receive.denyCurrentBranch=updateInstead receive-pack",
-        git_common_dir.to_str().unwrap(),
+        git_common_dir_str.as_ref(),
         &push_target,
     ])
     .map_err(|e| {

--- a/src/shell.rs
+++ b/src/shell.rs
@@ -1013,20 +1013,29 @@ mod tests {
         // Fish config path should include prefix in filename
         let fish_paths = Shell::Fish.config_paths(prefix).unwrap();
         assert!(
-            fish_paths[0].to_string_lossy().contains("custom-wt.fish"),
+            fish_paths[0]
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.contains("custom-wt.fish")),
             "Fish config should include prefix in filename"
         );
 
         // Bash and Zsh config paths are fixed (not affected by prefix)
         let bash_paths = Shell::Bash.config_paths(prefix).unwrap();
         assert!(
-            bash_paths[0].to_string_lossy().contains(".bashrc"),
+            bash_paths[0]
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.contains(".bashrc")),
             "Bash config should be .bashrc"
         );
 
         let zsh_paths = Shell::Zsh.config_paths(prefix).unwrap();
         assert!(
-            zsh_paths[0].to_string_lossy().contains(".zshrc"),
+            zsh_paths[0]
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.contains(".zshrc")),
             "Zsh config should be .zshrc"
         );
     }
@@ -1038,21 +1047,30 @@ mod tests {
         // Bash completion should include prefix in path
         let bash_path = Shell::Bash.completion_path(prefix).unwrap();
         assert!(
-            bash_path.to_string_lossy().contains("my-prefix"),
+            bash_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.contains("my-prefix")),
             "Bash completion should include prefix"
         );
 
         // Fish completion should include prefix in filename
         let fish_path = Shell::Fish.completion_path(prefix).unwrap();
         assert!(
-            fish_path.to_string_lossy().contains("my-prefix.fish"),
+            fish_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.contains("my-prefix.fish")),
             "Fish completion should include prefix in filename"
         );
 
         // Zsh completion should include prefix
         let zsh_path = Shell::Zsh.completion_path(prefix).unwrap();
         assert!(
-            zsh_path.to_string_lossy().contains("_my-prefix"),
+            zsh_path
+                .file_name()
+                .and_then(|n| n.to_str())
+                .is_some_and(|n| n.contains("_my-prefix")),
             "Zsh completion should include underscore prefix"
         );
     }


### PR DESCRIPTION
## Summary
- Replace `.to_str().unwrap()` with `.to_string_lossy()` to handle non-UTF-8 paths gracefully
- Replace string `.contains()` on full paths with proper `.file_name()` checks
- Use path component checks instead of string `.starts_with()` for semantic correctness
- Change ci_status.rs cache functions to accept `&Path` instead of `&str`

## Changes by File

**shell.rs** (6 test locations)
- Replaced `.to_string_lossy().contains()` with `.file_name().and_then(|n| n.to_str()).is_some_and(|n| n.contains())`
- Tests now check filename component specifically rather than full path string

**worktree.rs** (2 locations)
- Replaced `.to_str().unwrap()` with `.to_string_lossy()` for paths passed to git commands
- Eliminates panic potential on non-UTF-8 paths

**ci_status.rs** (multiple locations)
- Changed function signatures: `cache_dir()`, `cache_file()`, `read()`, `write()` now accept `&Path` instead of `&str`
- Made `ttl_for_repo()` accept `&Path` and hash path bytes directly using `as_os_str().hash()`
- Simplified `detect()` function to eliminate double conversion
- Updated tests to use `Path::new()` for all ttl_for_repo() calls

**display.rs** (1 location)
- Replaced string `.starts_with("..")` with proper path component check: `relative.components().next() == Some(Component::ParentDir)`
- This is a semantic correctness fix - string checking would incorrectly match paths like `./..foo/`

## Test Results
✅ All pre-commit lints passed  
✅ 399 unit tests passed  
✅ 720 integration tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)