### PR TITLE
test: remove explicit timeout param from wait_for_* functions

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -84,16 +84,19 @@ let timeout = Duration::from_millis(100);
 Use the helpers in `tests/common/mod.rs`:
 
 ```rust
-use crate::common::{wait_for_file, wait_for_file_count};
+use crate::common::{wait_for_file, wait_for_file_count, wait_for_file_content};
 
-// ✅ Poll for file existence with 5+ second timeout
-wait_for_file(&log_file, Duration::from_secs(5));
+// ✅ Poll for file existence (15-second default timeout)
+wait_for_file(&log_file);
 
 // ✅ Poll for multiple files
-wait_for_file_count(&log_dir, "log", 3, Duration::from_secs(5));
+wait_for_file_count(&log_dir, "log", 3);
+
+// ✅ Poll for file with non-empty content
+wait_for_file_content(&marker_file);
 ```
 
-These use exponential backoff (10ms → 500ms cap) for fast initial checks that back off on slow CI.
+These use exponential backoff (10ms → 500ms cap) for fast initial checks that back off on slow CI. The 15-second default timeout is generous enough to avoid flakiness under CI load.
 
 **Exception - testing absence:** When verifying something did NOT happen, polling doesn't work. Use a fixed 500ms+ sleep:
 

--- a/tests/integration_tests/bare_repository.rs
+++ b/tests/integration_tests/bare_repository.rs
@@ -7,7 +7,6 @@ use rstest::rstest;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use std::time::Duration;
 
 #[test]
 fn test_bare_repo_list_worktrees() {
@@ -408,7 +407,7 @@ fn test_bare_repo_background_logs_location() {
     // Wait for background process to create log file (poll instead of fixed sleep)
     // The key test is that the path is correct, not that content was written (background processes are flaky in tests)
     let log_path = test.bare_repo_path().join("wt-logs/feature-remove.log");
-    wait_for_file(&log_path, Duration::from_secs(5));
+    wait_for_file(&log_path);
 
     // Verify it's NOT in the worktree's .git directory (which doesn't exist for linked worktrees)
     let wrong_path = main_worktree.join(".git/wt-logs/feature-remove.log");

--- a/tests/integration_tests/e2e_shell_post_start.rs
+++ b/tests/integration_tests/e2e_shell_post_start.rs
@@ -8,7 +8,6 @@ use crate::common::{
 };
 use rstest::rstest;
 use std::fs;
-use std::time::Duration;
 
 /// Test that post-start background commands work with shell integration
 #[rstest]
@@ -91,7 +90,7 @@ approved-commands = ["sleep 0.05 && echo 'Background task done' > bg_marker.txt"
 
     // Wait for background command to complete AND flush content (allow plenty of margin on CI)
     let marker_file = worktree_path.join("bg_marker.txt");
-    wait_for_file_content(marker_file.as_path(), Duration::from_secs(2));
+    wait_for_file_content(marker_file.as_path());
 
     let content = fs::read_to_string(&marker_file).unwrap();
     assert!(
@@ -159,14 +158,8 @@ approved-commands = [
         .unwrap()
         .join("repo.parallel-test");
 
-    wait_for_file(
-        worktree_path.join("task1.txt").as_path(),
-        Duration::from_secs(2),
-    );
-    wait_for_file(
-        worktree_path.join("task2.txt").as_path(),
-        Duration::from_secs(2),
-    );
+    wait_for_file(worktree_path.join("task1.txt").as_path());
+    wait_for_file(worktree_path.join("task2.txt").as_path());
 }
 
 /// Test that post-create commands block before shell returns
@@ -287,7 +280,7 @@ approved-commands = ["sleep 0.05 && echo 'Fish background done' > fish_bg.txt"]
     // Wait for background command AND flush content (allow plenty of margin on CI)
     let worktree_path = repo.root_path().parent().unwrap().join("repo.fish-bg-test");
     let marker_file = worktree_path.join("fish_bg.txt");
-    wait_for_file_content(marker_file.as_path(), Duration::from_secs(2));
+    wait_for_file_content(marker_file.as_path());
 
     let content = fs::read_to_string(&marker_file).unwrap();
     assert!(

--- a/tests/integration_tests/remove.rs
+++ b/tests/integration_tests/remove.rs
@@ -5,7 +5,7 @@ use crate::common::{
 };
 use insta_cmd::assert_cmd_snapshot;
 use rstest::rstest;
-use std::time::Duration;
+use std::time::Duration; // For absence checks (SLEEP_FOR_ABSENCE_CHECK pattern)
 
 #[rstest]
 fn test_remove_already_on_default(repo: TestRepo) {
@@ -1066,7 +1066,7 @@ approved-commands = ["echo 'hook ran' > {}"]
         .unwrap();
 
     // Wait for the hook to create the marker file
-    wait_for_file(&marker_file, Duration::from_secs(5));
+    wait_for_file(&marker_file);
 
     // Marker file SHOULD exist - pre-remove hooks run before background removal starts
     assert!(


### PR DESCRIPTION
## Summary
- Add `BG_TIMEOUT` constant (15 seconds) to `tests/common/mod.rs`
- Remove timeout parameter from `wait_for_file`, `wait_for_file_content`, `wait_for_file_count`, `wait_for_file_lines`, and `wait_for_valid_json`
- Update ~35 call sites across 6 test files to use the simpler API
- Update `tests/CLAUDE.md` to document the new API

## Test plan
- [x] All 723 integration tests pass
- [x] Pre-commit lints pass
- [x] Code review completed

🤖 Generated with [Claude Code](https://claude.com/claude-code)