### PR TITLE
fix(ci): fix claude-ci-fix workflow parameter and permissions

### DIFF
--- a/.github/workflows/claude-ci-fix.yaml
+++ b/.github/workflows/claude-ci-fix.yaml
@@ -23,6 +23,7 @@ jobs:
       contents: write
       pull-requests: write
       actions: read
+      id-token: write
     steps:
       - name: 📂 Checkout code
         uses: actions/checkout@v6
@@ -66,7 +67,7 @@ jobs:
             actions: read
 
           # Provide Claude with context about the failure and instructions
-          direct_prompt: |
+          prompt: |
             CI has failed on main branch. Your job is to diagnose and fix the failure, then create a PR.
 
             ## Failed workflow information


### PR DESCRIPTION
## Summary

- Change `direct_prompt` to `prompt` (valid parameter for claude-code-action v1)
- Add `id-token: write` permission required for OIDC token authentication

## Test plan

- [ ] claude-ci-fix workflow runs successfully when CI fails on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)