### PR TITLE
fix: show warnings before action messages, not after

### DIFF
--- a/.claude/rules/cli-output-formatting.md
+++ b/.claude/rules/cli-output-formatting.md
@@ -195,6 +195,46 @@ show_message_based_on(is_merged);
 spawn_background(build_command_that_checks_merge_again());  // Duplicate check!
 ```
 
+## Warning Ordering
+
+**Core principle:** Warnings about state discovered during evaluation appear
+**before** the action message that follows from that evaluation.
+
+When a command evaluates state, discovers something unexpected, and proceeds
+anyway, the warning should come first:
+
+```
+▲ Branch-worktree mismatch; expected feature @ ~/workspace/project.feature ⚑
+◎ Removing feature worktree & branch in background (same commit as main, _)
+```
+
+Not:
+
+```
+◎ Removing feature worktree & branch in background (same commit as main, _)
+▲ Branch-worktree mismatch; expected feature @ ~/workspace/project.feature ⚑
+```
+
+**Why this ordering matters:** The action message announces a decision. Warnings
+discovered while making that decision should precede the announcement — they
+explain what we found before we decided to proceed. Showing warnings after the
+action makes them feel like afterthoughts rather than considered observations.
+
+**The pattern:**
+
+1. Evaluate state and gather information (discovery phase)
+2. Show warnings about unexpected state discovered during evaluation
+3. Show the action message (what we decided to do)
+4. Show hints about what the user might do next
+
+This applies to warnings that are:
+- Pre-computed during command evaluation (path mismatches, state anomalies)
+- About the state we found, not about the action we're taking
+- Informational rather than blocking (we proceed despite the warning)
+
+Warnings that result from the action itself (something failed during execution)
+naturally come after the action.
+
 ## Message Types
 
 See `output-system-architecture.md` for the API. This section covers when to use

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -311,7 +311,7 @@ pub fn handle_switch_output(
         Some(compute_shell_warning_reason())
     };
 
-    // Show branch-worktree mismatch warning after the main message
+    // Compute branch-worktree mismatch warning (shown before action messages)
     let branch_worktree_mismatch_warning = branch_info
         .expected_path
         .as_ref()
@@ -320,12 +320,13 @@ pub fn handle_switch_output(
     let display_path_for_hooks = match result {
         SwitchResult::AlreadyAt(_) => {
             // Already in target directory — no shell warning needed
-            super::print(info_message(cformat!(
-                "Already on worktree for <bold>{branch}</> @ <bold>{path_display}</>"
-            )))?;
+            // Show path mismatch warning first - discovered while checking current state
             if let Some(warning) = branch_worktree_mismatch_warning {
                 super::print(warning)?;
             }
+            super::print(info_message(cformat!(
+                "Already on worktree for <bold>{branch}</> @ <bold>{path_display}</>"
+            )))?;
             // User is already there - no path annotation needed
             None
         }
@@ -354,14 +355,15 @@ pub fn handle_switch_output(
                 Some(path.clone())
             } else {
                 // Shell integration active — user actually switched
+                // Show path mismatch warning first - discovered while evaluating the switch
+                if let Some(warning) = branch_worktree_mismatch_warning {
+                    super::print(warning)?;
+                }
                 super::print(info_message(format_switch_message(
                     branch, path, false, // worktree_created
                     false, // created_branch
                     None, None,
                 )))?;
-                if let Some(warning) = branch_worktree_mismatch_warning {
-                    super::print(warning)?;
-                }
                 // cd will happen - no path annotation needed
                 None
             }
@@ -677,6 +679,11 @@ fn handle_removed_worktree_output(
         // - Branch kept (any reason): "worktree in background" + hint (if relevant)
         let branch_was_integrated = pre_computed_integration.is_some();
 
+        // Show path mismatch warning first - we discovered this while evaluating the removal
+        if let Some(expected) = expected_path {
+            super::print(format_path_mismatch_warning(branch_name, expected))?;
+        }
+
         let action = if should_delete_branch {
             // Branch will be deleted (integrated or force-deleted)
             cformat!(
@@ -687,11 +694,6 @@ fn handle_removed_worktree_output(
             cformat!("<cyan>◎ Removing <bold>{branch_name}</> worktree in background</>")
         };
         super::print(FormattedMessage::new(action))?;
-
-        // Show path mismatch warning if the worktree is at an unexpected location
-        if let Some(expected) = expected_path {
-            super::print(format_path_mismatch_warning(branch_name, expected))?;
-        }
 
         // Show hints for branch status
         if !should_delete_branch {
@@ -786,6 +788,11 @@ fn handle_removed_worktree_output(
         // Message structure parallel to background mode:
         // - Branch deleted (integrated/force): "worktree & branch (reason)"
         // - Branch kept (any reason): "worktree" + hint (if relevant)
+        // Show path mismatch warning first - we discovered this while evaluating the removal
+        if let Some(expected) = expected_path {
+            super::print(format_path_mismatch_warning(branch_name, expected))?;
+        }
+
         let msg = if branch_deleted {
             let flag_note = get_flag_note(deletion_mode, &outcome, effective_target.as_deref());
             let flag_text = &flag_note.text;
@@ -798,11 +805,6 @@ fn handle_removed_worktree_output(
             cformat!("<green>✓ Removed <bold>{branch_name}</> worktree</>")
         };
         super::print(FormattedMessage::new(msg))?;
-
-        // Show path mismatch warning if the worktree was at an unexpected location
-        if let Some(expected) = expected_path {
-            super::print(format_path_mismatch_warning(branch_name, expected))?;
-        }
 
         // Show hints for branch status
         if !branch_deleted {

--- a/tests/snapshots/integration__integration_tests__remove__remove_path_mismatch_warning.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_path_mismatch_warning.snap
@@ -32,5 +32,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
 [33m▲[39m [33mBranch-worktree mismatch; expected [1mfeature[22m @ [1m_REPO_.feature[22m [31m⚑[39m[39m
+[36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m

--- a/tests/snapshots/integration__integration_tests__remove__remove_path_mismatch_warning_foreground.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_path_mismatch_warning_foreground.snap
@@ -34,5 +34,5 @@ exit_code: 0
 
 ----- stderr -----
 [36m◎[39m [36mRemoving [1mfeature-fg[22m worktree...[39m
-[32m✓ Removed [1mfeature-fg[22m worktree & branch (same commit as [1mmain[22m,[39m [2m_[22m[32m)[39m
 [33m▲[39m [33mBranch-worktree mismatch; expected [1mfeature-fg[22m @ [1m_REPO_.feature-fg[22m [31m⚑[39m[39m
+[32m✓ Removed [1mfeature-fg[22m worktree & branch (same commit as [1mmain[22m,[39m [2m_[22m[32m)[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_already_at_branch_worktree_mismatch.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_already_at_branch_worktree_mismatch.snap
@@ -21,6 +21,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -31,6 +32,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m Already on worktree for [1mfeature-already[22m @ [1m[PROJECT_ID][22m
 [33m▲[39m [33mBranch-worktree mismatch; expected [1mfeature-already[22m @ [1m_REPO_.feature-already[22m [31m⚑[39m[39m
+[2m○[22m Already on worktree for [1mfeature-already[22m @ [1m[PROJECT_ID][22m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_branch_worktree_mismatch_shows_hint.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_branch_worktree_mismatch_shows_hint.snap
@@ -21,6 +21,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_DIRECTIVE_FILE: "[DIRECTIVE_FILE]"
@@ -32,5 +33,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m Switched to worktree for [1mfeature[22m @ [1m[PROJECT_ID][22m
 [33m▲[39m [33mBranch-worktree mismatch; expected [1mfeature[22m @ [1m_REPO_.feature[22m [31m⚑[39m[39m
+[2m○[22m Switched to worktree for [1mfeature[22m @ [1m[PROJECT_ID][22m


### PR DESCRIPTION
## Summary

- Warnings about state discovered during evaluation now appear **before** the action message that follows from that discovery
- Previously, warnings like "Branch-worktree mismatch" appeared after "Removing worktree..." which made them feel like afterthoughts
- Added "Warning Ordering" guideline to cli-output-formatting.md documenting this principle

**Affected commands:**
- `wt switch` (AlreadyAt, Existing with shell integration)
- `wt remove` (background and synchronous modes)

**Before:**
```
◎ Removing feature worktree & branch in background (same commit as main, _)
▲ Branch-worktree mismatch; expected feature @ ~/workspace/project.feature ⚑
```

**After:**
```
▲ Branch-worktree mismatch; expected feature @ ~/workspace/project.feature ⚑
◎ Removing feature worktree & branch in background (same commit as main, _)
```

## Test plan

- [x] All integration tests pass
- [x] Snapshot tests updated to reflect new ordering
- [x] Searched codebase for other out-of-order warnings (none found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)