### PR TITLE
feat(hooks): add base and base_worktree_path template variables

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/hook-types-reference.md
+++ b/.claude-plugin/skills/worktrunk/reference/hook-types-reference.md
@@ -6,16 +6,17 @@ Detailed behavior and use cases for all seven Worktrunk hook types.
 
 | Hook | When | Blocking? | Fail-Fast? | Variables | Execution |
 |------|------|-----------|------------|-----------|-----------|
-| `post-create` | After creating worktree | Yes | No | Basic | Sequential |
-| `post-start` | After creating worktree | No (background) | No | Basic | Parallel |
-| `post-switch` | After every switch | No (background) | No | Basic | Parallel |
+| `post-create` | After creating worktree | Yes | No | Basic + Base | Sequential |
+| `post-start` | After creating worktree | No (background) | No | Basic + Base | Parallel |
+| `post-switch` | After every switch | No (background) | No | Basic + Base | Parallel |
 | `pre-commit` | Before committing during merge | Yes | Yes | Basic + Merge | Sequential |
 | `pre-merge` | Before merging to target | Yes | Yes | Basic + Merge | Sequential |
 | `post-merge` | After successful merge | Yes | No | Basic + Merge | Sequential |
 | `pre-remove` | Before worktree removed | Yes | Yes | Basic | Sequential |
 
 **Basic variables**: `{{ repo }}`, `{{ repo_path }}`, `{{ branch }}`, `{{ worktree_name }}`, `{{ worktree_path }}`, `{{ main_worktree_path }}`, `{{ default_branch }}`, `{{ commit }}`, `{{ short_commit }}`, `{{ remote }}`, `{{ remote_url }}`, `{{ upstream }}`
-**Merge variables**: Basic + `{{ target }}`
+**Base variables**: `{{ base }}`, `{{ base_worktree_path }}`
+**Merge variables**: `{{ target }}`
 **Filters**: `{{ branch | sanitize }}` (replace `/` `\` with `-`), `{{ branch | hash_port }}` (port 10000-19999)
 
 ## Detailed Behavior
@@ -263,6 +264,18 @@ Available:
 - `{{ remote }}` - Primary remote name (e.g., "origin")
 - `{{ remote_url }}` - Remote URL (e.g., "git@github.com:user/repo.git")
 - `{{ upstream }}` - Upstream tracking branch (e.g., "origin/feature")
+
+### Base Variables (Creation Hooks)
+
+```toml
+post-create = "echo 'Created from {{ base }} at {{ base_worktree_path }}'"
+```
+
+Available in: `post-create`, `post-start`, `post-switch` — only when creating a new worktree (not when switching to existing worktrees).
+
+Additional variables:
+- `{{ base }}` - Base branch that new worktree was created from (e.g., "main")
+- `{{ base_worktree_path }}` - Absolute path to base branch worktree (empty if base has no worktree)
 
 ### Merge Variables (Merge Hooks Only)
 

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -153,6 +153,8 @@ Hooks can use template variables that expand at runtime:
 | `{{ remote_url }}` | git@github.com:user/repo.git | Remote URL |
 | `{{ upstream }}` | origin/feature | Upstream tracking branch |
 | `{{ target }}` | main | Target branch (merge hooks only) |
+| `{{ base }}` | main | Base branch (creation hooks only) |
+| `{{ base_worktree_path }}` | /path/to/myproject | Base branch worktree (creation hooks only) |
 
 See [Designing effective hooks](#designing-effective-hooks) for `main_worktree_path` patterns.
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -2098,6 +2098,8 @@ Hooks can use template variables that expand at runtime:
 | `{{ remote_url }}` | git@github.com:user/repo.git | Remote URL |
 | `{{ upstream }}` | origin/feature | Upstream tracking branch |
 | `{{ target }}` | main | Target branch (merge hooks only) |
+| `{{ base }}` | main | Base branch (creation hooks only) |
+| `{{ base_worktree_path }}` | /path/to/myproject | Base branch worktree (creation hooks only) |
 
 See [Designing effective hooks](#designing-effective-hooks) for `main_worktree_path` patterns.
 

--- a/src/commands/command_executor.rs
+++ b/src/commands/command_executor.rs
@@ -82,9 +82,6 @@ pub fn build_hook_context(
     map.insert("repo_path".into(), repo_path.clone());
     map.insert("worktree_path".into(), worktree.clone());
 
-    // TODO: Add `base` (branch) and `base_worktree_path` for post-create/post-switch hooks.
-    // Requires tracking source worktree before switch and passing via extra_vars.
-
     // Deprecated aliases (kept for backward compatibility)
     map.insert("main_worktree".into(), repo_name.into());
     map.insert("repo_root".into(), repo_path);

--- a/src/output/global.rs
+++ b/src/output/global.rs
@@ -337,11 +337,11 @@ pub fn pre_hook_display_path(hooks_run_at: &std::path::Path) -> Option<&std::pat
 /// # Examples
 ///
 /// ```ignore
-/// // In post-create, post-switch, post-merge hooks:
-/// ctx.spawn_post_start_commands(post_hook_display_path(&destination))?;
+/// // In post-create, post-start, post-switch hooks (creation path):
+/// ctx.spawn_post_start_commands(&extra_vars, post_hook_display_path(&destination))?;
 ///
 /// // After remove when switching to main:
-/// ctx.spawn_post_switch_commands(post_hook_display_path(main_path))?;
+/// ctx.spawn_post_switch_commands(&[], post_hook_display_path(main_path))?;
 /// ```
 pub fn post_hook_display_path(destination: &std::path::Path) -> Option<&std::path::Path> {
     if is_shell_integration_active() {

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -551,7 +551,8 @@ fn spawn_post_switch_after_remove(
         &repo_root,
         false, // force=false for CommandContext
     );
-    ctx.spawn_post_switch_commands(super::post_hook_display_path(main_path))
+    // No base context for remove-triggered switch (we're returning to main, not creating)
+    ctx.spawn_post_switch_commands(&[], super::post_hook_display_path(main_path))
 }
 
 /// Handle output for RemovedWorktree removal

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_base_variables.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_base_variables.snap
@@ -1,0 +1,45 @@
+---
+source: tests/integration_tests/post_start_commands.rs
+info:
+  program: wt
+  args:
+    - switch
+    - "--create"
+    - feature
+    - "--base"
+    - main
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "150"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mRunning post-create [1mproject:base[22m @ [1m_REPO_.feature[22m:[39m
+[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Base: main'[0m[2m [0m[2m[36m>[0m[2m base_info.txt
+[0m[36m◎[39m [36mRunning post-create [1mproject:base_path[22m @ [1m_REPO_.feature[22m:[39m
+[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Base Path: _REPO_'[0m[2m [0m[2m[36m>>[0m[2m base_info.txt
+[0m[32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
+[2m↳[22m [2mCustomize worktree locations: [90mwt config create[39m[22m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
+[2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m


### PR DESCRIPTION
## Summary

- Add two new template variables for creation hooks (post-create, post-start, post-switch when creating)
- `{{ base }}` — the branch the new worktree was created from (e.g., "main")
- `{{ base_worktree_path }}` — absolute POSIX path to the base branch's worktree

## Use case

Copy files from the base worktree when creating new worktrees:

```toml
[post-create]
copy-env = "cp {{ base_worktree_path }}/.env {{ worktree_path }}/.env"
```

## Implementation

- Add `base_worktree_path` field to `SwitchResult::Created` to compute once and reuse
- Pass through `extra_vars` pattern (same as `target` for merge hooks)
- Variables only available on creation, not existing worktree switches

Closes the TODO at `src/commands/command_executor.rs:85`.

## Test plan

- [x] Added `test_post_create_base_variables` integration test
- [x] All 724 integration tests pass
- [x] Codex review completed with feedback addressed

🤖 Generated with [Claude Code](https://claude.com/claude-code)