### PR TITLE
feat(select): add Tab 4 for upstream diff preview

### DIFF
--- a/docs/content/select.md
+++ b/docs/content/select.md
@@ -32,6 +32,7 @@ Toggle between views with number keys:
 1. **HEAD±** — Diff of uncommitted changes
 2. **log** — Recent commits; commits already on the default branch have dimmed hashes
 3. **main…±** — Diff of changes since the merge-base with the default branch
+4. **remote⇅** — Diff vs upstream tracking branch (ahead/behind)
 
 ## Keybindings
 
@@ -41,7 +42,7 @@ Toggle between views with number keys:
 | `Enter` | Switch to selected worktree |
 | `Esc` | Cancel |
 | (type) | Filter worktrees |
-| `1`/`2`/`3` | Switch preview tab |
+| `1`/`2`/`3`/`4` | Switch preview tab |
 | `Alt-p` | Toggle preview panel |
 | `Ctrl-u`/`Ctrl-d` | Scroll preview up/down |
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1883,6 +1883,7 @@ Toggle between views with number keys:
 1. **HEAD±** — Diff of uncommitted changes
 2. **log** — Recent commits; commits already on the default branch have dimmed hashes
 3. **main…±** — Diff of changes since the merge-base with the default branch
+4. **remote⇅** — Diff vs upstream tracking branch (ahead/behind)
 
 ## Keybindings
 
@@ -1892,7 +1893,7 @@ Toggle between views with number keys:
 | `Enter` | Switch to selected worktree |
 | `Esc` | Cancel |
 | (type) | Filter worktrees |
-| `1`/`2`/`3` | Switch preview tab |
+| `1`/`2`/`3`/`4` | Switch preview tab |
 | `Alt-p` | Toggle preview panel |
 | `Ctrl-u`/`Ctrl-d` | Scroll preview up/down |
 


### PR DESCRIPTION
## Summary
- Add "remote⇅" tab to `wt select` showing ahead/behind diff vs upstream tracking branch
- Aligns with `wt list`'s "Remote⇅" column
- Shell-escape state path in skim bindings for security

## Test plan
- [x] All 22 select tests pass
- [x] All 402 lib/bin tests pass
- [x] All 723 integration tests pass
- [x] Pre-commit lints pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)