### PR TITLE
docs: add warning placement framework and validate config in wt config show

### DIFF
--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -366,6 +366,61 @@ fn test_config_show_warns_unknown_user_keys(mut repo: TestRepo, temp_home: TempD
 }
 
 #[rstest]
+fn test_config_show_invalid_user_toml(mut repo: TestRepo, temp_home: TempDir) {
+    repo.setup_mock_ci_tools_unauthenticated();
+
+    // Create global config with invalid TOML syntax
+    let global_config_dir = temp_home.path().join(".config").join("worktrunk");
+    fs::create_dir_all(&global_config_dir).unwrap();
+    fs::write(
+        global_config_dir.join("config.toml"),
+        "this is not valid toml {{{",
+    )
+    .unwrap();
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        repo.configure_mock_commands(&mut cmd);
+        cmd.arg("config").arg("show").current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
+#[rstest]
+fn test_config_show_invalid_project_toml(mut repo: TestRepo, temp_home: TempDir) {
+    repo.setup_mock_ci_tools_unauthenticated();
+
+    // Create valid global config
+    let global_config_dir = temp_home.path().join(".config").join("worktrunk");
+    fs::create_dir_all(&global_config_dir).unwrap();
+    fs::write(
+        global_config_dir.join("config.toml"),
+        "worktree-path = \"../{{ repo }}.{{ branch }}\"",
+    )
+    .unwrap();
+
+    // Create project config with invalid TOML syntax
+    let config_dir = repo.root_path().join(".config");
+    fs::create_dir_all(&config_dir).unwrap();
+    fs::write(config_dir.join("wt.toml"), "invalid = [unclosed bracket").unwrap();
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        repo.configure_mock_commands(&mut cmd);
+        cmd.arg("config").arg("show").current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
+#[rstest]
 fn test_config_show_full_not_configured(mut repo: TestRepo, temp_home: TempDir) {
     // Setup mock gh/glab for deterministic BINARIES output
     repo.setup_mock_ci_tools_unauthenticated();

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_project_toml.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_project_toml.snap
@@ -1,0 +1,57 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - show
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "150"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+
+[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[31m✗[39m [31mInvalid config[39m
+[107m [0m TOML parse error at line 1, column 28
+[107m [0m   |
+[107m [0m 1 | invalid = [unclosed bracket
+[107m [0m   |                            ^
+[107m [0m unclosed array, expected `]`
+[107m [0m invalid = [unclosed bracket
+
+[36mSHELL INTEGRATION[39m
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+
+[2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
+[2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m
+[2m○[22m [2mSkipped fish; ~/.config/fish/conf.d not found[22m
+
+[36mOTHER[39m  wt [VERSION]
+[2m↳[22m [2mClaude Code plugin not installed ([1mclaude[22m not found)[22m
+[2m○[22m Hyperlinks: [1minactive[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_user_toml.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_user_toml.snap
@@ -1,0 +1,57 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - show
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "150"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[31m✗[39m [31mInvalid config[39m
+[107m [0m TOML parse error at line 1, column 6
+[107m [0m   |
+[107m [0m 1 | this is not valid toml {{{
+[107m [0m   |      ^
+[107m [0m key with no value, expected `=`
+[107m [0m this is not valid toml {{{
+
+[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[2m↳[22m [2mNot found[22m
+
+[36mSHELL INTEGRATION[39m
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+
+[2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
+[2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m
+[2m○[22m [2mSkipped fish; ~/.config/fish/conf.d not found[22m
+
+[36mOTHER[39m  wt [VERSION]
+[2m↳[22m [2mClaude Code plugin not installed ([1mclaude[22m not found)[22m
+[2m○[22m Hyperlinks: [1minactive[22m


### PR DESCRIPTION
## Summary

- Add documentation distinguishing when to use inline warnings vs `wt config show` vs `log::warn!`
- `wt config show` now validates TOML syntax and schema, displaying parse errors

## Changes

**Documentation** (`.claude/rules/cli-output-formatting.md`):
- Decision tree for warning placement based on issue characteristics
- Temporary/immediate impact → inline warning
- Persists until user action → `wt config show`
- Not user-fixable → `log::warn!`

**Code** (`src/commands/config.rs`):
- Validate config syntax + schema in `wt config show`
- Error details rendered via `format_with_gutter()` to avoid markup interpretation
- Message: "Invalid config" (covers both syntax and schema errors)

## Test plan

- [x] `test_config_show_invalid_user_toml` - verifies error for invalid user config
- [x] `test_config_show_invalid_project_toml` - verifies error for invalid project config
- [x] All existing config_show tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)