### PR TITLE
feat(branch-resolution): implement fuzzy matching for worktree switching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1494,6 +1494,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5438dd2b2ff4c6df6e1ce22d825ed2fa93ee2922235cc45186991717f0a892d"
 
 [[package]]
+name = "nucleo-matcher"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf33f538733d1a5a3494b836ba913207f14d9d4a1d3cd67030c5061bdd2cac85"
+dependencies = [
+ "memchr",
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3228,6 +3238,7 @@ dependencies = [
  "minijinja",
  "nix 0.30.1",
  "normalize-path",
+ "nucleo-matcher",
  "once_cell",
  "osc8",
  "pathdiff",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ urlencoding = "2.1"
 regex = "1.12"
 ignore = "0.4"
 reflink-copy = "0.1"
+nucleo-matcher = "0.3"
 
 [target.'cfg(unix)'.dependencies]
 skim = "0.20"

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use worktrunk::HookType;
 use worktrunk::config::ProjectConfig;
-use worktrunk::git::Repository;
+use worktrunk::git::{Repository, WorktreeResolutionMode};
 use worktrunk::styling::info_message;
 
 use super::command_approval::approve_command_batch;
@@ -96,7 +96,8 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
     let squash_enabled = squash && commit;
 
     // Get target branch (default to default branch if not provided)
-    let target_branch = repo.resolve_target_branch(target)?;
+    // Use strict mode - target branch must exist exactly
+    let target_branch = repo.resolve_target_branch(target, WorktreeResolutionMode::Strict)?;
     // Worktree for target is optional: if present we use it for safety checks and as destination.
     let target_worktree_path = repo.worktree_for_branch(&target_branch)?;
 

--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -13,7 +13,7 @@ use anyhow::Context;
 use color_print::cformat;
 use worktrunk::HookType;
 use worktrunk::config::WorktrunkConfig;
-use worktrunk::git::Repository;
+use worktrunk::git::{Repository, WorktreeResolutionMode};
 use worktrunk::styling::{
     format_with_gutter, hint_message, info_message, progress_message, success_message,
 };
@@ -103,7 +103,7 @@ pub fn handle_squash(
     let generator = CommitGenerator::new(&env.config.commit_generation);
 
     // Get target branch (default to default branch if not provided)
-    let target_branch = repo.resolve_target_branch(target)?;
+    let target_branch = repo.resolve_target_branch(target, WorktreeResolutionMode::Strict)?;
 
     // Auto-stage changes before running pre-commit hooks so both beta and merge paths behave identically
     match stage_mode {
@@ -296,7 +296,7 @@ pub fn step_show_squash_prompt(
     let repo = Repository::current();
 
     // Get target branch (default to default branch if not provided)
-    let target_branch = repo.resolve_target_branch(target)?;
+    let target_branch = repo.resolve_target_branch(target, WorktreeResolutionMode::Strict)?;
 
     // Get current branch
     let current_branch = repo.current_branch()?.unwrap_or("HEAD");
@@ -342,7 +342,7 @@ pub fn handle_rebase(target: Option<&str>) -> anyhow::Result<RebaseResult> {
     let repo = Repository::current();
 
     // Get target branch (default to default branch if not provided)
-    let target_branch = repo.resolve_target_branch(target)?;
+    let target_branch = repo.resolve_target_branch(target, WorktreeResolutionMode::Strict)?;
 
     // Check if already up-to-date (linear extension of target, no merge commits)
     if repo.is_rebased_onto(&target_branch)? {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -41,7 +41,7 @@ pub use error::{
     exit_code,
 };
 pub use parse::{parse_porcelain_z, parse_untracked_files};
-pub use repository::{Repository, ResolvedWorktree, set_base_path};
+pub use repository::{Repository, ResolvedWorktree, WorktreeResolutionMode, set_base_path};
 pub use url::{GitRemoteUrl, parse_owner_repo, parse_remote_host, parse_remote_owner};
 /// Why branch content is considered integrated into the target branch.
 ///

--- a/src/git/repository/tests.rs
+++ b/src/git/repository/tests.rs
@@ -268,7 +268,7 @@ fn test_parse_remote_default_branch_branch_with_slash() {
     assert_eq!(branch, "feature/new-ui");
 }
 
-use super::ResolvedWorktree;
+use super::{Repository, ResolvedWorktree};
 
 #[test]
 fn test_resolved_worktree_debug() {
@@ -403,4 +403,73 @@ fn test_default_branch_name_display() {
             .unwrap();
         assert_eq!(branch, expected);
     }
+}
+
+#[test]
+fn test_fuzzy_match_exact_match() {
+    // Exact match should return the match
+    let branches = vec![
+        "main".to_string(),
+        "online-mods".to_string(),
+        "feature".to_string(),
+    ];
+    let result = Repository::fuzzy_match_branch("online-mods", &branches);
+    assert_eq!(result, Some("online-mods"));
+}
+
+#[test]
+fn test_fuzzy_match_prefix() {
+    // Prefix match: "onli" should match "online-mods"
+    let branches = vec![
+        "main".to_string(),
+        "online-mods".to_string(),
+        "online-config".to_string(),
+        "feature".to_string(),
+    ];
+    let result = Repository::fuzzy_match_branch("onli", &branches);
+    // Should match one of the online branches
+    assert!(result == Some("online-mods") || result == Some("online-config"));
+}
+
+#[test]
+fn test_fuzzy_match_subsequence() {
+    // Subsequence match: "f-b" should match "feature-branch"
+    let branches = vec![
+        "main".to_string(),
+        "feature-branch".to_string(),
+        "feature-build".to_string(),
+    ];
+    let result = Repository::fuzzy_match_branch("f-b", &branches);
+    assert!(result.is_some());
+    let matched = result.unwrap();
+    // Should match one of the feature branches
+    assert!(matched == "feature-build" || matched == "feature-branch");
+}
+
+#[test]
+fn test_fuzzy_match_no_match() {
+    // No match should return None
+    let branches = vec![
+        "main".to_string(),
+        "online-mods".to_string(),
+        "feature".to_string(),
+    ];
+    let result = Repository::fuzzy_match_branch("xyz", &branches);
+    assert_eq!(result, None);
+}
+
+#[test]
+fn test_fuzzy_match_empty_input() {
+    // Empty input should return None
+    let branches = vec!["main".to_string(), "online-mods".to_string()];
+    let result = Repository::fuzzy_match_branch("", &branches);
+    assert_eq!(result, None);
+}
+
+#[test]
+fn test_fuzzy_match_empty_branches() {
+    // Empty branches should return None
+    let branches = vec![];
+    let result = Repository::fuzzy_match_branch("onli", &branches);
+    assert_eq!(result, None);
 }


### PR DESCRIPTION
Motivation:
- Users frequently abbreviate branch names when switching to existing worktrees (e.g., 'wt switch feat' for 'feature/long-branch-name')
- Current strict matching requires exact branch names, reducing usability
- Need to balance convenience with safety for operations like branch creation

Changes:
- Add WorktreeResolutionMode enum to control fuzzy vs strict matching behavior
- Implement Smith-Waterman fuzzy matching using nucleo-matcher library
- Update Repository::resolve_worktree_name() and resolve_target_branch() to accept resolution mode parameter
- Use fuzzy mode only for 'wt switch' without --create flag
- Use strict mode for:
  - 'wt switch -c' (branch creation should require exact names)
  - All merge/rebase/push operations (must target exact branches)
  - Explicit --base arguments (always require exact matches)
- Add comprehensive unit tests for fuzzy matching behavior
- Add implementation notes documenting the design and behavior

Benefits:
- Improved UX for switching to existing worktrees with abbreviated names
- Prevents accidental branch creation with misspelled names
- Consistent strict matching for merge/rebase targets
- Backward compatible - exact matches still work as before