### PR TITLE
docs: emphasize .worktreeinclude in copy-ignored section

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/tips-patterns.md
+++ b/.claude-plugin/skills/worktrunk/reference/tips-patterns.md
@@ -14,7 +14,7 @@ wsc feature -- 'Fix GH #322'          # Runs `claude 'Fix GH #322'`
 
 ## Eliminate cold starts
 
-Use [`wt step copy-ignored`](https://worktrunk.dev/step/#wt-step-copy-ignored) in a `post-create` hook to copy gitignored files (caches, dependencies) between worktrees:
+Use [`wt step copy-ignored`](https://worktrunk.dev/step/#wt-step-copy-ignored) in a `post-create` hook to copy gitignored files listed in `.worktreeinclude` (caches, dependencies) between worktrees:
 
 ```toml
 [post-create]
@@ -22,7 +22,7 @@ copy = "wt step copy-ignored"
 install = "npm ci"
 ```
 
-Create a `.worktreeinclude` file listing what to copy (uses gitignore syntax):
+`.worktreeinclude` uses gitignore syntax:
 
 ```gitignore
 # .worktreeinclude

--- a/docs/content/tips-patterns.md
+++ b/docs/content/tips-patterns.md
@@ -20,7 +20,7 @@ wsc feature -- 'Fix GH #322'          # Runs `claude 'Fix GH #322'`
 
 ## Eliminate cold starts
 
-Use [`wt step copy-ignored`](@/step.md#wt-step-copy-ignored) in a `post-create` hook to copy gitignored files (caches, dependencies) between worktrees:
+Use [`wt step copy-ignored`](@/step.md#wt-step-copy-ignored) in a `post-create` hook to copy gitignored files listed in `.worktreeinclude` (caches, dependencies) between worktrees:
 
 ```toml
 [post-create]
@@ -28,7 +28,7 @@ copy = "wt step copy-ignored"
 install = "npm ci"
 ```
 
-Create a `.worktreeinclude` file listing what to copy (uses gitignore syntax):
+`.worktreeinclude` uses gitignore syntax:
 
 ```gitignore
 # .worktreeinclude


### PR DESCRIPTION
## Summary

- Front-load `.worktreeinclude` in the first sentence of "Eliminate cold starts" section
- Simplify second sentence since the config file is now introduced earlier

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> _This was written by Claude Code on behalf of max-sixty_