### PR TITLE
feat(select): add 500ms timeout for git commands to improve TUI responsiveness

### DIFF
--- a/src/commands/list/mod.rs
+++ b/src/commands/list/mod.rs
@@ -186,6 +186,7 @@ pub fn handle_list(
         show_progress,
         render_table,
         config,
+        None, // No timeout for wt list
     )?;
 
     let Some(ListData { items, .. }) = list_data else {

--- a/src/commands/select.rs
+++ b/src/commands/select.rs
@@ -871,6 +871,12 @@ pub fn handle_select() -> anyhow::Result<()> {
     .into_iter()
     .collect();
 
+    // Use 500ms timeout for git commands to show TUI faster on large repos.
+    // Typical slow operations: merge-tree ~400-1800ms, rev-list ~200-600ms.
+    // 500ms allows most operations to complete while cutting off tail latency.
+    // Operations that timeout fail silently (data not shown), but TUI stays responsive.
+    let command_timeout = Some(std::time::Duration::from_millis(500));
+
     let Some(list_data) = collect::collect(
         &repo,
         true,  // show_branches (include branches without worktrees)
@@ -879,6 +885,7 @@ pub fn handle_select() -> anyhow::Result<()> {
         false, // show_progress (no progress bars)
         false, // render_table (select renders its own UI)
         &config,
+        command_timeout,
     )?
     else {
         return Ok(());


### PR DESCRIPTION
## Summary

- Add thread-local command timeout to `shell_exec::run()` for killing slow git commands
- `wt select` uses 500ms timeout to show TUI faster on large repos with many branches
- `wt list` continues to wait for all data (no timeout)

Addresses performance issues on repos with 100+ branches where git operations (merge-tree, rev-list, diff) can take 400-1800ms each.

**Architecture**: Thread-local timeout set per-worker in Rayon's thread pool. Repository and TaskContext stay clean - timeout is purely a runner concern.

## Test plan

- [x] Unit tests for timeout behavior (`test_run_with_timeout_*`)
- [x] All existing tests pass (757 integration, 413 unit)
- [ ] Manual test on large repo with many branches

Closes #461

🤖 Generated with [Claude Code](https://claude.ai/code)