### PR TITLE
Add benchmark for GH #461: branches at different history depths

### DIFF
--- a/benches/CLAUDE.md
+++ b/benches/CLAUDE.md
@@ -11,8 +11,8 @@ cargo bench --bench list -- --skip cold --skip real --skip divergent_branches
 # Run specific group
 cargo bench --bench list many_branches
 
-# GH #461 scenario (200 branches with divergence)
-cargo bench --bench list divergent_branches
+# GH #461 scenario (200 branches on rust-lang/rust)
+cargo bench --bench list real_repo_many_branches
 
 # All benchmarks (~1 hour)
 cargo bench --bench list


### PR DESCRIPTION
## Summary

- Adds `real_repo_many_branches` benchmark that reproduces the ~15s `wt select` delay reported in #461
- Key finding: slowdown comes from **branch divergence depth** (how far back branches diverge in history), not from commits per branch
- Uses 50 branches at different historical points on rust-lang/rust (~14s per iteration)

Scaling discovered:
| Branches | Time |
|----------|------|
| 20 at different depths | ~5s |
| 50 at different depths | ~11s |
| 100 at different depths | ~24s |
| 200 at different depths | >30s (times out) |

## Test plan

- [x] Benchmark runs successfully: `cargo bench --bench list real_repo_many_branches`
- [x] Pre-commit checks pass
- [x] Benchmark timing (~14s) matches #461 report (~15s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)