### PR TITLE
fix(ci): use bot token so Claude commits trigger CI workflows

### DIFF
--- a/.github/workflows/claude-ci-fix.yaml
+++ b/.github/workflows/claude-ci-fix.yaml
@@ -31,6 +31,8 @@ jobs:
           ref: main
           fetch-depth: 0
           fetch-tags: true
+          # Use bot token so pushed commits trigger CI workflows
+          token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
 
       - name: 🔧 Configure git for Claude
         run: |
@@ -63,6 +65,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Use bot token so pushed commits trigger CI workflows
+          github_token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
           additional_permissions: |
             actions: read
 

--- a/.github/workflows/claude-mention.yaml
+++ b/.github/workflows/claude-mention.yaml
@@ -36,6 +36,8 @@ jobs:
             github.event.issue.number) || github.ref }}
           fetch-depth: 0 # Get more history for better context
           fetch-tags: true
+          # Use bot token so pushed commits trigger CI workflows
+          token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
 
       - name: 🔧 Configure git for Claude
         run: |
@@ -68,6 +70,8 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          # Use bot token so pushed commits trigger CI workflows
+          github_token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |


### PR DESCRIPTION
## Summary

- Add `WORKTRUNK_BOT_TOKEN` to checkout steps so git operations use the bot token
- Add `github_token` parameter to `claude-code-action` so Claude's GitHub API calls use it

This fixes the issue where Claude's pushed commits don't trigger CI workflows. `GITHUB_TOKEN` is intentionally blocked from triggering workflows to prevent infinite loops, but PATs and bot tokens don't have this restriction.

## Test plan

- [ ] Verify workflows still run correctly
- [ ] Test that Claude commits on a PR trigger CI (can test after merge on PR #486)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>