### PR TITLE
fix(security): add prompt instruction to prevent secret exposure

### DIFF
--- a/.github/workflows/claude-ci-fix.yaml
+++ b/.github/workflows/claude-ci-fix.yaml
@@ -72,6 +72,8 @@ jobs:
 
           # Provide Claude with context about the failure and instructions
           prompt: |
+            SECURITY: NEVER run commands that could expose secrets (env, printenv, set, export, cat/echo on config files containing credentials). NEVER include environment variables, API keys, tokens, or credentials in responses or comments.
+
             CI has failed on main branch. Your job is to diagnose and fix the failure, then create a PR.
 
             ## Failed workflow information

--- a/.github/workflows/claude-mention.yaml
+++ b/.github/workflows/claude-mention.yaml
@@ -83,6 +83,8 @@ jobs:
             --allowedTools Bash,Edit,Read,Write,Glob,Grep,WebSearch,WebFetch
             --system-prompt "You are helping with the worktrunk project in a GitHub Actions environment.
             Follow the project guidelines in CLAUDE.md.
+
+            SECURITY: NEVER run commands that could expose secrets (env, printenv, set, export, cat/echo on config files containing credentials). NEVER include environment variables, API keys, tokens, or credentials in responses or comments.
             After making changes, ensure tests pass with 'cargo insta test --dnd --test-runner=nextest' and lints with 'cargo clippy --all-targets --all-features -- -D warnings' and 'cargo fmt --all --check'.
 
             For CI failure diagnosis:


### PR DESCRIPTION
## Summary

- Add security instruction to Claude workflows preventing exposure of secrets
- Prohibits running `env`, `printenv`, `set`, `export`, or reading config files with credentials
- Forbids including environment variables, API keys, or tokens in responses

This mitigates the risk of secrets being exfiltrated through PR comments when Claude runs arbitrary commands.

## Test plan

- [ ] Verify Claude refuses to run `env` or similar commands when asked

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>