### PR TITLE
fix(completion): exclude deprecated args from tab completions

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -11,6 +11,11 @@ use crate::display::format_relative_time_short;
 use worktrunk::config::{ProjectConfig, WorktrunkConfig};
 use worktrunk::git::{BranchCategory, HookType, Repository};
 
+/// Deprecated args that should never appear in completions.
+/// These are hidden from help AND completions, unlike other hidden args
+/// that appear when completing `--`.
+const DEPRECATED_ARGS: &[&str] = &["--no-background"];
+
 /// Handle shell-initiated completion requests via `COMPLETE=$SHELL wt`
 pub fn maybe_handle_env_completion() -> bool {
     let Some(shell_name) = std::env::var_os("COMPLETE") else {
@@ -103,6 +108,15 @@ pub fn maybe_handle_env_completion() -> bool {
     } else {
         completions
     };
+
+    // Filter out deprecated args - they should never appear in completions
+    let completions: Vec<_> = completions
+        .into_iter()
+        .filter(|c| {
+            let value = c.get_value().to_string_lossy();
+            !DEPRECATED_ARGS.contains(&value.as_ref())
+        })
+        .collect();
 
     // Write completions in the appropriate format for the shell
     let shell_name = shell_name.to_string_lossy();


### PR DESCRIPTION
## Summary

- Deprecated args like `--no-background` no longer appear in shell completions when typing `--<TAB>`
- Add `DEPRECATED_ARGS` constant and filter completions post-generation
- Add test covering all three commands with `--no-background` (`wt remove`, `wt hook post-start`, `wt hook post-switch`)

## Context

The completion system shows all hidden args when completing `--` (when all candidates are hidden, clap_complete shows them all). This meant deprecated args appeared alongside regular hidden args like `--squash`. Now deprecated args are filtered out while other hidden toggle flags still appear when explicitly requested.

## Test plan

- [x] `cargo test --test integration completion` - all 40 completion tests pass
- [x] New test `test_complete_excludes_deprecated_args` verifies `--no-background` doesn't appear for bash/zsh/fish

> _This was written by Claude Code on behalf of max-sixty_