### PR TITLE
ci: add JUnit XML timing artifacts for test analysis

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -13,6 +13,11 @@
 
 [profile.default]
 slow-timeout = { period = "60s", terminate-after = 1 }
+status-level = "fail"
+success-output = "never"
+
+[profile.default.junit]
+path = "junit.xml"
 
 # The ci_status tests spawn many parallel threads and processes (~30 threads, ~34
 # child processes each). Mark them as "heavy" so nextest limits how many run

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -11,7 +11,7 @@ sync = 'if [ "{{ target }}" = "main" ]; then git pull && git push; fi'
 
 [pre-merge]
 pre-commit = "if [ -n \"$MSYSTEM\" ]; then SKIP=lychee-system pre-commit run --all-files; else pre-commit run --all-files; fi"
-insta = "RUSTFLAGS='-D warnings' NEXTEST_STATUS_LEVEL=fail NEXTEST_SUCCESS_OUTPUT=never NEXTEST_NO_INPUT_HANDLER=1 cargo insta test --test-runner nextest --dnd --check $([ \"$(uname)\" = 'Linux' ] && echo '--unreferenced reject') --features shell-integration-tests"
+insta = "RUSTFLAGS='-D warnings' NEXTEST_NO_INPUT_HANDLER=1 cargo insta test --test-runner nextest --dnd --check $([ \"$(uname)\" = 'Linux' ] && echo '--unreferenced reject') --features shell-integration-tests"
 doctest = "RUSTDOCFLAGS='-Dwarnings' cargo test --doc"
 doc = "RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps"
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -100,6 +100,13 @@ jobs:
     - name: 🧪 Pre-merge hooks
       run: wt hook pre-merge --yes
 
+    - name: 📊 Upload test timing
+      if: always()
+      uses: actions/upload-artifact@v6
+      with:
+        name: junit-${{ matrix.os }}
+        path: target/nextest/default/junit.xml
+
   # Check if Cargo files changed (for conditional jobs below)
   changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

- Move nextest env vars (`NEXTEST_STATUS_LEVEL`, `NEXTEST_SUCCESS_OUTPUT`) into `.config/nextest.toml`
- Add JUnit XML output to capture per-test timing data
- Upload timing artifacts per-OS in CI to diagnose slow Windows tests (~10 min)

## Test plan

- [ ] CI passes on all platforms
- [ ] JUnit artifacts are uploaded for each OS
- [ ] After merge, download artifacts and analyze test timing

> _This was written by Claude Code on behalf of max-sixty_