### PR TITLE
refactor: simplify TaskContext and introduce BranchRef type

### DIFF
--- a/.claude/rules/caching-strategy.md
+++ b/.claude/rules/caching-strategy.md
@@ -31,6 +31,7 @@ shares the cache — all clones see the same cached values.
 - `project_identifier()` — derived from remote URL
 - `primary_remote()` — git config, doesn't change
 - `default_branch()` — from git config or detection, doesn't change
+- `integration_target()` — effective target for integration checks (local default or upstream if ahead)
 - `merge_base()` — keyed by (commit1, commit2) pair
 - `ahead_behind` — keyed by (base_ref, branch_name), populated by `batch_ahead_behind()`
 - `project_config` — loaded from .config/wt.toml

--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -277,13 +277,12 @@ fn render_runtime_info(out: &mut String) -> anyhow::Result<()> {
 /// Run full diagnostic checks (CI tools, commit generation) and render to buffer
 fn render_diagnostics(out: &mut String) -> anyhow::Result<()> {
     use super::list::ci_status::{CiPlatform, CiToolsStatus, get_platform_for_repo};
-    use worktrunk::config::ProjectConfig;
 
     writeln!(out, "{}", format_heading("DIAGNOSTICS", None))?;
 
     // Check CI tool based on detected platform (with config override support)
     let repo = Repository::current()?;
-    let project_config = ProjectConfig::load(&repo, true).ok().flatten();
+    let project_config = repo.load_project_config().ok().flatten();
     let platform_override = project_config.as_ref().and_then(|c| c.ci_platform());
     let platform = get_platform_for_repo(&repo, platform_override);
 

--- a/src/commands/list/ci_status.rs
+++ b/src/commands/list/ci_status.rs
@@ -1156,10 +1156,8 @@ impl PrStatus {
         local_head: &str,
         has_upstream: bool,
     ) -> Option<Self> {
-        use worktrunk::config::ProjectConfig;
-
-        // Load project config for platform override
-        let project_config = ProjectConfig::load(repo, false).ok().flatten();
+        // Load project config for platform override (cached in Repository)
+        let project_config = repo.load_project_config().ok().flatten();
         let platform_override = project_config.as_ref().and_then(|c| c.ci_platform());
 
         // Determine platform (config override or URL detection)

--- a/src/commands/list/model.rs
+++ b/src/commands/list/model.rs
@@ -226,9 +226,9 @@ impl WorktreeData {
         self.prunable.is_some()
     }
 
-    /// Create WorktreeData from a Worktree, with all computed fields set to None.
+    /// Create WorktreeData from a WorktreeInfo, with all computed fields set to None.
     pub(crate) fn from_worktree(
-        wt: &worktrunk::git::Worktree,
+        wt: &worktrunk::git::WorktreeInfo,
         is_main: bool,
         is_current: bool,
         is_previous: bool,

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -208,7 +208,7 @@ pub fn compute_worktree_path(
 /// Note: For hot paths where default_branch and is_bare are already known,
 /// use `is_worktree_at_expected_path_with` to avoid redundant git calls.
 fn is_worktree_at_expected_path(
-    wt: &worktrunk::git::Worktree,
+    wt: &worktrunk::git::WorktreeInfo,
     repo: &Repository,
     config: &WorktrunkConfig,
 ) -> bool {
@@ -233,7 +233,7 @@ fn paths_match(a: &std::path::Path, b: &std::path::Path) -> bool {
 /// Use this when `default_branch` and `is_bare` are already known (e.g., in list command)
 /// to avoid redundant git calls.
 pub fn is_worktree_at_expected_path_with(
-    wt: &worktrunk::git::Worktree,
+    wt: &worktrunk::git::WorktreeInfo,
     repo: &Repository,
     config: &WorktrunkConfig,
     default_branch: &str,
@@ -309,7 +309,7 @@ fn compute_worktree_path_with(
 /// "Consistent" means the worktree path matches `compute_worktree_path(branch)`,
 /// which returns repo root for default branch and templated path for others.
 pub fn worktree_display_name(
-    wt: &worktrunk::git::Worktree,
+    wt: &worktrunk::git::WorktreeInfo,
     repo: &Repository,
     config: &WorktrunkConfig,
 ) -> String {

--- a/src/git/repository/tests.rs
+++ b/src/git/repository/tests.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use super::super::{DefaultBranchName, Worktree, finalize_worktree};
+use super::super::{DefaultBranchName, WorktreeInfo, finalize_worktree};
 
 #[test]
 fn test_parse_worktree_list() {
@@ -14,7 +14,7 @@ branch refs/heads/feature
 
 ";
 
-    let worktrees = Worktree::parse_porcelain_list(output).unwrap();
+    let worktrees = WorktreeInfo::parse_porcelain_list(output).unwrap();
     assert_eq!(worktrees.len(), 2);
 
     assert_eq!(worktrees[0].path, PathBuf::from("/path/to/main"));
@@ -36,7 +36,7 @@ detached
 
 ";
 
-    let worktrees = Worktree::parse_porcelain_list(output).unwrap();
+    let worktrees = WorktreeInfo::parse_porcelain_list(output).unwrap();
     assert_eq!(worktrees.len(), 1);
     assert!(worktrees[0].detached);
     assert_eq!(worktrees[0].branch, None);
@@ -45,7 +45,7 @@ detached
 #[test]
 fn test_finalize_worktree_with_branch() {
     // Worktree with a branch should not be modified
-    let wt = Worktree {
+    let wt = WorktreeInfo {
         path: PathBuf::from("/path/to/worktree"),
         head: "abcd1234".to_string(),
         branch: Some("feature".to_string()),
@@ -62,7 +62,7 @@ fn test_finalize_worktree_with_branch() {
 #[test]
 fn test_finalize_worktree_detached_with_branch() {
     // Detached worktree with a branch (unusual but possible) should keep the branch
-    let wt = Worktree {
+    let wt = WorktreeInfo {
         path: PathBuf::from("/path/to/worktree"),
         head: "abcd1234".to_string(),
         branch: Some("feature".to_string()),
@@ -82,7 +82,7 @@ fn test_finalize_worktree_detached_no_branch() {
     // Note: This test validates the logic flow but doesn't test actual file reading
     // since that would require setting up git rebase state files.
     // Actual rebase detection has been manually verified.
-    let wt = Worktree {
+    let wt = WorktreeInfo {
         path: PathBuf::from("/nonexistent/path"),
         head: "abcd1234".to_string(),
         branch: None,
@@ -107,7 +107,7 @@ locked reason for lock
 
 ";
 
-    let worktrees = Worktree::parse_porcelain_list(output).unwrap();
+    let worktrees = WorktreeInfo::parse_porcelain_list(output).unwrap();
     assert_eq!(worktrees.len(), 1);
     assert_eq!(worktrees[0].locked, Some("reason for lock".to_string()));
 }
@@ -120,7 +120,7 @@ bare
 
 ";
 
-    let worktrees = Worktree::parse_porcelain_list(output).unwrap();
+    let worktrees = WorktreeInfo::parse_porcelain_list(output).unwrap();
     assert_eq!(worktrees.len(), 1);
     assert!(worktrees[0].bare);
 }
@@ -331,7 +331,7 @@ locked
 
 ";
 
-    let worktrees = Worktree::parse_porcelain_list(output).unwrap();
+    let worktrees = WorktreeInfo::parse_porcelain_list(output).unwrap();
     assert_eq!(worktrees.len(), 1);
     // Empty lock reason should still be recorded
     assert_eq!(worktrees[0].locked, Some(String::new()));
@@ -346,7 +346,7 @@ prunable gitdir file points to non-existent location
 
 ";
 
-    let worktrees = Worktree::parse_porcelain_list(output).unwrap();
+    let worktrees = WorktreeInfo::parse_porcelain_list(output).unwrap();
     assert_eq!(worktrees.len(), 1);
     assert!(worktrees[0].prunable.is_some());
     assert!(
@@ -378,7 +378,7 @@ detached
 
 ";
 
-    let worktrees = Worktree::parse_porcelain_list(output).unwrap();
+    let worktrees = WorktreeInfo::parse_porcelain_list(output).unwrap();
     assert_eq!(worktrees.len(), 4);
     assert_eq!(worktrees[0].branch, Some("main".to_string()));
     assert_eq!(worktrees[1].branch, Some("feature-a".to_string()));


### PR DESCRIPTION
## Summary

- Rename `Worktree` → `WorktreeInfo` (parsed data record from `git worktree list`)
- Rename `WorktreeView` → `WorkingTree` (borrowed handle for running git commands)
- Add `BranchRef` type with `Option<PathBuf>` for worktree path, replacing the empty `PathBuf` sentinel value convention
- Remove `default_branch`/`target` fields from `TaskContext`; tasks now derive these from cached `Repository` methods
- Add `integration_target()` cache to `Repository`
- Simplify `work_items_for_worktree`/`work_items_for_branch` and `populate_item` signatures

The `BranchRef` type makes the worktree vs branch-only distinction explicit at the type level, improving code clarity and eliminating potential bugs from the empty-path convention.

## Test plan

- [x] All unit tests pass (`cargo test --lib --bins`)
- [x] All integration tests pass (`cargo test --test integration`)
- [x] Pre-commit lints pass

> _This was written by Claude Code on behalf of max-sixty_