### PR TITLE
fix: remove apple_sdk framework

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -11,8 +11,16 @@
     crane.url = "github:ipetkov/crane";
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay, crane }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      rust-overlay,
+      crane,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         overlays = [ (import rust-overlay) ];
         pkgs = import nixpkgs {
@@ -21,7 +29,10 @@
 
         # Use latest stable Rust (must meet MSRV of 1.89)
         rustToolchain = pkgs.rust-bin.stable.latest.default.override {
-          extensions = [ "rust-src" "rust-analyzer" ];
+          extensions = [
+            "rust-src"
+            "rust-analyzer"
+          ];
         };
 
         craneLib = (crane.mkLib pkgs).overrideToolchain rustToolchain;
@@ -29,7 +40,8 @@
         # Filter source to include Cargo files plus templates (needed by askama)
         src = pkgs.lib.cleanSourceWith {
           src = ./.;
-          filter = p: type:
+          filter =
+            p: type:
             (craneLib.filterCargoSources p type)
             || (pkgs.lib.hasInfix "/templates/" p)
             || (baseNameOf (dirOf p) == "templates");
@@ -44,12 +56,15 @@
             pkg-config
           ];
 
-          buildInputs = with pkgs; [
-            # Required for tree-sitter (syntax-highlighting feature, enabled by default)
-            tree-sitter
-          ] ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
-            libiconv
-          ];
+          buildInputs =
+            with pkgs;
+            [
+              # Required for tree-sitter (syntax-highlighting feature, enabled by default)
+              tree-sitter
+            ]
+            ++ pkgs.lib.optionals pkgs.stdenv.isDarwin [
+              libiconv
+            ];
 
           # vergen-gitcl needs git info; VERGEN_IDEMPOTENT makes it emit
           # placeholder values when .git isn't available (which is the case
@@ -57,41 +72,51 @@
           VERGEN_IDEMPOTENT = "1";
 
           # Optionally provide git describe via environment if flake has rev
-          VERGEN_GIT_DESCRIBE = self.shortRev or self.dirtyShortRev or "nix-${self.lastModifiedDate or "unknown"}";
+          VERGEN_GIT_DESCRIBE =
+            self.shortRev or self.dirtyShortRev or "nix-${self.lastModifiedDate or "unknown"}";
         };
 
         # Build just the cargo dependencies for caching
         cargoArtifacts = craneLib.buildDepsOnly commonArgs;
 
         # Build the actual package
-        worktrunk = craneLib.buildPackage (commonArgs // {
-          inherit cargoArtifacts;
+        worktrunk = craneLib.buildPackage (
+          commonArgs
+          // {
+            inherit cargoArtifacts;
 
-          # Skip tests during package build - they require:
-          # - Snapshot files (insta) which bloat the source
-          # - Real system time (SOURCE_DATE_EPOCH breaks some tests)
-          # Tests should run in CI instead
-          doCheck = false;
+            # Skip tests during package build - they require:
+            # - Snapshot files (insta) which bloat the source
+            # - Real system time (SOURCE_DATE_EPOCH breaks some tests)
+            # Tests should run in CI instead
+            doCheck = false;
 
-          meta = with pkgs.lib; {
-            description = "A CLI for Git worktree management, designed for parallel AI agent workflows";
-            homepage = "https://github.com/max-sixty/worktrunk";
-            license = with licenses; [ mit asl20 ];
-            maintainers = [ ];
-            mainProgram = "wt";
-          };
-        });
+            meta = with pkgs.lib; {
+              description = "A CLI for Git worktree management, designed for parallel AI agent workflows";
+              homepage = "https://github.com/max-sixty/worktrunk";
+              license = with licenses; [
+                mit
+                asl20
+              ];
+              maintainers = [ ];
+              mainProgram = "wt";
+            };
+          }
+        );
 
         # Build with git-wt feature for Windows compatibility
-        worktrunk-with-git-wt = craneLib.buildPackage (commonArgs // {
-          inherit cargoArtifacts;
-          cargoExtraArgs = "--features git-wt";
-          doCheck = false;
+        worktrunk-with-git-wt = craneLib.buildPackage (
+          commonArgs
+          // {
+            inherit cargoArtifacts;
+            cargoExtraArgs = "--features git-wt";
+            doCheck = false;
 
-          meta = worktrunk.meta // {
-            description = "Worktrunk with git-wt binary (for 'git wt' subcommand)";
-          };
-        });
+            meta = worktrunk.meta // {
+              description = "Worktrunk with git-wt binary (for 'git wt' subcommand)";
+            };
+          }
+        );
 
       in
       {
@@ -99,10 +124,13 @@
           inherit worktrunk;
 
           # Run clippy
-          worktrunk-clippy = craneLib.cargoClippy (commonArgs // {
-            inherit cargoArtifacts;
-            cargoClippyExtraArgs = "--all-targets -- --deny warnings";
-          });
+          worktrunk-clippy = craneLib.cargoClippy (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              cargoClippyExtraArgs = "--all-targets -- --deny warnings";
+            }
+          );
 
           # Check formatting
           worktrunk-fmt = craneLib.cargoFmt { inherit src; };


### PR DESCRIPTION
Building this using nix-darwin causes failures as:
```
error: darwin.apple_sdk_11_0 has been removed as it was a legacy compatibility stub; see <https://nixos.org/manual/nixpkgs/stable/#sec-darwin-legacy-frameworks> for migration instructions
```

removing the `apple_sdk` solves it. Also took the opportunity to fix some linting issues ~and add the [nixfmt](https://github.com/NixOS/nixfmt) to the pre-commit~