### PR TITLE
refactor: leverage Repository caching to simplify worktree path functions

### DIFF
--- a/.claude/rules/caching-strategy.md
+++ b/.claude/rules/caching-strategy.md
@@ -30,6 +30,7 @@ shares the cache — all clones see the same cached values.
 - `current_branch()` — per-worktree, keyed by path
 - `project_identifier()` — derived from remote URL
 - `primary_remote()` — git config, doesn't change
+- `primary_remote_url()` — derived from primary_remote, doesn't change
 - `default_branch()` — from git config or detection, doesn't change
 - `integration_target()` — effective target for integration checks (local default or upstream if ahead)
 - `merge_base()` — keyed by (commit1, commit2) pair

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -41,7 +41,7 @@ pub use step_commands::{
 };
 pub use worktree::{
     ResolutionContext, compute_worktree_path, handle_remove, handle_remove_current, handle_switch,
-    is_worktree_at_expected_path_with, resolve_worktree_arg, worktree_display_name,
+    is_worktree_at_expected_path, resolve_worktree_arg, worktree_display_name,
 };
 
 // Re-export Shell from the canonical location


### PR DESCRIPTION
## Summary

- Remove `_with()` function variants (`is_worktree_at_expected_path_with`, `compute_worktree_path_with`) that accepted pre-computed `default_branch` and `is_bare` values — these optimizations are now handled by Repository's `Arc<RepoCache>`
- Simplify `collect.rs` join! macro by removing `is_bare` from parallel fetch (now lazily cached when needed)
- Use cached `integration_target()` instead of computing from `effective_integration_target(&default_branch)`
- Add `primary_remote_url()` to RepoCache for efficient URL lookups

Net result: 5 files changed, 69 insertions(+), 94 deletions(-) — cleaner code with same performance.

## Test plan

- [x] All unit tests pass (414)
- [x] All integration tests pass (776)
- [x] Pre-commit lints pass

🤖 Generated with [Claude Code](https://claude.ai/code)