### PR TITLE
Improve wt-switch demo with better hooks and Claude instruction

### DIFF
--- a/docs/demos/build
+++ b/docs/demos/build
@@ -137,15 +137,26 @@ def prepare_merge_demo(
 
 def prepare_switch(env: DemoEnv):
     """Switch demo with Claude Code UI."""
-    hooks_config = '[post-start]\ndeps = "npm install"\n'
+    dev_cmd = "npm run dev -- --port {{ branch | hash_port }}"
+    hooks_config = f"""[post-start]
+copy = "wt step copy-ignored"
+dev = "{dev_cmd}"
+"""
     prepare_demo_repo(env, REPO_ROOT, hooks_config=hooks_config)
-    _write_user_config(env, ["npm install"])
+    _write_user_config(env, [dev_cmd, "wt step copy-ignored"])
+
+    # Create .env file (gitignored) so copy-ignored has something to copy
+    gitignore = env.repo / ".gitignore"
+    gitignore.write_text(gitignore.read_text() + ".env\n")
+    env_file = env.repo / ".env"
+    env_file.write_text("DATABASE_URL=postgres://localhost/acme_dev\nAPI_KEY=dev-key-123\n")
 
     setup_claude_code_config(
         env,
         [
             str(env.repo),
             str(env.work_base / "acme.alpha"),
+            str(env.work_base / "acme.api"),
             str(env.work_base / "acme.dashboard"),
         ],
     )

--- a/docs/demos/tapes/wt-switch.tape
+++ b/docs/demos/tapes/wt-switch.tape
@@ -26,8 +26,8 @@ Type "wt switch --create api"
 Enter
 Sleep 1.5s
 
-# Create with specific command execution - launch Claude Code UI
-Type "wt switch --execute claude --create dashboard"
-Sleep 1s
+# Create with specific command execution - launch Claude with initial prompt
+Type "wt switch --execute claude --create dashboard -- 'Add settings page'"
+Sleep 500ms
 Enter
 Sleep 6s


### PR DESCRIPTION
## Summary

- Add copy-ignored and dev server hooks (both as post-start for background execution)
- Use `{{ branch | hash_port }}` template for dev server port
- Add `.env` file so copy-ignored has something to demonstrate
- Use `-- 'Add settings page'` to showcase passing instructions to Claude
- Reduce pre-enter pause from 1s to 500ms for snappier feel

## Test plan

- [x] Rebuilt wt-switch demo GIFs locally
- [x] Verified hooks show correctly (copy and dev both in post-start)
- [x] Verified Claude command shows with instruction
- [x] Published assets to worktrunk-assets repo

🤖 Generated with [Claude Code](https://claude.ai/code)