### PR TITLE
Remove --refresh flag from config state get commands

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/config.md
+++ b/.claude-plugin/skills/worktrunk/reference/config.md
@@ -752,7 +752,7 @@ Useful in scripts to avoid hardcoding `main` or `master`:
 git rebase $(wt config state default-branch)
 ```
 
-Without a subcommand, runs `get`. Use `set` to override, `get --refresh` to re-detect, or `clear` to reset.
+Without a subcommand, runs `get`. Use `set` to override, or `clear` then `get` to re-detect.
 
 ### Detection
 
@@ -820,7 +820,7 @@ Caches GitHub/GitLab CI status for display in [`wt list`](https://worktrunk.dev/
 
 See [`wt list` CI status](https://worktrunk.dev/list/#ci-status) for display symbols and colors.
 
-Without a subcommand, runs `get` for the current branch. Use `get --refresh` to force re-fetch or `clear --all` to reset cache.
+Without a subcommand, runs `get` for the current branch. Use `clear` to reset cache for a branch or `clear --all` to reset all.
 
 ### Command reference
 

--- a/.claude-plugin/skills/worktrunk/reference/faq.md
+++ b/.claude-plugin/skills/worktrunk/reference/faq.md
@@ -82,7 +82,7 @@ Git TUIs operate on a single repository. Worktrunk manages multiple worktrees, r
 
 Worktrunk checks the local git cache first, queries the remote if needed, and falls back to local inference when no remote exists. The result is cached for fast subsequent lookups.
 
-If the remote's default branch has changed (e.g., renamed from master to main), refresh with `wt config state default-branch get --refresh`.
+If the remote's default branch has changed (e.g., renamed from master to main), clear the cache with `wt config state default-branch clear`.
 
 For full details on the detection mechanism, see `wt config state default-branch --help`.
 

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -770,7 +770,7 @@ Useful in scripts to avoid hardcoding `main` or `master`:
 git rebase $(wt config state default-branch)
 ```
 
-Without a subcommand, runs `get`. Use `set` to override, `get --refresh` to re-detect, or `clear` to reset.
+Without a subcommand, runs `get`. Use `set` to override, or `clear` then `get` to re-detect.
 
 ### Detection
 
@@ -841,7 +841,7 @@ Caches GitHub/GitLab CI status for display in [`wt list`](@/list.md#ci-status).
 
 See [`wt list` CI status](@/list.md#ci-status) for display symbols and colors.
 
-Without a subcommand, runs `get` for the current branch. Use `get --refresh` to force re-fetch or `clear --all` to reset cache.
+Without a subcommand, runs `get` for the current branch. Use `clear` to reset cache for a branch or `clear --all` to reset all.
 
 ### Command reference
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -92,7 +92,7 @@ Git TUIs operate on a single repository. Worktrunk manages multiple worktrees, r
 
 Worktrunk checks the local git cache first, queries the remote if needed, and falls back to local inference when no remote exists. The result is cached for fast subsequent lookups.
 
-If the remote's default branch has changed (e.g., renamed from master to main), refresh with `wt config state default-branch get --refresh`.
+If the remote's default branch has changed (e.g., renamed from master to main), clear the cache with `wt config state default-branch clear`.
 
 For full details on the detection mechanism, see `wt config state default-branch --help`.
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -279,7 +279,7 @@ pub enum StateCommand {
 git rebase $(wt config state default-branch)
 ```
 
-Without a subcommand, runs `get`. Use `set` to override, `get --refresh` to re-detect, or `clear` to reset.
+Without a subcommand, runs `get`. Use `set` to override, or `clear` then `get` to re-detect.
 
 ## Detection
 
@@ -344,7 +344,7 @@ Without a subcommand, runs `get`. Use `set` to override or `clear` to reset."#
 
 See [`wt list` CI status](@/list.md#ci-status) for display symbols and colors.
 
-Without a subcommand, runs `get` for the current branch. Use `get --refresh` to force re-fetch or `clear --all` to reset cache."#
+Without a subcommand, runs `get` for the current branch. Use `clear` to reset cache for a branch or `clear --all` to reset all."#
     )]
     CiStatus {
         #[command(subcommand)]
@@ -496,15 +496,11 @@ Get the default branch:
 wt config state default-branch
 ```
 
-Force refresh from remote:
+Clear cache and re-detect:
 ```console
-wt config state default-branch get --refresh
+wt config state default-branch clear && wt config state default-branch get
 ```"#)]
-    Get {
-        /// Force refresh from remote
-        #[arg(long)]
-        refresh: bool,
-    },
+    Get,
 
     /// Set the default branch
     #[command(after_long_help = r#"## Examples
@@ -564,21 +560,17 @@ Get CI status for current branch:
 wt config state ci-status
 ```
 
-Force refresh from GitHub/GitLab:
-```console
-wt config state ci-status get --refresh
-```
-
 Get CI status for a specific branch:
 ```console
 wt config state ci-status get --branch=feature
+```
+
+Clear cache and re-fetch:
+```console
+wt config state ci-status clear && wt config state ci-status get
 ```"#
     )]
     Get {
-        /// Force refresh from GitHub/GitLab
-        #[arg(long)]
-        refresh: bool,
-
         /// Target branch (defaults to current)
         #[arg(long, add = crate::completion::branch_value_completer())]
         branch: Option<String>,

--- a/src/commands/list/mod.rs
+++ b/src/commands/list/mod.rs
@@ -16,7 +16,7 @@
 //! 2. **Default branch lookup** (~1-5ms)
 //!    - Reads cached value from `.git/refs/remotes/origin/HEAD`
 //!    - Falls back to `git remote show origin` if not cached (~100-300ms network)
-//!    - Refresh with `wt config state get default-branch --refresh`
+//!    - Clear cache with `wt config state default-branch clear` to force re-detection
 //!
 //! 3. **Sort worktrees** (<1ms)
 //!    - Orders by: current → main → rest by timestamp (most recent first)
@@ -95,7 +95,7 @@
 //! This is a git-native cache stored in `.git/refs/remotes/origin/HEAD`. All other data is
 //! fetched fresh on each `wt list` invocation.
 //!
-//! Refresh with: `wt config state get default-branch --refresh`
+//! Clear cache with: `wt config state default-branch clear`
 //!
 //! ## Performance Characteristics
 //!

--- a/src/git/repository/config.rs
+++ b/src/git/repository/config.rs
@@ -115,26 +115,10 @@ impl Repository {
         Ok(count)
     }
 
-    /// Refresh the default branch cache by querying the remote.
-    ///
-    /// This forces a network call to `git ls-remote` to fetch the current default
-    /// branch from the remote, then updates the local cache. Use this when you
-    /// suspect the cached default branch is stale (e.g., after a repository's
-    /// default branch has been changed on the remote).
-    ///
-    /// Returns the refreshed default branch name.
-    pub fn refresh_default_branch(&self) -> anyhow::Result<String> {
-        let remote = self.primary_remote()?;
-        let branch = self.query_remote_default_branch(&remote)?;
-        // Update worktrunk's cache
-        let _ = self.run_command(&["config", "worktrunk.default-branch", &branch]);
-        Ok(branch)
-    }
-
     /// Set the default branch manually.
     ///
-    /// This sets worktrunk's cache (`worktrunk.default-branch`). Use `--refresh`
-    /// to re-query the remote and update git's cache.
+    /// This sets worktrunk's cache (`worktrunk.default-branch`). Use `clear` then
+    /// `get` to re-detect from remote.
     pub fn set_default_branch(&self, branch: &str) -> anyhow::Result<()> {
         self.run_command(&["config", "worktrunk.default-branch", branch])?;
         Ok(())

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -317,8 +317,8 @@ impl Repository {
 
     /// Detect the default branch without using worktrunk's cache.
     ///
-    /// Used by `default_branch()` to populate the cache, and by
-    /// `wt config state get default-branch --refresh` to force re-detection.
+    /// Used by `default_branch()` to populate the cache, and after
+    /// `wt config state default-branch clear` to force re-detection.
     pub fn detect_default_branch(&self) -> anyhow::Result<String> {
         // Try to get from the primary remote
         if let Ok(remote) = self.primary_remote() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1002,10 +1002,9 @@ fn main() {
             ConfigCommand::Show { full } => handle_config_show(full),
             ConfigCommand::State { action } => match action {
                 StateCommand::DefaultBranch { action } => match action {
-                    Some(DefaultBranchAction::Get { refresh }) => {
-                        handle_state_get("default-branch", refresh, None)
+                    Some(DefaultBranchAction::Get) | None => {
+                        handle_state_get("default-branch", None)
                     }
-                    None => handle_state_get("default-branch", false, None),
                     Some(DefaultBranchAction::Set { branch }) => {
                         handle_state_set("default-branch", branch, None)
                     }
@@ -1015,7 +1014,7 @@ fn main() {
                 },
                 StateCommand::PreviousBranch { action } => match action {
                     Some(PreviousBranchAction::Get) | None => {
-                        handle_state_get("previous-branch", false, None)
+                        handle_state_get("previous-branch", None)
                     }
                     Some(PreviousBranchAction::Set { branch }) => {
                         handle_state_set("previous-branch", branch, None)
@@ -1025,17 +1024,15 @@ fn main() {
                     }
                 },
                 StateCommand::CiStatus { action } => match action {
-                    Some(CiStatusAction::Get { refresh, branch }) => {
-                        handle_state_get("ci-status", refresh, branch)
-                    }
-                    None => handle_state_get("ci-status", false, None),
+                    Some(CiStatusAction::Get { branch }) => handle_state_get("ci-status", branch),
+                    None => handle_state_get("ci-status", None),
                     Some(CiStatusAction::Clear { branch, all }) => {
                         handle_state_clear("ci-status", branch, all)
                     }
                 },
                 StateCommand::Marker { action } => match action {
-                    Some(MarkerAction::Get { branch }) => handle_state_get("marker", false, branch),
-                    None => handle_state_get("marker", false, None),
+                    Some(MarkerAction::Get { branch }) => handle_state_get("marker", branch),
+                    None => handle_state_get("marker", None),
                     Some(MarkerAction::Set { value, branch }) => {
                         handle_state_set("marker", value, branch)
                     }
@@ -1044,7 +1041,7 @@ fn main() {
                     }
                 },
                 StateCommand::Logs { action } => match action {
-                    Some(LogsAction::Get) | None => handle_state_get("logs", false, None),
+                    Some(LogsAction::Get) | None => handle_state_get("logs", None),
                     Some(LogsAction::Clear) => handle_state_clear("logs", None, false),
                 },
                 StateCommand::Hints { action } => match action {

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
@@ -9,7 +9,7 @@ info:
     - "--help"
   env:
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
@@ -66,4 +66,4 @@ Caches GitHub/GitLab CI status for display in [2mwt list[0m.
 
 See [2mwt list[0m CI status for display symbols and colors.
 
-Without a subcommand, runs [2mget[0m for the current branch. Use [2mget --refresh[0m to force re-fetch or [2mclear --all[0m to reset cache.
+Without a subcommand, runs [2mget[0m for the current branch. Use [2mclear[0m to reset cache for a branch or [2mclear --all[0m to reset all.

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
@@ -49,7 +49,7 @@ Useful in scripts to avoid hardcoding [2mmain[0m or [2mmaster[0m:
 
   [2mgit rebase $(wt config state default-branch)
 
-Without a subcommand, runs [2mget[0m. Use [2mset[0m to override, [2mget --refresh[0m to re-detect, or [2mclear[0m to reset.
+Without a subcommand, runs [2mget[0m. Use [2mset[0m to override, or [2mclear[0m then [2mget[0m to re-detect.
 
 [32mDetection
 


### PR DESCRIPTION
## Summary

- Remove `--refresh` flag from `wt config state default-branch get` and `wt config state ci-status get`
- The flag conflated two operations (clear cache + fetch fresh). Now `get` purely reads cached state
- To force re-detection, use explicit two-step: `clear` then `get`

## Test plan

- [x] All 776 integration tests pass
- [x] Pre-commit lints pass
- [x] Help snapshots updated
- [x] Documentation synced

> _This was written by Claude Code on behalf of @max-sixty_