### PR TITLE
fix: remove bright-black styling from flags in info/warning messages

### DIFF
--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -154,9 +154,7 @@ impl CommitOptions<'_> {
 
         // Show skip message
         if self.no_verify && any_hooks_exist {
-            crate::output::print(info_message(cformat!(
-                "Skipping pre-commit hooks (<bright-black>--no-verify</>)"
-            )))?;
+            crate::output::print(info_message("Skipping pre-commit hooks (--no-verify)"))?;
         }
 
         if !self.no_verify {

--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -131,9 +131,7 @@ pub fn handle_squash(
     let has_any_pre_commit = has_project_pre_commit || has_user_pre_commit;
 
     if skip_pre_commit && has_any_pre_commit {
-        crate::output::print(info_message(cformat!(
-            "Skipping pre-commit hooks (<bright-black>--no-verify</>)"
-        )))?;
+        crate::output::print(info_message("Skipping pre-commit hooks (--no-verify)"))?;
     }
 
     // Run pre-commit hooks (user first, then project)

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -565,7 +565,7 @@ pub fn handle_switch(
             let path_display = worktrunk::path::format_path_for_display(&worktree_path);
             let backup_display = worktrunk::path::format_path_for_display(&backup_path);
             crate::output::print(warning_message(cformat!(
-                "Moving <bold>{path_display}</> to <bold>{backup_display}</> (<bright-black>--clobber</>)"
+                "Moving <bold>{path_display}</> to <bold>{backup_display}</> (--clobber)"
             )))?;
 
             std::fs::rename(&worktree_path, &backup_path)

--- a/tests/snapshots/integration__integration_tests__merge__step_commit_with_both_flags.snap
+++ b/tests/snapshots/integration__integration_tests__merge__step_commit_with_both_flags.snap
@@ -10,7 +10,7 @@ info:
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
@@ -23,6 +23,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_COMMIT_GENERATION__ARGS: "fix: update file"
     WORKTRUNK_COMMIT_GENERATION__COMMAND: echo
@@ -35,7 +36,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m Skipping pre-commit hooks ([90m--no-verify[39m)
+[2m○[22m Skipping pre-commit hooks (--no-verify)
 [36m◎[39m [36mGenerating commit message and committing tracked changes... [90m(1 file, [32m+1[39m, [31m-1[39m[39m[90m)[39m[39m
 [107m [0m [1mfix: update file[22m
 [32m✓[39m [32mCommitted changes @ [2m[HASH][22m[39m

--- a/tests/snapshots/integration__integration_tests__merge__step_commit_with_no_verify_flag.snap
+++ b/tests/snapshots/integration__integration_tests__merge__step_commit_with_no_verify_flag.snap
@@ -9,7 +9,7 @@ info:
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_COMMIT_GENERATION__ARGS: "feat: add file"
     WORKTRUNK_COMMIT_GENERATION__COMMAND: echo
@@ -34,7 +35,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m Skipping pre-commit hooks ([90m--no-verify[39m)
+[2m○[22m Skipping pre-commit hooks (--no-verify)
 [33m▲[39m [33mAuto-staging 2 untracked paths:[39m
 [107m [0m .config/
 [107m [0m file1.txt

--- a/tests/snapshots/integration__integration_tests__merge__step_squash_with_both_flags.snap
+++ b/tests/snapshots/integration__integration_tests__merge__step_squash_with_both_flags.snap
@@ -10,7 +10,7 @@ info:
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
@@ -23,6 +23,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_COMMIT_GENERATION__ARGS: "squash: combined commits"
     WORKTRUNK_COMMIT_GENERATION__COMMAND: echo
@@ -35,7 +36,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m Skipping pre-commit hooks ([90m--no-verify[39m)
+[2m○[22m Skipping pre-commit hooks (--no-verify)
 [36m◎[39m [36mSquashing 2 commits & tracked changes into a single commit [90m(3 files, [32m+3[39m[39m[90m)[39m...[39m
 [2m↳[22m [2mBackup created @ ef0df66[22m
 [36m◎[39m [36mGenerating squash commit message...[39m

--- a/tests/snapshots/integration__integration_tests__merge__step_squash_with_no_verify_flag.snap
+++ b/tests/snapshots/integration__integration_tests__merge__step_squash_with_no_verify_flag.snap
@@ -9,7 +9,7 @@ info:
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_COMMIT_GENERATION__ARGS: "squash: combined commits"
     WORKTRUNK_COMMIT_GENERATION__COMMAND: echo
@@ -34,7 +35,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m Skipping pre-commit hooks ([90m--no-verify[39m)
+[2m○[22m Skipping pre-commit hooks (--no-verify)
 [36m◎[39m [36mSquashing 2 commits into a single commit [90m(3 files, [32m+3[39m[39m[90m)[39m...[39m
 [36m◎[39m [36mGenerating squash commit message...[39m
 [107m [0m [1msquash: combined commits[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_clobber_path_with_extension.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_clobber_path_with_extension.snap
@@ -10,7 +10,7 @@ info:
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
@@ -34,7 +34,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mMoving [1m_REPO_.clobber-ext.txt[22m to [1m_REPO_.clobber-ext.txt.bak.20250102-000000[22m ([90m--clobber[39m)[39m
+[33m▲[39m [33mMoving [1m_REPO_.clobber-ext.txt[22m to [1m_REPO_.clobber-ext.txt.bak.20250102-000000[22m (--clobber)[39m
 [32m✓[39m [32mCreated branch [1mclobber-ext.txt[22m and worktree from [1mmain[22m @ [1m_REPO_.clobber-ext.txt[22m[39m
 [2m↳[22m [2mCustomize worktree locations: [90mwt config create[39m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_clobber_removes_stale_dir.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_clobber_removes_stale_dir.snap
@@ -10,7 +10,7 @@ info:
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
@@ -34,7 +34,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mMoving [1m_REPO_.clobber-dir-test[22m to [1m_REPO_.clobber-dir-test.bak.20250102-000000[22m ([90m--clobber[39m)[39m
+[33m▲[39m [33mMoving [1m_REPO_.clobber-dir-test[22m to [1m_REPO_.clobber-dir-test.bak.20250102-000000[22m (--clobber)[39m
 [32m✓[39m [32mCreated branch [1mclobber-dir-test[22m and worktree from [1mmain[22m @ [1m_REPO_.clobber-dir-test[22m[39m
 [2m↳[22m [2mCustomize worktree locations: [90mwt config create[39m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_clobber_removes_stale_file.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_clobber_removes_stale_file.snap
@@ -10,7 +10,7 @@ info:
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
@@ -34,7 +34,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mMoving [1m_REPO_.clobber-file-test[22m to [1m_REPO_.clobber-file-test.bak.20250102-000000[22m ([90m--clobber[39m)[39m
+[33m▲[39m [33mMoving [1m_REPO_.clobber-file-test[22m to [1m_REPO_.clobber-file-test.bak.20250102-000000[22m (--clobber)[39m
 [32m✓[39m [32mCreated branch [1mclobber-file-test[22m and worktree from [1mmain[22m @ [1m_REPO_.clobber-file-test[22m[39m
 [2m↳[22m [2mCustomize worktree locations: [90mwt config create[39m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m


### PR DESCRIPTION
## Summary
- Remove `<bright-black>` styling from `--clobber` in warning message (worktree.rs)
- Remove `<bright-black>` styling from `--no-verify` in info messages (commit.rs, step_commands.rs)

Per cli-output-formatting.md, reason parentheses should inherit the message color, not use bright-black (which is for stats parentheses).

## Test plan
- [x] Snapshot tests updated and passing

> _This was written by Claude Code on behalf of max-sixty_