### PR TITLE
Add timeout_effect benchmark for GH #461 investigation

### DIFF
--- a/benches/list.rs
+++ b/benches/list.rs
@@ -8,11 +8,13 @@
 //   - many_branches: 100 branches (warm + cold)
 //   - divergent_branches: 200 branches × 20 commits on synthetic repo (warm + cold)
 //   - real_repo_many_branches: 50 branches at different history depths / GH #461 (warm only)
+//   - timeout_effect: Compare with/without 500ms command timeout on rust repo / GH #461 fix
 //
 // Run examples:
 //   cargo bench --bench list                         # All benchmarks
 //   cargo bench --bench list skeleton                # Progressive rendering
 //   cargo bench --bench list real_repo_many_branches # GH #461 scenario (large repo + many branches)
+//   cargo bench --bench list timeout_effect          # Test timeout fix for GH #461
 //   cargo bench --bench list -- --skip cold          # Skip cold cache variants
 //   cargo bench --bench list -- --skip real          # Skip rust repo clone
 
@@ -583,6 +585,49 @@ fn bench_divergent_branches(c: &mut Criterion) {
     group.finish();
 }
 
+/// Helper to set up rust repo workspace with branches at different history depths.
+/// Returns the workspace path (temp dir must outlive usage).
+fn setup_rust_workspace_with_branches(temp: &tempfile::TempDir, num_branches: usize) -> PathBuf {
+    let rust_repo = get_or_clone_rust_repo();
+    let workspace_main = temp.path().join("main");
+
+    // Clone rust repo locally
+    let clone_output = Command::new("git")
+        .args([
+            "clone",
+            "--local",
+            rust_repo.to_str().unwrap(),
+            workspace_main.to_str().unwrap(),
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        clone_output.status.success(),
+        "Failed to clone rust repo to workspace"
+    );
+
+    // Get commits spread across history
+    let log_output = Command::new("git")
+        .args(["log", "--oneline", "-n", "5000", "--format=%H"])
+        .current_dir(&workspace_main)
+        .output()
+        .unwrap();
+    let log_str = String::from_utf8_lossy(&log_output.stdout);
+    let step = 5000 / num_branches;
+    let commits: Vec<&str> = log_str.lines().step_by(step).take(num_branches).collect();
+
+    // Create branches pointing to different historical commits
+    for (i, commit) in commits.iter().enumerate() {
+        let branch_name = format!("feature-{i:03}");
+        run_git(&workspace_main, &["branch", &branch_name, commit]);
+    }
+
+    // Warm the cache
+    run_git(&workspace_main, &["status"]);
+
+    workspace_main
+}
+
 /// Benchmark GH #461 scenario: large real repo (rust-lang/rust) with branches at different
 /// historical points.
 ///
@@ -606,47 +651,54 @@ fn bench_real_repo_many_branches(c: &mut Criterion) {
 
     // Only test warm cache - cold cache would be extremely slow
     group.bench_function("warm", |b| {
-        let rust_repo = get_or_clone_rust_repo();
         let temp = tempfile::tempdir().unwrap();
-        let workspace_main = temp.path().join("main");
-
-        // Clone rust repo locally
-        let clone_output = Command::new("git")
-            .args([
-                "clone",
-                "--local",
-                rust_repo.to_str().unwrap(),
-                workspace_main.to_str().unwrap(),
-            ])
-            .output()
-            .unwrap();
-        assert!(
-            clone_output.status.success(),
-            "Failed to clone rust repo to workspace"
-        );
-
-        // Get commits spread across history (every 100th commit from last 5000 = 50 branches)
-        let log_output = Command::new("git")
-            .args(["log", "--oneline", "-n", "5000", "--format=%H"])
-            .current_dir(&workspace_main)
-            .output()
-            .unwrap();
-        let log_str = String::from_utf8_lossy(&log_output.stdout);
-        let commits: Vec<&str> = log_str.lines().step_by(100).take(50).collect();
-
-        // Create 50 branches pointing to different historical commits
-        // This is fast (just creates refs, no checkout needed)
-        for (i, commit) in commits.iter().enumerate() {
-            let branch_name = format!("feature-{i:03}");
-            run_git(&workspace_main, &["branch", &branch_name, commit]);
-        }
-
-        // Warm the cache
-        run_git(&workspace_main, &["status"]);
+        let workspace_main = setup_rust_workspace_with_branches(&temp, 50);
 
         b.iter(|| {
             Command::new(&binary)
                 .args(["list", "--branches"])
+                .current_dir(&workspace_main)
+                .output()
+                .unwrap();
+        });
+    });
+
+    group.finish();
+}
+
+/// Benchmark the effect of command timeout on GH #461 scenario.
+///
+/// Compares `wt list --branches` with and without the 500ms timeout.
+/// The timeout kills slow git commands (merge-tree, rev-list) that would
+/// otherwise block the TUI for seconds.
+fn bench_timeout_effect(c: &mut Criterion) {
+    let mut group = c.benchmark_group("timeout_effect");
+    group.measurement_time(std::time::Duration::from_secs(60));
+    group.sample_size(10);
+
+    let binary = get_release_binary();
+
+    // Set up workspace once for both benchmarks
+    let temp = tempfile::tempdir().unwrap();
+    let workspace_main = setup_rust_workspace_with_branches(&temp, 50);
+
+    // Without timeout (baseline)
+    group.bench_function("no_timeout", |b| {
+        b.iter(|| {
+            Command::new(&binary)
+                .args(["list", "--branches"])
+                .current_dir(&workspace_main)
+                .output()
+                .unwrap();
+        });
+    });
+
+    // With 500ms timeout (GH #461 fix)
+    group.bench_function("timeout_500ms", |b| {
+        b.iter(|| {
+            Command::new(&binary)
+                .args(["list", "--branches"])
+                .env("WORKTRUNK_COMMAND_TIMEOUT_MS", "500")
                 .current_dir(&workspace_main)
                 .output()
                 .unwrap();
@@ -662,6 +714,6 @@ criterion_group! {
         .sample_size(30)
         .measurement_time(std::time::Duration::from_secs(15))
         .warm_up_time(std::time::Duration::from_secs(3));
-    targets = bench_skeleton, bench_complete, bench_worktree_scaling, bench_real_repo, bench_many_branches, bench_divergent_branches, bench_real_repo_many_branches
+    targets = bench_skeleton, bench_complete, bench_worktree_scaling, bench_real_repo, bench_many_branches, bench_divergent_branches, bench_real_repo_many_branches, bench_timeout_effect
 }
 criterion_main!(benches);


### PR DESCRIPTION
## Summary
- Adds `bench_timeout_effect` benchmark comparing `wt list --branches` with and without command timeout on rust-lang/rust clone with 50 branches at different history depths
- Refactors common setup code into `setup_rust_workspace_with_branches` helper

## Test plan
- [x] Ran `cargo bench --bench list timeout_effect -- --test` - both benchmarks pass

> _This was written by Claude Code on behalf of @max-sixty_