### PR TITLE
Remove PowerShell fallback on Windows, require Git for Windows

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/faq.md
+++ b/.claude-plugin/skills/worktrunk/reference/faq.md
@@ -115,9 +115,9 @@ We're considering better solutions — a better name, anyone?
 | Hooks | ✅ | ❌ (bash syntax) |
 | `wt select` | ❌ | ❌ |
 
-**Git Bash** (recommended) comes with [Git for Windows](https://gitforwindows.org/). Worktrunk auto-detects it when installed.
+**Git for Windows** is required — it provides Git Bash, which Worktrunk uses for hook execution. [Download here](https://gitforwindows.org/).
 
-**PowerShell** works for basic operations, but hooks fail in pure PowerShell because they use bash syntax. With Git for Windows installed, Worktrunk auto-detects Git Bash for hook execution even when PowerShell is the interactive shell.
+**PowerShell** works as the interactive shell for core commands, shell integration, and tab completion. Hooks use bash syntax and run via Git Bash, so Git for Windows must be installed even when PowerShell is the interactive shell.
 
 **`wt select`** uses [skim](https://github.com/skim-rs/skim), which only supports Unix. Use `wt list` and `wt switch <branch>` instead.
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -125,9 +125,9 @@ We're considering better solutions — a better name, anyone?
 | Hooks | ✅ | ❌ (bash syntax) |
 | `wt select` | ❌ | ❌ |
 
-**Git Bash** (recommended) comes with [Git for Windows](https://gitforwindows.org/). Worktrunk auto-detects it when installed.
+**Git for Windows** is required — it provides Git Bash, which Worktrunk uses for hook execution. [Download here](https://gitforwindows.org/).
 
-**PowerShell** works for basic operations, but hooks fail in pure PowerShell because they use bash syntax. With Git for Windows installed, Worktrunk auto-detects Git Bash for hook execution even when PowerShell is the interactive shell.
+**PowerShell** works as the interactive shell for core commands, shell integration, and tab completion. Hooks use bash syntax and run via Git Bash, so Git for Windows must be installed even when PowerShell is the interactive shell.
 
 **`wt select`** uses [skim](https://github.com/skim-rs/skim), which only supports Unix. Use `wt list` and `wt switch <branch>` instead.
 

--- a/src/commands/configure_shell.rs
+++ b/src/commands/configure_shell.rs
@@ -3,10 +3,9 @@ use std::io::{self, BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use worktrunk::path::format_path_for_display;
 use worktrunk::shell::{self, Shell};
-use worktrunk::shell_exec::ShellConfig;
 use worktrunk::styling::{
     INFO_SYMBOL, PROMPT_SYMBOL, SUCCESS_SYMBOL, format_bash_with_gutter, format_with_gutter,
-    hint_message, warning_message,
+    warning_message,
 };
 
 use crate::output;
@@ -190,22 +189,6 @@ pub fn handle_configure_shell(
     // Only flag if we positively detect it's missing (Some(false)).
     // If detection fails (None), stay silent - we can't be sure.
     let zsh_needs_compinit = should_check_compinit && shell::detect_zsh_compinit() == Some(false);
-
-    // On Windows without Git Bash, show advisory about PowerShell limitations
-    let powershell_was_configured = result
-        .configured
-        .iter()
-        .any(|r| r.shell == Shell::PowerShell && !matches!(r.action, ConfigAction::AlreadyExists));
-
-    if powershell_was_configured && ShellConfig::get().is_windows_without_git_bash() {
-        let _ = crate::output::blank();
-        let _ = crate::output::print(warning_message(
-            "PowerShell mode: hooks using bash syntax won't work",
-        ));
-        let _ = crate::output::print(hint_message(
-            "Install Git for Windows for full hook support",
-        ));
-    }
 
     Ok(ScanResult {
         configured: result.configured,


### PR DESCRIPTION
## Summary

- Remove PowerShell fallback when Git Bash isn't found on Windows
- Now panics with clear error message pointing to Git for Windows download
- Since worktrunk requires git anyway, requiring Git for Windows is reasonable

## Changes

- Remove PowerShell fallback in `detect_windows_shell()`
- Remove `is_windows_without_git_bash()` method (no longer needed)
- Remove unreachable warning block in `configure_shell.rs`
- Update FAQ docs to clarify Git for Windows is required
- Simplify Windows tests

## Test plan

- [x] All tests pass
- [x] Pre-commit checks pass
- [ ] Windows CI confirms Git Bash detection works

> _This was written by Claude Code on behalf of max-sixty_