### PR TITLE
docs: clarify terminology in code comments

### DIFF
--- a/src/cli/step.rs
+++ b/src/cli/step.rs
@@ -58,7 +58,7 @@ pub enum StepCommand {
     /// Fast-forward target to current branch
     ///
     /// Updates the local target branch (e.g., `main`) to include current commits.
-    /// Similar to `git push . HEAD:<target>` but uses
+    /// Similar to `git push . HEAD:<target>`, but uses
     /// `receive.denyCurrentBranch=updateInstead` internally.
     Push {
         /// Target branch

--- a/src/commands/list/collect.rs
+++ b/src/commands/list/collect.rs
@@ -148,29 +148,29 @@ pub(super) enum TaskResult {
         item_idx: usize,
         commit: CommitDetails,
     },
-    /// Ahead/behind counts vs main
+    /// Ahead/behind counts vs default branch
     AheadBehind {
         item_idx: usize,
         counts: AheadBehind,
     },
-    /// Whether HEAD's tree SHA matches main's tree SHA (committed content identical)
+    /// Whether HEAD's tree SHA matches integration target's tree SHA (committed content identical)
     CommittedTreesMatch {
         item_idx: usize,
         committed_trees_match: bool,
     },
-    /// Whether branch has file changes beyond the merge-base (three-dot diff)
+    /// Whether branch has file changes beyond the merge-base with integration target (three-dot diff)
     HasFileChanges {
         item_idx: usize,
         has_file_changes: bool,
     },
-    /// Whether merging branch into main would add changes (merge simulation)
+    /// Whether merging branch into integration target would add changes (merge simulation)
     WouldMergeAdd {
         item_idx: usize,
         would_merge_add: bool,
     },
-    /// Whether branch HEAD is ancestor of main (same commit or already merged)
+    /// Whether branch HEAD is ancestor of integration target (same commit or already merged)
     IsAncestor { item_idx: usize, is_ancestor: bool },
-    /// Line diff vs main branch
+    /// Line diff vs default branch
     BranchDiff {
         item_idx: usize,
         branch_diff: BranchDiffTotals,
@@ -184,7 +184,7 @@ pub(super) enum TaskResult {
         working_tree_status: WorkingTreeStatus,
         has_conflicts: bool,
     },
-    /// Potential merge conflicts with main (merge-tree simulation on committed HEAD)
+    /// Potential merge conflicts with default branch (merge-tree simulation on committed HEAD)
     MergeTreeConflicts {
         item_idx: usize,
         has_merge_tree_conflicts: bool,
@@ -749,8 +749,8 @@ pub fn collect(
     let branches_without_worktrees = branches_without_worktrees?;
     let remote_branches = remote_branches?;
 
-    // Main worktree is the worktree on the default branch (if exists), else first worktree.
-    // find_home returns None only if worktrees is empty, which shouldn't happen for wt list.
+    // Main worktree is the worktree on the default branch (if exists), else first non-prunable worktree.
+    // find_home returns None if all worktrees are prunable or the list is empty.
     let main_worktree = WorktreeInfo::find_home(&worktrees, &default_branch)
         .cloned()
         .ok_or_else(|| anyhow::anyhow!("No worktrees found"))?;

--- a/src/commands/list/json_output.rs
+++ b/src/commands/list/json_output.rs
@@ -9,9 +9,9 @@
 //!
 //! Fields are organized by concept, matching the status display subcolumns:
 //! - `working_tree`: staged/modified/untracked changes
-//! - `main_state`: relationship to main (would_conflict, same_commit, integrated, diverged, ahead, behind)
+//! - `main_state`: relationship to the default branch (would_conflict, same_commit, integrated, diverged, ahead, behind)
 //! - `operation_state`: git operations in progress (conflicts, rebase, merge)
-//! - `main`: relationship to main branch (ahead/behind/diff counts)
+//! - `main`: relationship to the default branch (ahead/behind/diff counts)
 //! - `remote`: relationship to tracking branch
 //! - `worktree`: worktree-specific state (locked, prunable, etc.)
 
@@ -43,8 +43,8 @@ pub struct JsonItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub working_tree: Option<JsonWorkingTree>,
 
-    /// Main branch relationship: would_conflict, same_commit, integrated, diverged, ahead, behind
-    /// (null for main branch itself)
+    /// Default branch relationship: would_conflict, same_commit, integrated, diverged, ahead, behind
+    /// (null for default branch itself)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub main_state: Option<&'static str>,
 
@@ -57,7 +57,7 @@ pub struct JsonItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operation_state: Option<&'static str>,
 
-    /// Relationship to main branch (absent when is_main == true)
+    /// Relationship to default branch (absent when is_main == true)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub main: Option<JsonMain>,
 
@@ -72,10 +72,10 @@ pub struct JsonItem {
     /// This is the main worktree
     pub is_main: bool,
 
-    /// This is the current worktree (matches $PWD)
+    /// This is the current worktree (matches repo discovery path: PWD or `-C`)
     pub is_current: bool,
 
-    /// This was the previous worktree (from wt switch)
+    /// This was the previous worktree (from `worktrunk.history`)
     pub is_previous: bool,
 
     /// CI status from PR or branch workflow
@@ -137,7 +137,7 @@ pub struct JsonWorkingTree {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diff: Option<JsonDiff>,
 
-    /// Lines added/deleted in working tree vs main branch
+    /// Lines added/deleted in working tree vs default branch
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diff_vs_main: Option<JsonDiff>,
 }
@@ -158,16 +158,16 @@ impl From<LineDiff> for JsonDiff {
     }
 }
 
-/// Relationship to main branch
+/// Relationship to default branch
 #[derive(Debug, Clone, Serialize)]
 pub struct JsonMain {
-    /// Commits ahead of main
+    /// Commits ahead of default branch
     pub ahead: usize,
 
-    /// Commits behind main
+    /// Commits behind default branch
     pub behind: usize,
 
-    /// Lines added/deleted vs main branch
+    /// Lines added/deleted vs default branch
     #[serde(skip_serializing_if = "Option::is_none")]
     pub diff: Option<JsonDiff>,
 }
@@ -191,7 +191,7 @@ pub struct JsonRemote {
 /// Worktree-specific state
 #[derive(Debug, Clone, Serialize)]
 pub struct JsonWorktree {
-    /// Worktree state: "no_worktree", "branch_worktree_mismatch", "prunable", "locked" (absent when normal)
+    /// Worktree state: "branch_worktree_mismatch", "prunable", "locked" (absent when normal)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub state: Option<&'static str>,
 

--- a/src/verbose_log.rs
+++ b/src/verbose_log.rs
@@ -66,11 +66,6 @@ pub fn log_file_path() -> Option<PathBuf> {
 
 /// Try to create the verbose log file in the repo's wt-logs directory.
 ///
-/// TODO: This uses current_dir() which ignores the `-C` flag. If a user runs
-/// `wt -C /other/repo list --verbose` from outside the repo, the log file
-/// will be created in the wrong location (or not at all). To fix this,
-/// verbose_log::init() would need to run after set_base_path(), or accept
-/// a repository parameter.
 fn try_create_log_file() -> Option<(PathBuf, File)> {
     // Find the git repo from current directory
     let repo = worktrunk::git::Repository::current().ok()?;


### PR DESCRIPTION
## Summary
- Replace "main" with "default branch" or "integration target" where referring to the configurable target branch, not the literal branch
- Remove obsolete TODO about -C flag (verbose_log now uses Repository)
- Fix minor punctuation in step.rs help text

🤖 Generated with [Claude Code](https://claude.com/claude-code)