### PR TITLE
feat(select): add --branches and --remotes flags

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/select.md
+++ b/.claude-plugin/skills/worktrunk/reference/select.md
@@ -31,7 +31,7 @@ Toggle between views with number keys:
 | `Alt-p` | Toggle preview panel |
 | `Ctrl-u`/`Ctrl-d` | Scroll preview up/down |
 
-Branches without worktrees are included — selecting one creates a worktree. (`wt list` requires `--branches` to show them.)
+With `--branches`, branches without worktrees are included — selecting one creates a worktree. This matches `wt list --branches`.
 
 ## Configuration
 
@@ -55,6 +55,12 @@ Browse and switch worktrees with live preview.
 Usage: <b><span class=c>wt select</span></b> <span class=c>[OPTIONS]</span>
 
 <b><span class=g>Options:</span></b>
+      <b><span class=c>--branches</span></b>
+          Include branches without worktrees
+
+      <b><span class=c>--remotes</span></b>
+          Include remote branches
+
   <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
           Print help (see a summary with &#39;-h&#39;)
 

--- a/docs/content/select.md
+++ b/docs/content/select.md
@@ -46,7 +46,7 @@ Toggle between views with number keys:
 | `Alt-p` | Toggle preview panel |
 | `Ctrl-u`/`Ctrl-d` | Scroll preview up/down |
 
-Branches without worktrees are included — selecting one creates a worktree. (`wt list` requires `--branches` to show them.)
+With `--branches`, branches without worktrees are included — selecting one creates a worktree. This matches `wt list --branches`.
 
 ## Configuration
 
@@ -76,6 +76,12 @@ Browse and switch worktrees with live preview.
 Usage: <b><span class=c>wt select</span></b> <span class=c>[OPTIONS]</span>
 
 <b><span class=g>Options:</span></b>
+      <b><span class=c>--branches</span></b>
+          Include branches without worktrees
+
+      <b><span class=c>--remotes</span></b>
+          Include remote branches
+
   <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
           Print help (see a summary with &#39;-h&#39;)
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -883,7 +883,7 @@ Toggle between views with number keys:
 | `Alt-p` | Toggle preview panel |
 | `Ctrl-u`/`Ctrl-d` | Scroll preview up/down |
 
-Branches without worktrees are included — selecting one creates a worktree. (`wt list` requires `--branches` to show them.)
+With `--branches`, branches without worktrees are included — selecting one creates a worktree. This matches `wt list --branches`.
 
 ## Configuration
 
@@ -904,7 +904,15 @@ This is useful when the default pager doesn't render correctly in the embedded p
 - [`wt switch`](@/switch.md) — Direct switching to a known target branch
 "#
     )]
-    Select,
+    Select {
+        /// Include branches without worktrees
+        #[arg(long)]
+        branches: bool,
+
+        /// Include remote branches
+        #[arg(long)]
+        remotes: bool,
+    },
 
     /// Run individual operations
     #[command(

--- a/src/commands/select.rs
+++ b/src/commands/select.rs
@@ -852,7 +852,11 @@ where
     }
 }
 
-pub fn handle_select() -> anyhow::Result<()> {
+pub fn handle_select(
+    show_branches: bool,
+    show_remotes: bool,
+    config: &WorktrunkConfig,
+) -> anyhow::Result<()> {
     use std::io::IsTerminal;
 
     // Select requires an interactive terminal for the TUI
@@ -864,11 +868,6 @@ pub fn handle_select() -> anyhow::Result<()> {
 
     // Initialize preview mode state file (auto-cleanup on drop)
     let state = PreviewState::new();
-
-    // Load config (or use default) for path mismatch detection
-    let config = WorktrunkConfig::load()
-        .inspect_err(|e| log::warn!("Config load failed, using defaults: {}", e))
-        .unwrap_or_default();
 
     // Gather list data using simplified collection (buffered mode)
     // Skip expensive operations not needed for select UI
@@ -888,12 +887,12 @@ pub fn handle_select() -> anyhow::Result<()> {
 
     let Some(list_data) = collect::collect(
         &repo,
-        true,  // show_branches (include branches without worktrees)
-        false, // show_remotes (local branches only, not remote branches)
+        show_branches,
+        show_remotes,
         &skip_tasks,
         false, // show_progress (no progress bars)
         false, // render_table (select renders its own UI)
-        &config,
+        config,
         command_timeout,
         true, // skip_expensive_for_stale (faster for repos with many stale branches)
     )?


### PR DESCRIPTION
## Summary

- Add `--branches` and `--remotes` flags to `wt select`, matching `wt list`
- Share `[list]` config section with `wt list` for consistent defaults
- Default behavior now shows only worktrees (previously always showed branches)

## Test plan

- [x] Existing `test_select_with_branches` updated to use `--branches` flag
- [x] New `test_select_respects_list_config` verifies config sharing works
- [x] All tests pass including shell integration tests

🤖 Generated with [Claude Code](https://claude.ai/code)

> _This was written by Claude Code on behalf of maximilian_