### PR TITLE
feat: add --dry-run flag to shell install/uninstall commands

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -69,6 +69,10 @@ Use --yes to skip confirmation."#
         #[arg(short, long)]
         yes: bool,
 
+        /// Show what would be changed
+        #[arg(long)]
+        dry_run: bool,
+
         /// Command name for shell integration (defaults to binary name)
         ///
         /// Use this to create shell integration for an alternate command name.
@@ -113,6 +117,10 @@ Detects various forms of the integration pattern regardless of:
         /// Skip confirmation prompt
         #[arg(short, long)]
         yes: bool,
+
+        /// Show what would be changed
+        #[arg(long)]
+        dry_run: bool,
     },
 
     /// Show output theme samples

--- a/src/output/shell_integration.rs
+++ b/src/output/shell_integration.rs
@@ -387,7 +387,7 @@ pub fn prompt_shell_integration(
     }
 
     // Install for all shells with config files (same as `wt config shell install`)
-    let install_result = handle_configure_shell(None, true, binary_name.to_string())
+    let install_result = handle_configure_shell(None, true, false, binary_name.to_string())
         .map_err(|e| anyhow::anyhow!("Failed to configure shell integration: {e}"))?;
 
     print_shell_install_result(&install_result)?;


### PR DESCRIPTION
## Summary

- Add `--dry-run` flag to `wt config shell install` and `wt config shell uninstall` commands
- When passed, shows what would be changed without prompting or applying modifications
- Useful for scripting, CI pipelines, and non-interactive contexts

## Test plan

- [x] `cargo test --lib --bins` passes
- [x] `cargo test --test integration` passes
- [x] `pre-commit run --all-files` passes
- [ ] Manual test: `wt config shell install --dry-run` shows preview without prompting
- [ ] Manual test: `wt config shell uninstall --dry-run` shows preview without prompting

🤖 Generated with [Claude Code](https://claude.ai/code)