### PR TITLE
docs: consolidate template variables reference into hook.md

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/config.md
+++ b/.claude-plugin/skills/worktrunk/reference/config.md
@@ -523,17 +523,15 @@ With `--project`, creates `.config/wt.toml` in the current repository:
 # Named commands appear in output, making it easier to identify failures.
 
 # ============================================================================
-# Template Variables
+# Template Variables — see https://worktrunk.dev/hook/#template-variables
 # ============================================================================
-# All hooks support these variables:
+# Common variables:
 #   {{ repo }}               - Repository directory name (e.g., "myproject")
 #   {{ branch }}             - Branch name (e.g., "feature/auth")
 #   {{ worktree_path }}      - Absolute path to worktree
 #   {{ main_worktree_path }} - Absolute path to main worktree
 #   {{ default_branch }}     - Default branch name (e.g., "main")
-#
-# Merge hooks (pre-commit, pre-merge, post-merge) also support:
-#   {{ target }}             - Target branch for the merge
+#   {{ target }}             - Target branch (merge hooks only)
 #
 # Filters:
 #   {{ branch | sanitize }}     - Replace / and \ with - (e.g., "feature-auth")

--- a/.claude-plugin/skills/worktrunk/reference/hook.md
+++ b/.claude-plugin/skills/worktrunk/reference/hook.md
@@ -150,8 +150,6 @@ Hooks can use template variables that expand at runtime:
 
 See [Designing effective hooks](#designing-effective-hooks) for `main_worktree_path` patterns.
 
-**Deprecated:** `repo_root` (use `repo_path`), `worktree` (use `worktree_path`), `main_worktree` (use `repo`). These still work but emit warnings.
-
 ### Filters
 
 Templates support Jinja2 filters for transforming values:

--- a/.claude-plugin/skills/worktrunk/reference/step.md
+++ b/.claude-plugin/skills/worktrunk/reference/step.md
@@ -202,25 +202,7 @@ Context JSON is piped to stdin for scripts that need structured data.
 
 ### Template variables
 
-All variables are shell-escaped:
-
-| Variable | Description |
-|----------|-------------|
-| `{{ branch }}` | Branch name (raw, e.g., `feature/auth`) |
-| `{{ branch \| sanitize }}` | Branch name with `/` and `\` replaced by `-` |
-| `{{ repo }}` | Repository directory name (e.g., `myproject`) |
-| `{{ repo_path }}` | Absolute path to repository root |
-| `{{ worktree_name }}` | Worktree directory name |
-| `{{ worktree_path }}` | Absolute path to current worktree |
-| `{{ main_worktree_path }}` | Default branch worktree path |
-| `{{ commit }}` | Current HEAD commit SHA (full) |
-| `{{ short_commit }}` | Current HEAD commit SHA (7 chars) |
-| `{{ default_branch }}` | Default branch name (e.g., "main") |
-| `{{ remote }}` | Primary remote name (e.g., "origin") |
-| `{{ remote_url }}` | Primary remote URL |
-| `{{ upstream }}` | Upstream tracking branch, if configured |
-
-**Deprecated:** `repo_root` (use `repo_path`), `worktree` (use `worktree_path`), `main_worktree` (use `repo`).
+All variables are shell-escaped. See [`wt hook` template variables](https://worktrunk.dev/hook/#template-variables) for the complete list and filters.
 
 ### Examples
 

--- a/dev/wt.example.toml
+++ b/dev/wt.example.toml
@@ -20,17 +20,15 @@
 # Named commands appear in output, making it easier to identify failures.
 
 # ============================================================================
-# Template Variables
+# Template Variables — see https://worktrunk.dev/hook/#template-variables
 # ============================================================================
-# All hooks support these variables:
+# Common variables:
 #   {{ repo }}               - Repository directory name (e.g., "myproject")
 #   {{ branch }}             - Branch name (e.g., "feature/auth")
 #   {{ worktree_path }}      - Absolute path to worktree
 #   {{ main_worktree_path }} - Absolute path to main worktree
 #   {{ default_branch }}     - Default branch name (e.g., "main")
-#
-# Merge hooks (pre-commit, pre-merge, post-merge) also support:
-#   {{ target }}             - Target branch for the merge
+#   {{ target }}             - Target branch (merge hooks only)
 #
 # Filters:
 #   {{ branch | sanitize }}     - Replace / and \ with - (e.g., "feature-auth")

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -533,17 +533,15 @@ With `--project`, creates `.config/wt.toml` in the current repository:
 # Named commands appear in output, making it easier to identify failures.
 
 # ============================================================================
-# Template Variables
+# Template Variables — see https://worktrunk.dev/hook/#template-variables
 # ============================================================================
-# All hooks support these variables:
+# Common variables:
 #   {{ repo }}               - Repository directory name (e.g., "myproject")
 #   {{ branch }}             - Branch name (e.g., "feature/auth")
 #   {{ worktree_path }}      - Absolute path to worktree
 #   {{ main_worktree_path }} - Absolute path to main worktree
 #   {{ default_branch }}     - Default branch name (e.g., "main")
-#
-# Merge hooks (pre-commit, pre-merge, post-merge) also support:
-#   {{ target }}             - Target branch for the merge
+#   {{ target }}             - Target branch (merge hooks only)
 #
 # Filters:
 #   {{ branch | sanitize }}     - Replace / and \ with - (e.g., "feature-auth")

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -158,8 +158,6 @@ Hooks can use template variables that expand at runtime:
 
 See [Designing effective hooks](#designing-effective-hooks) for `main_worktree_path` patterns.
 
-**Deprecated:** `repo_root` (use `repo_path`), `worktree` (use `worktree_path`), `main_worktree` (use `repo`). These still work but emit warnings.
-
 ### Filters
 
 Templates support Jinja2 filters for transforming values:

--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -220,25 +220,7 @@ Context JSON is piped to stdin for scripts that need structured data.
 
 ### Template variables
 
-All variables are shell-escaped:
-
-| Variable | Description |
-|----------|-------------|
-| `{{ branch }}` | Branch name (raw, e.g., `feature/auth`) |
-| `{{ branch \| sanitize }}` | Branch name with `/` and `\` replaced by `-` |
-| `{{ repo }}` | Repository directory name (e.g., `myproject`) |
-| `{{ repo_path }}` | Absolute path to repository root |
-| `{{ worktree_name }}` | Worktree directory name |
-| `{{ worktree_path }}` | Absolute path to current worktree |
-| `{{ main_worktree_path }}` | Default branch worktree path |
-| `{{ commit }}` | Current HEAD commit SHA (full) |
-| `{{ short_commit }}` | Current HEAD commit SHA (7 chars) |
-| `{{ default_branch }}` | Default branch name (e.g., "main") |
-| `{{ remote }}` | Primary remote name (e.g., "origin") |
-| `{{ remote_url }}` | Primary remote URL |
-| `{{ upstream }}` | Upstream tracking branch, if configured |
-
-**Deprecated:** `repo_root` (use `repo_path`), `worktree` (use `worktree_path`), `main_worktree` (use `repo`).
+All variables are shell-escaped. See [`wt hook` template variables](@/hook.md#template-variables) for the complete list and filters.
 
 ### Examples
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1150,8 +1150,6 @@ Hooks can use template variables that expand at runtime:
 
 See [Designing effective hooks](#designing-effective-hooks) for `main_worktree_path` patterns.
 
-**Deprecated:** `repo_root` (use `repo_path`), `worktree` (use `worktree_path`), `main_worktree` (use `repo`). These still work but emit warnings.
-
 ### Filters
 
 Templates support Jinja2 filters for transforming values:

--- a/src/cli/step.rs
+++ b/src/cli/step.rs
@@ -172,25 +172,7 @@ Context JSON is piped to stdin for scripts that need structured data.
 
 ## Template variables
 
-All variables are shell-escaped:
-
-| Variable | Description |
-|----------|-------------|
-| `{{ branch }}` | Branch name (raw, e.g., `feature/auth`) |
-| `{{ branch \| sanitize }}` | Branch name with `/` and `\` replaced by `-` |
-| `{{ repo }}` | Repository directory name (e.g., `myproject`) |
-| `{{ repo_path }}` | Absolute path to repository root |
-| `{{ worktree_name }}` | Worktree directory name |
-| `{{ worktree_path }}` | Absolute path to current worktree |
-| `{{ main_worktree_path }}` | Default branch worktree path |
-| `{{ commit }}` | Current HEAD commit SHA (full) |
-| `{{ short_commit }}` | Current HEAD commit SHA (7 chars) |
-| `{{ default_branch }}` | Default branch name (e.g., "main") |
-| `{{ remote }}` | Primary remote name (e.g., "origin") |
-| `{{ remote_url }}` | Primary remote URL |
-| `{{ upstream }}` | Upstream tracking branch, if configured |
-
-**Deprecated:** `repo_root` (use `repo_path`), `worktree` (use `worktree_path`), `main_worktree` (use `repo`).
+All variables are shell-escaped. See [`wt hook` template variables](@/hook.md#template-variables) for the complete list and filters.
 
 ## Examples
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -270,17 +270,15 @@ With [2m--project[0m, creates [2m.config/wt.toml[0m in the current repositor
   [2m# Named commands appear in output, making it easier to identify failures.
   [2m
   [2m# ============================================================================
-  [2m# Template Variables
+  [2m# Template Variables — see https://worktrunk.dev/hook/#template-variables
   [2m# ============================================================================
-  [2m# All hooks support these variables:
+  [2m# Common variables:
   [2m#   {{ repo }}               - Repository directory name (e.g., "myproject")
   [2m#   {{ branch }}             - Branch name (e.g., "feature/auth")
   [2m#   {{ worktree_path }}      - Absolute path to worktree
   [2m#   {{ main_worktree_path }} - Absolute path to main worktree
   [2m#   {{ default_branch }}     - Default branch name (e.g., "main")
-  [2m#
-  [2m# Merge hooks (pre-commit, pre-merge, post-merge) also support:
-  [2m#   {{ target }}             - Target branch for the merge
+  [2m#   {{ target }}             - Target branch (merge hooks only)
   [2m#
   [2m# Filters:
   [2m#   {{ branch | sanitize }}     - Replace / and \ with - (e.g., "feature-auth")


### PR DESCRIPTION
## Summary

- Remove deprecated variable mentions (`repo_root`, `worktree`, `main_worktree`) from all docs
- Replace duplicate table in step.md with link to hook.md#template-variables
- Add URL to canonical reference in project config template
- All filters (`sanitize`, `sanitize_db`, `hash_port`) documented in hook.md

## Test plan

- [x] `cargo test --test integration test_command_pages_are_in_sync` passes
- [x] `pre-commit run --all-files` passes

> _This was written by Claude Code on behalf of @max-sixty_