### PR TITLE
test: add coverage tests for --dry-run flag

### DIFF
--- a/tests/snapshots/integration__integration_tests__configure_shell__configure_shell_dry_run.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__configure_shell_dry_run.snap
@@ -1,0 +1,40 @@
+---
+source: tests/integration_tests/configure_shell.rs
+info:
+  program: wt
+  args:
+    - config
+    - shell
+    - install
+    - zsh
+    - "--dry-run"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SHELL: /bin/zsh
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[2m○[22m Will add shell extension & completions for [1mzsh[0m @ [1m~/.zshrc
+[107m [0m [2m[0m[2m[35mif[0m[2m [0m[2m[34mcommand[0m[2m [0m[2m[36m-v[0m[2m wt [0m[2m[36m>[0m[2m/dev/null [0m[2m[33m2[0m[2m>&1; [0m[2m[35mthen[0m[2m [0m[2m[34meval[0m[2m [0m[2m[32m"$([0m[2m[34mcommand[0m[2m wt config shell init zsh)"[0m[2m; [0m[2m[35mfi[0m[2m

--- a/tests/snapshots/integration__integration_tests__configure_shell__configure_shell_dry_run_already_configured.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__configure_shell_dry_run_already_configured.snap
@@ -1,0 +1,38 @@
+---
+source: tests/integration_tests/configure_shell.rs
+info:
+  program: wt
+  args:
+    - config
+    - shell
+    - install
+    - zsh
+    - "--dry-run"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SHELL: /bin/zsh
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__configure_shell__configure_shell_dry_run_multiple.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__configure_shell_dry_run_multiple.snap
@@ -1,0 +1,42 @@
+---
+source: tests/integration_tests/configure_shell.rs
+info:
+  program: wt
+  args:
+    - config
+    - shell
+    - install
+    - "--dry-run"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SHELL: /bin/zsh
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[2m○[22m Will add shell extension & completions for [1mbash[0m @ [1m~/.bashrc
+[107m [0m [2m[0m[2m[35mif[0m[2m [0m[2m[34mcommand[0m[2m [0m[2m[36m-v[0m[2m wt [0m[2m[36m>[0m[2m/dev/null [0m[2m[33m2[0m[2m>&1; [0m[2m[35mthen[0m[2m [0m[2m[34meval[0m[2m [0m[2m[32m"$([0m[2m[34mcommand[0m[2m wt config shell init bash)"[0m[2m; [0m[2m[35mfi[0m[2m
+
+[2m○[22m Will add shell extension & completions for [1mzsh[0m @ [1m~/.zshrc
+[107m [0m [2m[0m[2m[35mif[0m[2m [0m[2m[34mcommand[0m[2m [0m[2m[36m-v[0m[2m wt [0m[2m[36m>[0m[2m/dev/null [0m[2m[33m2[0m[2m>&1; [0m[2m[35mthen[0m[2m [0m[2m[34meval[0m[2m [0m[2m[32m"$([0m[2m[34mcommand[0m[2m wt config shell init zsh)"[0m[2m; [0m[2m[35mfi[0m[2m

--- a/tests/snapshots/integration__integration_tests__configure_shell__uninstall_shell_dry_run.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__uninstall_shell_dry_run.snap
@@ -1,0 +1,39 @@
+---
+source: tests/integration_tests/configure_shell.rs
+info:
+  program: wt
+  args:
+    - config
+    - shell
+    - uninstall
+    - zsh
+    - "--dry-run"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SHELL: /bin/zsh
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[2m○[22m Will remove shell extension & completions for [1mzsh[0m @ [1m~/.zshrc

--- a/tests/snapshots/integration__integration_tests__configure_shell__uninstall_shell_dry_run_fish.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__uninstall_shell_dry_run_fish.snap
@@ -1,0 +1,40 @@
+---
+source: tests/integration_tests/configure_shell.rs
+info:
+  program: wt
+  args:
+    - config
+    - shell
+    - uninstall
+    - fish
+    - "--dry-run"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SHELL: /bin/fish
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[2m○[22m Will remove shell extension for [1mfish[0m @ [1m~/.config/fish/conf.d/wt.fish
+[2m○[22m Will remove completions for [1mfish[0m @ [1m~/.config/fish/completions/wt.fish

--- a/tests/snapshots/integration__integration_tests__configure_shell__uninstall_shell_dry_run_multiple.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__uninstall_shell_dry_run_multiple.snap
@@ -1,0 +1,39 @@
+---
+source: tests/integration_tests/configure_shell.rs
+info:
+  program: wt
+  args:
+    - config
+    - shell
+    - uninstall
+    - "--dry-run"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SHELL: /bin/zsh
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[2m○[22m Will remove shell extension & completions for [1mbash[0m @ [1m~/.bashrc
+[2m○[22m Will remove shell extension & completions for [1mzsh[0m @ [1m~/.zshrc


### PR DESCRIPTION
## Summary

- Add 6 integration tests covering the dry-run code paths added in #543
- Tests verify that `--dry-run` shows preview without modifying files
- Includes fish test to cover completion_results loop in `show_uninstall_preview`

This addresses the codecov/patch failure from #543 by adding tests for the new code.

## Test plan

- [x] All new tests pass
- [x] `pre-commit run --all-files` passes
- [x] Coverage of added lines verified locally

🤖 Generated with [Claude Code](https://claude.ai/code)