### PR TITLE
test: add GitLab MR status and shell config creation tests

### DIFF
--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_filters_by_project_id.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_filters_by_project_id.snap
@@ -1,0 +1,39 @@
+---
+source: tests/integration_tests/ci_status.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main         [2m^[22m                                    .                         [32m●[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature[0m      [2m_[22m                                    [2m../repo.feature[0m           [32m●[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+
+[2m○[22m [2mShowing 2 worktrees
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_conflicts.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_conflicts.snap
@@ -1,0 +1,39 @@
+---
+source: tests/integration_tests/ci_status.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main         [2m^[22m                                    .                         [33m●[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature[0m      [2m_[22m                                    [2m../repo.feature[0m           [33m●[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+
+[2m○[22m [2mShowing 2 worktrees
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_failed.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_failed.snap
@@ -1,0 +1,39 @@
+---
+source: tests/integration_tests/ci_status.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main         [2m^[22m                                    .                         [31m●[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature[0m      [2m_[22m                                    [2m../repo.feature[0m           [31m●[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+
+[2m○[22m [2mShowing 2 worktrees
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_passed.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_passed.snap
@@ -1,0 +1,39 @@
+---
+source: tests/integration_tests/ci_status.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main         [2m^[22m                                    .                         [32m●[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature[0m      [2m_[22m                                    [2m../repo.feature[0m           [32m●[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+
+[2m○[22m [2mShowing 2 worktrees
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_pending.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_pending.snap
@@ -1,0 +1,39 @@
+---
+source: tests/integration_tests/ci_status.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main         [2m^[22m                                    .                         [34m●[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature[0m      [2m_[22m                                    [2m../repo.feature[0m           [34m●[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+
+[2m○[22m [2mShowing 2 worktrees
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_running.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_running.snap
@@ -1,0 +1,39 @@
+---
+source: tests/integration_tests/ci_status.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main         [2m^[22m                                    .                         [34m●[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature[0m      [2m_[22m                                    [2m../repo.feature[0m           [34m●[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+
+[2m○[22m [2mShowing 2 worktrees
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_no_ci.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_no_ci.snap
@@ -1,0 +1,39 @@
+---
+source: tests/integration_tests/ci_status.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main         [2m^[22m                                    .                         [90m●[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ [2mfeature[0m      [2m_[22m                                    [2m../repo.feature[0m           [90m●[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
+
+[2m○[22m [2mShowing 2 worktrees
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_stale_mr.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_stale_mr.snap
@@ -1,0 +1,39 @@
+---
+source: tests/integration_tests/ci_status.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m             [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main         [2m^[22m                                    .                         [2m[32m●[0m   [2ma1e809f5[0m  [2m1d[0m    [2mInitial commit
++ feature      [2m↑[22m                 [32m↑1[0m        [32m+1[0m       ../repo.feature           [2m[32m●[0m   [2m1b2eaadd[0m  [2m1d[0m    [2mLocal commit
+
+[2m○[22m [2mShowing 2 worktrees, 1 ahead
+
+----- stderr -----


### PR DESCRIPTION
## Summary
- Add mock `glab` infrastructure for GitLab MR testing (parallel to existing `gh` mock)
- Add 8 GitLab MR status tests covering: passed, failed, running, pending, conflicts, stale MR, no CI, project ID filtering
- Add shell config file creation test (when .zshrc doesn't exist)

This improves code coverage for `ci_status.rs` and `configure_shell.rs`.

## Test plan
- [x] All new tests pass locally
- [x] Pre-commit checks pass
- [ ] CI passes

> _This was written by Claude Code on behalf of the user_