### PR TITLE
fix: simplify post-merge hook failure output

### DIFF
--- a/tests/snapshots/integration__integration_tests__merge__merge_post_merge_command_failure.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_post_merge_command_failure.snap
@@ -9,7 +9,7 @@ info:
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
@@ -22,6 +22,7 @@ info:
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -42,6 +43,4 @@ exit_code: 1
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mRunning post-merge project hook @ [1m_REPO_[22m:[39m
 [107m [0m [2m[0m[2m[34mexit[0m[2m 1
-[0m[33m▲[39m [33mCommand failed: exit status: 1[39m
-[31m✗[39m [31mpost-merge command failed: exit status: 1[39m
-[2m↳[22m [2mTo skip post-merge hooks, re-run with [90m--no-verify[39m[22m
+[0m[31m✗[39m [31mCommand failed: exit status: 1[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_failing_command.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_failing_command.snap
@@ -9,7 +9,7 @@ info:
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
@@ -35,7 +35,7 @@ exit_code: 0
 ----- stderr -----
 [36m◎[39m [36mRunning post-create project hook @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mexit[0m[2m 1
-[0m[33m▲[39m [33mCommand failed: exit status: 1[39m
+[0m[31m✗[39m [31mCommand failed: exit status: 1[39m
 [32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [2m↳[22m [2mCustomize worktree locations: [90mwt config create[39m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_post_create_failure.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_post_create_failure.snap
@@ -9,7 +9,7 @@ info:
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
@@ -35,7 +35,7 @@ exit_code: 0
 ----- stderr -----
 [36m◎[39m [36mRunning post-create [1muser:failing[22m @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mexit[0m[2m 1
-[0m[33m▲[39m [33mCommand [1mfailing[22m failed: exit status: 1[39m
+[0m[31m✗[39m [31mCommand [1mfailing[22m failed: exit status: 1[39m
 [32m✓[39m [32mCreated branch [1mfeature[22m and worktree from [1mmain[22m @ [1m_REPO_.feature[22m[39m
 [2m↳[22m [2mCustomize worktree locations: [90mwt config create[39m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m


### PR DESCRIPTION
## Summary

- Remove redundant final error message for Warn strategy failures (warnings are already shown inline as failures occur)
- Change inline failure messages from warnings to errors (since the command exits non-zero, they're errors not warnings)
- Drop questionable `--no-verify` hint for post-merge (the merge already succeeded, hint is confusing)

**Before:**
```
▲ Command failed: exit status: 1
✗ post-merge command failed: exit status: 1
↳ To skip post-merge hooks, re-run with --no-verify
```

**After:**
```
✗ Command failed: exit status: 1
```
(exits with code 1)

## Test plan

- [x] All 797 integration tests pass
- [x] All 626 unit tests pass
- [x] Pre-commit lints pass

🤖 Generated with [Claude Code](https://claude.ai/code)