### PR TITLE
feat: suggest nested subcommands for unrecognized commands

### DIFF
--- a/tests/snapshots/integration__integration_tests__help__nested_subcommand_hook_post_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__nested_subcommand_hook_post_create.snap
@@ -1,0 +1,28 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - post-create
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+---
+success: false
+exit_code: 2
+----- stdout -----
+
+----- stderr -----
+[1m[31merror:[0m unrecognized subcommand '[1m[33mpost-create[0m'
+
+[1m[32mUsage:[0m [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND]
+
+For more information, try '[1m[36m--help[0m'.
+
+  [33mtip:[39m  did you mean [36m[1mwt hook post-create[39m[22m?

--- a/tests/snapshots/integration__integration_tests__help__nested_subcommand_hook_pre_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__nested_subcommand_hook_pre_merge.snap
@@ -1,0 +1,30 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - pre-merge
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+---
+success: false
+exit_code: 2
+----- stdout -----
+
+----- stderr -----
+[1m[31merror:[0m unrecognized subcommand '[1m[33mpre-merge[0m'
+
+  [1m[32mtip:[0m a similar subcommand exists: '[1m[32mremove[0m'
+
+[1m[32mUsage:[0m [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND]
+
+For more information, try '[1m[36m--help[0m'.
+
+  [33mtip:[39m  did you mean [36m[1mwt hook pre-merge[39m[22m?

--- a/tests/snapshots/integration__integration_tests__help__nested_subcommand_step_commit.snap
+++ b/tests/snapshots/integration__integration_tests__help__nested_subcommand_step_commit.snap
@@ -1,0 +1,28 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - commit
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+---
+success: false
+exit_code: 2
+----- stdout -----
+
+----- stderr -----
+[1m[31merror:[0m unrecognized subcommand '[1m[33mcommit[0m'
+
+[1m[32mUsage:[0m [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND]
+
+For more information, try '[1m[36m--help[0m'.
+
+  [33mtip:[39m  did you mean [36m[1mwt step commit[39m[22m?

--- a/tests/snapshots/integration__integration_tests__help__nested_subcommand_step_squash.snap
+++ b/tests/snapshots/integration__integration_tests__help__nested_subcommand_step_squash.snap
@@ -1,0 +1,28 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - squash
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+---
+success: false
+exit_code: 2
+----- stdout -----
+
+----- stderr -----
+[1m[31merror:[0m unrecognized subcommand '[1m[33msquash[0m'
+
+[1m[32mUsage:[0m [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND]
+
+For more information, try '[1m[36m--help[0m'.
+
+  [33mtip:[39m  did you mean [36m[1mwt step squash[39m[22m?


### PR DESCRIPTION
## Summary

- When users type a nested subcommand at the top level (e.g., `wt squash` instead of `wt step squash`), show a helpful suggestion
- Adds `suggest_nested_subcommand()` to check if unknown command matches a subcommand of `step` or `hook`
- Enhances error handler to show "did you mean wt step squash?" tip

## Example

```
$ wt squash
error: unrecognized subcommand 'squash'

Usage: wt [OPTIONS] [COMMAND]

For more information, try '--help'.

  tip:  did you mean wt step squash?
```

## Test plan

- [x] Added snapshot tests for step subcommands (`squash`, `commit`)
- [x] Added snapshot tests for hook subcommands (`pre-merge`, `post-create`)
- [x] All 801 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)