### PR TITLE
docs: add performance benchmarks to copy-ignored documentation

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/step.md
+++ b/.claude-plugin/skills/worktrunk/reference/step.md
@@ -137,6 +137,16 @@ Only gitignored files are copied — tracked files are never touched. If `.workt
 - Skips existing files (safe to re-run)
 - Skips symlinks and `.git` entries
 
+### Performance
+
+Reflink copies share disk blocks until modified — no data is actually copied. For a 31GB `target/` directory with 110k files:
+
+| Method | Time |
+|--------|------|
+| Full copy (`cp -R`) | 2m 5s |
+| COW copy (`cp -Rc`) | ~60s |
+| `wt step copy-ignored` | ~31s |
+
 ### Language-specific notes
 
 #### Rust

--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -152,6 +152,16 @@ Only gitignored files are copied — tracked files are never touched. If `.workt
 - Skips existing files (safe to re-run)
 - Skips symlinks and `.git` entries
 
+### Performance
+
+Reflink copies share disk blocks until modified — no data is actually copied. For a 31GB `target/` directory with 110k files:
+
+| Method | Time |
+|--------|------|
+| Full copy (`cp -R`) | 2m 5s |
+| COW copy (`cp -Rc`) | ~60s |
+| `wt step copy-ignored` | ~31s |
+
 ### Language-specific notes
 
 #### Rust

--- a/src/cli/step.rs
+++ b/src/cli/step.rs
@@ -126,6 +126,16 @@ Only gitignored files are copied — tracked files are never touched. If `.workt
 - Skips existing files (safe to re-run)
 - Skips symlinks and `.git` entries
 
+## Performance
+
+Reflink copies share disk blocks until modified — no data is actually copied. For a 31GB `target/` directory with 110k files:
+
+| Method | Time |
+|--------|------|
+| Full copy (`cp -R`) | 2m 5s |
+| COW copy (`cp -Rc`) | ~60s |
+| `wt step copy-ignored` | ~31s |
+
 ## Language-specific notes
 
 ### Rust


### PR DESCRIPTION
## Summary
- Add Performance section to `wt step copy-ignored` documentation
- Document real-world benchmarks for 31GB target/ directory with 110k files
- Compare full copy (2m 5s), COW copy (60s), and wt step copy-ignored (31s)

## Test plan
- [x] Pre-commit passes
- [x] All tests pass (including doc sync tests)
- [x] Documentation renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)