### PR TITLE
docs: clarify --force vs -D flags in wt remove

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/remove.md
+++ b/.claude-plugin/skills/worktrunk/reference/remove.md
@@ -41,19 +41,30 @@ Worktrunk checks five conditions (in order of cost):
 4. **Trees match** — Branch tree SHA equals target tree SHA. Shows `⊂`.
 5. **Merge adds nothing** — Simulated merge produces the same tree as target. Handles squash-merged branches where target has advanced. Shows `⊂`.
 
-The "same commit" check uses the local default branch; for other checks, **target** means the default branch, or its upstream (e.g., `origin/main`) when strictly ahead.
+The 'same commit' check uses the local default branch; for other checks, 'target' means the default branch, or its upstream (e.g., `origin/main`) when strictly ahead.
 
 Branches showing `_` or `⊂` are dimmed as safe to delete.
 
-Use `-D` to force-delete branches with unmerged changes. Use `--no-delete-branch` to keep the branch regardless of status.
+## Force flags
+
+Worktrunk has two force flags for different situations:
+
+| Flag | Scope | When to use |
+|------|-------|-------------|
+| `--force` (`-f`) | Worktree | Worktree has untracked files (build artifacts, IDE config) |
+| `--force-delete` (`-D`) | Branch | Branch has unmerged commits |
+
+```bash
+wt remove feature --force       # Remove worktree with untracked files
+wt remove feature -D            # Delete unmerged branch
+wt remove feature --force -D    # Both
+```
+
+Without `--force`, removal fails if the worktree contains untracked files. Without `-D`, removal keeps branches with unmerged changes. Use `--no-delete-branch` to keep the branch regardless of merge status.
 
 ## Background removal
 
 Removal runs in the background by default (returns immediately). Logs are written to `.git/wt-logs/{branch}-remove.log`. Use `--foreground` to run in the foreground.
-
-## Shortcuts
-
-`@` (current), `-` (previous), `^` (default branch). See [`wt switch`](https://worktrunk.dev/switch/#shortcuts).
 
 ## Command reference
 

--- a/docs/content/remove.md
+++ b/docs/content/remove.md
@@ -49,19 +49,30 @@ Worktrunk checks five conditions (in order of cost):
 4. **Trees match** — Branch tree SHA equals target tree SHA. Shows `⊂`.
 5. **Merge adds nothing** — Simulated merge produces the same tree as target. Handles squash-merged branches where target has advanced. Shows `⊂`.
 
-The "same commit" check uses the local default branch; for other checks, **target** means the default branch, or its upstream (e.g., `origin/main`) when strictly ahead.
+The 'same commit' check uses the local default branch; for other checks, 'target' means the default branch, or its upstream (e.g., `origin/main`) when strictly ahead.
 
 Branches showing `_` or `⊂` are dimmed as safe to delete.
 
-Use `-D` to force-delete branches with unmerged changes. Use `--no-delete-branch` to keep the branch regardless of status.
+## Force flags
+
+Worktrunk has two force flags for different situations:
+
+| Flag | Scope | When to use |
+|------|-------|-------------|
+| `--force` (`-f`) | Worktree | Worktree has untracked files (build artifacts, IDE config) |
+| `--force-delete` (`-D`) | Branch | Branch has unmerged commits |
+
+```bash
+wt remove feature --force       # Remove worktree with untracked files
+wt remove feature -D            # Delete unmerged branch
+wt remove feature --force -D    # Both
+```
+
+Without `--force`, removal fails if the worktree contains untracked files. Without `-D`, removal keeps branches with unmerged changes. Use `--no-delete-branch` to keep the branch regardless of merge status.
 
 ## Background removal
 
 Removal runs in the background by default (returns immediately). Logs are written to `.git/wt-logs/{branch}-remove.log`. Use `--foreground` to run in the foreground.
-
-## Shortcuts
-
-`@` (current), `-` (previous), `^` (default branch). See [`wt switch`](@/switch.md#shortcuts).
 
 ## See also
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -679,19 +679,30 @@ Worktrunk checks five conditions (in order of cost):
 4. **Trees match** — Branch tree SHA equals target tree SHA. Shows `⊂`.
 5. **Merge adds nothing** — Simulated merge produces the same tree as target. Handles squash-merged branches where target has advanced. Shows `⊂`.
 
-The "same commit" check uses the local default branch; for other checks, **target** means the default branch, or its upstream (e.g., `origin/main`) when strictly ahead.
+The 'same commit' check uses the local default branch; for other checks, 'target' means the default branch, or its upstream (e.g., `origin/main`) when strictly ahead.
 
 Branches showing `_` or `⊂` are dimmed as safe to delete.
 
-Use `-D` to force-delete branches with unmerged changes. Use `--no-delete-branch` to keep the branch regardless of status.
+## Force flags
+
+Worktrunk has two force flags for different situations:
+
+| Flag | Scope | When to use |
+|------|-------|-------------|
+| `--force` (`-f`) | Worktree | Worktree has untracked files (build artifacts, IDE config) |
+| `--force-delete` (`-D`) | Branch | Branch has unmerged commits |
+
+```console
+wt remove feature --force       # Remove worktree with untracked files
+wt remove feature -D            # Delete unmerged branch
+wt remove feature --force -D    # Both
+```
+
+Without `--force`, removal fails if the worktree contains untracked files. Without `-D`, removal keeps branches with unmerged changes. Use `--no-delete-branch` to keep the branch regardless of merge status.
 
 ## Background removal
 
 Removal runs in the background by default (returns immediately). Logs are written to `.git/wt-logs/{branch}-remove.log`. Use `--foreground` to run in the foreground.
-
-## Shortcuts
-
-`@` (current), `-` (previous), `^` (default branch). See [`wt switch`](@/switch.md#shortcuts).
 
 ## See also
 

--- a/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
@@ -95,19 +95,28 @@ Worktrunk checks five conditions (in order of cost):
 4. [1mTrees match[0m — Branch tree SHA equals target tree SHA. Shows [2m⊂[0m.
 5. [1mMerge adds nothing[0m — Simulated merge produces the same tree as target. Handles squash-merged branches where target has advanced. Shows [2m⊂[0m.
 
-The "same commit" check uses the local default branch; for other checks, [1mtarget[0m means the default branch, or its upstream (e.g., [2morigin/main[0m) when strictly ahead.
+The 'same commit' check uses the local default branch; for other checks, 'target' means the default branch, or its upstream (e.g., [2morigin/main[0m) when strictly ahead.
 
 Branches showing [2m_[0m or [2m⊂[0m are dimmed as safe to delete.
 
-Use [2m-D[0m to force-delete branches with unmerged changes. Use [2m--no-delete-branch[0m to keep the branch regardless of status.
+[32mForce flags
+
+Worktrunk has two force flags for different situations:
+
+          Flag          Scope                          When to use                         
+   ─────────────────── ──────── ────────────────────────────────────────────────────────── 
+   --force (-f)        Worktree Worktree has untracked files (build artifacts, IDE config) 
+   --force-delete (-D) Branch   Branch has unmerged commits                                
+
+  [2mwt remove feature --force       # Remove worktree with untracked files
+  [2mwt remove feature -D            # Delete unmerged branch
+  [2mwt remove feature --force -D    # Both
+
+Without [2m--force[0m, removal fails if the worktree contains untracked files. Without [2m-D[0m, removal keeps branches with unmerged changes. Use [2m--no-delete-branch[0m to keep the branch regardless of merge status.
 
 [32mBackground removal
 
 Removal runs in the background by default (returns immediately). Logs are written to [2m.git/wt-logs/{branch}-remove.log[0m. Use [2m--foreground[0m to run in the foreground.
-
-[32mShortcuts
-
-[2m@[0m (current), [2m-[0m (previous), [2m^[0m (default branch). See [2mwt switch[0m.
 
 [32mSee also
 


### PR DESCRIPTION
## Summary

- Add "Force flags" section explaining the difference between `--force` (worktree) and `-D` (branch)
- Remove irrelevant "Shortcuts" section from `wt remove` docs
- Use consistent single-quote styling for 'target' and 'same commit'

Closes #564

## Test plan

- [x] All 801 integration tests pass
- [x] Pre-commit lints pass
- [x] Snapshots updated for help output changes

🤖 Generated with [Claude Code](https://claude.ai/code)

> _This was written by Claude Code on behalf of max-sixty_