### PR TITLE
Fix error message for invalid base branch in switch --create

### DIFF
--- a/tests/integration_tests/switch.rs
+++ b/tests/integration_tests/switch.rs
@@ -176,6 +176,18 @@ fn test_switch_base_without_create_warning(repo: TestRepo) {
         &["--base", "main", "main"],
     );
 }
+
+#[rstest]
+fn test_switch_create_with_invalid_base(repo: TestRepo) {
+    // Issue #562: Error message should identify the invalid base branch,
+    // not the target branch being created
+    snapshot_switch(
+        "switch_create_invalid_base",
+        &repo,
+        &["--create", "new-feature", "--base", "nonexistent-base"],
+    );
+}
+
 // Internal mode tests
 #[rstest]
 fn test_switch_internal_mode(repo: TestRepo) {

--- a/tests/snapshots/integration__integration_tests__switch__switch_create_invalid_base.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_create_invalid_base.snap
@@ -1,0 +1,40 @@
+---
+source: tests/integration_tests/switch.rs
+assertion_line: 54
+info:
+  program: wt
+  args:
+    - switch
+    - "--create"
+    - new-feature
+    - "--base"
+    - nonexistent-base
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[31m✗[39m [31mBranch [1mnonexistent-base[22m not found[39m
+[2m↳[22m [2mTo create a new branch, run [90mwt switch nonexistent-base --create[39m; to list branches, run [90mwt list --branches --remotes[39m[22m


### PR DESCRIPTION
## Summary

- Fix error message when `--base` specifies a nonexistent branch
- Add upfront validation for target branch (no `--create`) and base branch (`--create --base`)
- Remove git error message parsing for 'invalid reference' since upfront validation now catches these cases

## Test plan

- [x] New snapshot test `test_switch_create_with_invalid_base` verifies error shows "nonexistent-base" not "new-feature"
- [x] Existing test `test_switch_without_directive_file` covers switching to nonexistent branch
- [x] All 1973 tests pass

Fixes #562

🤖 Generated with [Claude Code](https://claude.ai/code)