### PR TITLE
Tighten visibility and remove dead code

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -3,13 +3,13 @@ mod hook;
 mod list;
 mod step;
 
-pub use config::{
+pub(crate) use config::{
     ApprovalsCommand, CiStatusAction, ConfigCommand, ConfigShellCommand, DefaultBranchAction,
     HintsAction, LogsAction, MarkerAction, PreviousBranchAction, StateCommand,
 };
-pub use hook::HookCommand;
-pub use list::ListSubcommand;
-pub use step::StepCommand;
+pub(crate) use hook::HookCommand;
+pub(crate) use list::ListSubcommand;
+pub(crate) use step::StepCommand;
 
 use clap::builder::styling::{AnsiColor, Color, Styles};
 use clap::{Command, CommandFactory, Parser, Subcommand, ValueEnum};
@@ -106,7 +106,7 @@ fn shell_value_name() -> &'static str {
 }
 
 /// Build a clap Command for Cli with the shared help template applied recursively.
-pub fn build_command() -> Command {
+pub(crate) fn build_command() -> Command {
     let cmd = apply_help_template_recursive(Cli::command(), DEFAULT_COMMAND_NAME);
 
     // Set value_name for Shell args to show options in usage/errors
@@ -130,7 +130,7 @@ const NESTED_COMMAND_PARENTS: &[&str] = &["step", "hook"];
 /// Check if an unrecognized subcommand matches a nested subcommand.
 ///
 /// Returns the full command path if found, e.g., "wt step squash" for "squash".
-pub fn suggest_nested_subcommand(cmd: &Command, unknown: &str) -> Option<String> {
+pub(crate) fn suggest_nested_subcommand(cmd: &Command, unknown: &str) -> Option<String> {
     for parent in NESTED_COMMAND_PARENTS {
         if let Some(parent_cmd) = cmd.get_subcommands().find(|c| c.get_name() == *parent)
             && parent_cmd
@@ -159,7 +159,7 @@ fn apply_help_template_recursive(mut cmd: Command, path: &str) -> Command {
 ///
 /// Returns the git describe version if available (e.g., "v0.8.5-3-gabcdef"),
 /// otherwise falls back to the cargo package version (e.g., "0.8.5").
-pub fn version_str() -> &'static str {
+pub(crate) fn version_str() -> &'static str {
     static VERSION: OnceLock<String> = OnceLock::new();
     VERSION.get_or_init(|| {
         let git_version = env!("VERGEN_GIT_DESCRIBE");
@@ -174,7 +174,7 @@ pub fn version_str() -> &'static str {
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
-pub enum OutputFormat {
+pub(crate) enum OutputFormat {
     /// Human-readable table format
     Table,
     /// JSON output
@@ -204,7 +204,7 @@ Run `wt config create` to customize worktree locations.
 
 Docs: https://worktrunk.dev
 GitHub: https://github.com/max-sixty/worktrunk")]
-pub struct Cli {
+pub(crate) struct Cli {
     /// Working directory for this command
     #[arg(
         short = 'C',
@@ -241,7 +241,7 @@ pub struct Cli {
 }
 
 #[derive(Subcommand)]
-pub enum Commands {
+pub(crate) enum Commands {
     /// Switch to a worktree
     #[command(
         after_long_help = r#"Change directory to a worktree, creating one if needed.

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,58 +1,60 @@
-pub mod branch_deletion;
-pub mod command_approval;
-pub mod command_executor;
-pub mod commit;
-pub mod config;
-pub mod configure_shell;
-pub mod context;
+pub(crate) mod branch_deletion;
+pub(crate) mod command_approval;
+pub(crate) mod command_executor;
+pub(crate) mod commit;
+pub(crate) mod config;
+pub(crate) mod configure_shell;
+pub(crate) mod context;
 mod for_each;
 mod hook_commands;
 mod hook_filter;
 mod hooks;
-pub mod init;
-pub mod list;
-pub mod merge;
-pub mod process;
-pub mod project_config;
-pub mod repository_ext;
+pub(crate) mod init;
+pub(crate) mod list;
+pub(crate) mod merge;
+pub(crate) mod process;
+pub(crate) mod project_config;
+pub(crate) mod repository_ext;
 #[cfg(unix)]
-pub mod select;
-pub mod statusline;
-pub mod step_commands;
-pub mod worktree;
+pub(crate) mod select;
+pub(crate) mod statusline;
+pub(crate) mod step_commands;
+pub(crate) mod worktree;
 
-pub use command_approval::approve_hooks;
-pub use config::{
+pub(crate) use command_approval::approve_hooks;
+pub(crate) use config::{
     handle_config_create, handle_config_show, handle_hints_clear, handle_hints_get,
     handle_state_clear, handle_state_clear_all, handle_state_get, handle_state_set,
     handle_state_show,
 };
-pub use configure_shell::{handle_configure_shell, handle_show_theme, handle_unconfigure_shell};
-pub use for_each::step_for_each;
-pub use hook_commands::{add_approvals, clear_approvals, handle_hook_show, run_hook};
-pub use init::handle_init;
-pub use list::handle_list;
-pub use merge::{MergeOptions, execute_pre_remove_commands, handle_merge};
+pub(crate) use configure_shell::{
+    handle_configure_shell, handle_show_theme, handle_unconfigure_shell,
+};
+pub(crate) use for_each::step_for_each;
+pub(crate) use hook_commands::{add_approvals, clear_approvals, handle_hook_show, run_hook};
+pub(crate) use init::handle_init;
+pub(crate) use list::handle_list;
+pub(crate) use merge::{MergeOptions, execute_pre_remove_commands, handle_merge};
 #[cfg(unix)]
-pub use select::handle_select;
-pub use step_commands::{
+pub(crate) use select::handle_select;
+pub(crate) use step_commands::{
     RebaseResult, SquashResult, handle_rebase, handle_squash, step_commit, step_copy_ignored,
     step_show_squash_prompt,
 };
-pub use worktree::{
+pub(crate) use worktree::{
     ResolutionContext, compute_worktree_path, handle_remove, handle_remove_current, handle_switch,
     is_worktree_at_expected_path, resolve_worktree_arg, worktree_display_name,
 };
 
 // Re-export Shell from the canonical location
-pub use worktrunk::shell::Shell;
+pub(crate) use worktrunk::shell::Shell;
 
 /// Format command execution label with optional command name.
 ///
 /// Examples:
 /// - `format_command_label("post-create", Some("install"))` → `"Running post-create install"` (with bold)
 /// - `format_command_label("post-create", None)` → `"Running post-create"`
-pub fn format_command_label(command_type: &str, name: Option<&str>) -> String {
+pub(crate) fn format_command_label(command_type: &str, name: Option<&str>) -> String {
     use color_print::cformat;
 
     match name {
@@ -69,7 +71,7 @@ pub fn format_command_label(command_type: &str, name: Option<&str>) -> String {
 /// # Arguments
 /// * `repo` - The repository to query
 /// * `range` - The commit range to diff (e.g., "HEAD~1..HEAD" or "main..HEAD")
-pub fn show_diffstat(repo: &worktrunk::git::Repository, range: &str) -> anyhow::Result<()> {
+pub(crate) fn show_diffstat(repo: &worktrunk::git::Repository, range: &str) -> anyhow::Result<()> {
     use worktrunk::styling::format_with_gutter;
 
     let term_width = crate::display::get_terminal_width();

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -17,7 +17,7 @@ use worktrunk::git::{BranchCategory, HookType, Repository};
 const DEPRECATED_ARGS: &[&str] = &["--no-background"];
 
 /// Handle shell-initiated completion requests via `COMPLETE=$SHELL wt`
-pub fn maybe_handle_env_completion() -> bool {
+pub(crate) fn maybe_handle_env_completion() -> bool {
     let Some(shell_name) = std::env::var_os("COMPLETE") else {
         return false;
     };
@@ -152,7 +152,7 @@ pub fn maybe_handle_env_completion() -> bool {
 }
 
 /// Branch completion without additional context filtering (e.g., --base, merge target).
-pub fn branch_value_completer() -> ArgValueCompleter {
+pub(crate) fn branch_value_completer() -> ArgValueCompleter {
     ArgValueCompleter::new(BranchCompleter {
         suppress_with_create: false,
         exclude_remote_only: false,
@@ -162,7 +162,7 @@ pub fn branch_value_completer() -> ArgValueCompleter {
 
 /// Branch completion for positional arguments (switch, select).
 /// Suppresses completions when --create flag is present.
-pub fn worktree_branch_completer() -> ArgValueCompleter {
+pub(crate) fn worktree_branch_completer() -> ArgValueCompleter {
     ArgValueCompleter::new(BranchCompleter {
         suppress_with_create: true,
         exclude_remote_only: false,
@@ -171,7 +171,7 @@ pub fn worktree_branch_completer() -> ArgValueCompleter {
 }
 
 /// Branch completion for remove command - excludes remote-only branches.
-pub fn local_branches_completer() -> ArgValueCompleter {
+pub(crate) fn local_branches_completer() -> ArgValueCompleter {
     ArgValueCompleter::new(BranchCompleter {
         suppress_with_create: false,
         exclude_remote_only: true,
@@ -180,7 +180,7 @@ pub fn local_branches_completer() -> ArgValueCompleter {
 }
 
 /// Branch completion for commands that only operate on worktrees (e.g., copy-ignored).
-pub fn worktree_only_completer() -> ArgValueCompleter {
+pub(crate) fn worktree_only_completer() -> ArgValueCompleter {
     ArgValueCompleter::new(BranchCompleter {
         suppress_with_create: false,
         exclude_remote_only: false,
@@ -190,7 +190,7 @@ pub fn worktree_only_completer() -> ArgValueCompleter {
 
 /// Hook command name completion for `wt step <hook-type> <name>`.
 /// Completes with command names from the project config for the hook type being invoked.
-pub fn hook_command_name_completer() -> ArgValueCompleter {
+pub(crate) fn hook_command_name_completer() -> ArgValueCompleter {
     ArgValueCompleter::new(HookCommandCompleter)
 }
 

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -101,7 +101,7 @@ Shell integration: {{ shell_integration }}
 "#;
 
 /// Collected diagnostic information for issue reporting.
-pub struct DiagnosticReport {
+pub(crate) struct DiagnosticReport {
     /// Formatted markdown content
     content: String,
 }
@@ -195,7 +195,7 @@ impl DiagnosticReport {
 /// TODO: Consider showing this hint automatically when any `log::warn!` occurs
 /// during command execution, since runtime warnings often indicate unexpected
 /// conditions that could be bugs worth reporting.
-pub fn issue_hint() -> String {
+pub(crate) fn issue_hint() -> String {
     cformat!("To create a diagnostic file, run with <bright-black>-vv</>")
 }
 

--- a/src/display.rs
+++ b/src/display.rs
@@ -11,7 +11,7 @@ use worktrunk::path::format_path_for_display;
 use worktrunk::utils::get_now;
 
 /// Format timestamp as abbreviated relative time (e.g., "2h")
-pub fn format_relative_time_short(timestamp: i64) -> String {
+pub(crate) fn format_relative_time_short(timestamp: i64) -> String {
     // Cast to i64 for signed arithmetic (handles future timestamps)
     format_relative_time_impl(timestamp, get_now() as i64)
 }
@@ -60,7 +60,7 @@ fn format_relative_time_impl(timestamp: i64, now: i64) -> String {
 /// - Child of main: `./subdir`
 /// - Sibling: `../sibling`
 /// - Unrelated paths fall back to `~/...` or absolute
-pub fn shorten_path(path: &Path, main_worktree_path: &Path) -> String {
+pub(crate) fn shorten_path(path: &Path, main_worktree_path: &Path) -> String {
     use std::path::Component;
 
     // Same path = main worktree
@@ -87,7 +87,7 @@ pub fn shorten_path(path: &Path, main_worktree_path: &Path) -> String {
 ///
 /// Truncates at character boundary (mid-word if needed) to fill the allocated
 /// column width exactly. This ensures consistent table output width.
-pub fn truncate_to_width(text: &str, max_width: usize) -> String {
+pub(crate) fn truncate_to_width(text: &str, max_width: usize) -> String {
     use unicode_width::UnicodeWidthChar;
     use worktrunk::styling::visual_width;
 
@@ -115,7 +115,7 @@ pub fn truncate_to_width(text: &str, max_width: usize) -> String {
 }
 
 // Re-export from styling for convenience
-pub use worktrunk::styling::{get_terminal_width, truncate_visible};
+pub(crate) use worktrunk::styling::{get_terminal_width, truncate_visible};
 
 #[cfg(test)]
 mod tests {

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -74,7 +74,7 @@ impl From<(usize, usize)> for LineDiff {
 
 /// Diff statistics (files changed, insertions, deletions).
 #[derive(Debug, Default)]
-pub struct DiffStats {
+pub(crate) struct DiffStats {
     pub files: usize,
     pub insertions: usize,
     pub deletions: usize,

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -29,7 +29,8 @@ use std::sync::LazyLock;
 static HEAVY_OPS_SEMAPHORE: LazyLock<Semaphore> = LazyLock::new(|| Semaphore::new(4));
 
 // Re-exports from submodules
-pub use diff::{DiffStats, LineDiff, parse_numstat_line};
+pub(crate) use diff::DiffStats;
+pub use diff::{LineDiff, parse_numstat_line};
 pub use error::{
     // Typed error enum (Display produces styled output)
     GitError,
@@ -42,7 +43,8 @@ pub use error::{
 };
 pub use parse::{parse_porcelain_z, parse_untracked_files};
 pub use repository::{Repository, ResolvedWorktree, WorkingTree, set_base_path};
-pub use url::{GitRemoteUrl, parse_owner_repo, parse_remote_host, parse_remote_owner};
+pub(crate) use url::GitRemoteUrl;
+pub use url::{parse_owner_repo, parse_remote_owner};
 /// Why branch content is considered integrated into the target branch.
 ///
 /// Used by both `wt list` (for status symbols) and `wt remove` (for messages).

--- a/src/help_pager.rs
+++ b/src/help_pager.rs
@@ -72,7 +72,7 @@ fn detect_help_pager() -> Option<String> {
 /// Note: All fallbacks output to stderr for consistency with pager behavior
 /// (which sends output to stderr via `>&2`). This ensures `config show`
 /// works correctly since stdout is reserved for data output.
-pub fn show_help_in_pager(help_text: &str) -> std::io::Result<()> {
+pub(crate) fn show_help_in_pager(help_text: &str) -> std::io::Result<()> {
     let Some(pager_cmd) = detect_help_pager() else {
         log::debug!("No pager configured, printing help directly to stderr");
         eprint!("{}", help_text);

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -408,7 +408,7 @@ fn build_prompt(
     Ok(rendered)
 }
 
-pub fn generate_commit_message(
+pub(crate) fn generate_commit_message(
     commit_generation_config: &CommitGenerationConfig,
 ) -> anyhow::Result<String> {
     // Check if commit generation is configured (non-empty command)
@@ -470,7 +470,7 @@ fn try_generate_commit_message(
 ///
 /// Gathers the staged diff, branch name, repo name, and recent commits, then renders
 /// the prompt template. Used by both normal commit generation and `--show-prompt`.
-pub fn build_commit_prompt(config: &CommitGenerationConfig) -> anyhow::Result<String> {
+pub(crate) fn build_commit_prompt(config: &CommitGenerationConfig) -> anyhow::Result<String> {
     let repo = Repository::current()?;
 
     // Get staged diff and diffstat
@@ -517,7 +517,7 @@ pub fn build_commit_prompt(config: &CommitGenerationConfig) -> anyhow::Result<St
     build_prompt(config, TemplateType::Commit, &context)
 }
 
-pub fn generate_squash_message(
+pub(crate) fn generate_squash_message(
     target_branch: &str,
     merge_base: &str,
     subjects: &[String],
@@ -564,7 +564,7 @@ pub fn generate_squash_message(
 ///
 /// Gathers the combined diff, commit subjects, branch names, and recent commits, then
 /// renders the prompt template. Used by both normal squash generation and `--show-prompt`.
-pub fn build_squash_prompt(
+pub(crate) fn build_squash_prompt(
     target_branch: &str,
     merge_base: &str,
     subjects: &[String],
@@ -626,7 +626,7 @@ const SYNTHETIC_DIFF_STAT: &str = " src/main.rs | 4 ++++
 ///
 /// Returns Ok(message) if the LLM command succeeds, or an error describing
 /// what went wrong (command not found, API error, empty response, etc.)
-pub fn test_commit_generation(
+pub(crate) fn test_commit_generation(
     commit_generation_config: &CommitGenerationConfig,
 ) -> anyhow::Result<String> {
     if !commit_generation_config.is_configured() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ mod output;
 mod pager;
 mod verbose_log;
 
-pub use crate::cli::OutputFormat;
+pub(crate) use crate::cli::OutputFormat;
 
 use commands::command_executor::{CommandContext, build_hook_context};
 #[cfg(unix)]
@@ -81,7 +81,7 @@ fn is_git_subcommand() -> bool {
 ///
 /// Used in error messages to show what command was actually run.
 /// Returns the full invocation path (e.g., `target/debug/wt`, `./wt`, `wt`).
-pub fn invocation_path() -> String {
+pub(crate) fn invocation_path() -> String {
     std::env::args().next().unwrap_or_else(|| "wt".to_string())
 }
 
@@ -143,7 +143,7 @@ pub fn invocation_path() -> String {
 ///
 /// The argv\[0\] heuristic is simple, fast, and catches all cases where shell
 /// integration won't work because the shell wrapper wasn't invoked.
-pub fn was_invoked_with_explicit_path() -> bool {
+pub(crate) fn was_invoked_with_explicit_path() -> bool {
     std::env::args()
         .next()
         .map(|arg0| arg0.contains('/') || arg0.contains('\\'))

--- a/src/md_help.rs
+++ b/src/md_help.rs
@@ -40,7 +40,7 @@ fn render_markdown_in_help(help: &str) -> String {
 ///
 /// If `width` is provided, prose text is wrapped to that width. Tables, code blocks,
 /// and headers are never wrapped (tables need full-width rows for alignment).
-pub fn render_markdown_in_help_with_width(help: &str, width: Option<usize>) -> String {
+pub(crate) fn render_markdown_in_help_with_width(help: &str, width: Option<usize>) -> String {
     let green = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Green)));
     let dimmed = Style::new().dimmed();
 
@@ -128,7 +128,7 @@ fn render_table(lines: &[&str], max_width: Option<usize>) -> String {
 }
 
 /// Render a markdown table from markdown source string (no indent)
-pub fn render_markdown_table(markdown: &str) -> String {
+pub(crate) fn render_markdown_table(markdown: &str) -> String {
     let lines: Vec<&str> = markdown
         .lines()
         .filter(|l| l.trim().starts_with('|') && l.trim().ends_with('|'))

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -29,19 +29,19 @@
 //! See [`shell_integration`] module for the complete spec of warning messages.
 
 mod global;
-pub mod handlers;
-pub mod shell_integration;
+pub(crate) mod handlers;
+pub(crate) mod shell_integration;
 
 // Re-export the public API
-pub use global::{
+pub(crate) use global::{
     blank, change_directory, execute, flush, is_shell_integration_active, post_hook_display_path,
     pre_hook_display_path, print, stdout, terminate_output,
 };
 // Re-export output handlers
-pub use handlers::{
+pub(crate) use handlers::{
     execute_command_in_worktree, execute_user_command, handle_remove_output, handle_switch_output,
 };
 // Re-export shell integration functions
-pub use shell_integration::{
+pub(crate) use shell_integration::{
     print_shell_install_result, print_skipped_shells, prompt_shell_integration,
 };

--- a/src/verbose_log.rs
+++ b/src/verbose_log.rs
@@ -27,7 +27,7 @@ struct VerboseLog {
 ///
 /// Should be called early in main() when `--verbose` is set.
 /// Tries to find a git repo and create the log file.
-pub fn init() {
+pub(crate) fn init() {
     let mutex = VERBOSE_LOG.get_or_init(|| Mutex::new(None));
     let Ok(mut guard) = mutex.lock() else { return };
 
@@ -41,7 +41,7 @@ pub fn init() {
 ///
 /// Call this from the log format function. The line should be
 /// plain text (no ANSI codes) for readability in issue reports.
-pub fn write_line(line: &str) {
+pub(crate) fn write_line(line: &str) {
     if let Some(mutex) = VERBOSE_LOG.get()
         && let Ok(mut guard) = mutex.lock()
         && let Some(log) = guard.as_mut()
@@ -55,7 +55,7 @@ pub fn write_line(line: &str) {
 /// Get the path to the verbose log file, if it was created.
 ///
 /// Used by the diagnostic module to include log contents.
-pub fn log_file_path() -> Option<PathBuf> {
+pub(crate) fn log_file_path() -> Option<PathBuf> {
     VERBOSE_LOG.get().and_then(|mutex| {
         mutex
             .lock()


### PR DESCRIPTION
## Summary

- Change ~90 items from `pub` to `pub(crate)` in binary-only modules (cli, commands, output, completion, llm, display, etc.)
- Remove dead code found via tightened visibility:
  - `parse_remote_host()` function (only used in its own tests)
  - `GitRemoteUrl::host()` method (never called in production)
- Make internal-only types `pub(crate)` in library (`GitRemoteUrl`, `DiffStats`)

## Test plan

- [x] All 641 library tests pass
- [x] Build succeeds with no warnings
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>