### PR TITLE
fix: ensure pager auto-quits when help fits on screen

### DIFF
--- a/src/help_pager.rs
+++ b/src/help_pager.rs
@@ -93,7 +93,10 @@ pub(crate) fn show_help_in_pager(help_text: &str) -> std::io::Result<()> {
     log::debug!("Invoking pager: {}", pager_cmd);
 
     // LESS flags: F=quit if one screen, R=allow colors, X=no termcap init
-    let less_flags = std::env::var("LESS").unwrap_or_else(|_| "FRX".to_string());
+    // Append FRX to user's LESS setting to ensure these flags are always on for help,
+    // while preserving any other user preferences (search settings, mouse behavior, etc.)
+    let user_less = std::env::var("LESS").unwrap_or_default();
+    let less_flags = format!("{}FRX", user_less);
 
     // Always send pager output to stderr (standard for help text, like git)
     // This works in all cases: direct invocation, shell wrapper, piping, etc.


### PR DESCRIPTION
## Summary

- Append `FRX` to user's LESS env var instead of using it only as a fallback
- Ensures the `F` flag (quit if one screen) is always active for help output
- Fixes issue where users with `LESS=-R` (common oh-my-zsh default) would get stuck in the pager even when help fits on screen

Addresses the issue reported in #583 — the root cause was that we respected the user's LESS setting which often lacks the `F` flag.

## Test plan

- [x] Verified with tmux TTY testing that `LESS=-R` now auto-quits (becomes `-RFRX`)
- [x] Verified that user preferences are preserved (we append, not replace)
- [x] Verified that later flags win in LESS, so even `LESS=-+F` (explicitly disabled) gets re-enabled

🤖 Generated with [Claude Code](https://claude.ai/code)