### PR TITLE
Improve hint when --create shadows a remote branch

### DIFF
--- a/.claude/rules/cli-output-formatting.md
+++ b/.claude/rules/cli-output-formatting.md
@@ -317,8 +317,8 @@ command for easy copying:
 "To delete the unmerged branch, run wt remove feature -D"
 "To rebase onto main, run wt step rebase or wt merge"
 
-// GOOD - when user needs to modify their command
-"To switch to the remote branch, remove --create; run wt switch feature"
+// GOOD - recovery command after shadowing a remote branch
+"To switch to the remote branch, remove this added branch and then run without --create: wt remove feature && wt switch feature"
 
 // BAD - command without context
 "wt remove feature -D deletes unmerged branches"

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -459,9 +459,10 @@ pub fn handle_switch(
             crate::output::print(warning_message(cformat!(
                 "Branch <bold>{resolved_branch}</> exists on remote ({remote_ref}); creating new branch from base instead"
             )))?;
-            let cmd = suggest_command("switch", &[&resolved_branch], &[]);
+            let remove_cmd = suggest_command("remove", &[&resolved_branch], &[]);
+            let switch_cmd = suggest_command("switch", &[&resolved_branch], &[]);
             crate::output::print(hint_message(cformat!(
-                "To switch to the remote branch, remove <bright-black>--create</>; run <bright-black>{cmd}</>"
+                "To switch to the remote branch, remove this added branch and then run without <bright-black>--create</>: <bright-black>{remove_cmd} && {switch_cmd}</>"
             )))?;
         }
     }

--- a/tests/snapshots/integration__integration_tests__switch__switch_create_remote_only.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_create_remote_only.snap
@@ -9,7 +9,7 @@ info:
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
@@ -34,7 +34,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mBranch [1mremote-feature[22m exists on remote (origin/remote-feature); creating new branch from base instead[39m
-[2m↳[22m [2mTo switch to the remote branch, remove [90m--create[39m; run [90mwt switch remote-feature[39m[22m
+[2m↳[22m [2mTo switch to the remote branch, remove this added branch and then run without [90m--create[39m: [90mwt remove remote-feature && wt switch remote-feature[39m[22m
 [32m✓[39m [32mCreated branch [1mremote-feature[22m and worktree from [1mmain[22m @ [1m_REPO_.remote-feature[22m[39m
 [2m↳[22m [2mCustomize worktree locations: [90mwt config create[39m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m


### PR DESCRIPTION
## Summary

- Fixed misleading hint when `wt switch --create` shadows a remote branch
- Previous hint suggested "remove --create; run wt switch feature" which wouldn't work after proceeding (local branch exists)
- New hint shows recovery command: `wt remove feature && wt switch feature`

## Test plan

- [x] Snapshot test updated and passes
- [x] Pre-commit lints pass

🤖 Generated with [Claude Code](https://claude.ai/code)