### PR TITLE
fix(ci): correct SHA256 hash updates in Homebrew formula

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -353,10 +353,10 @@ jobs:
           sed -i "s|/v[0-9.]*-*[^/]*/worktrunk-x86_64-apple-darwin|/v${VERSION}/worktrunk-x86_64-apple-darwin|g" Formula/wt.rb
           sed -i "s|/v[0-9.]*-*[^/]*/worktrunk-x86_64-unknown-linux-musl|/v${VERSION}/worktrunk-x86_64-unknown-linux-musl|g" Formula/wt.rb
 
-          # Update SHA256 hashes (order: arm, intel, linux in file)
-          sed -i "0,/sha256 \"[a-f0-9]\{64\}\"/s//sha256 \"${SHA_ARM}\"/" Formula/wt.rb
-          sed -i "0,/sha256 \"[a-f0-9]\{64\}\"/s//sha256 \"${SHA_INTEL}\"/" Formula/wt.rb
-          sed -i "0,/sha256 \"[a-f0-9]\{64\}\"/s//sha256 \"${SHA_LINUX}\"/" Formula/wt.rb
+          # Update SHA256 hashes by matching the URL context above each sha256
+          sed -i "/aarch64-apple-darwin/{n;s/sha256 \"[a-f0-9]\{64\}\"/sha256 \"${SHA_ARM}\"/}" Formula/wt.rb
+          sed -i "/x86_64-apple-darwin/{n;s/sha256 \"[a-f0-9]\{64\}\"/sha256 \"${SHA_INTEL}\"/}" Formula/wt.rb
+          sed -i "/x86_64-unknown-linux-musl/{n;s/sha256 \"[a-f0-9]\{64\}\"/sha256 \"${SHA_LINUX}\"/}" Formula/wt.rb
 
           echo "Updated formula:"
           head -30 Formula/wt.rb


### PR DESCRIPTION
## Summary

- Fix sed commands that were repeatedly overwriting the first sha256 line instead of updating each platform's hash independently

The previous approach used `0,/pattern/s//` to replace the "first match", but after each replacement the new hash was still a valid 64-char hex string. Subsequent seds kept matching and overwriting the same line, leaving the ARM position with the Linux hash while Intel and Linux positions were never updated.

This has been broken since the workflow was added (v0.12.0). The v0.13.1 formula currently has:
- ARM slot: Linux hash (wrong)
- Intel slot: stale v0.12.0 hash
- Linux slot: stale v0.12.0 hash

## Test plan

- [ ] Fix the homebrew-worktrunk formula manually for v0.13.1
- [ ] Next release will use the corrected sed pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)