### PR TITLE
fix: `wt step copy-ignored` fails in bare repository setups

### DIFF
--- a/tests/snapshots/integration__integration_tests__step_copy_ignored__copy_ignored_bare_repo.snap
+++ b/tests/snapshots/integration__integration_tests__step_copy_ignored__copy_ignored_bare_repo.snap
@@ -1,0 +1,31 @@
+---
+source: tests/integration_tests/step_copy_ignored.rs
+info:
+  program: wt
+  args:
+    - step
+    - copy-ignored
+  env:
+    CLICOLOR_FORCE: ""
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    LANG: C
+    LC_ALL: C
+    NO_COLOR: ""
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+✓ Copied 1 entry

--- a/tests/snapshots/integration__integration_tests__step_copy_ignored__copy_ignored_no_default_branch_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__step_copy_ignored__copy_ignored_no_default_branch_worktree.snap
@@ -1,0 +1,35 @@
+---
+source: tests/integration_tests/step_copy_ignored.rs
+info:
+  program: wt
+  args:
+    - step
+    - copy-ignored
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[31m✗[39m [31mNo worktree found for branch [1mmain[22m[39m


### PR DESCRIPTION
## Summary

- Fixes #598: `wt step copy-ignored` fails in bare repo with "git ls-files failed: fatal: this operation must be run in a work tree"
- Root cause: For bare repos, `worktree_base()` returns the bare repo directory (no working tree), but `git ls-files` requires an actual worktree
- Fix: Use `worktree_for_branch(default_branch)` to find the actual worktree path instead of `worktree_base()`
- Also adds clear error when default branch has no worktree: "No worktree found for branch main"

## Test plan

- [x] Added `test_copy_ignored_bare_repo` - reproduces issue #598 and verifies fix
- [x] Added `test_copy_ignored_no_default_branch_worktree` - tests edge case with clear error message
- [x] All 820 integration tests pass
- [x] Pre-commit lints pass

🤖 Generated with [Claude Code](https://claude.ai/code)