### PR TITLE
refactor: replace IntegrationProvider trait with IntegrationSignals struct

### DIFF
--- a/src/commands/branch_deletion.rs
+++ b/src/commands/branch_deletion.rs
@@ -4,7 +4,7 @@
 //! deleted after its worktree is removed. It checks if the branch's content has
 //! been integrated into the target branch.
 
-use worktrunk::git::{IntegrationReason, Repository};
+use worktrunk::git::{IntegrationReason, Repository, check_integration, compute_integration_lazy};
 
 /// Result of an integration check, including which target was used.
 pub struct IntegrationResult {
@@ -34,40 +34,30 @@ pub struct BranchDeletionResult {
 ///
 /// Returns the reason if the branch is safe to delete (ordered by check cost):
 /// - `SameCommit`: Branch HEAD is literally the same commit as target
+/// - `Ancestor`: Branch is ancestor of target (target has moved past)
 /// - `NoAddedChanges`: Branch has no file changes beyond merge-base (empty three-dot diff)
 /// - `TreesMatch`: The branch's tree SHA matches the target's tree SHA (squash merge/rebase)
 /// - `MergeAddsNothing`: Merge simulation shows branch would add nothing (squash + target advanced)
 ///
 /// Also returns the effective target used (may be upstream if it's ahead of local).
 ///
-/// Returns None reason if no condition is met, or if an error occurs (e.g., invalid refs).
-/// This fail-safe default prevents accidental branch deletion when integration cannot
-/// be determined.
+/// Errors are propagated rather than silently returning None.
 pub fn get_integration_reason(
     repo: &Repository,
     branch_name: &str,
     target: &str,
-) -> IntegrationResult {
+) -> anyhow::Result<IntegrationResult> {
     let effective_target = repo.effective_integration_target(target);
 
-    let reason = check_integration_against(repo, branch_name, &effective_target);
+    // Use lazy computation with short-circuit evaluation.
+    // Expensive checks (would_merge_add) are skipped if cheaper ones succeed.
+    let signals = compute_integration_lazy(repo, branch_name, &effective_target)?;
+    let reason = check_integration(&signals);
 
-    IntegrationResult {
+    Ok(IntegrationResult {
         reason,
         effective_target,
-    }
-}
-
-/// Check integration against a specific target ref.
-fn check_integration_against(
-    repo: &Repository,
-    branch_name: &str,
-    target: &str,
-) -> Option<IntegrationReason> {
-    // Use lazy provider for short-circuit evaluation.
-    // Expensive checks (would_merge_add) are skipped if cheaper ones succeed.
-    let mut provider = worktrunk::git::LazyGitIntegration::new(repo, branch_name, target);
-    worktrunk::git::check_integration(&mut provider)
+    })
 }
 
 /// Attempt to delete a branch if it's integrated or force_delete is set.
@@ -84,7 +74,7 @@ pub fn delete_branch_if_safe(
     let IntegrationResult {
         reason,
         effective_target,
-    } = get_integration_reason(repo, branch_name, target);
+    } = get_integration_reason(repo, branch_name, target)?;
 
     // Determine outcome based on integration and force flag
     let outcome = match (reason, force_delete) {

--- a/src/commands/list/model.rs
+++ b/src/commands/list/model.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use worktrunk::git::{IntegrationReason, LineDiff, PrecomputedIntegration, check_integration};
+use worktrunk::git::{IntegrationReason, IntegrationSignals, LineDiff, check_integration};
 
 use super::ci_status::PrStatus;
 use super::columns::ColumnKind;
@@ -763,20 +763,17 @@ impl ListItem {
 
         // Compute is_same_commit from ahead/behind counts (vs stats_base/main)
         // This detects "same commit as main" for the _ symbol
-        let is_same_commit = self
-            .counts
-            .as_ref()
-            .is_some_and(|c| c.ahead == 0 && c.behind == 0);
+        let is_same_commit = self.counts.as_ref().map(|c| c.ahead == 0 && c.behind == 0);
 
         // Use the shared integration check (same logic as wt remove)
-        let mut provider = PrecomputedIntegration {
+        let signals = IntegrationSignals {
             is_same_commit,
-            is_ancestor: self.is_ancestor.unwrap_or(false),
-            has_added_changes: self.has_file_changes.unwrap_or(true), // default: assume has changes
-            trees_match: self.committed_trees_match.unwrap_or(false),
-            would_merge_add: self.would_merge_add.unwrap_or(true), // default: assume would add
+            is_ancestor: self.is_ancestor,
+            has_added_changes: self.has_file_changes,
+            trees_match: self.committed_trees_match,
+            would_merge_add: self.would_merge_add,
         };
-        let reason = check_integration(&mut provider);
+        let reason = check_integration(&signals);
 
         // Convert to MainState, with SameCommit becoming Empty for display
         match reason {

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -210,9 +210,9 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
         let worktree_root = repo.current_worktree().root()?.to_path_buf();
         // After a successful merge, compute integration reason from main_path
         let effective_target = repo.effective_integration_target(&target_branch);
-        let mut provider =
-            worktrunk::git::LazyGitIntegration::new(repo, &current_branch, &effective_target);
-        let integration_reason = worktrunk::git::check_integration(&mut provider);
+        let signals =
+            worktrunk::git::compute_integration_lazy(repo, &current_branch, &effective_target)?;
+        let integration_reason = worktrunk::git::check_integration(&signals);
         // Compute expected_path for path mismatch detection
         let expected_path = get_path_mismatch(repo, &current_branch, &worktree_root, config);
         let remove_result = RemoveResult::RemovedWorktree {

--- a/src/commands/repository_ext.rs
+++ b/src/commands/repository_ext.rs
@@ -344,8 +344,10 @@ fn compute_integration_reason(
     // removed during the operation.
     let repo = Repository::at(main_path).ok()?;
     let effective_target = repo.effective_integration_target(target);
-    let mut provider = worktrunk::git::LazyGitIntegration::new(&repo, branch, &effective_target);
-    worktrunk::git::check_integration(&mut provider)
+    // Use lazy computation with short-circuit. On error, return None (informational only).
+    let signals =
+        worktrunk::git::compute_integration_lazy(&repo, branch, &effective_target).ok()?;
+    worktrunk::git::check_integration(&signals)
 }
 
 /// Warn about untracked files that will be auto-staged.


### PR DESCRIPTION
## Summary

- Replace `IntegrationProvider` trait + `LazyGitIntegration`/`PrecomputedIntegration` impls with a single `IntegrationSignals` struct
- Change fields from `bool` to `Option<bool>` — "unknown/failed" is now explicit, not silently defaulted via `.unwrap_or()`
- Add `compute_integration_lazy()` function with short-circuit evaluation and `?` error propagation
- `check_integration()` now takes `&IntegrationSignals` instead of `&mut impl IntegrationProvider`

**Error handling per context:**
- `branch_deletion.rs`, `merge.rs`: Errors propagate via `?` (critical path — branch deletion should fail if we can't verify integration)
- `repository_ext.rs`: Uses `.ok()?` (informational only — graceful degradation)

## Test plan

- [x] `cargo test --lib --bins` passes (432 tests)
- [x] `cargo test --test integration` passes (820 tests)
- [x] `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>