### PR TITLE
Refactor: rename worktree_path function to worktree_path_of_branch

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/hook.md
+++ b/.claude-plugin/skills/worktrunk/reference/hook.md
@@ -178,14 +178,14 @@ Templates also support functions for dynamic lookups:
 
 | Function | Example | Description |
 |----------|---------|-------------|
-| `worktree_path(branch)` | `{{ worktree_path("main") }}` | Look up the path of a branch's worktree |
+| `worktree_path_of_branch(branch)` | `{{ worktree_path_of_branch("main") }}` | Look up the path of a branch's worktree |
 
-The `worktree_path` function returns the filesystem path of a worktree given a branch name, or an empty string if no worktree exists for that branch. This is useful for referencing files in other worktrees:
+The `worktree_path_of_branch` function returns the filesystem path of a worktree given a branch name, or an empty string if no worktree exists for that branch. This is useful for referencing files in other worktrees:
 
 ```toml
 [post-create]
 # Copy config from main worktree
-setup = "cp {{ worktree_path('main') }}/config.local {{ worktree_path }}"
+setup = "cp {{ worktree_path_of_branch('main') }}/config.local {{ worktree_path }}"
 ```
 
 ### JSON context

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -186,14 +186,14 @@ Templates also support functions for dynamic lookups:
 
 | Function | Example | Description |
 |----------|---------|-------------|
-| `worktree_path(branch)` | `{{ worktree_path("main") }}` | Look up the path of a branch's worktree |
+| `worktree_path_of_branch(branch)` | `{{ worktree_path_of_branch("main") }}` | Look up the path of a branch's worktree |
 
-The `worktree_path` function returns the filesystem path of a worktree given a branch name, or an empty string if no worktree exists for that branch. This is useful for referencing files in other worktrees:
+The `worktree_path_of_branch` function returns the filesystem path of a worktree given a branch name, or an empty string if no worktree exists for that branch. This is useful for referencing files in other worktrees:
 
 ```toml
 [post-create]
 # Copy config from main worktree
-setup = "cp {{ worktree_path('main') }}/config.local {{ worktree_path }}"
+setup = "cp {{ worktree_path_of_branch('main') }}/config.local {{ worktree_path }}"
 ```
 
 ### JSON context

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1214,14 +1214,14 @@ Templates also support functions for dynamic lookups:
 
 | Function | Example | Description |
 |----------|---------|-------------|
-| `worktree_path(branch)` | `{{ worktree_path("main") }}` | Look up the path of a branch's worktree |
+| `worktree_path_of_branch(branch)` | `{{ worktree_path_of_branch("main") }}` | Look up the path of a branch's worktree |
 
-The `worktree_path` function returns the filesystem path of a worktree given a branch name, or an empty string if no worktree exists for that branch. This is useful for referencing files in other worktrees:
+The `worktree_path_of_branch` function returns the filesystem path of a worktree given a branch name, or an empty string if no worktree exists for that branch. This is useful for referencing files in other worktrees:
 
 ```toml
 [post-create]
 # Copy config from main worktree
-setup = "cp {{ worktree_path('main') }}/config.local {{ worktree_path }}"
+setup = "cp {{ worktree_path_of_branch('main') }}/config.local {{ worktree_path }}"
 ```
 
 ### JSON context

--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -179,7 +179,7 @@ fn short_hash(s: &str) -> String {
 /// - `hash_port` — Hash to deterministic port number (10000-19999)
 ///
 /// # Functions
-/// - `worktree_path(branch)` — Look up the filesystem path of a branch's worktree
+/// - `worktree_path_of_branch(branch)` — Look up the filesystem path of a branch's worktree
 ///   Returns empty string if branch has no worktree.
 pub fn expand_template(
     template: &str,
@@ -217,9 +217,9 @@ pub fn expand_template(
     });
     env.add_filter("hash_port", |value: String| string_to_port(&value));
 
-    // Register worktree_path function for looking up branch worktree paths
+    // Register worktree_path_of_branch function for looking up branch worktree paths
     let repo_clone = repo.clone();
-    env.add_function("worktree_path", move |branch: String| -> String {
+    env.add_function("worktree_path_of_branch", move |branch: String| -> String {
         repo_clone
             .worktree_for_branch(&branch)
             .ok()

--- a/tests/integration_tests/doc_templates.rs
+++ b/tests/integration_tests/doc_templates.rs
@@ -417,16 +417,16 @@ fn test_doc_combined_filters(repo: TestRepo) {
 }
 
 // =============================================================================
-// worktree_path Function
+// worktree_path_of_branch Function
 // =============================================================================
 
 #[rstest]
-fn test_worktree_path_function_registered(repo: TestRepo) {
-    // Test that worktree_path function is callable and returns empty for nonexistent branch
+fn test_worktree_path_of_branch_function_registered(repo: TestRepo) {
+    // Test that worktree_path_of_branch function is callable and returns empty for nonexistent branch
     let repository = Repository::at(repo.root_path()).unwrap();
     let vars: HashMap<&str, &str> = HashMap::new();
     let result = expand_template(
-        "{{ worktree_path('nonexistent') }}",
+        "{{ worktree_path_of_branch('nonexistent') }}",
         &vars,
         false,
         &repository,


### PR DESCRIPTION
Update function name across documentation, CLI help text, template
expansion implementation, and tests for improved clarity.
