### PR TITLE
refactor: simplify default branch detection

### DIFF
--- a/src/commands/list/collect.rs
+++ b/src/commands/list/collect.rs
@@ -66,9 +66,8 @@
 //! command returns quickly after signaling the daemon. By the time the worker thread
 //! starts executing `git status` commands, daemons have had time to initialize.
 //!
-//! **Invalid default branch warning:** Uses cached value from `default_branch()` which
-//! ran during pre-skeleton. The `invalid_default_branch_config()` call is a pure cache
-//! read with no git commands.
+//! **Invalid default branch warning:** `invalid_default_branch_config()` reads the value
+//! cached by `default_branch()` during pre-skeleton. It's a pure cache read.
 //!
 //! When adding new features, ask: "Can this be computed after skeleton?" If yes, defer it.
 //! The skeleton shows `·` placeholder for gutter symbols, filled in when data loads.

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -65,8 +65,8 @@ pub(super) struct RepoCache {
     pub(super) is_bare: OnceCell<bool>,
     /// Default branch (main, master, etc.)
     pub(super) default_branch: OnceCell<Option<String>>,
-    /// Invalid default branch config (set when user configured a non-existent branch).
-    /// Populated by `default_branch()` as a side effect, read by `invalid_default_branch_config()`.
+    /// Invalid default branch config (user configured a branch that doesn't exist).
+    /// Populated by `default_branch()` during config validation.
     pub(super) invalid_default_branch: OnceCell<Option<String>>,
     /// Effective integration target (local default branch or upstream if ahead)
     pub(super) integration_target: OnceCell<Option<String>>,


### PR DESCRIPTION
## Summary

- Consolidate `detect_default_branch()` into `default_branch()` — the public method was only called internally
- Replace public `detect_default_branch()` with private `detect_from_remote()` helper
- Update comments to clarify cache relationships
- Remove stale TODO comment

## Test plan

- [x] All 824 tests pass
- [x] Code review confirmed zero behavioral change across all 5 code paths

> _This was written by Claude Code on behalf of max-sixty_