### PR TITLE
fix: remove trailing blank lines from --help output

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -451,7 +451,6 @@ Usage: <b><span class=c>wt config show</span></b> <span class=c>[OPTIONS]</span>
           Show debug info (-v), or also write diagnostic report (-vv)
 {% end %}
 
-
 ## wt config state
 
 State is stored in `.git/` (config entries and log files), separate from configuration files.
@@ -583,7 +582,6 @@ Usage: <b><span class=c>wt config state default-branch</span></b> <span class=c>
           Show debug info (-v), or also write diagnostic report (-vv)
 {% end %}
 
-
 ## wt config state ci-status
 
 Caches GitHub/GitLab CI status for display in [`wt list`](@/list.md#ci-status).
@@ -635,7 +633,6 @@ Usage: <b><span class=c>wt config state ci-status</span></b> <span class=c>[OPTI
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Show debug info (-v), or also write diagnostic report (-vv)
 {% end %}
-
 
 ## wt config state marker
 
@@ -694,7 +691,6 @@ Usage: <b><span class=c>wt config state marker</span></b> <span class=c>[OPTIONS
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Show debug info (-v), or also write diagnostic report (-vv)
 {% end %}
-
 
 ## wt config state logs
 

--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -221,7 +221,6 @@ Usage: <b><span class=c>wt step copy-ignored</span></b> <span class=c>[OPTIONS]<
           Show debug info (-v), or also write diagnostic report (-vv)
 {% end %}
 
-
 ## wt step for-each
 
 Executes a command sequentially in every worktree with real-time output. Continues on failure and shows a summary at the end.

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -261,13 +261,9 @@ Clear all stored state:
 ```console
 wt config state clear
 ```
-
 <!-- subdoc: default-branch -->
-
 <!-- subdoc: ci-status -->
-
 <!-- subdoc: marker -->
-
 <!-- subdoc: logs -->"#
     )]
     State {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1022,11 +1022,8 @@ wt step commit --show-prompt | llm -m gpt-5-nano
 
 - [`wt merge`](@/merge.md) — Runs commit → squash → rebase → hooks → push → cleanup automatically
 - [`wt hook`](@/hook.md) — Run configured hooks
-
 <!-- subdoc: copy-ignored -->
-
-<!-- subdoc: for-each -->
-"#
+<!-- subdoc: for-each -->"#
     )]
     Step {
         #[command(subcommand)]
@@ -1805,11 +1802,8 @@ WORKTRUNK_COMMIT_GENERATION__ARGS="test: automated commit" \
 | `WORKTRUNK_MAX_CONCURRENT_COMMANDS` | Max parallel git commands (default: 32). Lower if hitting file descriptor limits. |
 | `NO_COLOR` | Disable colored output ([standard](https://no-color.org/)) |
 | `CLICOLOR_FORCE` | Force colored output even when not a TTY |
-
 <!-- subdoc: show -->
-
-<!-- subdoc: state -->
-"#)
+<!-- subdoc: state -->"#)
     )]
     Config {
         #[command(subcommand)]


### PR DESCRIPTION
## Summary
- Remove unnecessary blank lines between `<!-- subdoc: ... -->` markers in CLI help strings
- These HTML comment markers are invisible in terminal output but their surrounding blank lines were appearing as trailing whitespace in `--help` output

## Test plan
- [x] Verified `wt config state --help`, `wt step --help`, `wt config --help` no longer have trailing blank lines
- [x] All help tests pass
- [x] Doc sync test passes (auto-updated docs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)