### PR TITLE
fix(docs): prevent code block layout jump on page load

### DIFF
--- a/docs/static/code-copy.js
+++ b/docs/static/code-copy.js
@@ -1,16 +1,17 @@
 // Copy-to-clipboard for code blocks
 // Strips leading `$ ` from bash/shell blocks (detected via data-lang or syntect classes)
-// Wraps pre in a container so copy button stays fixed during horizontal scroll
+//
+// Split into two phases to prevent layout jump on page load:
+// 1. Wrapper script (inline, sync) - wraps <pre> elements before first paint
+// 2. Button script (deferred) - adds copy buttons after DOM ready
 
 document.addEventListener('DOMContentLoaded', function() {
-  const codeBlocks = document.querySelectorAll('.content pre');
+  // Find all code blocks that were wrapped by the inline script
+  const wrappers = document.querySelectorAll('.code-block-wrapper');
 
-  codeBlocks.forEach(function(block) {
-    // Wrap pre in a container for proper button positioning
-    const wrapper = document.createElement('div');
-    wrapper.className = 'code-block-wrapper';
-    block.parentNode.insertBefore(wrapper, block);
-    wrapper.appendChild(block);
+  wrappers.forEach(function(wrapper) {
+    const block = wrapper.querySelector('pre');
+    if (!block) return;
 
     const button = document.createElement('button');
     button.className = 'code-copy-btn';
@@ -45,7 +46,6 @@ document.addEventListener('DOMContentLoaded', function() {
       });
     });
 
-    // Add button to wrapper (outside the scrollable pre)
     wrapper.appendChild(button);
   });
 });

--- a/docs/templates/base.html
+++ b/docs/templates/base.html
@@ -229,6 +229,20 @@
             </a>
         </div>
     </footer>
+    <script>
+    // Wrap code blocks in containers SYNCHRONOUSLY before first paint to prevent layout jump.
+    // The deferred code-copy.js will add copy buttons to these wrappers later.
+    (function() {
+        var blocks = document.querySelectorAll('.content pre');
+        for (var i = 0; i < blocks.length; i++) {
+            var block = blocks[i];
+            var wrapper = document.createElement('div');
+            wrapper.className = 'code-block-wrapper';
+            block.parentNode.insertBefore(wrapper, block);
+            wrapper.appendChild(block);
+        }
+    })();
+    </script>
 </body>
 
 </html>


### PR DESCRIPTION
## Summary

- Fix visual "jump" when reloading doc pages with code blocks
- Move wrapper DOM creation from deferred JS to synchronous inline script

## Test plan

- [x] Reload https://worktrunk.dev/step/ and verify code blocks don't jump
- [x] Verify copy buttons still work after the change

🤖 Generated with [Claude Code](https://claude.com/claude-code)