### PR TITLE
feat(docs): include long_about subtitles in web docs

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/merge.md
+++ b/.claude-plugin/skills/worktrunk/reference/merge.md
@@ -1,5 +1,7 @@
 # wt merge
 
+Squash & rebase, fast-forward target, remove the worktree.
+
 Merge the current branch into the target branch, defaulting to the main branch. Unlike `git merge`, this merges the current branch into a target (rather than a target into the current branch). Similar to clicking "Merge pull request" on GitHub.
 
 ## Examples

--- a/.claude-plugin/skills/worktrunk/reference/select.md
+++ b/.claude-plugin/skills/worktrunk/reference/select.md
@@ -1,5 +1,7 @@
 # wt select
 
+Browse and switch worktrees with live preview.
+
 Interactive worktree picker with live preview. Navigate worktrees with keyboard shortcuts and press Enter to switch.
 
 ## Examples

--- a/.claude-plugin/skills/worktrunk/reference/switch.md
+++ b/.claude-plugin/skills/worktrunk/reference/switch.md
@@ -1,5 +1,7 @@
 # wt switch
 
+Change directory to a worktree, creating one if needed.
+
 Worktrees are addressed by branch name; paths are computed from a configurable template. Unlike `git switch`, this navigates between worktrees rather than changing branches in place.
 
 ## Examples

--- a/docs/content/merge.md
+++ b/docs/content/merge.md
@@ -8,6 +8,8 @@ group = "Commands"
 
 <!-- ⚠️ AUTO-GENERATED from `wt merge --help-page` — edit cli.rs to update -->
 
+Squash & rebase, fast-forward target, remove the worktree.
+
 Merge the current branch into the target branch, defaulting to the main branch. Unlike `git merge`, this merges the current branch into a target (rather than a target into the current branch). Similar to clicking "Merge pull request" on GitHub.
 
 <figure class="demo">

--- a/docs/content/select.md
+++ b/docs/content/select.md
@@ -8,6 +8,8 @@ group = "Commands"
 
 <!-- ⚠️ AUTO-GENERATED from `wt select --help-page` — edit cli.rs to update -->
 
+Browse and switch worktrees with live preview.
+
 Interactive worktree picker with live preview. Navigate worktrees with keyboard shortcuts and press Enter to switch.
 
 <figure class="demo">

--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -8,14 +8,16 @@ group = "Commands"
 
 <!-- ⚠️ AUTO-GENERATED from `wt switch --help-page` — edit cli.rs to update -->
 
+Change directory to a worktree, creating one if needed.
+
+Worktrees are addressed by branch name; paths are computed from a configurable template. Unlike `git switch`, this navigates between worktrees rather than changing branches in place.
+
 <figure class="demo">
 <picture>
   <source srcset="/assets/docs/dark/wt-switch.gif" media="(prefers-color-scheme: dark)">
   <img src="/assets/docs/light/wt-switch.gif" alt="wt switch demo" width="1600" height="900">
 </picture>
 </figure>
-
-Worktrees are addressed by branch name; paths are computed from a configurable template. Unlike `git switch`, this navigates between worktrees rather than changing branches in place.
 
 ## Examples
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -245,9 +245,9 @@ pub(crate) enum Commands {
     /// Switch to a worktree
     ///
     /// Change directory to a worktree, creating one if needed.
-    #[command(after_long_help = r#"<!-- demo: wt-switch.gif 1600x900 -->
-
-Worktrees are addressed by branch name; paths are computed from a configurable template. Unlike `git switch`, this navigates between worktrees rather than changing branches in place.
+    #[command(
+        after_long_help = r#"Worktrees are addressed by branch name; paths are computed from a configurable template. Unlike `git switch`, this navigates between worktrees rather than changing branches in place.
+<!-- demo: wt-switch.gif 1600x900 -->
 
 ## Examples
 
@@ -308,7 +308,8 @@ To change which branch a worktree is on, use `git switch` inside that worktree.
 - [`wt list`](@/list.md) — View all worktrees
 - [`wt remove`](@/remove.md) — Delete worktrees when done
 - [`wt merge`](@/merge.md) — Integrate changes back to the default branch
-"#)]
+"#
+    )]
     Switch {
         /// Branch name
         ///

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -84,7 +84,6 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m<BRANCH>[0m [1m[36m[--
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
           Show debug info (-v), or also write diagnostic report (-vv)
 
-
 Worktrees are addressed by branch name; paths are computed from a configurable template. Unlike [2mgit switch[0m, this navigates between worktrees rather than changing branches in place.
 
 [32mExamples


### PR DESCRIPTION
## Summary

- The `--help-page` generator now extracts subtitles from `long_about` doc comments and includes them in web docs
- Fixes `wt switch` to place the demo GIF after the intro text (matching the pattern of `list`, `merge`, `select`)
- Command pages now show: subtitle → conceptual intro → demo → examples

## Test plan

- [x] All 824 integration tests pass
- [x] Pre-commit lints pass
- [x] Verified generated docs show correct ordering

> _This was written by Claude Code on behalf of @max-sixty_