### PR TITLE
Add tests for user messages and document coverage behavior

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -263,6 +263,20 @@ When CI shows a codecov/patch failure, investigate before declaring "ready to me
    - Write a test that exercises it, or
    - Document why it's intentionally untested (e.g., error paths requiring external system mocks)
 
+### How Coverage Works with Integration Tests
+
+Coverage is collected via `cargo llvm-cov` which instruments the binary. **Subprocess execution IS captured** — when tests spawn `wt` via `assert_cmd_snapshot!`, the instrumented binary writes coverage data to profile files that get merged into the report.
+
+When investigating uncovered lines:
+
+1. Run `task coverage` first to see actual coverage % (~92% is normal)
+2. Use `cargo llvm-cov report --show-missing-lines | grep <file>` to find specific uncovered lines
+3. **Check if tests already exist** for that functionality before writing new ones
+4. Remaining uncovered lines are typically:
+   - Error handling paths requiring mocked git failures
+   - Edge cases in shell integration states (e.g., running as `git wt`)
+   - Test assertion code (only executes when tests fail)
+
 ## Benchmarks
 
 See `benches/CLAUDE.md` for details.

--- a/tests/integration_tests/merge.rs
+++ b/tests/integration_tests/merge.rs
@@ -1943,3 +1943,20 @@ fn test_step_rebase_with_merge_commit(mut repo: TestRepo) {
         cmd
     });
 }
+
+/// Test `wt step rebase` when the feature branch is already up to date with main.
+///
+/// This should show "Already up to date with main" message.
+#[rstest]
+fn test_step_rebase_already_up_to_date(mut repo: TestRepo) {
+    // Create a feature worktree but don't advance main (feature is based on main's HEAD)
+    let feature_wt = repo.add_worktree("feature");
+
+    // Run `wt step rebase` - should show "Already up to date with main"
+    assert_cmd_snapshot!(make_snapshot_cmd(
+        &repo,
+        "step",
+        &["rebase"],
+        Some(&feature_wt)
+    ));
+}

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_clear_no_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_clear_no_approvals.snap
@@ -1,0 +1,36 @@
+---
+source: tests/integration_tests/hook_show.rs
+info:
+  program: wt
+  args:
+    - hook
+    - approvals
+    - clear
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[2m○[22m No approvals to clear for this project

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_clear_with_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_clear_with_approvals.snap
@@ -1,0 +1,36 @@
+---
+source: tests/integration_tests/hook_show.rs
+info:
+  program: wt
+  args:
+    - hook
+    - approvals
+    - clear
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[32m✓[39m [32mCleared 3 approvals for this project[39m

--- a/tests/snapshots/integration__integration_tests__merge__step_rebase_already_up_to_date.snap
+++ b/tests/snapshots/integration__integration_tests__merge__step_rebase_already_up_to_date.snap
@@ -1,0 +1,35 @@
+---
+source: tests/integration_tests/merge.rs
+info:
+  program: wt
+  args:
+    - step
+    - rebase
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[2m○[22m Already up to date with [1mmain[22m


### PR DESCRIPTION
## Summary

- Add snapshot tests for previously uncovered user-facing messages:
  - `test_step_rebase_already_up_to_date`: covers "Already up to date with main" message
  - `test_hook_clear_no_approvals`: covers "No approvals to clear for this project" message  
  - `test_hook_clear_with_approvals`: covers "Cleared N approvals for this project" message
- Document how coverage works with integration tests in CLAUDE.md to prevent future confusion about subprocess coverage instrumentation

## Test plan

- [x] All 827+ integration tests pass
- [x] Pre-commit lints pass
- [x] New snapshots reviewed and capture correct output

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>