### PR TITLE
feat: support commit-ish refs in --base flag

### DIFF
--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -618,11 +618,11 @@ pub fn plan_switch(
         )))?;
     }
 
-    // Resolve base branch for creation
+    // Resolve base ref for creation (accepts any commit-ish: branch, tag, SHA, HEAD)
     let base_branch = if create {
         match resolved_base {
             Some(ref b) => {
-                if !repo.branch_exists(b)? {
+                if !repo.ref_exists(b)? {
                     return Err(GitError::InvalidReference {
                         reference: b.clone(),
                     }

--- a/src/git/repository/branches.rs
+++ b/src/git/repository/branches.rs
@@ -32,6 +32,22 @@ impl Repository {
             .is_ok())
     }
 
+    /// Check if a git reference exists (branch, tag, commit SHA, HEAD, etc.).
+    ///
+    /// Accepts any valid commit-ish: branch names, tags, HEAD, commit SHAs,
+    /// and relative refs like HEAD~2.
+    pub fn ref_exists(&self, reference: &str) -> anyhow::Result<bool> {
+        // Use rev-parse to check if the reference resolves to a valid commit
+        // The ^{commit} suffix ensures we get the commit object, not a tag
+        Ok(self
+            .run_command(&[
+                "rev-parse",
+                "--verify",
+                &format!("{}^{{commit}}", reference),
+            ])
+            .is_ok())
+    }
+
     /// Find which remotes have a branch with the given name.
     ///
     /// Returns a list of remote names that have this branch (e.g., `["origin"]`).

--- a/tests/integration_tests/switch.rs
+++ b/tests/integration_tests/switch.rs
@@ -188,6 +188,18 @@ fn test_switch_create_with_invalid_base(repo: TestRepo) {
     );
 }
 
+#[rstest]
+fn test_switch_base_accepts_commitish(repo: TestRepo) {
+    // Issue #630: --base should accept any commit-ish, not just branch names
+    // Test HEAD as base (common use case: branch from current HEAD)
+    repo.commit("Initial commit on main");
+    snapshot_switch(
+        "switch_base_commitish_head",
+        &repo,
+        &["--create", "feature-from-head", "--base", "HEAD"],
+    );
+}
+
 // Internal mode tests
 #[rstest]
 fn test_switch_internal_mode(repo: TestRepo) {

--- a/tests/snapshots/integration__integration_tests__switch__switch_base_commitish_head.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_base_commitish_head.snap
@@ -1,0 +1,41 @@
+---
+source: tests/integration_tests/switch.rs
+info:
+  program: wt
+  args:
+    - switch
+    - "--create"
+    - feature-from-head
+    - "--base"
+    - HEAD
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[32m✓[39m [32mCreated branch [1mfeature-from-head[22m from [1mHEAD[22m and worktree @ [1m_REPO_.feature-from-head[22m[39m
+[2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
+[2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m


### PR DESCRIPTION
## Summary

- Add `ref_exists()` method to validate any commit-ish (branch, tag, SHA, HEAD, etc.)
- Change `--base` validation from `branch_exists()` to `ref_exists()`
- Add test for `--base HEAD` use case

Fixes #630

## Test plan

- [x] `wt switch --create feature --base HEAD` works
- [x] `wt switch --create feature --base v1.0` works (tags)
- [x] `wt switch --create feature --base abc1234` works (SHAs)
- [x] Invalid refs still fail with clear error
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

> _This was written by Claude Code on behalf of max-sixty_