### PR TITLE
feat: add upfront validation for target refs in commands

### DIFF
--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -95,8 +95,8 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
     // --no-commit implies --no-squash
     let squash_enabled = squash && commit;
 
-    // Get target branch (default to default branch if not provided)
-    let target_branch = repo.resolve_target_branch(target)?;
+    // Get and validate target branch (must be a branch since we're updating it)
+    let target_branch = repo.require_target_branch(target)?;
     // Worktree for target is optional: if present we use it for safety checks and as destination.
     let target_worktree_path = repo.worktree_for_branch(&target_branch)?;
 

--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -102,8 +102,8 @@ pub fn handle_squash(
     let ctx = env.context(yes);
     let generator = CommitGenerator::new(&env.config.commit_generation);
 
-    // Get target branch (default to default branch if not provided)
-    let target_branch = repo.resolve_target_branch(target)?;
+    // Get and validate target ref (any commit-ish for merge-base calculation)
+    let target_branch = repo.require_target_ref(target)?;
 
     // Auto-stage changes before running pre-commit hooks so both beta and merge paths behave identically
     match stage_mode {
@@ -295,8 +295,8 @@ pub fn step_show_squash_prompt(
 ) -> anyhow::Result<()> {
     let repo = Repository::current()?;
 
-    // Get target branch (default to default branch if not provided)
-    let target_branch = repo.resolve_target_branch(target)?;
+    // Get and validate target ref (any commit-ish for merge-base calculation)
+    let target_branch = repo.require_target_ref(target)?;
 
     // Get current branch
     let current_branch = repo
@@ -346,8 +346,8 @@ pub fn handle_rebase(target: Option<&str>) -> anyhow::Result<RebaseResult> {
 
     let repo = Repository::current()?;
 
-    // Get target branch (default to default branch if not provided)
-    let target_branch = repo.resolve_target_branch(target)?;
+    // Get and validate target ref (any commit-ish for rebase)
+    let target_branch = repo.require_target_ref(target)?;
 
     // Check if already up-to-date (linear extension of target, no merge commits)
     if repo.is_rebased_onto(&target_branch)? {

--- a/src/commands/worktree.rs
+++ b/src/commands/worktree.rs
@@ -938,8 +938,8 @@ pub fn handle_push(
 ) -> anyhow::Result<()> {
     let repo = Repository::current()?;
 
-    // Get target branch (default to default branch if not provided)
-    let target_branch = repo.resolve_target_branch(target)?;
+    // Get and validate target branch (must be a branch since we're updating it)
+    let target_branch = repo.require_target_branch(target)?;
 
     // A worktree for the target branch is optional for push:
     // - If present, we use it to check for overlapping dirty files.

--- a/tests/snapshots/integration__integration_tests__merge__merge_invalid_target.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_invalid_target.snap
@@ -1,0 +1,36 @@
+---
+source: tests/integration_tests/merge.rs
+info:
+  program: wt
+  args:
+    - merge
+    - nonexistent-branch
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[31m✗[39m [31mBranch [1mnonexistent-branch[22m not found[39m
+[2m↳[22m [2mTo create a new branch, run [90mwt switch nonexistent-branch --create[39m; to list branches, run [90mwt list --branches --remotes[39m[22m

--- a/tests/snapshots/integration__integration_tests__merge__step_rebase_accepts_tag.snap
+++ b/tests/snapshots/integration__integration_tests__merge__step_rebase_accepts_tag.snap
@@ -1,0 +1,36 @@
+---
+source: tests/integration_tests/merge.rs
+info:
+  program: wt
+  args:
+    - step
+    - rebase
+    - v1.0
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[2m○[22m Already up to date with [1mv1.0[22m

--- a/tests/snapshots/integration__integration_tests__merge__step_rebase_invalid_target.snap
+++ b/tests/snapshots/integration__integration_tests__merge__step_rebase_invalid_target.snap
@@ -1,0 +1,37 @@
+---
+source: tests/integration_tests/merge.rs
+info:
+  program: wt
+  args:
+    - step
+    - rebase
+    - nonexistent-ref
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[31m✗[39m [31mBranch [1mnonexistent-ref[22m not found[39m
+[2m↳[22m [2mTo create a new branch, run [90mwt switch nonexistent-ref --create[39m; to list branches, run [90mwt list --branches --remotes[39m[22m


### PR DESCRIPTION
## Summary

Follow-up to #637. Adds upfront validation for target arguments across commands:

- Add `require_target_branch()` for commands that update a branch ref (merge, push)
- Add `require_target_ref()` for commands that reference a commit (rebase, squash)
- Add tests for invalid targets and commit-ish acceptance

This ensures users get clear "Branch X not found" errors before approval prompts, rather than after approving or when git fails with unclear errors.

## Test plan

- [x] `wt merge nonexistent` fails with clear error before approval
- [x] `wt step push nonexistent` fails with clear error
- [x] `wt step rebase nonexistent` fails with clear error
- [x] `wt step rebase v1.0` works (tag accepted as commit-ish)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

> _This was written by Claude Code on behalf of max-sixty_