### PR TITLE
fix: prevent copy-ignored from copying nested worktrees

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/step.md
+++ b/.claude-plugin/skills/worktrunk/reference/step.md
@@ -263,7 +263,7 @@ Only gitignored files are copied — tracked files are never touched. If `.workt
 - Uses copy-on-write (reflink) when available for space-efficient copies
 - Handles nested `.gitignore` files, global excludes, and `.git/info/exclude`
 - Skips existing files (safe to re-run)
-- Skips symlinks and `.git` entries
+- Skips `.git` entries and other worktrees
 
 ### Performance
 

--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -282,7 +282,7 @@ Only gitignored files are copied — tracked files are never touched. If `.workt
 - Uses copy-on-write (reflink) when available for space-efficient copies
 - Handles nested `.gitignore` files, global excludes, and `.git/info/exclude`
 - Skips existing files (safe to re-run)
-- Skips symlinks and `.git` entries
+- Skips `.git` entries and other worktrees
 
 ### Performance
 

--- a/src/cli/step.rs
+++ b/src/cli/step.rs
@@ -198,7 +198,7 @@ Only gitignored files are copied — tracked files are never touched. If `.workt
 - Uses copy-on-write (reflink) when available for space-efficient copies
 - Handles nested `.gitignore` files, global excludes, and `.git/info/exclude`
 - Skips existing files (safe to re-run)
-- Skips symlinks and `.git` entries
+- Skips `.git` entries and other worktrees
 
 ## Performance
 

--- a/tests/snapshots/integration__integration_tests__step_copy_ignored__copy_ignored_skips_nested_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__step_copy_ignored__copy_ignored_skips_nested_worktrees.snap
@@ -1,0 +1,35 @@
+---
+source: tests/integration_tests/step_copy_ignored.rs
+info:
+  program: wt
+  args:
+    - step
+    - copy-ignored
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[32m✓[39m [32mCopied 1 entry[39m


### PR DESCRIPTION
## Summary

- Filter out ignored entries that contain other worktrees (prevents copying `.worktrees/` when `worktree-path = ".worktrees/..."`)
- Copy symlinks instead of skipping them (fixes `node_modules/.bin/` and similar)
- Update docs to reflect the behavior

Fixes #641

## Test plan

- [x] New test `test_copy_ignored_skips_nested_worktrees` verifies nested worktrees are excluded while regular ignored files are still copied
- [x] All 832 integration tests pass
- [x] Lints pass

🤖 Generated with [Claude Code](https://claude.ai/code)

> _This was written by Claude Code on behalf of max-sixty_