### PR TITLE
docs: document post-start/pre-remove cleanup pattern

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/hook.md
+++ b/.claude-plugin/skills/worktrunk/reference/hook.md
@@ -276,6 +276,8 @@ Both run when creating a worktree. The difference:
 
 Many tasks work well in `post-start` — they'll likely be ready by the time they're needed, especially when the fallback is recompiling. If unsure, prefer `post-start` for faster worktree creation.
 
+Background processes spawned by `post-start` outlive the worktree — pair them with `pre-remove` hooks to clean up. See [Dev servers](#dev-servers) and [Databases](#databases) for examples.
+
 ### Copying untracked files
 
 Git worktrees share the repository but not untracked files (dependencies, caches, `.env`). Use [`wt step copy-ignored`](https://worktrunk.dev/step/#wt-step-copy-ignored) to copy gitignored files:
@@ -294,6 +296,9 @@ Run a dev server per worktree on a deterministic port using `hash_port`:
 ```toml
 [post-start]
 server = "npm run dev -- --port {{ branch | hash_port }}"
+
+[pre-remove]
+server = "lsof -ti :{{ branch | hash_port }} | xargs kill 2>/dev/null || true"
 ```
 
 The port is stable across machines and restarts — `feature-api` always gets the same port. Show it in `wt list`:

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -284,6 +284,8 @@ Both run when creating a worktree. The difference:
 
 Many tasks work well in `post-start` — they'll likely be ready by the time they're needed, especially when the fallback is recompiling. If unsure, prefer `post-start` for faster worktree creation.
 
+Background processes spawned by `post-start` outlive the worktree — pair them with `pre-remove` hooks to clean up. See [Dev servers](#dev-servers) and [Databases](#databases) for examples.
+
 ### Copying untracked files
 
 Git worktrees share the repository but not untracked files (dependencies, caches, `.env`). Use [`wt step copy-ignored`](@/step.md#wt-step-copy-ignored) to copy gitignored files:
@@ -302,6 +304,9 @@ Run a dev server per worktree on a deterministic port using `hash_port`:
 ```toml
 [post-start]
 server = "npm run dev -- --port {{ branch | hash_port }}"
+
+[pre-remove]
+server = "lsof -ti :{{ branch | hash_port }} | xargs kill 2>/dev/null || true"
 ```
 
 The port is stable across machines and restarts — `feature-api` always gets the same port. Show it in `wt list`:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1272,6 +1272,8 @@ Both run when creating a worktree. The difference:
 
 Many tasks work well in `post-start` — they'll likely be ready by the time they're needed, especially when the fallback is recompiling. If unsure, prefer `post-start` for faster worktree creation.
 
+Background processes spawned by `post-start` outlive the worktree — pair them with `pre-remove` hooks to clean up. See [Dev servers](#dev-servers) and [Databases](#databases) for examples.
+
 ### Copying untracked files
 
 Git worktrees share the repository but not untracked files (dependencies, caches, `.env`). Use [`wt step copy-ignored`](@/step.md#wt-step-copy-ignored) to copy gitignored files:
@@ -1290,6 +1292,9 @@ Run a dev server per worktree on a deterministic port using `hash_port`:
 ```toml
 [post-start]
 server = "npm run dev -- --port {{ branch | hash_port }}"
+
+[pre-remove]
+server = "lsof -ti :{{ branch | hash_port }} | xargs kill 2>/dev/null || true"
 ```
 
 The port is stable across machines and restarts — `feature-api` always gets the same port. Show it in `wt list`:


### PR DESCRIPTION
## Summary

- Add general principle about background process cleanup to "post-create vs post-start" section
- Add pre-remove example to Dev servers section (matching existing Databases pattern)

Background processes spawned by `post-start` hooks outlive worktree removal. This documents the pattern of pairing them with `pre-remove` hooks for cleanup.

## Test plan

- [x] Pre-commit checks pass
- [x] Docs sync test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)