### PR TITLE
perf(tests): remove nextest thread constraints and use wait_for helper

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,14 +19,6 @@ success-output = "never"
 [profile.default.junit]
 path = "junit.xml"
 
-# The ci_status tests spawn many parallel threads and processes (~30 threads, ~34
-# child processes each). Mark them as "heavy" so nextest limits how many run
-# concurrently. threads-required=4 means on an 8-core machine, only 2 of these
-# tests run at once instead of 8.
-[[profile.default.overrides]]
-filter = 'test(/integration_tests::ci_status::test_list_full/)'
-threads-required = 4
-
 # The source_flag test runs `cargo run` inside a PTY, which can take longer than
 # 60s when cargo needs to check/compile dependencies on slow CI runners.
 [[profile.default.overrides]]

--- a/tests/integration_tests/bare_repository.rs
+++ b/tests/integration_tests/bare_repository.rs
@@ -1,6 +1,6 @@
 use crate::common::{
     BareRepoTest, TestRepo, TestRepoBase, canonicalize, configure_directive_file, directive_file,
-    repo, setup_temp_snapshot_settings, wait_for_file, wt_command,
+    repo, setup_temp_snapshot_settings, wait_for, wait_for_file, wt_command,
 };
 use insta_cmd::assert_cmd_snapshot;
 use rstest::rstest;
@@ -364,16 +364,7 @@ fn test_bare_repo_merge_workflow() {
     }
 
     // Wait for background removal to complete
-    for _ in 0..50 {
-        if !feature_worktree.exists() {
-            break;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(100));
-    }
-    assert!(
-        !feature_worktree.exists(),
-        "Feature worktree should be removed after merge"
-    );
+    wait_for("feature worktree removed", || !feature_worktree.exists());
 
     // Verify main worktree still exists and has the feature commit
     assert!(main_worktree.exists());


### PR DESCRIPTION
## Summary

- Remove `threads-required=4` constraint for ci_status tests — tests are robust enough to run with full parallelism
- Replace manual poll loop with `wait_for` helper in bare_repository test, which uses exponential backoff

## Test plan

- [x] ci_status tests pass without thread constraints
- [x] bare_repository tests pass with `wait_for`
- [x] Pre-commit lints pass

🤖 Generated with [Claude Code](https://claude.ai/code)