### PR TITLE
feat: -h never opens pager, --help uses pager (git convention)

### DIFF
--- a/src/commands/config.rs
+++ b/src/commands/config.rs
@@ -171,8 +171,8 @@ pub fn handle_config_show(full: bool) -> anyhow::Result<()> {
     show_output.push('\n');
     render_runtime_info(&mut show_output)?;
 
-    // Display through pager
-    if let Err(e) = show_help_in_pager(&show_output) {
+    // Display through pager (config show is always long-form output)
+    if let Err(e) = show_help_in_pager(&show_output, true) {
         log::debug!("Pager invocation failed: {}", e);
         // Fall back to direct output via eprintln (matches help behavior)
         worktrunk::styling::eprintln!("{}", show_output);
@@ -1117,7 +1117,7 @@ pub fn handle_state_get(key: &str, branch: Option<String>) -> anyhow::Result<()>
             render_log_files(&mut out, &repo)?;
 
             // Display through pager (fall back to stderr if pager unavailable)
-            if show_help_in_pager(&out).is_err() {
+            if show_help_in_pager(&out, true).is_err() {
                 worktrunk::styling::eprintln!("{}", out);
             }
         }
@@ -1603,7 +1603,7 @@ fn handle_state_show_table(repo: &Repository) -> anyhow::Result<()> {
     render_log_files(&mut out, repo)?;
 
     // Display through pager (fall back to stderr if pager unavailable)
-    if let Err(e) = show_help_in_pager(&out) {
+    if let Err(e) = show_help_in_pager(&out, true) {
         log::debug!("Pager invocation failed: {}", e);
         // Fall back to direct output via eprintln (matches help behavior)
         worktrunk::styling::eprintln!("{}", out);

--- a/src/commands/hook_commands.rs
+++ b/src/commands/hook_commands.rs
@@ -424,7 +424,7 @@ pub fn handle_hook_show(hook_type_filter: Option<&str>, expanded: bool) -> anyho
     )?;
 
     // Display through pager (fall back to stderr if pager unavailable)
-    if show_help_in_pager(&output).is_err() {
+    if show_help_in_pager(&output, true).is_err() {
         worktrunk::styling::eprintln!("{}", output);
     }
 


### PR DESCRIPTION
## Summary

- Follows git's help pager convention: `-h` never opens a pager, `--help` uses pager when content doesn't fit
- Addresses feedback in #583 that forcing a pager for short help breaks muscle memory

## Changes

- Added `use_pager` parameter to `show_help_in_pager()` in `src/help_pager.rs`
- Detect `-h` vs `--help` in `maybe_handle_help_with_pager()` in `src/help.rs`
- Other commands (`wt config show`, `wt hook show`, `wt config state show`) always use pager since they display long-form output

## Test plan

- [x] `wt -h` prints directly to terminal without pager
- [x] `wt --help` uses pager when content doesn't fit (less -F quits if fits)
- [x] `wt merge -h` prints directly
- [x] `wt merge --help` uses pager
- [x] `wt config show` uses pager (unchanged behavior)
- [x] All existing tests pass

Closes #583

🤖 Generated with [Claude Code](https://claude.ai/code)

_This was written by Claude Code on behalf of max-sixty_