### PR TITLE
fix(powershell): handle multiple binaries with same name

### DIFF
--- a/src/snapshots/worktrunk__shell__tests__init_powershell.snap
+++ b/src/snapshots/worktrunk__shell__tests__init_powershell.snap
@@ -19,7 +19,8 @@ if (Get-Command wt -ErrorAction SilentlyContinue) {
             [string[]]$Arguments
         )
 
-        $wtBin = (Get-Command wt -CommandType Application).Source
+        # Select-Object -First 1 handles case where multiple binaries match (e.g., wt.exe from Windows Terminal)
+        $wtBin = (Get-Command wt -CommandType Application | Select-Object -First 1).Source
         $directiveFile = [System.IO.Path]::GetTempFileName()
 
         try {
@@ -67,7 +68,7 @@ if (Get-Command wt -ErrorAction SilentlyContinue) {
     # This registers Register-ArgumentCompleter with proper handling
     $env:COMPLETE = "powershell"
     try {
-        & (Get-Command wt -CommandType Application) | Out-String | Invoke-Expression
+        & (Get-Command wt -CommandType Application | Select-Object -First 1) | Out-String | Invoke-Expression
     }
     finally {
         Remove-Item Env:\COMPLETE -ErrorAction SilentlyContinue

--- a/templates/powershell.ps1
+++ b/templates/powershell.ps1
@@ -15,7 +15,8 @@ if (Get-Command {{ cmd }} -ErrorAction SilentlyContinue) {
             [string[]]$Arguments
         )
 
-        $wtBin = (Get-Command {{ cmd }} -CommandType Application).Source
+        # Select-Object -First 1 handles case where multiple binaries match (e.g., wt.exe from Windows Terminal)
+        $wtBin = (Get-Command {{ cmd }} -CommandType Application | Select-Object -First 1).Source
         $directiveFile = [System.IO.Path]::GetTempFileName()
 
         try {
@@ -63,7 +64,7 @@ if (Get-Command {{ cmd }} -ErrorAction SilentlyContinue) {
     # This registers Register-ArgumentCompleter with proper handling
     $env:COMPLETE = "powershell"
     try {
-        & (Get-Command {{ cmd }} -CommandType Application) | Out-String | Invoke-Expression
+        & (Get-Command {{ cmd }} -CommandType Application | Select-Object -First 1) | Out-String | Invoke-Expression
     }
     finally {
         Remove-Item Env:\COMPLETE -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Summary

Fixes the PowerShell shell integration to handle cases where multiple binaries with the same name exist (e.g., Windows Terminal's `wt.exe` alongside worktrunk's `wt.exe`).

- Added `Select-Object -First 1` to `Get-Command` calls to handle array results
- Fixes `Cannot convert 'System.Object[]' to the type 'System.String'` error
- Fixes `The term 'wt.exe wt.exe' is not recognized...` error

Relates to #648 — this addresses issue (1) from that PR's description. The Winget installation instructions in #648 are still valuable for users who prefer to avoid the name collision entirely by using `git-wt`.

## Test plan

- [x] Unit tests pass
- [x] Snapshot updated for PowerShell init output
- [ ] Manual testing on Windows with both Windows Terminal and worktrunk installed

> _This was written by Claude Code on behalf of @max-sixty_