### PR TITLE
refactor(process): remove redundant sh -c wrapping in spawn_detached

### DIFF
--- a/src/commands/process.rs
+++ b/src/commands/process.rs
@@ -105,7 +105,7 @@ fn spawn_detached_unix(
         None => command.to_string(),
     };
 
-    let shell_cmd = format!("sh -c {} &", shell_escape::escape(full_command.into()));
+    let shell_cmd = format!("{} &", full_command);
 
     // Log only the operation identifier, not the full command (which may contain context_json
     // with user data that shouldn't appear in debug logs)


### PR DESCRIPTION
## Summary

- Removes redundant `sh -c` wrapping in `spawn_detached_unix`
- The command was being wrapped twice: once in shell_cmd formatting (`sh -c {} &`), and again via `Command::new("sh").arg("-c")`
- Simplifies to just `{} &` since the outer Command already provides shell interpretation

## Test plan

- [x] Unit tests pass
- [x] Integration tests pass (832 tests)

🤖 Generated with [Claude Code](https://claude.ai/code)

> _This was written by Claude Code on behalf of @max-sixty_