### PR TITLE
fix: don't report branch creation when local branch already exists

### DIFF
--- a/tests/snapshots/integration__integration_tests__switch__switch_dwim_from_remote.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_dwim_from_remote.snap
@@ -1,0 +1,38 @@
+---
+source: tests/integration_tests/switch.rs
+info:
+  program: wt
+  args:
+    - switch
+    - dwim-feature
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: /var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpk2rrMV/mock-bin
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[32m✓[39m [32mCreated branch [1mdwim-feature[22m (tracking [1morigin/dwim-feature[22m) and worktree @ [1m_REPO_.dwim-feature[22m[39m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
+[2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_existing_local_with_upstream.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_existing_local_with_upstream.snap
@@ -1,0 +1,38 @@
+---
+source: tests/integration_tests/switch.rs
+info:
+  program: wt
+  args:
+    - switch
+    - tracked-feature
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: /var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmptQDDmu/mock-bin
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[32m✓[39m [32mCreated worktree for [1mtracked-feature[22m @ [1m_REPO_.tracked-feature[22m[39m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
+[2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m


### PR DESCRIPTION
## Summary
- Fixes #656: When switching to an existing local branch that tracks a remote, don't incorrectly report "Created branch X (tracking remote)"
- Track whether local branch existed BEFORE `git worktree add` to distinguish DWIM branch creation from pre-existing branches
- Add tests for both scenarios: DWIM from remote and existing local branch with upstream

## Test plan
- [x] `test_switch_dwim_from_remote` - Verifies "Created branch X (tracking remote)" when git DWIM creates local from remote
- [x] `test_switch_existing_local_branch_with_upstream` - Verifies "Created worktree for X" when local branch already exists
- [x] All 834 integration tests pass
- [x] Adversarial testing found no issues

> _This was written by Claude Code on behalf of max-sixty_