### PR TITLE
docs: add Windows install guidance

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/faq.md
+++ b/.claude-plugin/skills/worktrunk/reference/faq.md
@@ -86,23 +86,6 @@ If the remote's default branch has changed (e.g., renamed from master to main), 
 
 For full details on the detection mechanism, see `wt config state default-branch --help`.
 
-## On Windows, `wt` conflicts with Windows Terminal
-
-Windows Terminal uses `wt` as its command-line launcher, so running `wt` invokes Terminal instead of Worktrunk.
-
-As an immediate workaround, install as `git-wt`:
-
-```bash
-cargo install worktrunk --features git-wt
-git-wt config shell install
-```
-
-This creates a `git-wt` shell function with directory changing and completions.
-
-`git wt` (as a git subcommand) also works but cannot change directories since git runs subcommands as subprocesses.
-
-We're considering better solutions — a better name, anyone?
-
 ## Does Worktrunk work on Windows?
 
 **Experimental.** Core functionality works, but some features are unavailable.

--- a/.claude-plugin/skills/worktrunk/reference/worktrunk.md
+++ b/.claude-plugin/skills/worktrunk/reference/worktrunk.md
@@ -91,6 +91,20 @@ Shell integration allows commands to change directories.
 cargo install worktrunk && wt config shell install
 ```
 
+<details>
+<summary><strong>Windows</strong></summary>
+
+On Windows, `wt` defaults to Windows Terminal's command. Winget additionally installs Worktrunk as `git-wt` to avoid the conflict:
+
+```bash
+winget install max-sixty.worktrunk
+git-wt config shell install
+```
+
+Alternatively, disable Windows Terminal's alias (Settings → Privacy & security → For developers → App Execution Aliases → disable "Windows Terminal") to use `wt` directly.
+
+</details>
+
 ## Next steps
 
 - Learn the core commands: [`wt switch`](https://worktrunk.dev/switch/), [`wt list`](https://worktrunk.dev/list/), [`wt merge`](https://worktrunk.dev/merge/), [`wt remove`](https://worktrunk.dev/remove/)

--- a/README.md
+++ b/README.md
@@ -111,6 +111,20 @@ Shell integration allows commands to change directories.
 cargo install worktrunk && wt config shell install
 ```
 
+<details>
+<summary><strong>Windows</strong></summary>
+
+On Windows, `wt` defaults to Windows Terminal's command. Winget additionally installs Worktrunk as `git-wt` to avoid the conflict:
+
+```bash
+winget install max-sixty.worktrunk
+git-wt config shell install
+```
+
+Alternatively, disable Windows Terminal's alias (Settings → Privacy & security → For developers → App Execution Aliases → disable "Windows Terminal") to use `wt` directly.
+
+</details>
+
 ## Next steps
 
 - Learn the core commands: [`wt switch`](https://worktrunk.dev/switch/), [`wt list`](https://worktrunk.dev/list/), [`wt merge`](https://worktrunk.dev/merge/), [`wt remove`](https://worktrunk.dev/remove/)

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -96,23 +96,6 @@ If the remote's default branch has changed (e.g., renamed from master to main), 
 
 For full details on the detection mechanism, see `wt config state default-branch --help`.
 
-## On Windows, `wt` conflicts with Windows Terminal
-
-Windows Terminal uses `wt` as its command-line launcher, so running `wt` invokes Terminal instead of Worktrunk.
-
-As an immediate workaround, install as `git-wt`:
-
-```bash
-cargo install worktrunk --features git-wt
-git-wt config shell install
-```
-
-This creates a `git-wt` shell function with directory changing and completions.
-
-`git wt` (as a git subcommand) also works but cannot change directories since git runs subcommands as subprocesses.
-
-We're considering better solutions — a better name, anyone?
-
 ## Does Worktrunk work on Windows?
 
 **Experimental.** Core functionality works, but some features are unavailable.

--- a/docs/content/worktrunk.md
+++ b/docs/content/worktrunk.md
@@ -110,6 +110,20 @@ Shell integration allows commands to change directories.
 cargo install worktrunk && wt config shell install
 ```
 
+<details>
+<summary><strong>Windows</strong></summary>
+
+On Windows, `wt` defaults to Windows Terminal's command. Winget additionally installs Worktrunk as `git-wt` to avoid the conflict:
+
+```bash
+winget install max-sixty.worktrunk
+git-wt config shell install
+```
+
+Alternatively, disable Windows Terminal's alias (Settings → Privacy & security → For developers → App Execution Aliases → disable "Windows Terminal") to use `wt` directly.
+
+</details>
+
 ## Next steps
 
 - Learn the core commands: [`wt switch`](@/switch.md), [`wt list`](@/list.md), [`wt merge`](@/merge.md), [`wt remove`](@/remove.md)


### PR DESCRIPTION
## Summary

- Add Windows installation guidance to README and docs
- Move Windows Terminal conflict FAQ to main documentation (more discoverable than FAQ)
- Remove duplicate FAQ entry

## Test plan
- [x] CI passes
- [x] Documentation builds correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)