### PR TITLE
fix(remove): make --force flag work with dirty worktrees

### DIFF
--- a/.claude/rules/cli-output-formatting.md
+++ b/.claude/rules/cli-output-formatting.md
@@ -140,6 +140,20 @@ behavior:
 "Removing feature worktree in background; retaining branch"
 ```
 
+**Flag locality:** Place flag indicators adjacent to the concept they modify.
+Flags should appear immediately after the noun/action they affect, not at the
+end of the message:
+
+```rust
+// GOOD - (--force) is adjacent to "worktree" which it modifies
+"Removing feature worktree (--force) & branch in background (same commit as main, _)"
+// BAD - (--force) at end, disconnected from the worktree removal it enables
+"Removing feature worktree & branch in background (same commit as main, _) (--force)"
+```
+
+This principle ensures readers can immediately understand what each annotation
+modifies.
+
 **Parallel structure:** Related messages should follow the same pattern:
 
 ```rust

--- a/src/commands/repository_ext.rs
+++ b/src/commands/repository_ext.rs
@@ -161,8 +161,10 @@ impl RepositoryCliExt for Repository {
             return Err(GitError::CannotRemoveMainWorktree.into());
         }
 
-        // Ensure the working tree is clean
-        target_wt.ensure_clean("remove worktree", branch_name.as_deref())?;
+        // Check working tree cleanliness (unless --force, which passes through to git)
+        if !force_worktree {
+            target_wt.ensure_clean("remove worktree", branch_name.as_deref())?;
+        }
 
         // Compute main_path and changed_directory based on whether we're removing current
         let (main_path, changed_directory) = if is_current {

--- a/tests/snapshots/integration__integration_tests__remove__remove_force_with_force_delete.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_force_with_force_delete.snap
@@ -1,0 +1,38 @@
+---
+source: tests/integration_tests/remove.rs
+info:
+  program: wt
+  args:
+    - remove
+    - "--force"
+    - "-D"
+    - feature-dirty-unmerged
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: /var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmp22EH0v/mock-bin
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎ Removing [1mfeature-dirty-unmerged[22m worktree (--force) & branch in background (--force-delete)[39m

--- a/tests/snapshots/integration__integration_tests__remove__remove_force_with_modified_files.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_force_with_modified_files.snap
@@ -1,0 +1,38 @@
+---
+source: tests/integration_tests/remove.rs
+info:
+  program: wt
+  args:
+    - remove
+    - "--force"
+    - feature-modified
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: /var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpZBmXa4/mock-bin
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎ Removing [1mfeature-modified[22m worktree (--force) in background[39m
+[2m↳[22m [2mBranch unmerged; to delete, run [90mwt remove feature-modified -D[39m[22m

--- a/tests/snapshots/integration__integration_tests__remove__remove_force_with_staged_files.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_force_with_staged_files.snap
@@ -1,0 +1,37 @@
+---
+source: tests/integration_tests/remove.rs
+info:
+  program: wt
+  args:
+    - remove
+    - "--force"
+    - feature-staged
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: /var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpikz508/mock-bin
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎ Removing [1mfeature-staged[22m worktree (--force) & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m

--- a/tests/snapshots/integration__integration_tests__remove__remove_force_with_untracked_files.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_force_with_untracked_files.snap
@@ -1,0 +1,37 @@
+---
+source: tests/integration_tests/remove.rs
+info:
+  program: wt
+  args:
+    - remove
+    - "--force"
+    - feature-untracked
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: /var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmppcKJg1/mock-bin
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎ Removing [1mfeature-untracked[22m worktree (--force) & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m


### PR DESCRIPTION
## Summary

Fixes #658 — the `--force` flag was documented to allow removal of worktrees with uncommitted changes, but `ensure_clean()` was called unconditionally, blocking removal before git could apply `--force`.

- Skip `ensure_clean()` when `force_worktree=true`, letting git handle dirty worktrees
- Add `(--force)` indicator to removal messages, placed adjacent to "worktree" per flag locality principle
- Add tests for `--force` with untracked, modified, and staged files
- Add test for `--force` + `-D` combination
- Document flag locality principle in CLI output guidelines

## Test plan

- [x] `cargo test --test integration remove` — all 72 tests pass
- [x] Verified output format: `◎ Removing feature worktree (--force) & branch in background (same commit as main, _)`

🤖 Generated with [Claude Code](https://claude.ai/code)