### PR TITLE
fix: convert bare URLs to proper markdown links in docs

### DIFF
--- a/.claude-plugin/CLAUDE.md
+++ b/.claude-plugin/CLAUDE.md
@@ -42,4 +42,4 @@ The hooks track Claude Code activity via git config (`worktrunk.status.{branch}`
 
 **Problem**: If the user interrupts Claude Code (Escape/Ctrl+C), the 🤖 status persists because there's no `UserInterrupt` hook. The `Stop` hook explicitly does not fire on user interrupt.
 
-**Tracking**: https://github.com/anthropics/claude-code/issues/9516
+**Tracking**: [claude-code#9516](https://github.com/anthropics/claude-code/issues/9516)

--- a/.claude-plugin/skills/worktrunk/reference/config.md
+++ b/.claude-plugin/skills/worktrunk/reference/config.md
@@ -80,7 +80,7 @@ worktree-path = "../{{ branch | sanitize }}"
 
 ## LLM commit messages
 
-Generate commit messages automatically during merge. Requires an external CLI tool. See <https://worktrunk.dev/llm-commits/> for setup details and template customization.
+Generate commit messages automatically during merge. Requires an external CLI tool. See [LLM commits docs](https://worktrunk.dev/llm-commits/) for setup and template customization.
 
 Using [llm](https://github.com/simonw/llm) (install: `pip install llm llm-anthropic`):
 
@@ -156,7 +156,7 @@ Commands approved for project hooks. Auto-populated when approving hooks on firs
 approved-commands = ["npm ci", "npm test"]
 ```
 
-For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at `<repo>/.config/wt.toml`. Run `wt config create --project` to create one, or see <https://worktrunk.dev/hook/>.
+For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at `<repo>/.config/wt.toml`. Run `wt config create --project` to create one, or see [`wt hook` docs](https://worktrunk.dev/hook/).
 
 ### Custom prompt templates
 

--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -38,21 +38,21 @@
 #
 # ## LLM commit messages
 #
-# Generate commit messages automatically during merge. Requires an external CLI tool. See <https://worktrunk.dev/llm-commits/> for setup details and template customization.
+# Generate commit messages automatically during merge. Requires an external CLI tool. See LLM commits docs (https://worktrunk.dev/llm-commits/) for setup and template customization.
 #
-# Using [llm](https://github.com/simonw/llm) (install: `pip install llm llm-anthropic`):
+# Using llm (https://github.com/simonw/llm) (install: `pip install llm llm-anthropic`):
 #
 # [commit-generation]
 # command = "llm"
 # args = ["-m", "claude-haiku-4.5"]
 #
-# Using [aichat](https://github.com/sigoden/aichat):
+# Using aichat (https://github.com/sigoden/aichat):
 #
 # [commit-generation]
 # command = "aichat"
 # args = ["-m", "claude:claude-haiku-4.5"]
 #
-# See [Custom prompt templates](#custom-prompt-templates) for inline template options.
+# See Custom prompt templates (#custom-prompt-templates) for inline template options.
 #
 # ## Commands
 #
@@ -100,11 +100,11 @@
 # [projects."github.com/user/repo"]
 # approved-commands = ["npm ci", "npm test"]
 #
-# For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at `<repo>/.config/wt.toml`. Run `wt config create --project` to create one, or see <https://worktrunk.dev/hook/>.
+# For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at `<repo>/.config/wt.toml`. Run `wt config create --project` to create one, or see `wt hook` docs (https://worktrunk.dev/hook/).
 #
 # ### Custom prompt templates
 #
-# Templates use [minijinja](https://docs.rs/minijinja/) syntax.
+# Templates use minijinja (https://docs.rs/minijinja/) syntax.
 #
 # #### Commit template
 #

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -88,7 +88,7 @@ worktree-path = "../{{ branch | sanitize }}"
 
 ## LLM commit messages
 
-Generate commit messages automatically during merge. Requires an external CLI tool. See <https://worktrunk.dev/llm-commits/> for setup details and template customization.
+Generate commit messages automatically during merge. Requires an external CLI tool. See [LLM commits docs](@/llm-commits.md) for setup and template customization.
 
 Using [llm](https://github.com/simonw/llm) (install: `pip install llm llm-anthropic`):
 
@@ -164,7 +164,7 @@ Commands approved for project hooks. Auto-populated when approving hooks on firs
 approved-commands = ["npm ci", "npm test"]
 ```
 
-For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at `<repo>/.config/wt.toml`. Run `wt config create --project` to create one, or see <https://worktrunk.dev/hook/>.
+For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at `<repo>/.config/wt.toml`. Run `wt config create --project` to create one, or see [`wt hook` docs](@/hook.md).
 
 ### Custom prompt templates
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1481,7 +1481,7 @@ worktree-path = "../{{ branch | sanitize }}"
 
 ## LLM commit messages
 
-Generate commit messages automatically during merge. Requires an external CLI tool. See <https://worktrunk.dev/llm-commits/> for setup details and template customization.
+Generate commit messages automatically during merge. Requires an external CLI tool. See [LLM commits docs](@/llm-commits.md) for setup and template customization.
 
 Using [llm](https://github.com/simonw/llm) (install: `pip install llm llm-anthropic`):
 
@@ -1557,7 +1557,7 @@ Commands approved for project hooks. Auto-populated when approving hooks on firs
 approved-commands = ["npm ci", "npm test"]
 ```
 
-For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at `<repo>/.config/wt.toml`. Run `wt config create --project` to create one, or see <https://worktrunk.dev/hook/>.
+For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at `<repo>/.config/wt.toml`. Run `wt config create --project` to create one, or see [`wt hook` docs](@/hook.md).
 
 ### Custom prompt templates
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -86,21 +86,21 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
   [2m#
   [2m# ## LLM commit messages
   [2m#
-  [2m# Generate commit messages automatically during merge. Requires an external CLI tool. See <https://worktrunk.dev/llm-commits/> for setup details and template customization.
+  [2m# Generate commit messages automatically during merge. Requires an external CLI tool. See LLM commits docs (https://worktrunk.dev/llm-commits/) for setup and template customization.
   [2m#
-  [2m# Using [llm](https://github.com/simonw/llm) (install: `pip install llm llm-anthropic`):
+  [2m# Using llm (https://github.com/simonw/llm) (install: `pip install llm llm-anthropic`):
   [2m#
   [2m# [commit-generation]
   [2m# command = "llm"
   [2m# args = ["-m", "claude-haiku-4.5"]
   [2m#
-  [2m# Using [aichat](https://github.com/sigoden/aichat):
+  [2m# Using aichat (https://github.com/sigoden/aichat):
   [2m#
   [2m# [commit-generation]
   [2m# command = "aichat"
   [2m# args = ["-m", "claude:claude-haiku-4.5"]
   [2m#
-  [2m# See [Custom prompt templates](#custom-prompt-templates) for inline template options.
+  [2m# See Custom prompt templates (#custom-prompt-templates) for inline template options.
   [2m#
   [2m# ## Commands
   [2m#
@@ -148,11 +148,11 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
   [2m# [projects."github.com/user/repo"]
   [2m# approved-commands = ["npm ci", "npm test"]
   [2m#
-  [2m# For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at `<repo>/.config/wt.toml`. Run `wt config create --project` to create one, or see <https://worktrunk.dev/hook/>.
+  [2m# For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at `<repo>/.config/wt.toml`. Run `wt config create --project` to create one, or see `wt hook` docs (https://worktrunk.dev/hook/).
   [2m#
   [2m# ### Custom prompt templates
   [2m#
-  [2m# Templates use [minijinja](https://docs.rs/minijinja/) syntax.
+  [2m# Templates use minijinja (https://docs.rs/minijinja/) syntax.
   [2m#
   [2m# #### Commit template
   [2m#

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -113,7 +113,7 @@ Controls where new worktrees are created. Paths are relative to the repository r
 
 [1m[32mLLM commit messages
 
-Generate commit messages automatically during merge. Requires an external CLI tool. See <https://worktrunk.dev/llm-commits/> for setup details and template customization.
+Generate commit messages automatically during merge. Requires an external CLI tool. See LLM commits docs for setup and template customization.
 
 Using llm (install: [2mpip install llm llm-anthropic[0m):
 
@@ -175,7 +175,7 @@ Commands approved for project hooks. Auto-populated when approving hooks on firs
   [2m[projects."github.com/user/repo"]
   [2mapproved-commands = ["npm ci", "npm test"]
 
-For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at [2m<repo>/.config/wt.toml[0m. Run [2mwt config create --project[0m to create one, or see <https://worktrunk.dev/hook/>.
+For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at [2m<repo>/.config/wt.toml[0m. Run [2mwt config create --project[0m to create one, or see [2mwt hook[0m docs.
 
 [32mCustom prompt templates
 


### PR DESCRIPTION
## Summary

- Convert angle-bracket URLs (`<https://...>`) to proper markdown links
- CLI help now shows descriptive text ("LLM commits docs", "`wt hook` docs") instead of raw URLs
- Web docs render as clickable links with descriptive anchor text

## Test plan

- [x] Pre-commit lints pass (including lychee link checker)
- [x] Help snapshot tests updated and pass
- [x] Doc sync test passes
- [x] CLI output verified manually

🤖 Generated with [Claude Code](https://claude.com/code)