### PR TITLE
ci: upload Claude Code session logs as artifacts

### DIFF
--- a/.github/workflows/claude-ci-fix.yaml
+++ b/.github/workflows/claude-ci-fix.yaml
@@ -123,3 +123,12 @@ jobs:
 
           claude_args: |
             --allowedTools Bash,Edit,Read,Write,Glob,Grep,WebSearch,WebFetch
+
+      - name: 📋 Upload Claude Code session logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-session-logs
+          path: ~/.claude/
+          retention-days: 30
+          if-no-files-found: warn

--- a/.github/workflows/claude-mention.yaml
+++ b/.github/workflows/claude-mention.yaml
@@ -104,3 +104,12 @@ jobs:
 
             This project is a git worktree manager that integrates with shells (bash, zsh, fish).
             Pay attention to shell integration, output formatting (anstyle), and snapshot tests."
+
+      - name: 📋 Upload Claude Code session logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: claude-session-logs
+          path: ~/.claude/
+          retention-days: 30
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary

- Add artifact upload step to `claude-ci-fix` and `claude-mention` workflows
- Uploads `~/.claude/` directory containing session logs after each run
- Retains artifacts for 30 days for debugging

## Motivation

PR #665 demonstrated incorrect root cause analysis by Claude when fixing a CI failure. The "fix" changed `.unwrap_or(false)` to `?` for a function that never returns `Err`, meaning the change had no effect. The actual failure was a flaky test (same commit passed on retry).

With session logs preserved as artifacts, we can debug what information Claude saw and where the reasoning went wrong.

## Test plan

- [ ] Verify artifact upload works on next Claude workflow run
- [ ] Check that logs are accessible and useful for debugging

---

> _This was written by Claude Code on behalf of max-sixty_