### PR TITLE
feat: add --force hint when removing dirty worktrees

### DIFF
--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -88,6 +88,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
         return Err(worktrunk::git::GitError::UncommittedChanges {
             action: Some("merge with --no-commit".into()),
             branch: Some(current_branch.clone()),
+            force_hint: false,
         }
         .into());
     }
@@ -203,8 +204,11 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
     if remove_effective {
         // STEP 1: Check for uncommitted changes before attempting cleanup
         // This prevents showing "Cleaning up worktree..." before failing
-        repo.current_worktree()
-            .ensure_clean("remove worktree after merge", Some(&current_branch))?;
+        repo.current_worktree().ensure_clean(
+            "remove worktree after merge",
+            Some(&current_branch),
+            false,
+        )?;
 
         // STEP 2: Remove worktree via shared remove output handler so final message matches wt remove
         let worktree_root = repo.current_worktree().root()?.to_path_buf();

--- a/src/commands/repository_ext.rs
+++ b/src/commands/repository_ext.rs
@@ -163,7 +163,7 @@ impl RepositoryCliExt for Repository {
 
         // Check working tree cleanliness (unless --force, which passes through to git)
         if !force_worktree {
-            target_wt.ensure_clean("remove worktree", branch_name.as_deref())?;
+            target_wt.ensure_clean("remove worktree", branch_name.as_deref(), true)?;
         }
 
         // Compute main_path and changed_directory based on whether we're removing current

--- a/src/git/repository/working_tree.rs
+++ b/src/git/repository/working_tree.rs
@@ -188,11 +188,18 @@ impl<'a> WorkingTree<'a> {
     /// Returns an error if there are uncommitted changes.
     /// - `action` describes what was blocked (e.g., "remove worktree").
     /// - `branch` identifies which branch for multi-worktree operations.
-    pub fn ensure_clean(&self, action: &str, branch: Option<&str>) -> anyhow::Result<()> {
+    /// - `force_hint` when true, the error hint mentions `--force` as an alternative.
+    pub fn ensure_clean(
+        &self,
+        action: &str,
+        branch: Option<&str>,
+        force_hint: bool,
+    ) -> anyhow::Result<()> {
         if self.is_dirty()? {
             return Err(GitError::UncommittedChanges {
                 action: Some(action.into()),
                 branch: branch.map(String::from),
+                force_hint,
             }
             .into());
         }

--- a/tests/integration_tests/git_error_display.rs
+++ b/tests/integration_tests/git_error_display.rs
@@ -100,6 +100,7 @@ fn display_uncommitted_changes() {
     let err = GitError::UncommittedChanges {
         action: Some("remove worktree".into()),
         branch: None,
+        force_hint: false,
     };
 
     assert_snapshot!("uncommitted_changes", err.to_string());
@@ -110,9 +111,21 @@ fn display_uncommitted_changes_with_branch() {
     let err = GitError::UncommittedChanges {
         action: Some("remove worktree".into()),
         branch: Some("feature-branch".into()),
+        force_hint: false,
     };
 
     assert_snapshot!("uncommitted_changes_with_branch", err.to_string());
+}
+
+#[test]
+fn display_uncommitted_changes_with_force_hint() {
+    let err = GitError::UncommittedChanges {
+        action: Some("remove worktree".into()),
+        branch: Some("feature-branch".into()),
+        force_hint: true,
+    };
+
+    assert_snapshot!("uncommitted_changes_with_force_hint", err.to_string());
 }
 
 #[test]

--- a/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__uncommitted_changes_with_force_hint.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__uncommitted_changes_with_force_hint.snap
@@ -1,0 +1,6 @@
+---
+source: tests/integration_tests/git_error_display.rs
+expression: err.to_string()
+---
+[31m✗[39m [31mCannot remove worktree: [1mfeature-branch[22m has uncommitted changes[39m
+[2m↳[22m [2mCommit or stash changes first, or to lose uncommitted changes, run [90mwt remove feature-branch --force[39m[22m

--- a/tests/snapshots/integration__integration_tests__remove__remove_by_name_dirty_target.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_by_name_dirty_target.snap
@@ -18,6 +18,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: /var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpFvoLMc/mock-bin
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"
@@ -33,4 +34,4 @@ exit_code: 1
 
 ----- stderr -----
 [31m✗[39m [31mCannot remove worktree: [1mfeature-dirty[22m has uncommitted changes[39m
-[2m↳[22m [2mCommit or stash changes first[22m
+[2m↳[22m [2mCommit or stash changes first, or to lose uncommitted changes, run [90mwt remove feature-dirty --force[39m[22m


### PR DESCRIPTION
## Summary

- When `wt remove` fails due to uncommitted changes, the hint now shows the full command to bypass the check
- The hint is context-aware: only appears for `wt remove` where `--force` is available, not for `wt merge` contexts

**Before:**
```
✗ Cannot remove worktree: feature has uncommitted changes
↳ Commit or stash changes first
```

**After:**
```
✗ Cannot remove worktree: feature has uncommitted changes
↳ Commit or stash changes first, or to lose uncommitted changes, run wt remove feature --force
```

## Test plan

- [x] Unit tests pass
- [x] Integration tests updated with new snapshot
- [x] New test case for force hint variant
- [x] Verified merge contexts still show simple hint (no `--force` available there)

🤖 Generated with [Claude Code](https://claude.ai/code)