### PR TITLE
Reorder FAQ by frequency/importance

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/faq.md
+++ b/.claude-plugin/skills/worktrunk/reference/faq.md
@@ -100,7 +100,7 @@ Worktrunk stores small amounts of cache and log data in the repository's `.git/`
 | Location | Purpose | Created by |
 |----------|---------|------------|
 | `.git/config` keys under `worktrunk.*` | Cached default branch, switch history, branch markers | Various commands |
-| `.git/wt-cache/ci-status/*.json` | CI status cache (~1KB each) | `wt list` when `gh` CLI is installed |
+| `.git/wt-cache/ci-status/*.json` | CI status cache (~1KB each) | `wt list` when `gh` or `glab` CLI is installed |
 | `.git/wt-logs/*.log` | Background command output | Hooks, background `wt remove` |
 
 None of this is tracked by git or pushed to remotes.
@@ -147,7 +147,7 @@ See [What files does Worktrunk create?](#what-files-does-worktrunk-create) for d
 
 ## What commands does Worktrunk execute?
 
-Worktrunk executes commands in four contexts:
+Worktrunk runs `git` commands internally and optionally runs `gh` (GitHub) or `glab` (GitLab) for CI status. Beyond that, user-defined commands execute in four contexts:
 
 1. **User hooks** (`~/.config/worktrunk/config.toml`) — Personal automation for all repositories
 2. **Project hooks** (`.config/wt.toml`) — Repository-specific automation

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -106,7 +106,7 @@ Worktrunk stores small amounts of cache and log data in the repository's `.git/`
 | Location | Purpose | Created by |
 |----------|---------|------------|
 | `.git/config` keys under `worktrunk.*` | Cached default branch, switch history, branch markers | Various commands |
-| `.git/wt-cache/ci-status/*.json` | CI status cache (~1KB each) | `wt list` when `gh` CLI is installed |
+| `.git/wt-cache/ci-status/*.json` | CI status cache (~1KB each) | `wt list` when `gh` or `glab` CLI is installed |
 | `.git/wt-logs/*.log` | Background command output | Hooks, background `wt remove` |
 
 None of this is tracked by git or pushed to remotes.
@@ -153,7 +153,7 @@ See [What files does Worktrunk create?](#what-files-does-worktrunk-create) for d
 
 ## What commands does Worktrunk execute?
 
-Worktrunk executes commands in four contexts:
+Worktrunk runs `git` commands internally and optionally runs `gh` (GitHub) or `glab` (GitLab) for CI status. Beyond that, user-defined commands execute in four contexts:
 
 1. **User hooks** (`~/.config/worktrunk/config.toml`) — Personal automation for all repositories
 2. **Project hooks** (`.config/wt.toml`) — Repository-specific automation


### PR DESCRIPTION
## Summary

- Reorder FAQ sections to put most-asked questions first
- Fix accuracy: mention both `gh` and `glab` for CI status features

New order:
1. Comparisons (evaluation)
2. Shell setup issues (common friction)
3. Files created / can delete / commands executed (trust)
4. Windows support
5. Default branch detection
6. C compilation errors (rare)
7. Contributing sections

> _This was written by Claude Code on behalf of max-sixty_