### PR TITLE
Fix demo scrolling to exclude descriptions

### DIFF
--- a/docs/sass/custom.scss
+++ b/docs/sass/custom.scss
@@ -366,9 +366,13 @@ main {
 
 // Demo GIFs - shrink to min-width, then horizontal scroll
 .content figure.demo {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
     margin-top: 0.25rem;
+
+    picture {
+        display: block;
+        overflow-x: auto;
+        -webkit-overflow-scrolling: touch;
+    }
 
     img {
         display: block;


### PR DESCRIPTION
Move overflow-x from figure.demo to the picture element so the figcaption stays in place while the image scrolls horizontally.