### PR TITLE
feat: add Codecov Test Analytics integration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -107,6 +107,13 @@ jobs:
         name: junit-${{ matrix.os }}
         path: target/nextest/default/junit.xml
 
+    - name: 📊 Upload test results to Codecov
+      if: ${{ !cancelled() && github.repository_owner == 'max-sixty' }}
+      uses: codecov/test-results-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        files: target/nextest/default/junit.xml
+
   # Check if Cargo files changed (for conditional jobs below)
   changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Upload JUnit XML test results to Codecov Test Analytics
- Enables test run time tracking, failure rate analysis, and flaky test detection
- Uses existing nextest JUnit output at `target/nextest/default/junit.xml`

## Test plan
- [ ] CI passes
- [ ] Verify test results appear in Codecov dashboard after merge

> _This was written by Claude Code on behalf of max-sixty_