### PR TITLE
feat(config): add diagnostic info to wt config show for debugging

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -642,6 +642,9 @@ pub fn configure_cli_command(cmd: &mut Command) {
     // Note: env_remove above may cause insta-cmd to capture empty values in snapshots,
     // but correctness (isolating from host WORKTRUNK_* vars) trumps snapshot aesthetics.
     cmd.env("WORKTRUNK_CONFIG_PATH", "/nonexistent/test/config.toml");
+    // Remove $SHELL to avoid platform-dependent diagnostic output (macOS has /bin/zsh,
+    // Linux has /bin/bash). Tests that need SHELL should set it explicitly.
+    cmd.env_remove("SHELL");
     cmd.env("CLICOLOR_FORCE", "1");
     cmd.env("SOURCE_DATE_EPOCH", TEST_EPOCH.to_string());
     // Use wide terminal to prevent wrapping differences across platforms.
@@ -2004,6 +2007,8 @@ pub fn add_standard_env_redactions(settings: &mut insta::Settings) {
     // Windows: etcetera uses APPDATA for config_dir()
     settings.add_redaction(".env.APPDATA", "[TEST_CONFIG_HOME]");
     settings.add_redaction(".env.PATH", "[PATH]");
+    // Mock commands directory (temp path for mock gh/glab binaries)
+    settings.add_redaction(".env.MOCK_CONFIG_DIR", "[MOCK_CONFIG_DIR]");
 }
 
 /// Create configured insta Settings for snapshot tests

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_claude_available_plugin_not_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_claude_available_plugin_not_installed.snap
@@ -18,8 +18,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -40,7 +42,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_empty_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_empty_project_config.snap
@@ -18,8 +18,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -40,7 +42,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_command_not_found.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_command_not_found.snap
@@ -19,8 +19,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -45,7 +47,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_not_configured.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_not_configured.snap
@@ -19,8 +19,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -41,7 +43,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_github_remote.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_github_remote.snap
@@ -18,8 +18,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -40,7 +42,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_gitlab_remote.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_gitlab_remote.snap
@@ -18,8 +18,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -40,7 +42,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_project_toml.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_project_toml.snap
@@ -18,8 +18,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -46,7 +48,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_user_toml.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_user_toml.snap
@@ -18,8 +18,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -46,7 +48,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_no_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_no_project_config.snap
@@ -18,8 +18,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -40,7 +42,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_no_user_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_no_user_config.snap
@@ -18,8 +18,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -40,7 +42,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_outside_git_repo.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_outside_git_repo.snap
@@ -11,8 +11,10 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     HOME: "[TEST_HOME]"
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -32,7 +34,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_partial_shell_config_shows_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_partial_shell_config_shows_hint.snap
@@ -18,8 +18,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -41,7 +43,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m↳[22m [2mNot configured shell extension & completions for bash[22m
 [2m○[22m Already configured shell extension & completions for [1mzsh[22m @ ~/.zshrc:2

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_plugin_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_plugin_installed.snap
@@ -18,8 +18,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -40,7 +42,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_warning.snap
@@ -18,8 +18,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -41,7 +43,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m↳[22m [2mNot configured shell extension & completions for bash[22m
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_project_keys.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_project_keys.snap
@@ -18,8 +18,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -42,7 +44,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_user_keys.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_user_keys.snap
@@ -18,8 +18,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -44,7 +46,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_whitespace_only_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_whitespace_only_project_config.snap
@@ -18,8 +18,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -40,7 +42,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_with_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_with_project_config.snap
@@ -18,8 +18,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -46,7 +48,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_correct_order.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_correct_order.snap
@@ -18,8 +18,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -41,7 +43,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m Already configured shell extension & completions for [1mzsh[22m @ ~/.zshrc:5
 [107m [0m [2m[0m[2m[35mif[0m[2m [0m[2m[34mcommand[0m[2m [0m[2m[36m-v[0m[2m wt [0m[2m[36m>[0m[2m/dev/null [0m[2m[33m2[0m[2m>&1; [0m[2m[35mthen[0m[2m [0m[2m[34meval[0m[2m [0m[2m[32m"$([0m[2m[34mcommand[0m[2m wt config shell init zsh)"[0m[2m; [0m[2m[35mfi[0m[2m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_warning.snap
@@ -18,8 +18,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -41,7 +43,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m Already configured shell extension & completions for [1mzsh[22m @ ~/.zshrc:2
 [107m [0m [2m[0m[2m[35mif[0m[2m [0m[2m[34mcommand[0m[2m [0m[2m[36m-v[0m[2m wt [0m[2m[36m>[0m[2m/dev/null [0m[2m[33m2[0m[2m>&1; [0m[2m[35mthen[0m[2m [0m[2m[34meval[0m[2m [0m[2m[32m"$([0m[2m[34mcommand[0m[2m wt config shell init zsh)"[0m[2m; [0m[2m[35mfi[0m[2m

--- a/tests/snapshots/integration__integration_tests__configure_shell__config_show_detects_fish_legacy_conf_d.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__config_show_detects_fish_legacy_conf_d.snap
@@ -18,6 +18,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SHELL: /bin/fish
@@ -41,7 +42,8 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m $SHELL: [1m/bin/fish[22m
 
 [2m○[22m [2mSkipped bash; ~/.bashrc not found[22m
 [2m○[22m [2mSkipped zsh; ~/.zshrc not found[22m

--- a/tests/snapshots/integration__integration_tests__configure_shell__config_show_fish_legacy_with_functions_dir.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__config_show_fish_legacy_with_functions_dir.snap
@@ -18,6 +18,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SHELL: /bin/fish
@@ -41,7 +42,8 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Binary invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m $SHELL: [1m/bin/fish[22m
 
 [2m○[22m Fish integration found in deprecated location @ [1m~/.config/fish/conf.d/wt.fish[22m
 [2m↳[22m [2mTo migrate to [90m~/.config/fish/functions/wt.fish[39m, run [90mwt config shell install fish[39m[22m

--- a/tests/snapshots/integration__integration_tests__remove__remove_by_name_dirty_target.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_by_name_dirty_target.snap
@@ -18,7 +18,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpFvoLMc/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__remove__remove_force_with_force_delete.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_force_with_force_delete.snap
@@ -20,7 +20,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmp22EH0v/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__remove__remove_force_with_modified_files.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_force_with_modified_files.snap
@@ -19,7 +19,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpZBmXa4/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__remove__remove_force_with_staged_files.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_force_with_staged_files.snap
@@ -19,7 +19,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpikz508/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__remove__remove_force_with_untracked_files.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_force_with_untracked_files.snap
@@ -19,7 +19,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmppcKJg1/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__switch__switch_dwim_from_remote.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_dwim_from_remote.snap
@@ -18,7 +18,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpk2rrMV/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__switch__switch_error_path_occupied_missing.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_error_path_occupied_missing.snap
@@ -19,7 +19,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpons9bk/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__switch__switch_existing_local_with_upstream.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_existing_local_with_upstream.snap
@@ -18,7 +18,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmptQDDmu/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_base_conflict.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_base_conflict.snap
@@ -20,7 +20,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpUkPMaC/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_create_conflict.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_create_conflict.snap
@@ -19,7 +19,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmp4ZpO8c/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_empty_branch.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_empty_branch.snap
@@ -18,7 +18,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /private/var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpaZU3Am/repo/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_fork.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_fork.snap
@@ -18,7 +18,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /private/var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmp21Mo4b/repo/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_fork_existing_different_pr.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_fork_existing_different_pr.snap
@@ -18,7 +18,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /private/var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmp3ZvcLv/repo/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_fork_existing_no_tracking.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_fork_existing_no_tracking.snap
@@ -18,7 +18,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /private/var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpmUEy2n/repo/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_fork_existing_same_pr.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_fork_existing_same_pr.snap
@@ -18,7 +18,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /private/var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpTYfCXg/repo/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_invalid_json.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_invalid_json.snap
@@ -18,7 +18,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /private/var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpRh8Dpz/repo/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_network_error.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_network_error.snap
@@ -18,7 +18,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /private/var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpt5UXqw/repo/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_not_authenticated.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_not_authenticated.snap
@@ -18,7 +18,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /private/var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpqAg3i9/repo/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_not_found.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_not_found.snap
@@ -18,7 +18,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /private/var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpUbK6oP/repo/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_rate_limit.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_rate_limit.snap
@@ -18,7 +18,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /private/var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpUBbBov/repo/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_same_repo.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_same_repo.snap
@@ -18,7 +18,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /private/var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpWBoesk/repo/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_unknown_error.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_unknown_error.snap
@@ -18,7 +18,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    MOCK_CONFIG_DIR: /private/var/folders/wf/s6ycxvvs4ln8qsdbfx40hnc40000gn/T/.tmpN24ynF/repo/mock-bin
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
     SOURCE_DATE_EPOCH: "1735776000"


### PR DESCRIPTION
## Summary
- Add diagnostic info to `wt config show` when shell integration is not active:
  - `Invoked as:` — argv[0], how the command was called
  - `Running from:` — actual binary path (only if different from invocation)
  - `$SHELL:` — user's default shell env var
- Add missing `MOCK_CONFIG_DIR` redaction to snapshot settings

These help diagnose issues like #678 where commands silently fail.

## Test plan
- [x] `cargo test --test integration test_config_show` passes
- [x] Snapshots properly redact `MOCK_CONFIG_DIR` temp paths

🤖 Generated with [Claude Code](https://claude.ai/code)