### PR TITLE
fix: add file locking to prevent config race conditions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -917,6 +917,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "fs2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9564fc758e15025b46aa6643b1b77d047d1a56a1aea6e01002ac0c7026876213"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3043,6 +3053,7 @@ dependencies = [
  "dunce",
  "env_logger",
  "etcetera",
+ "fs2",
  "home",
  "ignore",
  "indexmap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,7 @@ regex = "1.12"
 ignore = "0.4"
 reflink-copy = "0.1"
 dashmap = "6.1.0"
+fs2 = "0.4.3"
 
 [target.'cfg(unix)'.dependencies]
 skim = "0.20"


### PR DESCRIPTION
## Summary

Adds file locking using the `fs2` crate to prevent race conditions when multiple `wt` processes modify config simultaneously.

**The problem:** When multiple `wt` commands run concurrently (e.g., two terminal windows both approving commands), the config file could be corrupted due to TOCTOU (time-of-check time-of-use) race conditions.

**The fix:** `acquire_config_lock()` creates a `.lock` file and acquires an exclusive lock before any reload-modify-save operation. This ensures atomic updates.

## Changes

- Added `fs2 = "0.4.3"` dependency for cross-platform file locking
- Added `acquire_config_lock()` function in `src/config/user.rs`
- Updated `approve_command()`, `revoke_command()`, `revoke_project()`, and `set_skip_shell_integration_prompt()` to acquire lock before modifying config
- Added concurrent approval test with 10 threads using barrier synchronization

## Test plan

- [x] Existing tests pass
- [x] New test `test_truly_concurrent_approve_with_threads` verifies concurrent access is safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)