### PR TITLE
fix: canonicalize paths when resolving current worktree

### DIFF
--- a/tests/snapshots/integration__integration_tests__remove__remove_at_symbol_via_symlink.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_at_symbol_via_symlink.snap
@@ -1,0 +1,39 @@
+---
+source: tests/integration_tests/remove.rs
+info:
+  program: wt
+  args:
+    - remove
+    - "@"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SHELL: ""
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎ Removing [1mfeature-symlink[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
+[2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m


### PR DESCRIPTION
## Summary
- Fixes path comparison in `resolve_worktree("@")` and `current_worktree_info()` to properly handle symlinks
- Uses `dunce::canonicalize` on worktree paths before comparison since `root()` already returns canonicalized paths
- Prevents mismatch on systems with symlinks (e.g., macOS `/var` → `/private/var`)

## Test plan
- [x] Added Unix-only integration test `test_remove_at_symbol_via_symlink` that creates a worktree, symlinks to it, and verifies `wt remove @` works from the symlinked path
- [x] All 855 integration tests pass
- [x] Pre-commit lints pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)