### PR TITLE
fix(list): correct current worktree detection for nested worktrees

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1460,6 +1460,21 @@ impl TestRepo {
         canonical_path
     }
 
+    /// Creates a worktree at a custom path (for testing nested worktrees).
+    ///
+    /// Unlike `add_worktree`, this places the worktree at the specified path
+    /// rather than using the default sibling layout.
+    pub fn add_worktree_at_path(&mut self, branch: &str, path: &Path) -> PathBuf {
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let path_str = path.to_str().unwrap();
+        self.run_git(&["worktree", "add", "-b", branch, path_str]);
+
+        let canonical_path = canonicalize(path).unwrap();
+        self.worktrees
+            .insert(branch.to_string(), canonical_path.clone());
+        canonical_path
+    }
+
     /// Creates a worktree for the main branch (required for merge operations)
     ///
     /// This is a convenience method that creates a worktree for the main branch

--- a/tests/snapshots/integration__integration_tests__list__list_nested_worktree_current_indicator.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_nested_worktree_current_indicator.snap
@@ -1,0 +1,43 @@
+---
+source: tests/integration_tests/list.rs
+info:
+  program: wt
+  args:
+    - list
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SHELL: ""
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m                  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ [2mfeature[0m       [31m⚑[39m[2m_[22m                         [2m./.worktrees/feature[0m           [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
+^ main         [36m?[39m [2m^[22m[2m|[22m                        .                        [2m|[0m     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
++ feature-a      [2m↑[22m                 [32m↑1[0m      ../repo.feature-a              [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
++ feature-b      [2m↑[22m                 [32m↑1[0m      ../repo.feature-b              [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file
++ feature-c      [2m↑[22m                 [32m↑1[0m      ../repo.feature-c              [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
+
+[2m○[22m [2mShowing 5 worktrees, 1 with changes, 3 ahead
+
+----- stderr -----


### PR DESCRIPTION
## Summary

- Fix current worktree detection for worktrees placed inside other worktrees (e.g., `.worktrees/` layout)
- Use `git rev-parse --show-toplevel` instead of `starts_with` prefix matching
- Add regression tests for nested worktree scenarios

Previously, if a worktree was nested inside another (like `/repo/.worktrees/feature` inside `/repo`), the prefix matching would incorrectly match the parent worktree first, showing the `@` indicator on the wrong worktree.

## Test plan

- [x] Added `test_list_nested_worktree_current_indicator` snapshot test
- [x] Added `test_list_nested_worktree_json_is_current` JSON assertion test
- [x] All 856 integration tests pass

> _This was written by Claude Code on behalf of max-sixty_