### PR TITLE
refactor(list): use + for previous worktree gutter instead of -

### DIFF
--- a/src/commands/list/render.rs
+++ b/src/commands/list/render.rs
@@ -352,15 +352,13 @@ impl ColumnLayout {
             ColumnKind::Gutter => {
                 let mut cell = StyledLine::new();
                 let symbol = if let Some(data) = worktree_data {
-                    // Priority: @ (current) > ^ (main) > - (previous) > + (regular)
+                    // Priority: @ (current) > ^ (main) > + (regular, including previous)
                     if data.is_current {
                         "@ " // Current worktree
                     } else if data.is_main {
                         "^ " // Main worktree
-                    } else if data.is_previous {
-                        "- " // Previous worktree (wt switch -)
                     } else {
-                        "+ " // Regular worktree
+                        "+ " // Regular worktree (including previous)
                     }
                 } else {
                     "  " // Branch without worktree (two spaces to match width)

--- a/tests/integration_tests/list.rs
+++ b/tests/integration_tests/list.rs
@@ -125,7 +125,8 @@ fn test_list_previous_worktree_gutter(mut repo: TestRepo) {
     cmd.args(["switch", "main"]).current_dir(&feature_path);
     cmd.output().unwrap();
 
-    // Now list should show `-` for feature (the previous worktree, target of `wt switch -`)
+    // List shows previous worktree with `+` (same as regular worktrees).
+    // The previous worktree is the target of `wt switch -`.
     assert_cmd_snapshot!(list_snapshots::command(&repo, repo.root_path()));
 }
 

--- a/tests/snapshots/integration__integration_tests__list__list_previous_worktree_gutter.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_previous_worktree_gutter.snap
@@ -17,8 +17,10 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     PATH: "[PATH]"
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
@@ -31,7 +33,7 @@ exit_code: 0
 ----- stdout -----
   [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mPath[0m               [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
 @ main           [2m^[22m[2m|[22m                        .                     [2m|[0m     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
-- [2mfeature[0m        [2m_[22m                         [2m../repo.feature[0m             [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
++ [2mfeature[0m        [2m_[22m                         [2m../repo.feature[0m             [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
 + feature-a      [2m↑[22m                 [32m↑1[0m      ../repo.feature-a           [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
 + feature-b      [2m↑[22m                 [32m↑1[0m      ../repo.feature-b           [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file
 + feature-c      [2m↑[22m                 [32m↑1[0m      ../repo.feature-c           [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file


### PR DESCRIPTION
I never found the `-` helpful, and adds some visual noise.

Does anyone find this helpful? will merge if not

---

## Summary

- Changes the gutter symbol for "previous worktree" from `-` to `+`
- Simplifies the visual language: `@` (current), `^` (main), `+` (all others)
- The `wt switch -` command still works — this only affects the display

## Test plan

- [x] `cargo test --test integration` passes
- [x] Snapshot updated for `test_list_previous_worktree_gutter`

---

_This was written by Claude Code on behalf of @max-sixty_