### PR TITLE
refactor: require -vv for debug logging, reserve -v for future use

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/config.md
+++ b/.claude-plugin/skills/worktrunk/reference/config.md
@@ -405,7 +405,7 @@ Usage: <b><span class=c>wt config</span></b> <span class=c>[OPTIONS]</span> <spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 ## wt config show
 
@@ -447,7 +447,7 @@ Usage: <b><span class=c>wt config show</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 ## wt config state
 
@@ -522,7 +522,7 @@ Usage: <b><span class=c>wt config state</span></b> <span class=c>[OPTIONS]</span
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 ## wt config state default-branch
 
@@ -574,7 +574,7 @@ Usage: <b><span class=c>wt config state default-branch</span></b> <span class=c>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 ## wt config state ci-status
 
@@ -624,7 +624,7 @@ Usage: <b><span class=c>wt config state ci-status</span></b> <span class=c>[OPTI
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 ## wt config state marker
 
@@ -680,7 +680,7 @@ Usage: <b><span class=c>wt config state marker</span></b> <span class=c>[OPTIONS
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 ## wt config state logs
 
@@ -744,4 +744,4 @@ Usage: <b><span class=c>wt config state logs</span></b> <span class=c>[OPTIONS]<
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)

--- a/.claude-plugin/skills/worktrunk/reference/hook.md
+++ b/.claude-plugin/skills/worktrunk/reference/hook.md
@@ -418,7 +418,7 @@ Usage: <b><span class=c>wt hook</span></b> <span class=c>[OPTIONS]</span> <span 
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 ## wt hook approvals
 
@@ -467,4 +467,4 @@ Usage: <b><span class=c>wt hook approvals</span></b> <span class=c>[OPTIONS]</sp
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)

--- a/.claude-plugin/skills/worktrunk/reference/list.md
+++ b/.claude-plugin/skills/worktrunk/reference/list.md
@@ -281,4 +281,4 @@ Usage: <b><span class=c>wt list</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)

--- a/.claude-plugin/skills/worktrunk/reference/merge.md
+++ b/.claude-plugin/skills/worktrunk/reference/merge.md
@@ -117,4 +117,4 @@ Usage: <b><span class=c>wt merge</span></b> <span class=c>[OPTIONS]</span> <span
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)

--- a/.claude-plugin/skills/worktrunk/reference/remove.md
+++ b/.claude-plugin/skills/worktrunk/reference/remove.md
@@ -111,4 +111,4 @@ Usage: <b><span class=c>wt remove</span></b> <span class=c>[OPTIONS]</span> <spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)

--- a/.claude-plugin/skills/worktrunk/reference/select.md
+++ b/.claude-plugin/skills/worktrunk/reference/select.md
@@ -72,4 +72,4 @@ Usage: <b><span class=c>wt select</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)

--- a/.claude-plugin/skills/worktrunk/reference/step.md
+++ b/.claude-plugin/skills/worktrunk/reference/step.md
@@ -57,7 +57,7 @@ Usage: <b><span class=c>wt step</span></b> <span class=c>[OPTIONS]</span> <span 
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 ## wt step commit
 
@@ -138,7 +138,7 @@ Usage: <b><span class=c>wt step commit</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 ## wt step squash
 
@@ -222,7 +222,7 @@ Usage: <b><span class=c>wt step squash</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 ## wt step copy-ignored
 
@@ -343,7 +343,7 @@ Usage: <b><span class=c>wt step copy-ignored</span></b> <span class=c>[OPTIONS]<
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 ## wt step for-each
 
@@ -405,4 +405,4 @@ Usage: <b><span class=c>wt step for-each</span></b> <span class=c>[OPTIONS]</spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)

--- a/.claude-plugin/skills/worktrunk/reference/switch.md
+++ b/.claude-plugin/skills/worktrunk/reference/switch.md
@@ -146,4 +146,4 @@ Usage: <b><span class=c>wt switch</span></b> <span class=c>[OPTIONS]</span> <spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -414,7 +414,7 @@ Usage: <b><span class=c>wt config</span></b> <span class=c>[OPTIONS]</span> <spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 {% end %}
 
 ## wt config show
@@ -458,7 +458,7 @@ Usage: <b><span class=c>wt config show</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 {% end %}
 
 ## wt config state
@@ -535,7 +535,7 @@ Usage: <b><span class=c>wt config state</span></b> <span class=c>[OPTIONS]</span
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 {% end %}
 
 ## wt config state default-branch
@@ -589,7 +589,7 @@ Usage: <b><span class=c>wt config state default-branch</span></b> <span class=c>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 {% end %}
 
 ## wt config state ci-status
@@ -641,7 +641,7 @@ Usage: <b><span class=c>wt config state ci-status</span></b> <span class=c>[OPTI
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 {% end %}
 
 ## wt config state marker
@@ -699,7 +699,7 @@ Usage: <b><span class=c>wt config state marker</span></b> <span class=c>[OPTIONS
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 {% end %}
 
 ## wt config state logs
@@ -765,7 +765,7 @@ Usage: <b><span class=c>wt config state logs</span></b> <span class=c>[OPTIONS]<
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt config --help-page` -->

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -433,7 +433,7 @@ Usage: <b><span class=c>wt hook</span></b> <span class=c>[OPTIONS]</span> <span 
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 {% end %}
 
 ## wt hook approvals
@@ -484,7 +484,7 @@ Usage: <b><span class=c>wt hook approvals</span></b> <span class=c>[OPTIONS]</sp
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt hook --help-page` -->

--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -319,7 +319,7 @@ Usage: <b><span class=c>wt list</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt list --help-page` -->

--- a/docs/content/merge.md
+++ b/docs/content/merge.md
@@ -139,7 +139,7 @@ Usage: <b><span class=c>wt merge</span></b> <span class=c>[OPTIONS]</span> <span
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt merge --help-page` -->

--- a/docs/content/remove.md
+++ b/docs/content/remove.md
@@ -125,7 +125,7 @@ Usage: <b><span class=c>wt remove</span></b> <span class=c>[OPTIONS]</span> <spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt remove --help-page` -->

--- a/docs/content/select.md
+++ b/docs/content/select.md
@@ -95,7 +95,7 @@ Usage: <b><span class=c>wt select</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt select --help-page` -->

--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -71,7 +71,7 @@ Usage: <b><span class=c>wt step</span></b> <span class=c>[OPTIONS]</span> <span 
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 {% end %}
 
 ## wt step commit
@@ -154,7 +154,7 @@ Usage: <b><span class=c>wt step commit</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 {% end %}
 
 ## wt step squash
@@ -240,7 +240,7 @@ Usage: <b><span class=c>wt step squash</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 {% end %}
 
 ## wt step copy-ignored
@@ -363,7 +363,7 @@ Usage: <b><span class=c>wt step copy-ignored</span></b> <span class=c>[OPTIONS]<
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 {% end %}
 
 ## wt step for-each
@@ -427,7 +427,7 @@ Usage: <b><span class=c>wt step for-each</span></b> <span class=c>[OPTIONS]</spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt step --help-page` -->

--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -168,7 +168,7 @@ Usage: <b><span class=c>wt switch</span></b> <span class=c>[OPTIONS]</span> <spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt switch --help-page` -->

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -225,7 +225,7 @@ pub(crate) struct Cli {
     )]
     pub config: Option<std::path::PathBuf>,
 
-    /// Show debug info (-v), or also write diagnostic report (-vv)
+    /// Show debug info and write diagnostic report (-vv)
     #[arg(
         long,
         short = 'v',

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,8 +146,8 @@ fn main() {
     }
 
     // Configure logging based on --verbose flag or RUST_LOG env var
-    // When --verbose is set, also write logs to .git/wt-logs/verbose.log
-    if cli.verbose >= 1 {
+    // When -vv is set, also write logs to .git/wt-logs/verbose.log
+    if cli.verbose >= 2 {
         verbose_log::init();
     }
 
@@ -155,9 +155,9 @@ fn main() {
     let verbose_level = cli.verbose;
     let command_line = std::env::args().collect::<Vec<_>>().join(" ");
 
-    // --verbose takes precedence over RUST_LOG: use Builder::new() to ignore env var
+    // -vv takes precedence over RUST_LOG: use Builder::new() to ignore env var
     // Otherwise, respect RUST_LOG (defaulting to off)
-    let mut builder = if cli.verbose >= 1 {
+    let mut builder = if cli.verbose >= 2 {
         let mut b = env_logger::Builder::new();
         b.filter_level(log::LevelFilter::Debug);
         b

--- a/tests/integration_tests/diagnostic.rs
+++ b/tests/integration_tests/diagnostic.rs
@@ -397,35 +397,27 @@ fn test_vv_writes_diagnostic_on_error(mut repo: TestRepo) {
     );
 }
 
-/// With just -v (not -vv), diagnostic should NOT be written on successful commands.
-/// Diagnostics are only written when -vv is explicitly used (via main.rs hook).
+/// With just -v (not -vv), no logging files should be written.
+/// -v is reserved for future use; -vv is required for debug logging.
 #[rstest]
-fn test_v_does_not_write_diagnostic_without_error(repo: TestRepo) {
+fn test_v_does_not_enable_logging(repo: TestRepo) {
     // Run a successful command with just -v
     let output = repo.wt_command().args(["list", "-v"]).output().unwrap();
 
     assert!(output.status.success(), "Command should succeed");
 
-    // Diagnostic file should NOT exist (no error, not -vv)
-    let diagnostic_path = repo
-        .root_path()
-        .join(".git")
-        .join("wt-logs")
-        .join("diagnostic.md");
+    // Neither diagnostic.md nor verbose.log should exist with just -v
+    let wt_logs = repo.root_path().join(".git").join("wt-logs");
+    let diagnostic_path = wt_logs.join("diagnostic.md");
+    let verbose_log_path = wt_logs.join("verbose.log");
+
     assert!(
         !diagnostic_path.exists(),
-        "Diagnostic file should NOT be created with just -v on success"
+        "Diagnostic file should NOT be created with just -v"
     );
-
-    // But verbose.log should exist
-    let verbose_log_path = repo
-        .root_path()
-        .join(".git")
-        .join("wt-logs")
-        .join("verbose.log");
     assert!(
-        verbose_log_path.exists(),
-        "verbose.log should be created with -v"
+        !verbose_log_path.exists(),
+        "verbose.log should NOT be created with just -v (requires -vv)"
     );
 }
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -11,6 +11,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -40,7 +41,7 @@ Usage: [1m[36mwt config create[0m [36m[OPTIONS]
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 [1m[32mUser config
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -10,6 +10,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -44,7 +45,7 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 [1m[32mExamples
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_shell.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_shell.snap
@@ -8,9 +8,10 @@ info:
     - "--help"
   env:
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -37,4 +38,4 @@ Usage: [1m[36mwt config shell[0m [36m[OPTIONS][0m [36m<COMMAND>
 [1m[32mGlobal Options:
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Show debug info (-v), or also write diagnostic report (-vv)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Show debug info and write diagnostic report (-vv)

--- a/tests/snapshots/integration__integration_tests__help__help_config_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_short.snap
@@ -10,6 +10,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -36,4 +37,4 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>
 [1m[32mGlobal Options:
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Show debug info (-v), or also write diagnostic report (-vv)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Show debug info and write diagnostic report (-vv)

--- a/tests/snapshots/integration__integration_tests__help__help_config_show.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_show.snap
@@ -11,6 +11,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -40,7 +41,7 @@ Usage: [1m[36mwt config show[0m [36m[OPTIONS]
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 Shows location and contents of user config ([2m~/.config/worktrunk/config.toml[0m)
 and project config ([2m.config/wt.toml[0m).

--- a/tests/snapshots/integration__integration_tests__help__help_config_state.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state.snap
@@ -11,6 +11,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -47,7 +48,7 @@ Usage: [1m[36mwt config state[0m [36m[OPTIONS][0m [36m<COMMAND>
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 State is stored in [2m.git/[0m (config entries and log files), separate from configuration files.
 Use [2mwt config show[0m to view file-based configuration.

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
@@ -12,6 +12,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -42,7 +43,7 @@ Usage: [1m[36mwt config state ci-status[0m [36m[OPTIONS][0m [36m[COMMAND]
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 Caches GitHub/GitLab CI status for display in [2mwt list[0m.
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_clear.snap
@@ -9,9 +9,10 @@ info:
     - "--help"
   env:
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -38,7 +39,7 @@ Usage: [1m[36mwt config state clear[0m [36m[OPTIONS]
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 Clears all stored state:
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
@@ -12,6 +12,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -43,7 +44,7 @@ Usage: [1m[36mwt config state default-branch[0m [36m[OPTIONS][0m [36m[COMM
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 Useful in scripts to avoid hardcoding [2mmain[0m or [2mmaster[0m:
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_get.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_get.snap
@@ -9,9 +9,10 @@ info:
     - "--help"
   env:
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -43,7 +44,7 @@ Usage: [1m[36mwt config state get[0m [36m[OPTIONS]
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 Shows all stored state including:
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
@@ -12,6 +12,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -42,7 +43,7 @@ Usage: [1m[36mwt config state logs[0m [36m[OPTIONS][0m [36m[COMMAND]
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 View and manage logs from background operations.
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
@@ -12,6 +12,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -43,7 +44,7 @@ Usage: [1m[36mwt config state marker[0m [36m[OPTIONS][0m [36m[COMMAND]
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 Custom status text or emoji shown in the [2mwt list[0m Status column.
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch.snap
@@ -12,6 +12,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -43,7 +44,7 @@ Usage: [1m[36mwt config state previous-branch[0m [36m[OPTIONS][0m [36m[COM
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 Enables [2mwt switch -[0m to return to the previous worktree, similar to [2mcd -[0m or [2mgit checkout -[0m.
 

--- a/tests/snapshots/integration__integration_tests__help__help_hook_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_approvals.snap
@@ -11,6 +11,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -41,7 +42,7 @@ Usage: [1m[36mwt hook approvals[0m [36m[OPTIONS][0m [36m<COMMAND>
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 Project hooks require approval on first run to prevent untrusted projects from running arbitrary commands.
 

--- a/tests/snapshots/integration__integration_tests__help__help_hook_approvals_add.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_approvals_add.snap
@@ -9,9 +9,10 @@ info:
     - "--help"
   env:
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -41,7 +42,7 @@ Usage: [1m[36mwt hook approvals add[0m [36m[OPTIONS]
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 Prompts for approval of all project commands and saves them to user config.
 

--- a/tests/snapshots/integration__integration_tests__help__help_hook_approvals_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_approvals_clear.snap
@@ -9,9 +9,10 @@ info:
     - "--help"
   env:
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -41,7 +42,7 @@ Usage: [1m[36mwt hook approvals clear[0m [36m[OPTIONS]
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 Removes saved approvals, requiring re-approval on next command run.
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -60,7 +60,7 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS]
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 Shows uncommitted changes, divergence from the default branch and remote, and optional CI status.
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -61,7 +61,7 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS]
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 Shows uncommitted changes, divergence from the default branch and remote, and 
 optional CI status.

--- a/tests/snapshots/integration__integration_tests__help__help_list_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_short.snap
@@ -7,9 +7,10 @@ info:
     - "-h"
   env:
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -39,4 +40,4 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS]
 [1m[32mGlobal Options:
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Show debug info (-v), or also write diagnostic report (-vv)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Show debug info and write diagnostic report (-vv)

--- a/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
@@ -10,6 +10,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -68,7 +69,7 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 Unlike `git merge`, this merges current into target (not target into current). Similar to clicking "Merge pull request" on GitHub, but locally. Target defaults to the default branch.
 

--- a/tests/snapshots/integration__integration_tests__help__help_md_root.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_root.snap
@@ -9,6 +9,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -46,7 +47,7 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 Getting started
 

--- a/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
@@ -10,6 +10,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -70,7 +71,7 @@ Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET]
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 Unlike [2mgit merge[0m, this merges current into target (not target into current). Similar to clicking "Merge pull request" on GitHub, but locally. Target defaults to the default branch.
 

--- a/tests/snapshots/integration__integration_tests__help__help_merge_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_short.snap
@@ -10,6 +10,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -40,4 +41,4 @@ Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET]
 [1m[32mGlobal Options:
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Show debug info (-v), or also write diagnostic report (-vv)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Show debug info and write diagnostic report (-vv)

--- a/tests/snapshots/integration__integration_tests__help__help_no_args.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_no_args.snap
@@ -8,6 +8,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -39,4 +40,4 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND]
 [1m[32mGlobal Options:
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Show debug info (-v), or also write diagnostic report (-vv)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Show debug info and write diagnostic report (-vv)

--- a/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
@@ -10,6 +10,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -62,7 +63,7 @@ Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 [1m[32mExamples
 

--- a/tests/snapshots/integration__integration_tests__help__help_remove_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_short.snap
@@ -7,9 +7,10 @@ info:
     - "-h"
   env:
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -39,4 +40,4 @@ Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...
 [1m[32mGlobal Options:
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Show debug info (-v), or also write diagnostic report (-vv)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Show debug info and write diagnostic report (-vv)

--- a/tests/snapshots/integration__integration_tests__help__help_root_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root_long.snap
@@ -9,6 +9,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -48,7 +49,7 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND]
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 Getting started
 

--- a/tests/snapshots/integration__integration_tests__help__help_root_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root_short.snap
@@ -9,6 +9,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -40,4 +41,4 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND]
 [1m[32mGlobal Options:
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Show debug info (-v), or also write diagnostic report (-vv)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Show debug info and write diagnostic report (-vv)

--- a/tests/snapshots/integration__integration_tests__help__help_step_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_long.snap
@@ -10,6 +10,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -46,7 +47,7 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 [1m[32mExamples
 

--- a/tests/snapshots/integration__integration_tests__help__help_step_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_short.snap
@@ -6,12 +6,11 @@ info:
     - step
     - "-h"
   env:
-    CARGO_LLVM_COV: "1"
     CLICOLOR_FORCE: "1"
-    COLUMNS: "150"
+    COLUMNS: "500"
     GIT_EDITOR: ""
-    LLVM_PROFILE_FILE: /Users/maximilian/workspace/worktrunk.worktreeinclude/target/llvm-cov-target/worktrunk.worktreeinclude-%p-%m.profraw
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -40,4 +39,4 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
 [1m[32mGlobal Options:
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Show debug info (-v), or also write diagnostic report (-vv)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Show debug info and write diagnostic report (-vv)

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -10,6 +10,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -82,7 +83,7 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m<BRANCH>[0m [1m[36m[--
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
-          Show debug info (-v), or also write diagnostic report (-vv)
+          Show debug info and write diagnostic report (-vv)
 
 Worktrees are addressed by branch name; paths are computed from a configurable template. Unlike [2mgit switch[0m, this navigates between worktrees rather than changing branches in place.
 

--- a/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
@@ -10,6 +10,7 @@ info:
     COLUMNS: "500"
     GIT_EDITOR: ""
     RUST_LOG: warn
+    SHELL: ""
     SOURCE_DATE_EPOCH: "1735776000"
     TERM: alacritty
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
@@ -40,4 +41,4 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m<BRANCH>[0m [1m[36m[--
 [1m[32mGlobal Options:
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Show debug info (-v), or also write diagnostic report (-vv)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Show debug info and write diagnostic report (-vv)


### PR DESCRIPTION
## Summary

- Change verbosity threshold from `-v` to `-vv` for enabling debug logging
- `-v` is now reserved for future use (does nothing currently)
- `-vv` behavior unchanged: debug logging + verbose.log + diagnostic.md

## Test plan

- [x] Verified `-v` no longer creates logging files
- [x] Verified `-vv` still enables debug logging and diagnostics
- [x] All tests pass (`cargo run -- hook pre-merge --yes`)
- [x] Help text and docs updated

> _This was written by Claude Code on behalf of max-sixty_