### PR TITLE
feat: add verbose level tracking for -v flag

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -145,6 +145,9 @@ fn main() {
         set_config_path(path);
     }
 
+    // Initialize verbose level for output module
+    output::set_verbose_level(cli.verbose);
+
     // Configure logging based on --verbose flag or RUST_LOG env var
     // When -vv is set, also write logs to .git/wt-logs/verbose.log
     if cli.verbose >= 2 {

--- a/src/output/global.rs
+++ b/src/output/global.rs
@@ -47,6 +47,34 @@ use worktrunk::styling::{eprintln, stderr};
 /// unreachable - the lock is only held for trivial Option assignments that cannot panic.
 static OUTPUT_STATE: OnceLock<Mutex<OutputState>> = OnceLock::new();
 
+/// Global verbose level, set once from CLI flag at startup.
+static VERBOSE_LEVEL: OnceLock<u8> = OnceLock::new();
+
+/// Set the global verbose level from CLI flag.
+///
+/// Called once from main() after parsing args. If not called, defaults to 0.
+pub fn set_verbose_level(level: u8) {
+    VERBOSE_LEVEL.set(level).ok();
+}
+
+/// Get the verbose level (0 = default, 1 = -v, 2+ = -vv).
+// TODO(verbose-output): Reserved for showing extra details in command output.
+// See commit e13776c "reserve -v for future use".
+#[allow(dead_code)]
+pub fn verbose_level() -> u8 {
+    VERBOSE_LEVEL.get().copied().unwrap_or(0)
+}
+
+/// Check if single -v was passed (show extra details).
+///
+/// Returns true when verbose level is 1 or higher.
+// TODO(verbose-output): Reserved for showing extra details in command output.
+// See commit e13776c "reserve -v for future use".
+#[allow(dead_code)]
+pub fn is_verbose() -> bool {
+    verbose_level() >= 1
+}
+
 #[derive(Default)]
 struct OutputState {
     /// Path to the directive file (from WORKTRUNK_DIRECTIVE_FILE env var)

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -33,9 +33,12 @@ pub(crate) mod handlers;
 pub(crate) mod shell_integration;
 
 // Re-export the public API
+// TODO(verbose-output): verbose_level, is_verbose reserved per commit e13776c
+#[allow(unused_imports)]
 pub(crate) use global::{
-    blank, change_directory, execute, flush, is_shell_integration_active, post_hook_display_path,
-    pre_hook_display_path, print, stdout, terminate_output,
+    blank, change_directory, execute, flush, is_shell_integration_active, is_verbose,
+    post_hook_display_path, pre_hook_display_path, print, set_verbose_level, stdout,
+    terminate_output, verbose_level,
 };
 // Re-export output handlers
 pub(crate) use handlers::{


### PR DESCRIPTION
## Summary
- Add infrastructure to track `-v` flag so commands can show extra details
- Follows existing `OnceLock` pattern used by `set_base_path` and `set_config_path`
- API: `output::is_verbose()` and `output::verbose_level()`

Builds on e13776c which reserved `-v` for future use (requiring `-vv` for debug logging).

## Test plan
- [x] All tests pass (859 integration, 428 unit)
- [x] Lints pass

🤖 Generated with [Claude Code](https://claude.ai/code)