### PR TITLE
fix: handle CRLF line endings in multiline error display

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1147,13 +1147,15 @@ fn main() {
                     let _ = output::print(error_message(&msg));
                     let chain_text = chain.join("\n");
                     let _ = output::print(format_with_gutter(&chain_text, None));
-                } else if msg.contains('\n') {
+                } else if msg.contains('\n') || msg.contains('\r') {
                     // Multiline error without context - this shouldn't happen if all
                     // errors have proper context. Catch in debug builds, log in release.
                     debug_assert!(false, "Multiline error without context: {msg}");
                     log::warn!("Multiline error without context: {msg}");
+                    // Normalize line endings for display
+                    let normalized = msg.replace("\r\n", "\n").replace('\r', "\n");
                     let _ = output::print(error_message("Command failed"));
-                    let _ = output::print(format_with_gutter(&msg, None));
+                    let _ = output::print(format_with_gutter(&normalized, None));
                 } else {
                     // Single-line error without context: inline with emoji
                     let _ = output::print(error_message(&msg));

--- a/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__multiline_error_formatting.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__multiline_error_formatting.snap
@@ -1,0 +1,7 @@
+---
+source: tests/integration_tests/git_error_display.rs
+expression: "format!(\"{}\\n{}\", header, gutter)"
+---
+[31m✗[39m [31mCommand failed[39m
+[107m [0m fatal: Unable to read current working directory
+[107m [0m error: Could not determine cwd


### PR DESCRIPTION
## Summary

- Fixed multiline error detection to check for `\r` in addition to `\n`
- Added line ending normalization (`\r\n` → `\n`, `\r` → `\n`) before display
- Added tests for multiline error formatting and CRLF normalization

## Test plan

- [x] `multiline_error_formatting` test verifies header + gutter output
- [x] `multiline_error_crlf_normalization` test verifies line ending handling
- [x] All 870 integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)