### PR TITLE
fix: show expanded --execute command in gutter with path context

### DIFF
--- a/src/commands/select/mod.rs
+++ b/src/commands/select/mod.rs
@@ -229,7 +229,7 @@ pub fn handle_select(
         execute!(stderr(), crossterm::cursor::MoveTo(0, 0))?;
 
         // Show success message; emit cd directive if shell integration is active
-        handle_switch_output(&result, &branch_info, None)?;
+        handle_switch_output(&result, &branch_info)?;
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -766,8 +766,7 @@ fn main() {
                 // Show success message (temporal locality: immediately after worktree operation)
                 // Returns path to display in hooks when user's shell won't be in the worktree
                 // Also shows worktree-path hint on first --create (before shell integration warning)
-                let hooks_display_path =
-                    handle_switch_output(&result, &branch_info, execute.as_deref())?;
+                let hooks_display_path = handle_switch_output(&result, &branch_info)?;
 
                 // Offer shell integration if not already installed/active
                 // (only shows prompt/hint when shell integration isn't working)
@@ -867,7 +866,7 @@ fn main() {
                             .collect();
                         format!("{} {}", expanded_cmd, escaped_args.join(" "))
                     };
-                    execute_user_command(&full_cmd)?;
+                    execute_user_command(&full_cmd, hooks_display_path.as_deref())?;
                 }
 
                 Ok(())

--- a/tests/snapshots/integration__integration_tests__post_start_commands__execute_with_post_start.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__execute_with_post_start.snap
@@ -16,6 +16,7 @@ info:
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -38,9 +39,9 @@ exit_code: 0
 ----- stderr -----
 [32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
-[33m▲[39m [33mExecuting [1mecho 'Execute flag' > execute.txt[22m @ [1m_REPO_.feature[22m, but shell directory unchanged — shell integration not installed[39m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mRunning post-start project hook @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Background task'[0m[2m [0m[2m[36m>[0m[2m background.txt
-[36m◎[39m [36mExecuting (--execute):[39m
+[36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.feature[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Execute flag'[0m[2m [0m[2m[36m>[0m[2m execute.txt

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_arg_template_error.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_arg_template_error.snap
@@ -19,6 +19,7 @@ info:
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -41,6 +42,6 @@ exit_code: 1
 ----- stderr -----
 [32m✓[39m [32mCreated branch [1marg-error-test[22m from [1mmain[22m and worktree @ [1m_REPO_.arg-error-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
-[33m▲[39m [33mExecuting [1mecho[22m @ [1m_REPO_.arg-error-test[22m, but shell directory unchanged — shell integration not installed[39m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [31m✗[39m [31mFailed to expand argument template: Template syntax error: syntax error: unexpected end of input, expected end of variable block (in <string>:1)[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_creates_file.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_creates_file.snap
@@ -16,6 +16,7 @@ info:
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -38,7 +39,7 @@ exit_code: 0
 ----- stderr -----
 [32m✓[39m [32mCreated branch [1mfile-test[22m from [1mmain[22m and worktree @ [1m_REPO_.file-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
-[33m▲[39m [33mExecuting [1mecho 'test content' > test.txt[22m @ [1m_REPO_.file-test[22m, but shell directory unchanged — shell integration not installed[39m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mExecuting (--execute):[39m
+[36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.file-test[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test content'[0m[2m [0m[2m[36m>[0m[2m test.txt

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_existing.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_existing.snap
@@ -15,6 +15,7 @@ info:
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -35,7 +36,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mExecuting [1mecho 'existing worktree' > existing.txt[22m @ [1m_REPO_.existing-exec[22m, but shell directory unchanged — shell integration not installed[39m
+[33m▲[39m [33mWorktree for [1mexisting-exec[22m @ [1m_REPO_.existing-exec[22m, but cannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mExecuting (--execute):[39m
+[36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.existing-exec[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'existing worktree'[0m[2m [0m[2m[36m>[0m[2m existing.txt

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_failure.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_failure.snap
@@ -16,6 +16,7 @@ info:
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -38,7 +39,7 @@ exit_code: 1
 ----- stderr -----
 [32m✓[39m [32mCreated branch [1mfail-test[22m from [1mmain[22m and worktree @ [1m_REPO_.fail-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
-[33m▲[39m [33mExecuting [1mexit 1[22m @ [1m_REPO_.fail-test[22m, but shell directory unchanged — shell integration not installed[39m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mExecuting (--execute):[39m
+[36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.fail-test[22m:[39m
 [107m [0m [2m[0m[2m[34mexit[0m[2m 1

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_multiline.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_multiline.snap
@@ -16,6 +16,7 @@ info:
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -41,11 +42,9 @@ line3
 ----- stderr -----
 [32m✓[39m [32mCreated branch [1mmultiline-test[22m from [1mmain[22m and worktree @ [1m_REPO_.multiline-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
-[33m▲[39m [33mExecuting [1mecho 'line1'
-echo 'line2'
-echo 'line3'[22m @ [1m_REPO_.multiline-test[22m, but shell directory unchanged — shell integration not installed[39m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mExecuting (--execute):[39m
+[36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.multiline-test[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'line1'[0m[2m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'line2'[0m[2m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'line3'[0m[2m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_success.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_success.snap
@@ -16,6 +16,7 @@ info:
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -39,7 +40,7 @@ test output
 ----- stderr -----
 [32m✓[39m [32mCreated branch [1mexec-test[22m from [1mmain[22m and worktree @ [1m_REPO_.exec-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
-[33m▲[39m [33mExecuting [1mecho 'test output'[22m @ [1m_REPO_.exec-test[22m, but shell directory unchanged — shell integration not installed[39m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mExecuting (--execute):[39m
+[36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.exec-test[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test output'[0m[2m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_template_base.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_template_base.snap
@@ -18,6 +18,7 @@ info:
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -41,7 +42,7 @@ base=main
 ----- stderr -----
 [32m✓[39m [32mCreated branch [1mfrom-main[22m from [1mmain[22m and worktree @ [1m_REPO_.from-main[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
-[33m▲[39m [33mExecuting [1mecho 'base={{ base }}'[22m @ [1m_REPO_.from-main[22m, but shell directory unchanged — shell integration not installed[39m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mExecuting (--execute):[39m
+[36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.from-main[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'base=main'[0m[2m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_template_base_without_create.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_template_base_without_create.snap
@@ -15,6 +15,7 @@ info:
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -36,7 +37,7 @@ exit_code: 0
 base=
 
 ----- stderr -----
-[33m▲[39m [33mExecuting [1mecho 'base={{ base }}'[22m @ [1m_REPO_.existing[22m, but shell directory unchanged — shell integration not installed[39m
+[33m▲[39m [33mWorktree for [1mexisting[22m @ [1m_REPO_.existing[22m, but cannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mExecuting (--execute):[39m
+[36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.existing[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'base='[0m[2m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_template_branch.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_template_branch.snap
@@ -16,6 +16,7 @@ info:
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -39,7 +40,7 @@ branch=template-test
 ----- stderr -----
 [32m✓[39m [32mCreated branch [1mtemplate-test[22m from [1mmain[22m and worktree @ [1m_REPO_.template-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
-[33m▲[39m [33mExecuting [1mecho 'branch={{ branch }}'[22m @ [1m_REPO_.template-test[22m, but shell directory unchanged — shell integration not installed[39m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mExecuting (--execute):[39m
+[36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.template-test[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'branch=template-test'[0m[2m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_template_error.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_template_error.snap
@@ -16,6 +16,7 @@ info:
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -38,6 +39,6 @@ exit_code: 1
 ----- stderr -----
 [32m✓[39m [32mCreated branch [1merror-test[22m from [1mmain[22m and worktree @ [1m_REPO_.error-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
-[33m▲[39m [33mExecuting [1mecho {{ unclosed[22m @ [1m_REPO_.error-test[22m, but shell directory unchanged — shell integration not installed[39m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [31m✗[39m [31mFailed to expand --execute template: Template syntax error: syntax error: unexpected end of input, expected end of variable block (in <string>:1)[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_template_in_args.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_template_in_args.snap
@@ -19,6 +19,7 @@ info:
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -42,7 +43,7 @@ branch=args-test repo=repo
 ----- stderr -----
 [32m✓[39m [32mCreated branch [1margs-test[22m from [1mmain[22m and worktree @ [1m_REPO_.args-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
-[33m▲[39m [33mExecuting [1mecho[22m @ [1m_REPO_.args-test[22m, but shell directory unchanged — shell integration not installed[39m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mExecuting (--execute):[39m
+[36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.args-test[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'branch=args-test'[0m[2m [0m[2m[32m'repo=repo'[0m[2m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_template_shell_escape.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_template_shell_escape.snap
@@ -16,6 +16,7 @@ info:
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -39,7 +40,7 @@ feat;id
 ----- stderr -----
 [32m✓[39m [32mCreated branch [1mfeat;id[22m from [1mmain[22m and worktree @ [1m_REPO_.feat;id[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
-[33m▲[39m [33mExecuting [1mecho {{ branch }}[22m @ [1m_REPO_.feat;id[22m, but shell directory unchanged — shell integration not installed[39m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mExecuting (--execute):[39m
+[36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.feat;id[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'feat;id'[0m[2m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_template_with_filter.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_template_with_filter.snap
@@ -16,6 +16,7 @@ info:
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -39,7 +40,7 @@ sanitized=feature-with-slash
 ----- stderr -----
 [32m✓[39m [32mCreated branch [1mfeature/with-slash[22m from [1mmain[22m and worktree @ [1m_REPO_.feature-with-slash[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
-[33m▲[39m [33mExecuting [1mecho 'sanitized={{ branch | sanitize }}'[22m @ [1m_REPO_.feature-with-slash[22m, but shell directory unchanged — shell integration not installed[39m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mExecuting (--execute):[39m
+[36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.feature-with-slash[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'sanitized=feature-with-slash'[0m[2m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_template_worktree_path.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_template_worktree_path.snap
@@ -16,6 +16,7 @@ info:
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -39,7 +40,7 @@ path=_REPO_.path-test
 ----- stderr -----
 [32m✓[39m [32mCreated branch [1mpath-test[22m from [1mmain[22m and worktree @ [1m_REPO_.path-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
-[33m▲[39m [33mExecuting [1mecho 'path={{ worktree_path }}'[22m @ [1m_REPO_.path-test[22m, but shell directory unchanged — shell integration not installed[39m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mExecuting (--execute):[39m
+[36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.path-test[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'path=_REPO_.path-test'[0m[2m

--- a/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_execute_still_runs.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_execute_still_runs.snap
@@ -17,6 +17,7 @@ info:
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -40,7 +41,7 @@ execute command runs
 ----- stderr -----
 [32m✓[39m [32mCreated branch [1mno-hooks-test[22m from [1mmain[22m and worktree @ [1m_REPO_.no-hooks-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
-[33m▲[39m [33mExecuting [1mecho 'execute command runs'[22m @ [1m_REPO_.no-hooks-test[22m, but shell directory unchanged — shell integration not installed[39m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mExecuting (--execute):[39m
+[36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.no-hooks-test[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'execute command runs'[0m[2m

--- a/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_existing.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_existing.snap
@@ -16,6 +16,7 @@ info:
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -37,7 +38,7 @@ exit_code: 0
 execute still runs
 
 ----- stderr -----
-[33m▲[39m [33mExecuting [1mecho 'execute still runs'[22m @ [1m_REPO_.existing-no-hooks[22m, but shell directory unchanged — shell integration not installed[39m
+[33m▲[39m [33mWorktree for [1mexisting-no-hooks[22m @ [1m_REPO_.existing-no-hooks[22m, but cannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
-[36m◎[39m [36mExecuting (--execute):[39m
+[36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.existing-no-hooks[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'execute still runs'[0m[2m


### PR DESCRIPTION
## Summary

- Remove `execute_command` parameter from `handle_switch_output()` since it received the raw template before expansion
- Simplify warning to "Cannot change directory — {reason}" without mentioning the execute command  
- Add `display_path` parameter to `execute_user_command()` to show "@ path" when shell integration is not active
- The expanded command is now correctly displayed by `execute_user_command()` in a gutter format after template expansion

Fixes unexpanded template display issue where users would see `{% if branch %}echo {{ branch }}{% endif %}` instead of the actual command.

## Test plan

- [x] All 868 integration tests pass
- [x] All lints pass
- [x] Snapshot tests updated to reflect new output format

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>