### PR TITLE
fix: add missing article in help text

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/list.md
+++ b/.claude-plugin/skills/worktrunk/reference/list.md
@@ -225,7 +225,7 @@ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 
 ### main_state values
 
-These values describe relation to the default branch.
+These values describe the relation to the default branch.
 
 `"is_main"` `"orphan"` `"would_conflict"` `"empty"` `"same_commit"` `"integrated"` `"diverged"` `"ahead"` `"behind"`
 

--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -258,7 +258,7 @@ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 
 ### main_state values
 
-These values describe relation to the default branch.
+These values describe the relation to the default branch.
 
 `"is_main"` `"orphan"` `"would_conflict"` `"empty"` `"same_commit"` `"integrated"` `"diverged"` `"ahead"` `"behind"`
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -606,7 +606,7 @@ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 
 ### main_state values
 
-These values describe relation to the default branch.
+These values describe the relation to the default branch.
 
 `"is_main"` `"orphan"` `"would_conflict"` `"empty"` `"same_commit"` `"integrated"` `"diverged"` `"ahead"` `"behind"`
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -262,7 +262,7 @@ Query structured data with [2m--format=json[0m:
 
 [32mmain_state values
 
-These values describe relation to the default branch.
+These values describe the relation to the default branch.
 
 [2m"is_main"[0m [2m"orphan"[0m [2m"would_conflict"[0m [2m"empty"[0m [2m"same_commit"[0m [2m"integrated"[0m [2m"diverged"[0m [2m"ahead"[0m [2m"behind"
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -286,7 +286,7 @@ Query structured data with [2m--format=json[0m:
 
 [32mmain_state values
 
-These values describe relation to the default branch.
+These values describe the relation to the default branch.
 
 [2m"is_main"[0m [2m"orphan"[0m [2m"would_conflict"[0m [2m"empty"[0m [2m"same_commit"[0m [2m"integrated"[0m 
 [2m"diverged"[0m [2m"ahead"[0m [2m"behind"


### PR DESCRIPTION
Change "describe relation to" → "describe the relation to" for correct
grammar.