### PR TITLE
fix: redact credentials from URLs in -vv debug logs

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -29,7 +29,8 @@ pub use commands::{Command, CommandConfig};
 pub use deprecation::check_and_migrate as check_deprecated_vars;
 pub use deprecation::normalize_template_vars;
 pub use expansion::{
-    DEPRECATED_TEMPLATE_VARS, TEMPLATE_VARS, expand_template, sanitize_branch_name, sanitize_db,
+    DEPRECATED_TEMPLATE_VARS, TEMPLATE_VARS, expand_template, redact_credentials,
+    sanitize_branch_name, sanitize_db,
 };
 pub use hooks::HooksConfig;
 pub use project::{


### PR DESCRIPTION
## Summary

- Add `redact_credentials()` function that detects URLs with embedded credentials (`scheme://credentials@host`) and replaces the credential portion with `[REDACTED]`
- Apply redaction to both vars logging and result logging in `-vv` mode
- `-v` output (user-facing styled output) is intentionally NOT redacted since the user is interactively watching

## Test plan

- [x] Unit tests for various credential patterns (GitHub/GitLab tokens, user:password, git:// protocol)
- [x] Unit tests verify URLs without credentials are unchanged
- [x] Unit tests verify non-URL values pass through unchanged
- [x] Full test suite passes

> _This was written by Claude Code on behalf of max-sixty_