### PR TITLE
feat: add hint for explicit path invocation with shell integration

### DIFF
--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -22,7 +22,8 @@ use worktrunk::styling::{
 };
 
 use super::shell_integration::{
-    compute_shell_warning_reason, git_subcommand_warning, shell_integration_hint,
+    compute_shell_warning_reason, explicit_path_hint, git_subcommand_warning,
+    shell_integration_hint, should_show_explicit_path_hint,
 };
 
 /// Format a switch message based on what was created
@@ -254,7 +255,12 @@ fn print_switch_message_if_changed(
         super::print(warning_message(cformat!(
             "Cannot change directory — {reason}"
         )))?;
-        super::print(hint_message(shell_integration_hint()))?;
+        // Show appropriate hint based on invocation mode
+        if should_show_explicit_path_hint() {
+            super::print(hint_message(explicit_path_hint(&dest_branch)))?;
+        } else {
+            super::print(hint_message(shell_integration_hint()))?;
+        }
     }
     Ok(())
 }
@@ -343,10 +349,12 @@ pub fn handle_switch_output(
                 super::print(warning_message(cformat!(
                     "Worktree for <bold>{branch}</> @ <bold>{path_display}</>, but cannot change directory — {reason}"
                 )))?;
-                // Show git subcommand hint if running as git wt
+                // Show appropriate hint based on invocation mode
                 // (regular shell integration hint is shown by prompt_shell_integration in main.rs)
                 if is_git_subcommand {
                     super::print(hint_message(git_subcommand_warning()))?;
+                } else if should_show_explicit_path_hint() {
+                    super::print(hint_message(explicit_path_hint(branch)))?;
                 }
                 // User won't be there - show path in hook announcements
                 Some(path.clone())
@@ -403,10 +411,12 @@ pub fn handle_switch_output(
                 super::print(warning_message(cformat!(
                     "Cannot change directory — {reason}"
                 )))?;
-                // Show git subcommand hint if running as git wt
+                // Show appropriate hint based on invocation mode
                 // (regular shell integration hint is shown by prompt_shell_integration in main.rs)
                 if is_git_subcommand {
                     super::print(hint_message(git_subcommand_warning()))?;
+                } else if should_show_explicit_path_hint() {
+                    super::print(hint_message(explicit_path_hint(branch)))?;
                 }
                 // User won't be there - show path in hook announcements
                 Some(path.clone())

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_accept.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_accept.snap
@@ -15,3 +15,4 @@ test command
 [32m✓[39m [32mCreated branch [1mtest-approve[22m from [1mmain[22m and worktree @ [1m_REPO_.test-approve[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
 [33m▲[39m [33mCannot change directory — ran [BIN][22m; shell integration wraps [1mwt[22m[39m
+[2m↳[22m [2mTo change directory, run [90mwt switch test-approve[39m[22m

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_decline.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_decline.snap
@@ -13,3 +13,4 @@ n
 [32m✓[39m [32mCreated branch [1mtest-decline[22m from [1mmain[22m and worktree @ [1m_REPO_.test-decline[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
 [33m▲[39m [33mCannot change directory — ran [BIN][22m; shell integration wraps [1mwt[22m[39m
+[2m↳[22m [2mTo change directory, run [90mwt switch test-decline[39m[22m

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_mixed_approved_unapproved_accept.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_mixed_approved_unapproved_accept.snap
@@ -23,3 +23,4 @@ Third command
 [32m✓[39m [32mCreated branch [1mtest-mixed-accept[22m from [1mmain[22m and worktree @ [1m_REPO_.test-mixed-accept[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
 [33m▲[39m [33mCannot change directory — ran [BIN][22m; shell integration wraps [1mwt[22m[39m
+[2m↳[22m [2mTo change directory, run [90mwt switch test-mixed-accept[39m[22m

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_mixed_approved_unapproved_decline.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_mixed_approved_unapproved_decline.snap
@@ -15,3 +15,4 @@ n
 [32m✓[39m [32mCreated branch [1mtest-mixed-decline[22m from [1mmain[22m and worktree @ [1m_REPO_.test-mixed-decline[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
 [33m▲[39m [33mCannot change directory — ran [BIN][22m; shell integration wraps [1mwt[22m[39m
+[2m↳[22m [2mTo change directory, run [90mwt switch test-mixed-decline[39m[22m

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_multiple_commands.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_multiple_commands.snap
@@ -25,3 +25,4 @@ Third command
 [32m✓[39m [32mCreated branch [1mtest-multi[22m from [1mmain[22m and worktree @ [1m_REPO_.test-multi[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
 [33m▲[39m [33mCannot change directory — ran [BIN][22m; shell integration wraps [1mwt[22m[39m
+[2m↳[22m [2mTo change directory, run [90mwt switch test-multi[39m[22m

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_named_commands.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_named_commands.snap
@@ -25,3 +25,4 @@ Running tests...
 [32m✓[39m [32mCreated branch [1mtest-named[22m from [1mmain[22m and worktree @ [1m_REPO_.test-named[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
 [33m▲[39m [33mCannot change directory — ran [BIN][22m; shell integration wraps [1mwt[22m[39m
+[2m↳[22m [2mTo change directory, run [90mwt switch test-named[39m[22m

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_permission_error.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_permission_error.snap
@@ -17,3 +17,4 @@ test command
 [32m✓[39m [32mCreated branch [1mtest-permission[22m from [1mmain[22m and worktree @ [1m_REPO_.test-permission[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
 [33m▲[39m [33mCannot change directory — ran [BIN][22m; shell integration wraps [1mwt[22m[39m
+[2m↳[22m [2mTo change directory, run [90mwt switch test-permission[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_existing_with_shell_configured.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_existing_with_shell_configured.snap
@@ -13,6 +13,7 @@ info:
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -34,3 +35,4 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mWorktree for [1mshell-configured[22m @ [1m_REPO_.shell-configured[22m, but cannot change directory — ran [1m[PROJECT_ROOT]/target/debug/wt[22m; shell integration wraps [1mwt[22m[39m
+[2m↳[22m [2mTo change directory, run [90mwt switch shell-configured[39m[22m


### PR DESCRIPTION
## Summary

When users run wt via an explicit path (like `./target/debug/wt`) but shell integration is configured, the warning now includes a helpful hint showing how to change directory using the shell-wrapped command.

**Before:**
```
▲ Cannot change directory — ran ../../debug/wt; shell integration wraps wt
```

**After:**
```
▲ Cannot change directory — ran ../../debug/wt; shell integration wraps wt
↳ To change directory, run wt switch <branch>
```

This hint only appears when shell integration IS configured (so the suggested command would actually work). For cases where shell integration is not installed, the existing install hint is shown instead.

## Test plan

- [x] Unit tests for new `explicit_path_hint()` function
- [x] Updated snapshot test for switch with explicit path
- [x] All switch, merge, and remove integration tests pass

> _This was written by Claude Code on behalf of max-sixty_