### PR TITLE
fix: show both template and error on hook preview expansion failure

### DIFF
--- a/src/commands/hook_commands.rs
+++ b/src/commands/hook_commands.rs
@@ -626,7 +626,7 @@ fn expand_command_template(template: &str, ctx: &CommandContext, hook_type: Hook
         .collect();
 
     // Use the standard template expansion (shell-escaped)
-    // Falls back to raw template if expansion fails (e.g., missing optional variable)
+    // On any error, show both the template and error message
     worktrunk::config::expand_template(template, &vars, true, ctx.repo, "hook preview")
-        .unwrap_or_else(|_| template.to_string())
+        .unwrap_or_else(|err| format!("# Template error: {}\n{}", err, template))
 }

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_expanded_syntax_error.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_expanded_syntax_error.snap
@@ -1,0 +1,45 @@
+---
+source: tests/integration_tests/hook_show.rs
+info:
+  program: wt
+  args:
+    - hook
+    - show
+    - pre-commit
+    - "--expanded"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SHELL: ""
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36mUSER HOOKS[39m  [TEST_CONFIG]
+[2m↳[22m [2m(none configured)[22m
+
+[36mPROJECT HOOKS[39m  _REPO_/.config/wt.toml
+[36m❯[39m pre-commit [1mbroken[22m: [2m(requires approval)[22m
+[107m [0m [2m# Template error: Template syntax error: syntax error: unexpected end of input, expected end of variable block (in hook preview:1)[0m[2m
+[107m [0m [2m[0m[2m[34mecho[0m[2m {{ branch

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_expanded_undefined_var.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_expanded_undefined_var.snap
@@ -1,0 +1,45 @@
+---
+source: tests/integration_tests/hook_show.rs
+info:
+  program: wt
+  args:
+    - hook
+    - show
+    - pre-commit
+    - "--expanded"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SHELL: ""
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36mUSER HOOKS[39m  [TEST_CONFIG]
+[2m↳[22m [2m(none configured)[22m
+
+[36mPROJECT HOOKS[39m  _REPO_/.config/wt.toml
+[36m❯[39m pre-commit [1moptional-var[22m: [2m(requires approval)[22m
+[107m [0m [2m# Template error: Template render error: undefined value (in hook preview:1)[0m[2m
+[107m [0m [2m[0m[2m[34mecho[0m[2m {{ base }}

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_expanded_valid_template.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_expanded_valid_template.snap
@@ -1,0 +1,44 @@
+---
+source: tests/integration_tests/hook_show.rs
+info:
+  program: wt
+  args:
+    - hook
+    - show
+    - pre-commit
+    - "--expanded"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SHELL: ""
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36mUSER HOOKS[39m  [TEST_CONFIG]
+[2m↳[22m [2m(none configured)[22m
+
+[36mPROJECT HOOKS[39m  _REPO_/.config/wt.toml
+[36m❯[39m pre-commit [1mvalid[22m: [2m(requires approval)[22m
+[107m [0m [2m[0m[2m[34mecho[0m[2m branch=main repo=repo


### PR DESCRIPTION
## Summary

- Changed `wt hook show --expanded` to always show both template AND error on expansion failure
- Removed fragile string parsing (`if err.contains("undefined")`) that checked error message text
- Added tests for syntax errors, undefined variables, and valid templates

## Test plan

- [x] `test_hook_show_expanded_syntax_error` - verifies syntax errors show both error and template
- [x] `test_hook_show_expanded_undefined_var` - verifies undefined variables show both error and template  
- [x] `test_hook_show_expanded_valid_template` - verifies valid templates expand correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)