### PR TITLE
refactor: remove duplicate imports across codebase

### DIFF
--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -214,7 +214,6 @@ impl CommitOptions<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use worktrunk::config::CommitGenerationConfig;
 
     #[test]
     fn test_format_message_for_display_single_line() {

--- a/src/commands/configure_shell.rs
+++ b/src/commands/configure_shell.rs
@@ -124,9 +124,6 @@ fn is_worktrunk_managed_content(content: &str, cmd: &str) -> bool {
 ///
 /// Returns the paths of files that were cleaned up.
 fn cleanup_legacy_fish_conf_d(configured: &[ConfigureResult], cmd: &str) -> Vec<PathBuf> {
-    use worktrunk::path::format_path_for_display;
-    use worktrunk::styling::warning_message;
-
     let mut cleaned = Vec::new();
 
     // Clean up if fish was part of the install (regardless of whether it already existed)
@@ -719,8 +716,6 @@ pub fn prompt_for_install(
     cmd: &str,
     prompt_text: &str,
 ) -> Result<bool, String> {
-    use std::io::Write;
-
     // Flush before interactive prompt
     crate::output::flush().map_err(|e| e.to_string())?;
 
@@ -759,7 +754,6 @@ pub fn prompt_for_install(
 /// Prompt user for yes/no confirmation (simple [y/N] prompt)
 fn prompt_yes_no() -> Result<bool, String> {
     use anstyle::Style;
-    use std::io::Write;
     use worktrunk::styling::eprint;
 
     let bold = Style::new().bold();

--- a/src/commands/hook_commands.rs
+++ b/src/commands/hook_commands.rs
@@ -262,7 +262,6 @@ pub fn run_hook(
 /// Handle `wt hook approvals add` command - approve all commands in the project
 pub fn add_approvals(show_all: bool) -> anyhow::Result<()> {
     use super::command_approval::approve_command_batch;
-    use worktrunk::config::WorktrunkConfig;
 
     let repo = Repository::current()?;
     let project_id = repo.project_identifier()?;
@@ -322,8 +321,6 @@ pub fn add_approvals(show_all: bool) -> anyhow::Result<()> {
 
 /// Handle `wt hook approvals clear` command - clear approved commands
 pub fn clear_approvals(global: bool) -> anyhow::Result<()> {
-    use worktrunk::config::WorktrunkConfig;
-
     let mut config = WorktrunkConfig::load().context("Failed to load config")?;
 
     if global {

--- a/src/commands/list/json_output.rs
+++ b/src/commands/list/json_output.rs
@@ -453,12 +453,11 @@ pub fn to_json_items(items: &[ListItem]) -> Vec<JsonItem> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::list::ci_status::{CiSource, CiStatus};
+    use crate::commands::list::ci_status::CiStatus;
     use crate::commands::list::model::{
         Divergence, GitOperationState, MainState, OperationState, StatusSymbols, WorkingTreeStatus,
         WorktreeData, WorktreeState,
     };
-    use std::path::PathBuf;
 
     // ============================================================================
     // JsonDiff Tests

--- a/src/commands/list/layout.rs
+++ b/src/commands/list/layout.rs
@@ -195,7 +195,6 @@ const COMMIT_HASH_WIDTH: usize = 8;
 /// columns to be allocated at low priority (base_priority + EMPTY_PENALTY) for
 /// visual consistency on wide terminals.
 fn fit_header(header: &str, data_width: usize) -> usize {
-    use unicode_width::UnicodeWidthStr;
     data_width.max(header.width())
 }
 
@@ -892,8 +891,6 @@ pub fn calculate_layout_with_width(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::commands::list::columns::ColumnKind;
-    use std::path::PathBuf;
     use worktrunk::git::LineDiff;
 
     #[test]

--- a/src/commands/list/render.rs
+++ b/src/commands/list/render.rs
@@ -524,7 +524,7 @@ mod tests {
     use super::*;
     use crate::commands::list::layout::DiffDisplayConfig;
     use ansi_str::AnsiStr;
-    use worktrunk::styling::{ADDITION, DELETION, StyledLine};
+    use worktrunk::styling::{ADDITION, DELETION};
 
     fn format_diff_like_column(
         positive: usize,

--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -316,7 +316,6 @@ fn get_git_status_segments(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::Path;
 
     #[test]
     fn test_format_directory_fish_style() {

--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -343,8 +343,6 @@ pub enum RebaseResult {
 
 /// Handle shared rebase workflow (used by `wt step rebase` and `wt merge`)
 pub fn handle_rebase(target: Option<&str>) -> anyhow::Result<RebaseResult> {
-    use super::repository_ext::RepositoryCliExt;
-
     let repo = Repository::current()?;
 
     // Get and validate target ref (any commit-ish for rebase)

--- a/src/commands/worktree/switch.rs
+++ b/src/commands/worktree/switch.rs
@@ -36,7 +36,7 @@ fn resolve_switch_target(
     create: bool,
     base: Option<&str>,
 ) -> anyhow::Result<ResolvedTarget> {
-    use worktrunk::git::pr_ref::{fetch_pr_info, fork_remote_url, local_branch_name};
+    use worktrunk::git::pr_ref::{fetch_pr_info, local_branch_name};
 
     // Handle pr:<number> syntax
     if let Some(pr_number) = worktrunk::git::pr_ref::parse_pr_ref(branch) {

--- a/src/git/pr_ref.rs
+++ b/src/git/pr_ref.rs
@@ -525,8 +525,6 @@ pub fn fork_remote_url(owner: &str, repo: &str, reference_url: &str) -> String {
 /// Returns `Some(false)` if the branch exists but tracks something else.
 /// Returns `None` if the branch doesn't exist.
 pub fn branch_tracks_pr(repo_root: &std::path::Path, branch: &str, pr_number: u32) -> Option<bool> {
-    use crate::shell_exec::Cmd;
-
     let config_key = format!("branch.{}.merge", branch);
     let output = Cmd::new("git")
         .args(["config", "--get", &config_key])

--- a/src/help_pager.rs
+++ b/src/help_pager.rs
@@ -153,8 +153,7 @@ fn compute_less_flags(user_less: Option<&str>) -> String {
 
 #[cfg(test)]
 mod tests {
-    use super::compute_less_flags;
-    use crate::pager::parse_pager_value;
+    use super::{compute_less_flags, parse_pager_value};
 
     #[test]
     fn test_validate_excludes_cat() {

--- a/src/md_help.rs
+++ b/src/md_help.rs
@@ -318,7 +318,7 @@ fn render_inline_formatting(line: &str) -> String {
 
 /// Add colors to status symbols in help text (matching wt list output colors)
 fn colorize_status_symbols(text: &str) -> String {
-    use anstyle::{AnsiColor, Color as AnsiStyleColor, Style};
+    use anstyle::Color as AnsiStyleColor;
 
     // Define semantic styles matching src/commands/list/model.rs StatusSymbols::styled_symbols
     let error = Style::new().fg_color(Some(AnsiStyleColor::Ansi(AnsiColor::Red)));

--- a/src/output/global.rs
+++ b/src/output/global.rs
@@ -228,12 +228,9 @@ fn execute_command(command: String, target_dir: Option<&Path>) -> anyhow::Result
 /// Execute a command in the given directory (non-Unix: spawn and wait)
 #[cfg(not(unix))]
 fn execute_command(command: String, target_dir: Option<&Path>) -> anyhow::Result<()> {
+    use std::process::Stdio;
     use worktrunk::git::WorktrunkError;
     use worktrunk::shell_exec::Cmd;
-
-    // On non-Unix platforms, fall back to spawn-and-wait.
-    // This uses the shell abstraction (Git Bash if available).
-    use std::process::Stdio;
     let mut cmd = Cmd::shell(&command).stdin(Stdio::inherit());
     if let Some(dir) = target_dir {
         cmd = cmd.current_dir(dir);
@@ -363,7 +360,6 @@ pub fn post_hook_display_path(destination: &std::path::Path) -> Option<&std::pat
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
 
     #[test]
     fn test_compute_hooks_display_path_same_location() {

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -996,8 +996,6 @@ pub fn execute_command_in_worktree(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::path::PathBuf;
-    use worktrunk::git::IntegrationReason;
 
     #[test]
     fn test_format_switch_message() {

--- a/src/path.rs
+++ b/src/path.rs
@@ -142,9 +142,7 @@ pub fn sanitize_for_filename(value: &str) -> String {
 
 #[cfg(test)]
 mod tests {
-    use std::path::PathBuf;
-
-    use super::{format_path_for_display, home_dir, sanitize_for_filename, to_posix_path};
+    use super::{PathBuf, format_path_for_display, home_dir, sanitize_for_filename, to_posix_path};
 
     #[test]
     fn shortens_path_under_home() {

--- a/src/shell_exec.rs
+++ b/src/shell_exec.rs
@@ -255,7 +255,6 @@ fn run_with_timeout_impl(
 ) -> std::io::Result<std::process::Output> {
     use std::io::{ErrorKind, Read};
     use std::process::Stdio;
-    use std::time::Instant;
 
     // Spawn process with piped stdout/stderr
     let mut child = cmd

--- a/src/trace/chrome.rs
+++ b/src/trace/chrome.rs
@@ -162,7 +162,7 @@ mod tests {
     use std::time::Duration;
 
     use super::*;
-    use crate::trace::{TraceEntry, TraceResult};
+    use crate::trace::TraceResult;
 
     fn make_command_entry(
         command: &str,


### PR DESCRIPTION
## Summary
- Remove 26 duplicate imports across 17 files
- Consolidate test module imports to use parent namespace via `use super::*`
- Remove function-scope imports that shadow module-level ones

## Test plan
- [x] `cargo check --all-targets` passes
- [x] `cargo test --lib --bins` passes (429 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)