### PR TITLE
refactor: rename WorktrunkConfig to UserConfig

### DIFF
--- a/src/commands/command_approval.rs
+++ b/src/commands/command_approval.rs
@@ -22,7 +22,7 @@ use super::project_config::{HookCommand, collect_commands_for_hooks};
 use crate::output;
 use anyhow::Context;
 use color_print::cformat;
-use worktrunk::config::WorktrunkConfig;
+use worktrunk::config::UserConfig;
 use worktrunk::git::{GitError, HookType};
 use worktrunk::styling::{
     INFO_SYMBOL, PROMPT_SYMBOL, WARNING_SYMBOL, eprint, format_bash_with_gutter, hint_message,
@@ -41,7 +41,7 @@ use worktrunk::styling::{
 pub fn approve_command_batch(
     commands: &[HookCommand],
     project_id: &str,
-    config: &WorktrunkConfig,
+    config: &UserConfig,
     yes: bool,
     commands_already_filtered: bool,
 ) -> anyhow::Result<bool> {
@@ -69,7 +69,7 @@ pub fn approve_command_batch(
 
     // Only save approvals when interactively approved, not when using --yes
     if !yes {
-        let mut fresh_config = WorktrunkConfig::load().context("Failed to reload config")?;
+        let mut fresh_config = UserConfig::load().context("Failed to reload config")?;
 
         let project_entry = fresh_config
             .projects

--- a/src/commands/command_executor.rs
+++ b/src/commands/command_executor.rs
@@ -1,7 +1,7 @@
 use std::collections::HashMap;
 use std::path::Path;
 use worktrunk::HookType;
-use worktrunk::config::{Command, CommandConfig, WorktrunkConfig, expand_template};
+use worktrunk::config::{Command, CommandConfig, UserConfig, expand_template};
 use worktrunk::git::Repository;
 use worktrunk::path::to_posix_path;
 
@@ -17,7 +17,7 @@ pub struct PreparedCommand {
 #[derive(Clone, Copy, Debug)]
 pub struct CommandContext<'a> {
     pub repo: &'a Repository,
-    pub config: &'a WorktrunkConfig,
+    pub config: &'a UserConfig,
     /// Current branch name, if on a branch (None in detached HEAD state).
     pub branch: Option<&'a str>,
     pub worktree_path: &'a Path,
@@ -28,7 +28,7 @@ pub struct CommandContext<'a> {
 impl<'a> CommandContext<'a> {
     pub fn new(
         repo: &'a Repository,
-        config: &'a WorktrunkConfig,
+        config: &'a UserConfig,
         branch: Option<&'a str>,
         worktree_path: &'a Path,
         repo_root: &'a Path,

--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -9,7 +9,7 @@ use std::path::PathBuf;
 use anyhow::Context;
 use color_print::cformat;
 use worktrunk::config::{
-    ProjectConfig, WorktrunkConfig, find_unknown_project_keys, find_unknown_user_keys,
+    ProjectConfig, UserConfig, find_unknown_project_keys, find_unknown_user_keys,
 };
 use worktrunk::git::Repository;
 use worktrunk::path::format_path_for_display;
@@ -257,7 +257,7 @@ fn render_diagnostics(out: &mut String) -> anyhow::Result<()> {
     }
 
     // Test commit generation
-    let config = WorktrunkConfig::load()?;
+    let config = UserConfig::load()?;
     let commit_config = &config.commit_generation;
 
     if !commit_config.is_configured() {
@@ -331,7 +331,7 @@ fn render_user_config(out: &mut String) -> anyhow::Result<()> {
     }
 
     // Validate config (syntax + schema) and warn if invalid
-    if let Err(e) = toml::from_str::<WorktrunkConfig>(&contents) {
+    if let Err(e) = toml::from_str::<UserConfig>(&contents) {
         // Use gutter for error details to avoid markup interpretation of user content
         writeln!(out, "{}", error_message("Invalid config"))?;
         writeln!(out, "{}", format_with_gutter(&e.to_string(), None))?;

--- a/src/commands/context.rs
+++ b/src/commands/context.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use std::path::PathBuf;
-use worktrunk::config::WorktrunkConfig;
+use worktrunk::config::UserConfig;
 use worktrunk::git::Repository;
 
 use super::command_executor::CommandContext;
@@ -19,7 +19,7 @@ pub struct CommandEnv {
     pub repo: Repository,
     /// Current branch name, if on a branch (None in detached HEAD state).
     pub branch: Option<String>,
-    pub config: WorktrunkConfig,
+    pub config: UserConfig,
     pub worktree_path: PathBuf,
     pub repo_root: PathBuf,
 }
@@ -33,7 +33,7 @@ impl CommandEnv {
         let repo = Repository::current()?;
         let worktree_path = std::env::current_dir().context("Failed to get current directory")?;
         let branch = repo.require_current_branch(action)?;
-        let config = WorktrunkConfig::load().context("Failed to load config")?;
+        let config = UserConfig::load().context("Failed to load config")?;
         let repo_root = repo
             .repo_path()
             .context("Failed to determine repository root")?;
@@ -59,7 +59,7 @@ impl CommandEnv {
             .current_worktree()
             .branch()
             .context("Failed to determine current branch")?;
-        let config = WorktrunkConfig::load().context("Failed to load config")?;
+        let config = UserConfig::load().context("Failed to load config")?;
         let repo_root = repo
             .repo_path()
             .context("Failed to determine repository root")?;

--- a/src/commands/for_each.rs
+++ b/src/commands/for_each.rs
@@ -26,7 +26,7 @@ use std::io::Write;
 use std::process::Stdio;
 
 use color_print::cformat;
-use worktrunk::config::{WorktrunkConfig, expand_template};
+use worktrunk::config::{UserConfig, expand_template};
 use worktrunk::git::Repository;
 use worktrunk::git::WorktrunkError;
 use worktrunk::shell_exec::ShellConfig;
@@ -52,7 +52,7 @@ pub fn step_for_each(args: Vec<String>) -> anyhow::Result<()> {
         .into_iter()
         .filter(|wt| !wt.is_prunable())
         .collect();
-    let config = WorktrunkConfig::load()?;
+    let config = UserConfig::load()?;
 
     let mut failed: Vec<String> = Vec::new();
     let total = worktrees.len();

--- a/src/commands/hook_commands.rs
+++ b/src/commands/hook_commands.rs
@@ -11,7 +11,7 @@ use color_print::cformat;
 use std::fmt::Write as _;
 use strum::IntoEnumIterator;
 use worktrunk::HookType;
-use worktrunk::config::{CommandConfig, ProjectConfig, WorktrunkConfig};
+use worktrunk::config::{CommandConfig, ProjectConfig, UserConfig};
 use worktrunk::git::{GitError, Repository};
 use worktrunk::path::format_path_for_display;
 use worktrunk::styling::{
@@ -265,7 +265,7 @@ pub fn add_approvals(show_all: bool) -> anyhow::Result<()> {
 
     let repo = Repository::current()?;
     let project_id = repo.project_identifier()?;
-    let config = WorktrunkConfig::load().context("Failed to load config")?;
+    let config = UserConfig::load().context("Failed to load config")?;
 
     // Load project config (error if missing - this command requires it)
     let config_path = repo
@@ -321,7 +321,7 @@ pub fn add_approvals(show_all: bool) -> anyhow::Result<()> {
 
 /// Handle `wt hook approvals clear` command - clear approved commands
 pub fn clear_approvals(global: bool) -> anyhow::Result<()> {
-    let mut config = WorktrunkConfig::load().context("Failed to load config")?;
+    let mut config = UserConfig::load().context("Failed to load config")?;
 
     if global {
         // Clear all approvals for all projects
@@ -377,7 +377,7 @@ pub fn handle_hook_show(hook_type_filter: Option<&str>, expanded: bool) -> anyho
     use crate::help_pager::show_help_in_pager;
 
     let repo = Repository::current()?;
-    let config = WorktrunkConfig::load().context("Failed to load user config")?;
+    let config = UserConfig::load().context("Failed to load user config")?;
     let project_config = repo.load_project_config()?;
     let project_id = repo.project_identifier().ok();
 
@@ -431,7 +431,7 @@ pub fn handle_hook_show(hook_type_filter: Option<&str>, expanded: bool) -> anyho
 /// Render user hooks section
 fn render_user_hooks(
     out: &mut String,
-    config: &WorktrunkConfig,
+    config: &UserConfig,
     filter: Option<HookType>,
     ctx: Option<&CommandContext>,
 ) -> anyhow::Result<()> {
@@ -489,7 +489,7 @@ fn render_project_hooks(
     out: &mut String,
     repo: &Repository,
     project_config: Option<&ProjectConfig>,
-    user_config: &WorktrunkConfig,
+    user_config: &UserConfig,
     project_id: Option<&str>,
     filter: Option<HookType>,
     ctx: Option<&CommandContext>,
@@ -550,7 +550,7 @@ fn render_hook_commands(
     hook_type: HookType,
     config: &CommandConfig,
     // For project hooks: (user_config, project_id) to check approval status
-    approval_context: Option<(&WorktrunkConfig, Option<&str>)>,
+    approval_context: Option<(&UserConfig, Option<&str>)>,
     ctx: Option<&CommandContext>,
 ) -> anyhow::Result<()> {
     let commands = config.commands();

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -212,7 +212,7 @@ pub fn collect(
     skip_tasks: &std::collections::HashSet<TaskKind>,
     show_progress: bool,
     render_table: bool,
-    config: &worktrunk::config::WorktrunkConfig,
+    config: &worktrunk::config::UserConfig,
     command_timeout: Option<std::time::Duration>,
     skip_expensive_for_stale: bool,
 ) -> anyhow::Result<Option<super::model::ListData>> {

--- a/src/commands/list/mod.rs
+++ b/src/commands/list/mod.rs
@@ -147,7 +147,7 @@ pub fn handle_list(
     show_remotes: bool,
     show_full: bool,
     render_mode: RenderMode,
-    config: &worktrunk::config::WorktrunkConfig,
+    config: &worktrunk::config::UserConfig,
 ) -> anyhow::Result<()> {
     use collect::TaskKind;
 

--- a/src/commands/repository_ext.rs
+++ b/src/commands/repository_ext.rs
@@ -5,7 +5,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use super::worktree::{BranchDeletionMode, RemoveResult, get_path_mismatch};
 use anyhow::Context;
 use color_print::cformat;
-use worktrunk::config::WorktrunkConfig;
+use worktrunk::config::UserConfig;
 use worktrunk::git::{
     GitError, IntegrationReason, Repository, parse_porcelain_z, parse_untracked_files,
 };
@@ -39,7 +39,7 @@ pub trait RepositoryCliExt {
         target: RemoveTarget,
         deletion_mode: BranchDeletionMode,
         force_worktree: bool,
-        config: &WorktrunkConfig,
+        config: &UserConfig,
     ) -> anyhow::Result<RemoveResult>;
 
     /// Prepare the target worktree for push by auto-stashing non-overlapping changes when safe.
@@ -74,7 +74,7 @@ impl RepositoryCliExt for Repository {
         target: RemoveTarget,
         deletion_mode: BranchDeletionMode,
         force_worktree: bool,
-        config: &WorktrunkConfig,
+        config: &UserConfig,
     ) -> anyhow::Result<RemoveResult> {
         let current_path = self.current_worktree().root()?.to_path_buf();
         let worktrees = self.list_worktrees()?;

--- a/src/commands/select/mod.rs
+++ b/src/commands/select/mod.rs
@@ -11,7 +11,7 @@ use std::sync::Arc;
 
 use anyhow::Context;
 use skim::prelude::*;
-use worktrunk::config::WorktrunkConfig;
+use worktrunk::config::UserConfig;
 use worktrunk::git::Repository;
 
 use super::list::collect;
@@ -24,7 +24,7 @@ use preview::{PreviewLayout, PreviewState};
 pub fn handle_select(
     show_branches: bool,
     show_remotes: bool,
-    config: &WorktrunkConfig,
+    config: &UserConfig,
 ) -> anyhow::Result<()> {
     use std::io::IsTerminal;
 
@@ -214,7 +214,7 @@ pub fn handle_select(
         let identifier = selected.output().to_string();
 
         // Load config
-        let config = WorktrunkConfig::load().context("Failed to load config")?;
+        let config = UserConfig::load().context("Failed to load config")?;
         let repo = Repository::current().context("Failed to switch worktree")?;
 
         // Switch to the selected worktree (no creation, no approval prompts)

--- a/src/commands/select/pager.rs
+++ b/src/commands/select/pager.rs
@@ -6,7 +6,7 @@ use std::process::{Command, Stdio};
 use std::sync::OnceLock;
 use std::time::{Duration, Instant};
 
-use worktrunk::config::WorktrunkConfig;
+use worktrunk::config::UserConfig;
 use worktrunk::shell::extract_filename_from_path;
 
 use crate::pager::{git_config_pager, parse_pager_value};
@@ -34,7 +34,7 @@ pub(super) fn get_diff_pager() -> Option<&'static String> {
         .get_or_init(|| {
             // Check user config first for explicit pager override
             // When set, use exactly as specified (no auto-detection)
-            if let Ok(config) = WorktrunkConfig::load()
+            if let Ok(config) = UserConfig::load()
                 && let Some(select_config) = config.select
                 && let Some(pager) = select_config.pager
                 && !pager.trim().is_empty()
@@ -78,7 +78,7 @@ pub(super) fn pager_needs_paging_disabled(pager_cmd: &str) -> bool {
 
 /// Check if user has explicitly configured a select-specific pager.
 pub(super) fn has_explicit_pager_config() -> bool {
-    WorktrunkConfig::load()
+    UserConfig::load()
         .ok()
         .and_then(|config| config.select)
         .and_then(|select| select.pager)

--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -12,7 +12,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Context;
 use color_print::cformat;
 use worktrunk::HookType;
-use worktrunk::config::WorktrunkConfig;
+use worktrunk::config::UserConfig;
 use worktrunk::git::Repository;
 use worktrunk::styling::{
     format_with_gutter, hint_message, info_message, progress_message, success_message,
@@ -34,7 +34,7 @@ pub fn step_commit(
 
     // Handle --show-prompt early: just build and output the prompt
     if show_prompt {
-        let config = WorktrunkConfig::load().context("Failed to load config")?;
+        let config = UserConfig::load().context("Failed to load config")?;
         let prompt = crate::llm::build_commit_prompt(&config.commit_generation)?;
         crate::output::stdout(prompt)?;
         return Ok(());

--- a/src/commands/worktree/remove.rs
+++ b/src/commands/worktree/remove.rs
@@ -1,6 +1,6 @@
 //! Worktree remove operations.
 
-use worktrunk::config::WorktrunkConfig;
+use worktrunk::config::UserConfig;
 use worktrunk::git::Repository;
 
 use super::types::{BranchDeletionMode, RemoveResult};
@@ -12,7 +12,7 @@ pub fn handle_remove(
     no_delete_branch: bool,
     force_delete: bool,
     force_worktree: bool,
-    config: &WorktrunkConfig,
+    config: &UserConfig,
 ) -> anyhow::Result<RemoveResult> {
     let repo = Repository::current()?;
 
@@ -33,7 +33,7 @@ pub fn handle_remove_current(
     no_delete_branch: bool,
     force_delete: bool,
     force_worktree: bool,
-    config: &WorktrunkConfig,
+    config: &UserConfig,
 ) -> anyhow::Result<RemoveResult> {
     let repo = Repository::current()?;
 

--- a/src/commands/worktree/resolve.rs
+++ b/src/commands/worktree/resolve.rs
@@ -6,7 +6,7 @@ use std::path::{Path, PathBuf};
 
 use color_print::cformat;
 use normalize_path::NormalizePath;
-use worktrunk::config::WorktrunkConfig;
+use worktrunk::config::UserConfig;
 use worktrunk::git::{GitError, Repository, ResolvedWorktree};
 
 use super::types::ResolutionContext;
@@ -27,7 +27,7 @@ use super::types::ResolutionContext;
 pub fn resolve_worktree_arg(
     repo: &Repository,
     name: &str,
-    config: &WorktrunkConfig,
+    config: &UserConfig,
     context: ResolutionContext,
 ) -> anyhow::Result<ResolvedWorktree> {
     // Special symbols - delegate to Repository for consistent error handling
@@ -76,7 +76,7 @@ pub fn resolve_worktree_arg(
 pub fn compute_worktree_path(
     repo: &Repository,
     branch: &str,
-    config: &WorktrunkConfig,
+    config: &UserConfig,
 ) -> anyhow::Result<PathBuf> {
     let repo_root = repo.repo_path()?;
     let default_branch = repo.default_branch().unwrap_or_default();
@@ -116,7 +116,7 @@ pub fn compute_worktree_path(
 pub fn is_worktree_at_expected_path(
     wt: &worktrunk::git::WorktreeInfo,
     repo: &Repository,
-    config: &WorktrunkConfig,
+    config: &UserConfig,
 ) -> bool {
     match &wt.branch {
         Some(branch) => compute_worktree_path(repo, branch, config)
@@ -144,7 +144,7 @@ pub fn get_path_mismatch(
     repo: &Repository,
     branch: &str,
     actual_path: &std::path::Path,
-    config: &WorktrunkConfig,
+    config: &UserConfig,
 ) -> Option<PathBuf> {
     compute_worktree_path(repo, branch, config)
         .ok()
@@ -163,7 +163,7 @@ pub fn get_path_mismatch(
 pub fn worktree_display_name(
     wt: &worktrunk::git::WorktreeInfo,
     repo: &Repository,
-    config: &WorktrunkConfig,
+    config: &UserConfig,
 ) -> String {
     let dir_name = wt.dir_name();
 

--- a/src/commands/worktree/switch.rs
+++ b/src/commands/worktree/switch.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 use anyhow::Context;
 use color_print::cformat;
 use dunce::canonicalize;
-use worktrunk::config::WorktrunkConfig;
+use worktrunk::config::UserConfig;
 use worktrunk::git::pr_ref::fork_remote_url;
 use worktrunk::git::{GitError, Repository};
 use worktrunk::styling::{
@@ -465,7 +465,7 @@ pub fn plan_switch(
     create: bool,
     base: Option<&str>,
     clobber: bool,
-    config: &WorktrunkConfig,
+    config: &UserConfig,
 ) -> anyhow::Result<SwitchPlan> {
     // Record current branch for `wt switch -` support
     let new_previous = repo.current_worktree().branch().ok().flatten();
@@ -510,7 +510,7 @@ pub fn plan_switch(
 pub fn execute_switch(
     repo: &Repository,
     plan: SwitchPlan,
-    config: &WorktrunkConfig,
+    config: &UserConfig,
     force: bool,
     no_verify: bool,
 ) -> anyhow::Result<(SwitchResult, SwitchBranchInfo)> {

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -8,7 +8,7 @@ use clap_complete::env::CompleteEnv;
 
 use crate::cli;
 use crate::display::format_relative_time_short;
-use worktrunk::config::{ProjectConfig, WorktrunkConfig};
+use worktrunk::config::{ProjectConfig, UserConfig};
 use worktrunk::git::{BranchCategory, HookType, Repository};
 
 /// Deprecated args that should never appear in completions.
@@ -260,7 +260,7 @@ fn complete_hook_commands() -> Vec<CompletionCandidate> {
         };
 
     // Load user config and add user hook names
-    if let Ok(user_config) = WorktrunkConfig::load()
+    if let Ok(user_config) = UserConfig::load()
         && let Some(config) = user_config.hooks.get(hook_type)
     {
         add_named_commands(&mut candidates, config);

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -38,7 +38,7 @@ pub use project::{
     find_unknown_keys as find_unknown_project_keys,
 };
 pub use user::{
-    CommitGenerationConfig, StageMode, UserProjectConfig, WorktrunkConfig,
+    CommitGenerationConfig, StageMode, UserConfig, UserProjectConfig,
     find_unknown_keys as find_unknown_user_keys, get_config_path, set_config_path,
 };
 
@@ -72,7 +72,7 @@ mod tests {
 
     #[test]
     fn test_config_serialization() {
-        let config = WorktrunkConfig::default();
+        let config = UserConfig::default();
         let toml = toml::to_string(&config).unwrap();
         // worktree-path is not serialized when None (uses built-in default)
         assert!(!toml.contains("worktree-path"));
@@ -81,7 +81,7 @@ mod tests {
 
     #[test]
     fn test_config_serialization_with_worktree_path() {
-        let config = WorktrunkConfig {
+        let config = UserConfig {
             worktree_path: Some("custom/{{ branch }}".to_string()),
             ..Default::default()
         };
@@ -92,7 +92,7 @@ mod tests {
 
     #[test]
     fn test_default_config() {
-        let config = WorktrunkConfig::default();
+        let config = UserConfig::default();
         // worktree_path is None by default, but the getter returns the default
         assert!(config.worktree_path.is_none());
         assert_eq!(
@@ -106,7 +106,7 @@ mod tests {
     #[test]
     fn test_format_worktree_path() {
         let test = test_repo();
-        let config = WorktrunkConfig {
+        let config = UserConfig {
             worktree_path: Some("{{ main_worktree }}.{{ branch }}".to_string()),
             ..Default::default()
         };
@@ -121,7 +121,7 @@ mod tests {
     #[test]
     fn test_format_worktree_path_custom_template() {
         let test = test_repo();
-        let config = WorktrunkConfig {
+        let config = UserConfig {
             worktree_path: Some("{{ main_worktree }}-{{ branch }}".to_string()),
             ..Default::default()
         };
@@ -136,7 +136,7 @@ mod tests {
     #[test]
     fn test_format_worktree_path_only_branch() {
         let test = test_repo();
-        let config = WorktrunkConfig {
+        let config = UserConfig {
             worktree_path: Some(".worktrees/{{ main_worktree }}/{{ branch }}".to_string()),
             ..Default::default()
         };
@@ -152,7 +152,7 @@ mod tests {
     fn test_format_worktree_path_with_slashes() {
         let test = test_repo();
         // Use {{ branch | sanitize }} to replace slashes with dashes
-        let config = WorktrunkConfig {
+        let config = UserConfig {
             worktree_path: Some("{{ main_worktree }}.{{ branch | sanitize }}".to_string()),
             ..Default::default()
         };
@@ -167,7 +167,7 @@ mod tests {
     #[test]
     fn test_format_worktree_path_with_multiple_slashes() {
         let test = test_repo();
-        let config = WorktrunkConfig {
+        let config = UserConfig {
             worktree_path: Some(
                 ".worktrees/{{ main_worktree }}/{{ branch | sanitize }}".to_string(),
             ),
@@ -185,7 +185,7 @@ mod tests {
     fn test_format_worktree_path_with_backslashes() {
         let test = test_repo();
         // Windows-style path separators should also be sanitized
-        let config = WorktrunkConfig {
+        let config = UserConfig {
             worktree_path: Some(
                 ".worktrees/{{ main_worktree }}/{{ branch | sanitize }}".to_string(),
             ),
@@ -203,7 +203,7 @@ mod tests {
     fn test_format_worktree_path_raw_branch() {
         let test = test_repo();
         // {{ branch }} without filter gives raw branch name
-        let config = WorktrunkConfig {
+        let config = UserConfig {
             worktree_path: Some("{{ main_worktree }}.{{ branch }}".to_string()),
             ..Default::default()
         };
@@ -402,7 +402,7 @@ task2 = "echo 'Task 2 running' > task2.txt"
 
     #[test]
     fn test_is_command_approved() {
-        let mut config = WorktrunkConfig::default();
+        let mut config = UserConfig::default();
         config.projects.insert(
             "github.com/user/repo".to_string(),
             UserProjectConfig {
@@ -421,7 +421,7 @@ task2 = "echo 'Task 2 running' > task2.txt"
 
         let temp_dir = TempDir::new().unwrap();
         let config_path = temp_dir.path().join("test-config.toml");
-        let mut config = WorktrunkConfig::default();
+        let mut config = UserConfig::default();
 
         // First approval
         assert!(!config.is_command_approved("github.com/user/repo", "npm install"));
@@ -466,7 +466,7 @@ task2 = "echo 'Task 2 running' > task2.txt"
         let temp_dir = TempDir::new().unwrap();
         let config_path = temp_dir.path().join("test-config.toml");
 
-        let mut config = WorktrunkConfig::default();
+        let mut config = UserConfig::default();
 
         // Set up two approved commands
         config
@@ -512,7 +512,7 @@ task2 = "echo 'Task 2 running' > task2.txt"
         let temp_dir = TempDir::new().unwrap();
         let config_path = temp_dir.path().join("test-config.toml");
 
-        let mut config = WorktrunkConfig::default();
+        let mut config = UserConfig::default();
 
         // Revoking from non-existent project is a no-op
         config
@@ -542,7 +542,7 @@ task2 = "echo 'Task 2 running' > task2.txt"
         let temp_dir = TempDir::new().unwrap();
         let config_path = temp_dir.path().join("test-config.toml");
 
-        let mut config = WorktrunkConfig::default();
+        let mut config = UserConfig::default();
 
         // Set up multiple projects
         config
@@ -672,7 +672,7 @@ template-file = "~/file.txt"
 "#;
 
         // Parse the TOML directly
-        let config_result: Result<WorktrunkConfig, _> = toml::from_str(toml_content);
+        let config_result: Result<UserConfig, _> = toml::from_str(toml_content);
 
         // The deserialization should succeed, but validation in load() would fail
         // Since we can't easily test load() without env vars, we verify the fields deserialize
@@ -700,7 +700,7 @@ squash-template-file = "~/file.txt"
 "#;
 
         // Parse the TOML directly
-        let config_result: Result<WorktrunkConfig, _> = toml::from_str(toml_content);
+        let config_result: Result<UserConfig, _> = toml::from_str(toml_content);
 
         // The deserialization should succeed, but validation in load() would fail
         // Since we can't easily test load() without env vars, we verify the fields deserialize
@@ -790,7 +790,7 @@ log = "echo '{{ repo }}' >> ~/.log"
 test = "cargo test"
 lint = "cargo clippy"
 "#;
-        let config: WorktrunkConfig = toml::from_str(toml_str).unwrap();
+        let config: UserConfig = toml::from_str(toml_str).unwrap();
 
         // Check post-create
         let post_create = config
@@ -815,7 +815,7 @@ lint = "cargo clippy"
 worktree-path = "../{{ main_worktree }}.{{ branch }}"
 post-create = "npm install"
 "#;
-        let config: WorktrunkConfig = toml::from_str(toml_str).unwrap();
+        let config: UserConfig = toml::from_str(toml_str).unwrap();
 
         let post_create = config
             .hooks

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::Context;
 use clap::FromArgMatches;
 use color_print::cformat;
 use std::process;
-use worktrunk::config::{WorktrunkConfig, expand_template, set_config_path};
+use worktrunk::config::{UserConfig, expand_template, set_config_path};
 use worktrunk::git::{Repository, exit_code, set_base_path};
 use worktrunk::path::format_path_for_display;
 use worktrunk::shell::extract_filename_from_path;
@@ -480,7 +480,7 @@ fn main() {
                 verify,
                 stage,
                 show_prompt,
-            } => WorktrunkConfig::load()
+            } => UserConfig::load()
                 .context("Failed to load config")
                 .and_then(|config| {
                     let stage_final = stage
@@ -494,7 +494,7 @@ fn main() {
                 verify,
                 stage,
                 show_prompt,
-            } => WorktrunkConfig::load()
+            } => UserConfig::load()
                 .context("Failed to load config")
                 .and_then(|config| {
                     let stage_final = stage
@@ -626,7 +626,7 @@ fn main() {
         },
         #[cfg(unix)]
         Commands::Select { branches, remotes } => {
-            WorktrunkConfig::load()
+            UserConfig::load()
                 .context("Failed to load config")
                 .and_then(|config| {
                     // Get config values from [list] config (shared with wt list)
@@ -667,7 +667,7 @@ fn main() {
                 use commands::list::progressive::RenderMode;
 
                 // Load config and merge with CLI flags (CLI flags take precedence)
-                WorktrunkConfig::load()
+                UserConfig::load()
                     .context("Failed to load config")
                     .and_then(|config| {
                         // Get config values from global list config
@@ -715,7 +715,7 @@ fn main() {
             yes,
             clobber,
             verify,
-        } => WorktrunkConfig::load()
+        } => UserConfig::load()
             .context("Failed to load config")
             .and_then(|mut config| {
                 let repo = Repository::current().context("Failed to switch worktree")?;
@@ -888,7 +888,7 @@ fn main() {
             verify,
             yes,
             force,
-        } => WorktrunkConfig::load()
+        } => UserConfig::load()
             .context("Failed to load config")
             .and_then(|config| {
                 // Handle deprecated --no-background flag
@@ -1087,7 +1087,7 @@ fn main() {
             no_verify,
             yes,
             stage,
-        } => WorktrunkConfig::load()
+        } => UserConfig::load()
             .context("Failed to load config")
             .and_then(|config| {
                 // Convert paired flags to Option<bool>

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -10,7 +10,7 @@ use crate::commands::command_executor::CommandContext;
 use crate::commands::execute_pre_remove_commands;
 use crate::commands::process::{build_remove_command, spawn_detached};
 use crate::commands::worktree::{BranchDeletionMode, RemoveResult, SwitchBranchInfo, SwitchResult};
-use worktrunk::config::WorktrunkConfig;
+use worktrunk::config::UserConfig;
 use worktrunk::git::GitError;
 use worktrunk::git::IntegrationReason;
 use worktrunk::git::Repository;
@@ -392,7 +392,7 @@ pub fn handle_switch_output(
             // Show worktree-path config hint on first --create in this repo,
             // unless user already has a custom worktree-path config
             if *created_branch && let Ok(repo) = worktrunk::git::Repository::current() {
-                let has_custom_config = WorktrunkConfig::load()
+                let has_custom_config = UserConfig::load()
                     .map(|c| c.has_custom_worktree_path())
                     .unwrap_or(false);
                 if !has_custom_config && !repo.has_shown_hint("worktree-path") {
@@ -552,7 +552,7 @@ fn spawn_post_switch_after_remove(
     if !verify || !changed_directory {
         return Ok(());
     }
-    let Ok(config) = WorktrunkConfig::load() else {
+    let Ok(config) = UserConfig::load() else {
         return Ok(());
     };
     // Use main_path for discovery since we're called after the original worktree
@@ -781,7 +781,7 @@ fn handle_removed_worktree_output(
     // Non-zero exit aborts removal (FailFast strategy).
     // If hooks fail, we don't want the shell to cd to main_path.
     // For detached HEAD, {{ branch }} expands to "HEAD" in templates
-    if verify && let Ok(config) = WorktrunkConfig::load() {
+    if verify && let Ok(config) = UserConfig::load() {
         let ctx = CommandContext::new(
             &repo,
             &config,

--- a/src/output/shell_integration.rs
+++ b/src/output/shell_integration.rs
@@ -60,7 +60,7 @@
 
 use color_print::cformat;
 
-use worktrunk::config::WorktrunkConfig;
+use worktrunk::config::UserConfig;
 use worktrunk::path::format_path_for_display;
 use worktrunk::shell::{Shell, extract_filename_from_path};
 use worktrunk::styling::hint_message;
@@ -342,7 +342,7 @@ pub fn print_shell_install_result(
 ///
 /// Returns `Ok(true)` if installed, `Ok(false)` otherwise.
 pub fn prompt_shell_integration(
-    config: &mut WorktrunkConfig,
+    config: &mut UserConfig,
     binary_name: &str,
     skip_prompt: bool,
 ) -> anyhow::Result<bool> {

--- a/tests/integration_tests/approvals.rs
+++ b/tests/integration_tests/approvals.rs
@@ -3,7 +3,7 @@
 use crate::common::{TestRepo, make_snapshot_cmd, repo, setup_snapshot_settings};
 use insta_cmd::assert_cmd_snapshot;
 use rstest::rstest;
-use worktrunk::config::WorktrunkConfig;
+use worktrunk::config::UserConfig;
 
 /// Helper to snapshot add-approvals command
 fn snapshot_add_approvals(test_name: &str, repo: &TestRepo, args: &[&str]) {
@@ -69,7 +69,7 @@ fn test_clear_approvals_with_approvals(repo: TestRepo) {
     repo.commit("Add config");
 
     // Manually approve the command by writing to test config
-    let mut config = WorktrunkConfig::default();
+    let mut config = UserConfig::default();
     config
         .approve_command(
             project_id,
@@ -97,7 +97,7 @@ fn test_clear_approvals_global_with_approvals(repo: TestRepo) {
     repo.commit("Add config");
 
     // Manually approve the command
-    let mut config = WorktrunkConfig::default();
+    let mut config = UserConfig::default();
     config
         .approve_command(
             project_id,
@@ -124,7 +124,7 @@ fn test_clear_approvals_after_clear(repo: TestRepo) {
     repo.commit("Add config");
 
     // Manually approve the command
-    let mut config = WorktrunkConfig::default();
+    let mut config = UserConfig::default();
     config
         .approve_command(
             project_id.clone(),
@@ -158,7 +158,7 @@ lint = "echo 'third'"
 
     // Manually approve all commands
     let project_id = format!("{}/origin", repo.root_path().display());
-    let mut config = WorktrunkConfig::default();
+    let mut config = UserConfig::default();
     config
         .approve_command(
             project_id.clone(),
@@ -197,7 +197,7 @@ fn test_add_approvals_all_already_approved(repo: TestRepo) {
     repo.commit("Add config");
 
     // Manually approve the command
-    let mut config = WorktrunkConfig::default();
+    let mut config = UserConfig::default();
     config
         .approve_command(
             project_id,

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -708,7 +708,7 @@ post-create = "ln -sf {{ repo_root }}/node_modules {{ worktree }}/node_modules"
     )
     .unwrap();
 
-    // Use `wt list` which loads config through WorktrunkConfig::load() and triggers deprecation check
+    // Use `wt list` which loads config through UserConfig::load() and triggers deprecation check
     let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
     settings.bind(|| {
         let mut cmd = wt_command();

--- a/tests/integration_tests/select_config.rs
+++ b/tests/integration_tests/select_config.rs
@@ -1,4 +1,4 @@
-use worktrunk::config::WorktrunkConfig;
+use worktrunk::config::UserConfig;
 
 #[test]
 fn test_select_pager_config_deserialization() {
@@ -8,7 +8,7 @@ fn test_select_pager_config_deserialization() {
 pager = "test-pager --custom-flag"
 "#;
 
-    let config: WorktrunkConfig = toml::from_str(config_content).unwrap();
+    let config: UserConfig = toml::from_str(config_content).unwrap();
 
     assert!(config.select.is_some());
     let select = config.select.unwrap();
@@ -23,7 +23,7 @@ fn test_select_pager_config_empty_string() {
 pager = ""
 "#;
 
-    let config: WorktrunkConfig = toml::from_str(config_content).unwrap();
+    let config: UserConfig = toml::from_str(config_content).unwrap();
 
     assert!(config.select.is_some());
     let select = config.select.unwrap();
@@ -38,6 +38,6 @@ fn test_select_config_optional() {
 full = true
 "#;
 
-    let config: WorktrunkConfig = toml::from_str(config_content).unwrap();
+    let config: UserConfig = toml::from_str(config_content).unwrap();
     assert!(config.select.is_none());
 }

--- a/tests/integration_tests/shell_integration_prompt.rs
+++ b/tests/integration_tests/shell_integration_prompt.rs
@@ -10,7 +10,7 @@
 use crate::common::{TestRepo, repo};
 use rstest::rstest;
 use std::fs;
-use worktrunk::config::WorktrunkConfig;
+use worktrunk::config::UserConfig;
 
 ///
 /// When WORKTRUNK_DIRECTIVE_FILE is set (shell integration active), we should:
@@ -64,7 +64,7 @@ fn test_switch_with_active_shell_integration_no_prompt(repo: TestRepo) {
 fn test_switch_with_skip_prompt_flag(repo: TestRepo) {
     // Set the skip flag in config
     let config_path = repo.test_config_path();
-    let mut config = WorktrunkConfig::default();
+    let mut config = UserConfig::default();
     config.skip_shell_integration_prompt = true;
     config.save_to(config_path).unwrap();
 


### PR DESCRIPTION
## Summary
- Renames `WorktrunkConfig` to `UserConfig` across 26 files
- Clarifies that this struct represents user-level configuration (`~/.config/worktrunk/config.toml`), distinct from `ProjectConfig` which is checked into the repository

## Test plan
- [x] `cargo check` passes
- [x] All 429 unit tests pass
- [x] Pre-commit hooks pass (except transient lychee failure on star-history.com API)

> _This was written by Claude Code on behalf of max-sixty_