### PR TITLE
refactor: use path-slash crate and Path::file_name() for cross-platform paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1497,6 +1497,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "path-slash"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
+
+[[package]]
 name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3092,6 +3098,7 @@ dependencies = [
  "normalize-path",
  "once_cell",
  "osc8",
+ "path-slash",
  "pathdiff",
  "portable-pty",
  "rayon",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -139,6 +139,7 @@ regex = "1.12"
 vt100 = "0.16"
 ansi-to-html = "0.2.2"
 wt-perf = { path = "tests/helpers/wt-perf" }
+path-slash = "0.2.1"
 
 [[bench]]
 name = "completion"

--- a/src/commands/command_approval.rs
+++ b/src/commands/command_approval.rs
@@ -102,9 +102,13 @@ pub fn approve_command_batch(
 
 fn prompt_for_batch_approval(commands: &[&HookCommand], project_id: &str) -> anyhow::Result<bool> {
     use std::io::{self, IsTerminal, Write};
+    use std::path::Path;
 
-    // Extract just the directory name for display (handles both Unix '/' and Windows '\')
-    let project_name = project_id.rsplit(['/', '\\']).next().unwrap_or(project_id);
+    // Extract just the directory name for display
+    let project_name = Path::new(project_id)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .unwrap_or(project_id);
     let count = commands.len();
     let plural = if count == 1 { "" } else { "s" };
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1299,22 +1299,22 @@ impl TestRepo {
         self.remote.as_deref()
     }
 
-    /// Get the project identifier for test configs.
+    /// Get the project identifier (canonical path) for this test repo.
     ///
-    /// Returns the full canonical path of the repository. This works because the standard
-    /// fixture uses a local path remote (`../origin_git`) which doesn't parse
-    /// as a proper git URL, causing worktrunk to fall back to the full canonical path.
+    /// Returns the full canonical path of the repository. The standard fixture uses a local
+    /// path remote (`../origin_git`) which doesn't parse as a proper git URL, causing
+    /// worktrunk to fall back to the full canonical path.
     ///
-    /// Use this when writing test configs with `[projects."<id>"]` sections.
-    /// Backslashes are escaped for use in TOML string literals (Windows paths).
+    /// Use with TOML literal strings (single quotes) to avoid backslash escaping:
+    /// ```ignore
+    /// format!(r#"[projects.'{}']"#, repo.project_id())
+    /// ```
     pub fn project_id(&self) -> String {
-        let path = dunce::canonicalize(&self.root)
+        dunce::canonicalize(&self.root)
             .unwrap_or_else(|_| self.root.clone())
             .to_str()
             .unwrap_or("")
-            .to_string();
-        // Escape backslashes for TOML string literals (Windows paths)
-        path.replace('\\', "\\\\")
+            .to_string()
     }
 
     /// Get the path to the isolated test config file

--- a/tests/integration_tests/approval_pty.rs
+++ b/tests/integration_tests/approval_pty.rs
@@ -265,7 +265,7 @@ third = "echo 'Third command'"
 
     // Pre-approve the second command
     repo.write_test_config(&format!(
-        r#"[projects."{}"]
+        r#"[projects.'{}']
 approved-commands = ["echo 'Second command'"]
 "#,
         repo.project_id()
@@ -321,7 +321,7 @@ third = "echo 'Third command'"
 
     // Pre-approve the second command
     repo.write_test_config(&format!(
-        r#"[projects."{}"]
+        r#"[projects.'{}']
 approved-commands = ["echo 'Second command'"]
 "#,
         repo.project_id()

--- a/tests/integration_tests/approval_ui.rs
+++ b/tests/integration_tests/approval_ui.rs
@@ -90,7 +90,7 @@ third = "echo 'Third command'"
 
     // Pre-approve the second command
     repo.write_test_config(&format!(
-        r#"[projects."{}"]
+        r#"[projects.'{}']
 approved-commands = ["echo 'Second command'"]
 "#,
         repo.project_id()
@@ -142,7 +142,7 @@ fn test_already_approved_commands_skip_prompt(repo: TestRepo) {
 
     // Pre-approve the command
     repo.write_test_config(&format!(
-        r#"[projects."{}"]
+        r#"[projects.'{}']
 approved-commands = ["echo 'approved' > output.txt"]
 "#,
         repo.project_id()
@@ -174,7 +174,7 @@ third = "echo 'Third command'"
     fs::write(
         repo.test_config_path(),
         format!(
-            r#"[projects."{}"]
+            r#"[projects.'{}']
 approved-commands = ["echo 'Second command'"]
 "#,
             repo.project_id()

--- a/tests/integration_tests/hook_show.rs
+++ b/tests/integration_tests/hook_show.rs
@@ -128,7 +128,7 @@ fn test_hook_show_approval_status(repo: TestRepo, temp_home: TempDir) {
         format!(
             r#"worktree-path = "../{{{{ repo }}}}.{{{{ branch }}}}"
 
-[projects."{project_id_str}"]
+[projects.'{project_id_str}']
 approved-commands = ["cargo build"]
 "#
         ),
@@ -280,7 +280,7 @@ fn test_hook_clear_with_approvals(repo: TestRepo, temp_home: TempDir) {
         format!(
             r#"worktree-path = "../{{{{ repo }}}}.{{{{ branch }}}}"
 
-[projects."{project_id_str}"]
+[projects.'{project_id_str}']
 approved-commands = ["cargo build", "cargo test", "npm install"]
 "#
         ),

--- a/tests/integration_tests/merge.rs
+++ b/tests/integration_tests/merge.rs
@@ -5,6 +5,7 @@ use crate::common::{
     repo_with_multi_commit_feature, setup_snapshot_settings,
 };
 use insta_cmd::assert_cmd_snapshot;
+use path_slash::PathExt as _;
 use rstest::rstest;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -1074,7 +1075,7 @@ mod tests {
     // On Windows, use .exe extension for the config-driven mock binary
     let llm_name = if cfg!(windows) { "llm.exe" } else { "llm" };
     let llm_path = bin_dir.join(llm_name);
-    let llm_path_str = llm_path.to_string_lossy().replace('\\', "/");
+    let llm_path_str = llm_path.to_slash_lossy();
     let worktrunk_config = format!(
         r#"
 [commit-generation]

--- a/tests/integration_tests/remove.rs
+++ b/tests/integration_tests/remove.rs
@@ -4,6 +4,7 @@ use crate::common::{
     setup_temp_snapshot_settings, wt_command,
 };
 use insta_cmd::assert_cmd_snapshot;
+use path_slash::PathExt as _;
 use rstest::rstest;
 use std::time::Duration; // For absence checks (SLEEP_FOR_ABSENCE_CHECK pattern)
 
@@ -1165,7 +1166,7 @@ fn test_pre_remove_hook_runs_in_background_mode(mut repo: TestRepo) {
     // Create project config with hook that creates a file
     repo.write_project_config(&format!(
         r#"pre-remove = "echo 'hook ran' > {}""#,
-        marker_file.to_string_lossy().replace('\\', "/")
+        marker_file.to_slash_lossy()
     ));
     repo.commit("Add config");
 
@@ -1176,7 +1177,7 @@ fn test_pre_remove_hook_runs_in_background_mode(mut repo: TestRepo) {
 [projects."../origin"]
 approved-commands = ["echo 'hook ran' > {}"]
 "#,
-        marker_file.to_string_lossy().replace('\\', "/")
+        marker_file.to_slash_lossy()
     ));
 
     // Create a worktree to remove
@@ -1289,7 +1290,7 @@ fn test_pre_remove_hook_not_for_branch_only(repo: TestRepo) {
     // Create project config with hook
     repo.write_project_config(&format!(
         r#"pre-remove = "echo 'hook ran' > {}""#,
-        marker_file.to_string_lossy().replace('\\', "/")
+        marker_file.to_slash_lossy()
     ));
     repo.commit("Add config");
 
@@ -1300,7 +1301,7 @@ fn test_pre_remove_hook_not_for_branch_only(repo: TestRepo) {
 [projects."../origin"]
 approved-commands = ["echo 'hook ran' > {}"]
 "#,
-        marker_file.to_string_lossy().replace('\\', "/")
+        marker_file.to_slash_lossy()
     ));
 
     // Create a branch without a worktree
@@ -1334,7 +1335,7 @@ fn test_pre_remove_hook_skipped_with_no_verify(mut repo: TestRepo) {
     // Create project config with hook that creates a file
     repo.write_project_config(&format!(
         r#"pre-remove = "echo 'hook ran' > {}""#,
-        marker_file.to_string_lossy().replace('\\', "/")
+        marker_file.to_slash_lossy()
     ));
     repo.commit("Add config");
 
@@ -1345,7 +1346,7 @@ fn test_pre_remove_hook_skipped_with_no_verify(mut repo: TestRepo) {
 [projects."../origin"]
 approved-commands = ["echo 'hook ran' > {}"]
 "#,
-        marker_file.to_string_lossy().replace('\\', "/")
+        marker_file.to_slash_lossy()
     ));
 
     // Create a worktree to remove
@@ -1389,7 +1390,7 @@ fn test_pre_remove_hook_runs_for_detached_head(mut repo: TestRepo) {
     // Use short filename to avoid terminal line-wrapping differences between platforms
     // (macOS temp paths are ~60 chars vs Linux ~20 chars, affecting wrap points)
     let marker_file = repo.root_path().join("m.txt");
-    let marker_path = marker_file.to_string_lossy().replace('\\', "/");
+    let marker_path = marker_file.to_slash_lossy();
 
     // Create project config with pre-remove hook that creates a marker file
     repo.write_project_config(&format!(r#"pre-remove = "touch {marker_path}""#,));
@@ -1432,7 +1433,7 @@ fn test_pre_remove_hook_runs_for_detached_head_background(mut repo: TestRepo) {
     let marker_file = repo.root_path().join("detached-bg-hook-marker.txt");
 
     // Create project config with pre-remove hook that creates a marker file
-    let marker_path = marker_file.to_string_lossy().replace('\\', "/");
+    let marker_path = marker_file.to_slash_lossy();
     repo.write_project_config(&format!(r#"pre-remove = "touch {marker_path}""#,));
     repo.commit("Add config");
 
@@ -1478,7 +1479,7 @@ approved-commands = ["touch {marker_path}"]
 fn test_pre_remove_hook_branch_expansion_detached_head(mut repo: TestRepo) {
     // Create a file where the hook will write the branch template expansion
     let branch_file = repo.root_path().join("branch-expansion.txt");
-    let branch_path = branch_file.to_string_lossy().replace('\\', "/");
+    let branch_path = branch_file.to_slash_lossy();
 
     // Create project config with hook that writes {{ branch }} to file
     repo.write_project_config(&format!(


### PR DESCRIPTION
## Summary
- Replace manual `rsplit(['/', '\\'])` with `Path::file_name()` in production code
- Add `path-slash` dev dependency for `to_slash_lossy()` in tests
- Use TOML literal strings (single quotes) to avoid backslash escaping in test configs

## Why
Manual string manipulation for path handling is error-prone. This change uses proper abstractions:
- `std::path::Path::file_name()` for extracting directory names
- `path_slash` crate for converting paths to forward slashes in shell commands

The backslash-to-forward-slash conversion is necessary because hooks run via Git Bash on Windows, and backslashes are escape characters in bash.

## Test plan
- [x] All tests pass locally
- [x] Pre-commit lints pass

🤖 Generated with [Claude Code](https://claude.ai/code)