### PR TITLE
refactor: clarify target/integration naming across codebase

### DIFF
--- a/src/commands/branch_deletion.rs
+++ b/src/commands/branch_deletion.rs
@@ -20,14 +20,14 @@ pub enum BranchDeletionOutcome {
 pub struct BranchDeletionResult {
     pub outcome: BranchDeletionOutcome,
     /// The target that was actually checked against (may be upstream if ahead of local)
-    pub effective_target: String,
+    pub integration_target: String,
 }
 
 /// Attempt to delete a branch if it's integrated or force_delete is set.
 ///
 /// Returns `BranchDeletionResult` with:
 /// - `outcome`: Whether/why deletion occurred
-/// - `effective_target`: The ref checked against (may be upstream if ahead of local)
+/// - `integration_target`: The ref checked against (may be upstream if ahead of local)
 pub fn delete_branch_if_safe(
     repo: &Repository,
     branch_name: &str,
@@ -51,7 +51,7 @@ pub fn delete_branch_if_safe(
 
     Ok(BranchDeletionResult {
         outcome,
-        effective_target,
+        integration_target: effective_target,
     })
 }
 

--- a/src/commands/list/collect/results.rs
+++ b/src/commands/list/collect/results.rs
@@ -67,7 +67,7 @@ pub(super) fn apply_default(
             status_contexts[idx].has_working_tree_conflicts = None;
         }
         TaskKind::GitOperation => {
-            // Already defaults to GitOperationState::None in WorktreeData
+            // Already defaults to ActiveGitOperation::None in WorktreeData
         }
         TaskKind::UserMarker => {
             // Already defaults to None

--- a/src/commands/list/collect/tasks.rs
+++ b/src/commands/list/collect/tasks.rs
@@ -7,7 +7,7 @@ use worktrunk::git::{LineDiff, Repository};
 
 use super::super::ci_status::PrStatus;
 use super::super::model::{
-    AheadBehind, BranchDiffTotals, CommitDetails, GitOperationState, UpstreamStatus,
+    ActiveGitOperation, AheadBehind, BranchDiffTotals, CommitDetails, UpstreamStatus,
     WorkingTreeStatus,
 };
 use super::types::{ErrorCause, TaskError, TaskKind, TaskResult};
@@ -512,7 +512,7 @@ impl Task for GitOperationTask {
             .branch_ref
             .working_tree(&ctx.repo)
             .expect("GitOperationTask requires a worktree");
-        let git_operation = detect_git_operation(&wt);
+        let git_operation = detect_active_git_operation(&wt);
         Ok(TaskResult::GitOperation {
             item_idx: ctx.item_idx,
             git_operation,
@@ -654,13 +654,15 @@ impl Task for UrlStatusTask {
 // ============================================================================
 
 /// Detect if a worktree is in the middle of a git operation (rebase/merge).
-pub(crate) fn detect_git_operation(wt: &worktrunk::git::WorkingTree<'_>) -> GitOperationState {
+pub(crate) fn detect_active_git_operation(
+    wt: &worktrunk::git::WorkingTree<'_>,
+) -> ActiveGitOperation {
     if wt.is_rebasing().unwrap_or(false) {
-        GitOperationState::Rebase
+        ActiveGitOperation::Rebase
     } else if wt.is_merging().unwrap_or(false) {
-        GitOperationState::Merge
+        ActiveGitOperation::Merge
     } else {
-        GitOperationState::None
+        ActiveGitOperation::None
     }
 }
 

--- a/src/commands/list/collect/types.rs
+++ b/src/commands/list/collect/types.rs
@@ -10,7 +10,7 @@ use worktrunk::git::LineDiff;
 
 use super::super::ci_status::PrStatus;
 use super::super::model::{
-    AheadBehind, BranchDiffTotals, CommitDetails, GitOperationState, ListItem, UpstreamStatus,
+    ActiveGitOperation, AheadBehind, BranchDiffTotals, CommitDetails, ListItem, UpstreamStatus,
     WorkingTreeStatus,
 };
 
@@ -129,7 +129,7 @@ pub(crate) enum TaskResult {
     /// Git operation in progress (rebase/merge)
     GitOperation {
         item_idx: usize,
-        git_operation: GitOperationState,
+        git_operation: ActiveGitOperation,
     },
     /// User-defined status from git config
     UserMarker {

--- a/src/commands/list/json_output.rs
+++ b/src/commands/list/json_output.rs
@@ -455,8 +455,8 @@ mod tests {
     use super::*;
     use crate::commands::list::ci_status::CiStatus;
     use crate::commands::list::model::{
-        Divergence, GitOperationState, MainState, OperationState, StatusSymbols, WorkingTreeStatus,
-        WorktreeData, WorktreeState,
+        ActiveGitOperation, Divergence, MainState, OperationState, StatusSymbols,
+        WorkingTreeStatus, WorktreeData, WorktreeState,
     };
 
     // ============================================================================
@@ -631,7 +631,7 @@ mod tests {
             locked: None,
             prunable: None,
             working_tree_diff: None,
-            git_operation: GitOperationState::None,
+            git_operation: ActiveGitOperation::None,
             branch_worktree_mismatch: false,
             working_diff_display: None,
         }

--- a/src/commands/list/layout.rs
+++ b/src/commands/list/layout.rs
@@ -1183,7 +1183,7 @@ mod tests {
     #[test]
     fn test_visible_columns_follow_gap_rule() {
         use crate::commands::list::model::{
-            AheadBehind, BranchDiffTotals, CommitDetails, DisplayFields, GitOperationState,
+            ActiveGitOperation, AheadBehind, BranchDiffTotals, CommitDetails, DisplayFields,
             ItemKind, ListItem, StatusSymbols, UpstreamStatus, WorktreeData,
         };
 
@@ -1223,7 +1223,7 @@ mod tests {
                 locked: None,
                 prunable: None,
                 working_tree_diff: Some(LineDiff::from((100, 50))),
-                git_operation: GitOperationState::None,
+                git_operation: ActiveGitOperation::None,
                 is_main: false,
                 is_current: false,
                 is_previous: false,
@@ -1285,7 +1285,7 @@ mod tests {
     #[test]
     fn test_column_positions_with_empty_columns() {
         use crate::commands::list::model::{
-            AheadBehind, BranchDiffTotals, CommitDetails, DisplayFields, GitOperationState,
+            ActiveGitOperation, AheadBehind, BranchDiffTotals, CommitDetails, DisplayFields,
             ItemKind, ListItem, StatusSymbols, UpstreamStatus, WorktreeData,
         };
 
@@ -1321,7 +1321,7 @@ mod tests {
                 locked: None,
                 prunable: None,
                 working_tree_diff: Some(LineDiff::default()),
-                git_operation: GitOperationState::None,
+                git_operation: ActiveGitOperation::None,
                 is_main: true, // Primary worktree: no ahead/behind shown
                 is_current: false,
                 is_previous: false,

--- a/src/commands/list/model/item.rs
+++ b/src/commands/list/model/item.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 
 use worktrunk::git::{IntegrationReason, IntegrationSignals, LineDiff, check_integration};
 
-use super::state::{Divergence, GitOperationState, MainState, OperationState, WorktreeState};
+use super::state::{ActiveGitOperation, Divergence, MainState, OperationState, WorktreeState};
 use super::stats::{AheadBehind, BranchDiffTotals, CommitDetails, UpstreamStatus};
 use super::status_symbols::{StatusSymbols, WorkingTreeStatus};
 use crate::commands::list::ci_status::PrStatus;
@@ -79,8 +79,8 @@ pub struct WorktreeData {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub working_tree_diff: Option<LineDiff>,
     /// Git operation in progress (rebase/merge)
-    #[serde(skip_serializing_if = "GitOperationState::is_none")]
-    pub git_operation: GitOperationState,
+    #[serde(skip_serializing_if = "ActiveGitOperation::is_none")]
+    pub git_operation: ActiveGitOperation,
     pub is_main: bool,
     /// Whether this is the current worktree (matches repo discovery path: PWD or `-C`)
     #[serde(skip_serializing_if = "std::ops::Not::not")]
@@ -480,9 +480,9 @@ impl ListItem {
                 // Operation state - priority: conflicts > rebase > merge
                 let operation_state = if has_conflicts {
                     OperationState::Conflicts
-                } else if data.git_operation == GitOperationState::Rebase {
+                } else if data.git_operation == ActiveGitOperation::Rebase {
                     OperationState::Rebase
-                } else if data.git_operation == GitOperationState::Merge {
+                } else if data.git_operation == ActiveGitOperation::Merge {
                     OperationState::Merge
                 } else {
                     OperationState::None

--- a/src/commands/list/model/mod.rs
+++ b/src/commands/list/model/mod.rs
@@ -24,7 +24,7 @@ pub mod statusline_segment;
 #[allow(unused_imports)]
 pub use item::{DisplayFields, ItemKind, ListData, ListItem, WorktreeData};
 #[allow(unused_imports)]
-pub use state::{Divergence, GitOperationState, MainState, OperationState, WorktreeState};
+pub use state::{ActiveGitOperation, Divergence, MainState, OperationState, WorktreeState};
 #[allow(unused_imports)]
 pub use stats::{ActiveUpstream, AheadBehind, BranchDiffTotals, CommitDetails, UpstreamStatus};
 #[allow(unused_imports)]

--- a/src/commands/list/model/state.rs
+++ b/src/commands/list/model/state.rs
@@ -315,13 +315,15 @@ impl serde::Serialize for OperationState {
     }
 }
 
-/// Git operation state for a worktree
+/// Active git operation in a worktree
 ///
-/// Represents whether a worktree is in the middle of a git operation.
+/// Represents raw data about whether a worktree is in the middle of a git operation.
+/// This is distinct from [`OperationState`] which is the display enum (includes Conflicts,
+/// has symbols/colors).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Serialize, strum::IntoStaticStr)]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
-pub enum GitOperationState {
+pub enum ActiveGitOperation {
     #[strum(serialize = "")]
     #[serde(rename = "")]
     #[default]
@@ -332,7 +334,7 @@ pub enum GitOperationState {
     Merge,
 }
 
-impl GitOperationState {
+impl ActiveGitOperation {
     pub fn is_none(&self) -> bool {
         matches!(self, Self::None)
     }
@@ -670,19 +672,19 @@ mod tests {
     }
 
     // ============================================================================
-    // GitOperationState Tests
+    // ActiveGitOperation Tests
     // ============================================================================
 
     #[test]
     fn test_git_operation_state_default() {
-        let state = GitOperationState::default();
-        assert_eq!(state, GitOperationState::None);
+        let state = ActiveGitOperation::default();
+        assert_eq!(state, ActiveGitOperation::None);
     }
 
     #[test]
     fn test_git_operation_state_is_none() {
-        assert!(GitOperationState::None.is_none());
-        assert!(!GitOperationState::Rebase.is_none());
-        assert!(!GitOperationState::Merge.is_none());
+        assert!(ActiveGitOperation::None.is_none());
+        assert!(!ActiveGitOperation::Rebase.is_none());
+        assert!(!ActiveGitOperation::Merge.is_none());
     }
 }


### PR DESCRIPTION
## Summary

- Rename `target_branch` → `integration_target` in step_commands.rs (variable holds result of `require_target_ref()` but was named as if it's a branch)
- Rename `effective_target` → `integration_target` in display structs (`BranchDeletionResult`, `RemovalDisplayInfo`) for consistency
- Rename `GitOperationState` → `ActiveGitOperation` to clarify this is raw data vs `OperationState` which is the display enum (includes Conflicts, has symbols/colors)

## Test plan

- [x] `cargo build` passes
- [x] `cargo test --lib --bins` (429 tests) pass
- [x] `cargo test --test integration` (895 tests) pass
- [x] `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)