### PR TITLE
fix: use --show-toplevel for repo_path() to support submodules

### DIFF
--- a/tests/integration_tests/repository.rs
+++ b/tests/integration_tests/repository.rs
@@ -511,8 +511,8 @@ fn test_integration_functions_handle_remote_refs() {
 ///
 /// Previously, `repo_path()` derived the path from `git_common_dir.parent()`, which
 /// fails for submodules where git data is stored in `parent/.git/modules/sub`.
-/// The fix uses `git rev-parse --show-toplevel` which correctly returns the
-/// submodule's working directory.
+/// The fix tries `git rev-parse --show-toplevel` first (works for submodules),
+/// falling back to parent of git_common_dir for normal repos.
 #[test]
 fn test_repo_path_in_submodule() {
     use tempfile::TempDir;


### PR DESCRIPTION
The previous implementation derived repo_path from git_common_dir's parent, which fails for submodules where git data is stored in the parent repo's .git/modules/ directory.

## Bug report (previous implementation)

Problem: When running wt switch --create <branch> inside a git submodule, worktrees are created in the wrong location.

Reproduction:

```shell
# Inside a git submodule at /parent/submodule
wt switch --create feature

# Expected: /parent/submodule/.worktrees/feature
# Actual:   /parent/.git/modules/.worktrees/feature
```

Note: This affects configurations with relative worktree-path templates like `.worktrees/{{ branch | sanitize }} or .worktrees/{{ branch | sanitize }}`. The default sibling-directory config (`../{{ repo }}.{{ branch | sanitize }}`) may also be affected since it's relative to the incorrectly computed repo root.

Root Cause: `repo_path()` derived the working directory from `git_common_dir.parent()`, assuming .git is always inside the working tree. For submodules, git stores data in `parent/.git/modules/sub`, so `parent()` returns the wrong path.

Fix: Use `git rev-parse --show-toplevel` which correctly returns the working tree root regardless of where git stores its data.