### PR TITLE
refactor: use bare nouns for accessor functions (Rust convention)

### DIFF
--- a/.claude/rules/accessor-conventions.md
+++ b/.claude/rules/accessor-conventions.md
@@ -6,22 +6,31 @@ Function prefixes signal return behavior and side effects.
 
 | Prefix | Returns | Side Effects | Error Handling | Example |
 |--------|---------|--------------|----------------|---------|
-| `get_*` | `Option<T>` or `T` | None (may cache) | Returns None/default if absent | `get_config()`, `get_switch_previous()` |
+| (bare noun) | `Option<T>` or `T` | None (may cache) | Returns None/default if absent | `config()`, `switch_previous()` |
+| `set_*` | `Result<()>` | Writes state | Errors on failure | `set_switch_previous()`, `set_config()` |
 | `require_*` | `Result<T>` | None | Errors if absent | `require_branch()`, `require_target_ref()` |
 | `fetch_*` | `Result<T>` | Network I/O | Errors on failure | `fetch_pr_info()`, `fetch_mr_info()` |
 | `load_*` | `Result<T>` | File I/O | Errors on failure | `load_project_config()`, `load_template()` |
 
 ## When to Use Each
 
-**`get_*`** — Value may not exist and that's fine
+**Bare nouns** — Value may not exist and that's fine (Rust stdlib convention)
 ```rust
 // Returns Option - caller handles None
-if let Some(prev) = repo.get_switch_previous() {
+if let Some(prev) = repo.switch_previous() {
     // use prev
 }
 
-// Returns T with sensible default
-let width = get_terminal_width(); // defaults to 80 if detection fails
+// Returns Option - read from git config
+if let Some(marker) = repo.branch_marker("feature") {
+    println!("Branch marker: {marker}");
+}
+```
+
+**`set_*`** — Write state to storage
+```rust
+// Set the previous branch for wt switch -
+repo.set_switch_previous(Some(&branch))?;
 ```
 
 **`require_*`** — Value must exist for operation to proceed
@@ -45,9 +54,10 @@ let config = repo.load_project_config()?;
 ## Anti-patterns
 
 Avoid mixing semantics:
-- Don't use `get_*` if the function makes network calls (use `fetch_*`)
-- Don't use `get_*` if absence is an error (use `require_*`)
-- Don't use `load_*` for computed values (use `get_*`)
+- Don't use bare nouns if the function makes network calls (use `fetch_*`)
+- Don't use bare nouns if absence is an error (use `require_*`)
+- Don't use `load_*` for computed values (use bare nouns)
+- Don't use `get_*` prefix — use bare nouns instead (Rust convention)
 
 ## Related Patterns
 

--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -178,7 +178,7 @@ pub fn handle_state_get(key: &str, branch: Option<String>) -> anyhow::Result<()>
             })?;
             output::stdout(branch_name)?;
         }
-        "previous-branch" => match repo.get_switch_previous() {
+        "previous-branch" => match repo.switch_previous() {
             Some(prev) => output::stdout(prev)?,
             None => output::stdout("")?,
         },
@@ -187,7 +187,7 @@ pub fn handle_state_get(key: &str, branch: Option<String>) -> anyhow::Result<()>
                 Some(b) => b,
                 None => repo.require_current_branch("get marker for current branch")?,
             };
-            match repo.branch_keyed_marker(&branch_name) {
+            match repo.branch_marker(&branch_name) {
                 Some(marker) => output::stdout(marker)?,
                 None => output::stdout("")?,
             }
@@ -262,7 +262,7 @@ pub fn handle_state_set(key: &str, value: String, branch: Option<String>) -> any
             )))?;
         }
         "previous-branch" => {
-            repo.record_switch_previous(Some(&value))?;
+            repo.set_switch_previous(Some(&value))?;
             output::print(success_message(cformat!(
                 "Set previous branch to <bold>{value}</>"
             )))?;
@@ -489,7 +489,7 @@ fn handle_state_show_json(repo: &Repository) -> anyhow::Result<()> {
     let default_branch = repo.default_branch();
 
     // Get previous branch
-    let previous_branch = repo.get_switch_previous();
+    let previous_branch = repo.switch_previous();
 
     // Get markers
     let markers: Vec<serde_json::Value> = get_all_markers(repo)
@@ -598,7 +598,7 @@ fn handle_state_show_table(repo: &Repository) -> anyhow::Result<()> {
 
     // Show previous branch (for `wt switch -`)
     writeln!(out, "{}", format_heading("PREVIOUS BRANCH", None))?;
-    match repo.get_switch_previous() {
+    match repo.switch_previous() {
         Some(prev) => writeln!(out, "{}", format_with_gutter(&prev, None))?,
         None => writeln!(out, "{}", format_with_gutter("(none)", None))?,
     }

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -52,7 +52,7 @@
 //! Skeleton render
 //! ├─ is_builtin_fsmonitor_enabled()             (5ms, sequential - gate)
 //! ├─ rayon::scope(
-//! │    ├─ get_switch_previous()                 (5ms)
+//! │    ├─ switch_previous()                     (5ms)
 //! │    ├─ integration_target()                  (10ms)
 //! │    ├─ start_fsmonitor_daemon × N worktrees  (6ms each, all parallel)
 //! │  )                                          // ~10ms total (max of all spawns)
@@ -528,7 +528,7 @@ pub fn collect(
     rayon::scope(|s| {
         // Previous branch lookup (for gutter symbol)
         s.spawn(|_| {
-            let _ = previous_branch_cell.set(repo.get_switch_previous());
+            let _ = previous_branch_cell.set(repo.switch_previous());
         });
 
         // Integration target (upstream if ahead of local, else local)

--- a/src/commands/worktree/switch.rs
+++ b/src/commands/worktree/switch.rs
@@ -519,7 +519,7 @@ pub fn execute_switch(
             expected_path,
             new_previous,
         } => {
-            let _ = repo.record_switch_previous(new_previous.as_deref());
+            let _ = repo.set_switch_previous(new_previous.as_deref());
 
             let current_dir = std::env::current_dir()
                 .ok()
@@ -799,7 +799,7 @@ pub fn execute_switch(
             }
 
             // Record successful switch in history
-            let _ = repo.record_switch_previous(new_previous.as_deref());
+            let _ = repo.set_switch_previous(new_previous.as_deref());
 
             Ok((
                 SwitchResult::Created {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -40,7 +40,7 @@ pub use project::{
 };
 pub use user::{
     CommitConfig, CommitGenerationConfig, ListConfig, MergeConfig, StageMode, UserConfig,
-    UserProjectConfig, find_unknown_keys as find_unknown_user_keys, get_config_path,
+    UserProjectOverrides, find_unknown_keys as find_unknown_user_keys, get_config_path,
     set_config_path,
 };
 
@@ -389,15 +389,15 @@ task2 = "echo 'Task 2 running' > task2.txt"
 
     #[test]
     fn test_user_project_config_equality() {
-        let config1 = UserProjectConfig {
+        let config1 = UserProjectOverrides {
             approved_commands: vec!["npm install".to_string()],
             ..Default::default()
         };
-        let config2 = UserProjectConfig {
+        let config2 = UserProjectOverrides {
             approved_commands: vec!["npm install".to_string()],
             ..Default::default()
         };
-        let config3 = UserProjectConfig {
+        let config3 = UserProjectOverrides {
             approved_commands: vec!["npm test".to_string()],
             ..Default::default()
         };
@@ -410,7 +410,7 @@ task2 = "echo 'Task 2 running' > task2.txt"
         let mut config = UserConfig::default();
         config.projects.insert(
             "github.com/user/repo".to_string(),
-            UserProjectConfig {
+            UserProjectOverrides {
                 approved_commands: vec!["npm install".to_string()],
                 ..Default::default()
             },

--- a/src/git/repository/config.rs
+++ b/src/git/repository/config.rs
@@ -25,7 +25,7 @@ impl Repository {
     /// Read a user-defined marker from `worktrunk.state.<branch>.marker` in git config.
     ///
     /// Markers are stored as JSON: `{"marker": "text", "set_at": unix_timestamp}`.
-    pub fn branch_keyed_marker(&self, branch: &str) -> Option<String> {
+    pub fn branch_marker(&self, branch: &str) -> Option<String> {
         #[derive(serde::Deserialize)]
         struct MarkerValue {
             marker: Option<String>,
@@ -44,13 +44,13 @@ impl Repository {
 
     /// Read user-defined branch-keyed marker.
     pub fn user_marker(&self, branch: Option<&str>) -> Option<String> {
-        branch.and_then(|branch| self.branch_keyed_marker(branch))
+        branch.and_then(|branch| self.branch_marker(branch))
     }
 
-    /// Record the previous branch in worktrunk.history for `wt switch -` support.
+    /// Set the previous branch in worktrunk.history for `wt switch -` support.
     ///
     /// Stores the branch we're switching FROM, so `wt switch -` can return to it.
-    pub fn record_switch_previous(&self, previous: Option<&str>) -> anyhow::Result<()> {
+    pub fn set_switch_previous(&self, previous: Option<&str>) -> anyhow::Result<()> {
         if let Some(prev) = previous {
             self.run_command(&["config", "worktrunk.history", prev])?;
         }
@@ -61,7 +61,7 @@ impl Repository {
     /// Get the previous branch from worktrunk.history for `wt switch -`.
     ///
     /// Returns the branch we came from, enabling ping-pong switching.
-    pub fn get_switch_previous(&self) -> Option<String> {
+    pub fn switch_previous(&self) -> Option<String> {
         self.run_command(&["config", "--get", "worktrunk.history"])
             .ok()
             .map(|s| s.trim().to_string())

--- a/src/git/repository/worktrees.rs
+++ b/src/git/repository/worktrees.rs
@@ -138,7 +138,7 @@ impl Repository {
             }),
             "-" => {
                 // Read from worktrunk.history (recorded by wt switch operations)
-                self.get_switch_previous().ok_or_else(|| {
+                self.switch_previous().ok_or_else(|| {
                     GitError::Other {
                         message: cformat!(
                             "No previous branch found in history. Run <bright-black>wt list</> to see available worktrees."


### PR DESCRIPTION
## Summary
- Rename accessor functions to follow Rust stdlib conventions (bare nouns for getters, `set_*` for setters)
- Rename `UserProjectConfig` → `UserProjectOverrides` to clarify purpose
- Update accessor-conventions.md to document the pattern

## Test plan
- [x] All 429 unit tests pass
- [x] All 895 integration tests pass
- [x] All lints pass


🤖 Generated with [Claude Code](https://claude.com/claude-code)