### PR TITLE
feat: prune worktree metadata when directory is missing during remove

### DIFF
--- a/src/commands/repository_ext.rs
+++ b/src/commands/repository_ext.rs
@@ -91,10 +91,13 @@ impl RepositoryCliExt for Repository {
                 {
                     Some(wt) => {
                         if !wt.path.exists() {
-                            return Err(GitError::WorktreeMissing {
-                                branch: branch.into(),
-                            }
-                            .into());
+                            // Directory missing - prune and continue
+                            self.prune_worktrees()?;
+                            return Ok(RemoveResult::BranchOnly {
+                                branch_name: branch.to_string(),
+                                deletion_mode,
+                                pruned: true,
+                            });
                         }
                         if wt.locked.is_some() {
                             return Err(GitError::WorktreeLocked {
@@ -114,6 +117,7 @@ impl RepositoryCliExt for Repository {
                             return Ok(RemoveResult::BranchOnly {
                                 branch_name: branch.to_string(),
                                 deletion_mode,
+                                pruned: false,
                             });
                         }
                         // Check if branch exists on a remote

--- a/src/git/repository/worktrees.rs
+++ b/src/git/repository/worktrees.rs
@@ -92,6 +92,16 @@ impl Repository {
             .map(|wt| (wt.path.clone(), wt.branch.clone())))
     }
 
+    /// Prune worktree entries whose directories no longer exist.
+    ///
+    /// Git tracks worktrees in `.git/worktrees/`. If a worktree directory is deleted
+    /// externally (e.g., `rm -rf`), this method runs `git worktree prune` to clean
+    /// up the entries.
+    pub fn prune_worktrees(&self) -> anyhow::Result<()> {
+        self.run_command(&["worktree", "prune"])?;
+        Ok(())
+    }
+
     /// Remove a worktree at the specified path.
     ///
     /// When `force` is true, passes `--force` to `git worktree remove`,

--- a/tests/integration_tests/remove.rs
+++ b/tests/integration_tests/remove.rs
@@ -1639,3 +1639,106 @@ fn test_remove_at_symbol_via_symlink(mut repo: TestRepo) {
         Some(&symlink_path)
     ));
 }
+
+// ============================================================================
+// Pruned Worktree Tests
+// ============================================================================
+
+/// When a worktree's directory is deleted externally (e.g., `rm -rf`), the git
+/// metadata becomes stale. `wt remove` should prune this stale metadata and
+/// proceed with branch deletion, rather than erroring.
+///
+/// This makes `wt remove` more idempotent - it puts the repository into the
+/// correct end state regardless of whether the directory exists.
+#[rstest]
+fn test_remove_pruned_worktree_directory_missing(mut repo: TestRepo) {
+    // Create a worktree
+    let worktree_path = repo.add_worktree("feature-pruned");
+
+    // Verify the worktree exists
+    assert!(worktree_path.exists(), "Worktree should exist initially");
+
+    // Externally delete the worktree directory (simulating user running `rm -rf`)
+    std::fs::remove_dir_all(&worktree_path).expect("Failed to remove worktree directory");
+    assert!(
+        !worktree_path.exists(),
+        "Worktree directory should be deleted"
+    );
+
+    // Verify git still thinks the worktree exists (stale metadata)
+    let list_output = repo
+        .git_command()
+        .args(["worktree", "list", "--porcelain"])
+        .output()
+        .unwrap();
+    let list_str = String::from_utf8_lossy(&list_output.stdout);
+    assert!(
+        list_str.contains("feature-pruned"),
+        "Git should still list the stale worktree"
+    );
+
+    // `wt remove feature-pruned` should prune the stale metadata and delete the branch
+    // The info message should say "Worktree directory missing for feature-pruned; pruned stale metadata"
+    assert_cmd_snapshot!(make_snapshot_cmd(
+        &repo,
+        "remove",
+        &["feature-pruned"],
+        None
+    ));
+
+    // Verify the stale worktree metadata is cleaned up
+    let list_after = repo
+        .git_command()
+        .args(["worktree", "list", "--porcelain"])
+        .output()
+        .unwrap();
+    let list_after_str = String::from_utf8_lossy(&list_after.stdout);
+    assert!(
+        !list_after_str.contains("feature-pruned"),
+        "Stale worktree should be pruned"
+    );
+
+    // Verify the branch is deleted
+    let branch_exists = repo
+        .git_command()
+        .args(["branch", "--list", "feature-pruned"])
+        .output()
+        .unwrap();
+    assert!(
+        String::from_utf8_lossy(&branch_exists.stdout)
+            .trim()
+            .is_empty(),
+        "Branch should be deleted"
+    );
+}
+
+/// Test pruning with --no-delete-branch: should prune metadata but keep the branch
+#[rstest]
+fn test_remove_pruned_worktree_keep_branch(mut repo: TestRepo) {
+    // Create a worktree
+    let worktree_path = repo.add_worktree("feature-pruned-keep");
+
+    // Delete the worktree directory externally
+    std::fs::remove_dir_all(&worktree_path).expect("Failed to remove worktree directory");
+
+    // Remove with --no-delete-branch
+    assert_cmd_snapshot!(make_snapshot_cmd(
+        &repo,
+        "remove",
+        &["--no-delete-branch", "feature-pruned-keep"],
+        None
+    ));
+
+    // Verify the branch still exists
+    let branch_exists = repo
+        .git_command()
+        .args(["branch", "--list", "feature-pruned-keep"])
+        .output()
+        .unwrap();
+    assert!(
+        !String::from_utf8_lossy(&branch_exists.stdout)
+            .trim()
+            .is_empty(),
+        "Branch should still exist"
+    );
+}

--- a/tests/snapshots/integration__integration_tests__remove__remove_pruned_worktree_directory_missing.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_pruned_worktree_directory_missing.snap
@@ -1,0 +1,39 @@
+---
+source: tests/integration_tests/remove.rs
+info:
+  program: wt
+  args:
+    - remove
+    - feature-pruned
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SHELL: ""
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[2m○[22m Worktree directory missing for [1mfeature-pruned[22m; pruned
+[32m✓ Removed branch [1mfeature-pruned[22m (same commit as [1mmain[22m,[39m [2m_[22m[32m)[39m

--- a/tests/snapshots/integration__integration_tests__remove__remove_pruned_worktree_keep_branch.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_pruned_worktree_keep_branch.snap
@@ -1,0 +1,39 @@
+---
+source: tests/integration_tests/remove.rs
+info:
+  program: wt
+  args:
+    - remove
+    - "--no-delete-branch"
+    - feature-pruned-keep
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SHELL: ""
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[2m○[22m Worktree directory missing for [1mfeature-pruned-keep[22m; pruned


### PR DESCRIPTION
## Summary

- When a worktree's directory is deleted externally (e.g., `rm -rf`), `wt remove` now prunes the stale metadata and proceeds with branch deletion instead of erroring
- Shows an info message (`○ Worktree directory missing for <branch>; pruned`) rather than an error
- Makes `wt remove` more idempotent — it puts the repository into the correct end state regardless of whether the directory exists

Fixes #724

## Test plan

- [x] `test_remove_pruned_worktree_directory_missing` - verifies prune + branch deletion
- [x] `test_remove_pruned_worktree_keep_branch` - verifies prune with `--no-delete-branch`
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)