### PR TITLE
fix: detect CI status when pushremote is a URL

### DIFF
--- a/tests/snapshots/integration__integration_tests__ci_status__url_based_pushremote.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__url_based_pushremote.snap
@@ -1,0 +1,45 @@
+---
+source: tests/integration_tests/ci_status.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SHELL: ""
+    SOURCE_DATE_EPOCH: "1735776000"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mPath[0m               [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main           [2m^[22m[2m|[22m                                   .                     [2m|[0m         [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
++ [2mfeature[0m        [2m_[22m                                    [2m../repo.feature[0m             [32m●[0m   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m       ../repo.feature-a               [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m       ../repo.feature-b               [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m       ../repo.feature-c               [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead
+
+----- stderr -----


### PR DESCRIPTION
## Summary

- Fix CI status detection for branches where `pushremote` is set to a URL instead of a remote name
- This happens when using `gh pr checkout`, which sets `branch.<name>.pushremote` to the fork's URL directly

## Problem

The `@{push}` syntax fails when `pushremote` is a URL because git expects a remote name to resolve to a tracking ref:

```
$ git rev-parse --abbrev-ref 'fix/submodule-repo-path@{push}'
fatal: push destination 'refs/heads/fix/submodule-repo-path' on remote 'https://github.com/lajarre/worktrunk.git' has no local tracking branch
```

## Solution

Use `%(push:remotename)` via `git for-each-ref` instead, which returns either a remote name or URL directly without failing. Then check if the result is a URL (use directly) or remote name (look up its URL).

## Test plan

- [x] Added integration test `test_list_full_with_url_based_pushremote` that simulates `gh pr checkout` config
- [x] Verified fix on actual worktree with URL-based pushremote
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)