### PR TITLE
fix(errors): improve "not found" error messages

### DIFF
--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -205,8 +205,9 @@ pub fn handle_state_get(key: &str, branch: Option<String>) -> anyhow::Result<()>
                 .unwrap_or_default();
 
             if head.is_empty() {
-                return Err(worktrunk::git::GitError::InvalidReference {
-                    reference: branch_name,
+                return Err(worktrunk::git::GitError::BranchNotFound {
+                    branch: branch_name,
+                    show_create_hint: true,
                 }
                 .into());
             }

--- a/src/commands/repository_ext.rs
+++ b/src/commands/repository_ext.rs
@@ -129,8 +129,9 @@ impl RepositoryCliExt for Repository {
                             }
                             .into());
                         }
-                        return Err(GitError::NoWorktreeFound {
+                        return Err(GitError::BranchNotFound {
                             branch: branch.into(),
+                            show_create_hint: false,
                         }
                         .into());
                     }

--- a/src/commands/worktree/switch.rs
+++ b/src/commands/worktree/switch.rs
@@ -246,7 +246,7 @@ fn resolve_switch_target(
             ))?;
             None
         } else if !repo.ref_exists(&resolved)? {
-            return Err(GitError::InvalidReference {
+            return Err(GitError::ReferenceNotFound {
                 reference: resolved,
             }
             .into());
@@ -360,8 +360,9 @@ fn validate_worktree_creation(
     } = method
         && !repo.branch(branch).exists()?
     {
-        return Err(GitError::InvalidReference {
-            reference: branch.to_string(),
+        return Err(GitError::BranchNotFound {
+            branch: branch.to_string(),
+            show_create_hint: true,
         }
         .into());
     }

--- a/src/git/repository/config.rs
+++ b/src/git/repository/config.rs
@@ -246,7 +246,11 @@ impl Repository {
     pub fn require_target_branch(&self, target: Option<&str>) -> anyhow::Result<String> {
         let branch = self.resolve_target_branch(target)?;
         if !self.branch(&branch).exists()? {
-            return Err(GitError::InvalidReference { reference: branch }.into());
+            return Err(GitError::BranchNotFound {
+                branch,
+                show_create_hint: true,
+            }
+            .into());
         }
         Ok(branch)
     }
@@ -258,7 +262,7 @@ impl Repository {
     pub fn require_target_ref(&self, target: Option<&str>) -> anyhow::Result<String> {
         let reference = self.resolve_target_branch(target)?;
         if !self.ref_exists(&reference)? {
-            return Err(GitError::InvalidReference { reference }.into());
+            return Err(GitError::ReferenceNotFound { reference }.into());
         }
         Ok(reference)
     }

--- a/tests/integration_tests/git_error_display.rs
+++ b/tests/integration_tests/git_error_display.rs
@@ -38,12 +38,23 @@ fn display_worktree_missing() {
 }
 
 #[test]
-fn display_no_worktree_found() {
-    let err = GitError::NoWorktreeFound {
+fn branch_not_found() {
+    let err = GitError::BranchNotFound {
         branch: "nonexistent".into(),
+        show_create_hint: true,
     };
 
-    assert_snapshot!("no_worktree_found", err.to_string());
+    assert_snapshot!("branch_not_found", err.to_string());
+}
+
+#[test]
+fn branch_not_found_no_create_hint() {
+    let err = GitError::BranchNotFound {
+        branch: "nonexistent".into(),
+        show_create_hint: false,
+    };
+
+    assert_snapshot!("branch_not_found_no_create_hint", err.to_string());
 }
 
 #[test]
@@ -135,15 +146,6 @@ fn display_branch_already_exists() {
     };
 
     assert_snapshot!("branch_already_exists", err.to_string());
-}
-
-#[test]
-fn display_invalid_reference() {
-    let err = GitError::InvalidReference {
-        reference: "nonexistent-branch".into(),
-    };
-
-    assert_snapshot!("invalid_reference", err.to_string());
 }
 
 // ============================================================================

--- a/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__branch_not_found.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__branch_not_found.snap
@@ -1,0 +1,6 @@
+---
+source: tests/integration_tests/git_error_display.rs
+expression: err.to_string()
+---
+[31m✗[39m [31mNo branch named [1mnonexistent[22m[39m
+[2m↳[22m [2mTo create a new branch, run [90mwt switch nonexistent --create[39m; to list branches, run [90mwt list --branches --remotes[39m[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__branch_not_found_no_create_hint.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__branch_not_found_no_create_hint.snap
@@ -1,0 +1,6 @@
+---
+source: tests/integration_tests/git_error_display.rs
+expression: err.to_string()
+---
+[31m✗[39m [31mNo branch named [1mnonexistent[22m[39m
+[2m↳[22m [2mTo list branches, run [90mwt list --branches --remotes[39m[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__invalid_reference.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__invalid_reference.snap
@@ -1,6 +1,0 @@
----
-source: tests/integration_tests/git_error_display.rs
-expression: err.to_string()
----
-[31m✗[39m [31mBranch [1mnonexistent-branch[22m not found[39m
-[2m↳[22m [2mTo create a new branch, run [90mwt switch nonexistent-branch --create[39m; to list branches, run [90mwt list --branches --remotes[39m[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__no_worktree_found.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__no_worktree_found.snap
@@ -1,5 +1,0 @@
----
-source: tests/integration_tests/git_error_display.rs
-expression: err.to_string()
----
-[31m✗[39m [31mNo worktree found for branch [1mnonexistent[22m[39m

--- a/tests/snapshots/integration__integration_tests__directives__switch_without_directive_file.snap
+++ b/tests/snapshots/integration__integration_tests__directives__switch_without_directive_file.snap
@@ -35,5 +35,5 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[31m✗[39m [31mBranch [1mmy-feature[22m not found[39m
+[31m✗[39m [31mNo branch named [1mmy-feature[22m[39m
 [2m↳[22m [2mTo create a new branch, run [90mwt switch my-feature --create[39m; to list branches, run [90mwt list --branches --remotes[39m[22m

--- a/tests/snapshots/integration__integration_tests__merge__merge_invalid_target.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_invalid_target.snap
@@ -35,5 +35,5 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[31m✗[39m [31mBranch [1mnonexistent-branch[22m not found[39m
+[31m✗[39m [31mNo branch named [1mnonexistent-branch[22m[39m
 [2m↳[22m [2mTo create a new branch, run [90mwt switch nonexistent-branch --create[39m; to list branches, run [90mwt list --branches --remotes[39m[22m

--- a/tests/snapshots/integration__integration_tests__merge__step_rebase_invalid_target.snap
+++ b/tests/snapshots/integration__integration_tests__merge__step_rebase_invalid_target.snap
@@ -36,5 +36,4 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[31m✗[39m [31mBranch [1mnonexistent-ref[22m not found[39m
-[2m↳[22m [2mTo create a new branch, run [90mwt switch nonexistent-ref --create[39m; to list branches, run [90mwt list --branches --remotes[39m[22m
+[31m✗[39m [31mNo branch, tag, or commit named [1mnonexistent-ref[22m[39m

--- a/tests/snapshots/integration__integration_tests__remove__remove_multiple_nonexistent_force.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_multiple_nonexistent_force.snap
@@ -38,6 +38,9 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[31m✗[39m [31mNo worktree found for branch [1mfoo[22m[39m
-[31m✗[39m [31mNo worktree found for branch [1mbar[22m[39m
-[31m✗[39m [31mNo worktree found for branch [1mbaz[22m[39m
+[31m✗[39m [31mNo branch named [1mfoo[22m[39m
+[2m↳[22m [2mTo list branches, run [90mwt list --branches --remotes[39m[22m
+[31m✗[39m [31mNo branch named [1mbar[22m[39m
+[2m↳[22m [2mTo list branches, run [90mwt list --branches --remotes[39m[22m
+[31m✗[39m [31mNo branch named [1mbaz[22m[39m
+[2m↳[22m [2mTo list branches, run [90mwt list --branches --remotes[39m[22m

--- a/tests/snapshots/integration__integration_tests__remove__remove_nonexistent_branch.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_nonexistent_branch.snap
@@ -35,4 +35,5 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[31m✗[39m [31mNo worktree found for branch [1mnonexistent[22m[39m
+[31m✗[39m [31mNo branch named [1mnonexistent[22m[39m
+[2m↳[22m [2mTo list branches, run [90mwt list --branches --remotes[39m[22m

--- a/tests/snapshots/integration__integration_tests__remove__remove_nonexistent_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_nonexistent_worktree.snap
@@ -35,4 +35,5 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[31m✗[39m [31mNo worktree found for branch [1mnonexistent[22m[39m
+[31m✗[39m [31mNo branch named [1mnonexistent[22m[39m
+[2m↳[22m [2mTo list branches, run [90mwt list --branches --remotes[39m[22m

--- a/tests/snapshots/integration__integration_tests__remove__remove_partial_success.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_partial_success.snap
@@ -36,5 +36,6 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[31m✗[39m [31mNo worktree found for branch [1mnonexistent[22m[39m
+[31m✗[39m [31mNo branch named [1mnonexistent[22m[39m
+[2m↳[22m [2mTo list branches, run [90mwt list --branches --remotes[39m[22m
 [36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m

--- a/tests/snapshots/integration__integration_tests__security__error_message_with_directive_not_executed.snap
+++ b/tests/snapshots/integration__integration_tests__security__error_message_with_directive_not_executed.snap
@@ -36,5 +36,5 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[31m✗[39m [31mBranch [1m__WORKTRUNK_EXEC__echo PWNED > /tmp/hacked6[22m not found[39m
+[31m✗[39m [31mNo branch named [1m__WORKTRUNK_EXEC__echo PWNED > /tmp/hacked6[22m[39m
 [2m↳[22m [2mTo create a new branch, run [90mwt switch '__WORKTRUNK_EXEC__echo PWNED > /tmp/hacked6' --create[39m; to list branches, run [90mwt list --branches --remotes[39m[22m

--- a/tests/snapshots/integration__integration_tests__step_copy_ignored__copy_ignored_from_nonexistent_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__step_copy_ignored__copy_ignored_from_nonexistent_worktree.snap
@@ -37,4 +37,5 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[31m✗[39m [31mNo worktree found for branch [1morphan-branch[22m[39m
+[31m✗[39m [31mBranch [1morphan-branch[22m has no worktree[39m
+[2m↳[22m [2mTo create a worktree, run [90mwt switch orphan-branch[39m[22m

--- a/tests/snapshots/integration__integration_tests__step_copy_ignored__copy_ignored_to_nonexistent_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__step_copy_ignored__copy_ignored_to_nonexistent_worktree.snap
@@ -37,4 +37,5 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[31m✗[39m [31mNo worktree found for branch [1morphan-branch[22m[39m
+[31m✗[39m [31mBranch [1morphan-branch[22m has no worktree[39m
+[2m↳[22m [2mTo create a worktree, run [90mwt switch orphan-branch[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_create_invalid_base.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_create_invalid_base.snap
@@ -38,5 +38,4 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[31m✗[39m [31mBranch [1mnonexistent-base[22m not found[39m
-[2m↳[22m [2mTo create a new branch, run [90mwt switch nonexistent-base --create[39m; to list branches, run [90mwt list --branches --remotes[39m[22m
+[31m✗[39m [31mNo branch, tag, or commit named [1mnonexistent-base[22m[39m


### PR DESCRIPTION
## Summary

- Consolidate `NoWorktreeFound` and `InvalidReference` into clearer error types
- Add `ReferenceNotFound` for commit-ish validation (`--base` accepts tags/commits)
- Improve message phrasing to be more natural:
  - `BranchNotFound`: "No branch named **X**"
  - `ReferenceNotFound`: "No branch, tag, or commit named **X**"
  - `WorktreeNotFound`: "Branch **X** has no worktree"
- Context-aware hints: suppress "create branch" hint for `wt remove` operations

## Test plan

- [x] All 911 integration tests pass
- [x] All 430 unit tests pass
- [x] Snapshots updated and reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)