### PR TITLE
test: add snapshot tests for gh/glab CLI not installed

### DIFF
--- a/src/git/mr_ref.rs
+++ b/src/git/mr_ref.rs
@@ -104,7 +104,7 @@ pub fn fetch_mr_info(mr_number: u32, repo_root: &std::path::Path) -> anyhow::Res
             // Check if glab is not installed (OS error for command not found)
             if e.kind() == ErrorKind::NotFound {
                 bail!(
-                    "GitLab CLI (glab) not installed; install from https://gitlab.com/gitlab-org/cli"
+                    "GitLab CLI (glab) not installed; install from https://gitlab.com/gitlab-org/cli#installation"
                 );
             }
             return Err(anyhow::Error::from(e).context("Failed to run glab mr view"));

--- a/tests/snapshots/integration__integration_tests__switch__switch_mr_glab_not_installed.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_mr_glab_not_installed.snap
@@ -1,0 +1,39 @@
+---
+source: tests/integration_tests/switch.rs
+info:
+  program: wt
+  args:
+    - switch
+    - "mr:101"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mFetching MR !101...[39m
+[31m✗[39m [31mGitLab CLI (glab) not installed; install from https://gitlab.com/gitlab-org/cli#installation[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_gh_not_installed.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_gh_not_installed.snap
@@ -1,0 +1,39 @@
+---
+source: tests/integration_tests/switch.rs
+info:
+  program: wt
+  args:
+    - switch
+    - "pr:101"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mFetching PR #101...[39m
+[31m✗[39m [31mGitHub CLI (gh) not installed; install from https://cli.github.com/[39m


### PR DESCRIPTION
## Summary

- Add snapshot tests for when `gh` (GitHub CLI) or `glab` (GitLab CLI) is not installed
- Tests verify helpful error messages are shown with installation URLs
- Update glab installation URL to include `#installation` anchor

## Test plan

- [x] New tests pass: `cargo test --test integration "not_installed"`
- [x] All existing PR/MR switch tests still pass
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)