### PR TITLE
refactor: simplify help snapshot tests and remove dead README sync code

### DIFF
--- a/tests/integration_tests/help.rs
+++ b/tests/integration_tests/help.rs
@@ -19,9 +19,6 @@ use rstest::rstest;
 fn snapshot_help(test_name: &str, args: &[&str]) {
     let mut settings = Settings::clone_current();
     settings.set_snapshot_path("../snapshots");
-    // Remove trailing ANSI reset codes at end of lines for cross-platform consistency
-    settings.add_filter(r"\x1b\[0m$", "");
-    settings.add_filter(r"\x1b\[0m\n", "\n");
     settings.bind(|| {
         let mut cmd = wt_command();
         cmd.args(args);
@@ -125,9 +122,6 @@ fn test_help_md_subcommand() {
 fn test_help_list_narrow_terminal() {
     let mut settings = Settings::clone_current();
     settings.set_snapshot_path("../snapshots");
-    // Remove trailing ANSI reset codes for cross-platform consistency
-    settings.add_filter(r"\x1b\[0m$", "");
-    settings.add_filter(r"\x1b\[0m\n", "\n");
     settings.bind(|| {
         let mut cmd = wt_command();
         cmd.env("COLUMNS", "80");
@@ -156,9 +150,6 @@ fn test_nested_subcommand_suggestion(
 ) {
     let mut settings = Settings::clone_current();
     settings.set_snapshot_path("../snapshots");
-    // Remove trailing ANSI reset codes for cross-platform consistency
-    settings.add_filter(r"\x1b\[0m$", "");
-    settings.add_filter(r"\x1b\[0m\n", "\n");
     settings.bind(|| {
         let mut cmd = wt_command();
         cmd.arg(subcommand);

--- a/tests/snapshots/integration__integration_tests__help__help_config.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config.snap
@@ -1,0 +1,382 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config - Manage user & project configs
+
+Includes shell integration, hooks, and saved state.
+
+Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>
+
+[1m[32mCommands:
+  [1m[36mshell[0m   Shell integration setup
+  [1m[36mcreate[0m  Create configuration file
+  [1m[36mshow[0m    Show configuration files & locations
+  [1m[36mstate[0m   Manage internal data and cache
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+[1m[32mExamples
+
+Install shell integration (required for directory switching):
+
+  [2mwt config shell install
+
+Create user config file with documented examples:
+
+  [2mwt config create
+
+Create project config file ([2m.config/wt.toml[0m) for hooks:
+
+  [2mwt config create --project
+
+Show current configuration and file locations:
+
+  [2mwt config show
+
+[1m[32mConfiguration files
+
+        File                 Location                                Contains                     Committed & shared 
+   ────────────── ─────────────────────────────── ─────────────────────────────────────────────── ────────────────── 
+   User config    ~/.config/worktrunk/config.toml Worktree path template, LLM commit configs, etc ✗                  
+   Project config .config/wt.toml                 Project hooks, dev server URL                   ✓                  
+
+[2m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+[1m[32mWorktrunk User Configuration
+
+Create with [2mwt config create[0m.
+
+Location:
+
+- macOS/Linux: [2m~/.config/worktrunk/config.toml[0m (or [2m$XDG_CONFIG_HOME[0m if set)
+- Windows: [2m%APPDATA%\worktrunk\config.toml
+
+[1m[32mWorktree path template
+
+Controls where new worktrees are created. Paths are relative to the repository root.
+
+[1mVariables:
+
+- [2m{{ repo }}[0m — repository directory name
+- [2m{{ branch }}[0m — raw branch name (e.g., [2mfeature/auth[0m)
+- [2m{{ branch | sanitize }}[0m — filesystem-safe: [2m/[0m and [2m\[0m become [2m-[0m (e.g., [2mfeature-auth[0m)
+- [2m{{ branch | sanitize_db }}[0m — database-safe: lowercase, underscores, hash suffix (e.g., [2mfeature_auth_x7k[0m)
+
+[1mExamples[0m for repo at [2m~/code/myproject[0m, branch [2mfeature/auth[0m:
+
+  [2m# Default — siblings in parent directory
+  [2m# Creates: ~/code/myproject.feature-auth
+  [2mworktree-path = "../{{ repo }}.{{ branch | sanitize }}"
+  [2m
+  [2m# Inside the repository
+  [2m# Creates: ~/code/myproject/.worktrees/feature-auth
+  [2mworktree-path = ".worktrees/{{ branch | sanitize }}"
+  [2m
+  [2m# Namespaced (useful when multiple repos share a parent directory)
+  [2m# Creates: ~/code/worktrees/myproject/feature-auth
+  [2mworktree-path = "../worktrees/{{ repo }}/{{ branch | sanitize }}"
+  [2m
+  [2m# Nested bare repo (git clone --bare <url> project/.git)
+  [2m# Creates: ~/code/project/feature-auth (sibling to .git)
+  [2mworktree-path = "../{{ branch | sanitize }}"
+
+[1m[32mLLM commit messages
+
+Generate commit messages automatically during merge. Requires an external CLI tool. See LLM commits docs for setup and template customization.
+
+Using llm (install: [2mpip install llm llm-anthropic[0m):
+
+  [2m[commit-generation]
+  [2mcommand = "llm"
+  [2margs = ["-m", "claude-haiku-4.5"]
+
+Using aichat:
+
+  [2m[commit-generation]
+  [2mcommand = "aichat"
+  [2margs = ["-m", "claude:claude-haiku-4.5"]
+
+See Custom prompt templates for inline template options.
+
+[1m[32mCommands
+
+[32mList
+
+Persistent flag values for [2mwt list[0m. Override on command line as needed.
+
+  [2m[list]
+  [2mfull = false       # Show CI status and main…± diffstat columns (--full)
+  [2mbranches = false   # Include branches without worktrees (--branches)
+  [2mremotes = false    # Include remote-only branches (--remotes)
+
+[32mCommit
+
+Shared by [2mwt step commit[0m, [2mwt step squash[0m, and [2mwt merge[0m.
+
+  [2m[commit]
+  [2mstage = "all"      # What to stage before commit: "all", "tracked", or "none"
+
+[32mMerge
+
+All flags are on by default. Set to false to change default behavior.
+
+  [2m[merge]
+  [2msquash = true      # Squash commits into one (--no-squash to preserve history)
+  [2mcommit = true      # Commit uncommitted changes first (--no-commit to skip)
+  [2mrebase = true      # Rebase onto target before merge (--no-rebase to skip)
+  [2mremove = true      # Remove worktree after merge (--no-remove to keep)
+  [2mverify = true      # Run project hooks (--no-verify to skip)
+
+[32mSelect
+
+Pager behavior for [2mwt select[0m diff previews.
+
+  [2m[select]
+  [2m# Pager command with flags for diff preview (overrides git's core.pager)
+  [2m# Use this to specify pager flags needed for non-TTY contexts
+  [2m# Example:
+  [2m# pager = "delta --paging=never"
+
+[32mPer-project settings (Experimental)
+
+Per-project settings are keyed by project identifier (e.g., [2mgithub.com/user/repo[0m).
+These contain approved hook commands plus optional overrides of global settings.
+Setting overrides (worktree-path, list, commit, merge) are new; approved-commands is stable.
+
+  [2m[projects."github.com/user/repo"]
+  [2m# Approved hook commands (auto-populated when approving on first run)
+  [2mapproved-commands = ["npm ci", "npm test"]
+  [2m
+  [2m# Optional overrides (omit to use global settings)
+  [2mworktree-path = ".worktrees/{{ branch | sanitize }}"
+  [2mlist.full = true
+  [2mmerge.squash = false
+
+For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at [2m<repo>/.config/wt.toml[0m. Run [2mwt config create --project[0m to create one, or see [2mwt hook[0m docs.
+
+[32mCustom prompt templates
+
+Templates use minijinja syntax.
+
+[1mCommit template
+
+Available variables:
+
+- [2m{{ git_diff }}[0m, [2m{{ git_diff_stat }}[0m — diff content
+- [2m{{ branch }}[0m, [2m{{ repo }}[0m — context
+- [2m{{ recent_commits }}[0m — recent commit messages
+
+Default template:
+
+  [2m[commit-generation]
+  [2mtemplate = """
+  [2mWrite a commit message for the staged changes below.
+  [2m
+  [2m<format>
+  [2m- Subject under 50 chars, blank line, then optional body
+  [2m- Output only the commit message, no quotes or code blocks
+  [2m</format>
+  [2m
+  [2m<style>
+  [2m- Imperative mood: "Add feature" not "Added feature"
+  [2m- Match recent commit style (conventional commits if used)
+  [2m- Describe the change, not the intent or benefit
+  [2m</style>
+  [2m
+  [2m<diffstat>
+  [2m{{ git_diff_stat }}
+  [2m</diffstat>
+  [2m
+  [2m<diff>
+  [2m{{ git_diff }}
+  [2m</diff>
+  [2m
+  [2m<context>
+  [2mBranch: {{ branch }}
+  [2m{% if recent_commits %}<recent_commits>
+  [2m{% for commit in recent_commits %}- {{ commit }}
+  [2m{% endfor %}</recent_commits>{% endif %}
+  [2m</context>
+  [2m
+  [2m"""
+
+[1mSquash template
+
+Available variables (in addition to commit template variables):
+
+- [2m{{ commits }}[0m — list of commits being squashed
+- [2m{{ target_branch }}[0m — merge target branch
+
+Default template:
+
+  [2m[commit-generation]
+  [2msquash-template = """
+  [2mCombine these commits into a single commit message.
+  [2m
+  [2m<format>
+  [2m- Subject under 50 chars, blank line, then optional body
+  [2m- Output only the commit message, no quotes or code blocks
+  [2m</format>
+  [2m
+  [2m<style>
+  [2m- Imperative mood: "Add feature" not "Added feature"
+  [2m- Match the style of commits being squashed (conventional commits if used)
+  [2m- Describe the change, not the intent or benefit
+  [2m</style>
+  [2m
+  [2m<commits branch="{{ branch }}" target="{{ target_branch }}">
+  [2m{% for commit in commits %}- {{ commit }}
+  [2m{% endfor %}</commits>
+  [2m
+  [2m<diffstat>
+  [2m{{ git_diff_stat }}
+  [2m</diffstat>
+  [2m
+  [2m<diff>
+  [2m{{ git_diff }}
+  [2m</diff>
+  [2m
+  [2m"""
+
+[2m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+[1m[32mWorktrunk Project Configuration
+
+The project config defines lifecycle hooks and project-specific settings. This file is checked into version control and shared across the team.
+
+Create [2m.config/wt.toml[0m in the repository root:
+
+  [2m[post-create]
+  [2minstall = "npm ci"
+  [2m
+  [2m[pre-merge]
+  [2mtest = "npm test"
+  [2mlint = "npm run lint"
+
+See [2mwt hook[0m for complete documentation on hook types, execution order, template variables, and JSON context.
+
+[32mDev server URL
+
+The [2m[list][0m section adds a URL column to [2mwt list[0m:
+
+  [2m[list]
+  [2murl = "http://localhost:{{ branch | hash_port }}"
+
+URLs are dimmed when the port isn't listening.
+
+[32mCI platform override
+
+The [2m[ci][0m section overrides CI platform detection for GitHub Enterprise or self-hosted GitLab with custom domains:
+
+  [2m[ci]
+  [2mplatform = "github"  # or "gitlab"
+
+By default, the platform is detected from the remote URL. Use this when URL detection fails (e.g., [2mgit.mycompany.com[0m instead of [2mgithub.mycompany.com[0m).
+
+[2m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+[1m[32mShell integration
+
+Worktrunk needs shell integration to change directories when switching worktrees. Install with:
+
+  [2mwt config shell install
+
+Or manually add to the shell config:
+
+  [2m# For bash: add to ~/.bashrc
+  [2meval "$(wt config shell init bash)"
+  [2m
+  [2m# For zsh: add to ~/.zshrc
+  [2meval "$(wt config shell init zsh)"
+  [2m
+  [2m# For fish: add to ~/.config/fish/config.fish
+  [2mwt config shell init fish | source
+
+Without shell integration, [2mwt switch[0m prints the target directory but cannot [2mcd[0m into it.
+
+[32mSkip first-run prompt
+
+On first run without shell integration, Worktrunk offers to install it. Suppress this prompt in CI or automated environments:
+
+  [2mskip-shell-integration-prompt = true
+
+Or via environment variable:
+
+  [2mexport WORKTRUNK_SKIP_SHELL_INTEGRATION_PROMPT=true
+
+[1m[32mEnvironment variables
+
+All user config options can be overridden with environment variables using the [2mWORKTRUNK_[0m prefix.
+
+[32mNaming convention
+
+Config keys use kebab-case ([2mworktree-path[0m), while env vars use SCREAMING_SNAKE_CASE ([2mWORKTRUNK_WORKTREE_PATH[0m). The conversion happens automatically.
+
+For nested config sections, use double underscores to separate levels:
+
+            Config                   Environment Variable         
+   ───────────────────────── ──────────────────────────────────── 
+   worktree-path             WORKTRUNK_WORKTREE_PATH              
+   commit-generation.command WORKTRUNK_COMMIT_GENERATION__COMMAND 
+   commit-generation.args    WORKTRUNK_COMMIT_GENERATION__ARGS    
+
+Note the single underscore after [2mWORKTRUNK[0m and double underscores between nested keys.
+
+[32mArray values
+
+Array config values like [2margs = ["-m", "claude-haiku"][0m can be specified as a single string in environment variables:
+
+  [2mexport WORKTRUNK_COMMIT_GENERATION__ARGS="-m claude-haiku"
+
+[32mExample: CI/testing override
+
+Override the LLM command in CI to use a mock:
+
+  [2mWORKTRUNK_COMMIT_GENERATION__COMMAND=echo \
+  [2mWORKTRUNK_COMMIT_GENERATION__ARGS="test: automated commit" \
+  [2m  wt merge
+
+[32mOther environment variables
+
+               Variable                                                   Purpose                                      
+   ───────────────────────────────── ───────────────────────────────────────────────────────────────────────────────── 
+   WORKTRUNK_BIN                     Override binary path for shell wrappers (useful for testing dev builds)           
+   WORKTRUNK_CONFIG_PATH             Override user config file location                                                
+   WORKTRUNK_DIRECTIVE_FILE          Internal: set by shell wrappers to enable directory changes                       
+   WORKTRUNK_SHELL                   Internal: set by shell wrappers to indicate shell type (e.g., powershell)         
+   WORKTRUNK_MAX_CONCURRENT_COMMANDS Max parallel git commands (default: 32). Lower if hitting file descriptor limits. 
+   NO_COLOR                          Disable colored output (standard)                                                 
+   CLICOLOR_FORCE                    Force colored output even when not a TTY

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -25,329 +25,329 @@ exit_code: 0
 ----- stderr -----
 wt config create - Create configuration file
 
-Usage: [1m[36mwt config create[0m [36m[OPTIONS]
+Usage: [1m[36mwt config create[0m [36m[OPTIONS][0m
 
-[1m[32mOptions:
-      [1m[36m--project
+[1m[32mOptions:[0m
+      [1m[36m--project[0m
           Create project config ([1m.config/wt.toml[0m) instead of user config
 
-  [1m[36m-h[0m, [1m[36m--help
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
-[1m[32mUser config
+[1m[32mUser config[0m
 
 Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 
-  [2m# ## Worktrunk User Configuration
-  [2m#
-  [2m# Create with `wt config create`.
-  [2m#
-  [2m# Location:
-  [2m#
-  [2m# - macOS/Linux: `~/.config/worktrunk/config.toml` (or `$XDG_CONFIG_HOME` if set)
-  [2m# - Windows: `%APPDATA%\worktrunk\config.toml`
-  [2m#
-  [2m# ## Worktree path template
-  [2m#
-  [2m# Controls where new worktrees are created. Paths are relative to the repository root.
-  [2m#
-  [2m# **Variables:**
-  [2m#
-  [2m# - `{{ repo }}` — repository directory name
-  [2m# - `{{ branch }}` — raw branch name (e.g., `feature/auth`)
-  [2m# - `{{ branch | sanitize }}` — filesystem-safe: `/` and `\` become `-` (e.g., `feature-auth`)
-  [2m# - `{{ branch | sanitize_db }}` — database-safe: lowercase, underscores, hash suffix (e.g., `feature_auth_x7k`)
-  [2m#
-  [2m# **Examples** for repo at `~/code/myproject`, branch `feature/auth`:
-  [2m#
-  [2m# # Default — siblings in parent directory
-  [2m# # Creates: ~/code/myproject.feature-auth
-  [2m# worktree-path = "../{{ repo }}.{{ branch | sanitize }}"
-  [2m#
-  [2m# # Inside the repository
-  [2m# # Creates: ~/code/myproject/.worktrees/feature-auth
-  [2m# worktree-path = ".worktrees/{{ branch | sanitize }}"
-  [2m#
-  [2m# # Namespaced (useful when multiple repos share a parent directory)
-  [2m# # Creates: ~/code/worktrees/myproject/feature-auth
-  [2m# worktree-path = "../worktrees/{{ repo }}/{{ branch | sanitize }}"
-  [2m#
-  [2m# # Nested bare repo (git clone --bare <url> project/.git)
-  [2m# # Creates: ~/code/project/feature-auth (sibling to .git)
-  [2m# worktree-path = "../{{ branch | sanitize }}"
-  [2m#
-  [2m# ## LLM commit messages
-  [2m#
-  [2m# Generate commit messages automatically during merge. Requires an external CLI tool. See LLM commits docs (https://worktrunk.dev/llm-commits/) for setup and template customization.
-  [2m#
-  [2m# Using llm (https://github.com/simonw/llm) (install: `pip install llm llm-anthropic`):
-  [2m#
-  [2m# [commit-generation]
-  [2m# command = "llm"
-  [2m# args = ["-m", "claude-haiku-4.5"]
-  [2m#
-  [2m# Using aichat (https://github.com/sigoden/aichat):
-  [2m#
-  [2m# [commit-generation]
-  [2m# command = "aichat"
-  [2m# args = ["-m", "claude:claude-haiku-4.5"]
-  [2m#
-  [2m# See Custom prompt templates (#custom-prompt-templates) for inline template options.
-  [2m#
-  [2m# ## Commands
-  [2m#
-  [2m# ### List
-  [2m#
-  [2m# Persistent flag values for `wt list`. Override on command line as needed.
-  [2m#
-  [2m# [list]
-  [2m# full = false       # Show CI status and main…± diffstat columns (--full)
-  [2m# branches = false   # Include branches without worktrees (--branches)
-  [2m# remotes = false    # Include remote-only branches (--remotes)
-  [2m#
-  [2m# ### Commit
-  [2m#
-  [2m# Shared by `wt step commit`, `wt step squash`, and `wt merge`.
-  [2m#
-  [2m# [commit]
-  [2m# stage = "all"      # What to stage before commit: "all", "tracked", or "none"
-  [2m#
-  [2m# ### Merge
-  [2m#
-  [2m# All flags are on by default. Set to false to change default behavior.
-  [2m#
-  [2m# [merge]
-  [2m# squash = true      # Squash commits into one (--no-squash to preserve history)
-  [2m# commit = true      # Commit uncommitted changes first (--no-commit to skip)
-  [2m# rebase = true      # Rebase onto target before merge (--no-rebase to skip)
-  [2m# remove = true      # Remove worktree after merge (--no-remove to keep)
-  [2m# verify = true      # Run project hooks (--no-verify to skip)
-  [2m#
-  [2m# ### Select
-  [2m#
-  [2m# Pager behavior for `wt select` diff previews.
-  [2m#
-  [2m# [select]
-  [2m# # Pager command with flags for diff preview (overrides git's core.pager)
-  [2m# # Use this to specify pager flags needed for non-TTY contexts
-  [2m# # Example:
-  [2m# # pager = "delta --paging=never"
-  [2m#
-  [2m# ### Per-project settings (Experimental)
-  [2m#
-  [2m# Per-project settings are keyed by project identifier (e.g., `github.com/user/repo`).
-  [2m# These contain approved hook commands plus optional overrides of global settings.
-  [2m# Setting overrides (worktree-path, list, commit, merge) are new; approved-commands is stable.
-  [2m#
-  [2m# [projects."github.com/user/repo"]
-  [2m# # Approved hook commands (auto-populated when approving on first run)
-  [2m# approved-commands = ["npm ci", "npm test"]
-  [2m#
-  [2m# # Optional overrides (omit to use global settings)
-  [2m# worktree-path = ".worktrees/{{ branch | sanitize }}"
-  [2m# list.full = true
-  [2m# merge.squash = false
-  [2m#
-  [2m# For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at `<repo>/.config/wt.toml`. Run `wt config create --project` to create one, or see `wt hook` docs (https://worktrunk.dev/hook/).
-  [2m#
-  [2m# ### Custom prompt templates
-  [2m#
-  [2m# Templates use minijinja (https://docs.rs/minijinja/) syntax.
-  [2m#
-  [2m# #### Commit template
-  [2m#
-  [2m# Available variables:
-  [2m#
-  [2m# - `{{ git_diff }}`, `{{ git_diff_stat }}` — diff content
-  [2m# - `{{ branch }}`, `{{ repo }}` — context
-  [2m# - `{{ recent_commits }}` — recent commit messages
-  [2m#
-  [2m# Default template:
-  [2m#
-  [2m# <!-- DEFAULT_TEMPLATE_START -->
-  [2m# [commit-generation]
-  [2m# template = """
-  [2m# Write a commit message for the staged changes below.
-  [2m#
-  [2m# <format>
-  [2m# - Subject under 50 chars, blank line, then optional body
-  [2m# - Output only the commit message, no quotes or code blocks
-  [2m# </format>
-  [2m#
-  [2m# <style>
-  [2m# - Imperative mood: "Add feature" not "Added feature"
-  [2m# - Match recent commit style (conventional commits if used)
-  [2m# - Describe the change, not the intent or benefit
-  [2m# </style>
-  [2m#
-  [2m# <diffstat>
-  [2m# {{ git_diff_stat }}
-  [2m# </diffstat>
-  [2m#
-  [2m# <diff>
-  [2m# {{ git_diff }}
-  [2m# </diff>
-  [2m#
-  [2m# <context>
-  [2m# Branch: {{ branch }}
-  [2m# {% if recent_commits %}<recent_commits>
-  [2m# {% for commit in recent_commits %}- {{ commit }}
-  [2m# {% endfor %}</recent_commits>{% endif %}
-  [2m# </context>
-  [2m#
-  [2m# """
-  [2m# <!-- DEFAULT_TEMPLATE_END -->
-  [2m#
-  [2m# #### Squash template
-  [2m#
-  [2m# Available variables (in addition to commit template variables):
-  [2m#
-  [2m# - `{{ commits }}` — list of commits being squashed
-  [2m# - `{{ target_branch }}` — merge target branch
-  [2m#
-  [2m# Default template:
-  [2m#
-  [2m# <!-- DEFAULT_SQUASH_TEMPLATE_START -->
-  [2m# [commit-generation]
-  [2m# squash-template = """
-  [2m# Combine these commits into a single commit message.
-  [2m#
-  [2m# <format>
-  [2m# - Subject under 50 chars, blank line, then optional body
-  [2m# - Output only the commit message, no quotes or code blocks
-  [2m# </format>
-  [2m#
-  [2m# <style>
-  [2m# - Imperative mood: "Add feature" not "Added feature"
-  [2m# - Match the style of commits being squashed (conventional commits if used)
-  [2m# - Describe the change, not the intent or benefit
-  [2m# </style>
-  [2m#
-  [2m# <commits branch="{{ branch }}" target="{{ target_branch }}">
-  [2m# {% for commit in commits %}- {{ commit }}
-  [2m# {% endfor %}</commits>
-  [2m#
-  [2m# <diffstat>
-  [2m# {{ git_diff_stat }}
-  [2m# </diffstat>
-  [2m#
-  [2m# <diff>
-  [2m# {{ git_diff }}
-  [2m# </diff>
-  [2m#
-  [2m# """
-  [2m# <!-- DEFAULT_SQUASH_TEMPLATE_END -->
+  [2m# ## Worktrunk User Configuration[0m
+  [2m#[0m
+  [2m# Create with `wt config create`.[0m
+  [2m#[0m
+  [2m# Location:[0m
+  [2m#[0m
+  [2m# - macOS/Linux: `~/.config/worktrunk/config.toml` (or `$XDG_CONFIG_HOME` if set)[0m
+  [2m# - Windows: `%APPDATA%\worktrunk\config.toml`[0m
+  [2m#[0m
+  [2m# ## Worktree path template[0m
+  [2m#[0m
+  [2m# Controls where new worktrees are created. Paths are relative to the repository root.[0m
+  [2m#[0m
+  [2m# **Variables:**[0m
+  [2m#[0m
+  [2m# - `{{ repo }}` — repository directory name[0m
+  [2m# - `{{ branch }}` — raw branch name (e.g., `feature/auth`)[0m
+  [2m# - `{{ branch | sanitize }}` — filesystem-safe: `/` and `\` become `-` (e.g., `feature-auth`)[0m
+  [2m# - `{{ branch | sanitize_db }}` — database-safe: lowercase, underscores, hash suffix (e.g., `feature_auth_x7k`)[0m
+  [2m#[0m
+  [2m# **Examples** for repo at `~/code/myproject`, branch `feature/auth`:[0m
+  [2m#[0m
+  [2m# # Default — siblings in parent directory[0m
+  [2m# # Creates: ~/code/myproject.feature-auth[0m
+  [2m# worktree-path = "../{{ repo }}.{{ branch | sanitize }}"[0m
+  [2m#[0m
+  [2m# # Inside the repository[0m
+  [2m# # Creates: ~/code/myproject/.worktrees/feature-auth[0m
+  [2m# worktree-path = ".worktrees/{{ branch | sanitize }}"[0m
+  [2m#[0m
+  [2m# # Namespaced (useful when multiple repos share a parent directory)[0m
+  [2m# # Creates: ~/code/worktrees/myproject/feature-auth[0m
+  [2m# worktree-path = "../worktrees/{{ repo }}/{{ branch | sanitize }}"[0m
+  [2m#[0m
+  [2m# # Nested bare repo (git clone --bare <url> project/.git)[0m
+  [2m# # Creates: ~/code/project/feature-auth (sibling to .git)[0m
+  [2m# worktree-path = "../{{ branch | sanitize }}"[0m
+  [2m#[0m
+  [2m# ## LLM commit messages[0m
+  [2m#[0m
+  [2m# Generate commit messages automatically during merge. Requires an external CLI tool. See LLM commits docs (https://worktrunk.dev/llm-commits/) for setup and template customization.[0m
+  [2m#[0m
+  [2m# Using llm (https://github.com/simonw/llm) (install: `pip install llm llm-anthropic`):[0m
+  [2m#[0m
+  [2m# [commit-generation][0m
+  [2m# command = "llm"[0m
+  [2m# args = ["-m", "claude-haiku-4.5"][0m
+  [2m#[0m
+  [2m# Using aichat (https://github.com/sigoden/aichat):[0m
+  [2m#[0m
+  [2m# [commit-generation][0m
+  [2m# command = "aichat"[0m
+  [2m# args = ["-m", "claude:claude-haiku-4.5"][0m
+  [2m#[0m
+  [2m# See Custom prompt templates (#custom-prompt-templates) for inline template options.[0m
+  [2m#[0m
+  [2m# ## Commands[0m
+  [2m#[0m
+  [2m# ### List[0m
+  [2m#[0m
+  [2m# Persistent flag values for `wt list`. Override on command line as needed.[0m
+  [2m#[0m
+  [2m# [list][0m
+  [2m# full = false       # Show CI status and main…± diffstat columns (--full)[0m
+  [2m# branches = false   # Include branches without worktrees (--branches)[0m
+  [2m# remotes = false    # Include remote-only branches (--remotes)[0m
+  [2m#[0m
+  [2m# ### Commit[0m
+  [2m#[0m
+  [2m# Shared by `wt step commit`, `wt step squash`, and `wt merge`.[0m
+  [2m#[0m
+  [2m# [commit][0m
+  [2m# stage = "all"      # What to stage before commit: "all", "tracked", or "none"[0m
+  [2m#[0m
+  [2m# ### Merge[0m
+  [2m#[0m
+  [2m# All flags are on by default. Set to false to change default behavior.[0m
+  [2m#[0m
+  [2m# [merge][0m
+  [2m# squash = true      # Squash commits into one (--no-squash to preserve history)[0m
+  [2m# commit = true      # Commit uncommitted changes first (--no-commit to skip)[0m
+  [2m# rebase = true      # Rebase onto target before merge (--no-rebase to skip)[0m
+  [2m# remove = true      # Remove worktree after merge (--no-remove to keep)[0m
+  [2m# verify = true      # Run project hooks (--no-verify to skip)[0m
+  [2m#[0m
+  [2m# ### Select[0m
+  [2m#[0m
+  [2m# Pager behavior for `wt select` diff previews.[0m
+  [2m#[0m
+  [2m# [select][0m
+  [2m# # Pager command with flags for diff preview (overrides git's core.pager)[0m
+  [2m# # Use this to specify pager flags needed for non-TTY contexts[0m
+  [2m# # Example:[0m
+  [2m# # pager = "delta --paging=never"[0m
+  [2m#[0m
+  [2m# ### Per-project settings (Experimental)[0m
+  [2m#[0m
+  [2m# Per-project settings are keyed by project identifier (e.g., `github.com/user/repo`).[0m
+  [2m# These contain approved hook commands plus optional overrides of global settings.[0m
+  [2m# Setting overrides (worktree-path, list, commit, merge) are new; approved-commands is stable.[0m
+  [2m#[0m
+  [2m# [projects."github.com/user/repo"][0m
+  [2m# # Approved hook commands (auto-populated when approving on first run)[0m
+  [2m# approved-commands = ["npm ci", "npm test"][0m
+  [2m#[0m
+  [2m# # Optional overrides (omit to use global settings)[0m
+  [2m# worktree-path = ".worktrees/{{ branch | sanitize }}"[0m
+  [2m# list.full = true[0m
+  [2m# merge.squash = false[0m
+  [2m#[0m
+  [2m# For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at `<repo>/.config/wt.toml`. Run `wt config create --project` to create one, or see `wt hook` docs (https://worktrunk.dev/hook/).[0m
+  [2m#[0m
+  [2m# ### Custom prompt templates[0m
+  [2m#[0m
+  [2m# Templates use minijinja (https://docs.rs/minijinja/) syntax.[0m
+  [2m#[0m
+  [2m# #### Commit template[0m
+  [2m#[0m
+  [2m# Available variables:[0m
+  [2m#[0m
+  [2m# - `{{ git_diff }}`, `{{ git_diff_stat }}` — diff content[0m
+  [2m# - `{{ branch }}`, `{{ repo }}` — context[0m
+  [2m# - `{{ recent_commits }}` — recent commit messages[0m
+  [2m#[0m
+  [2m# Default template:[0m
+  [2m#[0m
+  [2m# <!-- DEFAULT_TEMPLATE_START -->[0m
+  [2m# [commit-generation][0m
+  [2m# template = """[0m
+  [2m# Write a commit message for the staged changes below.[0m
+  [2m#[0m
+  [2m# <format>[0m
+  [2m# - Subject under 50 chars, blank line, then optional body[0m
+  [2m# - Output only the commit message, no quotes or code blocks[0m
+  [2m# </format>[0m
+  [2m#[0m
+  [2m# <style>[0m
+  [2m# - Imperative mood: "Add feature" not "Added feature"[0m
+  [2m# - Match recent commit style (conventional commits if used)[0m
+  [2m# - Describe the change, not the intent or benefit[0m
+  [2m# </style>[0m
+  [2m#[0m
+  [2m# <diffstat>[0m
+  [2m# {{ git_diff_stat }}[0m
+  [2m# </diffstat>[0m
+  [2m#[0m
+  [2m# <diff>[0m
+  [2m# {{ git_diff }}[0m
+  [2m# </diff>[0m
+  [2m#[0m
+  [2m# <context>[0m
+  [2m# Branch: {{ branch }}[0m
+  [2m# {% if recent_commits %}<recent_commits>[0m
+  [2m# {% for commit in recent_commits %}- {{ commit }}[0m
+  [2m# {% endfor %}</recent_commits>{% endif %}[0m
+  [2m# </context>[0m
+  [2m#[0m
+  [2m# """[0m
+  [2m# <!-- DEFAULT_TEMPLATE_END -->[0m
+  [2m#[0m
+  [2m# #### Squash template[0m
+  [2m#[0m
+  [2m# Available variables (in addition to commit template variables):[0m
+  [2m#[0m
+  [2m# - `{{ commits }}` — list of commits being squashed[0m
+  [2m# - `{{ target_branch }}` — merge target branch[0m
+  [2m#[0m
+  [2m# Default template:[0m
+  [2m#[0m
+  [2m# <!-- DEFAULT_SQUASH_TEMPLATE_START -->[0m
+  [2m# [commit-generation][0m
+  [2m# squash-template = """[0m
+  [2m# Combine these commits into a single commit message.[0m
+  [2m#[0m
+  [2m# <format>[0m
+  [2m# - Subject under 50 chars, blank line, then optional body[0m
+  [2m# - Output only the commit message, no quotes or code blocks[0m
+  [2m# </format>[0m
+  [2m#[0m
+  [2m# <style>[0m
+  [2m# - Imperative mood: "Add feature" not "Added feature"[0m
+  [2m# - Match the style of commits being squashed (conventional commits if used)[0m
+  [2m# - Describe the change, not the intent or benefit[0m
+  [2m# </style>[0m
+  [2m#[0m
+  [2m# <commits branch="{{ branch }}" target="{{ target_branch }}">[0m
+  [2m# {% for commit in commits %}- {{ commit }}[0m
+  [2m# {% endfor %}</commits>[0m
+  [2m#[0m
+  [2m# <diffstat>[0m
+  [2m# {{ git_diff_stat }}[0m
+  [2m# </diffstat>[0m
+  [2m#[0m
+  [2m# <diff>[0m
+  [2m# {{ git_diff }}[0m
+  [2m# </diff>[0m
+  [2m#[0m
+  [2m# """[0m
+  [2m# <!-- DEFAULT_SQUASH_TEMPLATE_END -->[0m
 
-[1m[32mProject config
+[1m[32mProject config[0m
 
 With [2m--project[0m, creates [2m.config/wt.toml[0m in the current repository:
 
-  [2m# Worktrunk Project Configuration
-  [2m# Copy to: <repo>/.config/wt.toml
-  [2m#
-  [2m# Project-specific hooks that run automatically during worktree operations.
-  [2m# Check this file into git to share hooks across all developers.
-  [2m
-  [2m# ============================================================================
-  [2m# Hook Formats
-  [2m# ============================================================================
-  [2m# All hooks support two formats:
-  [2m#
-  [2m# Single command:
-  [2m#   post-create = "npm install"
-  [2m#
-  [2m# Named table (multiple commands):
-  [2m#   [post-create]
-  [2m#   deps = "npm install"
-  [2m#   build = "npm run build"
-  [2m#
-  [2m# Named commands appear in output, making it easier to identify failures.
-  [2m
-  [2m# ============================================================================
-  [2m# Template Variables — see https://worktrunk.dev/hook/#template-variables
-  [2m# ============================================================================
-  [2m# Common variables:
-  [2m#   {{ repo }}               - Repository directory name (e.g., "myproject")
-  [2m#   {{ branch }}             - Branch name (e.g., "feature/auth")
-  [2m#   {{ worktree_path }}      - Absolute path to worktree
-  [2m#   {{ primary_worktree_path }} - Main worktree (or default branch worktree for bare repos)
-  [2m#   {{ default_branch }}     - Default branch name (e.g., "main")
-  [2m#   {{ target }}             - Target branch (merge hooks only)
-  [2m#
-  [2m# Filters:
-  [2m#   {{ branch | sanitize }}     - Replace / and \ with - (e.g., "feature-auth")
-  [2m#   {{ branch | sanitize_db }}  - Database-safe identifier with hash suffix (e.g., "feature_auth_x7k")
-  [2m#   {{ branch | hash_port }}    - Deterministic port 10000-19999
-  [2m
-  [2m# ============================================================================
-  [2m# Hooks
-  [2m# ============================================================================
-  [2m
-  [2m# Post-Create: Runs after worktree creation, BLOCKS until complete
-  [2m# Use for: installing dependencies, setting up databases, copying configs
-  [2m#
-  [2m# [post-create]
-  [2m# deps = "npm ci"
-  [2m# env = "cp .env.example .env"
-  [2m
-  [2m# Post-Start: Runs in BACKGROUND after worktree creation (parallel)
-  [2m# Use for: dev servers, file watchers, background builds
-  [2m# Output logged to .git/wt-logs/{branch}-project-post-start-{name}.log
-  [2m#
-  [2m# [post-start]
-  [2m# server = "npm run dev -- --port {{ branch | hash_port }}"
-  [2m# watch = "npm run watch"
-  [2m
-  [2m# Post-Switch: Runs in BACKGROUND after every switch (parallel)
-  [2m# Use for: terminal tab naming, tmux window titles, IDE notifications
-  [2m#
-  [2m# post-switch = "echo -ne '\\033]0;{{ branch }}\\007'"
-  [2m
-  [2m# Pre-Commit: Runs before committing during merge, BLOCKS (fail-fast)
-  [2m# Use for: formatters, linters, quick checks
-  [2m#
-  [2m# [pre-commit]
-  [2m# format = "npm run format:check"
-  [2m# lint = "npm run lint"
-  [2m
-  [2m# Pre-Merge: Runs before merging to target, BLOCKS (fail-fast)
-  [2m# Use for: tests, build verification
-  [2m#
-  [2m# [pre-merge]
-  [2m# test = "npm test"
-  [2m# build = "npm run build"
-  [2m
-  [2m# Post-Merge: Runs after successful merge, BLOCKS
-  [2m# Use for: deployment, notifications
-  [2m#
-  [2m# post-merge = "echo 'Merged {{ branch }} to {{ target }}'"
-  [2m
-  [2m# Pre-Remove: Runs before worktree removal, BLOCKS (fail-fast)
-  [2m# Use for: cleanup, stopping services
-  [2m#
-  [2m# pre-remove = "docker compose down"
-  [2m
-  [2m# ============================================================================
-  [2m# Dev Server URL (shown in `wt list`)
-  [2m# ============================================================================
-  [2m# [list]
-  [2m# url = "http://localhost:{{ branch | hash_port }}"
-  [2m
-  [2m# ============================================================================
-  [2m# CI Platform Override
-  [2m# ============================================================================
-  [2m# Override CI platform detection for GitHub Enterprise or self-hosted GitLab
-  [2m# with custom domains where URL detection fails.
-  [2m#
-  [2m# [ci]
-  [2m# platform = "github"  # or "gitlab"
+  [2m# Worktrunk Project Configuration[0m
+  [2m# Copy to: <repo>/.config/wt.toml[0m
+  [2m#[0m
+  [2m# Project-specific hooks that run automatically during worktree operations.[0m
+  [2m# Check this file into git to share hooks across all developers.[0m
+  [2m[0m
+  [2m# ============================================================================[0m
+  [2m# Hook Formats[0m
+  [2m# ============================================================================[0m
+  [2m# All hooks support two formats:[0m
+  [2m#[0m
+  [2m# Single command:[0m
+  [2m#   post-create = "npm install"[0m
+  [2m#[0m
+  [2m# Named table (multiple commands):[0m
+  [2m#   [post-create][0m
+  [2m#   deps = "npm install"[0m
+  [2m#   build = "npm run build"[0m
+  [2m#[0m
+  [2m# Named commands appear in output, making it easier to identify failures.[0m
+  [2m[0m
+  [2m# ============================================================================[0m
+  [2m# Template Variables — see https://worktrunk.dev/hook/#template-variables[0m
+  [2m# ============================================================================[0m
+  [2m# Common variables:[0m
+  [2m#   {{ repo }}               - Repository directory name (e.g., "myproject")[0m
+  [2m#   {{ branch }}             - Branch name (e.g., "feature/auth")[0m
+  [2m#   {{ worktree_path }}      - Absolute path to worktree[0m
+  [2m#   {{ primary_worktree_path }} - Main worktree (or default branch worktree for bare repos)[0m
+  [2m#   {{ default_branch }}     - Default branch name (e.g., "main")[0m
+  [2m#   {{ target }}             - Target branch (merge hooks only)[0m
+  [2m#[0m
+  [2m# Filters:[0m
+  [2m#   {{ branch | sanitize }}     - Replace / and \ with - (e.g., "feature-auth")[0m
+  [2m#   {{ branch | sanitize_db }}  - Database-safe identifier with hash suffix (e.g., "feature_auth_x7k")[0m
+  [2m#   {{ branch | hash_port }}    - Deterministic port 10000-19999[0m
+  [2m[0m
+  [2m# ============================================================================[0m
+  [2m# Hooks[0m
+  [2m# ============================================================================[0m
+  [2m[0m
+  [2m# Post-Create: Runs after worktree creation, BLOCKS until complete[0m
+  [2m# Use for: installing dependencies, setting up databases, copying configs[0m
+  [2m#[0m
+  [2m# [post-create][0m
+  [2m# deps = "npm ci"[0m
+  [2m# env = "cp .env.example .env"[0m
+  [2m[0m
+  [2m# Post-Start: Runs in BACKGROUND after worktree creation (parallel)[0m
+  [2m# Use for: dev servers, file watchers, background builds[0m
+  [2m# Output logged to .git/wt-logs/{branch}-project-post-start-{name}.log[0m
+  [2m#[0m
+  [2m# [post-start][0m
+  [2m# server = "npm run dev -- --port {{ branch | hash_port }}"[0m
+  [2m# watch = "npm run watch"[0m
+  [2m[0m
+  [2m# Post-Switch: Runs in BACKGROUND after every switch (parallel)[0m
+  [2m# Use for: terminal tab naming, tmux window titles, IDE notifications[0m
+  [2m#[0m
+  [2m# post-switch = "echo -ne '\\033]0;{{ branch }}\\007'"[0m
+  [2m[0m
+  [2m# Pre-Commit: Runs before committing during merge, BLOCKS (fail-fast)[0m
+  [2m# Use for: formatters, linters, quick checks[0m
+  [2m#[0m
+  [2m# [pre-commit][0m
+  [2m# format = "npm run format:check"[0m
+  [2m# lint = "npm run lint"[0m
+  [2m[0m
+  [2m# Pre-Merge: Runs before merging to target, BLOCKS (fail-fast)[0m
+  [2m# Use for: tests, build verification[0m
+  [2m#[0m
+  [2m# [pre-merge][0m
+  [2m# test = "npm test"[0m
+  [2m# build = "npm run build"[0m
+  [2m[0m
+  [2m# Post-Merge: Runs after successful merge, BLOCKS[0m
+  [2m# Use for: deployment, notifications[0m
+  [2m#[0m
+  [2m# post-merge = "echo 'Merged {{ branch }} to {{ target }}'"[0m
+  [2m[0m
+  [2m# Pre-Remove: Runs before worktree removal, BLOCKS (fail-fast)[0m
+  [2m# Use for: cleanup, stopping services[0m
+  [2m#[0m
+  [2m# pre-remove = "docker compose down"[0m
+  [2m[0m
+  [2m# ============================================================================[0m
+  [2m# Dev Server URL (shown in `wt list`)[0m
+  [2m# ============================================================================[0m
+  [2m# [list][0m
+  [2m# url = "http://localhost:{{ branch | hash_port }}"[0m
+  [2m[0m
+  [2m# ============================================================================[0m
+  [2m# CI Platform Override[0m
+  [2m# ============================================================================[0m
+  [2m# Override CI platform detection for GitHub Enterprise or self-hosted GitLab[0m
+  [2m# with custom domains where URL detection fails.[0m
+  [2m#[0m
+  [2m# [ci][0m
+  [2m# platform = "github"  # or "gitlab"[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_create_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create_long.snap
@@ -1,0 +1,353 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - create
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config create - Create configuration file
+
+Usage: [1m[36mwt config create[0m [36m[OPTIONS]
+
+[1m[32mOptions:
+      [1m[36m--project
+          Create project config ([1m.config/wt.toml[0m) instead of user config
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+[1m[32mUser config
+
+Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
+
+  [2m# ## Worktrunk User Configuration
+  [2m#
+  [2m# Create with `wt config create`.
+  [2m#
+  [2m# Location:
+  [2m#
+  [2m# - macOS/Linux: `~/.config/worktrunk/config.toml` (or `$XDG_CONFIG_HOME` if set)
+  [2m# - Windows: `%APPDATA%\worktrunk\config.toml`
+  [2m#
+  [2m# ## Worktree path template
+  [2m#
+  [2m# Controls where new worktrees are created. Paths are relative to the repository root.
+  [2m#
+  [2m# **Variables:**
+  [2m#
+  [2m# - `{{ repo }}` — repository directory name
+  [2m# - `{{ branch }}` — raw branch name (e.g., `feature/auth`)
+  [2m# - `{{ branch | sanitize }}` — filesystem-safe: `/` and `\` become `-` (e.g., `feature-auth`)
+  [2m# - `{{ branch | sanitize_db }}` — database-safe: lowercase, underscores, hash suffix (e.g., `feature_auth_x7k`)
+  [2m#
+  [2m# **Examples** for repo at `~/code/myproject`, branch `feature/auth`:
+  [2m#
+  [2m# # Default — siblings in parent directory
+  [2m# # Creates: ~/code/myproject.feature-auth
+  [2m# worktree-path = "../{{ repo }}.{{ branch | sanitize }}"
+  [2m#
+  [2m# # Inside the repository
+  [2m# # Creates: ~/code/myproject/.worktrees/feature-auth
+  [2m# worktree-path = ".worktrees/{{ branch | sanitize }}"
+  [2m#
+  [2m# # Namespaced (useful when multiple repos share a parent directory)
+  [2m# # Creates: ~/code/worktrees/myproject/feature-auth
+  [2m# worktree-path = "../worktrees/{{ repo }}/{{ branch | sanitize }}"
+  [2m#
+  [2m# # Nested bare repo (git clone --bare <url> project/.git)
+  [2m# # Creates: ~/code/project/feature-auth (sibling to .git)
+  [2m# worktree-path = "../{{ branch | sanitize }}"
+  [2m#
+  [2m# ## LLM commit messages
+  [2m#
+  [2m# Generate commit messages automatically during merge. Requires an external CLI tool. See LLM commits docs (https://worktrunk.dev/llm-commits/) for setup and template customization.
+  [2m#
+  [2m# Using llm (https://github.com/simonw/llm) (install: `pip install llm llm-anthropic`):
+  [2m#
+  [2m# [commit-generation]
+  [2m# command = "llm"
+  [2m# args = ["-m", "claude-haiku-4.5"]
+  [2m#
+  [2m# Using aichat (https://github.com/sigoden/aichat):
+  [2m#
+  [2m# [commit-generation]
+  [2m# command = "aichat"
+  [2m# args = ["-m", "claude:claude-haiku-4.5"]
+  [2m#
+  [2m# See Custom prompt templates (#custom-prompt-templates) for inline template options.
+  [2m#
+  [2m# ## Commands
+  [2m#
+  [2m# ### List
+  [2m#
+  [2m# Persistent flag values for `wt list`. Override on command line as needed.
+  [2m#
+  [2m# [list]
+  [2m# full = false       # Show CI status and main…± diffstat columns (--full)
+  [2m# branches = false   # Include branches without worktrees (--branches)
+  [2m# remotes = false    # Include remote-only branches (--remotes)
+  [2m#
+  [2m# ### Commit
+  [2m#
+  [2m# Shared by `wt step commit`, `wt step squash`, and `wt merge`.
+  [2m#
+  [2m# [commit]
+  [2m# stage = "all"      # What to stage before commit: "all", "tracked", or "none"
+  [2m#
+  [2m# ### Merge
+  [2m#
+  [2m# All flags are on by default. Set to false to change default behavior.
+  [2m#
+  [2m# [merge]
+  [2m# squash = true      # Squash commits into one (--no-squash to preserve history)
+  [2m# commit = true      # Commit uncommitted changes first (--no-commit to skip)
+  [2m# rebase = true      # Rebase onto target before merge (--no-rebase to skip)
+  [2m# remove = true      # Remove worktree after merge (--no-remove to keep)
+  [2m# verify = true      # Run project hooks (--no-verify to skip)
+  [2m#
+  [2m# ### Select
+  [2m#
+  [2m# Pager behavior for `wt select` diff previews.
+  [2m#
+  [2m# [select]
+  [2m# # Pager command with flags for diff preview (overrides git's core.pager)
+  [2m# # Use this to specify pager flags needed for non-TTY contexts
+  [2m# # Example:
+  [2m# # pager = "delta --paging=never"
+  [2m#
+  [2m# ### Per-project settings (Experimental)
+  [2m#
+  [2m# Per-project settings are keyed by project identifier (e.g., `github.com/user/repo`).
+  [2m# These contain approved hook commands plus optional overrides of global settings.
+  [2m# Setting overrides (worktree-path, list, commit, merge) are new; approved-commands is stable.
+  [2m#
+  [2m# [projects."github.com/user/repo"]
+  [2m# # Approved hook commands (auto-populated when approving on first run)
+  [2m# approved-commands = ["npm ci", "npm test"]
+  [2m#
+  [2m# # Optional overrides (omit to use global settings)
+  [2m# worktree-path = ".worktrees/{{ branch | sanitize }}"
+  [2m# list.full = true
+  [2m# merge.squash = false
+  [2m#
+  [2m# For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at `<repo>/.config/wt.toml`. Run `wt config create --project` to create one, or see `wt hook` docs (https://worktrunk.dev/hook/).
+  [2m#
+  [2m# ### Custom prompt templates
+  [2m#
+  [2m# Templates use minijinja (https://docs.rs/minijinja/) syntax.
+  [2m#
+  [2m# #### Commit template
+  [2m#
+  [2m# Available variables:
+  [2m#
+  [2m# - `{{ git_diff }}`, `{{ git_diff_stat }}` — diff content
+  [2m# - `{{ branch }}`, `{{ repo }}` — context
+  [2m# - `{{ recent_commits }}` — recent commit messages
+  [2m#
+  [2m# Default template:
+  [2m#
+  [2m# <!-- DEFAULT_TEMPLATE_START -->
+  [2m# [commit-generation]
+  [2m# template = """
+  [2m# Write a commit message for the staged changes below.
+  [2m#
+  [2m# <format>
+  [2m# - Subject under 50 chars, blank line, then optional body
+  [2m# - Output only the commit message, no quotes or code blocks
+  [2m# </format>
+  [2m#
+  [2m# <style>
+  [2m# - Imperative mood: "Add feature" not "Added feature"
+  [2m# - Match recent commit style (conventional commits if used)
+  [2m# - Describe the change, not the intent or benefit
+  [2m# </style>
+  [2m#
+  [2m# <diffstat>
+  [2m# {{ git_diff_stat }}
+  [2m# </diffstat>
+  [2m#
+  [2m# <diff>
+  [2m# {{ git_diff }}
+  [2m# </diff>
+  [2m#
+  [2m# <context>
+  [2m# Branch: {{ branch }}
+  [2m# {% if recent_commits %}<recent_commits>
+  [2m# {% for commit in recent_commits %}- {{ commit }}
+  [2m# {% endfor %}</recent_commits>{% endif %}
+  [2m# </context>
+  [2m#
+  [2m# """
+  [2m# <!-- DEFAULT_TEMPLATE_END -->
+  [2m#
+  [2m# #### Squash template
+  [2m#
+  [2m# Available variables (in addition to commit template variables):
+  [2m#
+  [2m# - `{{ commits }}` — list of commits being squashed
+  [2m# - `{{ target_branch }}` — merge target branch
+  [2m#
+  [2m# Default template:
+  [2m#
+  [2m# <!-- DEFAULT_SQUASH_TEMPLATE_START -->
+  [2m# [commit-generation]
+  [2m# squash-template = """
+  [2m# Combine these commits into a single commit message.
+  [2m#
+  [2m# <format>
+  [2m# - Subject under 50 chars, blank line, then optional body
+  [2m# - Output only the commit message, no quotes or code blocks
+  [2m# </format>
+  [2m#
+  [2m# <style>
+  [2m# - Imperative mood: "Add feature" not "Added feature"
+  [2m# - Match the style of commits being squashed (conventional commits if used)
+  [2m# - Describe the change, not the intent or benefit
+  [2m# </style>
+  [2m#
+  [2m# <commits branch="{{ branch }}" target="{{ target_branch }}">
+  [2m# {% for commit in commits %}- {{ commit }}
+  [2m# {% endfor %}</commits>
+  [2m#
+  [2m# <diffstat>
+  [2m# {{ git_diff_stat }}
+  [2m# </diffstat>
+  [2m#
+  [2m# <diff>
+  [2m# {{ git_diff }}
+  [2m# </diff>
+  [2m#
+  [2m# """
+  [2m# <!-- DEFAULT_SQUASH_TEMPLATE_END -->
+
+[1m[32mProject config
+
+With [2m--project[0m, creates [2m.config/wt.toml[0m in the current repository:
+
+  [2m# Worktrunk Project Configuration
+  [2m# Copy to: <repo>/.config/wt.toml
+  [2m#
+  [2m# Project-specific hooks that run automatically during worktree operations.
+  [2m# Check this file into git to share hooks across all developers.
+  [2m
+  [2m# ============================================================================
+  [2m# Hook Formats
+  [2m# ============================================================================
+  [2m# All hooks support two formats:
+  [2m#
+  [2m# Single command:
+  [2m#   post-create = "npm install"
+  [2m#
+  [2m# Named table (multiple commands):
+  [2m#   [post-create]
+  [2m#   deps = "npm install"
+  [2m#   build = "npm run build"
+  [2m#
+  [2m# Named commands appear in output, making it easier to identify failures.
+  [2m
+  [2m# ============================================================================
+  [2m# Template Variables — see https://worktrunk.dev/hook/#template-variables
+  [2m# ============================================================================
+  [2m# Common variables:
+  [2m#   {{ repo }}               - Repository directory name (e.g., "myproject")
+  [2m#   {{ branch }}             - Branch name (e.g., "feature/auth")
+  [2m#   {{ worktree_path }}      - Absolute path to worktree
+  [2m#   {{ primary_worktree_path }} - Main worktree (or default branch worktree for bare repos)
+  [2m#   {{ default_branch }}     - Default branch name (e.g., "main")
+  [2m#   {{ target }}             - Target branch (merge hooks only)
+  [2m#
+  [2m# Filters:
+  [2m#   {{ branch | sanitize }}     - Replace / and \ with - (e.g., "feature-auth")
+  [2m#   {{ branch | sanitize_db }}  - Database-safe identifier with hash suffix (e.g., "feature_auth_x7k")
+  [2m#   {{ branch | hash_port }}    - Deterministic port 10000-19999
+  [2m
+  [2m# ============================================================================
+  [2m# Hooks
+  [2m# ============================================================================
+  [2m
+  [2m# Post-Create: Runs after worktree creation, BLOCKS until complete
+  [2m# Use for: installing dependencies, setting up databases, copying configs
+  [2m#
+  [2m# [post-create]
+  [2m# deps = "npm ci"
+  [2m# env = "cp .env.example .env"
+  [2m
+  [2m# Post-Start: Runs in BACKGROUND after worktree creation (parallel)
+  [2m# Use for: dev servers, file watchers, background builds
+  [2m# Output logged to .git/wt-logs/{branch}-project-post-start-{name}.log
+  [2m#
+  [2m# [post-start]
+  [2m# server = "npm run dev -- --port {{ branch | hash_port }}"
+  [2m# watch = "npm run watch"
+  [2m
+  [2m# Post-Switch: Runs in BACKGROUND after every switch (parallel)
+  [2m# Use for: terminal tab naming, tmux window titles, IDE notifications
+  [2m#
+  [2m# post-switch = "echo -ne '\\033]0;{{ branch }}\\007'"
+  [2m
+  [2m# Pre-Commit: Runs before committing during merge, BLOCKS (fail-fast)
+  [2m# Use for: formatters, linters, quick checks
+  [2m#
+  [2m# [pre-commit]
+  [2m# format = "npm run format:check"
+  [2m# lint = "npm run lint"
+  [2m
+  [2m# Pre-Merge: Runs before merging to target, BLOCKS (fail-fast)
+  [2m# Use for: tests, build verification
+  [2m#
+  [2m# [pre-merge]
+  [2m# test = "npm test"
+  [2m# build = "npm run build"
+  [2m
+  [2m# Post-Merge: Runs after successful merge, BLOCKS
+  [2m# Use for: deployment, notifications
+  [2m#
+  [2m# post-merge = "echo 'Merged {{ branch }} to {{ target }}'"
+  [2m
+  [2m# Pre-Remove: Runs before worktree removal, BLOCKS (fail-fast)
+  [2m# Use for: cleanup, stopping services
+  [2m#
+  [2m# pre-remove = "docker compose down"
+  [2m
+  [2m# ============================================================================
+  [2m# Dev Server URL (shown in `wt list`)
+  [2m# ============================================================================
+  [2m# [list]
+  [2m# url = "http://localhost:{{ branch | hash_port }}"
+  [2m
+  [2m# ============================================================================
+  [2m# CI Platform Override
+  [2m# ============================================================================
+  [2m# Override CI platform detection for GitHub Enterprise or self-hosted GitLab
+  [2m# with custom domains where URL detection fails.
+  [2m#
+  [2m# [ci]
+  [2m# platform = "github"  # or "gitlab"

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -22,73 +22,73 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-wt config - Manage user & project configs
+wt config - Manage user & project configs[0m
 
-Includes shell integration, hooks, and saved state.
+Includes shell integration, hooks, and saved state.[0m
 
-Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>
+Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 
-[1m[32mCommands:
+[1m[32mCommands:[0m
   [1m[36mshell[0m   Shell integration setup
   [1m[36mcreate[0m  Create configuration file
   [1m[36mshow[0m    Show configuration files & locations
   [1m[36mstate[0m   Manage internal data and cache
 
-[1m[32mOptions:
-  [1m[36m-h[0m, [1m[36m--help
+[1m[32mOptions:[0m
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
-[1m[32mExamples
+[1m[32mExamples[0m
 
 Install shell integration (required for directory switching):
 
-  [2mwt config shell install
+  [2mwt config shell install[0m
 
 Create user config file with documented examples:
 
-  [2mwt config create
+  [2mwt config create[0m
 
 Create project config file ([2m.config/wt.toml[0m) for hooks:
 
-  [2mwt config create --project
+  [2mwt config create --project[0m
 
 Show current configuration and file locations:
 
-  [2mwt config show
+  [2mwt config show[0m
 
-[1m[32mConfiguration files
+[1m[32mConfiguration files[0m
 
         File                 Location                                Contains                     Committed & shared 
    ────────────── ─────────────────────────────── ─────────────────────────────────────────────── ────────────────── 
    User config    ~/.config/worktrunk/config.toml Worktree path template, LLM commit configs, etc ✗                  
    Project config .config/wt.toml                 Project hooks, dev server URL                   ✓                  
 
-[2m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[2m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
 
-[1m[32mWorktrunk User Configuration
+[1m[32mWorktrunk User Configuration[0m
 
 Create with [2mwt config create[0m.
 
 Location:
 
 - macOS/Linux: [2m~/.config/worktrunk/config.toml[0m (or [2m$XDG_CONFIG_HOME[0m if set)
-- Windows: [2m%APPDATA%\worktrunk\config.toml
+- Windows: [2m%APPDATA%\worktrunk\config.toml[0m
 
-[1m[32mWorktree path template
+[1m[32mWorktree path template[0m
 
 Controls where new worktrees are created. Paths are relative to the repository root.
 
-[1mVariables:
+[1mVariables:[0m
 
 - [2m{{ repo }}[0m — repository directory name
 - [2m{{ branch }}[0m — raw branch name (e.g., [2mfeature/auth[0m)
@@ -97,101 +97,101 @@ Controls where new worktrees are created. Paths are relative to the repository r
 
 [1mExamples[0m for repo at [2m~/code/myproject[0m, branch [2mfeature/auth[0m:
 
-  [2m# Default — siblings in parent directory
-  [2m# Creates: ~/code/myproject.feature-auth
-  [2mworktree-path = "../{{ repo }}.{{ branch | sanitize }}"
-  [2m
-  [2m# Inside the repository
-  [2m# Creates: ~/code/myproject/.worktrees/feature-auth
-  [2mworktree-path = ".worktrees/{{ branch | sanitize }}"
-  [2m
-  [2m# Namespaced (useful when multiple repos share a parent directory)
-  [2m# Creates: ~/code/worktrees/myproject/feature-auth
-  [2mworktree-path = "../worktrees/{{ repo }}/{{ branch | sanitize }}"
-  [2m
-  [2m# Nested bare repo (git clone --bare <url> project/.git)
-  [2m# Creates: ~/code/project/feature-auth (sibling to .git)
-  [2mworktree-path = "../{{ branch | sanitize }}"
+  [2m# Default — siblings in parent directory[0m
+  [2m# Creates: ~/code/myproject.feature-auth[0m
+  [2mworktree-path = "../{{ repo }}.{{ branch | sanitize }}"[0m
+  [2m[0m
+  [2m# Inside the repository[0m
+  [2m# Creates: ~/code/myproject/.worktrees/feature-auth[0m
+  [2mworktree-path = ".worktrees/{{ branch | sanitize }}"[0m
+  [2m[0m
+  [2m# Namespaced (useful when multiple repos share a parent directory)[0m
+  [2m# Creates: ~/code/worktrees/myproject/feature-auth[0m
+  [2mworktree-path = "../worktrees/{{ repo }}/{{ branch | sanitize }}"[0m
+  [2m[0m
+  [2m# Nested bare repo (git clone --bare <url> project/.git)[0m
+  [2m# Creates: ~/code/project/feature-auth (sibling to .git)[0m
+  [2mworktree-path = "../{{ branch | sanitize }}"[0m
 
-[1m[32mLLM commit messages
+[1m[32mLLM commit messages[0m
 
 Generate commit messages automatically during merge. Requires an external CLI tool. See LLM commits docs for setup and template customization.
 
 Using llm (install: [2mpip install llm llm-anthropic[0m):
 
-  [2m[commit-generation]
-  [2mcommand = "llm"
-  [2margs = ["-m", "claude-haiku-4.5"]
+  [2m[commit-generation][0m
+  [2mcommand = "llm"[0m
+  [2margs = ["-m", "claude-haiku-4.5"][0m
 
 Using aichat:
 
-  [2m[commit-generation]
-  [2mcommand = "aichat"
-  [2margs = ["-m", "claude:claude-haiku-4.5"]
+  [2m[commit-generation][0m
+  [2mcommand = "aichat"[0m
+  [2margs = ["-m", "claude:claude-haiku-4.5"][0m
 
 See Custom prompt templates for inline template options.
 
-[1m[32mCommands
+[1m[32mCommands[0m
 
-[32mList
+[32mList[0m
 
 Persistent flag values for [2mwt list[0m. Override on command line as needed.
 
-  [2m[list]
-  [2mfull = false       # Show CI status and main…± diffstat columns (--full)
-  [2mbranches = false   # Include branches without worktrees (--branches)
-  [2mremotes = false    # Include remote-only branches (--remotes)
+  [2m[list][0m
+  [2mfull = false       # Show CI status and main…± diffstat columns (--full)[0m
+  [2mbranches = false   # Include branches without worktrees (--branches)[0m
+  [2mremotes = false    # Include remote-only branches (--remotes)[0m
 
-[32mCommit
+[32mCommit[0m
 
 Shared by [2mwt step commit[0m, [2mwt step squash[0m, and [2mwt merge[0m.
 
-  [2m[commit]
-  [2mstage = "all"      # What to stage before commit: "all", "tracked", or "none"
+  [2m[commit][0m
+  [2mstage = "all"      # What to stage before commit: "all", "tracked", or "none"[0m
 
-[32mMerge
+[32mMerge[0m
 
 All flags are on by default. Set to false to change default behavior.
 
-  [2m[merge]
-  [2msquash = true      # Squash commits into one (--no-squash to preserve history)
-  [2mcommit = true      # Commit uncommitted changes first (--no-commit to skip)
-  [2mrebase = true      # Rebase onto target before merge (--no-rebase to skip)
-  [2mremove = true      # Remove worktree after merge (--no-remove to keep)
-  [2mverify = true      # Run project hooks (--no-verify to skip)
+  [2m[merge][0m
+  [2msquash = true      # Squash commits into one (--no-squash to preserve history)[0m
+  [2mcommit = true      # Commit uncommitted changes first (--no-commit to skip)[0m
+  [2mrebase = true      # Rebase onto target before merge (--no-rebase to skip)[0m
+  [2mremove = true      # Remove worktree after merge (--no-remove to keep)[0m
+  [2mverify = true      # Run project hooks (--no-verify to skip)[0m
 
-[32mSelect
+[32mSelect[0m
 
 Pager behavior for [2mwt select[0m diff previews.
 
-  [2m[select]
-  [2m# Pager command with flags for diff preview (overrides git's core.pager)
-  [2m# Use this to specify pager flags needed for non-TTY contexts
-  [2m# Example:
-  [2m# pager = "delta --paging=never"
+  [2m[select][0m
+  [2m# Pager command with flags for diff preview (overrides git's core.pager)[0m
+  [2m# Use this to specify pager flags needed for non-TTY contexts[0m
+  [2m# Example:[0m
+  [2m# pager = "delta --paging=never"[0m
 
-[32mPer-project settings (Experimental)
+[32mPer-project settings (Experimental)[0m
 
 Per-project settings are keyed by project identifier (e.g., [2mgithub.com/user/repo[0m).
 These contain approved hook commands plus optional overrides of global settings.
 Setting overrides (worktree-path, list, commit, merge) are new; approved-commands is stable.
 
-  [2m[projects."github.com/user/repo"]
-  [2m# Approved hook commands (auto-populated when approving on first run)
-  [2mapproved-commands = ["npm ci", "npm test"]
-  [2m
-  [2m# Optional overrides (omit to use global settings)
-  [2mworktree-path = ".worktrees/{{ branch | sanitize }}"
-  [2mlist.full = true
-  [2mmerge.squash = false
+  [2m[projects."github.com/user/repo"][0m
+  [2m# Approved hook commands (auto-populated when approving on first run)[0m
+  [2mapproved-commands = ["npm ci", "npm test"][0m
+  [2m[0m
+  [2m# Optional overrides (omit to use global settings)[0m
+  [2mworktree-path = ".worktrees/{{ branch | sanitize }}"[0m
+  [2mlist.full = true[0m
+  [2mmerge.squash = false[0m
 
 For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at [2m<repo>/.config/wt.toml[0m. Run [2mwt config create --project[0m to create one, or see [2mwt hook[0m docs.
 
-[32mCustom prompt templates
+[32mCustom prompt templates[0m
 
 Templates use minijinja syntax.
 
-[1mCommit template
+[1mCommit template[0m
 
 Available variables:
 
@@ -201,39 +201,39 @@ Available variables:
 
 Default template:
 
-  [2m[commit-generation]
-  [2mtemplate = """
-  [2mWrite a commit message for the staged changes below.
-  [2m
-  [2m<format>
-  [2m- Subject under 50 chars, blank line, then optional body
-  [2m- Output only the commit message, no quotes or code blocks
-  [2m</format>
-  [2m
-  [2m<style>
-  [2m- Imperative mood: "Add feature" not "Added feature"
-  [2m- Match recent commit style (conventional commits if used)
-  [2m- Describe the change, not the intent or benefit
-  [2m</style>
-  [2m
-  [2m<diffstat>
-  [2m{{ git_diff_stat }}
-  [2m</diffstat>
-  [2m
-  [2m<diff>
-  [2m{{ git_diff }}
-  [2m</diff>
-  [2m
-  [2m<context>
-  [2mBranch: {{ branch }}
-  [2m{% if recent_commits %}<recent_commits>
-  [2m{% for commit in recent_commits %}- {{ commit }}
-  [2m{% endfor %}</recent_commits>{% endif %}
-  [2m</context>
-  [2m
-  [2m"""
+  [2m[commit-generation][0m
+  [2mtemplate = """[0m
+  [2mWrite a commit message for the staged changes below.[0m
+  [2m[0m
+  [2m<format>[0m
+  [2m- Subject under 50 chars, blank line, then optional body[0m
+  [2m- Output only the commit message, no quotes or code blocks[0m
+  [2m</format>[0m
+  [2m[0m
+  [2m<style>[0m
+  [2m- Imperative mood: "Add feature" not "Added feature"[0m
+  [2m- Match recent commit style (conventional commits if used)[0m
+  [2m- Describe the change, not the intent or benefit[0m
+  [2m</style>[0m
+  [2m[0m
+  [2m<diffstat>[0m
+  [2m{{ git_diff_stat }}[0m
+  [2m</diffstat>[0m
+  [2m[0m
+  [2m<diff>[0m
+  [2m{{ git_diff }}[0m
+  [2m</diff>[0m
+  [2m[0m
+  [2m<context>[0m
+  [2mBranch: {{ branch }}[0m
+  [2m{% if recent_commits %}<recent_commits>[0m
+  [2m{% for commit in recent_commits %}- {{ commit }}[0m
+  [2m{% endfor %}</recent_commits>{% endif %}[0m
+  [2m</context>[0m
+  [2m[0m
+  [2m"""[0m
 
-[1mSquash template
+[1mSquash template[0m
 
 Available variables (in addition to commit template variables):
 
@@ -242,106 +242,106 @@ Available variables (in addition to commit template variables):
 
 Default template:
 
-  [2m[commit-generation]
-  [2msquash-template = """
-  [2mCombine these commits into a single commit message.
-  [2m
-  [2m<format>
-  [2m- Subject under 50 chars, blank line, then optional body
-  [2m- Output only the commit message, no quotes or code blocks
-  [2m</format>
-  [2m
-  [2m<style>
-  [2m- Imperative mood: "Add feature" not "Added feature"
-  [2m- Match the style of commits being squashed (conventional commits if used)
-  [2m- Describe the change, not the intent or benefit
-  [2m</style>
-  [2m
-  [2m<commits branch="{{ branch }}" target="{{ target_branch }}">
-  [2m{% for commit in commits %}- {{ commit }}
-  [2m{% endfor %}</commits>
-  [2m
-  [2m<diffstat>
-  [2m{{ git_diff_stat }}
-  [2m</diffstat>
-  [2m
-  [2m<diff>
-  [2m{{ git_diff }}
-  [2m</diff>
-  [2m
-  [2m"""
+  [2m[commit-generation][0m
+  [2msquash-template = """[0m
+  [2mCombine these commits into a single commit message.[0m
+  [2m[0m
+  [2m<format>[0m
+  [2m- Subject under 50 chars, blank line, then optional body[0m
+  [2m- Output only the commit message, no quotes or code blocks[0m
+  [2m</format>[0m
+  [2m[0m
+  [2m<style>[0m
+  [2m- Imperative mood: "Add feature" not "Added feature"[0m
+  [2m- Match the style of commits being squashed (conventional commits if used)[0m
+  [2m- Describe the change, not the intent or benefit[0m
+  [2m</style>[0m
+  [2m[0m
+  [2m<commits branch="{{ branch }}" target="{{ target_branch }}">[0m
+  [2m{% for commit in commits %}- {{ commit }}[0m
+  [2m{% endfor %}</commits>[0m
+  [2m[0m
+  [2m<diffstat>[0m
+  [2m{{ git_diff_stat }}[0m
+  [2m</diffstat>[0m
+  [2m[0m
+  [2m<diff>[0m
+  [2m{{ git_diff }}[0m
+  [2m</diff>[0m
+  [2m[0m
+  [2m"""[0m
 
-[2m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[2m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
 
-[1m[32mWorktrunk Project Configuration
+[1m[32mWorktrunk Project Configuration[0m
 
 The project config defines lifecycle hooks and project-specific settings. This file is checked into version control and shared across the team.
 
 Create [2m.config/wt.toml[0m in the repository root:
 
-  [2m[post-create]
-  [2minstall = "npm ci"
-  [2m
-  [2m[pre-merge]
-  [2mtest = "npm test"
-  [2mlint = "npm run lint"
+  [2m[post-create][0m
+  [2minstall = "npm ci"[0m
+  [2m[0m
+  [2m[pre-merge][0m
+  [2mtest = "npm test"[0m
+  [2mlint = "npm run lint"[0m
 
 See [2mwt hook[0m for complete documentation on hook types, execution order, template variables, and JSON context.
 
-[32mDev server URL
+[32mDev server URL[0m
 
 The [2m[list][0m section adds a URL column to [2mwt list[0m:
 
-  [2m[list]
-  [2murl = "http://localhost:{{ branch | hash_port }}"
+  [2m[list][0m
+  [2murl = "http://localhost:{{ branch | hash_port }}"[0m
 
 URLs are dimmed when the port isn't listening.
 
-[32mCI platform override
+[32mCI platform override[0m
 
 The [2m[ci][0m section overrides CI platform detection for GitHub Enterprise or self-hosted GitLab with custom domains:
 
-  [2m[ci]
-  [2mplatform = "github"  # or "gitlab"
+  [2m[ci][0m
+  [2mplatform = "github"  # or "gitlab"[0m
 
 By default, the platform is detected from the remote URL. Use this when URL detection fails (e.g., [2mgit.mycompany.com[0m instead of [2mgithub.mycompany.com[0m).
 
-[2m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[2m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
 
-[1m[32mShell integration
+[1m[32mShell integration[0m
 
 Worktrunk needs shell integration to change directories when switching worktrees. Install with:
 
-  [2mwt config shell install
+  [2mwt config shell install[0m
 
 Or manually add to the shell config:
 
-  [2m# For bash: add to ~/.bashrc
-  [2meval "$(wt config shell init bash)"
-  [2m
-  [2m# For zsh: add to ~/.zshrc
-  [2meval "$(wt config shell init zsh)"
-  [2m
-  [2m# For fish: add to ~/.config/fish/config.fish
-  [2mwt config shell init fish | source
+  [2m# For bash: add to ~/.bashrc[0m
+  [2meval "$(wt config shell init bash)"[0m
+  [2m[0m
+  [2m# For zsh: add to ~/.zshrc[0m
+  [2meval "$(wt config shell init zsh)"[0m
+  [2m[0m
+  [2m# For fish: add to ~/.config/fish/config.fish[0m
+  [2mwt config shell init fish | source[0m
 
 Without shell integration, [2mwt switch[0m prints the target directory but cannot [2mcd[0m into it.
 
-[32mSkip first-run prompt
+[32mSkip first-run prompt[0m
 
 On first run without shell integration, Worktrunk offers to install it. Suppress this prompt in CI or automated environments:
 
-  [2mskip-shell-integration-prompt = true
+  [2mskip-shell-integration-prompt = true[0m
 
 Or via environment variable:
 
-  [2mexport WORKTRUNK_SKIP_SHELL_INTEGRATION_PROMPT=true
+  [2mexport WORKTRUNK_SKIP_SHELL_INTEGRATION_PROMPT=true[0m
 
-[1m[32mEnvironment variables
+[1m[32mEnvironment variables[0m
 
 All user config options can be overridden with environment variables using the [2mWORKTRUNK_[0m prefix.
 
-[32mNaming convention
+[32mNaming convention[0m
 
 Config keys use kebab-case ([2mworktree-path[0m), while env vars use SCREAMING_SNAKE_CASE ([2mWORKTRUNK_WORKTREE_PATH[0m). The conversion happens automatically.
 
@@ -355,21 +355,21 @@ For nested config sections, use double underscores to separate levels:
 
 Note the single underscore after [2mWORKTRUNK[0m and double underscores between nested keys.
 
-[32mArray values
+[32mArray values[0m
 
 Array config values like [2margs = ["-m", "claude-haiku"][0m can be specified as a single string in environment variables:
 
-  [2mexport WORKTRUNK_COMMIT_GENERATION__ARGS="-m claude-haiku"
+  [2mexport WORKTRUNK_COMMIT_GENERATION__ARGS="-m claude-haiku"[0m
 
-[32mExample: CI/testing override
+[32mExample: CI/testing override[0m
 
 Override the LLM command in CI to use a mock:
 
-  [2mWORKTRUNK_COMMIT_GENERATION__COMMAND=echo \
-  [2mWORKTRUNK_COMMIT_GENERATION__ARGS="test: automated commit" \
-  [2m  wt merge
+  [2mWORKTRUNK_COMMIT_GENERATION__COMMAND=echo \[0m
+  [2mWORKTRUNK_COMMIT_GENERATION__ARGS="test: automated commit" \[0m
+  [2m  wt merge[0m
 
-[32mOther environment variables
+[32mOther environment variables[0m
 
                Variable                                                   Purpose                                      
    ───────────────────────────────── ───────────────────────────────────────────────────────────────────────────────── 

--- a/tests/snapshots/integration__integration_tests__help__help_config_shell.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_shell.snap
@@ -25,18 +25,18 @@ exit_code: 0
 ----- stderr -----
 wt config shell - Shell integration setup
 
-Usage: [1m[36mwt config shell[0m [36m[OPTIONS][0m [36m<COMMAND>
+Usage: [1m[36mwt config shell[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 
-[1m[32mCommands:
+[1m[32mCommands:[0m
   [1m[36minit[0m        Generate shell integration code
   [1m[36minstall[0m     Write shell integration to config files
   [1m[36muninstall[0m   Remove shell integration from config files
   [1m[36mshow-theme[0m  Show output theme samples
 
-[1m[32mOptions:
+[1m[32mOptions:[0m
   [1m[36m-h[0m, [1m[36m--help[0m  Print help
 
-[1m[32mGlobal Options:
+[1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_config_shell_init.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_shell_init.snap
@@ -1,0 +1,69 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - shell
+    - init
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config shell init - Generate shell integration code
+
+Usage: [1m[36mwt config shell init[0m [36m[OPTIONS][0m [36m<bash|fish|zsh|powershell>
+
+[1m[32mArguments:
+  [36m<bash|fish|zsh|powershell>
+          Shell to generate code for
+          
+          [possible values: bash, fish, zsh, powershell]
+
+[1m[32mOptions:
+      [1m[36m--cmd[0m[36m [0m[36m<CMD>
+          Command name for shell integration (defaults to binary name)
+          
+          Use this to create shell integration for an alternate command name. For example, [1m--cmd=git-wt[0m creates a [1mgit-wt[0m shell function instead of [1mwt[0m, useful on Windows where [1mwt[0m conflicts with Windows Terminal.
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+Outputs shell code for [2meval[0m or sourcing. Most users should run [2mwt config shell install[0m instead, which adds this automatically.
+
+[1m[32mManual setup
+
+Add one line to the shell config:
+
+Bash (~/.bashrc):
+  [2meval "$(wt config shell init bash)"
+
+Fish (~/.config/fish/config.fish):
+  [2mwt config shell init fish | source
+
+Zsh (~/.zshrc):
+  [2meval "$(wt config shell init zsh)"

--- a/tests/snapshots/integration__integration_tests__help__help_config_shell_install.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_shell_install.snap
@@ -1,0 +1,73 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - shell
+    - install
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config shell install - Write shell integration to config files
+
+Usage: [1m[36mwt config shell install[0m [36m[OPTIONS][0m [36m[bash|fish|zsh|powershell]
+
+[1m[32mArguments:
+  [36m[bash|fish|zsh|powershell]
+          Shell to install (default: all)
+          
+          [possible values: bash, fish, zsh, powershell]
+
+[1m[32mOptions:
+  [1m[36m-y[0m, [1m[36m--yes
+          Skip confirmation prompt
+
+      [1m[36m--dry-run
+          Show what would be changed
+
+      [1m[36m--cmd[0m[36m [0m[36m<CMD>
+          Command name for shell integration (defaults to binary name)
+          
+          Use this to create shell integration for an alternate command name. For example, [1m--cmd=git-wt[0m creates a [1mgit-wt[0m shell function instead of [1mwt[0m, useful on Windows where [1mwt[0m conflicts with Windows Terminal.
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+Detects existing shell config files and adds the integration line.
+
+[1m[32mExamples
+
+Install for all detected shells:
+  [2mwt config shell install
+
+Install for specific shell only:
+  [2mwt config shell install zsh
+
+Shows proposed changes and waits for confirmation before modifying any files.
+Use --yes to skip confirmation.

--- a/tests/snapshots/integration__integration_tests__help__help_config_shell_show_theme.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_shell_show_theme.snap
@@ -1,0 +1,51 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - shell
+    - show-theme
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config shell show-theme - Show output theme samples
+
+Usage: [1m[36mwt config shell show-theme[0m [36m[OPTIONS]
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+Displays samples of all output message types to preview how worktrunk output will appear in the terminal.
+
+[1m[32mMessage types
+
+- Progress, success, error, warning, hint, info
+- Gutter formatting for quoted content
+- Prompts for user input

--- a/tests/snapshots/integration__integration_tests__help__help_config_shell_uninstall.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_shell_uninstall.snap
@@ -1,0 +1,74 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - shell
+    - uninstall
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config shell uninstall - Remove shell integration from config files
+
+Usage: [1m[36mwt config shell uninstall[0m [36m[OPTIONS][0m [36m[bash|fish|zsh|powershell]
+
+[1m[32mArguments:
+  [36m[bash|fish|zsh|powershell]
+          Shell to uninstall (default: all)
+          
+          [possible values: bash, fish, zsh, powershell]
+
+[1m[32mOptions:
+  [1m[36m-y[0m, [1m[36m--yes
+          Skip confirmation prompt
+
+      [1m[36m--dry-run
+          Show what would be changed
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+Removes shell integration lines from config files.
+
+[1m[32mExamples
+
+Uninstall from all shells:
+  [2mwt config shell uninstall
+
+Uninstall from specific shell only:
+  [2mwt config shell uninstall zsh
+
+Skip confirmation prompt:
+  [2mwt config shell uninstall --yes
+
+[1m[32mVersion tolerance
+
+Detects various forms of the integration pattern regardless of:
+- Command prefix (wt, worktree, etc.)
+- Minor syntax variations between versions

--- a/tests/snapshots/integration__integration_tests__help__help_config_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_short.snap
@@ -24,18 +24,18 @@ exit_code: 0
 ----- stderr -----
 wt config - Manage user & project configs
 
-Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>
+Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 
-[1m[32mCommands:
+[1m[32mCommands:[0m
   [1m[36mshell[0m   Shell integration setup
   [1m[36mcreate[0m  Create configuration file
   [1m[36mshow[0m    Show configuration files & locations
   [1m[36mstate[0m   Manage internal data and cache
 
-[1m[32mOptions:
+[1m[32mOptions:[0m
   [1m[36m-h[0m, [1m[36m--help[0m  Print help (see more with '--help')
 
-[1m[32mGlobal Options:
+[1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_config_show.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_show.snap
@@ -25,23 +25,23 @@ exit_code: 0
 ----- stderr -----
 wt config show - Show configuration files & locations
 
-Usage: [1m[36mwt config show[0m [36m[OPTIONS]
+Usage: [1m[36mwt config show[0m [36m[OPTIONS][0m
 
-[1m[32mOptions:
-      [1m[36m--full
+[1m[32mOptions:[0m
+      [1m[36m--full[0m
           Run diagnostic checks (CI tools, commit generation)
 
-  [1m[36m-h[0m, [1m[36m--help
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
 Shows location and contents of user config ([2m~/.config/worktrunk/config.toml[0m)
@@ -49,11 +49,11 @@ and project config ([2m.config/wt.toml[0m).
 
 If a config file doesn't exist, shows defaults that would be used.
 
-[1m[32mFull diagnostics
+[1m[32mFull diagnostics[0m
 
 Use [2m--full[0m to run diagnostic checks:
 
-  [2mwt config show --full
+  [2mwt config show --full[0m
 
 This tests:
 - [1mCI tool status[0m — Whether [2mgh[0m (GitHub) or [2mglab[0m (GitLab) is installed and authenticated

--- a/tests/snapshots/integration__integration_tests__help__help_config_state.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state.snap
@@ -25,9 +25,9 @@ exit_code: 0
 ----- stderr -----
 wt config state - Manage internal data and cache
 
-Usage: [1m[36mwt config state[0m [36m[OPTIONS][0m [36m<COMMAND>
+Usage: [1m[36mwt config state[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 
-[1m[32mCommands:
+[1m[32mCommands:[0m
   [1m[36mdefault-branch[0m   Default branch setting
   [1m[36mprevious-branch[0m  Previous branch (for [1mwt switch -[0m)
   [1m[36mci-status[0m        CI status cache
@@ -37,47 +37,47 @@ Usage: [1m[36mwt config state[0m [36m[OPTIONS][0m [36m<COMMAND>
   [1m[36mget[0m              Get all stored state
   [1m[36mclear[0m            Clear all stored state
 
-[1m[32mOptions:
-  [1m[36m-h[0m, [1m[36m--help
+[1m[32mOptions:[0m
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
 State is stored in [2m.git/[0m (config entries and log files), separate from configuration files.
 Use [2mwt config show[0m to view file-based configuration.
 
-[1m[32mKeys
+[1m[32mKeys[0m
 
 - [1mdefault-branch[0m: The repository's default branch ([2mmain[0m, [2mmaster[0m, etc.)
-- [1mprevious-branch[0m: Previous branch for [2mwt switch -
+- [1mprevious-branch[0m: Previous branch for [2mwt switch -[0m
 - [1mci-status[0m: CI/PR status for a branch (passed, running, failed, conflicts, no-ci, error)
 - [1mmarker[0m: Custom status marker for a branch (shown in [2mwt list[0m)
 - [1mlogs[0m: Background operation logs
 
-[1m[32mExamples
+[1m[32mExamples[0m
 
 Get the default branch:
-  [2mwt config state default-branch
+  [2mwt config state default-branch[0m
 
 Set the default branch manually:
-  [2mwt config state default-branch set main
+  [2mwt config state default-branch set main[0m
 
 Set a marker for current branch:
-  [2mwt config state marker set "🚧 WIP"
+  [2mwt config state marker set "🚧 WIP"[0m
 
 Clear all CI status cache:
-  [2mwt config state ci-status clear --all
+  [2mwt config state ci-status clear --all[0m
 
 Show all stored state:
-  [2mwt config state get
+  [2mwt config state get[0m
 
 Clear all stored state:
-  [2mwt config state clear
+  [2mwt config state clear[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
@@ -26,36 +26,36 @@ exit_code: 0
 ----- stderr -----
 wt config state ci-status - CI status cache
 
-Usage: [1m[36mwt config state ci-status[0m [36m[OPTIONS][0m [36m[COMMAND]
+Usage: [1m[36mwt config state ci-status[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 
-[1m[32mCommands:
+[1m[32mCommands:[0m
   [1m[36mget[0m    Get CI status for a branch
   [1m[36mclear[0m  Clear CI status cache
 
-[1m[32mOptions:
-  [1m[36m-h[0m, [1m[36m--help
+[1m[32mOptions:[0m
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
 Caches GitHub/GitLab CI status for display in [2mwt list[0m.
 
-[1m[32mHow it works
+[1m[32mHow it works[0m
 
 1. [1mPlatform detection[0m — From [2m[ci] platform[0m in project config, or detected from remote URL (github.com → GitHub, gitlab.com → GitLab)
 2. [1mCLI requirement[0m — Requires [2mgh[0m (GitHub) or [2mglab[0m (GitLab) CLI, authenticated
 3. [1mWhat's checked[0m — PRs/MRs first, then branch pipelines for branches with upstream
 4. [1mCaching[0m — Results cached 30-60 seconds per branch+commit
 
-[1m[32mStatus values
+[1m[32mStatus values[0m
 
     Status                   Meaning                 
    ───────── ─────────────────────────────────────── 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status_clear.snap
@@ -1,0 +1,61 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - state
+    - ci-status
+    - clear
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config state ci-status clear - Clear CI status cache
+
+Usage: [1m[36mwt config state ci-status clear[0m [36m[OPTIONS]
+
+[1m[32mOptions:
+      [1m[36m--branch[0m[36m [0m[36m<BRANCH>
+          Target branch (defaults to current)
+
+      [1m[36m--all
+          Clear all CI status cache
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+[1m[32mExamples
+
+Clear CI status for current branch:
+  [2mwt config state ci-status clear
+
+Clear CI status for a specific branch:
+  [2mwt config state ci-status clear --branch=feature
+
+Clear all CI status cache:
+  [2mwt config state ci-status clear --all

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status_get.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status_get.snap
@@ -1,0 +1,60 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - state
+    - ci-status
+    - get
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config state ci-status get - Get CI status for a branch
+
+Usage: [1m[36mwt config state ci-status get[0m [36m[OPTIONS]
+
+[1m[32mOptions:
+      [1m[36m--branch[0m[36m [0m[36m<BRANCH>
+          Target branch (defaults to current)
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+Returns: passed, running, failed, conflicts, no-ci, or error.
+
+[1m[32mExamples
+
+Get CI status for current branch:
+  [2mwt config state ci-status
+
+Get CI status for a specific branch:
+  [2mwt config state ci-status get --branch=feature
+
+Clear cache and re-fetch:
+  [2mwt config state ci-status clear && wt config state ci-status get

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_clear.snap
@@ -26,20 +26,20 @@ exit_code: 0
 ----- stderr -----
 wt config state clear - Clear all stored state
 
-Usage: [1m[36mwt config state clear[0m [36m[OPTIONS]
+Usage: [1m[36mwt config state clear[0m [36m[OPTIONS][0m
 
-[1m[32mOptions:
-  [1m[36m-h[0m, [1m[36m--help
+[1m[32mOptions:[0m
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
 Clears all stored state:

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
@@ -26,34 +26,34 @@ exit_code: 0
 ----- stderr -----
 wt config state default-branch - Default branch setting
 
-Usage: [1m[36mwt config state default-branch[0m [36m[OPTIONS][0m [36m[COMMAND]
+Usage: [1m[36mwt config state default-branch[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 
-[1m[32mCommands:
+[1m[32mCommands:[0m
   [1m[36mget[0m    Get the default branch
   [1m[36mset[0m    Set the default branch
   [1m[36mclear[0m  Clear the default branch cache
 
-[1m[32mOptions:
-  [1m[36m-h[0m, [1m[36m--help
+[1m[32mOptions:[0m
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
 Useful in scripts to avoid hardcoding [2mmain[0m or [2mmaster[0m:
 
-  [2mgit rebase $(wt config state default-branch)
+  [2mgit rebase $(wt config state default-branch)[0m
 
 Without a subcommand, runs [2mget[0m. Use [2mset[0m to override, or [2mclear[0m then [2mget[0m to re-detect.
 
-[1m[32mDetection
+[1m[32mDetection[0m
 
 Worktrunk detects the default branch automatically:
 
@@ -66,6 +66,6 @@ Once detected, the result is cached in [2mworktrunk.default-branch[0m for fast
 
 The local inference fallback uses these heuristics in order:
 - If only one local branch exists, uses it
-- For bare repos or empty repos, checks [2msymbolic-ref HEAD
-- Checks [2mgit config init.defaultBranch
-- Looks for common names: [2mmain[0m, [2mmaster[0m, [2mdevelop[0m, [2mtrunk
+- For bare repos or empty repos, checks [2msymbolic-ref HEAD[0m
+- Checks [2mgit config init.defaultBranch[0m
+- Looks for common names: [2mmain[0m, [2mmaster[0m, [2mdevelop[0m, [2mtrunk[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch_clear.snap
@@ -1,0 +1,38 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - state
+    - default-branch
+    - clear
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config state default-branch clear - Clear the default branch cache
+
+Usage: [1m[36mwt config state default-branch clear[0m [36m[OPTIONS]
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help[0m  Print help
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
+      [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch_get.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch_get.snap
@@ -1,0 +1,52 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - state
+    - default-branch
+    - get
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config state default-branch get - Get the default branch
+
+Usage: [1m[36mwt config state default-branch get[0m [36m[OPTIONS]
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+[1m[32mExamples
+
+Get the default branch:
+  [2mwt config state default-branch
+
+Clear cache and re-detect:
+  [2mwt config state default-branch clear && wt config state default-branch get

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch_set.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch_set.snap
@@ -1,0 +1,53 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - state
+    - default-branch
+    - set
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config state default-branch set - Set the default branch
+
+Usage: [1m[36mwt config state default-branch set[0m [36m[OPTIONS][0m [36m<BRANCH>
+
+[1m[32mArguments:
+  [36m<BRANCH>
+          Branch name to set as default
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+[1m[32mExamples
+
+Set the default branch:
+  [2mwt config state default-branch set main

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_get.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_get.snap
@@ -26,31 +26,31 @@ exit_code: 0
 ----- stderr -----
 wt config state get - Get all stored state
 
-Usage: [1m[36mwt config state get[0m [36m[OPTIONS]
+Usage: [1m[36mwt config state get[0m [36m[OPTIONS][0m
 
-[1m[32mOptions:
-      [1m[36m--format[0m[36m [0m[36m<FORMAT>
+[1m[32mOptions:[0m
+      [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m
           Output format (table, json)
           
           [default: table]
 
-  [1m[36m-h[0m, [1m[36m--help
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
 Shows all stored state including:
 
 - [1mDefault branch[0m: Cached result of querying remote for default branch
-- [1mPrevious branch[0m: Previous branch for [2mwt switch -
+- [1mPrevious branch[0m: Previous branch for [2mwt switch -[0m
 - [1mBranch markers[0m: User-defined branch notes
 - [1mCI status[0m: Cached GitHub/GitLab CI status per branch (30s TTL)
 - [1mHints[0m: One-time hints that have been shown

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_hints.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_hints.snap
@@ -1,0 +1,62 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - state
+    - hints
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config state hints - One-time hints shown in this repo
+
+Usage: [1m[36mwt config state hints[0m [36m[OPTIONS][0m [36m[COMMAND]
+
+[1m[32mCommands:
+  [1m[36mget[0m    List hints that have been shown
+  [1m[36mclear[0m  Clear hints (re-show on next trigger)
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+Some hints show once per repo on first use, then are recorded in git config
+as [2mworktrunk.hints.<name> = true[0m.
+
+[1m[32mCurrent hints
+
+       Name              Trigger                             Message                     
+   ───────────── ──────────────────────── ────────────────────────────────────────────── 
+   worktree-path First wt switch --create Customize worktree locations: wt config create 
+
+[1m[32mExamples
+
+  [2mwt config state hints              # list shown hints
+  [2mwt config state hints clear        # re-show all hints
+  [2mwt config state hints clear NAME   # re-show specific hint

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_hints_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_hints_clear.snap
@@ -1,0 +1,58 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - state
+    - hints
+    - clear
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config state hints clear - Clear hints (re-show on next trigger)
+
+Usage: [1m[36mwt config state hints clear[0m [36m[OPTIONS][0m [36m[NAME]
+
+[1m[32mArguments:
+  [36m[NAME]
+          Specific hint to clear (clears all if not specified)
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+Clears hint state so hints will show again on next trigger.
+
+[1m[32mExamples
+
+Clear all hints:
+  [2mwt config state hints clear
+
+Clear a specific hint:
+  [2mwt config state hints clear worktree-path

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_hints_get.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_hints_get.snap
@@ -1,0 +1,51 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - state
+    - hints
+    - get
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config state hints get - List hints that have been shown
+
+Usage: [1m[36mwt config state hints get[0m [36m[OPTIONS]
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+Lists which one-time hints have been shown in this repository.
+
+[1m[32mExamples
+
+List shown hints:
+  [2mwt config state hints

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
@@ -26,29 +26,29 @@ exit_code: 0
 ----- stderr -----
 wt config state logs - Background operation logs
 
-Usage: [1m[36mwt config state logs[0m [36m[OPTIONS][0m [36m[COMMAND]
+Usage: [1m[36mwt config state logs[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 
-[1m[32mCommands:
+[1m[32mCommands:[0m
   [1m[36mget[0m    List background operation log files
   [1m[36mclear[0m  Clear background operation logs
 
-[1m[32mOptions:
-  [1m[36m-h[0m, [1m[36m--help
+[1m[32mOptions:[0m
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
 View and manage logs from background operations.
 
-[1m[32mWhat's logged
+[1m[32mWhat's logged[0m
 
        Operation                     Log file                 
    ────────────────── ─────────────────────────────────────── 
@@ -57,23 +57,23 @@ View and manage logs from background operations.
 
 Source is [2muser[0m or [2mproject[0m depending on where the hook is defined.
 
-[1m[32mLocation
+[1m[32mLocation[0m
 
 All logs are stored in [2m.git/wt-logs/[0m (in the main worktree's git directory).
 
-[1m[32mBehavior
+[1m[32mBehavior[0m
 
 - [1mOverwrites[0m — Same operation on same branch overwrites previous log
 - [1mPersists[0m — Logs from deleted branches remain until manually cleared
 - [1mShared[0m — All worktrees write to the same log directory
 
-[1m[32mExamples
+[1m[32mExamples[0m
 
 List all log files:
-  [2mwt config state logs get
+  [2mwt config state logs get[0m
 
 View a specific log:
-  [2mcat "$(git rev-parse --git-dir)/wt-logs/feature-project-post-start-build.log"
+  [2mcat "$(git rev-parse --git-dir)/wt-logs/feature-project-post-start-build.log"[0m
 
 Clear all logs:
-  [2mwt config state logs clear
+  [2mwt config state logs clear[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_logs_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_logs_clear.snap
@@ -1,0 +1,38 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - state
+    - logs
+    - clear
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config state logs clear - Clear background operation logs
+
+Usage: [1m[36mwt config state logs clear[0m [36m[OPTIONS]
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help[0m  Print help
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
+      [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_logs_get.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_logs_get.snap
@@ -1,0 +1,51 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - state
+    - logs
+    - get
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config state logs get - List background operation log files
+
+Usage: [1m[36mwt config state logs get[0m [36m[OPTIONS]
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+Lists log files from background operations like post-start commands and worktree removal.
+
+[1m[32mExamples
+
+List log files:
+  [2mwt config state logs

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
@@ -26,48 +26,48 @@ exit_code: 0
 ----- stderr -----
 wt config state marker - Branch markers
 
-Usage: [1m[36mwt config state marker[0m [36m[OPTIONS][0m [36m[COMMAND]
+Usage: [1m[36mwt config state marker[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 
-[1m[32mCommands:
+[1m[32mCommands:[0m
   [1m[36mget[0m    Get marker for a branch
   [1m[36mset[0m    Set marker for a branch
   [1m[36mclear[0m  Clear marker for a branch
 
-[1m[32mOptions:
-  [1m[36m-h[0m, [1m[36m--help
+[1m[32mOptions:[0m
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
 Custom status text or emoji shown in the [2mwt list[0m Status column.
 
-[1m[32mDisplay
+[1m[32mDisplay[0m
 
 Markers appear at the start of the Status column:
 
-  [2mBranch    Status   Path
-  [2mmain      ^        ~/code/myproject
-  [2mfeature   🚧↑      ~/code/myproject.feature
-  [2mbugfix    🤖!↑⇡    ~/code/myproject.bugfix
+  [2mBranch    Status   Path[0m
+  [2mmain      ^        ~/code/myproject[0m
+  [2mfeature   🚧↑      ~/code/myproject.feature[0m
+  [2mbugfix    🤖!↑⇡    ~/code/myproject.bugfix[0m
 
-[1m[32mUse cases
+[1m[32mUse cases[0m
 
 - [1mWork status[0m — [2m🚧[0m WIP, [2m✅[0m ready for review, [2m🔥[0m urgent
 - [1mAgent tracking[0m — The Claude Code plugin sets markers automatically
-- [1mNotes[0m — Any short text: [2m"blocked"[0m, [2m"needs tests"
+- [1mNotes[0m — Any short text: [2m"blocked"[0m, [2m"needs tests"[0m
 
-[1m[32mStorage
+[1m[32mStorage[0m
 
 Stored in git config as [2mworktrunk.state.<branch>.marker[0m. Set directly with:
 
-  [2mgit config worktrunk.state.feature.marker '{"marker":"🚧","set_at":0}'
+  [2mgit config worktrunk.state.feature.marker '{"marker":"🚧","set_at":0}'[0m
 
 Without a subcommand, runs [2mget[0m for the current branch. For [2m--branch[0m, use [2mget --branch=NAME[0m.

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_marker_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_marker_clear.snap
@@ -1,0 +1,61 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - state
+    - marker
+    - clear
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config state marker clear - Clear marker for a branch
+
+Usage: [1m[36mwt config state marker clear[0m [36m[OPTIONS]
+
+[1m[32mOptions:
+      [1m[36m--branch[0m[36m [0m[36m<BRANCH>
+          Target branch (defaults to current)
+
+      [1m[36m--all
+          Clear all markers
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+[1m[32mExamples
+
+Clear marker for current branch:
+  [2mwt config state marker clear
+
+Clear marker for a specific branch:
+  [2mwt config state marker clear --branch=feature
+
+Clear all markers:
+  [2mwt config state marker clear --all

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_marker_get.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_marker_get.snap
@@ -1,0 +1,55 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - state
+    - marker
+    - get
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config state marker get - Get marker for a branch
+
+Usage: [1m[36mwt config state marker get[0m [36m[OPTIONS]
+
+[1m[32mOptions:
+      [1m[36m--branch[0m[36m [0m[36m<BRANCH>
+          Target branch (defaults to current)
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+[1m[32mExamples
+
+Get marker for current branch:
+  [2mwt config state marker
+
+Get marker for a specific branch:
+  [2mwt config state marker get --branch=feature

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_marker_set.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_marker_set.snap
@@ -1,0 +1,59 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - state
+    - marker
+    - set
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config state marker set - Set marker for a branch
+
+Usage: [1m[36mwt config state marker set[0m [36m[OPTIONS][0m [36m<VALUE>
+
+[1m[32mArguments:
+  [36m<VALUE>
+          Marker text (shown in [1mwt list[0m output)
+
+[1m[32mOptions:
+      [1m[36m--branch[0m[36m [0m[36m<BRANCH>
+          Target branch (defaults to current)
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+[1m[32mExamples
+
+Set marker for current branch:
+  [2mwt config state marker set "🚧 WIP"
+
+Set marker for a specific branch:
+  [2mwt config state marker set "✅ ready" --branch=feature

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch.snap
@@ -26,30 +26,30 @@ exit_code: 0
 ----- stderr -----
 wt config state previous-branch - Previous branch (for [1mwt switch -[0m)
 
-Usage: [1m[36mwt config state previous-branch[0m [36m[OPTIONS][0m [36m[COMMAND]
+Usage: [1m[36mwt config state previous-branch[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 
-[1m[32mCommands:
+[1m[32mCommands:[0m
   [1m[36mget[0m    Get the previous branch
   [1m[36mset[0m    Set the previous branch
   [1m[36mclear[0m  Clear the previous branch
 
-[1m[32mOptions:
-  [1m[36m-h[0m, [1m[36m--help
+[1m[32mOptions:[0m
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
 Enables [2mwt switch -[0m to return to the previous worktree, similar to [2mcd -[0m or [2mgit checkout -[0m.
 
-[1m[32mHow it works
+[1m[32mHow it works[0m
 
 Updated automatically on every [2mwt switch[0m. Stored in git config as [2mworktrunk.history[0m.
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch_clear.snap
@@ -1,0 +1,38 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - state
+    - previous-branch
+    - clear
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config state previous-branch clear - Clear the previous branch
+
+Usage: [1m[36mwt config state previous-branch clear[0m [36m[OPTIONS]
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help[0m  Print help
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
+      [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch_get.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch_get.snap
@@ -1,0 +1,49 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - state
+    - previous-branch
+    - get
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config state previous-branch get - Get the previous branch
+
+Usage: [1m[36mwt config state previous-branch get[0m [36m[OPTIONS]
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+[1m[32mExamples
+
+Get the previous branch (used by [2mwt switch -[0m):
+  [2mwt config state previous-branch

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch_set.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch_set.snap
@@ -1,0 +1,53 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - config
+    - state
+    - previous-branch
+    - set
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt config state previous-branch set - Set the previous branch
+
+Usage: [1m[36mwt config state previous-branch set[0m [36m[OPTIONS][0m [36m<BRANCH>
+
+[1m[32mArguments:
+  [36m<BRANCH>
+          Branch name to set as previous
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+[1m[32mExamples
+
+Set the previous branch:
+  [2mwt config state previous-branch set feature

--- a/tests/snapshots/integration__integration_tests__help__help_hook.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook.snap
@@ -1,0 +1,416 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - hook
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt hook - Run configured hooks
+
+Usage: [1m[36mwt hook[0m [36m[OPTIONS][0m [36m<COMMAND>
+
+[1m[32mCommands:
+  [1m[36mshow[0m         Show configured hooks
+  [1m[36mpost-create[0m  Run post-create hooks
+  [1m[36mpost-start[0m   Run post-start hooks
+  [1m[36mpost-switch[0m  Run post-switch hooks
+  [1m[36mpre-commit[0m   Run pre-commit hooks
+  [1m[36mpre-merge[0m    Run pre-merge hooks
+  [1m[36mpost-merge[0m   Run post-merge hooks
+  [1m[36mpre-remove[0m   Run pre-remove hooks
+  [1m[36mpost-remove[0m  Run post-remove hooks
+  [1m[36mapprovals[0m    Manage command approvals
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+Hooks are shell commands that run at key points in the worktree lifecycle — automatically during [2mwt switch[0m, [2mwt merge[0m, & [2mwt remove[0m, or on demand via [2mwt hook <type>[0m. Both user ([2m~/.config/worktrunk/config.toml[0m) and project ([2m.config/wt.toml[0m) hooks are supported.
+
+[1m[32mHook types
+
+      Hook                When               Blocking     Fail-fast 
+   ─────────── ────────────────────────── ─────────────── ───────── 
+   post-start  After worktree created     No (background) No        
+   post-create After worktree created     Yes             No        
+   post-switch After every switch         No (background) No        
+   pre-commit  Before commit during merge Yes             Yes       
+   pre-merge   Before merging to target   Yes             Yes       
+   post-merge  After successful merge     Yes             No        
+   pre-remove  Before worktree removed    Yes             Yes       
+   post-remove After worktree removed     No (background) No        
+
+[1mBlocking[0m: Command waits for hook to complete before continuing.
+[1mFail-fast[0m: First failure aborts the operation.
+
+Background hooks show a single-line summary by default. Use [2m-v[0m to see expanded command details.
+
+[32mpost-start
+
+Dev servers, long builds, file watchers, copying caches. Output logged to [2m.git/wt-logs/{branch}-{source}-post-start-{name}.log[0m.
+
+  [2m[post-start]
+  [2mcopy = "wt step copy-ignored"
+  [2mserver = "npm run dev -- --port {{ branch | hash_port }}"
+
+[32mpost-create
+
+Tasks that must complete before [2mpost-start[0m hooks or [2m--execute[0m run: dependency installation, environment file generation.
+
+  [2m[post-create]
+  [2minstall = "npm ci"
+  [2menv = "echo 'PORT={{ branch | hash_port }}' > .env.local"
+
+[32mpost-switch
+
+Triggers on all switch results: creating new worktrees, switching to existing ones, or staying on current. Output logged to [2m.git/wt-logs/{branch}-{source}-post-switch-{name}.log[0m.
+
+  [2m[post-switch]
+  [2mtmux = "[ -n \"$TMUX\" ] && tmux rename-window '{{ branch | sanitize }}'"
+
+[32mpre-commit
+
+Formatters, linters, type checking — runs during [2mwt merge[0m before the squash commit.
+
+  [2m[pre-commit]
+  [2mformat = "cargo fmt -- --check"
+  [2mlint = "cargo clippy -- -D warnings"
+
+[32mpre-merge
+
+Tests, security scans, build verification — runs after rebase, before merge to target.
+
+  [2m[pre-merge]
+  [2mtest = "cargo test"
+  [2mbuild = "cargo build --release"
+
+[32mpost-merge
+
+Deployment, notifications, installing updated binaries. Runs in the target branch worktree if it exists, otherwise the main worktree.
+
+  [2mpost-merge = "cargo install --path ."
+
+[32mpre-remove
+
+Cleanup tasks before worktree is deleted, saving test artifacts, backing up state. Runs in the worktree being removed, with access to worktree files.
+
+  [2m[pre-remove]
+  [2marchive = "tar -czf ~/.wt-logs/{{ branch }}.tar.gz test-results/ logs/ 2>/dev/null || true"
+
+[32mpost-remove
+
+Cleanup tasks after worktree removal: stopping dev servers, removing containers, notifying external systems. All template variables reference the removed worktree, so cleanup scripts can identify resources to clean up. Output logged to [2m.git/wt-logs/{branch}-{source}-post-remove-{name}.log[0m.
+
+  [2m[post-remove]
+  [2mkill-server = "lsof -ti :{{ branch | hash_port }} | xargs kill 2>/dev/null || true"
+  [2mremove-db = "docker stop {{ repo }}-{{ branch | sanitize }}-postgres 2>/dev/null || true"
+
+During [2mwt merge[0m, hooks run in this order: pre-commit → pre-merge → pre-remove → post-remove → post-merge. See [2mwt merge[0m for the complete pipeline.
+
+[1m[32mSecurity
+
+Project commands require approval on first run:
+
+  [2m▲ repo needs approval to execute 3 commands:
+  [2m
+  [2m○ post-create install:
+  [2m   echo 'Installing dependencies...'
+  [2m
+  [2m❯ Allow and remember? [y/N]
+
+- Approvals are saved to user config ([2m~/.config/worktrunk/config.toml[0m)
+- If a command changes, new approval is required
+- Use [2m--yes[0m to bypass prompts (useful for CI/automation)
+- Use [2m--no-verify[0m to skip hooks
+
+Manage approvals with [2mwt hook approvals add[0m and [2mwt hook approvals clear[0m.
+
+[1m[32mConfiguration
+
+Hooks can be defined in two places: project config ([2m.config/wt.toml[0m) for repository-specific automation, or user config ([2m~/.config/worktrunk/config.toml[0m) for personal automation across all repositories.
+
+[32mProject hooks
+
+Project hooks are defined in [2m.config/wt.toml[0m. They can be a single command or multiple named commands:
+
+  [2m# Single command (string)
+  [2mpost-create = "npm install"
+  [2m
+  [2m# Multiple commands (table) — run sequentially in declaration order
+  [2m[pre-merge]
+  [2mtest = "cargo test"
+  [2mbuild = "cargo build --release"
+
+[32mUser hooks
+
+Define hooks in [2m~/.config/worktrunk/config.toml[0m to run for all repositories. User hooks run before project hooks and don't require approval.
+
+  [2m# ~/.config/worktrunk/config.toml
+  [2m[post-create]
+  [2msetup = "echo 'Setting up worktree...'"
+  [2m
+  [2m[pre-merge]
+  [2mnotify = "notify-send 'Merging {{ branch }}'"
+
+User hooks support the same hook types and template variables as project hooks.
+
+[1mKey differences from project hooks:
+
+       Aspect        Project hooks             User hooks            
+   ─────────────── ───────────────── ─────────────────────────────── 
+   Location        .config/wt.toml   ~/.config/worktrunk/config.toml 
+   Scope           Single repository All repositories                
+   Approval        Required          Not required                    
+   Execution order After user hooks  Before project hooks            
+
+Skip hooks with [2m--no-verify[0m. To run a specific hook when user and project both define the same name, use [2muser:name[0m or [2mproject:name[0m syntax.
+
+[1mUse cases:
+- Personal notifications or logging
+- Editor/IDE integration
+- Repository-agnostic setup tasks
+- Filtering by repository using JSON context
+
+[1mFiltering by repository:
+
+User hooks receive JSON context on stdin, enabling repository-specific behavior:
+
+  [2m# ~/.config/worktrunk/config.toml
+  [2m[post-create]
+  [2mgitlab-setup = """
+  [2mpython3 -c '
+  [2mimport json, sys, subprocess
+  [2mctx = json.load(sys.stdin)
+  [2mif "gitlab" in ctx.get("remote", ""):
+  [2m    subprocess.run(["glab", "mr", "create", "--fill"])
+  [2m'
+  [2m"""
+
+[32mTemplate variables
+
+Hooks can use template variables that expand at runtime:
+
+            Variable                                   Description                          
+   ─────────────────────────── ──────────────────────────────────────────────────────────── 
+   {{ repo }}                  Repository directory name                                    
+   {{ repo_path }}             Absolute path to repository root                             
+   {{ branch }}                Branch name                                                  
+   {{ worktree_name }}         Worktree directory name                                      
+   {{ worktree_path }}         Absolute worktree path                                       
+   {{ primary_worktree_path }} Main worktree path (for bare repos: default branch worktree) 
+   {{ default_branch }}        Default branch name                                          
+   {{ commit }}                Full HEAD commit SHA                                         
+   {{ short_commit }}          Short HEAD commit SHA (7 chars)                              
+   {{ remote }}                Primary remote name                                          
+   {{ remote_url }}            Remote URL                                                   
+   {{ upstream }}              Upstream tracking branch (if set)                            
+   {{ target }}                Target branch (merge hooks only)                             
+   {{ base }}                  Base branch (creation hooks only)                            
+   {{ base_worktree_path }}    Base branch worktree (creation hooks only)                   
+
+Some variables may not be defined: [2mupstream[0m is only set when the branch tracks a remote; [2mtarget[0m, [2mbase[0m, and [2mbase_worktree_path[0m are hook-specific. Using an undefined variable directly errors — use conditionals for optional behavior:
+
+  [2m[post-create]
+  [2m# Rebase onto upstream if tracking a remote branch (e.g., wt switch --create feature origin/feature)
+  [2msync = "{% if upstream %}git fetch && git rebase {{ upstream }}{% endif %}"
+
+[32mWorktrunk filters
+
+Templates support Jinja2 filters for transforming values:
+
+     Filter             Example                                       Description                             
+   ─────────── ────────────────────────── ─────────────────────────────────────────────────────────────────── 
+   sanitize    {{ branch | sanitize }}    Replace / and \ with -                                              
+   sanitize_db {{ branch | sanitize_db }} Database-safe identifier with hash suffix ([a-z0-9_], max 63 chars) 
+   hash_port   {{ branch | hash_port }}   Hash to port 10000-19999                                            
+
+The [2msanitize[0m filter makes branch names safe for filesystem paths. The [2msanitize_db[0m filter produces database-safe identifiers (lowercase alphanumeric and underscores, no leading digits, with a 3-character hash suffix to avoid collisions and reserved words). The [2mhash_port[0m filter is useful for running dev servers on unique ports per worktree:
+
+  [2m[post-start]
+  [2mdev = "npm run dev -- --host {{ branch }}.lvh.me --port {{ branch | hash_port }}"
+
+Hash any string, including concatenations:
+
+  [2m# Unique port per repo+branch combination
+  [2mdev = "npm run dev --port {{ (repo ~ '-' ~ branch) | hash_port }}"
+
+[32mWorktrunk functions
+
+Templates also support functions for dynamic lookups:
+
+              Function                            Example                              Description               
+   ─────────────────────────────── ───────────────────────────────────── ─────────────────────────────────────── 
+   worktree_path_of_branch(branch) {{ worktree_path_of_branch("main") }} Look up the path of a branch's worktree 
+
+The [2mworktree_path_of_branch[0m function returns the filesystem path of a worktree given a branch name, or an empty string if no worktree exists for that branch. This is useful for referencing files in other worktrees:
+
+  [2m[post-create]
+  [2m# Copy config from main worktree
+  [2msetup = "cp {{ worktree_path_of_branch('main') }}/config.local {{ worktree_path }}"
+
+[32mJSON context
+
+Hooks also receive context as JSON on stdin, enabling hooks in any language:
+
+  [2mimport json, sys
+  [2mctx = json.load(sys.stdin)
+  [2mprint(f"Setting up {ctx['repo']} on branch {ctx['branch']}")
+
+The JSON includes all template variables plus [2mhook_type[0m and [2mhook_name[0m.
+
+[1m[32mRunning hooks manually
+
+[2mwt hook <type>[0m runs hooks on demand — useful for testing during development, running in CI pipelines, or re-running after a failure.
+
+  [2mwt hook pre-merge              # Run all pre-merge hooks
+  [2mwt hook pre-merge test         # Run hooks named "test" from both sources
+  [2mwt hook pre-merge user:        # Run all user hooks
+  [2mwt hook pre-merge project:     # Run all project hooks
+  [2mwt hook pre-merge user:test    # Run only user's "test" hook
+  [2mwt hook pre-merge project:test # Run only project's "test" hook
+  [2mwt hook pre-merge --yes        # Skip approval prompts (for CI)
+  [2mwt hook post-create --var branch=feature/test  # Override template variable
+
+The [2muser:[0m and [2mproject:[0m prefixes filter by source. Use [2muser:[0m or [2mproject:[0m alone to run all hooks from that source, or [2muser:name[0m / [2mproject:name[0m to run a specific hook.
+
+The [2m--var KEY=VALUE[0m flag overrides built-in template variables — useful for testing hooks with different contexts without switching to that context.
+
+[1m[32mDesigning effective hooks
+
+[32mpost-start vs post-create
+
+Both run when creating a worktree. The difference:
+
+      Hook           Execution                                 Best for                            
+   ─────────── ───────────────────── ───────────────────────────────────────────────────────────── 
+   post-start  Background, parallel  Long-running tasks that don't block worktree creation         
+   post-create Blocks until complete Tasks the developer needs before working (dependency install) 
+
+Many tasks work well in [2mpost-start[0m — they'll likely be ready by the time they're needed, especially when the fallback is recompiling. If unsure, prefer [2mpost-start[0m for faster worktree creation.
+
+Background processes spawned by [2mpost-start[0m outlive the worktree — pair them with [2mpost-remove[0m hooks to clean up. See Dev servers and Databases for examples.
+
+[32mCopying untracked files
+
+Git worktrees share the repository but not untracked files. [2mwt step copy-ignored[0m copies gitignored files between worktrees:
+
+  [2m[post-start]
+  [2mcopy = "wt step copy-ignored"
+
+Use [2mpost-create[0m instead if subsequent hooks or [2m--execute[0m command need the copied files immediately.
+
+[32mDev servers
+
+Run a dev server per worktree on a deterministic port using [2mhash_port[0m:
+
+  [2m[post-start]
+  [2mserver = "npm run dev -- --port {{ branch | hash_port }}"
+  [2m
+  [2m[post-remove]
+  [2mserver = "lsof -ti :{{ branch | hash_port }} | xargs kill 2>/dev/null || true"
+
+The port is stable across machines and restarts — [2mfeature-api[0m always gets the same port. Show it in [2mwt list[0m:
+
+  [2m[list]
+  [2murl = "http://localhost:{{ branch | hash_port }}"
+
+For subdomain-based routing (useful for cookies/CORS), use [2mlvh.me[0m which resolves to 127.0.0.1:
+
+  [2m[post-start]
+  [2mserver = "npm run dev -- --host {{ branch | sanitize }}.lvh.me --port {{ branch | hash_port }}"
+
+[32mDatabases
+
+Each worktree can have its own database. Docker containers get unique names and ports:
+
+  [2m[post-start]
+  [2mdb = """
+  [2mdocker run -d --rm \
+  [2m  --name {{ repo }}-{{ branch | sanitize }}-postgres \
+  [2m  -p {{ ('db-' ~ branch) | hash_port }}:5432 \
+  [2m  -e POSTGRES_DB={{ branch | sanitize_db }} \
+  [2m  -e POSTGRES_PASSWORD=dev \
+  [2m  postgres:16
+  [2m"""
+  [2m
+  [2m[post-remove]
+  [2mdb-stop = "docker stop {{ repo }}-{{ branch | sanitize }}-postgres 2>/dev/null || true"
+
+The [2m('db-' ~ branch)[0m concatenation hashes differently than plain [2mbranch[0m, so database and dev server ports don't collide.
+Jinja2's operator precedence has pipe [2m|[0m with higher precedence than concatenation [2m~[0m, meaning expressions need parentheses to filter concatenated values.
+
+Generate [2m.env.local[0m with the connection string:
+
+  [2m[post-create]
+  [2menv = """
+  [2mcat > .env.local << EOF
+  [2mDATABASE_URL=postgres://postgres:dev@localhost:{{ ('db-' ~ branch) | hash_port }}/{{ branch | sanitize_db }}
+  [2mDEV_PORT={{ branch | hash_port }}
+  [2mEOF
+  [2m"""
+
+[32mProgressive validation
+
+Quick checks before commit, thorough validation before merge:
+
+  [2m[pre-commit]
+  [2mlint = "npm run lint"
+  [2mtypecheck = "npm run typecheck"
+  [2m
+  [2m[pre-merge]
+  [2mtest = "npm test"
+  [2mbuild = "npm run build"
+
+[32mTarget-specific behavior
+
+Different actions for production vs staging:
+
+  [2mpost-merge = """
+  [2mif [ "{{ target }}" = "main" ]; then
+  [2m    npm run deploy:production
+  [2melif [ "{{ target }}" = "staging" ]; then
+  [2m    npm run deploy:staging
+  [2mfi
+  [2m"""
+
+[32mPython virtual environments
+
+Use [2muv sync[0m to recreate virtual environments (or [2mpython -m venv .venv && .venv/bin/pip install -r requirements.txt[0m for pip-based projects):
+
+  [2m[post-create]
+  [2minstall = "uv sync"
+
+For copying dependencies and caches between worktrees, see [2mwt step copy-ignored[0m.
+
+[1m[32mSee also
+
+- [2mwt merge[0m — Runs hooks automatically during merge
+- [2mwt switch[0m — Runs post-create/post-start hooks on [2m--create
+- [2mwt config[0m — Manage hook approvals

--- a/tests/snapshots/integration__integration_tests__help__help_hook_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_approvals.snap
@@ -25,39 +25,39 @@ exit_code: 0
 ----- stderr -----
 wt hook approvals - Manage command approvals
 
-Usage: [1m[36mwt hook approvals[0m [36m[OPTIONS][0m [36m<COMMAND>
+Usage: [1m[36mwt hook approvals[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 
-[1m[32mCommands:
+[1m[32mCommands:[0m
   [1m[36madd[0m    Store approvals in config
   [1m[36mclear[0m  Clear approved commands from config
 
-[1m[32mOptions:
-  [1m[36m-h[0m, [1m[36m--help
+[1m[32mOptions:[0m
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
 Project hooks require approval on first run to prevent untrusted projects from running arbitrary commands.
 
-[1m[32mExamples
+[1m[32mExamples[0m
 
 Pre-approve all commands for current project:
-  [2mwt hook approvals add
+  [2mwt hook approvals add[0m
 
 Clear approvals for current project:
-  [2mwt hook approvals clear
+  [2mwt hook approvals clear[0m
 
 Clear global approvals:
-  [2mwt hook approvals clear --global
+  [2mwt hook approvals clear --global[0m
 
-[1m[32mHow approvals work
+[1m[32mHow approvals work[0m
 
 Approved commands are saved to user config. Re-approval is required when the command template changes or the project moves. Use [2m--yes[0m to bypass prompts in CI.

--- a/tests/snapshots/integration__integration_tests__help__help_hook_approvals_add.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_approvals_add.snap
@@ -26,23 +26,23 @@ exit_code: 0
 ----- stderr -----
 wt hook approvals add - Store approvals in config
 
-Usage: [1m[36mwt hook approvals add[0m [36m[OPTIONS]
+Usage: [1m[36mwt hook approvals add[0m [36m[OPTIONS][0m
 
-[1m[32mOptions:
-      [1m[36m--all
+[1m[32mOptions:[0m
+      [1m[36m--all[0m
           Show all commands
 
-  [1m[36m-h[0m, [1m[36m--help
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
 Prompts for approval of all project commands and saves them to user config.

--- a/tests/snapshots/integration__integration_tests__help__help_hook_approvals_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_approvals_clear.snap
@@ -26,23 +26,23 @@ exit_code: 0
 ----- stderr -----
 wt hook approvals clear - Clear approved commands from config
 
-Usage: [1m[36mwt hook approvals clear[0m [36m[OPTIONS]
+Usage: [1m[36mwt hook approvals clear[0m [36m[OPTIONS][0m
 
-[1m[32mOptions:
-  [1m[36m-g[0m, [1m[36m--global
+[1m[32mOptions:[0m
+  [1m[36m-g[0m, [1m[36m--global[0m
           Clear global approvals
 
-  [1m[36m-h[0m, [1m[36m--help
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
 Removes saved approvals, requiring re-approval on next command run.

--- a/tests/snapshots/integration__integration_tests__help__help_hook_post_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_post_create.snap
@@ -1,0 +1,56 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - hook
+    - post-create
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt hook post-create - Run post-create hooks
+
+Blocking — waits for completion before continuing.
+
+Usage: [1m[36mwt hook post-create[0m [36m[OPTIONS][0m [36m[NAME]
+
+[1m[32mArguments:
+  [36m[NAME]
+          Filter by command name
+          
+          Supports [1muser:name[0m or [1mproject:name[0m to filter by source. [1muser:[0m alone runs all user hooks; [1mproject:[0m alone runs all project hooks.
+
+[1m[32mOptions:
+  [1m[36m-y[0m, [1m[36m--yes
+          Skip approval prompts
+
+      [1m[36m--var[0m[36m [0m[36m<KEY=VALUE>
+          Override built-in template variable (KEY=VALUE)
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_hook_post_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_post_merge.snap
@@ -1,0 +1,54 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - hook
+    - post-merge
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt hook post-merge - Run post-merge hooks
+
+Usage: [1m[36mwt hook post-merge[0m [36m[OPTIONS][0m [36m[NAME]
+
+[1m[32mArguments:
+  [36m[NAME]
+          Filter by command name
+          
+          Supports [1muser:name[0m or [1mproject:name[0m to filter by source. [1muser:[0m alone runs all user hooks; [1mproject:[0m alone runs all project hooks.
+
+[1m[32mOptions:
+  [1m[36m-y[0m, [1m[36m--yes
+          Skip approval prompts
+
+      [1m[36m--var[0m[36m [0m[36m<KEY=VALUE>
+          Override built-in template variable (KEY=VALUE)
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_hook_post_remove.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_post_remove.snap
@@ -1,0 +1,59 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - hook
+    - post-remove
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt hook post-remove - Run post-remove hooks
+
+Background by default. Use [1m--foreground[0m to run in foreground for debugging.
+
+Usage: [1m[36mwt hook post-remove[0m [36m[OPTIONS][0m [36m[NAME]
+
+[1m[32mArguments:
+  [36m[NAME]
+          Filter by command name
+          
+          Supports [1muser:name[0m or [1mproject:name[0m to filter by source. [1muser:[0m alone runs all user hooks; [1mproject:[0m alone runs all project hooks.
+
+[1m[32mOptions:
+  [1m[36m-y[0m, [1m[36m--yes
+          Skip approval prompts
+
+      [1m[36m--foreground
+          Run in foreground (block until complete)
+
+      [1m[36m--var[0m[36m [0m[36m<KEY=VALUE>
+          Override built-in template variable (KEY=VALUE)
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_hook_post_start.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_post_start.snap
@@ -1,0 +1,59 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - hook
+    - post-start
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt hook post-start - Run post-start hooks
+
+Background by default. Use [1m--foreground[0m to run in foreground for debugging.
+
+Usage: [1m[36mwt hook post-start[0m [36m[OPTIONS][0m [36m[NAME]
+
+[1m[32mArguments:
+  [36m[NAME]
+          Filter by command name
+          
+          Supports [1muser:name[0m or [1mproject:name[0m to filter by source. [1muser:[0m alone runs all user hooks; [1mproject:[0m alone runs all project hooks.
+
+[1m[32mOptions:
+  [1m[36m-y[0m, [1m[36m--yes
+          Skip approval prompts
+
+      [1m[36m--foreground
+          Run in foreground (block until complete)
+
+      [1m[36m--var[0m[36m [0m[36m<KEY=VALUE>
+          Override built-in template variable (KEY=VALUE)
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_hook_post_switch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_post_switch.snap
@@ -1,0 +1,59 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - hook
+    - post-switch
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt hook post-switch - Run post-switch hooks
+
+Background by default. Use [1m--foreground[0m to run in foreground for debugging.
+
+Usage: [1m[36mwt hook post-switch[0m [36m[OPTIONS][0m [36m[NAME]
+
+[1m[32mArguments:
+  [36m[NAME]
+          Filter by command name
+          
+          Supports [1muser:name[0m or [1mproject:name[0m to filter by source. [1muser:[0m alone runs all user hooks; [1mproject:[0m alone runs all project hooks.
+
+[1m[32mOptions:
+  [1m[36m-y[0m, [1m[36m--yes
+          Skip approval prompts
+
+      [1m[36m--foreground
+          Run in foreground (block until complete)
+
+      [1m[36m--var[0m[36m [0m[36m<KEY=VALUE>
+          Override built-in template variable (KEY=VALUE)
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_hook_pre_commit.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_pre_commit.snap
@@ -1,0 +1,54 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - hook
+    - pre-commit
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt hook pre-commit - Run pre-commit hooks
+
+Usage: [1m[36mwt hook pre-commit[0m [36m[OPTIONS][0m [36m[NAME]
+
+[1m[32mArguments:
+  [36m[NAME]
+          Filter by command name
+          
+          Supports [1muser:name[0m or [1mproject:name[0m to filter by source. [1muser:[0m alone runs all user hooks; [1mproject:[0m alone runs all project hooks.
+
+[1m[32mOptions:
+  [1m[36m-y[0m, [1m[36m--yes
+          Skip approval prompts
+
+      [1m[36m--var[0m[36m [0m[36m<KEY=VALUE>
+          Override built-in template variable (KEY=VALUE)
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_hook_pre_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_pre_merge.snap
@@ -1,0 +1,54 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - hook
+    - pre-merge
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt hook pre-merge - Run pre-merge hooks
+
+Usage: [1m[36mwt hook pre-merge[0m [36m[OPTIONS][0m [36m[NAME]
+
+[1m[32mArguments:
+  [36m[NAME]
+          Filter by command name
+          
+          Supports [1muser:name[0m or [1mproject:name[0m to filter by source. [1muser:[0m alone runs all user hooks; [1mproject:[0m alone runs all project hooks.
+
+[1m[32mOptions:
+  [1m[36m-y[0m, [1m[36m--yes
+          Skip approval prompts
+
+      [1m[36m--var[0m[36m [0m[36m<KEY=VALUE>
+          Override built-in template variable (KEY=VALUE)
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_hook_pre_remove.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_pre_remove.snap
@@ -1,0 +1,54 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - hook
+    - pre-remove
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt hook pre-remove - Run pre-remove hooks
+
+Usage: [1m[36mwt hook pre-remove[0m [36m[OPTIONS][0m [36m[NAME]
+
+[1m[32mArguments:
+  [36m[NAME]
+          Filter by command name
+          
+          Supports [1muser:name[0m or [1mproject:name[0m to filter by source. [1muser:[0m alone runs all user hooks; [1mproject:[0m alone runs all project hooks.
+
+[1m[32mOptions:
+  [1m[36m-y[0m, [1m[36m--yes
+          Skip approval prompts
+
+      [1m[36m--var[0m[36m [0m[36m<KEY=VALUE>
+          Override built-in template variable (KEY=VALUE)
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_hook_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_short.snap
@@ -1,0 +1,47 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - hook
+    - "-h"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt hook - Run configured hooks
+
+Usage: [1m[36mwt hook[0m [36m[OPTIONS][0m [36m<COMMAND>
+
+[1m[32mCommands:
+  [1m[36mshow[0m         Show configured hooks
+  [1m[36mpost-create[0m  Run post-create hooks
+  [1m[36mpost-start[0m   Run post-start hooks
+  [1m[36mpost-switch[0m  Run post-switch hooks
+  [1m[36mpre-commit[0m   Run pre-commit hooks
+  [1m[36mpre-merge[0m    Run pre-merge hooks
+  [1m[36mpost-merge[0m   Run post-merge hooks
+  [1m[36mpre-remove[0m   Run pre-remove hooks
+  [1m[36mpost-remove[0m  Run post-remove hooks
+  [1m[36mapprovals[0m    Manage command approvals
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help[0m  Print help (see more with '--help')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
+      [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_hook_show.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_show.snap
@@ -1,0 +1,53 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - hook
+    - show
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt hook show - Show configured hooks
+
+Lists user and project hooks. Project hooks show approval status (❓ = needs approval).
+
+Usage: [1m[36mwt hook show[0m [36m[OPTIONS][0m [36m[HOOK_TYPE]
+
+[1m[32mArguments:
+  [36m[HOOK_TYPE]
+          Hook type to show (default: all)
+          
+          [possible values: post-create, post-start, post-switch, pre-commit, pre-merge, post-merge, pre-remove, post-remove]
+
+[1m[32mOptions:
+      [1m[36m--expanded
+          Show expanded commands with current variables
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_list.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list.snap
@@ -1,0 +1,282 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt list - List worktrees and their status
+
+Usage: [1m[36mwt list[0m [36m[OPTIONS]
+       [1m[36mwt list[0m [36m<COMMAND>
+
+[1m[32mCommands:
+  [1m[36mstatusline[0m  Single-line status for shell prompts
+
+[1m[32mOptions:
+      [1m[36m--format[0m[36m [0m[36m<FORMAT>
+          Output format (table, json)
+          
+          [default: table]
+
+      [1m[36m--branches
+          Include branches without worktrees
+
+      [1m[36m--remotes
+          Include remote branches
+
+      [1m[36m--full
+          Include CI status and diff analysis (slower)
+
+      [1m[36m--progressive
+          Show fast info immediately, update with slow info
+          
+          Displays local data (branches, paths, status) first, then updates with remote data (CI, upstream) as it arrives. Auto-enabled for TTY.
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+Shows uncommitted changes, divergence from the default branch and remote, and optional CI status.
+
+
+The table renders progressively: branch names, paths, and commit hashes appear immediately, then status, divergence, and other columns fill in as background git operations complete. With [2m--full[0m, CI status fetches from the network — the table displays instantly and CI fills in as results arrive.
+
+[1m[32mExamples
+
+List all worktrees:
+
+  [2m$ wt list
+
+Include CI status and line diffs:
+
+  [2m$ wt list --full
+
+Include branches that don't have worktrees:
+
+  [2m$ wt list --branches --full
+
+Output as JSON for scripting:
+
+  [2m$ wt list --format=json
+
+[1m[32mColumns
+
+   Column                                Shows                               
+   ─────── ───────────────────────────────────────────────────────────────── 
+   Branch  Branch name                                                       
+   Status  Compact symbols (see below)                                       
+   HEAD±   Uncommitted changes: +added -deleted lines                        
+   main↕   Commits ahead/behind default branch                               
+   main…±  Line diffs since the merge-base with the default branch (--full)  
+   Path    Worktree directory                                                
+   Remote⇅ Commits ahead/behind tracking branch                              
+   URL     Dev server URL from project config (dimmed if port not listening) 
+   CI      Pipeline status (--full)                                          
+   Commit  Short hash (8 chars)                                              
+   Age     Time since last commit                                            
+   Message Last commit message (truncated)                                   
+
+Note: [2mmain↕[0m and [2mmain…±[0m refer to the default branch (header label stays [2mmain[0m for compactness). [2mmain…±[0m uses a merge-base (three-dot) diff.
+
+[32mCI status
+
+The CI column shows GitHub/GitLab pipeline status:
+
+   Indicator              Meaning              
+   ───────── ───────────────────────────────── 
+   ● green   All checks passed                 
+   ● blue    Checks running                    
+   ● red     Checks failed                     
+   ● yellow  Merge conflicts with base         
+   ● gray    No checks configured              
+   ⚠ yellow  Fetch error (rate limit, network) 
+   (blank)   No upstream or no PR/MR           
+
+CI indicators are clickable links to the PR or pipeline page. Any CI dot appears dimmed when there are unpushed local changes (stale status). PRs/MRs are checked first, then branch workflows/pipelines for branches with an upstream. Local-only branches show blank. Results are cached for 30-60 seconds; use [2mwt config state[0m to view or clear.
+
+[1m[32mStatus symbols
+
+The Status column has multiple subcolumns. Within each, only the first matching symbol is shown (listed in priority order):
+
+      Subcolumn     Symbol                                          Meaning                                           
+   ──────────────── ────── ────────────────────────────────────────────────────────────────────────────────────────── 
+   Working tree (1) +      Staged files                                                                               
+   Working tree (2) !      Modified files (unstaged)                                                                  
+   Working tree (3) ?      Untracked files                                                                            
+   Worktree         ✘      Merge conflicts                                                                            
+                    ⤴      Rebase in progress                                                                         
+                    ⤵      Merge in progress                                                                          
+                    /      Branch without worktree                                                                    
+                    ⚑      Branch-worktree mismatch (branch name doesn't match worktree path)                         
+                    ⊟      Prunable (directory missing)                                                               
+                    ⊞      Locked worktree                                                                            
+   Default branch   ^      Is the default branch                                                                      
+                    ∅      Orphan branch (no common ancestor with the default branch)                                 
+                    ✗      Would conflict if merged to the default branch (with --full, includes uncommitted changes) 
+                    _      Same commit as the default branch, clean                                                   
+                    –      Same commit as the default branch, uncommitted changes                                     
+                    ⊂      Content integrated into the default branch or target                                       
+                    ↕      Diverged from the default branch                                                           
+                    ↑      Ahead of the default branch                                                                
+                    ↓      Behind the default branch                                                                  
+   Remote           |      In sync with remote                                                                        
+                    ⇅      Diverged from remote                                                                       
+                    ⇡      Ahead of remote                                                                            
+                    ⇣      Behind remote                                                                              
+
+Rows are dimmed when safe to delete ([2m_[0m same commit with clean working tree or [2m⊂[0m content integrated).
+
+[2m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+
+[1m[32mJSON output
+
+Query structured data with [2m--format=json[0m:
+
+  [2m# Current worktree path (for scripts)
+  [2mwt list --format=json | jq -r '.[] | select(.is_current) | .path'
+  [2m
+  [2m# Branches with uncommitted changes
+  [2mwt list --format=json | jq '.[] | select(.working_tree.modified)'
+  [2m
+  [2m# Worktrees with merge conflicts
+  [2mwt list --format=json | jq '.[] | select(.operation_state == "conflicts")'
+  [2m
+  [2m# Branches ahead of main (needs merging)
+  [2mwt list --format=json | jq '.[] | select(.main.ahead > 0) | .branch'
+  [2m
+  [2m# Integrated branches (safe to remove)
+  [2mwt list --format=json | jq '.[] | select(.main_state == "integrated" or .main_state == "empty") | .branch'
+  [2m
+  [2m# Branches without worktrees
+  [2mwt list --format=json --branches | jq '.[] | select(.kind == "branch") | .branch'
+  [2m
+  [2m# Worktrees ahead of remote (needs pushing)
+  [2mwt list --format=json | jq '.[] | select(.remote.ahead > 0) | {branch, ahead: .remote.ahead}'
+  [2m
+  [2m# Stale CI (local changes not reflected in CI)
+  [2mwt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
+
+[1mFields:
+
+         Field           Type                                 Description                             
+   ────────────────── ─────────── ─────────────────────────────────────────────────────────────────── 
+   branch             string/null Branch name (null for detached HEAD)                                
+   path               string      Worktree path (absent for branches without worktrees)               
+   kind               string      "worktree" or "branch"                                              
+   commit             object      Commit info (see below)                                             
+   working_tree       object      Working tree state (see below)                                      
+   main_state         string      Relation to the default branch (see below)                          
+   integration_reason string      Why branch is integrated (see below)                                
+   operation_state    string      "conflicts", "rebase", or "merge" (absent when clean)               
+   main               object      Relationship to the default branch (see below, absent when is_main) 
+   remote             object      Tracking branch info (see below, absent when no tracking)           
+   worktree           object      Worktree metadata (see below)                                       
+   is_main            boolean     Is the main worktree                                                
+   is_current         boolean     Is the current worktree                                             
+   is_previous        boolean     Previous worktree from wt switch                                    
+   ci                 object      CI status (see below, absent when no CI)                            
+   url                string      Dev server URL from project config (absent when not configured)     
+   url_active         boolean     Whether the URL's port is listening (absent when not configured)    
+   statusline         string      Pre-formatted status with ANSI colors                               
+   symbols            string      Raw status symbols without colors (e.g., "!?↓")                     
+
+[32mCommit object
+
+     Field    Type          Description         
+   ───────── ────── ─────────────────────────── 
+   sha       string Full commit SHA (40 chars)  
+   short_sha string Short commit SHA (7 chars)  
+   message   string Commit message (first line) 
+   timestamp number Unix timestamp              
+
+[32mworking_tree object
+
+     Field    Type                 Description               
+   ───────── ─────── ─────────────────────────────────────── 
+   staged    boolean Has staged files                        
+   modified  boolean Has modified files (unstaged)           
+   untracked boolean Has untracked files                     
+   renamed   boolean Has renamed files                       
+   deleted   boolean Has deleted files                       
+   diff      object  Lines changed vs HEAD: {added, deleted} 
+
+[32mmain object
+
+   Field   Type                       Description                      
+   ────── ────── ───────────────────────────────────────────────────── 
+   ahead  number Commits ahead of the default branch                   
+   behind number Commits behind the default branch                     
+   diff   object Lines changed vs the default branch: {added, deleted} 
+
+[32mremote object
+
+   Field   Type          Description          
+   ────── ────── ──────────────────────────── 
+   name   string Remote name (e.g., "origin") 
+   branch string Remote branch name           
+   ahead  number Commits ahead of remote      
+   behind number Commits behind remote        
+
+[32mworktree object
+
+    Field    Type                                       Description                                      
+   ──────── ─────── ──────────────────────────────────────────────────────────────────────────────────── 
+   state    string  "no_worktree", "branch_worktree_mismatch", "prunable", "locked" (absent when normal) 
+   reason   string  Reason for locked/prunable state                                                     
+   detached boolean HEAD is detached                                                                     
+
+[32mci object
+
+   Field   Type                      Description                    
+   ────── ─────── ───────────────────────────────────────────────── 
+   status string  CI status (see below)                             
+   source string  "pr" (PR/MR) or "branch" (branch workflow)        
+   stale  boolean Local HEAD differs from remote (unpushed changes) 
+   url    string  URL to the PR/MR page                             
+
+[32mmain_state values
+
+These values describe the relation to the default branch.
+
+[2m"is_main"[0m [2m"orphan"[0m [2m"would_conflict"[0m [2m"empty"[0m [2m"same_commit"[0m [2m"integrated"[0m [2m"diverged"[0m [2m"ahead"[0m [2m"behind"
+
+[32mintegration_reason values
+
+When [2mmain_state == "integrated"[0m: [2m"ancestor"[0m [2m"trees_match"[0m [2m"no_added_changes"[0m [2m"merge_adds_nothing"
+
+[32mci.status values
+
+[2m"passed"[0m [2m"running"[0m [2m"failed"[0m [2m"conflicts"[0m [2m"no-ci"[0m [2m"error"
+
+Missing a field that would be generally useful? Open an issue at https://github.com/max-sixty/worktrunk.
+
+[1m[32mSee also
+
+- [2mwt select[0m — Interactive worktree picker with live preview

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -24,43 +24,43 @@ exit_code: 0
 ----- stderr -----
 wt list - List worktrees and their status
 
-Usage: [1m[36mwt list[0m [36m[OPTIONS]
-       [1m[36mwt list[0m [36m<COMMAND>
+Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
+       [1m[36mwt list[0m [36m<COMMAND>[0m
 
-[1m[32mCommands:
+[1m[32mCommands:[0m
   [1m[36mstatusline[0m  Single-line status for shell prompts
 
-[1m[32mOptions:
-      [1m[36m--format[0m[36m [0m[36m<FORMAT>
+[1m[32mOptions:[0m
+      [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m
           Output format (table, json)
           
           [default: table]
 
-      [1m[36m--branches
+      [1m[36m--branches[0m
           Include branches without worktrees
 
-      [1m[36m--remotes
+      [1m[36m--remotes[0m
           Include remote branches
 
-      [1m[36m--full
+      [1m[36m--full[0m
           Include CI status and diff analysis (slower)
 
-      [1m[36m--progressive
-          Show fast info immediately, update with slow info
+      [1m[36m--progressive[0m
+          Show fast info immediately, update with slow info[0m
           
-          Displays local data (branches, paths, status) first, then updates with remote data (CI, upstream) as it arrives. Auto-enabled for TTY.
+          Displays local data (branches, paths, status) first, then updates with remote data (CI, upstream) as it arrives. Auto-enabled for TTY.[0m
 
-  [1m[36m-h[0m, [1m[36m--help
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
 Shows uncommitted changes, divergence from the default branch and remote, and optional CI status.
@@ -68,25 +68,25 @@ Shows uncommitted changes, divergence from the default branch and remote, and op
 
 The table renders progressively: branch names, paths, and commit hashes appear immediately, then status, divergence, and other columns fill in as background git operations complete. With [2m--full[0m, CI status fetches from the network — the table displays instantly and CI fills in as results arrive.
 
-[1m[32mExamples
+[1m[32mExamples[0m
 
 List all worktrees:
 
-  [2m$ wt list
+  [2m$ wt list[0m
 
 Include CI status and line diffs:
 
-  [2m$ wt list --full
+  [2m$ wt list --full[0m
 
 Include branches that don't have worktrees:
 
-  [2m$ wt list --branches --full
+  [2m$ wt list --branches --full[0m
 
 Output as JSON for scripting:
 
-  [2m$ wt list --format=json
+  [2m$ wt list --format=json[0m
 
-[1m[32mColumns
+[1m[32mColumns[0m
 
    Column                                Shows                               
    ─────── ───────────────────────────────────────────────────────────────── 
@@ -105,7 +105,7 @@ Output as JSON for scripting:
 
 Note: [2mmain↕[0m and [2mmain…±[0m refer to the default branch (header label stays [2mmain[0m for compactness). [2mmain…±[0m uses a merge-base (three-dot) diff.
 
-[32mCI status
+[32mCI status[0m
 
 The CI column shows GitHub/GitLab pipeline status:
 
@@ -121,7 +121,7 @@ The CI column shows GitHub/GitLab pipeline status:
 
 CI indicators are clickable links to the PR or pipeline page. Any CI dot appears dimmed when there are unpushed local changes (stale status). PRs/MRs are checked first, then branch workflows/pipelines for branches with an upstream. Local-only branches show blank. Results are cached for 30-60 seconds; use [2mwt config state[0m to view or clear.
 
-[1m[32mStatus symbols
+[1m[32mStatus symbols[0m
 
 The Status column has multiple subcolumns. Within each, only the first matching symbol is shown (listed in priority order):
 
@@ -153,37 +153,37 @@ The Status column has multiple subcolumns. Within each, only the first matching 
 
 Rows are dimmed when safe to delete ([2m_[0m same commit with clean working tree or [2m⊂[0m content integrated).
 
-[2m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
+[2m────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────[0m
 
-[1m[32mJSON output
+[1m[32mJSON output[0m
 
 Query structured data with [2m--format=json[0m:
 
-  [2m# Current worktree path (for scripts)
-  [2mwt list --format=json | jq -r '.[] | select(.is_current) | .path'
-  [2m
-  [2m# Branches with uncommitted changes
-  [2mwt list --format=json | jq '.[] | select(.working_tree.modified)'
-  [2m
-  [2m# Worktrees with merge conflicts
-  [2mwt list --format=json | jq '.[] | select(.operation_state == "conflicts")'
-  [2m
-  [2m# Branches ahead of main (needs merging)
-  [2mwt list --format=json | jq '.[] | select(.main.ahead > 0) | .branch'
-  [2m
-  [2m# Integrated branches (safe to remove)
-  [2mwt list --format=json | jq '.[] | select(.main_state == "integrated" or .main_state == "empty") | .branch'
-  [2m
-  [2m# Branches without worktrees
-  [2mwt list --format=json --branches | jq '.[] | select(.kind == "branch") | .branch'
-  [2m
-  [2m# Worktrees ahead of remote (needs pushing)
-  [2mwt list --format=json | jq '.[] | select(.remote.ahead > 0) | {branch, ahead: .remote.ahead}'
-  [2m
-  [2m# Stale CI (local changes not reflected in CI)
-  [2mwt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
+  [2m# Current worktree path (for scripts)[0m
+  [2mwt list --format=json | jq -r '.[] | select(.is_current) | .path'[0m
+  [2m[0m
+  [2m# Branches with uncommitted changes[0m
+  [2mwt list --format=json | jq '.[] | select(.working_tree.modified)'[0m
+  [2m[0m
+  [2m# Worktrees with merge conflicts[0m
+  [2mwt list --format=json | jq '.[] | select(.operation_state == "conflicts")'[0m
+  [2m[0m
+  [2m# Branches ahead of main (needs merging)[0m
+  [2mwt list --format=json | jq '.[] | select(.main.ahead > 0) | .branch'[0m
+  [2m[0m
+  [2m# Integrated branches (safe to remove)[0m
+  [2mwt list --format=json | jq '.[] | select(.main_state == "integrated" or .main_state == "empty") | .branch'[0m
+  [2m[0m
+  [2m# Branches without worktrees[0m
+  [2mwt list --format=json --branches | jq '.[] | select(.kind == "branch") | .branch'[0m
+  [2m[0m
+  [2m# Worktrees ahead of remote (needs pushing)[0m
+  [2mwt list --format=json | jq '.[] | select(.remote.ahead > 0) | {branch, ahead: .remote.ahead}'[0m
+  [2m[0m
+  [2m# Stale CI (local changes not reflected in CI)[0m
+  [2mwt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'[0m
 
-[1mFields:
+[1mFields:[0m
 
          Field           Type                                 Description                             
    ────────────────── ─────────── ─────────────────────────────────────────────────────────────────── 
@@ -207,7 +207,7 @@ Query structured data with [2m--format=json[0m:
    statusline         string      Pre-formatted status with ANSI colors                               
    symbols            string      Raw status symbols without colors (e.g., "!?↓")                     
 
-[32mCommit object
+[32mCommit object[0m
 
      Field    Type          Description         
    ───────── ────── ─────────────────────────── 
@@ -216,7 +216,7 @@ Query structured data with [2m--format=json[0m:
    message   string Commit message (first line) 
    timestamp number Unix timestamp              
 
-[32mworking_tree object
+[32mworking_tree object[0m
 
      Field    Type                 Description               
    ───────── ─────── ─────────────────────────────────────── 
@@ -227,7 +227,7 @@ Query structured data with [2m--format=json[0m:
    deleted   boolean Has deleted files                       
    diff      object  Lines changed vs HEAD: {added, deleted} 
 
-[32mmain object
+[32mmain object[0m
 
    Field   Type                       Description                      
    ────── ────── ───────────────────────────────────────────────────── 
@@ -235,7 +235,7 @@ Query structured data with [2m--format=json[0m:
    behind number Commits behind the default branch                     
    diff   object Lines changed vs the default branch: {added, deleted} 
 
-[32mremote object
+[32mremote object[0m
 
    Field   Type          Description          
    ────── ────── ──────────────────────────── 
@@ -244,7 +244,7 @@ Query structured data with [2m--format=json[0m:
    ahead  number Commits ahead of remote      
    behind number Commits behind remote        
 
-[32mworktree object
+[32mworktree object[0m
 
     Field    Type                                       Description                                      
    ──────── ─────── ──────────────────────────────────────────────────────────────────────────────────── 
@@ -252,7 +252,7 @@ Query structured data with [2m--format=json[0m:
    reason   string  Reason for locked/prunable state                                                     
    detached boolean HEAD is detached                                                                     
 
-[32mci object
+[32mci object[0m
 
    Field   Type                      Description                    
    ────── ─────── ───────────────────────────────────────────────── 
@@ -261,22 +261,22 @@ Query structured data with [2m--format=json[0m:
    stale  boolean Local HEAD differs from remote (unpushed changes) 
    url    string  URL to the PR/MR page                             
 
-[32mmain_state values
+[32mmain_state values[0m
 
 These values describe the relation to the default branch.
 
-[2m"is_main"[0m [2m"orphan"[0m [2m"would_conflict"[0m [2m"empty"[0m [2m"same_commit"[0m [2m"integrated"[0m [2m"diverged"[0m [2m"ahead"[0m [2m"behind"
+[2m"is_main"[0m [2m"orphan"[0m [2m"would_conflict"[0m [2m"empty"[0m [2m"same_commit"[0m [2m"integrated"[0m [2m"diverged"[0m [2m"ahead"[0m [2m"behind"[0m
 
-[32mintegration_reason values
+[32mintegration_reason values[0m
 
-When [2mmain_state == "integrated"[0m: [2m"ancestor"[0m [2m"trees_match"[0m [2m"no_added_changes"[0m [2m"merge_adds_nothing"
+When [2mmain_state == "integrated"[0m: [2m"ancestor"[0m [2m"trees_match"[0m [2m"no_added_changes"[0m [2m"merge_adds_nothing"[0m
 
-[32mci.status values
+[32mci.status values[0m
 
-[2m"passed"[0m [2m"running"[0m [2m"failed"[0m [2m"conflicts"[0m [2m"no-ci"[0m [2m"error"
+[2m"passed"[0m [2m"running"[0m [2m"failed"[0m [2m"conflicts"[0m [2m"no-ci"[0m [2m"error"[0m
 
 Missing a field that would be generally useful? Open an issue at https://github.com/max-sixty/worktrunk.
 
-[1m[32mSee also
+[1m[32mSee also[0m
 
 - [2mwt select[0m — Interactive worktree picker with live preview

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -24,44 +24,44 @@ exit_code: 0
 ----- stderr -----
 wt list - List worktrees and their status
 
-Usage: [1m[36mwt list[0m [36m[OPTIONS]
-       [1m[36mwt list[0m [36m<COMMAND>
+Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
+       [1m[36mwt list[0m [36m<COMMAND>[0m
 
-[1m[32mCommands:
+[1m[32mCommands:[0m
   [1m[36mstatusline[0m  Single-line status for shell prompts
 
-[1m[32mOptions:
-      [1m[36m--format[0m[36m [0m[36m<FORMAT>
+[1m[32mOptions:[0m
+      [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m
           Output format (table, json)
           
           [default: table]
 
-      [1m[36m--branches
+      [1m[36m--branches[0m
           Include branches without worktrees
 
-      [1m[36m--remotes
+      [1m[36m--remotes[0m
           Include remote branches
 
-      [1m[36m--full
+      [1m[36m--full[0m
           Include CI status and diff analysis (slower)
 
-      [1m[36m--progressive
-          Show fast info immediately, update with slow info
+      [1m[36m--progressive[0m
+          Show fast info immediately, update with slow info[0m
           
           Displays local data (branches, paths, status) first, then updates with
-           remote data (CI, upstream) as it arrives. Auto-enabled for TTY.
+           remote data (CI, upstream) as it arrives. Auto-enabled for TTY.[0m
 
-  [1m[36m-h[0m, [1m[36m--help
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
 Shows uncommitted changes, divergence from the default branch and remote, and 
@@ -73,25 +73,25 @@ immediately, then status, divergence, and other columns fill in as background
 git operations complete. With [2m--full[0m, CI status fetches from the network — the 
 table displays instantly and CI fills in as results arrive.
 
-[1m[32mExamples
+[1m[32mExamples[0m
 
 List all worktrees:
 
-  [2m$ wt list
+  [2m$ wt list[0m
 
 Include CI status and line diffs:
 
-  [2m$ wt list --full
+  [2m$ wt list --full[0m
 
 Include branches that don't have worktrees:
 
-  [2m$ wt list --branches --full
+  [2m$ wt list --branches --full[0m
 
 Output as JSON for scripting:
 
-  [2m$ wt list --format=json
+  [2m$ wt list --format=json[0m
 
-[1m[32mColumns
+[1m[32mColumns[0m
 
    Column                                Shows                               
    ─────── ───────────────────────────────────────────────────────────────── 
@@ -111,7 +111,7 @@ Output as JSON for scripting:
 Note: [2mmain↕[0m and [2mmain…±[0m refer to the default branch (header label stays [2mmain[0m for 
 compactness). [2mmain…±[0m uses a merge-base (three-dot) diff.
 
-[32mCI status
+[32mCI status[0m
 
 The CI column shows GitHub/GitLab pipeline status:
 
@@ -131,7 +131,7 @@ checked first, then branch workflows/pipelines for branches with an upstream.
 Local-only branches show blank. Results are cached for 30-60 seconds; use [2mwt 
 [2mconfig state[0m to view or clear.
 
-[1m[32mStatus symbols
+[1m[32mStatus symbols[0m
 
 The Status column has multiple subcolumns. Within each, only the first matching 
 symbol is shown (listed in priority order):
@@ -169,37 +169,37 @@ symbol is shown (listed in priority order):
 Rows are dimmed when safe to delete ([2m_[0m same commit with clean working tree or [2m⊂[0m 
 content integrated).
 
-[2m────────────────────────────────────────────────────────────────────────────────
+[2m────────────────────────────────────────────────────────────────────────────────[0m
 
-[1m[32mJSON output
+[1m[32mJSON output[0m
 
 Query structured data with [2m--format=json[0m:
 
-  [2m# Current worktree path (for scripts)
-  [2mwt list --format=json | jq -r '.[] | select(.is_current) | .path'
-  [2m
-  [2m# Branches with uncommitted changes
-  [2mwt list --format=json | jq '.[] | select(.working_tree.modified)'
-  [2m
-  [2m# Worktrees with merge conflicts
-  [2mwt list --format=json | jq '.[] | select(.operation_state == "conflicts")'
-  [2m
-  [2m# Branches ahead of main (needs merging)
-  [2mwt list --format=json | jq '.[] | select(.main.ahead > 0) | .branch'
-  [2m
-  [2m# Integrated branches (safe to remove)
-  [2mwt list --format=json | jq '.[] | select(.main_state == "integrated" or .main_state == "empty") | .branch'
-  [2m
-  [2m# Branches without worktrees
-  [2mwt list --format=json --branches | jq '.[] | select(.kind == "branch") | .branch'
-  [2m
-  [2m# Worktrees ahead of remote (needs pushing)
-  [2mwt list --format=json | jq '.[] | select(.remote.ahead > 0) | {branch, ahead: .remote.ahead}'
-  [2m
-  [2m# Stale CI (local changes not reflected in CI)
-  [2mwt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
+  [2m# Current worktree path (for scripts)[0m
+  [2mwt list --format=json | jq -r '.[] | select(.is_current) | .path'[0m
+  [2m[0m
+  [2m# Branches with uncommitted changes[0m
+  [2mwt list --format=json | jq '.[] | select(.working_tree.modified)'[0m
+  [2m[0m
+  [2m# Worktrees with merge conflicts[0m
+  [2mwt list --format=json | jq '.[] | select(.operation_state == "conflicts")'[0m
+  [2m[0m
+  [2m# Branches ahead of main (needs merging)[0m
+  [2mwt list --format=json | jq '.[] | select(.main.ahead > 0) | .branch'[0m
+  [2m[0m
+  [2m# Integrated branches (safe to remove)[0m
+  [2mwt list --format=json | jq '.[] | select(.main_state == "integrated" or .main_state == "empty") | .branch'[0m
+  [2m[0m
+  [2m# Branches without worktrees[0m
+  [2mwt list --format=json --branches | jq '.[] | select(.kind == "branch") | .branch'[0m
+  [2m[0m
+  [2m# Worktrees ahead of remote (needs pushing)[0m
+  [2mwt list --format=json | jq '.[] | select(.remote.ahead > 0) | {branch, ahead: .remote.ahead}'[0m
+  [2m[0m
+  [2m# Stale CI (local changes not reflected in CI)[0m
+  [2mwt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'[0m
 
-[1mFields:
+[1mFields:[0m
 
          Field           Type                      Description                  
    ────────────────── ─────────── ───────────────────────────────────────────── 
@@ -230,7 +230,7 @@ Query structured data with [2m--format=json[0m:
    symbols            string      Raw status symbols without colors (e.g.,      
                                   "!?↓")                                        
 
-[32mCommit object
+[32mCommit object[0m
 
      Field    Type          Description         
    ───────── ────── ─────────────────────────── 
@@ -239,7 +239,7 @@ Query structured data with [2m--format=json[0m:
    message   string Commit message (first line) 
    timestamp number Unix timestamp              
 
-[32mworking_tree object
+[32mworking_tree object[0m
 
      Field    Type                 Description               
    ───────── ─────── ─────────────────────────────────────── 
@@ -250,7 +250,7 @@ Query structured data with [2m--format=json[0m:
    deleted   boolean Has deleted files                       
    diff      object  Lines changed vs HEAD: {added, deleted} 
 
-[32mmain object
+[32mmain object[0m
 
    Field   Type                       Description                      
    ────── ────── ───────────────────────────────────────────────────── 
@@ -258,7 +258,7 @@ Query structured data with [2m--format=json[0m:
    behind number Commits behind the default branch                     
    diff   object Lines changed vs the default branch: {added, deleted} 
 
-[32mremote object
+[32mremote object[0m
 
    Field   Type          Description          
    ────── ────── ──────────────────────────── 
@@ -267,7 +267,7 @@ Query structured data with [2m--format=json[0m:
    ahead  number Commits ahead of remote      
    behind number Commits behind remote        
 
-[32mworktree object
+[32mworktree object[0m
 
     Field    Type                           Description                         
    ──────── ─────── ─────────────────────────────────────────────────────────── 
@@ -276,7 +276,7 @@ Query structured data with [2m--format=json[0m:
    reason   string  Reason for locked/prunable state                            
    detached boolean HEAD is detached                                            
 
-[32mci object
+[32mci object[0m
 
    Field   Type                      Description                    
    ────── ─────── ───────────────────────────────────────────────── 
@@ -285,25 +285,25 @@ Query structured data with [2m--format=json[0m:
    stale  boolean Local HEAD differs from remote (unpushed changes) 
    url    string  URL to the PR/MR page                             
 
-[32mmain_state values
+[32mmain_state values[0m
 
 These values describe the relation to the default branch.
 
 [2m"is_main"[0m [2m"orphan"[0m [2m"would_conflict"[0m [2m"empty"[0m [2m"same_commit"[0m [2m"integrated"[0m 
-[2m"diverged"[0m [2m"ahead"[0m [2m"behind"
+[2m"diverged"[0m [2m"ahead"[0m [2m"behind"[0m
 
-[32mintegration_reason values
+[32mintegration_reason values[0m
 
 When [2mmain_state == "integrated"[0m: [2m"ancestor"[0m [2m"trees_match"[0m [2m"no_added_changes"[0m 
-[2m"merge_adds_nothing"
+[2m"merge_adds_nothing"[0m
 
-[32mci.status values
+[32mci.status values[0m
 
-[2m"passed"[0m [2m"running"[0m [2m"failed"[0m [2m"conflicts"[0m [2m"no-ci"[0m [2m"error"
+[2m"passed"[0m [2m"running"[0m [2m"failed"[0m [2m"conflicts"[0m [2m"no-ci"[0m [2m"error"[0m
 
 Missing a field that would be generally useful? Open an issue at 
 https://github.com/max-sixty/worktrunk.
 
-[1m[32mSee also
+[1m[32mSee also[0m
 
 - [2mwt select[0m — Interactive worktree picker with live preview

--- a/tests/snapshots/integration__integration_tests__help__help_list_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_short.snap
@@ -24,13 +24,13 @@ exit_code: 0
 ----- stderr -----
 wt list - List worktrees and their status
 
-Usage: [1m[36mwt list[0m [36m[OPTIONS]
-       [1m[36mwt list[0m [36m<COMMAND>
+Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
+       [1m[36mwt list[0m [36m<COMMAND>[0m
 
-[1m[32mCommands:
+[1m[32mCommands:[0m
   [1m[36mstatusline[0m  Single-line status for shell prompts
 
-[1m[32mOptions:
+[1m[32mOptions:[0m
       [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m  Output format (table, json) [default: table]
       [1m[36m--branches[0m         Include branches without worktrees
       [1m[36m--remotes[0m          Include remote branches
@@ -38,7 +38,7 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS]
       [1m[36m--progressive[0m      Show fast info immediately, update with slow info
   [1m[36m-h[0m, [1m[36m--help[0m             Print help (see more with '--help')
 
-[1m[32mGlobal Options:
+[1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_list_statusline.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_statusline.snap
@@ -1,0 +1,51 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - list
+    - statusline
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt list statusline - Single-line status for shell prompts
+
+For shell prompts, starship, or editor integrations.
+
+Usage: [1m[36mwt list statusline[0m [36m[OPTIONS]
+
+[1m[32mOptions:
+      [1m[36m--claude-code
+          Claude Code mode: read context from stdin, add directory and model
+          
+          Reads JSON from stdin with [1m.workspace.current_dir[0m and [1m.model.display_name[0m. Output: [1mdir  branch  status  ±working  commits  upstream  ci  | model[0m
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+Format: [2mbranch  status  ±working  commits  upstream  ci

--- a/tests/snapshots/integration__integration_tests__help__help_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge.snap
@@ -1,0 +1,132 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - merge
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt merge - Merge current branch into target
+
+Squash & rebase, fast-forward target, remove the worktree.
+
+Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET]
+
+[1m[32mArguments:
+  [36m[TARGET]
+          Target branch
+          
+          Defaults to default branch.
+
+[1m[32mOptions:
+      [1m[36m--no-squash
+          Skip commit squashing
+
+      [1m[36m--no-commit
+          Skip commit and squash
+
+      [1m[36m--no-rebase
+          Skip rebase (fail if not already rebased)
+
+      [1m[36m--no-remove
+          Keep worktree after merge
+
+      [1m[36m--no-verify
+          Skip hooks
+
+  [1m[36m-y[0m, [1m[36m--yes
+          Skip approval prompts
+
+      [1m[36m--stage[0m[36m [0m[36m<STAGE>
+          What to stage before committing [default: all]
+
+          Possible values:
+          - [1m[36mall[0m:     Stage everything: untracked files + unstaged tracked changes
+          - [1m[36mtracked[0m: Stage tracked changes only (like [1mgit add -u[0m)
+          - [1m[36mnone[0m:    Stage nothing, commit only what's already in the index
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+Unlike [2mgit merge[0m, this merges current into target (not target into current). Similar to clicking "Merge pull request" on GitHub, but locally. Target defaults to the default branch.
+
+
+[1m[32mExamples
+
+Merge to the default branch:
+
+  [2mwt merge
+
+Merge to a different branch:
+
+  [2mwt merge develop
+
+Keep the worktree after merging:
+
+  [2mwt merge --no-remove
+
+Preserve commit history (no squash):
+
+  [2mwt merge --no-squash
+
+Skip committing/squashing (rebase still runs unless --no-rebase):
+
+  [2mwt merge --no-commit
+
+[1m[32mPipeline
+
+[2mwt merge[0m runs these steps:
+
+1. [1mSquash[0m — Stages uncommitted changes, then combines all commits since target into one (like GitHub's "Squash and merge"). Use [2m--stage[0m to control what gets staged: [2mall[0m (default), [2mtracked[0m, or [2mnone[0m. A backup ref is saved to [2mrefs/wt-backup/<branch>[0m. With [2m--no-squash[0m, uncommitted changes become a separate commit and individual commits are preserved.
+2. [1mRebase[0m — Rebases onto target if behind. Skipped if already up-to-date. Conflicts abort immediately.
+3. [1mPre-merge hooks[0m — Hooks run after rebase, before merge. Failures abort. See [2mwt hook[0m.
+4. [1mMerge[0m — Fast-forward merge to the target branch. Non-fast-forward merges are rejected.
+5. [1mPre-remove hooks[0m — Hooks run before removing worktree. Failures abort.
+6. [1mCleanup[0m — Removes the worktree and branch. Use [2m--no-remove[0m to keep the worktree. When already on the target branch or in the main worktree, the worktree is preserved.
+7. [1mPost-merge hooks[0m — Hooks run after cleanup. Failures are logged but don't abort.
+
+Use [2m--no-commit[0m to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless [2m--no-rebase[0m is passed. Useful after preparing commits manually with [2mwt step[0m. Requires a clean working tree.
+
+[1m[32mLocal CI
+
+For personal projects, pre-merge hooks open up the possibility of a workflow with much faster iteration — an order of magnitude more small changes instead of fewer large ones.
+
+Historically, ensuring tests ran before merging was difficult to enforce locally. Remote CI was valuable for the process as much as the checks: it guaranteed validation happened. [2mwt merge[0m brings that guarantee local.
+
+The full workflow: start an agent (one of many) on a task, work elsewhere, return when it's ready. Review the diff, run [2mwt merge[0m, move on. Pre-merge hooks validate before merging — if they pass, the branch goes to the default branch and the worktree cleans up.
+
+  [2m[pre-merge]
+  [2mtest = "cargo test"
+  [2mlint = "cargo clippy"
+
+[1m[32mSee also
+
+- [2mwt step[0m — Run individual operations (commit, squash, rebase, push)
+- [2mwt remove[0m — Remove worktrees without merging
+- [2mwt switch[0m — Navigate to other worktrees

--- a/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
@@ -22,38 +22,38 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-wt merge - Merge current branch into target
+wt merge - Merge current branch into target[0m
 
-Squash & rebase, fast-forward target, remove the worktree.
+Squash & rebase, fast-forward target, remove the worktree.[0m
 
-Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET]
+Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET][0m
 
-[1m[32mArguments:
-  [36m[TARGET]
-          Target branch
+[1m[32mArguments:[0m
+  [36m[TARGET][0m
+          Target branch[0m
           
-          Defaults to default branch.
+          Defaults to default branch.[0m
 
-[1m[32mOptions:
-      [1m[36m--no-squash
+[1m[32mOptions:[0m
+      [1m[36m--no-squash[0m
           Skip commit squashing
 
-      [1m[36m--no-commit
+      [1m[36m--no-commit[0m
           Skip commit and squash
 
-      [1m[36m--no-rebase
+      [1m[36m--no-rebase[0m
           Skip rebase (fail if not already rebased)
 
-      [1m[36m--no-remove
+      [1m[36m--no-remove[0m
           Keep worktree after merge
 
-      [1m[36m--no-verify
+      [1m[36m--no-verify[0m
           Skip hooks
 
-  [1m[36m-y[0m, [1m[36m--yes
+  [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts
 
-      [1m[36m--stage[0m[36m [0m[36m<STAGE>
+      [1m[36m--stage[0m[36m [0m[36m<STAGE>[0m
           What to stage before committing [default: all]
 
           Possible values:
@@ -61,45 +61,45 @@ Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET]
           - [1m[36mtracked[0m: Stage tracked changes only (like [1mgit add -u[0m)
           - [1m[36mnone[0m:    Stage nothing, commit only what's already in the index
 
-  [1m[36m-h[0m, [1m[36m--help
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
 Unlike [2mgit merge[0m, this merges current into target (not target into current). Similar to clicking "Merge pull request" on GitHub, but locally. Target defaults to the default branch.
 
 
-[1m[32mExamples
+[1m[32mExamples[0m
 
 Merge to the default branch:
 
-  [2mwt merge
+  [2mwt merge[0m
 
 Merge to a different branch:
 
-  [2mwt merge develop
+  [2mwt merge develop[0m
 
 Keep the worktree after merging:
 
-  [2mwt merge --no-remove
+  [2mwt merge --no-remove[0m
 
 Preserve commit history (no squash):
 
-  [2mwt merge --no-squash
+  [2mwt merge --no-squash[0m
 
 Skip committing/squashing (rebase still runs unless --no-rebase):
 
-  [2mwt merge --no-commit
+  [2mwt merge --no-commit[0m
 
-[1m[32mPipeline
+[1m[32mPipeline[0m
 
 [2mwt merge[0m runs these steps:
 
@@ -113,7 +113,7 @@ Skip committing/squashing (rebase still runs unless --no-rebase):
 
 Use [2m--no-commit[0m to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless [2m--no-rebase[0m is passed. Useful after preparing commits manually with [2mwt step[0m. Requires a clean working tree.
 
-[1m[32mLocal CI
+[1m[32mLocal CI[0m
 
 For personal projects, pre-merge hooks open up the possibility of a workflow with much faster iteration — an order of magnitude more small changes instead of fewer large ones.
 
@@ -121,11 +121,11 @@ Historically, ensuring tests ran before merging was difficult to enforce locally
 
 The full workflow: start an agent (one of many) on a task, work elsewhere, return when it's ready. Review the diff, run [2mwt merge[0m, move on. Pre-merge hooks validate before merging — if they pass, the branch goes to the default branch and the worktree cleans up.
 
-  [2m[pre-merge]
-  [2mtest = "cargo test"
-  [2mlint = "cargo clippy"
+  [2m[pre-merge][0m
+  [2mtest = "cargo test"[0m
+  [2mlint = "cargo clippy"[0m
 
-[1m[32mSee also
+[1m[32mSee also[0m
 
 - [2mwt step[0m — Run individual operations (commit, squash, rebase, push)
 - [2mwt remove[0m — Remove worktrees without merging

--- a/tests/snapshots/integration__integration_tests__help__help_merge_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_short.snap
@@ -24,12 +24,12 @@ exit_code: 0
 ----- stderr -----
 wt merge - Merge current branch into target
 
-Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET]
+Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET][0m
 
-[1m[32mArguments:
+[1m[32mArguments:[0m
   [36m[TARGET][0m  Target branch
 
-[1m[32mOptions:
+[1m[32mOptions:[0m
       [1m[36m--no-squash[0m      Skip commit squashing
       [1m[36m--no-commit[0m      Skip commit and squash
       [1m[36m--no-rebase[0m      Skip rebase (fail if not already rebased)
@@ -39,7 +39,7 @@ Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET]
       [1m[36m--stage[0m[36m [0m[36m<STAGE>[0m  What to stage before committing [default: all] [possible values: all, tracked, none]
   [1m[36m-h[0m, [1m[36m--help[0m           Print help (see more with '--help')
 
-[1m[32mGlobal Options:
+[1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_no_args.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_no_args.snap
@@ -22,9 +22,9 @@ exit_code: 0
 ----- stderr -----
 wt - Git worktree management for parallel AI agent workflows
 
-Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND]
+Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 
-[1m[32mCommands:
+[1m[32mCommands:[0m
   [1m[36mswitch[0m  Switch to a worktree
   [1m[36mlist[0m    List worktrees and their status
   [1m[36mremove[0m  Remove worktree; delete branch if merged
@@ -34,11 +34,11 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND]
   [1m[36mhook[0m    Run configured hooks
   [1m[36mconfig[0m  Manage user & project configs
 
-[1m[32mOptions:
+[1m[32mOptions:[0m
   [1m[36m-h[0m, [1m[36m--help[0m     Print help (see more with '--help')
   [1m[36m-V[0m, [1m[36m--version[0m  Print version
 
-[1m[32mGlobal Options:
+[1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_remove.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove.snap
@@ -1,0 +1,126 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - remove
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt remove - Remove worktree; delete branch if merged
+
+For finished feature branches. Removes the current worktree by default.
+
+Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...
+
+[1m[32mArguments:
+  [36m[BRANCHES]...
+          Branch name [default: current]
+
+[1m[32mOptions:
+      [1m[36m--no-delete-branch
+          Keep branch after removal
+
+  [1m[36m-D[0m, [1m[36m--force-delete
+          Delete unmerged branches
+
+      [1m[36m--foreground
+          Run removal in foreground (block until complete)
+
+      [1m[36m--no-verify
+          Skip hooks
+
+  [1m[36m-y[0m, [1m[36m--yes
+          Skip approval prompts
+
+  [1m[36m-f[0m, [1m[36m--force
+          Force worktree removal
+          
+          Remove worktrees even if they contain untracked files (like build artifacts). Without this flag, removal fails if untracked files exist.
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+[1m[32mExamples
+
+Remove current worktree:
+
+  [2mwt remove
+
+Remove specific worktrees:
+
+  [2mwt remove feature-branch
+  [2mwt remove old-feature another-branch
+
+Keep the branch:
+
+  [2mwt remove --no-delete-branch feature-branch
+
+Force-delete an unmerged branch:
+
+  [2mwt remove -D experimental
+
+[1m[32mBranch cleanup
+
+By default, branches are deleted when merging them would add nothing. This works with squash-merge and rebase workflows where commit history differs but file changes match.
+
+Worktrunk checks five conditions (in order of cost):
+
+1. [1mSame commit[0m — Branch HEAD equals the default branch. Shows [2m_[0m in [2mwt list[0m.
+2. [1mAncestor[0m — Branch is in target's history (fast-forward or rebase case). Shows [2m⊂[0m.
+3. [1mNo added changes[0m — Three-dot diff ([2mtarget...branch[0m) is empty. Shows [2m⊂[0m.
+4. [1mTrees match[0m — Branch tree SHA equals target tree SHA. Shows [2m⊂[0m.
+5. [1mMerge adds nothing[0m — Simulated merge produces the same tree as target. Handles squash-merged branches where target has advanced. Shows [2m⊂[0m.
+
+The 'same commit' check uses the local default branch; for other checks, 'target' means the default branch, or its upstream (e.g., [2morigin/main[0m) when strictly ahead.
+
+Branches showing [2m_[0m or [2m⊂[0m are dimmed as safe to delete.
+
+[1m[32mForce flags
+
+Worktrunk has two force flags for different situations:
+
+          Flag          Scope                          When to use                         
+   ─────────────────── ──────── ────────────────────────────────────────────────────────── 
+   --force (-f)        Worktree Worktree has untracked files (build artifacts, IDE config) 
+   --force-delete (-D) Branch   Branch has unmerged commits                                
+
+  [2mwt remove feature --force       # Remove worktree with untracked files
+  [2mwt remove feature -D            # Delete unmerged branch
+  [2mwt remove feature --force -D    # Both
+
+Without [2m--force[0m, removal fails if the worktree contains untracked files. Without [2m-D[0m, removal keeps branches with unmerged changes. Use [2m--no-delete-branch[0m to keep the branch regardless of merge status.
+
+[1m[32mBackground removal
+
+Removal runs in the background by default (returns immediately). Logs are written to [2m.git/wt-logs/{branch}-remove.log[0m. Use [2m--foreground[0m to run in the foreground.
+
+[1m[32mSee also
+
+- [2mwt merge[0m — Remove worktree after merging
+- [2mwt list[0m — View all worktrees

--- a/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
@@ -22,70 +22,70 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-wt remove - Remove worktree; delete branch if merged
+wt remove - Remove worktree; delete branch if merged[0m
 
-For finished feature branches. Removes the current worktree by default.
+For finished feature branches. Removes the current worktree by default.[0m
 
-Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...
+Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...[0m
 
-[1m[32mArguments:
-  [36m[BRANCHES]...
+[1m[32mArguments:[0m
+  [36m[BRANCHES]...[0m
           Branch name [default: current]
 
-[1m[32mOptions:
-      [1m[36m--no-delete-branch
+[1m[32mOptions:[0m
+      [1m[36m--no-delete-branch[0m
           Keep branch after removal
 
-  [1m[36m-D[0m, [1m[36m--force-delete
+  [1m[36m-D[0m, [1m[36m--force-delete[0m
           Delete unmerged branches
 
-      [1m[36m--foreground
+      [1m[36m--foreground[0m
           Run removal in foreground (block until complete)
 
-      [1m[36m--no-verify
+      [1m[36m--no-verify[0m
           Skip hooks
 
-  [1m[36m-y[0m, [1m[36m--yes
+  [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts
 
-  [1m[36m-f[0m, [1m[36m--force
-          Force worktree removal
+  [1m[36m-f[0m, [1m[36m--force[0m
+          Force worktree removal[0m
           
-          Remove worktrees even if they contain untracked files (like build artifacts). Without this flag, removal fails if untracked files exist.
+          Remove worktrees even if they contain untracked files (like build artifacts). Without this flag, removal fails if untracked files exist.[0m
 
-  [1m[36m-h[0m, [1m[36m--help
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
-[1m[32mExamples
+[1m[32mExamples[0m
 
 Remove current worktree:
 
-  [2mwt remove
+  [2mwt remove[0m
 
 Remove specific worktrees:
 
-  [2mwt remove feature-branch
-  [2mwt remove old-feature another-branch
+  [2mwt remove feature-branch[0m
+  [2mwt remove old-feature another-branch[0m
 
 Keep the branch:
 
-  [2mwt remove --no-delete-branch feature-branch
+  [2mwt remove --no-delete-branch feature-branch[0m
 
 Force-delete an unmerged branch:
 
-  [2mwt remove -D experimental
+  [2mwt remove -D experimental[0m
 
-[1m[32mBranch cleanup
+[1m[32mBranch cleanup[0m
 
 By default, branches are deleted when merging them would add nothing. This works with squash-merge and rebase workflows where commit history differs but file changes match.
 
@@ -101,7 +101,7 @@ The 'same commit' check uses the local default branch; for other checks, 'target
 
 Branches showing [2m_[0m or [2m⊂[0m are dimmed as safe to delete.
 
-[1m[32mForce flags
+[1m[32mForce flags[0m
 
 Worktrunk has two force flags for different situations:
 
@@ -110,17 +110,17 @@ Worktrunk has two force flags for different situations:
    --force (-f)        Worktree Worktree has untracked files (build artifacts, IDE config) 
    --force-delete (-D) Branch   Branch has unmerged commits                                
 
-  [2mwt remove feature --force       # Remove worktree with untracked files
-  [2mwt remove feature -D            # Delete unmerged branch
-  [2mwt remove feature --force -D    # Both
+  [2mwt remove feature --force       # Remove worktree with untracked files[0m
+  [2mwt remove feature -D            # Delete unmerged branch[0m
+  [2mwt remove feature --force -D    # Both[0m
 
 Without [2m--force[0m, removal fails if the worktree contains untracked files. Without [2m-D[0m, removal keeps branches with unmerged changes. Use [2m--no-delete-branch[0m to keep the branch regardless of merge status.
 
-[1m[32mBackground removal
+[1m[32mBackground removal[0m
 
 Removal runs in the background by default (returns immediately). Logs are written to [2m.git/wt-logs/{branch}-remove.log[0m. Use [2m--foreground[0m to run in the foreground.
 
-[1m[32mSee also
+[1m[32mSee also[0m
 
 - [2mwt merge[0m — Remove worktree after merging
 - [2mwt list[0m — View all worktrees

--- a/tests/snapshots/integration__integration_tests__help__help_remove_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_short.snap
@@ -24,12 +24,12 @@ exit_code: 0
 ----- stderr -----
 wt remove - Remove worktree; delete branch if merged
 
-Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...
+Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...[0m
 
-[1m[32mArguments:
+[1m[32mArguments:[0m
   [36m[BRANCHES]...[0m  Branch name [default: current]
 
-[1m[32mOptions:
+[1m[32mOptions:[0m
       [1m[36m--no-delete-branch[0m  Keep branch after removal
   [1m[36m-D[0m, [1m[36m--force-delete[0m      Delete unmerged branches
       [1m[36m--foreground[0m        Run removal in foreground (block until complete)
@@ -38,7 +38,7 @@ Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...
   [1m[36m-f[0m, [1m[36m--force[0m             Force worktree removal
   [1m[36m-h[0m, [1m[36m--help[0m              Print help (see more with '--help')
 
-[1m[32mGlobal Options:
+[1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_root.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root.snap
@@ -1,0 +1,66 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt - Git worktree management for parallel AI agent workflows
+
+Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND]
+
+[1m[32mCommands:
+  [1m[36mswitch[0m  Switch to a worktree
+  [1m[36mlist[0m    List worktrees and their status
+  [1m[36mremove[0m  Remove worktree; delete branch if merged
+  [1m[36mmerge[0m   Merge current branch into target
+  [1m[36mselect[0m  Interactive worktree selector
+  [1m[36mstep[0m    Run individual operations
+  [1m[36mhook[0m    Run configured hooks
+  [1m[36mconfig[0m  Manage user & project configs
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+  [1m[36m-V[0m, [1m[36m--version
+          Print version
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+Getting started
+
+  wt switch --create feature    # Create worktree and branch
+  wt switch feature             # Switch to worktree
+  wt list                       # Show all worktrees
+  wt remove                     # Remove worktree; delete branch if merged
+
+Run [2mwt config shell install[0m to set up directory switching.
+Run [2mwt config create[0m to customize worktree locations.
+
+Docs: https://worktrunk.dev
+GitHub: https://github.com/max-sixty/worktrunk

--- a/tests/snapshots/integration__integration_tests__help__help_root_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root_long.snap
@@ -23,9 +23,9 @@ exit_code: 0
 ----- stderr -----
 wt - Git worktree management for parallel AI agent workflows
 
-Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND]
+Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 
-[1m[32mCommands:
+[1m[32mCommands:[0m
   [1m[36mswitch[0m  Switch to a worktree
   [1m[36mlist[0m    List worktrees and their status
   [1m[36mremove[0m  Remove worktree; delete branch if merged
@@ -35,21 +35,21 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND]
   [1m[36mhook[0m    Run configured hooks
   [1m[36mconfig[0m  Manage user & project configs
 
-[1m[32mOptions:
-  [1m[36m-h[0m, [1m[36m--help
+[1m[32mOptions:[0m
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-  [1m[36m-V[0m, [1m[36m--version
+  [1m[36m-V[0m, [1m[36m--version[0m
           Print version
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
 Getting started

--- a/tests/snapshots/integration__integration_tests__help__help_root_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root_short.snap
@@ -23,9 +23,9 @@ exit_code: 0
 ----- stderr -----
 wt - Git worktree management for parallel AI agent workflows
 
-Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND]
+Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 
-[1m[32mCommands:
+[1m[32mCommands:[0m
   [1m[36mswitch[0m  Switch to a worktree
   [1m[36mlist[0m    List worktrees and their status
   [1m[36mremove[0m  Remove worktree; delete branch if merged
@@ -35,11 +35,11 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND]
   [1m[36mhook[0m    Run configured hooks
   [1m[36mconfig[0m  Manage user & project configs
 
-[1m[32mOptions:
+[1m[32mOptions:[0m
   [1m[36m-h[0m, [1m[36m--help[0m     Print help (see more with '--help')
   [1m[36m-V[0m, [1m[36m--version[0m  Print version
 
-[1m[32mGlobal Options:
+[1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_select.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_select.snap
@@ -1,0 +1,97 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - select
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt select - Interactive worktree selector
+
+Browse and switch worktrees with live preview.
+
+Usage: [1m[36mwt select[0m [36m[OPTIONS]
+
+[1m[32mOptions:
+      [1m[36m--branches
+          Include branches without worktrees
+
+      [1m[36m--remotes
+          Include remote branches
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+
+[1m[32mExamples
+
+Open the selector:
+
+  [2mwt select
+
+[1m[32mPreview tabs
+
+Toggle between views with number keys:
+
+1. [1mHEAD±[0m — Diff of uncommitted changes
+2. [1mlog[0m — Recent commits; commits already on the default branch have dimmed hashes
+3. [1mmain…±[0m — Diff of changes since the merge-base with the default branch
+4. [1mremote⇅[0m — Diff vs upstream tracking branch (ahead/behind)
+
+[1m[32mKeybindings
+
+        Key                Action            
+   ───────────── ─────────────────────────── 
+   ↑/↓           Navigate worktree list      
+   Enter         Switch to selected worktree 
+   Esc           Cancel                      
+   (type)        Filter worktrees            
+   1/2/3/4       Switch preview tab          
+   Alt-p         Toggle preview panel        
+   Ctrl-u/Ctrl-d Scroll preview up/down      
+
+With [2m--branches[0m, branches without worktrees are included — selecting one creates a worktree. This matches [2mwt list --branches[0m.
+
+[1m[32mConfiguration
+
+[32mPager
+
+The preview panel pipes diff output through git's pager (typically [2mless[0m or [2mdelta[0m). Override pager behavior in user config:
+
+  [2m[select]
+  [2mpager = "delta --paging=never"
+
+This is useful when the default pager doesn't render correctly in the embedded preview panel.
+
+[1m[32mSee also
+
+- [2mwt list[0m — Static table view with all worktree metadata
+- [2mwt switch[0m — Direct switching to a known target branch
+
+Available on Unix only (macOS, Linux). On Windows, use [2mwt list[0m or [2mwt switch[0m directly.

--- a/tests/snapshots/integration__integration_tests__help__help_select_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_select_short.snap
@@ -1,0 +1,37 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - select
+    - "-h"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt select - Interactive worktree selector
+
+Usage: [1m[36mwt select[0m [36m[OPTIONS]
+
+[1m[32mOptions:
+      [1m[36m--branches[0m  Include branches without worktrees
+      [1m[36m--remotes[0m   Include remote branches
+  [1m[36m-h[0m, [1m[36m--help[0m      Print help (see more with '--help')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
+      [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_step.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step.snap
@@ -1,0 +1,78 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - step
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt step - Run individual operations
+
+The building blocks of [1mwt merge[0m — commit, squash, rebase, push — plus standalone utilities.
+
+Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
+
+[1m[32mCommands:
+  [1m[36mcommit[0m        Commit changes with LLM commit message
+  [1m[36msquash[0m        Squash commits since branching
+  [1m[36mpush[0m          Fast-forward target to current branch
+  [1m[36mrebase[0m        Rebase onto target
+  [1m[36mcopy-ignored[0m  Copy gitignored files to another worktree
+  [1m[36mfor-each[0m      [experimental] Run command in each worktree
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+[1m[32mExamples
+
+Commit with LLM-generated message:
+
+  [2mwt step commit
+
+Manual merge workflow with review between steps:
+
+  [2mwt step commit
+  [2mwt step squash
+  [2mwt step rebase
+  [2mwt step push
+
+[1m[32mOperations
+
+- [2mcommit[0m — Stage and commit with LLM-generated message
+- [2msquash[0m — Squash all branch commits into one with LLM-generated message
+- [2mrebase[0m — Rebase onto target branch
+- [2mpush[0m — Fast-forward target to current branch
+- [2mcopy-ignored[0m — Copy gitignored files between worktrees
+- [2mfor-each[0m — [experimental] Run a command in every worktree
+
+[1m[32mSee also
+
+- [2mwt merge[0m — Runs commit → squash → rebase → hooks → push → cleanup automatically
+- [2mwt hook[0m — Run configured hooks

--- a/tests/snapshots/integration__integration_tests__help__help_step_commit.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_commit.snap
@@ -1,0 +1,94 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - step
+    - commit
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt step commit - Commit changes with LLM commit message
+
+Stages working tree changes and commits with an LLM-generated message.
+
+Usage: [1m[36mwt step commit[0m [36m[OPTIONS]
+
+[1m[32mOptions:
+  [1m[36m-y[0m, [1m[36m--yes
+          Skip approval prompts
+
+      [1m[36m--no-verify
+          Skip hooks
+
+      [1m[36m--stage[0m[36m [0m[36m<STAGE>
+          What to stage before committing [default: all]
+
+          Possible values:
+          - [1m[36mall[0m:     Stage everything: untracked files + unstaged tracked changes
+          - [1m[36mtracked[0m: Stage tracked changes only (like [1mgit add -u[0m)
+          - [1m[36mnone[0m:    Stage nothing, commit only what's already in the index
+
+      [1m[36m--show-prompt
+          Show prompt without running LLM
+          
+          Outputs the rendered prompt to stdout for debugging or manual piping.
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+Stages all changes (including untracked files) and commits with an LLM-generated message.
+
+[1m[32mOptions
+
+[32m`--stage`
+
+Controls what to stage before committing:
+
+    Value                         Behavior                         
+   ─────── ─────────────────────────────────────────────────────── 
+   all     Stage all changes including untracked files (default)   
+   tracked Stage only modified tracked files                       
+   none    Don't stage anything, commit only what's already staged 
+
+  [2mwt step commit --stage=tracked
+
+Configure the default in user config:
+
+  [2m[commit]
+  [2mstage = "tracked"
+
+[32m`--show-prompt`
+
+Output the rendered LLM prompt to stdout without running the command. Useful for inspecting prompt templates or piping to other tools:
+
+  [2m# Inspect the rendered prompt
+  [2mwt step commit --show-prompt | less
+  [2m
+  [2m# Pipe to a different LLM
+  [2mwt step commit --show-prompt | llm -m gpt-5-nano

--- a/tests/snapshots/integration__integration_tests__help__help_step_copy_ignored.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_copy_ignored.snap
@@ -1,0 +1,132 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - step
+    - copy-ignored
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt step copy-ignored - Copy gitignored files to another worktree
+
+Copies gitignored files to another worktree. By default copies all gitignored files; use [1m.worktreeinclude[0m to limit what gets copied. Useful in hooks to copy build caches and dependencies to new worktrees. Skips symlinks and existing files.
+
+Usage: [1m[36mwt step copy-ignored[0m [36m[OPTIONS]
+
+[1m[32mOptions:
+      [1m[36m--from[0m[36m [0m[36m<FROM>
+          Source worktree branch
+          
+          Defaults to main worktree.
+
+      [1m[36m--to[0m[36m [0m[36m<TO>
+          Destination worktree branch
+          
+          Defaults to current worktree.
+
+      [1m[36m--dry-run
+          Show what would be copied
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+Git worktrees share the repository but not untracked files. This command copies gitignored files to another worktree, eliminating cold starts.
+
+[1m[32mSetup
+
+Add to the project config:
+
+  [2m# .config/wt.toml
+  [2m[post-start]
+  [2mcopy = "wt step copy-ignored"
+
+[1m[32mWhat gets copied
+
+All gitignored files are copied by default. Tracked files are never touched.
+
+To limit what gets copied, create [2m.worktreeinclude[0m with gitignore-style patterns. Files must be [1mboth[0m gitignored [1mand[0m in [2m.worktreeinclude[0m:
+
+  [2m# .worktreeinclude
+  [2m.env
+  [2mnode_modules/
+  [2mtarget/
+
+[1m[32mCommon patterns
+
+         Type                           Patterns                    
+   ───────────────── ────────────────────────────────────────────── 
+   Dependencies      node_modules/, .venv/, target/, vendor/, Pods/ 
+   Build caches      .cache/, .next/, .parcel-cache/, .turbo/       
+   Generated assets  Images, ML models, binaries too large for git  
+   Environment files .env (if not generated per-worktree)           
+
+[1m[32mFeatures
+
+- Uses copy-on-write (reflink) when available for space-efficient copies
+- Handles nested [2m.gitignore[0m files, global excludes, and [2m.git/info/exclude
+- Skips existing files (safe to re-run)
+- Skips [2m.git[0m entries and other worktrees
+
+[1m[32mPerformance
+
+Reflink copies share disk blocks until modified — no data is actually copied. For a 14GB [2mtarget/[0m directory:
+
+              Command            Time 
+   ───────────────────────────── ──── 
+   cp -R (full copy)             2m   
+   cp -Rc / wt step copy-ignored 20s  
+
+Uses per-file reflink (like [2mcp -Rc[0m) — copy time scales with file count.
+
+Use the [2mpost-start[0m hook so the copy runs in the background. Use [2mpost-create[0m instead if subsequent hooks or [2m--execute[0m command need the copied files immediately.
+
+[1m[32mLanguage-specific notes
+
+[32mRust
+
+The [2mtarget/[0m directory is huge (often 1-10GB). Copying with reflink cuts first build from ~68s to ~3s by reusing compiled dependencies.
+
+[32mNode.js
+
+[2mnode_modules/[0m is large but mostly static. If the project has no native dependencies, symlinks are even faster:
+
+  [2m[post-create]
+  [2mdeps = "ln -sf {{ primary_worktree_path }}/node_modules ."
+
+[32mPython
+
+Virtual environments contain absolute paths and can't be copied. Use [2muv sync[0m instead — it's fast enough that copying isn't worth it.
+
+[1m[32mBehavior vs Claude Code on desktop
+
+The [2m.worktreeinclude[0m pattern is shared with Claude Code on desktop, which copies matching files when creating worktrees. Differences:
+
+- worktrunk copies all gitignored files by default; Claude Code requires [2m.worktreeinclude
+- worktrunk uses copy-on-write for large directories like [2mtarget/[0m — potentially 30x faster on macOS, 6x on Linux
+- worktrunk runs as a configurable hook in the worktree lifecycle

--- a/tests/snapshots/integration__integration_tests__help__help_step_for_each.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_for_each.snap
@@ -1,0 +1,74 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - step
+    - for-each
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt step for-each - [experimental] Run command in each worktree
+
+Usage: [1m[36mwt step for-each[0m [36m[OPTIONS][0m [1m[36m--[0m [36m<ARGS>...
+
+[1m[32mArguments:
+  [36m<ARGS>...
+          Command template (see --help for all variables)
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+Executes a command sequentially in every worktree with real-time output. Continues on failure and shows a summary at the end.
+
+Context JSON is piped to stdin for scripts that need structured data.
+
+[1m[32mTemplate variables
+
+All variables are shell-escaped. See [2mwt hook[0m template variables for the complete list and filters.
+
+[1m[32mExamples
+
+Check status across all worktrees:
+
+  [2mwt step for-each -- git status --short
+
+Run npm install in all worktrees:
+
+  [2mwt step for-each -- npm install
+
+Use branch name in command:
+
+  [2mwt step for-each -- "echo Branch: {{ branch }}"
+
+Pull updates in worktrees with upstreams (skips others):
+
+  [2mgit fetch --prune && wt step for-each -- '[ "$(git rev-parse @{u} 2>/dev/null)" ] || exit 0; git pull --autostash'
+
+Note: This command is experimental and may change in future versions.

--- a/tests/snapshots/integration__integration_tests__help__help_step_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_long.snap
@@ -22,13 +22,13 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-wt step - Run individual operations
+wt step - Run individual operations[0m
 
-The building blocks of [1mwt merge[0m — commit, squash, rebase, push — plus standalone utilities.
+The building blocks of [1mwt merge[0m — commit, squash, rebase, push — plus standalone utilities.[0m
 
-Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
+Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 
-[1m[32mCommands:
+[1m[32mCommands:[0m
   [1m[36mcommit[0m        Commit changes with LLM commit message
   [1m[36msquash[0m        Squash commits since branching
   [1m[36mpush[0m          Fast-forward target to current branch
@@ -36,34 +36,34 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
   [1m[36mcopy-ignored[0m  Copy gitignored files to another worktree
   [1m[36mfor-each[0m      [experimental] Run command in each worktree
 
-[1m[32mOptions:
-  [1m[36m-h[0m, [1m[36m--help
+[1m[32mOptions:[0m
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
-[1m[32mExamples
+[1m[32mExamples[0m
 
 Commit with LLM-generated message:
 
-  [2mwt step commit
+  [2mwt step commit[0m
 
 Manual merge workflow with review between steps:
 
-  [2mwt step commit
-  [2mwt step squash
-  [2mwt step rebase
-  [2mwt step push
+  [2mwt step commit[0m
+  [2mwt step squash[0m
+  [2mwt step rebase[0m
+  [2mwt step push[0m
 
-[1m[32mOperations
+[1m[32mOperations[0m
 
 - [2mcommit[0m — Stage and commit with LLM-generated message
 - [2msquash[0m — Squash all branch commits into one with LLM-generated message
@@ -72,7 +72,7 @@ Manual merge workflow with review between steps:
 - [2mcopy-ignored[0m — Copy gitignored files between worktrees
 - [2mfor-each[0m — [experimental] Run a command in every worktree
 
-[1m[32mSee also
+[1m[32mSee also[0m
 
 - [2mwt merge[0m — Runs commit → squash → rebase → hooks → push → cleanup automatically
 - [2mwt hook[0m — Run configured hooks

--- a/tests/snapshots/integration__integration_tests__help__help_step_push.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_push.snap
@@ -1,0 +1,50 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - step
+    - push
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt step push - Fast-forward target to current branch
+
+Updates the local target branch (e.g., [1mmain[0m) to include current commits. Similar to [1mgit push . HEAD:<target>[0m, but uses [1mreceive.denyCurrentBranch=updateInstead[0m internally.
+
+Usage: [1m[36mwt step push[0m [36m[OPTIONS][0m [36m[TARGET]
+
+[1m[32mArguments:
+  [36m[TARGET]
+          Target branch
+          
+          Defaults to default branch.
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_step_rebase.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_rebase.snap
@@ -1,0 +1,48 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - step
+    - rebase
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt step rebase - Rebase onto target
+
+Usage: [1m[36mwt step rebase[0m [36m[OPTIONS][0m [36m[TARGET]
+
+[1m[32mArguments:
+  [36m[TARGET]
+          Target branch
+          
+          Defaults to default branch.
+
+[1m[32mOptions:
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_step_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_short.snap
@@ -24,9 +24,9 @@ exit_code: 0
 ----- stderr -----
 wt step - Run individual operations
 
-Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
+Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 
-[1m[32mCommands:
+[1m[32mCommands:[0m
   [1m[36mcommit[0m        Commit changes with LLM commit message
   [1m[36msquash[0m        Squash commits since branching
   [1m[36mpush[0m          Fast-forward target to current branch
@@ -34,10 +34,10 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
   [1m[36mcopy-ignored[0m  Copy gitignored files to another worktree
   [1m[36mfor-each[0m      [experimental] Run command in each worktree
 
-[1m[32mOptions:
+[1m[32mOptions:[0m
   [1m[36m-h[0m, [1m[36m--help[0m  Print help (see more with '--help')
 
-[1m[32mGlobal Options:
+[1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__help_step_squash.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_squash.snap
@@ -1,0 +1,96 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - step
+    - squash
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt step squash - Squash commits since branching
+
+Stages working tree changes, squashes all commits since diverging from target into one, generates message with LLM.
+
+Usage: [1m[36mwt step squash[0m [36m[OPTIONS][0m [36m[TARGET]
+
+[1m[32mArguments:
+  [36m[TARGET]
+          Target branch
+          
+          Defaults to default branch.
+
+[1m[32mOptions:
+  [1m[36m-y[0m, [1m[36m--yes
+          Skip approval prompts
+
+      [1m[36m--no-verify
+          Skip hooks
+
+      [1m[36m--stage[0m[36m [0m[36m<STAGE>
+          What to stage before committing [default: all]
+
+          Possible values:
+          - [1m[36mall[0m:     Stage everything: untracked files + unstaged tracked changes
+          - [1m[36mtracked[0m: Stage tracked changes only (like [1mgit add -u[0m)
+          - [1m[36mnone[0m:    Stage nothing, commit only what's already in the index
+
+      [1m[36m--show-prompt
+          Show prompt without running LLM
+          
+          Outputs the rendered prompt to stdout for debugging or manual piping.
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+Stages all changes (including untracked files), then squashes all commits since diverging from the target branch into a single commit with an LLM-generated message.
+
+[1m[32mOptions
+
+[32m`--stage`
+
+Controls what to stage before squashing:
+
+    Value                        Behavior                        
+   ─────── ───────────────────────────────────────────────────── 
+   all     Stage all changes including untracked files (default) 
+   tracked Stage only modified tracked files                     
+   none    Don't stage anything, squash only committed changes   
+
+  [2mwt step squash --stage=none
+
+Configure the default in user config:
+
+  [2m[commit]
+  [2mstage = "tracked"
+
+[32m`--show-prompt`
+
+Output the rendered LLM prompt to stdout without running the command. Useful for inspecting prompt templates or piping to other tools:
+
+  [2mwt step squash --show-prompt | less

--- a/tests/snapshots/integration__integration_tests__help__help_switch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch.snap
@@ -1,0 +1,172 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - switch
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_EDITOR: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+wt switch - Switch to a worktree
+
+Creates one if needed.
+
+Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m<BRANCH>[0m [1m[36m[--[0m [36m<EXECUTE_ARGS>...[0m[1m[36m]
+
+[1m[32mArguments:
+  [36m<BRANCH>
+          Branch name or shortcut
+          
+          Shortcuts: '^' (default branch), '-' (previous), '@' (current), 'pr:{N}' (GitHub PR), 'mr:{N}' (GitLab MR)
+
+  [36m[EXECUTE_ARGS]...
+          Additional arguments for --execute command (after --)
+          
+          Arguments after [1m--[0m are appended to the execute command. Each argument is expanded for templates, then POSIX shell-escaped.
+
+[1m[32mOptions:
+  [1m[36m-c[0m, [1m[36m--create
+          Create a new branch
+
+  [1m[36m-b[0m, [1m[36m--base[0m[36m [0m[36m<BASE>
+          Base branch
+          
+          Defaults to default branch.
+
+  [1m[36m-x[0m, [1m[36m--execute[0m[36m [0m[36m<EXECUTE>
+          Command to run after switch
+          
+          Replaces the wt process with the command after switching, giving it full terminal control. Useful for launching editors, AI agents, or other interactive tools.
+          
+          Supports ]8;;@/hook.md#template-variables\[4mhook template variables]8;;\[0m ([1m{{ branch }}[0m, [1m{{ worktree_path }}[0m, etc.) and filters. [1m{{ base }}[0m and [1m{{ base_worktree_path }}[0m require [1m--create[0m.
+          
+          Especially useful with shell aliases:
+          
+            [1m[1malias wsc='wt switch --create -x claude'
+            [1mwsc feature-branch -- 'Fix GH #322'
+          
+          Then [1mwsc feature-branch[0m creates the worktree and launches Claude Code. Arguments after [1m--[0m are passed to the command, so [1mwsc feature -- 'Fix GH #322'[0m runs [1mclaude 'Fix GH #322'[0m, starting Claude with a prompt.
+          
+          Template example: [1m-x 'code {{ worktree_path }}'[0m opens VS Code at the worktree, [1m-x 'tmux new -s {{ branch | sanitize }}'[0m starts a tmux session named after the branch.
+
+  [1m[36m-y[0m, [1m[36m--yes
+          Skip approval prompts
+
+      [1m[36m--clobber
+          Remove stale paths at target
+
+      [1m[36m--no-verify
+          Skip hooks
+
+  [1m[36m-h[0m, [1m[36m--help
+          Print help (see a summary with '-h')
+
+[1m[32mGlobal Options:
+  [1m[36m-C[0m[36m [0m[36m<path>
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>
+          User config file path
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+          Verbose output (-v: hooks, templates; -vv: debug report)
+
+Worktrees are addressed by branch name; paths are computed from a configurable template. Unlike [2mgit switch[0m, this navigates between worktrees rather than changing branches in place.
+
+[1m[32mExamples
+
+  [2mwt switch feature-auth           # Switch to worktree
+  [2mwt switch -                      # Previous worktree (like cd -)
+  [2mwt switch --create new-feature   # Create new branch and worktree
+  [2mwt switch --create hotfix --base production
+  [2mwt switch pr:123                 # Switch to PR #123's branch
+
+[1m[32mCreating a branch
+
+The [2m--create[0m flag creates a new branch from the [2m--base[0m branch (defaults to default branch). Without [2m--create[0m, the branch must already exist.
+
+[1mUpstream tracking:[0m Branches created with [2m--create[0m have no upstream tracking configured. This prevents accidental pushes to the wrong branch — for example, [2m--base origin/main[0m would otherwise make [2mgit push[0m target [2mmain[0m. Use [2mgit push -u origin <branch>[0m to set up tracking when you're ready.
+
+Without [2m--create[0m, switching to a remote branch (e.g., [2mwt switch feature[0m when only [2morigin/feature[0m exists) creates a local branch tracking the remote — this is the standard git behavior and is preserved.
+
+[1m[32mCreating worktrees
+
+If the branch already has a worktree, [2mwt switch[0m changes directories to it. Otherwise, it creates one, running hooks.
+
+When creating a worktree, worktrunk:
+
+1. Creates worktree at configured path
+2. Switches to new directory
+3. Runs post-create hooks (blocking)
+4. Spawns post-start hooks (background)
+
+  [2mwt switch feature                        # Existing branch → creates worktree
+  [2mwt switch --create feature               # New branch and worktree
+  [2mwt switch --create fix --base release    # New branch from release
+  [2mwt switch --create temp --no-verify      # Skip hooks
+
+[1m[32mShortcuts
+
+   Shortcut            Meaning            
+   ──────── ───────────────────────────── 
+   ^        Default branch (main/master)  
+   @        Current branch/worktree       
+   -        Previous worktree (like cd -) 
+   pr:{N}   GitHub PR #N's branch         
+   mr:{N}   GitLab MR !N's branch         
+
+  [2mwt switch -                      # Back to previous
+  [2mwt switch ^                      # Default branch worktree
+  [2mwt switch --create fix --base=@  # Branch from current HEAD
+  [2mwt switch pr:123                 # PR #123's branch
+  [2mwt switch mr:101                 # MR !101's branch
+
+[1m[32mGitHub pull requests (experimental)
+
+The [2mpr:<number>[0m syntax resolves the branch for a GitHub pull request. For same-repo PRs, it switches to the branch directly. For fork PRs, it fetches [2mrefs/pull/N/head[0m and configures [2mpushRemote[0m to the fork URL.
+
+  [2mwt switch pr:101                 # Checkout PR #101
+
+Requires [2mgh[0m CLI to be installed and authenticated. The [2m--create[0m flag cannot be used with [2mpr:[0m syntax since the branch already exists.
+
+[1mFork PRs:[0m The local branch uses the PR's branch name directly (e.g., [2mfeature-fix[0m), so [2mgit push[0m works normally. If a local branch with that name already exists tracking something else, rename it first.
+
+[1m[32mGitLab merge requests (experimental)
+
+The [2mmr:<number>[0m syntax resolves the branch for a GitLab merge request. For same-project MRs, it switches to the branch directly. For fork MRs, it fetches [2mrefs/merge-requests/N/head[0m and configures [2mpushRemote[0m to the fork URL.
+
+  [2mwt switch mr:101                 # Checkout MR !101
+
+Requires [2mglab[0m CLI to be installed and authenticated. The [2m--create[0m flag cannot be used with [2mmr:[0m syntax since the branch already exists.
+
+[1mFork MRs:[0m The local branch uses the MR's branch name directly, so [2mgit push[0m works normally. If a local branch with that name already exists tracking something else, rename it first.
+
+[1m[32mWhen wt switch fails
+
+- [1mBranch doesn't exist[0m — Use [2m--create[0m, or check [2mwt list --branches
+- [1mPath occupied[0m — Another worktree is at the target path; switch to it or remove it
+- [1mStale directory[0m — Use [2m--clobber[0m to remove a non-worktree directory at the target path
+
+To change which branch a worktree is on, use [2mgit switch[0m inside that worktree.
+
+[1m[32mSee also
+
+- [2mwt select[0m — Interactive worktree selection
+- [2mwt list[0m — View all worktrees
+- [2mwt remove[0m — Delete worktrees when done
+- [2mwt merge[0m — Integrate changes back to the default branch

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -22,81 +22,81 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-wt switch - Switch to a worktree
+wt switch - Switch to a worktree[0m
 
-Creates one if needed.
+Creates one if needed.[0m
 
-Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m<BRANCH>[0m [1m[36m[--[0m [36m<EXECUTE_ARGS>...[0m[1m[36m]
+Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m<BRANCH>[0m [1m[36m[--[0m [36m<EXECUTE_ARGS>...[0m[1m[36m][0m
 
-[1m[32mArguments:
-  [36m<BRANCH>
-          Branch name or shortcut
+[1m[32mArguments:[0m
+  [36m<BRANCH>[0m
+          Branch name or shortcut[0m
           
-          Shortcuts: '^' (default branch), '-' (previous), '@' (current), 'pr:{N}' (GitHub PR), 'mr:{N}' (GitLab MR)
+          Shortcuts: '^' (default branch), '-' (previous), '@' (current), 'pr:{N}' (GitHub PR), 'mr:{N}' (GitLab MR)[0m
 
-  [36m[EXECUTE_ARGS]...
-          Additional arguments for --execute command (after --)
+  [36m[EXECUTE_ARGS]...[0m
+          Additional arguments for --execute command (after --)[0m
           
-          Arguments after [1m--[0m are appended to the execute command. Each argument is expanded for templates, then POSIX shell-escaped.
+          Arguments after [1m--[0m are appended to the execute command. Each argument is expanded for templates, then POSIX shell-escaped.[0m
 
-[1m[32mOptions:
-  [1m[36m-c[0m, [1m[36m--create
+[1m[32mOptions:[0m
+  [1m[36m-c[0m, [1m[36m--create[0m
           Create a new branch
 
-  [1m[36m-b[0m, [1m[36m--base[0m[36m [0m[36m<BASE>
-          Base branch
+  [1m[36m-b[0m, [1m[36m--base[0m[36m [0m[36m<BASE>[0m
+          Base branch[0m
           
-          Defaults to default branch.
+          Defaults to default branch.[0m
 
-  [1m[36m-x[0m, [1m[36m--execute[0m[36m [0m[36m<EXECUTE>
-          Command to run after switch
+  [1m[36m-x[0m, [1m[36m--execute[0m[36m [0m[36m<EXECUTE>[0m
+          Command to run after switch[0m
           
-          Replaces the wt process with the command after switching, giving it full terminal control. Useful for launching editors, AI agents, or other interactive tools.
+          Replaces the wt process with the command after switching, giving it full terminal control. Useful for launching editors, AI agents, or other interactive tools.[0m
           
-          Supports ]8;;@/hook.md#template-variables\[4mhook template variables]8;;\[0m ([1m{{ branch }}[0m, [1m{{ worktree_path }}[0m, etc.) and filters. [1m{{ base }}[0m and [1m{{ base_worktree_path }}[0m require [1m--create[0m.
+          Supports ]8;;@/hook.md#template-variables\[4mhook template variables]8;;\[0m ([1m{{ branch }}[0m, [1m{{ worktree_path }}[0m, etc.) and filters. [1m{{ base }}[0m and [1m{{ base_worktree_path }}[0m require [1m--create[0m.[0m
           
-          Especially useful with shell aliases:
+          Especially useful with shell aliases:[0m
           
-            [1m[1malias wsc='wt switch --create -x claude'
-            [1mwsc feature-branch -- 'Fix GH #322'
+            [1m[1malias wsc='wt switch --create -x claude'[0m
+            [1mwsc feature-branch -- 'Fix GH #322'[0m
+          [0m
+          Then [1mwsc feature-branch[0m creates the worktree and launches Claude Code. Arguments after [1m--[0m are passed to the command, so [1mwsc feature -- 'Fix GH #322'[0m runs [1mclaude 'Fix GH #322'[0m, starting Claude with a prompt.[0m
           
-          Then [1mwsc feature-branch[0m creates the worktree and launches Claude Code. Arguments after [1m--[0m are passed to the command, so [1mwsc feature -- 'Fix GH #322'[0m runs [1mclaude 'Fix GH #322'[0m, starting Claude with a prompt.
-          
-          Template example: [1m-x 'code {{ worktree_path }}'[0m opens VS Code at the worktree, [1m-x 'tmux new -s {{ branch | sanitize }}'[0m starts a tmux session named after the branch.
+          Template example: [1m-x 'code {{ worktree_path }}'[0m opens VS Code at the worktree, [1m-x 'tmux new -s {{ branch | sanitize }}'[0m starts a tmux session named after the branch.[0m
 
-  [1m[36m-y[0m, [1m[36m--yes
+  [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts
 
-      [1m[36m--clobber
+      [1m[36m--clobber[0m
           Remove stale paths at target
 
-      [1m[36m--no-verify
+      [1m[36m--no-verify[0m
           Skip hooks
 
-  [1m[36m-h[0m, [1m[36m--help
+  [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
-[1m[32mGlobal Options:
-  [1m[36m-C[0m[36m [0m[36m<path>
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command
 
-      [1m[36m--config[0m[36m [0m[36m<path>
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
           User config file path
 
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: hooks, templates; -vv: debug report)
 
 Worktrees are addressed by branch name; paths are computed from a configurable template. Unlike [2mgit switch[0m, this navigates between worktrees rather than changing branches in place.
 
-[1m[32mExamples
+[1m[32mExamples[0m
 
-  [2mwt switch feature-auth           # Switch to worktree
-  [2mwt switch -                      # Previous worktree (like cd -)
-  [2mwt switch --create new-feature   # Create new branch and worktree
-  [2mwt switch --create hotfix --base production
-  [2mwt switch pr:123                 # Switch to PR #123's branch
+  [2mwt switch feature-auth           # Switch to worktree[0m
+  [2mwt switch -                      # Previous worktree (like cd -)[0m
+  [2mwt switch --create new-feature   # Create new branch and worktree[0m
+  [2mwt switch --create hotfix --base production[0m
+  [2mwt switch pr:123                 # Switch to PR #123's branch[0m
 
-[1m[32mCreating a branch
+[1m[32mCreating a branch[0m
 
 The [2m--create[0m flag creates a new branch from the [2m--base[0m branch (defaults to default branch). Without [2m--create[0m, the branch must already exist.
 
@@ -104,7 +104,7 @@ The [2m--create[0m flag creates a new branch from the [2m--base[0m branch (d
 
 Without [2m--create[0m, switching to a remote branch (e.g., [2mwt switch feature[0m when only [2morigin/feature[0m exists) creates a local branch tracking the remote — this is the standard git behavior and is preserved.
 
-[1m[32mCreating worktrees
+[1m[32mCreating worktrees[0m
 
 If the branch already has a worktree, [2mwt switch[0m changes directories to it. Otherwise, it creates one, running hooks.
 
@@ -115,12 +115,12 @@ When creating a worktree, worktrunk:
 3. Runs post-create hooks (blocking)
 4. Spawns post-start hooks (background)
 
-  [2mwt switch feature                        # Existing branch → creates worktree
-  [2mwt switch --create feature               # New branch and worktree
-  [2mwt switch --create fix --base release    # New branch from release
-  [2mwt switch --create temp --no-verify      # Skip hooks
+  [2mwt switch feature                        # Existing branch → creates worktree[0m
+  [2mwt switch --create feature               # New branch and worktree[0m
+  [2mwt switch --create fix --base release    # New branch from release[0m
+  [2mwt switch --create temp --no-verify      # Skip hooks[0m
 
-[1m[32mShortcuts
+[1m[32mShortcuts[0m
 
    Shortcut            Meaning            
    ──────── ───────────────────────────── 
@@ -130,41 +130,41 @@ When creating a worktree, worktrunk:
    pr:{N}   GitHub PR #N's branch         
    mr:{N}   GitLab MR !N's branch         
 
-  [2mwt switch -                      # Back to previous
-  [2mwt switch ^                      # Default branch worktree
-  [2mwt switch --create fix --base=@  # Branch from current HEAD
-  [2mwt switch pr:123                 # PR #123's branch
-  [2mwt switch mr:101                 # MR !101's branch
+  [2mwt switch -                      # Back to previous[0m
+  [2mwt switch ^                      # Default branch worktree[0m
+  [2mwt switch --create fix --base=@  # Branch from current HEAD[0m
+  [2mwt switch pr:123                 # PR #123's branch[0m
+  [2mwt switch mr:101                 # MR !101's branch[0m
 
-[1m[32mGitHub pull requests (experimental)
+[1m[32mGitHub pull requests (experimental)[0m
 
 The [2mpr:<number>[0m syntax resolves the branch for a GitHub pull request. For same-repo PRs, it switches to the branch directly. For fork PRs, it fetches [2mrefs/pull/N/head[0m and configures [2mpushRemote[0m to the fork URL.
 
-  [2mwt switch pr:101                 # Checkout PR #101
+  [2mwt switch pr:101                 # Checkout PR #101[0m
 
 Requires [2mgh[0m CLI to be installed and authenticated. The [2m--create[0m flag cannot be used with [2mpr:[0m syntax since the branch already exists.
 
 [1mFork PRs:[0m The local branch uses the PR's branch name directly (e.g., [2mfeature-fix[0m), so [2mgit push[0m works normally. If a local branch with that name already exists tracking something else, rename it first.
 
-[1m[32mGitLab merge requests (experimental)
+[1m[32mGitLab merge requests (experimental)[0m
 
 The [2mmr:<number>[0m syntax resolves the branch for a GitLab merge request. For same-project MRs, it switches to the branch directly. For fork MRs, it fetches [2mrefs/merge-requests/N/head[0m and configures [2mpushRemote[0m to the fork URL.
 
-  [2mwt switch mr:101                 # Checkout MR !101
+  [2mwt switch mr:101                 # Checkout MR !101[0m
 
 Requires [2mglab[0m CLI to be installed and authenticated. The [2m--create[0m flag cannot be used with [2mmr:[0m syntax since the branch already exists.
 
 [1mFork MRs:[0m The local branch uses the MR's branch name directly, so [2mgit push[0m works normally. If a local branch with that name already exists tracking something else, rename it first.
 
-[1m[32mWhen wt switch fails
+[1m[32mWhen wt switch fails[0m
 
-- [1mBranch doesn't exist[0m — Use [2m--create[0m, or check [2mwt list --branches
+- [1mBranch doesn't exist[0m — Use [2m--create[0m, or check [2mwt list --branches[0m
 - [1mPath occupied[0m — Another worktree is at the target path; switch to it or remove it
 - [1mStale directory[0m — Use [2m--clobber[0m to remove a non-worktree directory at the target path
 
 To change which branch a worktree is on, use [2mgit switch[0m inside that worktree.
 
-[1m[32mSee also
+[1m[32mSee also[0m
 
 - [2mwt select[0m — Interactive worktree selection
 - [2mwt list[0m — View all worktrees

--- a/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
@@ -24,13 +24,13 @@ exit_code: 0
 ----- stderr -----
 wt switch - Switch to a worktree
 
-Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m<BRANCH>[0m [1m[36m[--[0m [36m<EXECUTE_ARGS>...[0m[1m[36m]
+Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m<BRANCH>[0m [1m[36m[--[0m [36m<EXECUTE_ARGS>...[0m[1m[36m][0m
 
-[1m[32mArguments:
+[1m[32mArguments:[0m
   [36m<BRANCH>[0m           Branch name or shortcut
   [36m[EXECUTE_ARGS]...[0m  Additional arguments for --execute command (after --)
 
-[1m[32mOptions:
+[1m[32mOptions:[0m
   [1m[36m-c[0m, [1m[36m--create[0m             Create a new branch
   [1m[36m-b[0m, [1m[36m--base[0m[36m [0m[36m<BASE>[0m        Base branch
   [1m[36m-x[0m, [1m[36m--execute[0m[36m [0m[36m<EXECUTE>[0m  Command to run after switch
@@ -39,7 +39,7 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m<BRANCH>[0m [1m[36m[--
       [1m[36m--no-verify[0m          Skip hooks
   [1m[36m-h[0m, [1m[36m--help[0m               Print help (see more with '--help')
 
-[1m[32mGlobal Options:
+[1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)

--- a/tests/snapshots/integration__integration_tests__help__nested_subcommand_hook_post_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__nested_subcommand_hook_post_create.snap
@@ -23,7 +23,7 @@ exit_code: 2
 ----- stderr -----
 [1m[31merror:[0m unrecognized subcommand '[1m[33mpost-create[0m'
 
-[1m[32mUsage:[0m [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND]
+[1m[32mUsage:[0m [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 
 For more information, try '[1m[36m--help[0m'.
 

--- a/tests/snapshots/integration__integration_tests__help__nested_subcommand_hook_pre_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__nested_subcommand_hook_pre_merge.snap
@@ -25,7 +25,7 @@ exit_code: 2
 
   [1m[32mtip:[0m a similar subcommand exists: '[1m[32mremove[0m'
 
-[1m[32mUsage:[0m [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND]
+[1m[32mUsage:[0m [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 
 For more information, try '[1m[36m--help[0m'.
 

--- a/tests/snapshots/integration__integration_tests__help__nested_subcommand_step_commit.snap
+++ b/tests/snapshots/integration__integration_tests__help__nested_subcommand_step_commit.snap
@@ -23,7 +23,7 @@ exit_code: 2
 ----- stderr -----
 [1m[31merror:[0m unrecognized subcommand '[1m[33mcommit[0m'
 
-[1m[32mUsage:[0m [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND]
+[1m[32mUsage:[0m [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 
 For more information, try '[1m[36m--help[0m'.
 

--- a/tests/snapshots/integration__integration_tests__help__nested_subcommand_step_squash.snap
+++ b/tests/snapshots/integration__integration_tests__help__nested_subcommand_step_squash.snap
@@ -23,7 +23,7 @@ exit_code: 2
 ----- stderr -----
 [1m[31merror:[0m unrecognized subcommand '[1m[33msquash[0m'
 
-[1m[32mUsage:[0m [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND]
+[1m[32mUsage:[0m [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 
 For more information, try '[1m[36m--help[0m'.
 


### PR DESCRIPTION
## Summary

- Remove ANSI reset filters from help tests; snapshots now show actual output
- Remove dead `MarkerType::Snapshot` path in readme_sync (README only has section markers)
- Remove unused `OutputFormat::Readme`, `parse_snapshot_with_command`, `strip_code_block`
- Use `NO_COLOR=1` for help command discovery instead of stripping ANSI after

The README sync code had a dead code path for handling snapshot markers (`.snap` files), but the README only contains section markers (`docs/content/*.md#anchor`). This removes ~80 lines of unused code.

The ANSI reset filters in help tests were normalizing away trailing `\x1b[0m` codes from clap's section headers. These are consistent output, not a cross-platform issue, so snapshots now show actual output.

## Test plan

- [x] All help tests pass
- [x] All readme_sync tests pass  
- [x] pre-commit passes

🤖 Generated with [Claude Code](https://claude.ai/code)