### PR TITLE
docs: clarify worktree terminology (main, linked, primary)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,9 @@ Use deprecation warnings to get there smoothly when external interfaces must cha
 
 Use consistent terminology in documentation, help text, and code comments:
 
-- **main worktree** — the primary worktree (the original git directory), not "main branch worktree"
+- **main worktree** — the original git directory (from clone/init); bare repos have none
+- **linked worktree** — worktree created via `git worktree add` (git's official term)
+- **primary worktree** — the "home" worktree: main worktree for normal repos, default branch worktree for bare repos
 - **default branch** — the branch (main, master, etc.), not "main branch"
 - **target** — the destination for merge/rebase/push (e.g., "merge target"). Don't use "target" to mean worktrees — say "worktree" or "worktrees"
 

--- a/src/git/repository/worktrees.rs
+++ b/src/git/repository/worktrees.rs
@@ -55,14 +55,10 @@ impl Repository {
             .map(|wt| wt.path.clone()))
     }
 
-    /// The primary worktree — where established files (ignored files, configs) typically live.
+    /// The "home" worktree — main worktree for normal repos, default branch worktree for bare.
     ///
-    /// - Normal repos: the main worktree (repo root) — this is where you cloned and set things up
-    /// - Bare repos: the default branch's worktree — no main worktree exists
-    ///
+    /// Used as the default source for `copy-ignored` and the `{{ primary_worktree_path }}` template.
     /// Returns `None` for bare repos when no worktree has the default branch.
-    ///
-    /// For template var `{{ primary_worktree_path }}`.
     pub fn primary_worktree(&self) -> anyhow::Result<Option<PathBuf>> {
         if self.is_bare() {
             let Some(branch) = self.default_branch() else {


### PR DESCRIPTION
## Summary

- Update CLAUDE.md terminology section with all three worktree types (main, linked, primary)
- Simplify `primary_worktree()` docstring to be definition-first rather than behavior-focused

Git officially uses "main worktree" and "linked worktree". We also have "primary worktree" which is our abstraction for "the home worktree" that works for both normal and bare repos.

## Test plan

- [x] Lints pass
- [x] Unit tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)