### PR TITLE
docs: improve wt remove help text

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/remove.md
+++ b/.claude-plugin/skills/worktrunk/reference/remove.md
@@ -1,6 +1,6 @@
 # wt remove
 
-Remove worktree; delete branch if merged. For finished feature branches. Removes the current worktree by default.
+Remove worktree; delete branch if merged. Defaults to the current worktree.
 
 ## Examples
 
@@ -66,11 +66,15 @@ Without `--force`, removal fails if the worktree contains untracked files. Witho
 
 Removal runs in the background by default (returns immediately). Logs are written to `.git/wt-logs/{branch}-remove.log`. Use `--foreground` to run in the foreground.
 
+## Hooks
+
+`pre-remove` hooks run before the worktree is deleted (with access to worktree files). `post-remove` hooks run after removal. See [`wt hook`](https://worktrunk.dev/hook/) for configuration.
+
 ## Command reference
 
 wt remove - Remove worktree; delete branch if merged
 
-For finished feature branches. Removes the current worktree by default.
+Defaults to the current worktree.
 
 Usage: <b><span class=c>wt remove</span></b> <span class=c>[OPTIONS]</span> <span class=c>[BRANCHES]...</span>
 

--- a/docs/content/remove.md
+++ b/docs/content/remove.md
@@ -8,7 +8,7 @@ group = "Commands"
 
 <!-- ⚠️ AUTO-GENERATED from `wt remove --help-page` — edit cli.rs to update -->
 
-Remove worktree; delete branch if merged. For finished feature branches. Removes the current worktree by default.
+Remove worktree; delete branch if merged. Defaults to the current worktree.
 
 ## Examples
 
@@ -74,6 +74,10 @@ Without `--force`, removal fails if the worktree contains untracked files. Witho
 
 Removal runs in the background by default (returns immediately). Logs are written to `.git/wt-logs/{branch}-remove.log`. Use `--foreground` to run in the foreground.
 
+## Hooks
+
+`pre-remove` hooks run before the worktree is deleted (with access to worktree files). `post-remove` hooks run after removal. See [`wt hook`](@/hook.md) for configuration.
+
 ## See also
 
 - [`wt merge`](@/merge.md) — Remove worktree after merging
@@ -84,7 +88,7 @@ Removal runs in the background by default (returns immediately). Logs are writte
 {% terminal() %}
 wt remove - Remove worktree; delete branch if merged
 
-For finished feature branches. Removes the current worktree by default.
+Defaults to the current worktree.
 
 Usage: <b><span class=c>wt remove</span></b> <span class=c>[OPTIONS]</span> <span class=c>[BRANCHES]...</span>
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -682,7 +682,7 @@ Missing a field that would be generally useful? Open an issue at https://github.
 
     /// Remove worktree; delete branch if merged
     ///
-    /// For finished feature branches. Removes the current worktree by default.
+    /// Defaults to the current worktree.
     #[command(after_long_help = r#"## Examples
 
 Remove current worktree:
@@ -746,6 +746,10 @@ Without `--force`, removal fails if the worktree contains untracked files. Witho
 ## Background removal
 
 Removal runs in the background by default (returns immediately). Logs are written to `.git/wt-logs/{branch}-remove.log`. Use `--foreground` to run in the foreground.
+
+## Hooks
+
+`pre-remove` hooks run before the worktree is deleted (with access to worktree files). `post-remove` hooks run after removal. See [`wt hook`](@/hook.md) for configuration.
 
 ## See also
 

--- a/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
@@ -24,7 +24,7 @@ exit_code: 0
 ----- stderr -----
 wt remove - Remove worktree; delete branch if merged[0m
 
-For finished feature branches. Removes the current worktree by default.[0m
+Defaults to the current worktree.[0m
 
 Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...[0m
 
@@ -119,6 +119,10 @@ Without [2m--force[0m, removal fails if the worktree contains untracked files.
 [1m[32mBackground removal[0m
 
 Removal runs in the background by default (returns immediately). Logs are written to [2m.git/wt-logs/{branch}-remove.log[0m. Use [2m--foreground[0m to run in the foreground.
+
+[1m[32mHooks[0m
+
+[2mpre-remove[0m hooks run before the worktree is deleted (with access to worktree files). [2mpost-remove[0m hooks run after removal. See [2mwt hook[0m for configuration.
 
 [1m[32mSee also[0m
 


### PR DESCRIPTION
## Summary
- Simplify subdefinition to "Defaults to the current worktree."
- Add Hooks section documenting pre-remove and post-remove hooks

## Test plan
- [x] `pre-commit run --all-files` passes
- [x] `cargo test --lib --bins` passes
- [x] Doc sync test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)