### PR TITLE
Fix extra linebreak after demo comments in help output

### DIFF
--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -18,7 +18,6 @@ Shows uncommitted changes, divergence from the default branch and remote, and op
   <img src="/assets/docs/light/wt-list.gif" alt="wt list demo" width="1600" height="900">
 </picture>
 </figure>
-
 The table renders progressively: branch names, paths, and commit hashes appear immediately, then status, divergence, and other columns fill in as background git operations complete. With `--full`, CI status fetches from the network — the table displays instantly and CI fills in as results arrive.
 
 ## Examples

--- a/docs/content/merge.md
+++ b/docs/content/merge.md
@@ -18,7 +18,6 @@ Unlike `git merge`, this merges current into target (not target into current). S
   <img src="/assets/docs/light/wt-merge.gif" alt="wt merge demo" width="1600" height="900">
 </picture>
 </figure>
-
 ## Examples
 
 Merge to the default branch:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -413,7 +413,6 @@ To change which branch a worktree is on, use `git switch` inside that worktree.
         after_long_help = r#"Shows uncommitted changes, divergence from the default branch and remote, and optional CI status.
 
 <!-- demo: wt-list.gif 1600x900 -->
-
 The table renders progressively: branch names, paths, and commit hashes appear immediately, then status, divergence, and other columns fill in as background git operations complete. With `--full`, CI status fetches from the network — the table displays instantly and CI fills in as results arrive.
 
 ## Examples
@@ -796,7 +795,6 @@ Removal runs in the background by default (returns immediately). Logs are writte
         after_long_help = r#"Unlike `git merge`, this merges current into target (not target into current). Similar to clicking "Merge pull request" on GitHub, but locally. Target defaults to the default branch.
 
 <!-- demo: wt-merge.gif 1600x900 -->
-
 ## Examples
 
 Merge to the default branch:

--- a/tests/integration_tests/help.rs
+++ b/tests/integration_tests/help.rs
@@ -22,6 +22,21 @@ fn snapshot_help(test_name: &str, args: &[&str]) {
     settings.bind(|| {
         let mut cmd = wt_command();
         cmd.args(args);
+
+        // Check for double blank lines before snapshotting.
+        // Double blanks indicate formatting issues (e.g., HTML comments like
+        // `<!-- demo: file.gif -->` with blank lines on both sides).
+        let output = cmd.output().expect("failed to run command");
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !stderr.contains("\n\n\n"),
+            "Double blank line in help output for `wt {}`",
+            args.join(" ")
+        );
+
+        // Re-run for snapshot (assert_cmd_snapshot needs the Command)
+        let mut cmd = wt_command();
+        cmd.args(args);
         assert_cmd_snapshot!(test_name, cmd);
     });
 }

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -65,7 +65,6 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
 
 Shows uncommitted changes, divergence from the default branch and remote, and optional CI status.
 
-
 The table renders progressively: branch names, paths, and commit hashes appear immediately, then status, divergence, and other columns fill in as background git operations complete. With [2m--full[0m, CI status fetches from the network — the table displays instantly and CI fills in as results arrive.
 
 [1m[32mExamples[0m

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -67,7 +67,6 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
 Shows uncommitted changes, divergence from the default branch and remote, and 
 optional CI status.
 
-
 The table renders progressively: branch names, paths, and commit hashes appear 
 immediately, then status, divergence, and other columns fill in as background 
 git operations complete. With [2m--full[0m, CI status fetches from the network — the 

--- a/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
@@ -75,7 +75,6 @@ Global Options:
 Unlike `git merge`, this merges current into target (not target into current). Similar to clicking "Merge pull request" on GitHub, but locally. Target defaults to the default branch.
 
 <!-- demo: wt-merge.gif 1600x900 -->
-
 ## Examples
 
 Merge to the default branch:

--- a/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
@@ -76,7 +76,6 @@ Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET][0m
 
 Unlike [2mgit merge[0m, this merges current into target (not target into current). Similar to clicking "Merge pull request" on GitHub, but locally. Target defaults to the default branch.
 
-
 [1m[32mExamples[0m
 
 Merge to the default branch:


### PR DESCRIPTION
## Summary
- Demo HTML comments (`<!-- demo: file.gif -->`) had blank lines on both sides in source
- When stripped for terminal display, both blanks remained → double blank line in output
- Fixed by removing trailing blank after demo comments in `cli/mod.rs`
- Added check in `snapshot_help()` to catch this pattern in all help tests

## Test plan
- [x] `cargo test --test integration help` passes
- [x] `pre-commit run --all-files` passes
- [x] Verified `wt list --help` no longer has extra linebreak after first paragraph

🤖 Generated with [Claude Code](https://claude.com/code)