### PR TITLE
fix: improve BranchAlreadyExists hint wording

### DIFF
--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -310,7 +310,7 @@ impl std::fmt::Display for GitError {
                     "{}\n{}",
                     error_message(cformat!("Branch <bold>{branch}</> already exists")),
                     hint_message(cformat!(
-                        "To switch to the existing branch, remove <bright-black>--create</> and run <bright-black>{switch_cmd}</>"
+                        "To switch to the existing branch, run without <bright-black>--create</>: <bright-black>{switch_cmd}</>"
                     ))
                 )
             }
@@ -935,7 +935,7 @@ mod tests {
         let downcast = err.downcast_ref::<GitError>().expect("Should downcast");
         assert_snapshot!(downcast.to_string(), @"
         [31m✗[39m [31mBranch [1mmain[22m already exists[39m
-        [2m↳[22m [2mTo switch to the existing branch, remove [90m--create[39m and run [90mwt switch main[39m[22m
+        [2m↳[22m [2mTo switch to the existing branch, run without [90m--create[39m: [90mwt switch main[39m[22m
         ");
     }
 

--- a/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__branch_already_exists.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__branch_already_exists.snap
@@ -3,4 +3,4 @@ source: tests/integration_tests/git_error_display.rs
 expression: err.to_string()
 ---
 [31m✗[39m [31mBranch [1mfeature[22m already exists[39m
-[2m↳[22m [2mTo switch to the existing branch, remove [90m--create[39m and run [90mwt switch feature[39m[22m
+[2m↳[22m [2mTo switch to the existing branch, run without [90m--create[39m: [90mwt switch feature[39m[22m

--- a/tests/snapshots/integration__integration_tests__security__branch_name_with_cd_directive_not_executed.snap
+++ b/tests/snapshots/integration__integration_tests__security__branch_name_with_cd_directive_not_executed.snap
@@ -38,4 +38,4 @@ exit_code: 1
 
 ----- stderr -----
 [31m✗[39m [31mBranch [1m__WORKTRUNK_CD__/tmp[22m already exists[39m
-[2m↳[22m [2mTo switch to the existing branch, remove [90m--create[39m and run [90mwt switch __WORKTRUNK_CD__/tmp[39m[22m
+[2m↳[22m [2mTo switch to the existing branch, run without [90m--create[39m: [90mwt switch __WORKTRUNK_CD__/tmp[39m[22m

--- a/tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__command_failure.snap
+++ b/tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__command_failure.snap
@@ -4,4 +4,4 @@ expression: "&output.combined"
 ---
 
 [31m✗[39m [31mBranch [1mexisting[22m already exists[39m
-[2m↳[22m [2mTo switch to the existing branch, remove [90m--create[39m and run [90mwt switch existing[39m[22m
+[2m↳[22m [2mTo switch to the existing branch, run without [90m--create[39m: [90mwt switch existing[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_create_existing_error.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_create_existing_error.snap
@@ -37,4 +37,4 @@ exit_code: 1
 
 ----- stderr -----
 [31m✗[39m [31mBranch [1mfeature-y[22m already exists[39m
-[2m↳[22m [2mTo switch to the existing branch, remove [90m--create[39m and run [90mwt switch feature-y[39m[22m
+[2m↳[22m [2mTo switch to the existing branch, run without [90m--create[39m: [90mwt switch feature-y[39m[22m


### PR DESCRIPTION
## Summary
- Change hint from "remove --create and run" to "run without --create:" for clearer, more natural phrasing

## Test plan
- [x] Unit and integration tests updated and passing

> _This was written by Claude Code on behalf of max-sixty_