### PR TITLE
feat: add shorthand aliases for list and remove commands

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -410,6 +410,7 @@ To change which branch a worktree is on, use `git switch` inside that worktree.
 
     /// List worktrees and their status
     #[command(
+        visible_alias = "ls",
         after_long_help = r#"Shows uncommitted changes, divergence from the default branch and remote, and optional CI status.
 
 <!-- demo: wt-list.gif 1600x900 -->
@@ -682,7 +683,7 @@ Missing a field that would be generally useful? Open an issue at https://github.
     /// Remove worktree; delete branch if merged
     ///
     /// Defaults to the current worktree.
-    #[command(after_long_help = r#"## Examples
+    #[command(visible_alias = "rm", after_long_help = r#"## Examples
 
 Remove current worktree:
 

--- a/tests/snapshots/integration__integration_tests__help__help_md_root.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_root.snap
@@ -25,8 +25,8 @@ Usage: wt [OPTIONS] [COMMAND]
 
 Commands:
   switch  Switch to a worktree
-  list    List worktrees and their status
-  remove  Remove worktree; delete branch if merged
+  list    List worktrees and their status [aliases: ls]
+  remove  Remove worktree; delete branch if merged [aliases: rm]
   merge   Merge current branch into target
   select  Interactive worktree selector
   step    Run individual operations

--- a/tests/snapshots/integration__integration_tests__help__help_no_args.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_no_args.snap
@@ -26,8 +26,8 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 
 [1m[32mCommands:[0m
   [1m[36mswitch[0m  Switch to a worktree
-  [1m[36mlist[0m    List worktrees and their status
-  [1m[36mremove[0m  Remove worktree; delete branch if merged
+  [1m[36mlist[0m    List worktrees and their status [aliases: ls]
+  [1m[36mremove[0m  Remove worktree; delete branch if merged [aliases: rm]
   [1m[36mmerge[0m   Merge current branch into target
   [1m[36mselect[0m  Interactive worktree selector
   [1m[36mstep[0m    Run individual operations

--- a/tests/snapshots/integration__integration_tests__help__help_root_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root_long.snap
@@ -27,8 +27,8 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 
 [1m[32mCommands:[0m
   [1m[36mswitch[0m  Switch to a worktree
-  [1m[36mlist[0m    List worktrees and their status
-  [1m[36mremove[0m  Remove worktree; delete branch if merged
+  [1m[36mlist[0m    List worktrees and their status [aliases: ls]
+  [1m[36mremove[0m  Remove worktree; delete branch if merged [aliases: rm]
   [1m[36mmerge[0m   Merge current branch into target
   [1m[36mselect[0m  Interactive worktree selector
   [1m[36mstep[0m    Run individual operations

--- a/tests/snapshots/integration__integration_tests__help__help_root_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root_short.snap
@@ -27,8 +27,8 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 
 [1m[32mCommands:[0m
   [1m[36mswitch[0m  Switch to a worktree
-  [1m[36mlist[0m    List worktrees and their status
-  [1m[36mremove[0m  Remove worktree; delete branch if merged
+  [1m[36mlist[0m    List worktrees and their status [aliases: ls]
+  [1m[36mremove[0m  Remove worktree; delete branch if merged [aliases: rm]
   [1m[36mmerge[0m   Merge current branch into target
   [1m[36mselect[0m  Interactive worktree selector
   [1m[36mstep[0m    Run individual operations

--- a/tests/snapshots/integration__integration_tests__help__nested_subcommand_hook_pre_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__nested_subcommand_hook_pre_merge.snap
@@ -23,7 +23,7 @@ exit_code: 2
 ----- stderr -----
 [1m[31merror:[0m unrecognized subcommand '[1m[33mpre-merge[0m'
 
-  [1m[32mtip:[0m a similar subcommand exists: '[1m[32mremove[0m'
+  [1m[32mtip:[0m some similar subcommands exist: '[1m[32mremove[0m', '[1m[32mrm[0m'
 
 [1m[32mUsage:[0m [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 


### PR DESCRIPTION
## Summary

Adds visible aliases `ls` for `list` and `rm` for `remove` commands, addressing the request in #406.

These are common shortcuts that users intuitively try after installing worktrunk (as noted in the issue comments). The aliases are shown in help text, making them discoverable:

```
Commands:
  switch  Switch to a worktree
  list    List worktrees and their status [aliases: ls]
  remove  Remove worktree; delete branch if merged [aliases: rm]
  ...
```

## Changes

- Added `visible_alias = "ls"` to the `List` command
- Added `visible_alias = "rm"` to the `Remove` command
- Updated snapshots for help text changes

## Notes

Using `visible_alias` (vs hidden `alias`) shows the aliases in help text, which helps discoverability while still allowing tab completion to work with the full command names. This addresses the maintainer's concern about tab completion from the issue discussion.

Fixes #406

🤖 Generated with [Claude Code](https://claude.ai/code)