### PR TITLE
refactor: unify CI platform detection with CiPlatform methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -323,7 +323,7 @@
 - **`wt step copy-ignored`**: Copy gitignored files listed in `.worktreeinclude` between worktrees. Useful for syncing `.env` files, IDE settings, and build caches to new worktrees via post-create hooks. Uses COW (reflink) copying for efficient handling of large directories. Matches Claude Code Desktop's worktree file syncing behavior.
 - **`--foreground` flag**: Debug background hooks by running them in the foreground. Available on `wt hook post-start`, `wt hook post-switch`, and `wt remove`. Replaces the deprecated `--no-background` flag.
 - **`--var` flag for hooks**: Override template variables when running hooks manually, e.g., `wt hook post-create --var target=main`.
-- **`[ci] platform` config**: Explicitly set CI platform (`github` or `gitlab`) for GitHub Enterprise or self-hosted GitLab where URL-based detection fails.
+- **`ci.platform` config**: Explicitly set CI platform (`github` or `gitlab`) for GitHub Enterprise or self-hosted GitLab where URL-based detection fails.
 - **Upstream diff in `wt select`**: Tab 4 shows ahead/behind diff vs upstream tracking branch (remote⇅), matching the column in `wt list`.
 - **`{{ base }}` and `{{ base_worktree_path }}` variables**: New template variables for creation hooks (post-create, post-start, post-switch) to access the base branch name and worktree path.
 - **`-vv` diagnostic reports**: Double-verbose flag writes a diagnostic report to `.git/wt-logs/diagnostic.md` with environment info, configs, and logs for easy bug reporting.


### PR DESCRIPTION
## Summary

- Move platform-specific dispatch logic from separate `detect_github_ci` and `detect_gitlab_ci` functions to methods on `CiPlatform` enum
- Add `is_tool_available()`, `detect_pr_mr()`, `detect_branch()`, `detect_ci()` methods
- Make tool availability checking consistent (both platforms now check upfront)
- Remove "try both platforms" fallback - if URL detection fails, require `ci.platform` config

## Test plan

- [x] `cargo test --bin wt ci_status` - all 17 tests pass
- [x] `pre-commit run --all-files` - all checks pass

> _This was written by Claude Code on behalf of @max-sixty_