### PR TITLE
fix: improve --create conflict error for pr:/mr: syntax

### DIFF
--- a/src/commands/worktree/switch.rs
+++ b/src/commands/worktree/switch.rs
@@ -58,14 +58,7 @@ fn resolve_pr_ref(
     create: bool,
     base: Option<&str>,
 ) -> anyhow::Result<ResolvedTarget> {
-    // --create and --base are invalid with pr: syntax
-    if create {
-        return Err(GitError::RefCreateConflict {
-            ref_type: RefType::Pr,
-            number: pr_number,
-        }
-        .into());
-    }
+    // --base is invalid with pr: syntax (check early, no network needed)
     if base.is_some() {
         return Err(GitError::RefBaseConflict {
             ref_type: RefType::Pr,
@@ -88,6 +81,16 @@ fn resolve_pr_ref(
         "{}",
         format_with_gutter(&format_ref_context(&pr_info), None)
     );
+
+    // --create is invalid with pr: syntax (check after fetch to show branch name)
+    if create {
+        return Err(GitError::RefCreateConflict {
+            ref_type: RefType::Pr,
+            number: pr_number,
+            branch: pr_info.head_ref_name.clone(),
+        }
+        .into());
+    }
 
     if pr_info.is_cross_repository {
         // Fork PR: check if branch already exists and is tracking this PR
@@ -216,14 +219,7 @@ fn resolve_mr_ref(
     create: bool,
     base: Option<&str>,
 ) -> anyhow::Result<ResolvedTarget> {
-    // --create and --base are invalid with mr: syntax
-    if create {
-        return Err(GitError::RefCreateConflict {
-            ref_type: RefType::Mr,
-            number: mr_number,
-        }
-        .into());
-    }
+    // --base is invalid with mr: syntax (check early, no network needed)
     if base.is_some() {
         return Err(GitError::RefBaseConflict {
             ref_type: RefType::Mr,
@@ -246,6 +242,16 @@ fn resolve_mr_ref(
         "{}",
         format_with_gutter(&format_ref_context(&mr_info), None)
     );
+
+    // --create is invalid with mr: syntax (check after fetch to show branch name)
+    if create {
+        return Err(GitError::RefCreateConflict {
+            ref_type: RefType::Mr,
+            number: mr_number,
+            branch: mr_info.source_branch.clone(),
+        }
+        .into());
+    }
 
     if mr_info.is_cross_project {
         // Fork MR: check if branch already exists and is tracking this MR

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -221,6 +221,7 @@ pub enum GitError {
     RefCreateConflict {
         ref_type: RefType,
         number: u32,
+        branch: String,
     },
     /// --base flag used with pr:/mr: syntax (conflict - base is predetermined)
     RefBaseConflict {
@@ -689,17 +690,21 @@ impl std::fmt::Display for GitError {
                 )
             }
 
-            GitError::RefCreateConflict { ref_type, number } => {
+            GitError::RefCreateConflict {
+                ref_type,
+                number,
+                branch,
+            } => {
+                let name = ref_type.name();
                 let syntax = ref_type.syntax();
-                let name_plural = ref_type.name_plural();
                 write!(
                     f,
                     "{}\n{}",
                     error_message(cformat!(
-                        "Cannot use <bold>--create</> with <bold>{syntax}{number}</>"
+                        "Cannot create branch for <bold>{syntax}{number}</> — {name} already has branch <bold>{branch}</>"
                     )),
-                    hint_message(format!(
-                        "{name_plural} already have a branch; remove --create"
+                    hint_message(cformat!(
+                        "To switch to it: <bright-black>wt switch {syntax}{number}</>"
                     ))
                 )
             }

--- a/src/git/remote_ref.rs
+++ b/src/git/remote_ref.rs
@@ -110,6 +110,6 @@
 //! ## --create Conflict
 //!
 //! ```text
-//! ✗ Cannot use --create with pr:101
-//! ↳ PRs already have a branch; remove --create
+//! ✗ Cannot create branch for pr:101 — PR already has branch feature-auth
+//! ↳ To switch to it: wt switch pr:101
 //! ```

--- a/tests/snapshots/integration__integration_tests__switch__switch_mr_create_conflict.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_mr_create_conflict.snap
@@ -36,5 +36,8 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[31m✗[39m [31mCannot use [1m--create[22m with [1mmr:101[22m[39m
-[2m↳[22m [2mMRs already have a branch; remove --create[22m
+[36m◎[39m [36mFetching MR !101...[39m
+[107m [0m [1mFix authentication bug in login flow[22m (!101)
+[107m [0m by @alice · opened · [90mhttps://gitlab.com/owner/test-repo/-/merge_requests/101[39m
+[31m✗[39m [31mCannot create branch for [1mmr:101[22m — MR already has branch [1mfeature-auth[22m[39m
+[2m↳[22m [2mTo switch to it: [90mwt switch mr:101[39m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_create_conflict.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_create_conflict.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/integration_tests/switch.rs
+assertion_line: 1451
 info:
   program: wt
   args:
@@ -36,5 +37,8 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[31m✗[39m [31mCannot use [1m--create[22m with [1mpr:101[22m[39m
-[2m↳[22m [2mPRs already have a branch; remove --create[22m
+[36m◎[39m [36mFetching PR #101...[39m
+[107m [0m [1mFix authentication bug in login flow[22m (#101)
+[107m [0m by @alice · open · [90mhttps://github.com/owner/test-repo/pull/101[39m
+[31m✗[39m [31mCannot create branch for [1mpr:101[22m — PR already has branch [1mfeature-auth[22m[39m
+[2m↳[22m [2mTo switch to it: [90mwt switch pr:101[39m[22m


### PR DESCRIPTION
## Summary

- Improve error message when using `--create` with `pr:` or `mr:` syntax
- Show the branch name that the PR/MR already has, making it clear why `--create` doesn't make sense
- Move validation after fetching PR/MR info so we can display the branch name

**Before:**
```
✗ Cannot use --create with pr:101
↳ PRs already have a branch; remove --create
```

**After:**
```
◎ Fetching PR #101...
   ┃ Fix authentication bug in login flow (#101)
   ┃ by @alice · open · https://github.com/owner/test-repo/pull/101
✗ Cannot create branch for pr:101 — PR already has branch feature-auth
↳ To switch to it: wt switch pr:101
```

## Test plan

- [x] `cargo test --test integration test_switch_pr_create_conflict` passes
- [x] `cargo test --test integration test_switch_mr_create_conflict` passes
- [x] All 916 integration tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)