### PR TITLE
docs: use consistent worktree terminology

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/hook.md
+++ b/.claude-plugin/skills/worktrunk/reference/hook.md
@@ -198,7 +198,7 @@ Hooks can use template variables that expand at runtime:
 | `{{ branch }}` | Branch name |
 | `{{ worktree_name }}` | Worktree directory name |
 | `{{ worktree_path }}` | Absolute worktree path |
-| `{{ primary_worktree_path }}` | Main worktree path (for bare repos: default branch worktree) |
+| `{{ primary_worktree_path }}` | Primary worktree path (main worktree for normal repos; default branch worktree for bare repos) |
 | `{{ default_branch }}` | Default branch name |
 | `{{ commit }}` | Full HEAD commit SHA |
 | `{{ short_commit }}` | Short HEAD commit SHA (7 chars) |

--- a/.claude-plugin/skills/worktrunk/reference/tips-patterns.md
+++ b/.claude-plugin/skills/worktrunk/reference/tips-patterns.md
@@ -284,7 +284,7 @@ An alternative to the default sibling layout (`myproject.feature/`) uses a bare 
 ```
 myproject/
 ├── .git/       # bare repository
-├── main/       # main branch
+├── main/       # default branch
 ├── feature/    # feature branch
 └── bugfix/     # bugfix branch
 ```

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -206,7 +206,7 @@ Hooks can use template variables that expand at runtime:
 | `{{ branch }}` | Branch name |
 | `{{ worktree_name }}` | Worktree directory name |
 | `{{ worktree_path }}` | Absolute worktree path |
-| `{{ primary_worktree_path }}` | Main worktree path (for bare repos: default branch worktree) |
+| `{{ primary_worktree_path }}` | Primary worktree path (main worktree for normal repos; default branch worktree for bare repos) |
 | `{{ default_branch }}` | Default branch name |
 | `{{ commit }}` | Full HEAD commit SHA |
 | `{{ short_commit }}` | Short HEAD commit SHA (7 chars) |

--- a/docs/content/tips-patterns.md
+++ b/docs/content/tips-patterns.md
@@ -296,7 +296,7 @@ An alternative to the default sibling layout (`myproject.feature/`) uses a bare 
 ```
 myproject/
 ├── .git/       # bare repository
-├── main/       # main branch
+├── main/       # default branch
 ├── feature/    # feature branch
 └── bugfix/     # bugfix branch
 ```

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1232,7 +1232,7 @@ Hooks can use template variables that expand at runtime:
 | `{{ branch }}` | Branch name |
 | `{{ worktree_name }}` | Worktree directory name |
 | `{{ worktree_path }}` | Absolute worktree path |
-| `{{ primary_worktree_path }}` | Main worktree path (for bare repos: default branch worktree) |
+| `{{ primary_worktree_path }}` | Primary worktree path (main worktree for normal repos; default branch worktree for bare repos) |
 | `{{ default_branch }}` | Default branch name |
 | `{{ commit }}` | Full HEAD commit SHA |
 | `{{ short_commit }}` | Short HEAD commit SHA (7 chars) |

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -80,7 +80,7 @@ impl ProjectConfig {
 /// - `{{ branch }}` - Branch name (e.g., "feature/auth")
 /// - `{{ worktree_name }}` - Worktree directory name (e.g., "myproject.feature-auth")
 /// - `{{ worktree_path }}` - Absolute path to the worktree (e.g., "/path/to/myproject.feature-auth")
-/// - `{{ primary_worktree_path }}` - Main worktree path (or for bare repos, the default branch worktree)
+/// - `{{ primary_worktree_path }}` - Primary worktree path (main worktree for normal repos; default branch worktree for bare repos)
 /// - `{{ default_branch }}` - Default branch name (e.g., "main")
 /// - `{{ commit }}` - Current HEAD commit SHA (full 40-character hash)
 /// - `{{ short_commit }}` - Current HEAD commit SHA (short 7-character hash)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -175,7 +175,7 @@ pub fn repo_with_remote(mut repo: TestRepo) -> TestRepo {
     repo
 }
 
-/// Repo with main branch available for merge operations.
+/// Repo with default branch available for merge operations.
 ///
 /// The primary worktree is already on main, so no separate worktree is needed.
 /// This fixture exists for compatibility with tests that expect it.
@@ -1482,9 +1482,9 @@ impl TestRepo {
         canonical_path
     }
 
-    /// Creates a worktree for the main branch (required for merge operations)
+    /// Creates a worktree for the default branch (required for merge operations)
     ///
-    /// This is a convenience method that creates a worktree for the main branch
+    /// This is a convenience method that creates a worktree for the default branch
     /// in the standard location expected by merge tests. Returns the path to the
     /// created worktree.
     ///
@@ -1692,7 +1692,7 @@ impl TestRepo {
     /// Switch the primary worktree to a different branch
     ///
     /// Creates a new branch and switches to it in the primary worktree.
-    /// This is useful for testing scenarios where the primary worktree is not on the main branch.
+    /// This is useful for testing scenarios where the primary worktree is not on the default branch.
     pub fn switch_primary_to(&self, branch: &str) {
         self.run_git(&["switch", "-c", branch]);
     }


### PR DESCRIPTION
- Clarify primary_worktree_path template variable description to explain
  it's the primary worktree (main worktree for normal repos; default
  branch worktree for bare repos)
- Replace "main branch" with "default branch" in test comments and docs
  per CLAUDE.md terminology guidelines