### PR TITLE
docs: improve crate-level documentation for crates.io

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,24 +1,11 @@
-//! Worktrunk library - git worktree management.
+//! Git worktree management for parallel workflows.
 //!
-//! # Global State
+//! Worktrunk is a CLI tool — see <https://worktrunk.dev> for documentation
+//! and the [README](https://github.com/max-sixty/worktrunk) for an overview.
 //!
-//! Global state is intentionally scattered to live near its domain.
-//! All globals use safe patterns (`OnceLock`, `LazyLock`, `AtomicU8`, `thread_local!`).
-//!
-//! | Module | Global | Purpose |
-//! |--------|--------|---------|
-//! | [`shell_exec`] | `CMD_SEMAPHORE` | Limits concurrent command execution |
-//! | [`shell_exec`] | `TRACE_EPOCH` | Monotonic base for trace timestamps |
-//! | [`shell_exec`] | `SHELL_CONFIG` | Cached platform shell detection |
-//! | [`shell_exec`] | `COMMAND_TIMEOUT` | Thread-local timeout for Rayon workers |
-//! | [`styling`] | `VERBOSITY` | CLI verbosity level (`-v`, `-vv`) |
-//! | [`config::deprecation`](config) | `WARNED_PATHS` | Deduplicates deprecation warnings |
-//! | [`config::user`](config) | `CONFIG_PATH` | `--config` CLI override |
-//! | [`git::repository`](git) | `BASE_PATH` | `-C` flag override |
-//!
-//! Binary-only globals (declared in `main.rs`, not part of library API):
-//! - `src/output/global.rs`: `OUTPUT_STATE` - Shell integration directive file
-//! - `src/verbose_log.rs`: `VERBOSE_LOG` - Verbose log file handle
+//! The library API is not stable. If you're building tooling that integrates
+//! with worktrunk, please [open an issue](https://github.com/max-sixty/worktrunk/issues)
+//! to discuss your use case.
 
 pub mod config;
 pub mod git;


### PR DESCRIPTION
Replace internal implementation details (global state table) with a
brief description and links to the canonical documentation. Avoids
duplicating content that lives in the README and worktrunk.dev.