### PR TITLE
refactor: move inline imports to module top (batch 1/4)

### DIFF
--- a/src/config/commands.rs
+++ b/src/config/commands.rs
@@ -4,6 +4,7 @@
 //! of worktree and merge operations.
 
 use indexmap::IndexMap;
+use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize};
 
 /// Represents a command with its template and optionally expanded form
@@ -97,8 +98,6 @@ impl Serialize for CommandConfig {
     where
         S: serde::Serializer,
     {
-        use serde::ser::SerializeMap;
-
         // If single unnamed command, serialize as string
         if self.commands.len() == 1 && self.commands[0].name.is_none() {
             return self.commands[0].template.serialize(serializer);

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -11,16 +11,19 @@
 //! To regenerate a project config migration file, run `wt config state hints clear deprecated-project-config`.
 //! To regenerate a user config migration file, delete the existing `.new` file.
 
-use crate::config::WorktrunkConfig;
-use crate::styling::{eprintln, hint_message, warning_message};
-use color_print::cformat;
-use minijinja::Environment;
-use shell_escape::escape;
 use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::{Path, PathBuf};
 use std::sync::{LazyLock, Mutex};
+
+use color_print::cformat;
+use minijinja::Environment;
+use regex::Regex;
+use shell_escape::escape;
+
+use crate::config::WorktrunkConfig;
+use crate::styling::{eprintln, hint_message, warning_message};
 
 /// Tracks which config paths have already shown deprecation warnings this process.
 /// Prevents repeated warnings when config is loaded multiple times.
@@ -51,8 +54,6 @@ const DEPRECATED_VARS: &[(&str, &str)] = &[
 ///
 /// Returns `Cow::Borrowed` if no replacements needed, avoiding allocation.
 pub fn normalize_template_vars(template: &str) -> Cow<'_, str> {
-    use regex::Regex;
-
     // Quick check: if none of the deprecated vars appear, return borrowed
     if !DEPRECATED_VARS
         .iter()
@@ -128,8 +129,6 @@ fn collect_strings_from_value(value: &toml::Value, strings: &mut Vec<String>) {
 
 /// Replace all deprecated variables with their new names
 pub fn replace_deprecated_vars(content: &str) -> String {
-    use regex::Regex;
-
     let strings = extract_template_strings(content);
     let mut result = content.to_string();
 

--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -8,9 +8,12 @@
 //!
 //! See `wt hook --help` for available filters and functions.
 
+use std::borrow::Cow;
+
 use color_print::cformat;
 use minijinja::{Environment, UndefinedBehavior, Value};
 use regex::Regex;
+use shell_escape::escape;
 
 use crate::git::Repository;
 use crate::path::to_posix_path;
@@ -228,9 +231,6 @@ pub fn expand_template(
     repo: &Repository,
     name: &str,
 ) -> Result<String, String> {
-    use shell_escape::escape;
-    use std::borrow::Cow;
-
     // Build context map, optionally shell-escaping values
     let mut context = HashMap::new();
     for (key, value) in vars {

--- a/src/config/user.rs
+++ b/src/config/user.rs
@@ -2,11 +2,13 @@
 //!
 //! Personal preferences and per-project approved commands, not checked into git.
 
-use config::{Case, Config, ConfigError, File};
-use fs2::FileExt;
-use serde::{Deserialize, Deserializer, Serialize};
 use std::path::PathBuf;
 use std::sync::OnceLock;
+
+use config::{Case, Config, ConfigError, File};
+use fs2::FileExt;
+use serde::de;
+use serde::{Deserialize, Deserializer, Serialize};
 
 use super::HooksConfig;
 
@@ -67,8 +69,6 @@ fn deserialize_string_or_vec<'de, D>(deserializer: D) -> Result<Vec<String>, D::
 where
     D: Deserializer<'de>,
 {
-    use serde::de;
-
     struct StringOrVec;
 
     impl<'de> de::Visitor<'de> for StringOrVec {

--- a/src/display.rs
+++ b/src/display.rs
@@ -6,8 +6,11 @@
 //! - Text truncation with word boundaries
 //! - Terminal width detection
 
-use std::path::Path;
+use std::path::{Component, Path};
+
+use unicode_width::UnicodeWidthChar;
 use worktrunk::path::format_path_for_display;
+use worktrunk::styling::visual_width;
 use worktrunk::utils::get_now;
 
 /// Format timestamp as abbreviated relative time (e.g., "2h")
@@ -61,8 +64,6 @@ fn format_relative_time_impl(timestamp: i64, now: i64) -> String {
 /// - Sibling: `../sibling`
 /// - Unrelated paths fall back to `~/...` or absolute
 pub(crate) fn shorten_path(path: &Path, main_worktree_path: &Path) -> String {
-    use std::path::Component;
-
     // Same path = main worktree
     if path == main_worktree_path {
         return ".".to_string();
@@ -88,9 +89,6 @@ pub(crate) fn shorten_path(path: &Path, main_worktree_path: &Path) -> String {
 /// Truncates at character boundary (mid-word if needed) to fill the allocated
 /// column width exactly. This ensures consistent table output width.
 pub(crate) fn truncate_to_width(text: &str, max_width: usize) -> String {
-    use unicode_width::UnicodeWidthChar;
-    use worktrunk::styling::visual_width;
-
     if visual_width(text) <= max_width {
         return text.to_string();
     }

--- a/src/help.rs
+++ b/src/help.rs
@@ -8,6 +8,8 @@
 use std::process;
 
 use ansi_str::AnsiStr;
+use clap::ColorChoice;
+use clap::error::ErrorKind;
 use worktrunk::styling::eprintln;
 
 use crate::cli;
@@ -27,9 +29,6 @@ use crate::cli;
 ///
 /// Returns `true` if help was handled (caller should exit), `false` to continue normal parsing.
 pub fn maybe_handle_help_with_pager() -> bool {
-    use clap::ColorChoice;
-    use clap::error::ErrorKind;
-
     let args: Vec<String> = std::env::args().collect();
 
     // --help uses pager, -h prints directly (git convention)
@@ -128,9 +127,6 @@ pub fn maybe_handle_help_with_pager() -> bool {
 /// If `width` is provided, wraps text at that width (for web docs); otherwise uses default.
 /// Always preserves ANSI color codes for HTML conversion.
 fn get_help_reference(command_path: &[&str], width: Option<usize>) -> String {
-    use clap::ColorChoice;
-    use clap::error::ErrorKind;
-
     // Build args: ["wt", "config", "create", "--help"]
     let mut args: Vec<String> = vec!["wt".to_string()];
     args.extend(command_path.iter().map(|s| s.to_string()));
@@ -230,8 +226,6 @@ fn strip_ansi_codes(s: &str) -> String {
 ///
 /// This is used to generate docs/content/merge.md etc from the source.
 fn handle_help_page(args: &[String]) {
-    use clap::ColorChoice;
-
     let mut cmd = cli::build_command();
     cmd = cmd.color(ColorChoice::Never);
 

--- a/src/md_help.rs
+++ b/src/md_help.rs
@@ -1,6 +1,6 @@
 //! Minimal markdown rendering for CLI help text.
 
-use anstyle::{AnsiColor, Color, Style};
+use anstyle::{AnsiColor, Color, Color as AnsiStyleColor, Style};
 use termimad::{MadSkin, TableBorderChars};
 use unicode_width::UnicodeWidthStr;
 
@@ -318,8 +318,6 @@ fn render_inline_formatting(line: &str) -> String {
 
 /// Add colors to status symbols in help text (matching wt list output colors)
 fn colorize_status_symbols(text: &str) -> String {
-    use anstyle::Color as AnsiStyleColor;
-
     // Define semantic styles matching src/commands/list/model.rs StatusSymbols::styled_symbols
     let error = Style::new().fg_color(Some(AnsiStyleColor::Ansi(AnsiColor::Red)));
     let warning = Style::new().fg_color(Some(AnsiStyleColor::Ansi(AnsiColor::Yellow)));

--- a/src/path.rs
+++ b/src/path.rs
@@ -1,7 +1,7 @@
 use std::path::{Path, PathBuf};
 
 #[cfg(windows)]
-use crate::shell_exec::Cmd;
+use crate::shell_exec::{Cmd, ShellConfig};
 
 /// Convert a path to POSIX format for Git Bash compatibility.
 ///
@@ -20,8 +20,6 @@ use crate::shell_exec::Cmd;
 /// - `/tmp/test/repo` → `/tmp/test/repo` (unchanged on Unix)
 #[cfg(windows)]
 pub fn to_posix_path(path: &str) -> String {
-    use crate::shell_exec::ShellConfig;
-
     let Some(cygpath) = find_cygpath_from_shell(ShellConfig::get()) else {
         return path.to_string();
     };

--- a/src/styling/format.rs
+++ b/src/styling/format.rs
@@ -4,6 +4,8 @@
 
 #[cfg(feature = "syntax-highlighting")]
 use super::highlighting::bash_token_style;
+#[cfg(feature = "syntax-highlighting")]
+use tree_sitter_highlight::{HighlightConfiguration, HighlightEvent, Highlighter};
 
 // Import canonical implementations from parent module
 use super::{get_terminal_width, visual_width};
@@ -223,8 +225,6 @@ pub fn wrap_styled_text(styled: &str, max_width: usize) -> Vec<String> {
 
 #[cfg(feature = "syntax-highlighting")]
 fn format_bash_with_gutter_impl(content: &str, width_override: Option<usize>) -> String {
-    use tree_sitter_highlight::{HighlightConfiguration, HighlightEvent, Highlighter};
-
     let gutter = super::GUTTER;
     let reset = anstyle::Reset;
     let dim = anstyle::Style::new().dimmed();

--- a/src/styling/mod.rs
+++ b/src/styling/mod.rs
@@ -20,6 +20,9 @@ mod hyperlink;
 mod line;
 mod suggest;
 
+use ansi_str::AnsiStr;
+use unicode_width::UnicodeWidthStr;
+
 // Re-exports from anstream (auto-detecting output)
 pub use anstream::{eprint, eprintln, print, println, stderr, stdout};
 
@@ -96,8 +99,6 @@ pub fn get_terminal_width() -> usize {
 ///
 /// Uses unicode-width for proper handling of wide characters (CJK, emoji).
 pub fn visual_width(s: &str) -> usize {
-    use ansi_str::AnsiStr;
-    use unicode_width::UnicodeWidthStr;
     s.ansi_strip().width()
 }
 


### PR DESCRIPTION
## Summary
- Move inline imports from function scope to module scope in 10 files
- Follows Rust's standard import organization (std → external → crate-local)
- First of 4 batches to clean up inline imports across the codebase

## Files Changed
- `src/path.rs` - `ShellConfig`
- `src/display.rs` - `Component`, `UnicodeWidthChar`, `visual_width`
- `src/md_help.rs` - `Color as AnsiStyleColor`
- `src/help.rs` - `ColorChoice`, `ErrorKind`
- `src/styling/mod.rs` - `AnsiStr`, `UnicodeWidthStr`
- `src/styling/format.rs` - tree-sitter highlight types (with cfg gate)
- `src/config/expansion.rs` - `escape`, `Cow`
- `src/config/deprecation.rs` - `Regex`
- `src/config/user.rs` - `serde::de`
- `src/config/commands.rs` - `SerializeMap`

## Test plan
- [x] `cargo check` passes
- [x] `pre-commit run --all-files` passes
- [x] `cargo test --lib --bins` passes (434 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)