### PR TITLE
refactor: move inline imports to module top (batch 2/4)

### DIFF
--- a/src/git/repository/branch.rs
+++ b/src/git/repository/branch.rs
@@ -1,5 +1,7 @@
 //! Branch - a handle for branch-specific git operations.
 
+use crate::git::GitRemoteUrl;
+
 use super::Repository;
 
 /// A handle for running git commands on a specific branch.
@@ -175,7 +177,6 @@ impl<'a> Branch<'a> {
     /// Returns the push remote URL if configured and pointing to GitHub,
     /// otherwise returns `None`.
     pub fn github_push_url(&self) -> Option<String> {
-        use crate::git::GitRemoteUrl;
         let url = self.push_remote_url()?;
         let parsed = GitRemoteUrl::parse(&url)?;
         parsed.is_github().then_some(url)

--- a/src/git/repository/branches.rs
+++ b/src/git/repository/branches.rs
@@ -3,7 +3,7 @@
 //! For single-branch operations, see [`super::Branch`].
 //! This module contains multi-branch operations (listing, filtering, etc.).
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use super::{BranchCategory, CompletionBranch, Repository};
 
@@ -195,7 +195,6 @@ impl Repository {
 
         // Group by branch name, collecting all remotes that have each branch.
         // Uses HashMap for grouping, then sorts by timestamp to preserve recency order.
-        use std::collections::HashMap;
         let mut branch_remotes: HashMap<String, (Vec<String>, i64)> = HashMap::new();
 
         for line in remote_output.lines() {

--- a/src/git/repository/diff.rs
+++ b/src/git/repository/diff.rs
@@ -2,7 +2,7 @@
 
 use std::collections::HashMap;
 
-use anyhow::Context;
+use anyhow::{Context, bail};
 
 use super::{DiffStats, LineDiff, Repository};
 
@@ -147,8 +147,6 @@ impl Repository {
     /// when multiple tasks need the same merge-base (e.g., parallel `wt list` tasks).
     /// The cache key is normalized (sorted) since merge-base(A, B) == merge-base(B, A).
     pub fn merge_base(&self, commit1: &str, commit2: &str) -> anyhow::Result<Option<String>> {
-        use anyhow::bail;
-
         // Normalize key order since merge-base is symmetric: merge-base(A, B) == merge-base(B, A)
         let key = if commit1 <= commit2 {
             (commit1.to_string(), commit2.to_string())

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -16,9 +16,15 @@
 //! - `config.rs` - Git config, hints, markers, and default branch detection
 //! - `integration.rs` - Integration detection (same commit, ancestor, trees match)
 
-use crate::shell_exec::Cmd;
+use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, LazyLock, OnceLock};
+use std::process::Stdio;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::{Arc, LazyLock, Mutex, OnceLock};
+use std::thread;
+use std::time::{Duration, Instant};
+
+use crate::shell_exec::Cmd;
 
 use dashmap::DashMap;
 use once_cell::sync::OnceCell;
@@ -564,13 +570,6 @@ impl Repository {
         delay_ms: i64,
         progress_message: Option<String>,
     ) -> anyhow::Result<()> {
-        use std::io::{BufRead, BufReader, Write};
-        use std::process::Stdio;
-        use std::sync::Mutex;
-        use std::sync::atomic::{AtomicBool, Ordering};
-        use std::thread;
-        use std::time::{Duration, Instant};
-
         // Allow tests to override delay threshold (-1 to disable, 0 for immediate)
         let delay_ms = std::env::var("WT_TEST_DELAYED_STREAM_MS")
             .ok()

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -1,9 +1,12 @@
 //! Output handlers for worktree operations using the global output context
 
-use color_print::cformat;
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use worktrunk::styling::stderr;
+use std::process::Stdio;
+
+use color_print::cformat;
+use worktrunk::shell_exec::Cmd;
+use worktrunk::styling::{eprint, format_bash_with_gutter, stderr};
 
 use crate::commands::branch_deletion::{
     BranchDeletionOutcome, BranchDeletionResult, delete_branch_if_safe,
@@ -467,8 +470,6 @@ pub fn handle_switch_output(
 /// `display_path` is shown when the user's shell won't be in the worktree directory
 /// (shell integration not active). This helps users understand where the command runs.
 pub fn execute_user_command(command: &str, display_path: Option<&Path>) -> anyhow::Result<()> {
-    use worktrunk::styling::format_bash_with_gutter;
-
     // Show what command is being executed (section header + gutter content)
     // Include path when user's shell won't be there (shell integration not active)
     let header = match display_path {
@@ -1077,10 +1078,6 @@ pub fn execute_command_in_worktree(
     command: &str,
     stdin_content: Option<&str>,
 ) -> anyhow::Result<()> {
-    use std::io::Write;
-    use worktrunk::shell_exec::Cmd;
-    use worktrunk::styling::{eprint, stderr};
-
     // Flush stdout before executing command to ensure all our messages appear
     // before the child process output
     stderr().flush()?;
@@ -1092,7 +1089,6 @@ pub fn execute_command_in_worktree(
     stderr().flush().ok(); // Ignore flush errors - reset is best-effort, command execution should proceed
 
     // Execute with stdout→stderr redirect for deterministic ordering
-    use std::process::Stdio;
     let mut cmd = Cmd::shell(command)
         .current_dir(worktree_path)
         .stdout(Stdio::from(std::io::stderr()))

--- a/src/shell/detection.rs
+++ b/src/shell/detection.rs
@@ -4,6 +4,9 @@
 //! shell config files (`.bashrc`, `.zshrc`, etc.) for eval/source lines
 //! that invoke `wt config shell init`.
 
+use std::collections::HashSet;
+use std::fs;
+use std::io::{BufRead, BufReader};
 use std::path::PathBuf;
 
 use super::paths::{home_dir_required, powershell_profile_paths};
@@ -262,9 +265,6 @@ pub struct BypassAlias {
 
 /// Scan a single file for shell integration lines and potential false negatives.
 fn scan_file(path: &std::path::Path, cmd: &str) -> Option<FileDetectionResult> {
-    use std::fs;
-    use std::io::{BufRead, BufReader};
-
     let file = fs::File::open(path).ok()?;
     let reader = BufReader::new(file);
     let mut matched_lines = Vec::new();
@@ -394,8 +394,6 @@ fn detect_bypass_alias(line: &str, cmd: &str, line_number: usize) -> Option<Bypa
 ///
 /// Used by `wt config show` to provide debugging output.
 pub fn scan_for_detection_details(cmd: &str) -> Result<Vec<FileDetectionResult>, std::io::Error> {
-    use std::collections::HashSet;
-
     let home = home_dir_required()?;
     let mut results = Vec::new();
 

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -9,6 +9,8 @@ mod detection;
 mod paths;
 mod utils;
 
+use std::io::{BufRead, BufReader};
+
 use askama::Template;
 
 // Re-export public types and functions
@@ -124,8 +126,6 @@ impl Shell {
 
     /// Check if a file contains shell integration lines for the given command.
     fn file_has_integration(path: &std::path::Path, cmd: &str) -> Result<bool, std::io::Error> {
-        use std::io::{BufRead, BufReader};
-
         let file = std::fs::File::open(path)?;
         for line in BufReader::new(file).lines() {
             if is_shell_integration_line(&line?, cmd) {

--- a/src/shell/utils.rs
+++ b/src/shell/utils.rs
@@ -3,6 +3,9 @@
 //! This module provides utilities for detecting the current shell, extracting
 //! shell names from paths, and probing shell configuration state.
 
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
 use super::Shell;
 
 /// Extract executable name from a path, stripping `.exe` on Windows.
@@ -81,9 +84,6 @@ pub fn current_shell() -> Option<Shell> {
 /// - `Some(false)` if compinit is NOT enabled
 /// - `None` if detection failed (zsh not installed, timeout, error)
 pub fn detect_zsh_compinit() -> Option<bool> {
-    use std::process::{Command, Stdio};
-    use std::time::{Duration, Instant};
-
     // Allow tests to bypass this check since zsh subprocess behavior varies across CI envs
     if std::env::var("WORKTRUNK_TEST_COMPINIT_CONFIGURED").is_ok() {
         return Some(true); // Assume compinit is configured


### PR DESCRIPTION
## Summary
- Move inline imports from function scope to module scope in 10 files
- Second of 4 batches to clean up inline imports across the codebase

## Files Changed

**src/shell/**
- `mod.rs` - `BufRead`, `BufReader`
- `utils.rs` - `Command`, `Stdio`, `Duration`, `Instant`
- `detection.rs` - `fs`, `BufRead`, `BufReader`, `HashSet`

**src/git/repository/**
- `mod.rs` - Multiple std imports for `run_command_delayed_stream`
- `diff.rs` - `bail` (consolidated with `Context`)
- `branches.rs` - `HashMap` (consolidated with `HashSet`)
- `branch.rs` - `GitRemoteUrl`

**src/output/**
- `handlers.rs` - `format_bash_with_gutter`, `Cmd`, `eprint`, `Stdio`
- `shell_integration.rs` - `IsTerminal`, styling functions, `configure_shell` types
- `global.rs` - Platform-specific imports with proper cfg attributes

## Test plan
- [x] `cargo check` passes
- [x] `pre-commit run --all-files` passes
- [x] `cargo test --lib --bins` passes (434 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)