### PR TITLE
refactor: move inline imports to module top level (batch 3)

### DIFF
--- a/src/commands/command_approval.rs
+++ b/src/commands/command_approval.rs
@@ -17,8 +17,9 @@
 //! This ensures approval happens exactly once at the command entry point,
 //! eliminating the need to thread `auto_trust` through execution layers.
 
-use super::hook_filter::{HookSource, ParsedFilter};
-use super::project_config::{HookCommand, collect_commands_for_hooks};
+use std::io::{self, IsTerminal, Write};
+use std::path::Path;
+
 use anyhow::Context;
 use color_print::cformat;
 use worktrunk::config::UserConfig;
@@ -27,6 +28,9 @@ use worktrunk::styling::{
     INFO_SYMBOL, PROMPT_SYMBOL, WARNING_SYMBOL, eprint, eprintln, format_bash_with_gutter,
     hint_message, stderr, warning_message,
 };
+
+use super::hook_filter::{HookSource, ParsedFilter};
+use super::project_config::{HookCommand, collect_commands_for_hooks};
 
 /// Batch approval helper used when multiple commands are queued for execution.
 /// Returns `Ok(true)` when execution may continue, `Ok(false)` when the user
@@ -104,9 +108,6 @@ pub fn approve_command_batch(
 }
 
 fn prompt_for_batch_approval(commands: &[&HookCommand], project_id: &str) -> anyhow::Result<bool> {
-    use std::io::{self, IsTerminal, Write};
-    use std::path::Path;
-
     // Extract just the directory name for display
     let project_name = Path::new(project_id)
         .file_name()

--- a/src/commands/configure_shell.rs
+++ b/src/commands/configure_shell.rs
@@ -1,6 +1,9 @@
+use std::collections::HashSet;
 use std::fs::{self, OpenOptions};
 use std::io::{self, BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
+
+use anstyle::Style;
 use worktrunk::path::format_path_for_display;
 use worktrunk::shell::{self, Shell};
 use worktrunk::styling::{
@@ -590,8 +593,6 @@ pub fn show_install_preview(
     completion_results: &[CompletionResult],
     cmd: &str,
 ) {
-    use anstyle::Style;
-
     let bold = Style::new().bold();
 
     // Show shell extension changes
@@ -663,8 +664,6 @@ pub fn show_uninstall_preview(
     results: &[UninstallResult],
     completion_results: &[CompletionUninstallResult],
 ) {
-    use anstyle::Style;
-
     let bold = Style::new().bold();
 
     for result in results {
@@ -751,7 +750,6 @@ pub fn prompt_for_install(
 
 /// Prompt user for yes/no confirmation (simple [y/N] prompt)
 fn prompt_yes_no() -> Result<bool, String> {
-    use anstyle::Style;
     use worktrunk::styling::eprint;
 
     let bold = Style::new().bold();
@@ -1080,8 +1078,7 @@ fn uninstall_from_file(
 
     // Remove matching lines and any immediately preceding blank line
     // (install adds "\n{line}\n", so we remove both the blank and the integration line)
-    let mut indices_to_remove: std::collections::HashSet<usize> =
-        integration_lines.iter().map(|(i, _)| *i).collect();
+    let mut indices_to_remove: HashSet<usize> = integration_lines.iter().map(|(i, _)| *i).collect();
     for &(i, _) in &integration_lines {
         if i > 0 && lines[i - 1].trim().is_empty() {
             indices_to_remove.insert(i - 1);
@@ -1117,8 +1114,6 @@ fn prompt_for_uninstall_confirmation(
     results: &[UninstallResult],
     completion_results: &[CompletionUninstallResult],
 ) -> Result<bool, String> {
-    use anstyle::Style;
-
     for result in results {
         let bold = Style::new().bold();
         let shell = result.shell;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -49,14 +49,15 @@ pub(crate) use worktree::{
 // Re-export Shell from the canonical location
 pub(crate) use worktrunk::shell::Shell;
 
+use color_print::cformat;
+use worktrunk::styling::{eprintln, format_with_gutter};
+
 /// Format command execution label with optional command name.
 ///
 /// Examples:
 /// - `format_command_label("post-create", Some("install"))` → `"Running post-create install"` (with bold)
 /// - `format_command_label("post-create", None)` → `"Running post-create"`
 pub(crate) fn format_command_label(command_type: &str, name: Option<&str>) -> String {
-    use color_print::cformat;
-
     match name {
         Some(name) => cformat!("Running {command_type} <bold>{name}</>"),
         None => format!("Running {command_type}"),
@@ -72,8 +73,6 @@ pub(crate) fn format_command_label(command_type: &str, name: Option<&str>) -> St
 /// * `repo` - The repository to query
 /// * `range` - The commit range to diff (e.g., "HEAD~1..HEAD" or "main..HEAD")
 pub(crate) fn show_diffstat(repo: &worktrunk::git::Repository, range: &str) -> anyhow::Result<()> {
-    use worktrunk::styling::{eprintln, format_with_gutter};
-
     let term_width = crate::display::get_terminal_width();
     let stat_width = term_width.saturating_sub(worktrunk::styling::GUTTER_OVERHEAD);
     let diff_stat = repo

--- a/src/commands/worktree/resolve.rs
+++ b/src/commands/worktree/resolve.rs
@@ -5,6 +5,7 @@
 use std::path::{Path, PathBuf};
 
 use color_print::cformat;
+use dunce::canonicalize;
 use normalize_path::NormalizePath;
 use worktrunk::config::UserConfig;
 use worktrunk::git::{GitError, Repository, ResolvedWorktree};
@@ -131,7 +132,6 @@ pub fn is_worktree_at_expected_path(
 ///
 /// Returns `true` if the paths resolve to the same location.
 pub(super) fn paths_match(a: &std::path::Path, b: &std::path::Path) -> bool {
-    use dunce::canonicalize;
     let a_canonical = canonicalize(a).unwrap_or_else(|_| a.to_path_buf());
     let b_canonical = canonicalize(b).unwrap_or_else(|_| b.to_path_buf());
     a_canonical == b_canonical


### PR DESCRIPTION
## Summary

- Move imports from function scope to module top level in `src/commands/` files
- Files modified: mod.rs, step_commands.rs, statusline.rs, command_approval.rs, configure_shell.rs, hook_commands.rs, worktree/resolve.rs
- Follows Rust conventions for import organization

This is the third of four batches moving inline imports to follow Rust conventions. Function-local imports remain where strictly necessary (e.g., test-only imports within `#[cfg(test)]` modules).

## Test plan

- [x] `cargo check` passes
- [x] `pre-commit run --all-files` passes
- [x] All tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)