### PR TITLE
ci: instruct Claude to read file context for line comments

### DIFF
--- a/.github/workflows/claude-mention.yaml
+++ b/.github/workflows/claude-mention.yaml
@@ -104,7 +104,11 @@ jobs:
             - 'cargo doc --no-deps' - Build documentation
 
             This project is a git worktree manager that integrates with shells (bash, zsh, fish).
-            Pay attention to shell integration, output formatting (anstyle), and snapshot tests."
+            Pay attention to shell integration, output formatting (anstyle), and snapshot tests.
+
+            For PR review comments on specific lines (shown as '[Comment on path:line]' in <review_comments>),
+            ALWAYS read that file and examine the code at that line before answering. The question is about
+            that specific code, not about the PR in general."
 
       - name: 📋 Upload Claude Code session logs
         if: always()


### PR DESCRIPTION
## Summary

- Add instruction to Claude CI workflow to read file context when responding to PR review comments on specific lines
- Works around upstream issue where `diffHunk` isn't included in the prompt context

Upstream issue filed: https://github.com/anthropics/claude-code-action/issues/855

## Test plan

- [x] Workflow syntax is valid YAML
- [ ] Next PR review comment on a specific line should trigger Claude to read the file first

> _This was written by Claude Code on behalf of @max-sixty_