### PR TITLE
refactor: use anstream eprint consistently for TTY-aware output

### DIFF
--- a/src/commands/configure_shell.rs
+++ b/src/commands/configure_shell.rs
@@ -7,7 +7,7 @@ use anstyle::Style;
 use worktrunk::path::format_path_for_display;
 use worktrunk::shell::{self, Shell};
 use worktrunk::styling::{
-    INFO_SYMBOL, PROMPT_SYMBOL, SUCCESS_SYMBOL, eprintln, format_bash_with_gutter,
+    INFO_SYMBOL, PROMPT_SYMBOL, SUCCESS_SYMBOL, eprint, eprintln, format_bash_with_gutter,
     format_with_gutter, warning_message,
 };
 
@@ -750,8 +750,6 @@ pub fn prompt_for_install(
 
 /// Prompt user for yes/no confirmation (simple [y/N] prompt)
 fn prompt_yes_no() -> Result<bool, String> {
-    use worktrunk::styling::eprint;
-
     let bold = Style::new().bold();
     eprint!("{PROMPT_SYMBOL} Proceed? {bold}[y/N]{bold:#} ");
     io::stderr().flush().map_err(|e| e.to_string())?;

--- a/tests/snapshots/integration__integration_tests__configure_shell__pty_tests__install_preview_declined.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__pty_tests__install_preview_declined.snap
@@ -3,5 +3,5 @@ source: tests/integration_tests/configure_shell.rs
 expression: "output.trim_start_matches('\\n')"
 ---
 
-[36m❯[39m Install shell integration? [1m[y/N/?][22m 
+❯ Install shell integration? [y/N/?] 
 ✗ Cancelled by user

--- a/tests/snapshots/integration__integration_tests__configure_shell__pty_tests__install_preview_with_gutter.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__pty_tests__install_preview_with_gutter.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/configure_shell.rs
 expression: "output.trim_start_matches('\\n')"
 ---
 
-[36m❯[39m Install shell integration? [1m[y/N/?][22m 
+❯ Install shell integration? [y/N/?] 
 ✓ Added shell extension & completions for zsh @ ~/.zshrc
 ↳ Skipped bash; ~/.bashrc not found
 ↳ Skipped fish; ~/.config/fish/functions not found


### PR DESCRIPTION
## Summary

- Standardizes on `worktrunk::styling::eprint` (anstream) for all stderr output
- Anstream is TTY-aware: colors pass through on TTY, stripped otherwise
- Updates test snapshots to reflect correct behavior when TERM isn't set

This ensures consistent behavior across the codebase - no more mix of `std::eprint!` and `worktrunk::styling::eprint`.

## Test plan

- [x] `cargo check` passes
- [x] `pre-commit run --all-files` passes  
- [x] All 2058 tests pass

> _This was written by Claude Code on behalf of max-sixty_