### PR TITLE
refactor: remove legacy dur= trace format, use dur_us= only

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -165,7 +165,7 @@ let output = Cmd::new("gh")
     .run()?;  // no context for standalone tools
 ```
 
-Never use `cmd.output()` directly. `Cmd` provides debug logging (`$ git status [worktree-name]`) and timing traces (`[wt-trace] cmd="..." dur=12.3ms ok=true`).
+Never use `cmd.output()` directly. `Cmd` provides debug logging (`$ git status [worktree-name]`) and timing traces (`[wt-trace] cmd="..." dur_us=12300 ok=true`).
 
 For git commands, prefer `Repository::run_command()` which wraps `Cmd` with worktree context.
 

--- a/tests/helpers/wt-perf/src/main.rs
+++ b/tests/helpers/wt-perf/src/main.rs
@@ -206,7 +206,9 @@ fn main() {
                 eprintln!("No trace entries found in input.");
                 eprintln!();
                 eprintln!("Trace lines should look like:");
-                eprintln!("  [wt-trace] ts=1234567890 tid=3 cmd=\"git status\" dur=12.3ms ok=true");
+                eprintln!(
+                    "  [wt-trace] ts=1234567890 tid=3 cmd=\"git status\" dur_us=12300 ok=true"
+                );
                 eprintln!("  [wt-trace] ts=1234567890 tid=3 event=\"Showed skeleton\"");
                 eprintln!();
                 eprintln!("To capture traces, run with RUST_LOG=debug:");

--- a/tests/integration_tests/analyze_trace.rs
+++ b/tests/integration_tests/analyze_trace.rs
@@ -19,12 +19,12 @@ fn wt_perf_bin() -> std::path::PathBuf {
 /// Test that the binary produces Chrome Trace Format JSON for sample trace input.
 #[test]
 fn test_wt_perf_trace_from_stdin() {
-    let sample_trace = r#"[wt-trace] ts=1000000 tid=1 cmd="git status" dur=10.0ms ok=true
-[wt-trace] ts=1010000 tid=1 cmd="git status" dur=15.0ms ok=true
-[wt-trace] ts=1025000 tid=1 cmd="git diff" dur=100.0ms ok=true
+    let sample_trace = r#"[wt-trace] ts=1000000 tid=1 cmd="git status" dur_us=10000 ok=true
+[wt-trace] ts=1010000 tid=1 cmd="git status" dur_us=15000 ok=true
+[wt-trace] ts=1025000 tid=1 cmd="git diff" dur_us=100000 ok=true
 [wt-trace] ts=1025000 tid=2 event="Showed skeleton"
-[wt-trace] ts=1125000 tid=1 cmd="git merge-base HEAD main" dur=500.0ms ok=true
-[wt-trace] ts=1625000 tid=1 cmd="gh pr list" dur=200.0ms ok=true"#;
+[wt-trace] ts=1125000 tid=1 cmd="git merge-base HEAD main" dur_us=500000 ok=true
+[wt-trace] ts=1625000 tid=1 cmd="gh pr list" dur_us=200000 ok=true"#;
 
     let mut child = Command::new(wt_perf_bin())
         .arg("trace")
@@ -127,10 +127,10 @@ fn test_wt_perf_trace_from_file() {
     let temp_dir = tempfile::tempdir().expect("Failed to create temp dir");
     let log_file = temp_dir.path().join("trace.log");
 
-    let sample_trace = r#"[wt-trace] ts=1000000 tid=1 cmd="git rev-parse" dur=5.0ms ok=true
-[wt-trace] ts=1005000 tid=1 cmd="git status" dur=10.0ms ok=true
+    let sample_trace = r#"[wt-trace] ts=1000000 tid=1 cmd="git rev-parse" dur_us=5000 ok=true
+[wt-trace] ts=1005000 tid=1 cmd="git status" dur_us=10000 ok=true
 [wt-trace] ts=1015000 tid=1 event="Skeleton displayed"
-[wt-trace] ts=1015000 tid=2 cmd="git diff" dur=50.0ms ok=true"#;
+[wt-trace] ts=1015000 tid=2 cmd="git diff" dur_us=50000 ok=true"#;
 
     std::fs::write(&log_file, sample_trace).expect("Failed to write sample log");
 


### PR DESCRIPTION
## Summary
- Remove backwards compatibility for old `dur=...ms` trace format
- All traces now use `dur_us=` (microseconds) to avoid floating-point precision loss
- Update all tests and documentation to use the new format

## Test plan
- [x] Unit tests pass (`cargo test -p worktrunk --lib trace::`)
- [x] Integration tests pass (`cargo test --test integration analyze_trace`)
- [x] Pre-commit lints pass

🤖 Generated with [Claude Code](https://claude.ai/code)