### PR TITLE
docs: clarify user project-specific settings section

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/config.md
+++ b/.claude-plugin/skills/worktrunk/reference/config.md
@@ -131,24 +131,31 @@ Pager behavior for `wt select` diff previews.
 # pager = "delta --paging=never"
 ```
 
-### Per-project settings (Experimental)
+### User project-specific settings
 
-Per-project settings are keyed by project identifier (e.g., `github.com/user/repo`).
-These contain approved hook commands plus optional overrides of global settings.
-Setting overrides (worktree-path, list, commit, merge) are new; approved-commands is stable.
+User config settings apply to all projects. [Project config](https://worktrunk.dev/config/#worktrunk-project-configuration) settings are shared with teammates. The `[projects]` table holds personal, project-specific settings like approved hook commands and worktree layout. Entries are keyed by project identifier (e.g., `github.com/user/repo`).
+
+#### Approved hook commands
+
+When a project hook runs for the first time, worktrunk asks for approval. Approved commands are saved here, preventing repeated prompts.
 
 ```toml
 [projects."github.com/user/repo"]
-# Approved hook commands (auto-populated when approving on first run)
 approved-commands = ["npm ci", "npm test"]
+```
 
-# Optional overrides (omit to use global settings)
+Auto-managed. To reset, delete the entry or run `wt hook approve --clear`.
+
+#### Setting overrides (Experimental)
+
+Override global settings for a specific project. Useful when one repo needs a different worktree layout or merge behavior.
+
+```toml
+[projects."github.com/user/repo"]
 worktree-path = ".worktrees/{{ branch | sanitize }}"
 list.full = true
 merge.squash = false
 ```
-
-For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at `<repo>/.config/wt.toml`. Run `wt config create --project` to create one, or see [`wt hook` docs](https://worktrunk.dev/hook/).
 
 ### Custom prompt templates
 

--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -81,22 +81,27 @@
 # # Example:
 # # pager = "delta --paging=never"
 #
-# ### Per-project settings (Experimental)
+# ### User project-specific settings
 #
-# Per-project settings are keyed by project identifier (e.g., `github.com/user/repo`).
-# These contain approved hook commands plus optional overrides of global settings.
-# Setting overrides (worktree-path, list, commit, merge) are new; approved-commands is stable.
+# User config settings apply to all projects. Project config (https://worktrunk.dev/config.md#worktrunk-project-configuration/) settings are shared with teammates. The `[projects]` table holds personal, project-specific settings like approved hook commands and worktree layout. Entries are keyed by project identifier (e.g., `github.com/user/repo`).
+#
+# #### Approved hook commands
+#
+# When a project hook runs for the first time, worktrunk asks for approval. Approved commands are saved here, preventing repeated prompts.
 #
 # [projects."github.com/user/repo"]
-# # Approved hook commands (auto-populated when approving on first run)
 # approved-commands = ["npm ci", "npm test"]
 #
-# # Optional overrides (omit to use global settings)
+# Auto-managed. To reset, delete the entry or run `wt hook approve --clear`.
+#
+# #### Setting overrides (Experimental)
+#
+# Override global settings for a specific project. Useful when one repo needs a different worktree layout or merge behavior.
+#
+# [projects."github.com/user/repo"]
 # worktree-path = ".worktrees/{{ branch | sanitize }}"
 # list.full = true
 # merge.squash = false
-#
-# For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at `<repo>/.config/wt.toml`. Run `wt config create --project` to create one, or see `wt hook` docs (https://worktrunk.dev/hook/).
 #
 # ### Custom prompt templates
 #

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -139,24 +139,31 @@ Pager behavior for `wt select` diff previews.
 # pager = "delta --paging=never"
 ```
 
-### Per-project settings (Experimental)
+### User project-specific settings
 
-Per-project settings are keyed by project identifier (e.g., `github.com/user/repo`).
-These contain approved hook commands plus optional overrides of global settings.
-Setting overrides (worktree-path, list, commit, merge) are new; approved-commands is stable.
+User config settings apply to all projects. [Project config](@/config.md#worktrunk-project-configuration) settings are shared with teammates. The `[projects]` table holds personal, project-specific settings like approved hook commands and worktree layout. Entries are keyed by project identifier (e.g., `github.com/user/repo`).
+
+#### Approved hook commands
+
+When a project hook runs for the first time, worktrunk asks for approval. Approved commands are saved here, preventing repeated prompts.
 
 ```toml
 [projects."github.com/user/repo"]
-# Approved hook commands (auto-populated when approving on first run)
 approved-commands = ["npm ci", "npm test"]
+```
 
-# Optional overrides (omit to use global settings)
+Auto-managed. To reset, delete the entry or run `wt hook approve --clear`.
+
+#### Setting overrides (Experimental)
+
+Override global settings for a specific project. Useful when one repo needs a different worktree layout or merge behavior.
+
+```toml
+[projects."github.com/user/repo"]
 worktree-path = ".worktrees/{{ branch | sanitize }}"
 list.full = true
 merge.squash = false
 ```
-
-For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at `<repo>/.config/wt.toml`. Run `wt config create --project` to create one, or see [`wt hook` docs](@/hook.md).
 
 ### Custom prompt templates
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1594,24 +1594,31 @@ Pager behavior for `wt select` diff previews.
 # pager = "delta --paging=never"
 ```
 
-### Per-project settings (Experimental)
+### User project-specific settings
 
-Per-project settings are keyed by project identifier (e.g., `github.com/user/repo`).
-These contain approved hook commands plus optional overrides of global settings.
-Setting overrides (worktree-path, list, commit, merge) are new; approved-commands is stable.
+User config settings apply to all projects. [Project config](@/config.md#worktrunk-project-configuration) settings are shared with teammates. The `[projects]` table holds personal, project-specific settings like approved hook commands and worktree layout. Entries are keyed by project identifier (e.g., `github.com/user/repo`).
+
+#### Approved hook commands
+
+When a project hook runs for the first time, worktrunk asks for approval. Approved commands are saved here, preventing repeated prompts.
 
 ```toml
 [projects."github.com/user/repo"]
-# Approved hook commands (auto-populated when approving on first run)
 approved-commands = ["npm ci", "npm test"]
+```
 
-# Optional overrides (omit to use global settings)
+Auto-managed. To reset, delete the entry or run `wt hook approve --clear`.
+
+#### Setting overrides (Experimental)
+
+Override global settings for a specific project. Useful when one repo needs a different worktree layout or merge behavior.
+
+```toml
+[projects."github.com/user/repo"]
 worktree-path = ".worktrees/{{ branch | sanitize }}"
 list.full = true
 merge.squash = false
 ```
-
-For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at `<repo>/.config/wt.toml`. Run `wt config create --project` to create one, or see [`wt hook` docs](@/hook.md).
 
 ### Custom prompt templates
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -133,22 +133,27 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
   [2m# # Example:[0m
   [2m# # pager = "delta --paging=never"[0m
   [2m#[0m
-  [2m# ### Per-project settings (Experimental)[0m
+  [2m# ### User project-specific settings[0m
   [2m#[0m
-  [2m# Per-project settings are keyed by project identifier (e.g., `github.com/user/repo`).[0m
-  [2m# These contain approved hook commands plus optional overrides of global settings.[0m
-  [2m# Setting overrides (worktree-path, list, commit, merge) are new; approved-commands is stable.[0m
+  [2m# User config settings apply to all projects. Project config (https://worktrunk.dev/config.md#worktrunk-project-configuration/) settings are shared with teammates. The `[projects]` table holds personal, project-specific settings like approved hook commands and worktree layout. Entries are keyed by project identifier (e.g., `github.com/user/repo`).[0m
+  [2m#[0m
+  [2m# #### Approved hook commands[0m
+  [2m#[0m
+  [2m# When a project hook runs for the first time, worktrunk asks for approval. Approved commands are saved here, preventing repeated prompts.[0m
   [2m#[0m
   [2m# [projects."github.com/user/repo"][0m
-  [2m# # Approved hook commands (auto-populated when approving on first run)[0m
   [2m# approved-commands = ["npm ci", "npm test"][0m
   [2m#[0m
-  [2m# # Optional overrides (omit to use global settings)[0m
+  [2m# Auto-managed. To reset, delete the entry or run `wt hook approve --clear`.[0m
+  [2m#[0m
+  [2m# #### Setting overrides (Experimental)[0m
+  [2m#[0m
+  [2m# Override global settings for a specific project. Useful when one repo needs a different worktree layout or merge behavior.[0m
+  [2m#[0m
+  [2m# [projects."github.com/user/repo"][0m
   [2m# worktree-path = ".worktrees/{{ branch | sanitize }}"[0m
   [2m# list.full = true[0m
   [2m# merge.squash = false[0m
-  [2m#[0m
-  [2m# For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at `<repo>/.config/wt.toml`. Run `wt config create --project` to create one, or see `wt hook` docs (https://worktrunk.dev/hook/).[0m
   [2m#[0m
   [2m# ### Custom prompt templates[0m
   [2m#[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -160,22 +160,27 @@ Pager behavior for [2mwt select[0m diff previews.
   [2m# Example:[0m
   [2m# pager = "delta --paging=never"[0m
 
-[32mPer-project settings (Experimental)[0m
+[32mUser project-specific settings[0m
 
-Per-project settings are keyed by project identifier (e.g., [2mgithub.com/user/repo[0m).
-These contain approved hook commands plus optional overrides of global settings.
-Setting overrides (worktree-path, list, commit, merge) are new; approved-commands is stable.
+User config settings apply to all projects. Project config settings are shared with teammates. The [2m[projects][0m table holds personal, project-specific settings like approved hook commands and worktree layout. Entries are keyed by project identifier (e.g., [2mgithub.com/user/repo[0m).
+
+[1mApproved hook commands[0m
+
+When a project hook runs for the first time, worktrunk asks for approval. Approved commands are saved here, preventing repeated prompts.
 
   [2m[projects."github.com/user/repo"][0m
-  [2m# Approved hook commands (auto-populated when approving on first run)[0m
   [2mapproved-commands = ["npm ci", "npm test"][0m
-  [2m[0m
-  [2m# Optional overrides (omit to use global settings)[0m
+
+Auto-managed. To reset, delete the entry or run [2mwt hook approve --clear[0m.
+
+[1mSetting overrides (Experimental)[0m
+
+Override global settings for a specific project. Useful when one repo needs a different worktree layout or merge behavior.
+
+  [2m[projects."github.com/user/repo"][0m
   [2mworktree-path = ".worktrees/{{ branch | sanitize }}"[0m
   [2mlist.full = true[0m
   [2mmerge.squash = false[0m
-
-For project-specific hooks (post-create, post-start, pre-merge, etc.), use a project config at [2m<repo>/.config/wt.toml[0m. Run [2mwt config create --project[0m to create one, or see [2mwt hook[0m docs.
 
 [32mCustom prompt templates[0m
 


### PR DESCRIPTION
## Summary

- Restructure per-project settings docs to clarify the user/project config distinction
- Rename section from "Per-project settings" to "User project-specific settings"  
- Split into subsections: "Approved hook commands" (auto-managed) and "Setting overrides" (experimental)
- Add intro explaining how this fits between global user settings and shared project config
- Link to project config documentation

## Test plan

- [x] All tests pass (923 integration tests)
- [x] Pre-commit checks pass
- [x] Doc sync tests verify generated files match source

🤖 Generated with [Claude Code](https://claude.ai/code)