### PR TITLE
fix: prevent spurious [commit] header in config migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3113,6 +3113,7 @@ dependencies = [
  "shellexpand",
  "shlex",
  "signal-hook 0.4.1",
+ "similar",
  "skim",
  "strum",
  "supports-hyperlinks",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -140,6 +140,7 @@ regex = "1.12"
 vt100 = "0.16"
 ansi-to-html = "0.2.2"
 wt-perf = { path = "tests/helpers/wt-perf" }
+similar = "2.7.0"
 
 [[bench]]
 name = "completion"

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -269,9 +269,13 @@ pub fn migrate_commit_generation_sections(content: &str) -> String {
             // Merge args into command if present
             merge_args_into_command(&mut table);
 
-            // Ensure [commit] section exists
+            // Ensure [commit] section exists.
+            // Mark as implicit so it doesn't render a separate [commit] header
+            // (only [commit.generation] will render)
             if !doc.contains_key("commit") {
-                doc["commit"] = toml_edit::Item::Table(toml_edit::Table::new());
+                let mut commit_table = toml_edit::Table::new();
+                commit_table.set_implicit(true);
+                doc.insert("commit", toml_edit::Item::Table(commit_table));
             }
 
             // Move to [commit.generation]
@@ -310,10 +314,12 @@ pub fn migrate_commit_generation_sections(content: &str) -> String {
                         // Merge args into command if present
                         merge_args_into_command(&mut table);
 
-                        // Ensure [projects."...".commit] section exists
+                        // Ensure [projects."...".commit] section exists.
+                        // Mark as implicit so it doesn't render a separate header
                         if !project_table.contains_key("commit") {
-                            project_table
-                                .insert("commit", toml_edit::Item::Table(toml_edit::Table::new()));
+                            let mut commit_table = toml_edit::Table::new();
+                            commit_table.set_implicit(true);
+                            project_table.insert("commit", toml_edit::Item::Table(commit_table));
                         }
 
                         // Move to [projects."...".commit.generation]
@@ -1614,5 +1620,134 @@ other = "value"
         let content = "this is [not valid {toml";
         let result = migrate_commit_generation_sections(content);
         assert_eq!(result, content, "Invalid TOML should be returned unchanged");
+    }
+
+    // Snapshot tests for migration output (showing diffs)
+
+    /// Generate a unified diff between original and migrated content
+    fn migration_diff(original: &str, migrated: &str) -> String {
+        use similar::{ChangeTag, TextDiff};
+        let diff = TextDiff::from_lines(original, migrated);
+        let mut output = String::new();
+        for change in diff.iter_all_changes() {
+            let sign = match change.tag() {
+                ChangeTag::Delete => "-",
+                ChangeTag::Insert => "+",
+                ChangeTag::Equal => " ",
+            };
+            output.push_str(&format!("{}{}", sign, change));
+        }
+        output
+    }
+
+    #[test]
+    fn snapshot_migrate_commit_generation_simple() {
+        let content = r#"
+[commit-generation]
+command = "llm -m haiku"
+"#;
+        let result = migrate_commit_generation_sections(content);
+        insta::assert_snapshot!(migration_diff(content, &result));
+    }
+
+    #[test]
+    fn snapshot_migrate_commit_generation_with_args() {
+        let content = r#"
+[commit-generation]
+command = "llm"
+args = ["-m", "claude-haiku-4.5"]
+"#;
+        let result = migrate_commit_generation_sections(content);
+        insta::assert_snapshot!(migration_diff(content, &result));
+    }
+
+    #[test]
+    fn snapshot_migrate_with_trailing_sections() {
+        // This is the bug case: [commit-generation] in the middle of the file
+        // followed by other sections. The migration should not add an extra
+        // [commit] section at the end.
+        let content = r#"# Config file
+worktree-path = "../{{ repo }}.{{ branch | sanitize }}"
+
+[commit-generation]
+command = "llm"
+args = ["-m", "claude-haiku-4.5"]
+
+[list]
+branches = true
+remotes = false
+"#;
+        let result = migrate_commit_generation_sections(content);
+        insta::assert_snapshot!(migration_diff(content, &result));
+    }
+
+    #[test]
+    fn snapshot_migrate_preserves_existing_commit_section() {
+        let content = r#"
+[commit]
+stage = "all"
+
+[commit-generation]
+command = "llm -m haiku"
+"#;
+        let result = migrate_commit_generation_sections(content);
+        insta::assert_snapshot!(migration_diff(content, &result));
+    }
+
+    #[test]
+    fn snapshot_migrate_project_level() {
+        let content = r#"
+[projects."github.com/user/repo"]
+approved-commands = ["npm test"]
+
+[projects."github.com/user/repo".commit-generation]
+command = "llm"
+args = ["-m", "gpt-4"]
+"#;
+        let result = migrate_commit_generation_sections(content);
+        insta::assert_snapshot!(migration_diff(content, &result));
+    }
+
+    #[test]
+    fn snapshot_migrate_combined_top_and_project() {
+        let content = r#"
+[commit-generation]
+command = "llm -m haiku"
+
+[projects."github.com/user/repo".commit-generation]
+command = "llm -m gpt-4"
+
+[list]
+branches = true
+"#;
+        let result = migrate_commit_generation_sections(content);
+        insta::assert_snapshot!(migration_diff(content, &result));
+    }
+
+    #[test]
+    fn test_set_implicit_suppresses_parent_header() {
+        // Verifies that set_implicit(true) prevents an empty parent table from
+        // rendering its own header. This is the key technique used in
+        // migrate_commit_generation_sections to avoid creating spurious [commit]
+        // headers when migrating [commit-generation] to [commit.generation].
+        use toml_edit::{DocumentMut, Item, Table};
+
+        let mut doc: DocumentMut = "[foo]\nbar = 1\n".parse().unwrap();
+        let mut commit_table = Table::new();
+        commit_table.set_implicit(true);
+        let mut gen_table = Table::new();
+        gen_table.insert("command", toml_edit::value("llm"));
+        commit_table.insert("generation", Item::Table(gen_table));
+        doc.insert("commit", Item::Table(commit_table));
+        let result = doc.to_string();
+
+        assert!(
+            !result.contains("\n[commit]\n"),
+            "set_implicit should suppress separate [commit] header"
+        );
+        assert!(
+            result.contains("[commit.generation]"),
+            "Should have [commit.generation] header"
+        );
     }
 }

--- a/src/config/snapshots/worktrunk__config__deprecation__tests__snapshot_migrate_combined_top_and_project.snap
+++ b/src/config/snapshots/worktrunk__config__deprecation__tests__snapshot_migrate_combined_top_and_project.snap
@@ -1,0 +1,15 @@
+---
+source: src/config/deprecation.rs
+expression: "migration_diff(content, &result)"
+---
+ 
+-[commit-generation]
++[commit.generation]
+ command = "llm -m haiku"
+ 
+-[projects."github.com/user/repo".commit-generation]
++[projects."github.com/user/repo".commit.generation]
+ command = "llm -m gpt-4"
+ 
+ [list]
+ branches = true

--- a/src/config/snapshots/worktrunk__config__deprecation__tests__snapshot_migrate_commit_generation_simple.snap
+++ b/src/config/snapshots/worktrunk__config__deprecation__tests__snapshot_migrate_commit_generation_simple.snap
@@ -1,0 +1,8 @@
+---
+source: src/config/deprecation.rs
+expression: "migration_diff(content, &result)"
+---
+ 
+-[commit-generation]
++[commit.generation]
+ command = "llm -m haiku"

--- a/src/config/snapshots/worktrunk__config__deprecation__tests__snapshot_migrate_commit_generation_with_args.snap
+++ b/src/config/snapshots/worktrunk__config__deprecation__tests__snapshot_migrate_commit_generation_with_args.snap
@@ -1,0 +1,10 @@
+---
+source: src/config/deprecation.rs
+expression: "migration_diff(content, &result)"
+---
+ 
+-[commit-generation]
+-command = "llm"
+-args = ["-m", "claude-haiku-4.5"]
++[commit.generation]
++command = "llm -m claude-haiku-4.5"

--- a/src/config/snapshots/worktrunk__config__deprecation__tests__snapshot_migrate_preserves_existing_commit_section.snap
+++ b/src/config/snapshots/worktrunk__config__deprecation__tests__snapshot_migrate_preserves_existing_commit_section.snap
@@ -1,0 +1,11 @@
+---
+source: src/config/deprecation.rs
+expression: "migration_diff(content, &result)"
+---
+ 
+ [commit]
+ stage = "all"
+ 
+-[commit-generation]
++[commit.generation]
+ command = "llm -m haiku"

--- a/src/config/snapshots/worktrunk__config__deprecation__tests__snapshot_migrate_project_level.snap
+++ b/src/config/snapshots/worktrunk__config__deprecation__tests__snapshot_migrate_project_level.snap
@@ -1,0 +1,13 @@
+---
+source: src/config/deprecation.rs
+expression: "migration_diff(content, &result)"
+---
+ 
+ [projects."github.com/user/repo"]
+ approved-commands = ["npm test"]
+ 
+-[projects."github.com/user/repo".commit-generation]
+-command = "llm"
+-args = ["-m", "gpt-4"]
++[projects."github.com/user/repo".commit.generation]
++command = "llm -m gpt-4"

--- a/src/config/snapshots/worktrunk__config__deprecation__tests__snapshot_migrate_with_trailing_sections.snap
+++ b/src/config/snapshots/worktrunk__config__deprecation__tests__snapshot_migrate_with_trailing_sections.snap
@@ -1,0 +1,16 @@
+---
+source: src/config/deprecation.rs
+expression: "migration_diff(content, &result)"
+---
+ # Config file
+ worktree-path = "../{{ repo }}.{{ branch | sanitize }}"
+ 
+-[commit-generation]
+-command = "llm"
+-args = ["-m", "claude-haiku-4.5"]
++[commit.generation]
++command = "llm -m claude-haiku-4.5"
+ 
+ [list]
+ branches = true
+ remotes = false

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
@@ -40,15 +40,13 @@ exit_code: 0
 [2m↳[22m [2mWrote migrated [1mconfig.toml.new[22m. To apply:[22m
 [107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEMP_HOME]/.config/worktrunk/config.toml.new [TEMP_HOME]/.config/worktrunk/config.toml
 [107m [0m [1mdiff --git a[TEMP_HOME]/.config/worktrunk/config.toml b[TEMP_HOME]/.config/worktrunk/config.toml.new
-[107m [0m [1mindex de80729..eb69d44 100644[m
+[107m [0m [1mindex de80729..131a2fd 100644[m
 [107m [0m [1m--- a[TEMP_HOME]/.config/worktrunk/config.toml
 [107m [0m [1m+++ b[TEMP_HOME]/.config/worktrunk/config.toml.new
-[107m [0m [36m@@ -1,4 +1,6 @@[m
+[107m [0m [36m@@ -1,4 +1,4 @@[m
 [107m [0m  worktree-path = "../{{ repo }}.{{ branch }}"[m
 [107m [0m  [m
 [107m [0m [31m-[projects."github.com/example/repo".commit-generation][m
-[107m [0m [32m+[m[32m[projects."github.com/example/repo".commit][m
-[107m [0m [32m+[m
 [107m [0m [32m+[m[32m[projects."github.com/example/repo".commit.generation][m
 [107m [0m  command = "llm -m gpt-4"[m
 [107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
@@ -43,14 +43,13 @@ exit_code: 0
 [2m↳[22m [2mWrote migrated [1mwt.toml.new[22m. To apply:[22m
 [107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m _REPO_/.config/wt.toml.new _REPO_/.config/wt.toml
 [107m [0m [1mdiff --git a_REPO_/.config/wt.toml b_REPO_/.config/wt.toml.new[m
-[107m [0m [1mindex 074c30f..e97c84f 100644[m
+[107m [0m [1mindex 074c30f..bcaf404 100644[m
 [107m [0m [1m--- a_REPO_/.config/wt.toml[m
 [107m [0m [1m+++ b_REPO_/.config/wt.toml.new[m
-[107m [0m [36m@@ -1,2 +1,3 @@[m
+[107m [0m [36m@@ -1,2 +1,2 @@[m
 [107m [0m [31m-[commit-generation][m
 [107m [0m [31m-command = "claude"[m
 [107m [0m / No newline at end of file[m
-[107m [0m [32m+[m[32m[commit][m
 [107m [0m [32m+[m[32m[commit.generation][m
 [107m [0m [32m+[m[32mcommand = "claude"[m
 [33m▲[39m [33mKey [1mcommit-generation[22m belongs in user config (will be ignored)[39m


### PR DESCRIPTION
## Summary
- Fixes bug where config migration created spurious `[commit]` section header at end of file
- Uses `set_implicit(true)` to suppress empty parent table headers in toml_edit
- Adds snapshot tests showing unified diffs of migration output

## Test plan
- [x] Unit tests pass (68 deprecation tests)
- [x] Integration tests pass (939 tests)
- [x] Verified fix on actual user config file

🤖 Generated with [Claude Code](https://claude.ai/code)