### PR TITLE
docs: clarify user project-specific settings section

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/config.md
+++ b/.claude-plugin/skills/worktrunk/reference/config.md
@@ -155,18 +155,24 @@ Pager behavior for `wt select` diff previews.
 
 ### User project-specific settings
 
-User config settings apply to all projects. [Project config](https://worktrunk.dev/config/#worktrunk-project-configuration) settings are shared with teammates. The `[projects]` table holds personal, project-specific settings like approved hook commands and worktree layout. Entries are keyed by project identifier (e.g., `github.com/user/repo`).
+For context:
+
+- [Project config](https://worktrunk.dev/config/#worktrunk-project-configuration) settings are shared with teammates.
+- User configs generally apply to all projects.
+- User configs _also_ has a `[projects]` table which holds project-specific settings for the user, such as approved hook commands and worktree layout. That's what this section covers.
+
+Entries are keyed by project identifier (e.g., `github.com/user/repo`).
 
 #### Approved hook commands
 
-When a project hook runs for the first time, worktrunk asks for approval. Approved commands are saved here, preventing repeated prompts.
+When a project hook runs for the first time, Worktrunk asks for approval. Approved commands are saved here, preventing repeated prompts.
 
 ```toml
 [projects."github.com/user/repo"]
 approved-commands = ["npm ci", "npm test"]
 ```
 
-Auto-managed. To reset, delete the entry or run `wt hook approve --clear`.
+To reset, delete the entry or run `wt hook approvals clear`.
 
 #### Setting overrides (Experimental)
 

--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -83,16 +83,22 @@
 #
 # ### User project-specific settings
 #
-# User config settings apply to all projects. Project config (https://worktrunk.dev/config.md#worktrunk-project-configuration/) settings are shared with teammates. The `[projects]` table holds personal, project-specific settings like approved hook commands and worktree layout. Entries are keyed by project identifier (e.g., `github.com/user/repo`).
+# For context:
+#
+# - Project config (https://worktrunk.dev/config.md#worktrunk-project-configuration/) settings are shared with teammates.
+# - User configs generally apply to all projects.
+# - User configs _also_ has a `[projects]` table which holds project-specific settings for the user, such as approved hook commands and worktree layout. That's what this section covers.
+#
+# Entries are keyed by project identifier (e.g., `github.com/user/repo`).
 #
 # #### Approved hook commands
 #
-# When a project hook runs for the first time, worktrunk asks for approval. Approved commands are saved here, preventing repeated prompts.
+# When a project hook runs for the first time, Worktrunk asks for approval. Approved commands are saved here, preventing repeated prompts.
 #
 # [projects."github.com/user/repo"]
 # approved-commands = ["npm ci", "npm test"]
 #
-# Auto-managed. To reset, delete the entry or run `wt hook approve --clear`.
+# To reset, delete the entry or run `wt hook approvals clear`.
 #
 # #### Setting overrides (Experimental)
 #

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -163,18 +163,24 @@ Pager behavior for `wt select` diff previews.
 
 ### User project-specific settings
 
-User config settings apply to all projects. [Project config](@/config.md#worktrunk-project-configuration) settings are shared with teammates. The `[projects]` table holds personal, project-specific settings like approved hook commands and worktree layout. Entries are keyed by project identifier (e.g., `github.com/user/repo`).
+For context:
+
+- [Project config](@/config.md#worktrunk-project-configuration) settings are shared with teammates.
+- User configs generally apply to all projects.
+- User configs _also_ has a `[projects]` table which holds project-specific settings for the user, such as approved hook commands and worktree layout. That's what this section covers.
+
+Entries are keyed by project identifier (e.g., `github.com/user/repo`).
 
 #### Approved hook commands
 
-When a project hook runs for the first time, worktrunk asks for approval. Approved commands are saved here, preventing repeated prompts.
+When a project hook runs for the first time, Worktrunk asks for approval. Approved commands are saved here, preventing repeated prompts.
 
 ```toml
 [projects."github.com/user/repo"]
 approved-commands = ["npm ci", "npm test"]
 ```
 
-Auto-managed. To reset, delete the entry or run `wt hook approve --clear`.
+To reset, delete the entry or run `wt hook approvals clear`.
 
 #### Setting overrides (Experimental)
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1619,18 +1619,24 @@ Pager behavior for `wt select` diff previews.
 
 ### User project-specific settings
 
-User config settings apply to all projects. [Project config](@/config.md#worktrunk-project-configuration) settings are shared with teammates. The `[projects]` table holds personal, project-specific settings like approved hook commands and worktree layout. Entries are keyed by project identifier (e.g., `github.com/user/repo`).
+For context:
+
+- [Project config](@/config.md#worktrunk-project-configuration) settings are shared with teammates.
+- User configs generally apply to all projects.
+- User configs _also_ has a `[projects]` table which holds project-specific settings for the user, such as approved hook commands and worktree layout. That's what this section covers.
+
+Entries are keyed by project identifier (e.g., `github.com/user/repo`).
 
 #### Approved hook commands
 
-When a project hook runs for the first time, worktrunk asks for approval. Approved commands are saved here, preventing repeated prompts.
+When a project hook runs for the first time, Worktrunk asks for approval. Approved commands are saved here, preventing repeated prompts.
 
 ```toml
 [projects."github.com/user/repo"]
 approved-commands = ["npm ci", "npm test"]
 ```
 
-Auto-managed. To reset, delete the entry or run `wt hook approve --clear`.
+To reset, delete the entry or run `wt hook approvals clear`.
 
 #### Setting overrides (Experimental)
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -135,16 +135,22 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
   [2m#[0m
   [2m# ### User project-specific settings[0m
   [2m#[0m
-  [2m# User config settings apply to all projects. Project config (https://worktrunk.dev/config.md#worktrunk-project-configuration/) settings are shared with teammates. The `[projects]` table holds personal, project-specific settings like approved hook commands and worktree layout. Entries are keyed by project identifier (e.g., `github.com/user/repo`).[0m
+  [2m# For context:[0m
+  [2m#[0m
+  [2m# - Project config (https://worktrunk.dev/config.md#worktrunk-project-configuration/) settings are shared with teammates.[0m
+  [2m# - User configs generally apply to all projects.[0m
+  [2m# - User configs _also_ has a `[projects]` table which holds project-specific settings for the user, such as approved hook commands and worktree layout. That's what this section covers.[0m
+  [2m#[0m
+  [2m# Entries are keyed by project identifier (e.g., `github.com/user/repo`).[0m
   [2m#[0m
   [2m# #### Approved hook commands[0m
   [2m#[0m
-  [2m# When a project hook runs for the first time, worktrunk asks for approval. Approved commands are saved here, preventing repeated prompts.[0m
+  [2m# When a project hook runs for the first time, Worktrunk asks for approval. Approved commands are saved here, preventing repeated prompts.[0m
   [2m#[0m
   [2m# [projects."github.com/user/repo"][0m
   [2m# approved-commands = ["npm ci", "npm test"][0m
   [2m#[0m
-  [2m# Auto-managed. To reset, delete the entry or run `wt hook approve --clear`.[0m
+  [2m# To reset, delete the entry or run `wt hook approvals clear`.[0m
   [2m#[0m
   [2m# #### Setting overrides (Experimental)[0m
   [2m#[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -180,16 +180,22 @@ Pager behavior for [2mwt select[0m diff previews.
 
 [32mUser project-specific settings[0m
 
-User config settings apply to all projects. Project config settings are shared with teammates. The [2m[projects][0m table holds personal, project-specific settings like approved hook commands and worktree layout. Entries are keyed by project identifier (e.g., [2mgithub.com/user/repo[0m).
+For context:
+
+- Project config settings are shared with teammates.
+- User configs generally apply to all projects.
+- User configs _also_ has a [2m[projects][0m table which holds project-specific settings for the user, such as approved hook commands and worktree layout. That's what this section covers.
+
+Entries are keyed by project identifier (e.g., [2mgithub.com/user/repo[0m).
 
 [1mApproved hook commands[0m
 
-When a project hook runs for the first time, worktrunk asks for approval. Approved commands are saved here, preventing repeated prompts.
+When a project hook runs for the first time, Worktrunk asks for approval. Approved commands are saved here, preventing repeated prompts.
 
   [2m[projects."github.com/user/repo"][0m
   [2mapproved-commands = ["npm ci", "npm test"][0m
 
-Auto-managed. To reset, delete the entry or run [2mwt hook approve --clear[0m.
+To reset, delete the entry or run [2mwt hook approvals clear[0m.
 
 [1mSetting overrides (Experimental)[0m
 


### PR DESCRIPTION
## Summary

- Restructure intro paragraph for "User project-specific settings" as bullet list for clearer context about how user config, project config, and `[projects]` table relate
- Fix casing: "worktrunk" → "Worktrunk"
- Fix outdated command: `wt hook approve --clear` → `wt hook approvals clear`

## Test plan

- [x] Tests pass (`wt hook pre-merge --yes`)
- [x] Help snapshots updated

🤖 Generated with [Claude Code](https://claude.ai/code)

_This was written by Claude Code on behalf of @max-sixty_