### PR TITLE
fix: use bright-black instead of bold in hint messages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,14 @@ Use consistent terminology in documentation, help text, and code comments:
 - **default branch** — the branch (main, master, etc.), not "main branch"
 - **target** — the destination for merge/rebase/push (e.g., "merge target"). Don't use "target" to mean worktrees — say "worktree" or "worktrees"
 
+## Skills
+
+Check `.claude/skills/` for available skills and load those relevant to your task.
+
+Key skills:
+
+- **`writing-user-outputs`** — Required when modifying user-facing messages, hints, warnings, errors, or any terminal output formatting. Documents ANSI color nesting rules, message patterns, and output system architecture.
+
 ## Testing
 
 ### Running Tests

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -584,8 +584,7 @@ fn write_migration_file(
     eprintln!(
         "{}",
         hint_message(cformat!(
-            "Wrote migrated <bold>{}</>. To apply:",
-            new_filename
+            "Wrote migrated <bright-black>{new_filename}</>. To apply:"
         ))
     );
     eprintln!(
@@ -717,8 +716,7 @@ pub fn format_deprecation_details(info: &DeprecationInfo) -> String {
             out,
             "{}",
             hint_message(cformat!(
-                "Wrote migrated <bold>{}</>. To apply:",
-                new_filename
+                "Wrote migrated <bright-black>{new_filename}</>. To apply:"
             ))
         );
         let _ = writeln!(

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
@@ -37,7 +37,7 @@ exit_code: 0
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUser config uses deprecated template variables: [2mrepo_root[22m → [1mrepo_path[22m, [2mmain_worktree[22m → [1mrepo[22m[39m
-[2m↳[22m [2mWrote migrated [1mconfig.toml.new[22m. To apply:[22m
+[2m↳[22m [2mWrote migrated [90mconfig.toml.new[39m. To apply:[22m
 [107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEMP_HOME]/.config/worktrunk/config.toml.new [TEMP_HOME]/.config/worktrunk/config.toml
 [107m [0m [1mdiff --git a[TEMP_HOME]/.config/worktrunk/config.toml b[TEMP_HOME]/.config/worktrunk/config.toml.new
 [107m [0m [1mindex d95d100..ceb381d 100644[m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
@@ -37,7 +37,7 @@ exit_code: 0
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUser config uses deprecated config sections: [projects."github.com/example/repo".commit-generation] → [projects."github.com/example/repo".commit.generation][39m
-[2m↳[22m [2mWrote migrated [1mconfig.toml.new[22m. To apply:[22m
+[2m↳[22m [2mWrote migrated [90mconfig.toml.new[39m. To apply:[22m
 [107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEMP_HOME]/.config/worktrunk/config.toml.new [TEMP_HOME]/.config/worktrunk/config.toml
 [107m [0m [1mdiff --git a[TEMP_HOME]/.config/worktrunk/config.toml b[TEMP_HOME]/.config/worktrunk/config.toml.new
 [107m [0m [1mindex de80729..eb69d44 100644[m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
@@ -40,7 +40,7 @@ exit_code: 0
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
 [33m▲[39m [33mProject config uses deprecated config sections: [commit-generation] → [commit.generation][39m
-[2m↳[22m [2mWrote migrated [1mwt.toml.new[22m. To apply:[22m
+[2m↳[22m [2mWrote migrated [90mwt.toml.new[39m. To apply:[22m
 [107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m _REPO_/.config/wt.toml.new _REPO_/.config/wt.toml
 [107m [0m [1mdiff --git a_REPO_/.config/wt.toml b_REPO_/.config/wt.toml.new[m
 [107m [0m [1mindex 074c30f..e97c84f 100644[m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_project_level_shows_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_project_level_shows_warning.snap
@@ -42,5 +42,5 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mUser config has deprecated settings. To see details, run [90mwt config show[39m[39m
-[2m↳[22m [2mWrote migrated [1mtest-config.toml.new[22m. To apply:[22m
+[2m↳[22m [2mWrote migrated [90mtest-config.toml.new[39m. To apply:[22m
 [107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEST_CONFIG_NEW] [TEST_CONFIG]

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_section_shows_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_section_shows_warning.snap
@@ -42,5 +42,5 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mUser config has deprecated settings. To see details, run [90mwt config show[39m[39m
-[2m↳[22m [2mWrote migrated [1mtest-config.toml.new[22m. To apply:[22m
+[2m↳[22m [2mWrote migrated [90mtest-config.toml.new[39m. To apply:[22m
 [107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEST_CONFIG_NEW] [TEST_CONFIG]

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_show_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_show_warning.snap
@@ -42,5 +42,5 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mUser config has deprecated settings. To see details, run [90mwt config show[39m[39m
-[2m↳[22m [2mWrote migrated [1mtest-config.toml.new[22m. To apply:[22m
+[2m↳[22m [2mWrote migrated [90mtest-config.toml.new[39m. To apply:[22m
 [107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEST_CONFIG_NEW] [TEST_CONFIG]

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_verbose_shows_content.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_verbose_shows_content.snap
@@ -43,7 +43,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mUser config has deprecated settings. To see details, run [90mwt config show[39m[39m
-[2m↳[22m [2mWrote migrated [1mtest-config.toml.new[22m. To apply:[22m
+[2m↳[22m [2mWrote migrated [90mtest-config.toml.new[39m. To apply:[22m
 [107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEST_CONFIG_NEW] [TEST_CONFIG]
 [2m○[22m Expanding [1mworktree-path[22m
 [107m [0m ../{{ main_worktree }}.{{ branch }} [2m→[22m ../repo.feature-a


### PR DESCRIPTION
## Summary

- Fix hint message formatting where `<bold>` inside `<dim>` caused text after the bold section to lose dim styling (both use ANSI reset code `[22m]`)
- Use `<bright-black>` for filenames in hint messages instead - foreground codes (`[90m`/`[39m`) don't interfere with intensity codes
- Add Skills section to CLAUDE.md documenting the `writing-user-outputs` skill

## Test plan

- [x] Existing snapshot tests updated and passing
- [x] `pre-commit run --all-files` passes

🤖 Generated with [Claude Code](https://claude.ai/code)