### PR TITLE
feat(statusline): add context window gauge for Claude Code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -74,7 +74,8 @@ repos:
         # select.rs: skim API's selected.output() is not Command::output()
         # tests/benches: test utilities run commands directly
         # src/config/{test,expansion,mod,user}.rs: TestRepo test fixtures use git init directly
-        exclude: '^(src/shell_exec\.rs|src/commands/select/|src/config/(test|expansion|mod|user)\.rs|tests/|benches/)'
+        # src/styling/mod.rs: terminal width detection probes should be silent/quick
+        exclude: '^(src/shell_exec\.rs|src/commands/select/|src/config/(test|expansion|mod|user)\.rs|src/styling/mod\.rs|tests/|benches/)'
 
 ci:
   # pre-commit.ci doesn't have Rust toolchain, so skip Rust-specific hooks.


### PR DESCRIPTION
## Summary

- Add moon phase gauge (🌕🌔🌓🌒🌑) showing context window usage in Claude Code statusline mode
- Gauge gets darker as context fills, using exponential halving thresholds (ratio 16:8:4:2:1) for finer granularity at high usage
- Add parent TTY detection for terminal width in subprocess environments (Unix)
- Simplify JSON parsing using `serde_json::Value` with pointer syntax

## Test plan

- [x] Unit tests for gauge formatting at all boundaries
- [x] Integration tests for Claude Code mode with context window
- [x] Manual verification of thresholds (51→🌕, 52→🌔, 77→🌔, 78→🌓, etc.)

🤖 Generated with [Claude Code](https://claude.ai/code)