### PR TITLE
feat(statusline): increase CI status truncation priority

### DIFF
--- a/src/commands/list/columns.rs
+++ b/src/commands/list/columns.rs
@@ -80,17 +80,20 @@ impl ColumnSpec {
 }
 
 /// Static registry of all possible columns in display order.
+///
+/// Note: base_priority determines truncation order (lower = kept longer),
+/// which is independent of display order (position in array).
 pub const COLUMN_SPECS: &[ColumnSpec] = &[
     ColumnSpec::new(ColumnKind::Gutter, 0, None),
     ColumnSpec::new(ColumnKind::Branch, 1, None),
     ColumnSpec::new(ColumnKind::Status, 2, None),
     ColumnSpec::new(ColumnKind::WorkingDiff, 3, None),
     ColumnSpec::new(ColumnKind::AheadBehind, 4, None),
-    ColumnSpec::new(ColumnKind::BranchDiff, 5, Some(TaskKind::BranchDiff)),
-    ColumnSpec::new(ColumnKind::Path, 6, None),
-    ColumnSpec::new(ColumnKind::Upstream, 7, None),
-    ColumnSpec::new(ColumnKind::Url, 8, Some(TaskKind::UrlStatus)),
-    ColumnSpec::new(ColumnKind::CiStatus, 9, Some(TaskKind::CiStatus)),
+    ColumnSpec::new(ColumnKind::BranchDiff, 6, Some(TaskKind::BranchDiff)),
+    ColumnSpec::new(ColumnKind::Path, 7, None),
+    ColumnSpec::new(ColumnKind::Upstream, 8, None),
+    ColumnSpec::new(ColumnKind::Url, 9, Some(TaskKind::UrlStatus)),
+    ColumnSpec::new(ColumnKind::CiStatus, 5, Some(TaskKind::CiStatus)),
     ColumnSpec::new(ColumnKind::Commit, 10, None),
     ColumnSpec::new(ColumnKind::Time, 11, None),
     ColumnSpec::new(ColumnKind::Message, 12, None),


### PR DESCRIPTION
## Summary

- Move CiStatus from truncation priority 9 to 5
- CI pass/fail is now retained longer than BranchDiff, Path, Upstream, and Url when statusline truncates
- Display order in `wt list` unchanged (only truncation priority changed)

## Test plan

- [x] `cargo test --lib columns` — column tests pass
- [x] `cargo test --lib statusline` — statusline tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)