### PR TITLE
fix: prevent panics and incorrect behavior in hooks and CI status

### DIFF
--- a/src/commands/list/ci_status/gitlab.rs
+++ b/src/commands/list/ci_status/gitlab.rs
@@ -139,14 +139,21 @@ pub(super) fn detect_gitlab(
             );
         }
         matched
+    } else if mr_list.len() == 1 {
+        // If we can't determine project ID but there's only one MR, it's unambiguous
+        mr_list.first()
+    } else if mr_list.is_empty() {
+        // No MRs found
+        None
     } else {
-        // If we can't determine project ID, fall back to first MR
+        // Multiple MRs exist but we can't determine which project we're in.
+        // Don't guess - return None to avoid showing wrong project's CI status.
         log::debug!(
-            "No project ID for {}, using first MR for branch {}",
-            repo_root.display(),
+            "Found {} MRs for branch {} but no project ID to filter - skipping to avoid ambiguity",
+            mr_list.len(),
             branch.full_name
         );
-        mr_list.first()
+        None
     }?;
 
     // Step 2: Fetch full MR details to get pipeline status.

--- a/tests/integration_tests/config_state.rs
+++ b/tests/integration_tests/config_state.rs
@@ -1312,8 +1312,8 @@ fn test_state_logs_get_hook_with_branch_flag(repo: TestRepo) {
 
 #[rstest]
 fn test_state_logs_get_hook_invalid_format(repo: TestRepo) {
-    // Test invalid hook spec format (too many colons)
-    let output = wt_state_cmd(&repo, "logs", "get", &["--hook=a:b:c:d"])
+    // Test invalid hook spec format (missing required segments)
+    let output = wt_state_cmd(&repo, "logs", "get", &["--hook=user"])
         .output()
         .unwrap();
     assert!(!output.status.success());
@@ -1321,6 +1321,21 @@ fn test_state_logs_get_hook_invalid_format(repo: TestRepo) {
     assert!(
         stderr.contains("Invalid log spec"),
         "Expected 'Invalid log spec' error: {}",
+        stderr
+    );
+}
+
+#[rstest]
+fn test_state_logs_get_hook_rejects_colons_in_name(repo: TestRepo) {
+    // Hook names cannot contain colons (makes parsing ambiguous)
+    let output = wt_state_cmd(&repo, "logs", "get", &["--hook=user:post-start:my:server"])
+        .output()
+        .unwrap();
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Invalid log spec"),
+        "Colons in hook names should be rejected: {}",
         stderr
     );
 }


### PR DESCRIPTION
## Summary

Bug fixes discovered during code review of changes since v0.18.2:

- **CommandConfig serialization**: Auto-generate names (`_1`, `_2`, etc.) for unnamed commands when serializing mixed named/unnamed configs. This prevents an `unwrap()` panic when merging unnamed global hooks with named project hooks.

- **Hook names**: Ban colons in hook names at config load time, and reject them in log spec parsing. This keeps parsing unambiguous (`source:hook-type:name`) without adding complexity.

- **GitLab MR detection**: Return `None` when multiple MRs exist but project ID is unknown, instead of incorrectly returning the first MR's CI status (which could be from a different project).

## Test plan

- [x] Unit tests for hook name validation (`test_deserialize_rejects_colons_in_name`)
- [x] Unit tests for log spec parsing (`test_hook_log_parse_rejects_colons_in_name`, `test_hook_log_parse_rejects_empty_name`)
- [x] Unit tests for mixed serialization (`test_serialize_mixed_named_unnamed_commands`)
- [x] Integration test for CLI rejection (`test_state_logs_get_hook_rejects_colons_in_name`)
- [x] All 947 integration tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)