### PR TITLE
fix: address 5 bugs in template expansion, caching, and concurrency

### DIFF
--- a/src/commands/list/ci_status/mod.rs
+++ b/src/commands/list/ci_status/mod.rs
@@ -379,6 +379,7 @@ impl PrStatus {
             status: status.clone(),
             checked_at: now_secs,
             head: local_head.to_string(),
+            branch: branch.full_name.clone(),
         };
         cached.write(repo, &branch.full_name);
 

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -299,10 +299,11 @@ pub fn collect(
     // Detect current worktree using git rev-parse --show-toplevel (via WorkingTree::root).
     // This correctly handles worktrees placed inside other worktrees (e.g., .worktrees/ layout)
     // by letting git resolve the actual worktree root rather than using prefix matching.
+    // Canonicalize both paths to handle symlinks (e.g., macOS /var -> /private/var).
     let current_worktree_path = repo.current_worktree().root().ok().and_then(|root| {
         worktrees
             .iter()
-            .find(|wt| wt.path == root)
+            .find(|wt| canonicalize(&wt.path).map(|p| p == root).unwrap_or(false))
             .map(|wt| wt.path.clone())
     });
     // Show warning if user configured a default branch that doesn't exist locally

--- a/src/shell_exec.rs
+++ b/src/shell_exec.rs
@@ -39,6 +39,8 @@ fn max_concurrent_commands() -> usize {
     std::env::var("WORKTRUNK_MAX_CONCURRENT_COMMANDS")
         .ok()
         .and_then(|s| s.parse().ok())
+        // 0 = no limit (use usize::MAX as effectively unlimited)
+        .map(|n: usize| if n == 0 { usize::MAX } else { n })
         .unwrap_or(DEFAULT_CONCURRENT_COMMANDS)
 }
 
@@ -889,6 +891,17 @@ fn forward_signal_with_escalation(pgid: i32, sig: i32) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_max_concurrent_commands_defaults() {
+        // When no env var is set, default should be used
+        assert!(max_concurrent_commands() >= 1, "Default should be >= 1");
+        assert_eq!(
+            max_concurrent_commands(),
+            DEFAULT_CONCURRENT_COMMANDS,
+            "Without env var, should use default"
+        );
+    }
 
     #[test]
     fn test_shell_config_is_available() {

--- a/tests/integration_tests/config_state.rs
+++ b/tests/integration_tests/config_state.rs
@@ -609,7 +609,7 @@ fn test_state_clear_all_comprehensive(repo: TestRepo) {
     write_ci_cache(
         &repo,
         "feature",
-        r#"{"checked_at":1704067200,"head":"abc123"}"#,
+        r#"{"checked_at":1704067200,"head":"abc123","branch":"feature"}"#,
     );
 
     // Logs
@@ -699,7 +699,7 @@ fn test_state_get_with_ci_entries(repo: TestRepo) {
         &repo,
         "feature",
         &format!(
-            r#"{{"status":{{"ci_status":"passed","source":"pull-request","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"abc12345def67890"}}"#
+            r#"{{"status":{{"ci_status":"passed","source":"pull-request","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"abc12345def67890","branch":"feature"}}"#
         ),
     );
 
@@ -707,14 +707,16 @@ fn test_state_get_with_ci_entries(repo: TestRepo) {
         &repo,
         "bugfix",
         &format!(
-            r#"{{"status":{{"ci_status":"failed","source":"branch","is_stale":true}},"checked_at":{TEST_EPOCH},"head":"111222333444555"}}"#
+            r#"{{"status":{{"ci_status":"failed","source":"branch","is_stale":true}},"checked_at":{TEST_EPOCH},"head":"111222333444555","branch":"bugfix"}}"#
         ),
     );
 
     write_ci_cache(
         &repo,
         "main",
-        &format!(r#"{{"status":null,"checked_at":{TEST_EPOCH},"head":"deadbeef12345678"}}"#),
+        &format!(
+            r#"{{"status":null,"checked_at":{TEST_EPOCH},"head":"deadbeef12345678","branch":"main"}}"#
+        ),
     );
 
     let output = wt_state_get_cmd(&repo).output().unwrap();
@@ -755,7 +757,7 @@ fn test_state_get_comprehensive(repo: TestRepo) {
         &repo,
         "feature",
         &format!(
-            r#"{{"status":{{"ci_status":"passed","source":"pull-request","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"abc12345def67890"}}"#
+            r#"{{"status":{{"ci_status":"passed","source":"pull-request","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"abc12345def67890","branch":"feature"}}"#
         ),
     );
 
@@ -812,7 +814,7 @@ fn test_state_get_json_comprehensive(repo: TestRepo) {
         &repo,
         "feature",
         &format!(
-            r#"{{"status":{{"ci_status":"passed","source":"pull-request","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"abc12345def67890"}}"#
+            r#"{{"status":{{"ci_status":"passed","source":"pull-request","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"abc12345def67890","branch":"feature"}}"#
         ),
     );
 
@@ -885,14 +887,14 @@ fn test_state_clear_ci_status_all_with_entries(repo: TestRepo) {
         &repo,
         "feature",
         &format!(
-            r#"{{"status":{{"ci_status":"passed","source":"pull-request","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"abc12345"}}"#
+            r#"{{"status":{{"ci_status":"passed","source":"pull-request","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"abc12345","branch":"feature"}}"#
         ),
     );
     write_ci_cache(
         &repo,
         "bugfix",
         &format!(
-            r#"{{"status":{{"ci_status":"failed","source":"branch","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"def67890"}}"#
+            r#"{{"status":{{"ci_status":"failed","source":"branch","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"def67890","branch":"bugfix"}}"#
         ),
     );
 
@@ -910,7 +912,7 @@ fn test_state_clear_ci_status_all_single_entry(repo: TestRepo) {
         &repo,
         "feature",
         &format!(
-            r#"{{"status":{{"ci_status":"passed","source":"pull-request","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"abc12345"}}"#
+            r#"{{"status":{{"ci_status":"passed","source":"pull-request","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"abc12345","branch":"feature"}}"#
         ),
     );
 

--- a/tests/integration_tests/list.rs
+++ b/tests/integration_tests/list.rs
@@ -1586,7 +1586,7 @@ fn mock_ci_status(repo: &TestRepo, branch: &str, status: &str, source: &str, is_
 
     // Build the cache JSON (matches CachedCiStatus struct)
     let cache_json = format!(
-        r#"{{"status":{{"ci_status":"{}","source":"{}","is_stale":{}}},"checked_at":{},"head":"{}"}}"#,
+        r#"{{"status":{{"ci_status":"{}","source":"{}","is_stale":{}}},"checked_at":{},"head":"{}","branch":"{}"}}"#,
         status,
         source,
         is_stale,
@@ -1594,7 +1594,8 @@ fn mock_ci_status(repo: &TestRepo, branch: &str, status: &str, source: &str, is_
             .duration_since(std::time::UNIX_EPOCH)
             .unwrap()
             .as_secs(),
-        head
+        head,
+        branch
     );
 
     // Get git common dir for cache location


### PR DESCRIPTION
## Summary

- **worktree_path_of_branch shell escape**: Template function now respects `shell_escape` flag, escaping paths with spaces/metacharacters
- **Windows CI cache rename**: Added `#[cfg(windows)]` to remove target file before rename (fs::rename fails on Windows if target exists)
- **CI cache branch display**: Added `branch` field to `CachedCiStatus` so `wt config state show` displays original branch names instead of sanitized filenames
- **Symlink path comparison**: Canonicalize paths before comparing to fix current worktree detection on macOS (/var → /private/var)
- **Zero semaphore deadlock**: Treat `WORKTRUNK_MAX_CONCURRENT_COMMANDS=0` as "no limit" (usize::MAX) instead of deadlocking

## Test plan

- [x] Added `test_worktree_path_of_branch_shell_escape` regression test
- [x] Added `test_max_concurrent_commands_defaults` test
- [x] Updated CI cache test fixtures to include `branch` field
- [x] All 947 integration tests pass
- [x] All 450 lib/bin tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)