### PR TITLE
fix(config show): add visual separator between diff and current config

### DIFF
--- a/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
@@ -50,6 +50,7 @@ exit_code: 0
 [107m [0m [36m@@ -1 +1 @@[m
 [107m [0m [31m-post-create = "ln -sf {{ main_worktree }}/node_modules"[m
 [107m [0m [32m+[m[32mpost-create = "ln -sf {{ repo }}/node_modules"[m
+[2m○[22m Current config:
 [107m [0m post-create = [32m"ln -sf {{ main_worktree }}/node_modules"
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
@@ -49,6 +49,7 @@ exit_code: 0
 [107m [0m [31m-post-create = "ln -sf {{ repo_root }}/node_modules"[m
 [107m [0m [32m+[m[32mworktree-path = "../{{ repo }}.{{ branch }}"[m
 [107m [0m [32m+[m[32mpost-create = "ln -sf {{ repo_path }}/node_modules"[m
+[2m○[22m Current config:
 [107m [0m worktree-path = [32m"../{{ main_worktree }}.{{ branch }}"
 [107m [0m post-create = [32m"ln -sf {{ repo_root }}/node_modules"
 

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
@@ -50,6 +50,7 @@ exit_code: 0
 [107m [0m [31m-[projects."github.com/example/repo".commit-generation][m
 [107m [0m [32m+[m[32m[projects."github.com/example/repo".commit.generation][m
 [107m [0m  command = "llm -m gpt-4"[m
+[2m○[22m Current config:
 [107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
 [107m [0m 
 [107m [0m [1m[36m[projects."github.com/example/repo".commit-generation]

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
@@ -41,6 +41,7 @@ exit_code: 0
 [36mPROJECT CONFIG[39m  [PROJECT_ID]
 [33m▲[39m [33mProject config uses deprecated template variables: [2mmain_worktree[22m → [1mrepo[22m[39m
 [2m↳[22m [2mTo generate migration file, run [90mwt config show[39m from main worktree[22m
+[2m○[22m Current config:
 [107m [0m post-create = [32m"ln -sf {{ main_worktree }}/node_modules"
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
@@ -54,6 +54,7 @@ exit_code: 0
 [107m [0m [32m+[m[32m[commit.generation][m
 [107m [0m [32m+[m[32mcommand = "claude"[m
 [33m▲[39m [33mKey [1mcommit-generation[22m belongs in user config (will be ignored)[39m
+[2m○[22m Current config:
 [107m [0m [1m[36m[commit-generation]
 [107m [0m command = [32m"claude"
 


### PR DESCRIPTION
## Summary

- Add "Current config:" label before TOML content when deprecation diff is shown
- Clearly separates migration diff from actual config file display

Previously, `wt config show` with deprecated config would show a diff immediately followed by the config file with no visual break, making it confusing which was which.

## Test plan

- [x] Snapshot tests updated for 5 affected test cases
- [x] Verified output manually with `wt config show`

🤖 Generated with [Claude Code](https://claude.com/claude-code)