### PR TITLE
docs(llm-commits): Update template documentation

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/llm-commits.md
+++ b/.claude-plugin/skills/worktrunk/reference/llm-commits.md
@@ -84,22 +84,9 @@ See [`wt merge`](https://worktrunk.dev/merge/) and [`wt step`](https://worktrunk
 
 Worktrunk uses [minijinja](https://docs.rs/minijinja/) templates (Jinja2-like syntax) to build prompts. There are sensible defaults, but templates are fully customizable.
 
-### Template variables
-
-All variables are available in both templates:
-
-| Variable | Description |
-|----------|-------------|
-| `{{ git_diff }}` | The diff (staged changes or combined diff for squash) |
-| `{{ branch }}` | Current branch name |
-| `{{ recent_commits }}` | Recent commit subjects (for style reference) |
-| `{{ repo }}` | Repository name |
-| `{{ commits }}` | Commit messages being squashed (chronological order) |
-| `{{ target_branch }}` | Branch being merged into |
-
 ### Custom templates
 
-Override the defaults with inline templates or external files:
+Override the defaults with inline templates:
 
 ```toml
 [commit.generation]
@@ -123,6 +110,18 @@ Diff:
 {{ git_diff }}
 """
 ```
+
+### Template variables
+
+| Variable | Description |
+|----------|-------------|
+| `{{ git_diff }}` | The diff (staged changes or combined diff for squash) |
+| `{{ git_diff_stat }}` | Diff statistics (files changed, insertions, deletions) |
+| `{{ branch }}` | Current branch name |
+| `{{ repo }}` | Repository name |
+| `{{ recent_commits }}` | Recent commit subjects (for style reference) |
+| `{{ commits }}` | Commits being squashed (squash template only) |
+| `{{ target_branch }}` | Merge target branch (squash template only) |
 
 ### Template syntax
 

--- a/docs/content/llm-commits.md
+++ b/docs/content/llm-commits.md
@@ -97,22 +97,9 @@ See [`wt merge`](@/merge.md) and [`wt step`](@/step.md) for full documentation.
 
 Worktrunk uses [minijinja](https://docs.rs/minijinja/) templates (Jinja2-like syntax) to build prompts. There are sensible defaults, but templates are fully customizable.
 
-### Template variables
-
-All variables are available in both templates:
-
-| Variable | Description |
-|----------|-------------|
-| `{{ git_diff }}` | The diff (staged changes or combined diff for squash) |
-| `{{ branch }}` | Current branch name |
-| `{{ recent_commits }}` | Recent commit subjects (for style reference) |
-| `{{ repo }}` | Repository name |
-| `{{ commits }}` | Commit messages being squashed (chronological order) |
-| `{{ target_branch }}` | Branch being merged into |
-
 ### Custom templates
 
-Override the defaults with inline templates or external files:
+Override the defaults with inline templates:
 
 ```toml
 [commit.generation]
@@ -136,6 +123,18 @@ Diff:
 {{ git_diff }}
 """
 ```
+
+### Template variables
+
+| Variable | Description |
+|----------|-------------|
+| `{{ git_diff }}` | The diff (staged changes or combined diff for squash) |
+| `{{ git_diff_stat }}` | Diff statistics (files changed, insertions, deletions) |
+| `{{ branch }}` | Current branch name |
+| `{{ repo }}` | Repository name |
+| `{{ recent_commits }}` | Recent commit subjects (for style reference) |
+| `{{ commits }}` | Commits being squashed (squash template only) |
+| `{{ target_branch }}` | Merge target branch (squash template only) |
 
 ### Template syntax
 


### PR DESCRIPTION
## Summary

- Remove reference to deprecated `template-file` and `squash-template-file` options
- Add missing `{{ git_diff_stat }}` template variable to the docs table
- Clarify which variables are squash-template only
- Move variables table after the example for natural reading order

🤖 Generated with [Claude Code](https://claude.ai/code)

> _This was written by Claude Code on behalf of @max-sixty_