### PR TITLE
fix(docs): add blank line after demo figures for markdown separation

### DIFF
--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -18,6 +18,7 @@ Shows uncommitted changes, divergence from the default branch and remote, and op
   <img src="/assets/docs/light/wt-list.gif" alt="wt list demo" width="1600" height="900">
 </picture>
 </figure>
+
 The table renders progressively: branch names, paths, and commit hashes appear immediately, then status, divergence, and other columns fill in as background git operations complete. With `--full`, CI status fetches from the network — the table displays instantly and CI fills in as results arrive.
 
 ## Examples

--- a/docs/content/merge.md
+++ b/docs/content/merge.md
@@ -18,6 +18,7 @@ Unlike `git merge`, this merges current into target (not target into current). S
   <img src="/assets/docs/light/wt-merge.gif" alt="wt merge demo" width="1600" height="900">
 </picture>
 </figure>
+
 ## Examples
 
 Merge to the default branch:

--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -18,6 +18,7 @@ Worktrees are addressed by branch name; paths are computed from a configurable t
   <img src="/assets/docs/light/wt-switch.gif" alt="wt switch demo" width="1600" height="900">
 </picture>
 </figure>
+
 ## Examples
 
 ```bash

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -926,7 +926,6 @@ lint = "cargo clippy"
     /// Browse and switch worktrees with live preview.
     #[cfg_attr(not(unix), command(hide = true))]
     #[command(after_long_help = r#"<!-- demo: wt-select.gif 1600x800 -->
-
 ## Examples
 
 Open the selector:

--- a/src/help.rs
+++ b/src/help.rs
@@ -552,9 +552,9 @@ fn expand_demo_placeholders(text: &str) -> String {
             // Use figure.demo class for proper mobile styling (no shrink, horizontal scroll)
             // Generate <picture> element for light/dark theme switching
             // Assets are organized as: /assets/docs/{light,dark}/filename.gif
-            // Blank line after is already in source; blank line before comes from section separation
+            // Add trailing newline for markdown paragraph separation after the figure
             let replacement = format!(
-                "<figure class=\"demo\">\n<picture>\n  <source srcset=\"/assets/docs/dark/{filename}\" media=\"(prefers-color-scheme: dark)\">\n  <img src=\"/assets/docs/light/{filename}\" alt=\"{alt_text} demo\"{dim_attrs}>\n</picture>\n</figure>"
+                "<figure class=\"demo\">\n<picture>\n  <source srcset=\"/assets/docs/dark/{filename}\" media=\"(prefers-color-scheme: dark)\">\n  <img src=\"/assets/docs/light/{filename}\" alt=\"{alt_text} demo\"{dim_attrs}>\n</picture>\n</figure>\n"
             );
             let end = after_prefix + end_offset + SUFFIX.len();
             result.replace_range(start..end, &replacement);


### PR DESCRIPTION
## Summary
- `expand_demo_placeholders()` now adds trailing `\n` after `</figure>` for proper markdown paragraph separation in web docs
- Terminal `--help` output unaffected (HTML comments are stripped, spacing comes from blank line before demo)
- Removes inconsistent extra blank line from `wt select`'s demo placeholder

Fixes the missing linebreak issue on https://worktrunk.dev/list/ where the paragraph after the demo was running together with the figure.

## Test plan
- [x] Verified `wt list --help` has single blank line (not double)
- [x] Verified web docs render correctly (list, switch, select pages checked in browser)
- [x] Pre-commit checks pass
- [x] Doc sync test passes

🤖 Generated with [Claude Code](https://claude.ai/code)