### PR TITLE
docs: simplify skip-shell-integration-prompt documentation

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/config.md
+++ b/.claude-plugin/skills/worktrunk/reference/config.md
@@ -327,17 +327,7 @@ Without shell integration, `wt switch` prints the target directory but cannot `c
 
 ### Skip first-run prompt
 
-On first run without shell integration, Worktrunk offers to install it. Suppress this prompt in CI or automated environments:
-
-```toml
-skip-shell-integration-prompt = true
-```
-
-Or via environment variable:
-
-```bash
-export WORKTRUNK_SKIP_SHELL_INTEGRATION_PROMPT=true
-```
+On first run without shell integration, Worktrunk offers to install it. Declining sets `skip-shell-integration-prompt = true` automatically.
 
 ## Environment variables
 

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -335,17 +335,7 @@ Without shell integration, `wt switch` prints the target directory but cannot `c
 
 ### Skip first-run prompt
 
-On first run without shell integration, Worktrunk offers to install it. Suppress this prompt in CI or automated environments:
-
-```toml
-skip-shell-integration-prompt = true
-```
-
-Or via environment variable:
-
-```bash
-export WORKTRUNK_SKIP_SHELL_INTEGRATION_PROMPT=true
-```
+On first run without shell integration, Worktrunk offers to install it. Declining sets `skip-shell-integration-prompt = true` automatically.
 
 ## Environment variables
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1775,17 +1775,7 @@ Without shell integration, `wt switch` prints the target directory but cannot `c
 
 ### Skip first-run prompt
 
-On first run without shell integration, Worktrunk offers to install it. Suppress this prompt in CI or automated environments:
-
-```toml
-skip-shell-integration-prompt = true
-```
-
-Or via environment variable:
-
-```bash
-export WORKTRUNK_SKIP_SHELL_INTEGRATION_PROMPT=true
-```
+On first run without shell integration, Worktrunk offers to install it. Declining sets `skip-shell-integration-prompt = true` automatically.
 
 ## Environment variables
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -333,13 +333,7 @@ Without shell integration, [2mwt switch[0m prints the target directory but can
 
 [32mSkip first-run prompt[0m
 
-On first run without shell integration, Worktrunk offers to install it. Suppress this prompt in CI or automated environments:
-
-  [2mskip-shell-integration-prompt = true[0m
-
-Or via environment variable:
-
-  [2mexport WORKTRUNK_SKIP_SHELL_INTEGRATION_PROMPT=true[0m
+On first run without shell integration, Worktrunk offers to install it. Declining sets [2mskip-shell-integration-prompt = true[0m automatically.
 
 [1m[32mEnvironment variables[0m
 


### PR DESCRIPTION
## Summary
- Reduced from 13 lines to 1 line
- Removed misleading CI configuration guidance (prompt is already suppressed without TTY)
- Now accurately describes that this config is set automatically when declining the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)