### PR TITLE
feat(demos): add snapshot mode for regression testing

### DIFF
--- a/docs/demos/CLAUDE.md
+++ b/docs/demos/CLAUDE.md
@@ -43,6 +43,33 @@ Regenerate a single demo:
 | docs | wt-core, wt-switch, wt-list, wt-commit, wt-statusline, wt-merge, wt-select, wt-zellij-omnibus |
 | social | wt-switch, wt-statusline, wt-list, wt-list-remove, wt-hooks, wt-devserver, wt-commit, wt-merge, wt-select, wt-core, wt-zellij-omnibus |
 
+## Snapshot testing
+
+```bash
+./docs/demos/build docs --snapshot           # Generate all snapshots
+./docs/demos/build docs --snapshot --only wt-list  # Single demo
+```
+
+Snapshots capture command output (not terminal rendering) and are committed to `docs/demos/snapshots/`. Use them to catch regressions like new hints creeping in.
+
+**How to use:**
+1. After changing wt output, regenerate snapshots: `./docs/demos/build docs --snapshot`
+2. Review the diff - small changes (commit hashes, minor formatting) are expected
+3. Commit the updated snapshots alongside your changes
+
+**What changes are expected:**
+- Commit hashes change each run (demo repo is recreated)
+- Column widths may shift slightly
+
+**What changes indicate regressions:**
+- New hints or warnings appearing
+- Output format changes you didn't intend
+- New lines or missing output
+
+**Limitations:**
+- Tab completion sequences are not replayed; only `Type "command"` + `Enter` patterns are extracted
+- TUI demos (wt-select, wt-switch, wt-statusline, wt-zellij-omnibus) are skipped since they require interactive input
+
 ## Prerequisites
 
 **Requires Go** — The VHS fork is built from source ([install Go](https://go.dev/dl/)).

--- a/docs/demos/build
+++ b/docs/demos/build
@@ -43,6 +43,7 @@ from shared import (  # noqa: E402
     SIZE_DOCS,
     SIZE_SOCIAL,
     record_text,
+    record_snapshot,
     build_tape_replacements,
     ensure_vhs_binary,
 )
@@ -50,6 +51,10 @@ from shared import (  # noqa: E402
 REPO_ROOT = SCRIPT_DIR.parent.parent
 OUT_DIR = SCRIPT_DIR.parent / "static" / "assets"
 TAPES_DIR = SCRIPT_DIR / "tapes"
+SNAPSHOTS_DIR = SCRIPT_DIR / "snapshots"
+
+# Demos that use TUI or interactive input - not suitable for command snapshots
+TUI_DEMOS = {"wt-select", "wt-switch", "wt-statusline", "wt-zellij-omnibus"}
 
 
 # =============================================================================
@@ -342,6 +347,7 @@ def record_demo(
     demo_size: DemoSize,
     vhs_binary: str,
     text_mode: bool = False,
+    snapshot_mode: bool = False,
 ):
     """Record a single demo (runs in subprocess for parallel execution)."""
     tape_path = TAPES_DIR / tape_file
@@ -356,7 +362,11 @@ def record_demo(
 
     replacements = build_tape_replacements(env, REPO_ROOT)
 
-    if text_mode:
+    if snapshot_mode:
+        output_snap = SNAPSHOTS_DIR / f"{output_name}.snap"
+        record_snapshot(env, tape_path, output_snap, REPO_ROOT)
+        print(f"✓ {output_name}: Snapshot saved to {output_snap}")
+    elif text_mode:
         output_txt = mode_out_dir / f"{output_name}.txt"
         record_text(env, tape_path, output_txt, replacements, REPO_ROOT)
         print(f"✓ {output_name}: Text saved to {output_txt}")
@@ -432,6 +442,11 @@ Examples:
         "--text", action="store_true", help="Record text output instead of GIFs"
     )
     parser.add_argument(
+        "--snapshot",
+        action="store_true",
+        help="Record command output snapshots for regression testing (non-TUI demos only)",
+    )
+    parser.add_argument(
         "--sequential",
         action="store_true",
         help="Record demos sequentially instead of in parallel",
@@ -444,6 +459,14 @@ Examples:
 
     if args.shell and args.text:
         print("--shell and --text are mutually exclusive")
+        return
+
+    if args.shell and args.snapshot:
+        print("--shell and --snapshot are mutually exclusive")
+        return
+
+    if args.text and args.snapshot:
+        print("--text and --snapshot are mutually exclusive")
         return
 
     # Check dependencies (VHS is built from source, not required in PATH)
@@ -475,6 +498,17 @@ Examples:
             print(f"Available for {args.target}: {', '.join(all_names)}")
             return
 
+    # Filter out TUI demos in snapshot mode
+    if args.snapshot:
+        original_count = len(demos)
+        demos = [(t, n, s) for t, n, s in demos if n not in TUI_DEMOS]
+        skipped = original_count - len(demos)
+        if skipped:
+            print(f"Skipping {skipped} TUI demo(s) (not snapshotable)")
+        if not demos:
+            print("No snapshotable demos found")
+            return
+
     # Handle --shell mode (interactive, must be sequential)
     if args.shell:
         tape_file, output_name, setup_func = demos[0]
@@ -501,6 +535,7 @@ Examples:
                     demo_size,
                     vhs_binary,
                     args.text,
+                    args.snapshot,
                 )
             except Exception as e:
                 print(f"✗ {output_name}: {e}")
@@ -521,6 +556,7 @@ Examples:
                     demo_size,
                     vhs_binary,
                     args.text,
+                    args.snapshot,
                 ): output_name
                 for tape_file, output_name, setup_func in demos
             }

--- a/docs/demos/shared/__init__.py
+++ b/docs/demos/shared/__init__.py
@@ -27,6 +27,9 @@ from .lib import (
     # Text output recording
     record_text,
     build_tape_replacements,
+    # Snapshot recording
+    extract_commands_from_tape,
+    record_snapshot,
     # External dependencies
     ensure_vhs_binary,
 )
@@ -61,6 +64,9 @@ __all__ = [
     # Text output recording
     "record_text",
     "build_tape_replacements",
+    # Snapshot recording
+    "extract_commands_from_tape",
+    "record_snapshot",
     # External dependencies
     "ensure_vhs_binary",
 ]

--- a/docs/demos/snapshots/wt-commit.snap
+++ b/docs/demos/snapshots/wt-commit.snap
@@ -1,0 +1,26 @@
+$ wt switch hooks
+○ Switched to worktree for hooks @ <DEMO_DIR>/.demo-wt-commit/w/acme.hooks
+[0m
+$ git diff --staged --stat
+ src/lib.rs        |  1 +
+ src/validation.rs | 23 +++++++++++++++++++++++
+ 2 files changed, 24 insertions(+)
+
+$ wt step commit
+◎ Generating commit message and committing changes... (2 files, +25)
+  feat(validation): add input validation utilities
+  
+  Add validation module with is_positive and is_non_empty helpers
+  for validating user input. Includes comprehensive test coverage.
+✓ Committed changes @ 200f6f2
+[0m
+$ git log -1
+commit 200f6f2d9731f93626892c1a410f942217189339
+Author: Worktrunk Demo <demo@example.com>
+Date:   Mon Jan 26 13:27:07 2026 -0800
+
+    feat(validation): add input validation utilities
+    
+    Add validation module with is_positive and is_non_empty helpers
+    for validating user input. Includes comprehensive test coverage.
+[0m

--- a/docs/demos/snapshots/wt-core.snap
+++ b/docs/demos/snapshots/wt-core.snap
@@ -1,0 +1,35 @@
+$ wt list
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main         [2m^[22m[2m|[22m                           [2m|[0m     [2m9b344c49[0m  [2m1d[0m    [2mdocs: add developm…[0m
++ hooks    [36m+[39m[36m![39m  [2m↑[22m       [32m+2[0m        [32m↑1[0m               [2m0967fab5[0m  [2m2h[0m    [2mfeat: add math ope…[0m
++ [2mbilling[0m      [2m_[22m[2m|[22m                           [2m|[0m     [2m9b344c49[0m  [2m1d[0m    [2mdocs: add developm…[0m
++ alpha     [36m![39m[36m?[39m [2m↑[22m[2m⇡[22m    [32m+105[0m  [31m-14[0m   [32m↑5[0m       [32m⇡1[0m      [2mf31634d7[0m  [2m3d[0m    [2mdocs: add FAQ sect…[0m
++ beta     [36m+[39m   [2m↓[22m[2m|[22m      [32m+2[0m            [2m[31m↓1[0m     [2m|[0m     [2mb10e3edd[0m  [2m5d[0m    [2mAdd project hooks[0m
+
+[2m○[22m [2mShowing 5 worktrees, 3 with changes, 2 ahead, 1 column hidden[0m
+[0m
+$ wt switch alpha
+○ Switched to worktree for alpha @ <DEMO_DIR>/.demo-wt-core/w/acme.alpha
+[0m
+$ wt switch --create api
+✓ Created branch api from main and worktree @ <DEMO_DIR>/.demo-wt-core/w/acme.api
+◎ Running post-start hooks: project:dev
+[0m
+$ wt list --full
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m
+@ [2mapi[0m          [2m_[22m                                                 [2m9b344c49[0m  [2m1d[0m
+^ main         [2m^[22m[2m|[22m                                      [2m|[0m         [2m9b344c49[0m  [2m1d[0m
++ hooks    [36m+[39m[36m![39m  [2m↑[22m       [32m+2[0m        [32m↑1[0m       [32m+12[0m   [31m-7[0m               [2m0967fab5[0m  [2m2h[0m
++ [2mbilling[0m      [2m_[22m[2m|[22m                                      [2m|[0m         [2m9b344c49[0m  [2m1d[0m
++ alpha     [36m![39m[36m?[39m [2m↑[22m[2m⇡[22m    [32m+105[0m  [31m-14[0m   [32m↑5[0m      [32m+264[0m   [31m-3[0m   [32m⇡1[0m          [2mf31634d7[0m  [2m3d[0m
++ beta     [36m+[39m   [2m↓[22m[2m|[22m      [32m+2[0m            [2m[31m↓1[0m                [2m|[0m         [2mb10e3edd[0m  [2m5d[0m
+
+[2m○[22m [2mShowing 6 worktrees, 3 with changes, 2 ahead, 2 columns hidden[0m
+[0m
+$ wt remove
+◎ Running pre-remove project:cleanup:
+  flyctl scale count 0
+Scaling app to 0 machines
+◎ Removing api worktree & branch in background (same commit as main, _)
+○ Switched to worktree for main @ <DEMO_DIR>/.demo-wt-core/w/acme
+[0m[0m

--- a/docs/demos/snapshots/wt-list.snap
+++ b/docs/demos/snapshots/wt-list.snap
@@ -1,0 +1,32 @@
+$ wt list
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main         [2m^[22m[2m|[22m                           [2m|[0m     [2m9b344c49[0m  [2m1d[0m    [2mdocs: add developm…[0m
++ hooks    [36m+[39m[36m![39m  [2m↑[22m       [32m+2[0m        [32m↑1[0m               [2m0967fab5[0m  [2m2h[0m    [2mfeat: add math ope…[0m
++ [2mbilling[0m      [2m_[22m[2m|[22m                           [2m|[0m     [2m9b344c49[0m  [2m1d[0m    [2mdocs: add developm…[0m
++ alpha     [36m![39m[36m?[39m [2m↑[22m[2m⇡[22m    [32m+105[0m  [31m-14[0m   [32m↑5[0m       [32m⇡1[0m      [2mf31634d7[0m  [2m3d[0m    [2mdocs: add FAQ sect…[0m
++ beta     [36m+[39m   [2m↓[22m[2m|[22m      [32m+2[0m            [2m[31m↓1[0m     [2m|[0m     [2mb10e3edd[0m  [2m5d[0m    [2mAdd project hooks[0m
+
+[2m○[22m [2mShowing 5 worktrees, 3 with changes, 2 ahead, 1 column hidden[0m
+[0m
+$ wt list --full
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m
+@ main         [2m^[22m[2m|[22m                                      [2m|[0m         [2m9b344c49[0m  [2m1d[0m
++ hooks    [36m+[39m[36m![39m  [2m↑[22m       [32m+2[0m        [32m↑1[0m       [32m+12[0m   [31m-7[0m               [2m0967fab5[0m  [2m2h[0m
++ [2mbilling[0m      [2m_[22m[2m|[22m                                      [2m|[0m         [2m9b344c49[0m  [2m1d[0m
++ alpha     [36m![39m[36m?[39m [2m↑[22m[2m⇡[22m    [32m+105[0m  [31m-14[0m   [32m↑5[0m      [32m+264[0m   [31m-3[0m   [32m⇡1[0m          [2mf31634d7[0m  [2m3d[0m
++ beta     [36m+[39m   [2m↓[22m[2m|[22m      [32m+2[0m            [2m[31m↓1[0m                [2m|[0m         [2mb10e3edd[0m  [2m5d[0m
+
+[2m○[22m [2mShowing 5 worktrees, 3 with changes, 2 ahead, 2 columns hidden[0m
+[0m
+$ wt list --branches
+  [1mBranch[0m        [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main              [2m^[22m[2m|[22m                           [2m|[0m     [2m9b344c49[0m  [2m1d[0m    [2mdocs: add dev…[0m
++ hooks         [36m+[39m[36m![39m  [2m↑[22m       [32m+2[0m        [32m↑1[0m               [2m0967fab5[0m  [2m2h[0m    [2mfeat: add mat…[0m
++ [2mbilling[0m           [2m_[22m[2m|[22m                           [2m|[0m     [2m9b344c49[0m  [2m1d[0m    [2mdocs: add dev…[0m
++ alpha          [36m![39m[36m?[39m [2m↑[22m[2m⇡[22m    [32m+105[0m  [31m-14[0m   [32m↑5[0m       [32m⇡1[0m      [2mf31634d7[0m  [2m3d[0m    [2mdocs: add FAQ…[0m
++ beta          [36m+[39m   [2m↓[22m[2m|[22m      [32m+2[0m            [2m[31m↓1[0m     [2m|[0m     [2mb10e3edd[0m  [2m5d[0m    [2mAdd project h…[0m
+  [2mdocs/readme[0m      [2m/[22m[2m⊂[22m                     [2m[31m↓1[0m           [2mb10e3edd[0m  [2m5d[0m    [2mAdd project h…[0m
+  [2mspike/search[0m     [2m/[22m[2m⊂[22m                     [2m[31m↓1[0m           [2mb10e3edd[0m  [2m5d[0m    [2mAdd project h…[0m
+
+[2m○[22m [2mShowing 5 worktrees, 2 remote branches, 3 with changes, 2 ahead, 1 column hidden[0m
+[0m[0m

--- a/docs/demos/snapshots/wt-merge.snap
+++ b/docs/demos/snapshots/wt-merge.snap
@@ -1,0 +1,37 @@
+$ wt list
+  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main        [2m^[22m[2m|[22m                           [2m|[0m     [2m9a898ce6[0m  [2m1d[0m    [2mdocs: add developme…[0m
++ hooks   [36m+[39m[36m![39m  [2m↑[22m      [32m+25[0m        [32m↑1[0m               [2me5bf91b7[0m  [2m2h[0m    [2mfeat: add math oper…[0m
++ alpha    [36m![39m[36m?[39m [2m↑[22m[2m⇡[22m    [32m+105[0m  [31m-14[0m   [32m↑5[0m       [32m⇡1[0m      [2m99a8f5d5[0m  [2m3d[0m    [2mdocs: add FAQ secti…[0m
++ beta    [36m+[39m   [2m↓[22m[2m|[22m      [32m+2[0m            [2m[31m↓1[0m     [2m|[0m     [2m77adea27[0m  [2m5d[0m    [2mAdd project hooks[0m
+
+[2m○[22m [2mShowing 4 worktrees, 3 with changes, 2 ahead, 1 column hidden[0m
+[0m
+$ wt switch --create notes
+✓ Created branch notes from main and worktree @ <DEMO_DIR>/.demo-wt-merge/w/acme.notes
+[0m
+$ wt merge
+◎ Running pre-merge project:test:
+  cargo nextest run
+    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.02s
+    Starting 2 tests across 1 binary
+        PASS [   0.001s] acme::tests::test_add
+        PASS [   0.001s] acme::tests::test_add_zeros
+------------
+     Summary [   0.002s] 2 tests run: 2 passed, 0 skipped
+○ Already up to date with main (no new commits, no rebase needed)
+◎ Removing notes worktree & branch in background (same commit as main, _)
+○ Switched to worktree for main @ <DEMO_DIR>/.demo-wt-merge/w/acme
+[0m
+$ wt list --branches --full
+  [1mBranch[0m        [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCI[0m  [1mCommit[0m    [1mAge[0m
+@ main              [2m^[22m[2m|[22m                                      [2m|[0m         [2m9a898ce6[0m  [2m1d[0m
++ hooks         [36m+[39m[36m![39m  [2m↑[22m      [32m+25[0m        [32m↑1[0m       [32m+12[0m   [31m-7[0m               [2me5bf91b7[0m  [2m2h[0m
++ [2mnotes[0m             [2m_[22m                                                 [2m9a898ce6[0m  [2m1d[0m
++ alpha          [36m![39m[36m?[39m [2m↑[22m[2m⇡[22m    [32m+105[0m  [31m-14[0m   [32m↑5[0m      [32m+264[0m   [31m-3[0m   [32m⇡1[0m          [2m99a8f5d5[0m  [2m3d[0m
++ beta          [36m+[39m   [2m↓[22m[2m|[22m      [32m+2[0m            [2m[31m↓1[0m                [2m|[0m         [2m77adea27[0m  [2m5d[0m
+  [2mdocs/readme[0m      [2m/[22m[2m⊂[22m                     [2m[31m↓1[0m                          [2m77adea27[0m  [2m5d[0m
+  [2mspike/search[0m     [2m/[22m[2m⊂[22m                     [2m[31m↓1[0m                          [2m77adea27[0m  [2m5d[0m
+
+[2m○[22m [2mShowing 5 worktrees, 2 remote branches, 3 with changes, 2 ahead, 2 columns hidden[0m
+[0m[0m


### PR DESCRIPTION
## Summary

- Add `--snapshot` flag to demo build script for regression testing
- Extracts wt/git commands from VHS tapes and captures their output
- Normalizes temp paths to `<DEMO_DIR>` for stable diffs
- Skips TUI demos automatically
- Documents usage and limitations

This catches unexpected changes like new hints or warnings appearing in demos (like the worktree-path hint that crept in earlier).

## Usage

```bash
./docs/demos/build docs --snapshot           # Generate all snapshots
./docs/demos/build docs --snapshot --only wt-list  # Single demo
```

## Test plan

- [x] Run `./docs/demos/build docs --snapshot` - generates 4 snapshots
- [x] Verify temp paths are normalized to `<DEMO_DIR>`
- [x] Verify TUI demos are skipped
- [x] Run pre-commit - passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)