### PR TITLE
Add blank line before prompts, not after

### DIFF
--- a/.claude/skills/writing-user-outputs/SKILL.md
+++ b/.claude/skills/writing-user-outputs/SKILL.md
@@ -463,31 +463,34 @@ parsing.
 Specific rules:
 
 - **No leading/trailing blanks** — Start immediately, end cleanly
-- **One blank after prompts** — Separate user input from results
+- **Blank before prompts, not after** — Signal "pause, something interactive is
+  happening" before the prompt; once the user responds, output flows continuously
 - **One blank between phases** — When a sub-operation completes and a different
   operation begins, add a blank line to visually separate them
 - **Never double blanks** — One blank line maximum between elements
 
-**Phase separation:** A "phase" is a logically distinct operation. Examples:
-
-- First-time config setup completing → main command workflow starting
-- Interactive prompt with results → unrelated command output
-- One complete sub-operation → another unrelated sub-operation
+**Prompt spacing:** A blank line before the prompt signals "something different
+is about to happen" and gives the user's eye a natural stopping point before they
+need to read and respond. No blank line after — the user's input ends the
+interactive moment and subsequent output flows naturally from that decision.
 
 ```
-❯ Configure claude for commit messages? [y/N/?] y
+◎ Detecting available LLM tools...
 
+❯ Configure claude for commit messages? [y/N/?] y
 ✓ Added to user config:
    ┃ [commit.generation]
    ┃ command = "..."
 ↳ View config: wt config show
-                                      ← Blank line separates phases
+
 ▲ Auto-staging 1 untracked path:
    ┃ a
 ◎ Generating commit message...
 ```
 
-The blank line signals "that's done, now we're doing something else."
+**Phase separation:** A "phase" is a logically distinct operation. The blank
+line between the hint and warning above signals "config setup is done, now we're
+doing the main command workflow."
 
 **Interactive prompts** must flush stderr before blocking on stdin:
 

--- a/src/commands/command_approval.rs
+++ b/src/commands/command_approval.rs
@@ -122,7 +122,6 @@ fn prompt_for_batch_approval(commands: &[&HookCommand], project_id: &str) -> any
             "{WARNING_SYMBOL} <yellow><bold>{project_name}</> needs approval to execute <bold>{count}</> command{plural}:</>"
         )
     );
-    eprintln!();
 
     for cmd in commands {
         // Format as: {phase} {bold}{name}{bold:#}:
@@ -144,7 +143,8 @@ fn prompt_for_batch_approval(commands: &[&HookCommand], project_id: &str) -> any
         return Err(GitError::NotInteractive.into());
     }
 
-    // Flush stderr before showing prompt to ensure all output is visible
+    // Blank line before prompt for visual separation
+    worktrunk::styling::eprintln!();
     stderr().flush()?;
 
     eprint!(
@@ -156,7 +156,8 @@ fn prompt_for_batch_approval(commands: &[&HookCommand], project_id: &str) -> any
     let mut response = String::new();
     io::stdin().read_line(&mut response)?;
 
-    eprintln!();
+    // End the prompt line on stderr (user's input went to stdin, not stderr)
+    worktrunk::styling::eprintln!();
 
     Ok(response.trim().eq_ignore_ascii_case("y"))
 }

--- a/src/commands/configure_shell.rs
+++ b/src/commands/configure_shell.rs
@@ -736,6 +736,8 @@ pub fn prompt_for_install(
 
 /// Prompt user for yes/no confirmation (simple [y/N] prompt)
 fn prompt_yes_no() -> Result<bool, String> {
+    // Blank line before prompt for visual separation
+    eprintln!();
     eprint!(
         "{} ",
         prompt_message(color_print::cformat!("Proceed? <bold>[y/N]</>"))
@@ -747,6 +749,7 @@ fn prompt_yes_no() -> Result<bool, String> {
         .read_line(&mut input)
         .map_err(|e| e.to_string())?;
 
+    // End the prompt line on stderr (user's input went to stdin, not stderr)
     eprintln!();
 
     let response = input.trim().to_lowercase();

--- a/src/output/commit_generation.rs
+++ b/src/output/commit_generation.rs
@@ -4,7 +4,7 @@
 //! attempt a commit without configuration. Detects available tools (claude, codex)
 //! and offers to auto-configure the recommended settings.
 
-use std::io::{self, IsTerminal, Write};
+use std::io::{self, IsTerminal};
 
 use color_print::cformat;
 use worktrunk::config::UserConfig;
@@ -137,9 +137,6 @@ pub fn prompt_commit_generation(config: &mut UserConfig) -> anyhow::Result<bool>
     let config_preview = format!("[commit.generation]\ncommand = {formatted_command}");
 
     // Show prompt with preview on ?
-    eprintln!();
-    io::stderr().flush()?;
-
     let response = prompt_yes_no_preview(
         &cformat!("Configure <bold>{tool}</> for commit messages?"),
         || {

--- a/src/output/prompt.rs
+++ b/src/output/prompt.rs
@@ -41,6 +41,9 @@ pub fn prompt_yes_no_preview(
     prompt_text: &str,
     show_preview: impl Fn(),
 ) -> io::Result<PromptResponse> {
+    // Blank line before first prompt for visual separation
+    worktrunk::styling::eprintln!();
+
     loop {
         eprint!(
             "{}",
@@ -51,19 +54,19 @@ pub fn prompt_yes_no_preview(
         let mut input = String::new();
         io::stdin().read_line(&mut input)?;
 
+        // End the prompt line on stderr (user's input went to stdin, not stderr)
+        worktrunk::styling::eprintln!();
+
         let response = input.trim().to_lowercase();
         match response.as_str() {
             "y" | "yes" => {
-                worktrunk::styling::eprintln!();
                 return Ok(PromptResponse::Accepted);
             }
             "?" => {
-                worktrunk::styling::eprintln!();
                 show_preview();
                 // Loop back to prompt again
             }
             _ => {
-                worktrunk::styling::eprintln!();
                 return Ok(PromptResponse::Declined);
             }
         }

--- a/src/output/shell_integration.rs
+++ b/src/output/shell_integration.rs
@@ -423,7 +423,6 @@ pub fn prompt_shell_integration(
 
     // TTY + first time: Show interactive prompt
     // Accepting installs for all shells with config files (same as `wt config shell install`)
-    eprintln!();
     let confirmed = prompt_for_install(
         &scan.configured,
         &scan.completion_results,

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_accept.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_accept.snap
@@ -5,9 +5,9 @@ expression: "&output"
 y
 
 [33m▲[39m [33m[1mrepo[22m needs approval to execute [1m1[22m command:[39m
-
 [2m○[22m post-create:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m
+
 [36m❯[39m [36mAllow and remember? [1m[y/N][22m[39m 
 [36m◎[39m [36mRunning post-create project hook @ [1m_REPO_.test-approve[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_decline.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_decline.snap
@@ -5,9 +5,9 @@ expression: "&output"
 n
 
 [33m▲[39m [33m[1mrepo[22m needs approval to execute [1m1[22m command:[39m
-
 [2m○[22m post-create:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m
+
 [36m❯[39m [36mAllow and remember? [1m[y/N][22m[39m 
 [2m○[22m Commands declined, continuing worktree creation
 [32m✓[39m [32mCreated branch [1mtest-decline[22m from [1mmain[22m and worktree @ [1m_REPO_.test-decline[22m[39m

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_mixed_approved_unapproved_accept.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_mixed_approved_unapproved_accept.snap
@@ -5,11 +5,11 @@ expression: "&output"
 y
 
 [33m▲[39m [33m[1mrepo[22m needs approval to execute [1m2[22m commands:[39m
-
 [2m○[22m post-create [1mfirst[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'First command'[0m[2m
 [2m○[22m post-create [1mthird[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Third command'[0m[2m
+
 [36m❯[39m [36mAllow and remember? [1m[y/N][22m[39m 
 [36m◎[39m [36mRunning post-create [1mproject:first[22m @ [1m_REPO_.test-mixed-accept[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'First command'[0m[2m

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_mixed_approved_unapproved_decline.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_mixed_approved_unapproved_decline.snap
@@ -5,11 +5,11 @@ expression: "&output"
 n
 
 [33m▲[39m [33m[1mrepo[22m needs approval to execute [1m2[22m commands:[39m
-
 [2m○[22m post-create [1mfirst[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'First command'[0m[2m
 [2m○[22m post-create [1mthird[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Third command'[0m[2m
+
 [36m❯[39m [36mAllow and remember? [1m[y/N][22m[39m 
 [2m○[22m Commands declined, continuing worktree creation
 [32m✓[39m [32mCreated branch [1mtest-mixed-decline[22m from [1mmain[22m and worktree @ [1m_REPO_.test-mixed-decline[22m[39m

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_multiple_commands.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_multiple_commands.snap
@@ -5,13 +5,13 @@ expression: "&output"
 y
 
 [33m▲[39m [33m[1mrepo[22m needs approval to execute [1m3[22m commands:[39m
-
 [2m○[22m post-create [1mfirst[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'First command'[0m[2m
 [2m○[22m post-create [1msecond[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Second command'[0m[2m
 [2m○[22m post-create [1mthird[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Third command'[0m[2m
+
 [36m❯[39m [36mAllow and remember? [1m[y/N][22m[39m 
 [36m◎[39m [36mRunning post-create [1mproject:first[22m @ [1m_REPO_.test-multi[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'First command'[0m[2m

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_named_commands.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_named_commands.snap
@@ -5,13 +5,13 @@ expression: "&output"
 y
 
 [33m▲[39m [33m[1mrepo[22m needs approval to execute [1m3[22m commands:[39m
-
 [2m○[22m post-create [1minstall[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Installing dependencies...'[0m[2m
 [2m○[22m post-create [1mbuild[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Building project...'[0m[2m
 [2m○[22m post-create [1mtest[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Running tests...'[0m[2m
+
 [36m❯[39m [36mAllow and remember? [1m[y/N][22m[39m 
 [36m◎[39m [36mRunning post-create [1mproject:install[22m @ [1m_REPO_.test-named[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Installing dependencies...'[0m[2m

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_permission_error.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_permission_error.snap
@@ -5,9 +5,9 @@ expression: "&output"
 y
 
 [33m▲[39m [33m[1mrepo[22m needs approval to execute [1m1[22m command:[39m
-
 [2m○[22m post-create:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m
+
 [36m❯[39m [36mAllow and remember? [1m[y/N][22m[39m 
 [33m▲[39m [33mFailed to save command approval: Failed to write config file: Permission denied (os error 13)[39m
 [2m↳[22m [2mApproval will be requested again next time.[22m

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_remove_decline.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_remove_decline.snap
@@ -5,9 +5,9 @@ expression: "&output"
 n
 
 [33m▲[39m [33m[1mrepo[22m needs approval to execute [1m1[22m command:[39m
-
 [2m○[22m pre-remove:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'pre-remove hook'[0m[2m
+
 [36m❯[39m [36mAllow and remember? [1m[y/N][22m[39m 
 [2m○[22m Commands declined, continuing removal
 [36m◎ Removing [1mto-remove[22m worktree & branch in background (ancestor of [1mmain[22m,[39m [2m⊂[22m[36m)[39m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_fails_in_non_tty.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_fails_in_non_tty.snap
@@ -37,7 +37,6 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
-
 [2m○[22m post-create:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_mixed_approved_unapproved.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_mixed_approved_unapproved.snap
@@ -7,7 +7,6 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33m[1mrepo[22m needs approval to execute [1m2[22m commands:[39m
-
 [2m○[22m post-create [1mfirst[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'First command'[0m[2m
 [2m○[22m post-create [1mthird[22m:

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_multiple_commands.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_multiple_commands.snap
@@ -7,7 +7,6 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m4[22m commands:[39m
-
 [2m○[22m post-create [1mbranch[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Branch: {{ branch }}'[0m[2m
 [2m○[22m post-create [1mworktree[22m:

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_named_commands.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_named_commands.snap
@@ -7,7 +7,6 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m3[22m commands:[39m
-
 [2m○[22m post-create [1minstall[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Installing dependencies...'[0m[2m
 [2m○[22m post-create [1mbuild[22m:

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_single_command.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_single_command.snap
@@ -7,7 +7,6 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
-
 [2m○[22m post-create:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Worktree path: {{ worktree_path }}'[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m

--- a/tests/snapshots/integration__integration_tests__approval_ui__decline_approval_skips_only_unapproved.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__decline_approval_skips_only_unapproved.snap
@@ -7,7 +7,6 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33m[1mrepo[22m needs approval to execute [1m2[22m commands:[39m
-
 [2m○[22m post-create [1mfirst[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'First command'[0m[2m
 [2m○[22m post-create [1mthird[22m:

--- a/tests/snapshots/integration__integration_tests__approval_ui__project_prefix_all_requires_approval.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__project_prefix_all_requires_approval.snap
@@ -7,7 +7,6 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m2[22m commands:[39m
-
 [2m○[22m pre-merge [1mtest[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Running project test'[0m[2m
 [2m○[22m pre-merge [1mlint[22m:

--- a/tests/snapshots/integration__integration_tests__approval_ui__project_prefix_requires_approval.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__project_prefix_requires_approval.snap
@@ -7,7 +7,6 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
-
 [2m○[22m pre-merge [1mtest[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Running project test'[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m

--- a/tests/snapshots/integration__integration_tests__approval_ui__run_hook_post_merge_requires_approval.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__run_hook_post_merge_requires_approval.snap
@@ -7,7 +7,6 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
-
 [2m○[22m post-merge:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Post-merge cleanup for {{ branch }}'[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m

--- a/tests/snapshots/integration__integration_tests__approval_ui__run_hook_pre_merge_requires_approval.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__run_hook_pre_merge_requires_approval.snap
@@ -7,7 +7,6 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
-
 [2m○[22m pre-merge:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Running pre-merge checks on {{ branch }}'[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m

--- a/tests/snapshots/integration__integration_tests__approval_ui__yes_does_not_save_approvals_second_run.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__yes_does_not_save_approvals_second_run.snap
@@ -7,7 +7,6 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
-
 [2m○[22m post-create:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m [0m[2m[36m>[0m[2m output.txt
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_already_approved.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_already_approved.snap
@@ -37,7 +37,6 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
-
 [2m○[22m post-create:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test'[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_none_approved.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_none_approved.snap
@@ -38,7 +38,6 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
-
 [2m○[22m post-create:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test'[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m

--- a/tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__readme_example_approval_prompt.snap
+++ b/tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__readme_example_approval_prompt.snap
@@ -5,11 +5,11 @@ expression: prompt_only
 n
 
 ▲ repo needs approval to execute 3 commands:
-
 ○ post-create install:
   echo 'Installing dependencies...'
 ○ post-create build:
   echo 'Building project...'
 ○ post-create test:
   echo 'Running tests...'
+
 ❯ Allow and remember? [y/N]


### PR DESCRIPTION
## Summary

- Standardize prompt spacing: blank line before prompts, no blank line after
- Remove spurious blank line between warning and command list in approval flow
- Update writing-user-outputs skill to document the guideline

## Test plan

- [x] All 1095 tests pass (including shell integration tests)
- [x] Pre-commit lints pass
- [x] Snapshot outputs reviewed for correct spacing

🤖 Generated with [Claude Code](https://claude.ai/code)