### PR TITLE
fix(docs): correct broken worktrunk.dev URLs

### DIFF
--- a/.config/lychee.toml
+++ b/.config/lychee.toml
@@ -45,7 +45,6 @@ exclude = [
     "npmjs\\.com",
     "incident\\.io",
     "git-scm\\.com",
-    "worktrunk\\.dev",
 
     # Package registries and badges (frequently return 429 or block CI)
     "crates\\.io",

--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -85,7 +85,7 @@
 #
 # For context:
 #
-# - Project config (https://worktrunk.dev/config.md#project-configuration/) settings are shared with teammates.
+# - Project config (https://worktrunk.dev/config/#project-configuration) settings are shared with teammates.
 # - User configs generally apply to all projects.
 # - User configs _also_ has a `[projects]` table which holds project-specific settings for the user, such as approved hook commands and worktree layout. That's what this section covers.
 #

--- a/templates/fish_wrapper.fish
+++ b/templates/fish_wrapper.fish
@@ -1,6 +1,6 @@
 # worktrunk shell integration for fish
 # Sources full integration from binary on first use.
-# Docs: https://worktrunk.dev/docs/shell-integration
+# Docs: https://worktrunk.dev/config/#shell-integration
 # Check: {{ cmd }} config show | Uninstall: {{ cmd }} config shell uninstall
 
 function {{ cmd }}

--- a/tests/integration_tests/readme_sync.rs
+++ b/tests/integration_tests/readme_sync.rs
@@ -978,8 +978,15 @@ fn convert_markdown_links_for_config(line: &str) -> String {
 
             // Convert Zola @/ links to full URLs
             let url = if let Some(path) = url.strip_prefix("@/") {
-                let page = path.trim_end_matches(".md");
-                format!("https://worktrunk.dev/{page}/")
+                // Handle anchors: @/config.md#section → config/#section
+                let (page, anchor) = match path.split_once('#') {
+                    Some((p, a)) => (p.trim_end_matches(".md"), Some(a)),
+                    None => (path.trim_end_matches(".md"), None),
+                };
+                match anchor {
+                    Some(a) => format!("https://worktrunk.dev/{page}/#{a}"),
+                    None => format!("https://worktrunk.dev/{page}/"),
+                }
             } else {
                 url.to_string()
             };

--- a/tests/snapshots/integration__integration_tests__configure_shell__configure_shell_fish_dry_run.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__configure_shell_fish_dry_run.snap
@@ -41,7 +41,7 @@ exit_code: 0
 [2m○[22m Will create shell extension for [1mfish[0m @ [1m~/.config/fish/functions/wt.fish
 [107m [0m [2m# worktrunk shell integration for fish[0m[2m
 [107m [0m [2m# Sources full integration from binary on first use.[0m[2m
-[107m [0m [2m# Docs: https://worktrunk.dev/docs/shell-integration[0m[2m
+[107m [0m [2m# Docs: https://worktrunk.dev/config/#shell-integration[0m[2m
 [107m [0m [2m# Check: wt config show | Uninstall: wt config shell uninstall[0m[2m
 [107m [0m [2m
 [107m [0m [2m[0m[2m[35mfunction[0m[2m wt

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -137,7 +137,7 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
   [2m#[0m
   [2m# For context:[0m
   [2m#[0m
-  [2m# - Project config (https://worktrunk.dev/config.md#project-configuration/) settings are shared with teammates.[0m
+  [2m# - Project config (https://worktrunk.dev/config/#project-configuration) settings are shared with teammates.[0m
   [2m# - User configs generally apply to all projects.[0m
   [2m# - User configs _also_ has a `[projects]` table which holds project-specific settings for the user, such as approved hook commands and worktree layout. That's what this section covers.[0m
   [2m#[0m


### PR DESCRIPTION
## Summary

- Fix broken URL in fish shell wrapper: `/docs/shell-integration` → `/config/#shell-integration`
- Fix broken URL in config example: `/config.md#project-configuration/` → `/config/#project-configuration`
- Remove `worktrunk.dev` from lychee exclusions so future broken links to our own docs are caught

## Test plan

- [x] `lychee` now validates worktrunk.dev URLs
- [x] Pre-commit checks pass

> _This was written by Claude Code on behalf of max-sixty_