### PR TITLE
perf(config): speed up `wt config show` by avoiding claude --version

### DIFF
--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -73,11 +73,11 @@ pub fn handle_config_show(full: bool) -> anyhow::Result<()> {
 
 /// Check if Claude Code CLI is available
 fn is_claude_available() -> bool {
-    Cmd::new("claude")
-        .arg("--version")
-        .run()
-        .map(|o| o.status.success())
-        .unwrap_or(false)
+    // Allow tests to override detection
+    if let Ok(val) = std::env::var("WORKTRUNK_TEST_CLAUDE_INSTALLED") {
+        return val == "1";
+    }
+    which::which("claude").is_ok()
 }
 
 /// Get the home directory for Claude Code config detection


### PR DESCRIPTION
## Summary

- Replace `claude --version` (1.2s Node.js startup) with `which::which("claude")` for detecting Claude Code availability
- Add `WORKTRUNK_TEST_CLAUDE_INSTALLED` env var for test isolation

## Performance

~1.2s → ~150ms (8x faster)

## Test plan

- [x] All unit tests pass
- [x] All integration tests pass (986 tests)
- [x] Verified timing improvement with `time wt config show`

🤖 Generated with [Claude Code](https://claude.com/claude-code)