### PR TITLE
refactor(output): downgrade 'no worktree' message to info

### DIFF
--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -545,10 +545,10 @@ fn handle_branch_only_output(
             ))
         );
     } else {
-        // No worktree at all - warn since user asked to remove something that doesn't exist
+        // No worktree at all, but branch exists - informational since branch removal will proceed
         eprintln!(
             "{}",
-            warning_message(cformat!(
+            info_message(cformat!(
                 "No worktree found for branch <bold>{branch_name}</>"
             ))
         );

--- a/tests/snapshots/integration__integration_tests__remove__remove_branch_matching_tree_content.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_branch_matching_tree_content.snap
@@ -25,6 +25,7 @@ info:
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     WT_TEST_DELAYED_STREAM_MS: "-1"
     WT_TEST_EPOCH: "1735776000"
@@ -35,5 +36,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mNo worktree found for branch [1mfeature-squashed[22m[39m
+[2m○[22m No worktree found for branch [1mfeature-squashed[22m
 [32m✓ Removed branch [1mfeature-squashed[22m (tree matches [1mmain[22m,[39m [2m⊂[22m[32m)[39m

--- a/tests/snapshots/integration__integration_tests__remove__remove_branch_no_worktree_path_occupied.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_branch_no_worktree_path_occupied.snap
@@ -25,6 +25,7 @@ info:
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     WT_TEST_DELAYED_STREAM_MS: "-1"
     WT_TEST_EPOCH: "1735776000"
@@ -35,5 +36,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mNo worktree found for branch [1mnpm[22m[39m
+[2m○[22m No worktree found for branch [1mnpm[22m
 [32m✓ Removed branch [1mnpm[22m (same commit as [1mmain[22m,[39m [2m_[22m[32m)[39m

--- a/tests/snapshots/integration__integration_tests__remove__remove_branch_only_force_delete.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_branch_only_force_delete.snap
@@ -26,6 +26,7 @@ info:
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     WT_TEST_DELAYED_STREAM_MS: "-1"
     WT_TEST_EPOCH: "1735776000"
@@ -36,5 +37,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mNo worktree found for branch [1mfeature-force[22m[39m
+[2m○[22m No worktree found for branch [1mfeature-force[22m
 [32m✓ Removed branch [1mfeature-force[22m (--force-delete)[39m

--- a/tests/snapshots/integration__integration_tests__remove__remove_branch_only_merged.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_branch_only_merged.snap
@@ -25,6 +25,7 @@ info:
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     WT_TEST_DELAYED_STREAM_MS: "-1"
     WT_TEST_EPOCH: "1735776000"
@@ -35,5 +36,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mNo worktree found for branch [1mfeature-merged[22m[39m
+[2m○[22m No worktree found for branch [1mfeature-merged[22m
 [32m✓ Removed branch [1mfeature-merged[22m (same commit as [1mmain[22m,[39m [2m_[22m[32m)[39m

--- a/tests/snapshots/integration__integration_tests__remove__remove_branch_only_unmerged.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_branch_only_unmerged.snap
@@ -25,6 +25,7 @@ info:
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     WT_TEST_DELAYED_STREAM_MS: "-1"
     WT_TEST_EPOCH: "1735776000"
@@ -35,6 +36,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mNo worktree found for branch [1mfeature-unmerged[22m[39m
+[2m○[22m No worktree found for branch [1mfeature-unmerged[22m
 [2m○[22m Branch [1mfeature-unmerged[22m retained; has unmerged changes
 [2m↳[22m [2mTo delete the unmerged branch, run [90mwt remove feature-unmerged -D[39m[22m

--- a/tests/snapshots/integration__integration_tests__remove__remove_detached_worktree_in_multi.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_detached_worktree_in_multi.snap
@@ -26,6 +26,7 @@ info:
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     WT_TEST_DELAYED_STREAM_MS: "-1"
     WT_TEST_EPOCH: "1735776000"
@@ -38,6 +39,6 @@ exit_code: 0
 ----- stderr -----
 [36m◎ Removing [1mfeature-a[22m worktree in background[39m
 [2m↳[22m [2mBranch unmerged; to delete, run [90mwt remove feature-a -D[39m[22m
-[33m▲[39m [33mNo worktree found for branch [1mfeature-b[22m[39m
+[2m○[22m No worktree found for branch [1mfeature-b[22m
 [2m○[22m Branch [1mfeature-b[22m retained; has unmerged changes
 [2m↳[22m [2mTo delete the unmerged branch, run [90mwt remove feature-b -D[39m[22m

--- a/tests/snapshots/integration__integration_tests__remove__remove_squash_merged_then_main_advanced.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_squash_merged_then_main_advanced.snap
@@ -25,6 +25,7 @@ info:
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     WT_TEST_DELAYED_STREAM_MS: "-1"
     WT_TEST_EPOCH: "1735776000"
@@ -35,5 +36,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mNo worktree found for branch [1mfeature-squash[22m[39m
+[2m○[22m No worktree found for branch [1mfeature-squash[22m
 [32m✓ Removed branch [1mfeature-squash[22m (all changes in [1mmain[22m,[39m [2m⊂[22m[32m)[39m


### PR DESCRIPTION
## Summary

- Downgrades the "No worktree found for branch X" message from warning (▲) to info (○) when removing a branch that has no associated worktree
- The BranchOnly code path is only reached when the branch exists locally, so this is informational rather than a warning scenario

## Test plan

- Existing snapshot tests updated to reflect the new output format
- `wt hook pre-merge --yes` passes

> _This was written by Claude Code on behalf of max-sixty_