### PR TITLE
docs(relocate): document main worktree behavior

### DIFF
--- a/src/cli/step.rs
+++ b/src/cli/step.rs
@@ -363,6 +363,12 @@ this by using a temporary location.
 With `--clobber`, non-worktree paths at target locations are moved to
 `<path>.bak-<timestamp>` before relocating.
 
+## Main worktree behavior
+
+The main worktree can't be moved with `git worktree move`. Instead, relocate
+switches it to the default branch and creates a new linked worktree at the
+expected path. Untracked and gitignored files remain at the original location.
+
 ## Skipped worktrees
 
 - **Dirty** (without `--commit`) — use `--commit` to auto-commit first


### PR DESCRIPTION
## Summary

- Adds documentation explaining the behavioral difference when relocating the main worktree vs linked worktrees
- Main worktree can't use `git worktree move`, so relocate switches to the default branch and creates a new linked worktree
- Documents that untracked and gitignored files remain at the original location

🤖 Generated with [Claude Code](https://claude.ai/code)