### PR TITLE
refactor: simplify command structure and remove dead code

### DIFF
--- a/src/commands/context.rs
+++ b/src/commands/context.rs
@@ -28,11 +28,10 @@ impl CommandEnv {
     ///
     /// `action` describes what command is running (e.g., "merge", "squash").
     /// Used in error messages when the environment can't be loaded.
-    pub fn for_action(action: &str) -> anyhow::Result<Self> {
+    pub fn for_action(action: &str, config: UserConfig) -> anyhow::Result<Self> {
         let repo = Repository::current()?;
         let worktree_path = std::env::current_dir().context("Failed to get current directory")?;
         let branch = repo.require_current_branch(action)?;
-        let config = UserConfig::load().context("Failed to load config")?;
 
         Ok(Self {
             repo,

--- a/src/commands/handle_switch.rs
+++ b/src/commands/handle_switch.rs
@@ -1,0 +1,185 @@
+//! Switch command handler.
+
+use std::collections::HashMap;
+
+use anyhow::Context;
+use worktrunk::HookType;
+use worktrunk::config::{UserConfig, expand_template};
+use worktrunk::git::Repository;
+use worktrunk::styling::{eprintln, info_message};
+
+use super::command_approval::approve_hooks;
+use super::command_executor::{CommandContext, build_hook_context};
+use super::worktree::{SwitchResult, execute_switch, plan_switch};
+use crate::output::{
+    execute_user_command, handle_switch_output, is_shell_integration_active,
+    prompt_shell_integration,
+};
+
+/// Options for the switch command
+pub struct SwitchOptions<'a> {
+    pub branch: &'a str,
+    pub create: bool,
+    pub base: Option<&'a str>,
+    pub execute: Option<&'a str>,
+    pub execute_args: &'a [String],
+    pub yes: bool,
+    pub clobber: bool,
+    pub verify: bool,
+}
+
+/// Handle the switch command.
+pub fn handle_switch(
+    opts: SwitchOptions<'_>,
+    config: &mut UserConfig,
+    binary_name: &str,
+) -> anyhow::Result<()> {
+    let SwitchOptions {
+        branch,
+        create,
+        base,
+        execute,
+        execute_args,
+        yes,
+        clobber,
+        verify,
+    } = opts;
+
+    let repo = Repository::current().context("Failed to switch worktree")?;
+
+    // Validate FIRST (before approval) - fails fast if branch doesn't exist, etc.
+    let plan = plan_switch(&repo, branch, create, base, clobber, config)?;
+
+    // "Approve at the Gate": collect and approve hooks upfront
+    // This ensures approval happens once at the command entry point
+    // If user declines, skip hooks but continue with worktree operation
+    let approved = if verify {
+        let ctx = CommandContext::new(
+            &repo,
+            config,
+            Some(plan.branch()),
+            plan.worktree_path(),
+            yes,
+        );
+        // Approve different hooks based on whether we're creating or switching
+        if plan.is_create() {
+            approve_hooks(
+                &ctx,
+                &[
+                    HookType::PostCreate,
+                    HookType::PostStart,
+                    HookType::PostSwitch,
+                ],
+            )?
+        } else {
+            // When switching to existing, only post-switch needs approval
+            approve_hooks(&ctx, &[HookType::PostSwitch])?
+        }
+    } else {
+        true // --no-verify: skip all hooks
+    };
+
+    // Skip hooks if --no-verify or user declined approval
+    let skip_hooks = !verify || !approved;
+
+    // Show message if user declined approval
+    if !approved {
+        eprintln!(
+            "{}",
+            info_message(if plan.is_create() {
+                "Commands declined, continuing worktree creation"
+            } else {
+                "Commands declined"
+            })
+        );
+    }
+
+    // Execute the validated plan
+    let (result, branch_info) = execute_switch(&repo, plan, config, yes, skip_hooks)?;
+
+    // Show success message (temporal locality: immediately after worktree operation)
+    // Returns path to display in hooks when user's shell won't be in the worktree
+    // Also shows worktree-path hint on first --create (before shell integration warning)
+    let hooks_display_path = handle_switch_output(&result, &branch_info)?;
+
+    // Offer shell integration if not already installed/active
+    // (only shows prompt/hint when shell integration isn't working)
+    // With --execute: show hints only (don't interrupt with prompt)
+    // Best-effort: don't fail switch if offer fails
+    if !is_shell_integration_active() {
+        let skip_prompt = execute.is_some();
+        let _ = prompt_shell_integration(config, binary_name, skip_prompt);
+    }
+
+    // Build extra vars for base branch context (used by both hooks and --execute)
+    // "base" is the branch we branched from when creating a new worktree.
+    // For existing worktrees, there's no base concept.
+    let (base_branch, base_worktree_path): (Option<&str>, Option<&str>) = match &result {
+        SwitchResult::Created {
+            base_branch,
+            base_worktree_path,
+            ..
+        } => (base_branch.as_deref(), base_worktree_path.as_deref()),
+        SwitchResult::Existing { .. } | SwitchResult::AlreadyAt(_) => (None, None),
+    };
+    let extra_vars: Vec<(&str, &str)> = [
+        base_branch.map(|b| ("base", b)),
+        base_worktree_path.map(|p| ("base_worktree_path", p)),
+    ]
+    .into_iter()
+    .flatten()
+    .collect();
+
+    // Spawn background hooks after success message
+    // - post-switch: runs on ALL switches (shows "@ path" when shell won't be there)
+    // - post-start: runs only when creating a NEW worktree
+    if !skip_hooks {
+        let ctx = CommandContext::new(&repo, config, Some(&branch_info.branch), result.path(), yes);
+
+        // Post-switch runs first (immediate "I'm here" signal)
+        ctx.spawn_post_switch_commands(&extra_vars, hooks_display_path.as_deref())?;
+
+        // Post-start runs only on creation (setup tasks)
+        if matches!(&result, SwitchResult::Created { .. }) {
+            ctx.spawn_post_start_commands(&extra_vars, hooks_display_path.as_deref())?;
+        }
+    }
+
+    // Execute user command after post-start hooks have been spawned
+    // Note: execute_args requires execute via clap's `requires` attribute
+    if let Some(cmd) = execute {
+        // Build template context for expansion (includes base vars when creating)
+        let ctx = CommandContext::new(&repo, config, Some(&branch_info.branch), result.path(), yes);
+        let template_vars = build_hook_context(&ctx, &extra_vars);
+        let vars: HashMap<&str, &str> = template_vars
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+
+        // Expand template variables in command (shell_escape: true for safety)
+        let expanded_cmd = expand_template(cmd, &vars, true, &repo, "--execute command")
+            .map_err(|e| anyhow::anyhow!("Failed to expand --execute template: {}", e))?;
+
+        // Append any trailing args (after --) to the execute command
+        // Each arg is also expanded, then shell-escaped
+        let full_cmd = if execute_args.is_empty() {
+            expanded_cmd
+        } else {
+            let expanded_args: Result<Vec<_>, _> = execute_args
+                .iter()
+                .map(|arg| {
+                    expand_template(arg, &vars, false, &repo, "--execute argument")
+                        .map_err(|e| anyhow::anyhow!("Failed to expand argument template: {}", e))
+                })
+                .collect();
+            let escaped_args: Vec<_> = expanded_args?
+                .iter()
+                .map(|arg| shlex::try_quote(arg).unwrap_or(arg.into()).into_owned())
+                .collect();
+            format!("{} {}", expanded_cmd, escaped_args.join(" "))
+        };
+        execute_user_command(&full_cmd, hooks_display_path.as_deref())?;
+    }
+
+    Ok(())
+}

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -1,8 +1,6 @@
-use std::path::Path;
-
 use anyhow::Context;
 use worktrunk::HookType;
-use worktrunk::config::{ProjectConfig, UserConfig};
+use worktrunk::config::UserConfig;
 use worktrunk::git::Repository;
 use worktrunk::styling::{eprintln, info_message};
 
@@ -10,7 +8,7 @@ use super::command_approval::approve_command_batch;
 use super::command_executor::CommandContext;
 use super::commit::CommitOptions;
 use super::context::CommandEnv;
-use super::hooks::{HookFailureStrategy, run_hook_with_filter};
+use super::hooks::{HookFailureStrategy, execute_hook};
 use super::project_config::{HookCommand, collect_commands_for_hooks};
 use super::repository_ext::RepositoryCliExt;
 use super::worktree::{
@@ -51,7 +49,7 @@ fn collect_merge_commands(
     let mut all_commands = Vec::new();
     let project_config = match repo.load_project_config()? {
         Some(cfg) => cfg,
-        None => return Ok((all_commands, repo.project_identifier()?.to_string())),
+        None => return Ok((all_commands, repo.project_identifier()?)),
     };
 
     let mut hooks = Vec::new();
@@ -74,7 +72,7 @@ fn collect_merge_commands(
 
     all_commands.extend(collect_commands_for_hooks(&project_config, &hooks));
 
-    let project_id = repo.project_identifier()?.to_string();
+    let project_id = repo.project_identifier()?;
     Ok((all_commands, project_id))
 }
 
@@ -90,13 +88,14 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
         stage,
     } = opts;
 
-    // One-time LLM setup prompt (errors logged internally; don't block merge)
+    // Load config once, run LLM setup prompt if committing, then reuse config
+    let mut config = UserConfig::load().context("Failed to load config")?;
     if commit_opt.unwrap_or(true) {
-        let mut config = UserConfig::load().context("Failed to load config")?;
+        // One-time LLM setup prompt (errors logged internally; don't block merge)
         let _ = crate::output::prompt_commit_generation(&mut config);
     }
 
-    let env = CommandEnv::for_action("merge")?;
+    let env = CommandEnv::for_action("merge", config)?;
     let repo = &env.repo;
     let config = &env.config;
     // Merge requires being on a branch (can't merge from detached HEAD)
@@ -134,7 +133,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
     if !commit && current_wt.is_dirty()? {
         return Err(worktrunk::git::GitError::UncommittedChanges {
             action: Some("merge with --no-commit".into()),
-            branch: Some(current_branch.clone()),
+            branch: Some(current_branch),
             force_hint: false,
         }
         .into());
@@ -214,10 +213,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
     } else {
         // --no-rebase: verify already rebased, fail if not
         if !repo.is_rebased_onto(&target_branch)? {
-            return Err(worktrunk::git::GitError::NotRebased {
-                target_branch: target_branch.clone(),
-            }
-            .into());
+            return Err(worktrunk::git::GitError::NotRebased { target_branch }.into());
         }
         false // Already rebased, no rebase occurred
     };
@@ -226,8 +222,14 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
     // Do this after commit/squash/rebase to validate the final state that will be pushed
     if verify {
         let ctx = env.context(yes);
-        let project_config = repo.load_project_config()?.unwrap_or_default();
-        run_pre_merge_commands(&project_config, &ctx, &target_branch, None, &[])?;
+        execute_hook(
+            &ctx,
+            HookType::PreMerge,
+            &[("target", target_branch.as_str())],
+            HookFailureStrategy::FailFast,
+            None,
+            crate::output::pre_hook_display_path(ctx.worktree_path),
+        )?;
     }
 
     // Fast-forward push to target branch with commit/squash/rebase info for consolidated message
@@ -254,7 +256,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
         current_wt.ensure_clean("remove worktree after merge", Some(&current_branch), false)?;
 
         // STEP 2: Remove worktree via shared remove output handler so final message matches wt remove
-        let worktree_root = current_wt.root()?.to_path_buf();
+        let worktree_root = current_wt.root()?;
         // After a successful merge, get integration reason
         let (_, integration_reason) = repo.integration_reason(&current_branch, &target_branch)?;
         // Compute expected_path for path mismatch detection
@@ -306,104 +308,15 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
             // or worktree preserved so they stay in feature)
             crate::output::pre_hook_display_path(&destination_path)
         };
-        execute_post_merge_commands(&ctx, &target_branch, None, display_path, &[])?;
+        execute_hook(
+            &ctx,
+            HookType::PostMerge,
+            &[("target", target_branch.as_str())],
+            HookFailureStrategy::Warn,
+            None,
+            display_path,
+        )?;
     }
 
     Ok(())
-}
-
-/// Run pre-merge commands sequentially (blocking, fail-fast)
-///
-/// Runs user hooks first, then project hooks.
-/// Approval is handled at the gate (command entry point).
-pub fn run_pre_merge_commands(
-    project_config: &ProjectConfig,
-    ctx: &CommandContext,
-    target_branch: &str,
-    name_filter: Option<&str>,
-    extra_vars: &[(&str, &str)],
-) -> anyhow::Result<()> {
-    // Combine target with any custom vars (custom vars take precedence, added last)
-    let mut vars = vec![("target", target_branch)];
-    vars.extend_from_slice(extra_vars);
-    let user_hooks = ctx.config.hooks(ctx.project_id().as_deref());
-    run_hook_with_filter(
-        ctx,
-        user_hooks.pre_merge.as_ref(),
-        project_config.hooks.pre_merge.as_ref(),
-        HookType::PreMerge,
-        &vars,
-        HookFailureStrategy::FailFast,
-        name_filter,
-        crate::output::pre_hook_display_path(ctx.worktree_path),
-    )
-    .map_err(worktrunk::git::add_hook_skip_hint)
-}
-
-/// Execute post-merge commands sequentially in the target worktree (blocking)
-///
-/// Runs user hooks first, then project hooks.
-/// Approval is handled at the gate (command entry point).
-///
-/// `display_path`: Pass `ctx.hooks_display_path()` for automatic detection, or
-/// explicit `Some(path)` when hooks run somewhere the user won't be cd'd to.
-pub fn execute_post_merge_commands(
-    ctx: &CommandContext,
-    target_branch: &str,
-    name_filter: Option<&str>,
-    display_path: Option<&Path>,
-    extra_vars: &[(&str, &str)],
-) -> anyhow::Result<()> {
-    // Load project config from the main worktree path
-    let project_config = ctx.repo.load_project_config()?;
-
-    // Combine target with any custom vars (custom vars take precedence, added last)
-    let mut vars = vec![("target", target_branch)];
-    vars.extend_from_slice(extra_vars);
-    let user_hooks = ctx.config.hooks(ctx.project_id().as_deref());
-    run_hook_with_filter(
-        ctx,
-        user_hooks.post_merge.as_ref(),
-        project_config
-            .as_ref()
-            .and_then(|c| c.hooks.post_merge.as_ref()),
-        HookType::PostMerge,
-        &vars,
-        HookFailureStrategy::Warn,
-        name_filter,
-        display_path,
-    )
-    .map_err(worktrunk::git::add_hook_skip_hint)
-}
-
-/// Execute pre-remove commands sequentially in the worktree (blocking)
-///
-/// Runs user hooks first, then project hooks.
-/// Runs before a worktree is removed. Non-zero exit aborts the removal.
-/// Approval is handled at the gate (command entry point).
-///
-/// `display_path`: Pass `ctx.hooks_display_path()` for automatic detection, or
-/// explicit `Some(path)` when hooks run somewhere the user won't be cd'd to.
-pub fn execute_pre_remove_commands(
-    ctx: &CommandContext,
-    name_filter: Option<&str>,
-    display_path: Option<&Path>,
-    extra_vars: &[(&str, &str)],
-) -> anyhow::Result<()> {
-    let project_config = ctx.repo.load_project_config()?;
-    let user_hooks = ctx.config.hooks(ctx.project_id().as_deref());
-
-    run_hook_with_filter(
-        ctx,
-        user_hooks.pre_remove.as_ref(),
-        project_config
-            .as_ref()
-            .and_then(|c| c.hooks.pre_remove.as_ref()),
-        HookType::PreRemove,
-        extra_vars,
-        HookFailureStrategy::FailFast,
-        name_filter,
-        display_path,
-    )
-    .map_err(worktrunk::git::add_hook_skip_hint)
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -6,9 +6,10 @@ pub(crate) mod config;
 pub(crate) mod configure_shell;
 pub(crate) mod context;
 mod for_each;
+mod handle_switch;
 mod hook_commands;
 mod hook_filter;
-mod hooks;
+pub(crate) mod hooks;
 pub(crate) mod init;
 pub(crate) mod list;
 pub(crate) mod merge;
@@ -31,10 +32,11 @@ pub(crate) use configure_shell::{
     handle_configure_shell, handle_show_theme, handle_unconfigure_shell,
 };
 pub(crate) use for_each::step_for_each;
+pub(crate) use handle_switch::{SwitchOptions, handle_switch};
 pub(crate) use hook_commands::{add_approvals, clear_approvals, handle_hook_show, run_hook};
 pub(crate) use init::{handle_completions, handle_init};
 pub(crate) use list::handle_list;
-pub(crate) use merge::{MergeOptions, execute_pre_remove_commands, handle_merge};
+pub(crate) use merge::{MergeOptions, handle_merge};
 #[cfg(unix)]
 pub(crate) use select::handle_select;
 pub(crate) use step_commands::{
@@ -42,8 +44,8 @@ pub(crate) use step_commands::{
     step_relocate, step_show_squash_prompt,
 };
 pub(crate) use worktree::{
-    OperationMode, execute_switch, handle_remove, handle_remove_current,
-    is_worktree_at_expected_path, plan_switch, resolve_worktree_arg, worktree_display_name,
+    OperationMode, handle_remove, handle_remove_current, is_worktree_at_expected_path,
+    resolve_worktree_arg, worktree_display_name,
 };
 
 // Re-export Shell from the canonical location


### PR DESCRIPTION
## Summary

- Extract switch handler from main.rs to handle_switch.rs (minimal extraction)
- Centralize hook execution in hooks.rs (`execute_hook`, `spawn_hook_background`)
- Remove dead `for_action` method, rename `for_action_with_config` to `for_action`
- Move approval logic into `handle_squash` (matching `step_commit` pattern)
- Remove redundant `.clone()` calls in return blocks (Rust is flow-sensitive)
- Remove redundant `.to_string()`/`.to_path_buf()` on types that already return owned values
- Delete `test_squash_result_clone` test (testing derived Clone adds no value)

## Test plan

- [x] All 988 integration tests pass
- [x] All 465 unit tests pass
- [x] Pre-commit hooks pass
- [x] No clippy warnings for redundant_clone in modified files

🤖 Generated with [Claude Code](https://claude.ai/code)