### PR TITLE
fix(context): respect `-C` flag in CommandEnv worktree path

### DIFF
--- a/src/commands/context.rs
+++ b/src/commands/context.rs
@@ -30,7 +30,7 @@ impl CommandEnv {
     /// Used in error messages when the environment can't be loaded.
     pub fn for_action(action: &str, config: UserConfig) -> anyhow::Result<Self> {
         let repo = Repository::current()?;
-        let worktree_path = std::env::current_dir().context("Failed to get current directory")?;
+        let worktree_path = repo.current_worktree().path().to_path_buf();
         let branch = repo.require_current_branch(action)?;
 
         Ok(Self {
@@ -47,10 +47,10 @@ impl CommandEnv {
     /// such as running hooks (where `{{ branch }}` expands to "HEAD" if detached).
     pub fn for_action_branchless() -> anyhow::Result<Self> {
         let repo = Repository::current()?;
-        let worktree_path = std::env::current_dir().context("Failed to get current directory")?;
+        let current_wt = repo.current_worktree();
+        let worktree_path = current_wt.path().to_path_buf();
         // Propagate git errors (broken repo, missing git) but allow None for detached HEAD
-        let branch = repo
-            .current_worktree()
+        let branch = current_wt
             .branch()
             .context("Failed to determine current branch")?;
         let config = UserConfig::load().context("Failed to load config")?;

--- a/src/git/repository/working_tree.rs
+++ b/src/git/repository/working_tree.rs
@@ -57,6 +57,14 @@ impl<'a> WorkingTree<'a> {
         self.repo
     }
 
+    /// Get the path this WorkingTree was created with.
+    ///
+    /// This is the path passed to `worktree_at()` or `base_path()` for `current_worktree()`.
+    /// For the canonical git-determined root, use [`root()`](Self::root) instead.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
     /// Run a git command in this worktree and return stdout.
     pub fn run_command(&self, args: &[&str]) -> anyhow::Result<String> {
         let output = self.run_command_output(args)?;

--- a/src/output/global.rs
+++ b/src/output/global.rs
@@ -251,7 +251,18 @@ pub fn compute_hooks_display_path<'a>(
     hooks_run_at: &'a std::path::Path,
     user_location: &std::path::Path,
 ) -> Option<&'a std::path::Path> {
-    if hooks_run_at == user_location {
+    // Canonicalize both paths for comparison to handle relative vs absolute paths
+    // (e.g., "." vs "/absolute/path/to/cwd"). Fall back to direct comparison if
+    // canonicalization fails (e.g., path doesn't exist).
+    let same_location = match (
+        dunce::canonicalize(hooks_run_at),
+        dunce::canonicalize(user_location),
+    ) {
+        (Ok(h), Ok(u)) => h == u,
+        _ => hooks_run_at == user_location,
+    };
+
+    if same_location {
         None
     } else {
         Some(hooks_run_at)


### PR DESCRIPTION
## Summary

- Fix bug where `CommandEnv` used `std::env::current_dir()` instead of respecting the `-C` flag path
- Add `path()` accessor to `WorkingTree` to expose the stored worktree path
- Canonicalize paths in `compute_hooks_display_path()` to handle relative vs absolute path comparison

This caused hooks to fail when running `wt -C /path/to/worktree hook ...` because `CommandContext` received the wrong worktree path.

## Test plan

- [x] All tests pass (`cargo run -- hook pre-merge --yes`)
- [x] Verified fix by running `wt -C /path hook post-merge` from different worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)