### PR TITLE
fix(ci): check for existing fix PRs before creating duplicates

### DIFF
--- a/.github/workflows/claude-ci-fix.yaml
+++ b/.github/workflows/claude-ci-fix.yaml
@@ -86,37 +86,47 @@ jobs:
 
             ## Instructions
 
-            1. **Diagnose the failure**:
+            1. **Check for existing fix PRs**:
+               - Run `gh pr list --state open --label "automated-fix" --json number,title,body,headRefName` to see open fix PRs
+               - Also check `gh pr list --state open --head "fix/ci-"` for PRs on fix branches
+               - If an open PR already addresses this same failure (same root cause), STOP HERE:
+                 - Comment on that PR: `gh pr comment NNN --body "Run ${{ github.event.workflow_run.id }} also failed with this issue — this PR should fix it."`
+                 - Do not create a duplicate PR
+               - If no existing PR addresses this issue, continue
+
+            2. **Diagnose the failure**:
                - Run `gh run view ${{ github.event.workflow_run.id }} --log-failed` to see the failure logs
                - Identify which job(s) failed and why
                - Look for specific error messages, test failures, or lint errors
 
-            2. **Find the root cause**:
+            3. **Find the root cause**:
                - Don't just fix the symptom — investigate WHY the failure occurred
                - Check if there's a shared helper, constant, or pattern that should be updated
                - Look for similar code that might have the same issue
                - Ask: "If this broke here, could it break elsewhere for the same reason?"
 
-            3. **Reproduce locally**:
+            4. **Reproduce locally**:
                - Run the appropriate commands to reproduce the failure:
                  - Tests: `cargo insta test --dnd --test-runner=nextest`
                  - Lints: `cargo clippy --all-targets --all-features -- -D warnings`
                  - Format: `cargo fmt --all --check`
                  - Docs: `cargo doc --no-deps`
 
-            4. **Fix at the right level**:
+            5. **Fix at the right level**:
                - Fix the underlying cause, not just the immediate symptom
                - If a value should be in a shared constant, add it there
                - If a helper is missing functionality, extend the helper
                - Avoid duplicating fixes across multiple files when a single shared fix would work
 
-            5. **Create a fix branch and PR**:
-               - Create a new branch: `git checkout -b fix/ci-${{ github.event.workflow_run.id }}`
+            6. **Create a fix branch and PR**:
+               - BEFORE creating a PR, re-check for existing fix PRs (step 1) — one may have been created while you were working
+               - If an existing PR now addresses this issue, comment on it (as in step 1) and STOP
+               - Otherwise: create a new branch: `git checkout -b fix/ci-${{ github.event.workflow_run.id }}`
                - Commit your changes with a clear message explaining the fix
                - Push the branch: `git push -u origin fix/ci-${{ github.event.workflow_run.id }}`
-               - Create a PR with `gh pr create`
+               - Create a PR with `gh pr create --label "automated-fix"`
 
-            6. **PR description format**:
+            7. **PR description format**:
                ```
                ## Problem
                [What failed and the root cause]
@@ -135,7 +145,7 @@ jobs:
                🤖 Automated fix for [failed run](${{ github.event.workflow_run.html_url }})
                ```
 
-            7. **Iterate until CI passes**:
+            8. **Iterate until CI passes**:
                - After pushing, monitor CI with `gh run list --branch fix/ci-${{ github.event.workflow_run.id }}`
                - Wait for CI to complete with `gh run watch`
                - If CI fails, diagnose with `gh run view <run-id> --log-failed`


### PR DESCRIPTION
## Summary
- Instruct CI fix agent to check for open fix PRs before starting work
- Re-check before creating a new PR (one may have been created while working)
- If an existing PR addresses the same root cause, comment on it instead of duplicating
- Add `automated-fix` label to new PRs for easier discovery

## Test plan
- [ ] Verify workflow syntax is valid
- [ ] Next CI failure should check for existing PRs first

Addresses the duplicate PR issue seen with #920 and #921.

🤖 Generated with [Claude Code](https://claude.com/claude-code)