### PR TITLE
fix: skip URL template expansion when UrlStatus is skipped

### DIFF
--- a/src/commands/list/collect/execution.rs
+++ b/src/commands/list/collect/execution.rs
@@ -345,23 +345,17 @@ mod tests {
 
         let items = work_items_for_worktree(&repo, &wt, 0, &options, &expected_results, &tx);
 
-        assert!(
-            rx.try_recv().is_err(),
-            "UrlStatus placeholder should not be sent when UrlStatus is skipped"
-        );
-        assert!(
-            !items.iter().any(|item| item.kind == TaskKind::UrlStatus),
-            "UrlStatus work item should not be created when skipped"
-        );
+        // No placeholder sent
+        assert!(rx.try_recv().is_err());
+        // No UrlStatus work item created
+        assert!(!items.iter().any(|item| item.kind == TaskKind::UrlStatus));
+        // No UrlStatus in expected results
         assert!(
             !expected_results
                 .results_for(0)
-                .contains(&TaskKind::UrlStatus),
-            "Expected results should not include UrlStatus when skipped"
+                .contains(&TaskKind::UrlStatus)
         );
-        assert!(
-            items.iter().all(|item| item.ctx.item_url.is_none()),
-            "item_url should be None when UrlStatus is skipped"
-        );
+        // item_url is None for all items
+        assert!(items.iter().all(|item| item.ctx.item_url.is_none()));
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -72,24 +72,17 @@ mod tests {
 
     #[test]
     fn test_format_timestamp_iso8601_u64_overflow() {
-        // Test timestamps that exceed i64::MAX (handled by try_from)
+        // Timestamps exceeding i64::MAX are handled by try_from
         let too_large = (i64::MAX as u64) + 1;
         let formatted = format_timestamp_iso8601(too_large);
-        assert!(
-            formatted.starts_with("invalid-timestamp("),
-            "Timestamps > i64::MAX should return invalid-timestamp placeholder"
-        );
+        assert!(formatted.starts_with("invalid-timestamp("));
     }
 
     #[test]
     fn test_format_timestamp_iso8601_chrono_out_of_range() {
-        // Test timestamps within i64 range but beyond chrono's supported dates
-        // chrono supports dates up to ~year 262143 (about 8.2e12 seconds)
+        // Timestamps within i64 but beyond chrono's range (~year 262143)
         let chrono_out_of_range: u64 = 9_000_000_000_000; // ~year 287396
         let formatted = format_timestamp_iso8601(chrono_out_of_range);
-        assert!(
-            formatted.starts_with("invalid-timestamp("),
-            "Timestamps beyond chrono's range should return invalid-timestamp placeholder"
-        );
+        assert!(formatted.starts_with("invalid-timestamp("));
     }
 }


### PR DESCRIPTION
## Summary

- Skip URL template expansion and placeholder sending when `--skip url-status` is used, avoiding unnecessary work
- Fix `format_timestamp_iso8601` to return explicit `invalid-timestamp(...)` placeholder for out-of-range timestamps instead of silently falling back to current time
- Fix clippy warnings (collapsible-if, items-after-test-module, direct Command::output())

## Test plan

- [x] New unit test `test_skip_url_status_suppresses_placeholder_and_task` verifies URL skip behavior
- [x] New unit test `test_format_timestamp_iso8601_out_of_range` verifies timestamp handling
- [x] All existing tests pass
- [x] Pre-commit checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)