### PR TITLE
Improve permission test skip detection for elevated privileges

### DIFF
--- a/src/config/user/tests.rs
+++ b/src/config/user/tests.rs
@@ -2014,8 +2014,10 @@ fn test_reload_projects_from_permission_error() {
     }
     let _guard = RestorePerms(&config_path);
 
-    // Skip this test when running as root (common in CI containers)
-    if std::env::var("USER").as_deref() == Ok("root") {
+    // Test if permissions actually restrict us (skip if running as root)
+    // Root can read any file regardless of permissions, so the test would be meaningless
+    if std::fs::read_to_string(&config_path).is_ok() {
+        eprintln!("Skipping permission test - running with elevated privileges");
         return;
     }
 


### PR DESCRIPTION
## Summary
Improved the permission test skip logic in `test_reload_projects_from_permission_error` to more reliably detect when tests are running with elevated privileges, rather than relying solely on the `USER` environment variable.

## Changes
- Replaced `USER` environment variable check with an actual file permission test
- The test now attempts to read the restricted config file to determine if permission restrictions are in effect
- Added clarifying comments explaining why the test is skipped when running with elevated privileges
- Added stderr message to inform users when the permission test is being skipped

## Implementation Details
The previous approach of checking `USER == "root"` was fragile because:
- The `USER` environment variable may not be set or reliable in all environments
- Users could have elevated privileges without the USER variable indicating "root"

The new approach directly tests whether file permissions are enforced by attempting to read a file that should be restricted. If the read succeeds, it indicates the test is running with elevated privileges (where permission restrictions don't apply), making the test meaningless. This is more robust and works across different privilege escalation methods and environments.

https://claude.ai/code/session_01W2AfqRWaKqyK9oVax2i3wt