### PR TITLE
feat(switch): add --no-cd flag to skip directory change

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/switch.md
+++ b/.claude-plugin/skills/worktrunk/reference/switch.md
@@ -189,6 +189,12 @@ Usage: <b><span class=c>wt switch</span></b> <span class=c>[OPTIONS]</span> <spa
       <b><span class=c>--clobber</span></b>
           Remove stale paths at target
 
+      <b><span class=c>--no-cd</span></b>
+          Skip directory change after switching
+
+          Hooks still run normally. Useful when hooks handle navigation (e.g.,
+          tmux workflows) or for CI/automation.
+
       <b><span class=c>--no-verify</span></b>
           Skip hooks
 

--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -218,6 +218,12 @@ Usage: <b><span class=c>wt switch</span></b> <span class=c>[OPTIONS]</span> <spa
       <b><span class=c>--clobber</span></b>
           Remove stale paths at target
 
+      <b><span class=c>--no-cd</span></b>
+          Skip directory change after switching
+
+          Hooks still run normally. Useful when hooks handle navigation (e.g.,
+          tmux workflows) or for CI/automation.
+
       <b><span class=c>--no-verify</span></b>
           Skip hooks
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -449,6 +449,13 @@ To change which branch a worktree is on, use `git switch` inside that worktree.
         #[arg(long, requires = "branch")]
         clobber: bool,
 
+        /// Skip directory change after switching
+        ///
+        /// Hooks still run normally. Useful when hooks handle navigation
+        /// (e.g., tmux workflows) or for CI/automation.
+        #[arg(long)]
+        no_cd: bool,
+
         /// Skip hooks
         #[arg(long = "no-verify", action = clap::ArgAction::SetFalse, default_value_t = true)]
         verify: bool,

--- a/src/commands/handle_switch.rs
+++ b/src/commands/handle_switch.rs
@@ -25,6 +25,8 @@ pub struct SwitchOptions<'a> {
     pub execute_args: &'a [String],
     pub yes: bool,
     pub clobber: bool,
+    /// Whether to change directory after switching (default: true)
+    pub change_dir: bool,
     pub verify: bool,
 }
 
@@ -42,6 +44,7 @@ pub fn handle_switch(
         execute_args,
         yes,
         clobber,
+        change_dir,
         verify,
     } = opts;
 
@@ -100,7 +103,7 @@ pub fn handle_switch(
     // Show success message (temporal locality: immediately after worktree operation)
     // Returns path to display in hooks when user's shell won't be in the worktree
     // Also shows worktree-path hint on first --create (before shell integration warning)
-    let hooks_display_path = handle_switch_output(&result, &branch_info)?;
+    let hooks_display_path = handle_switch_output(&result, &branch_info, change_dir)?;
 
     // Offer shell integration if not already installed/active
     // (only shows prompt/hint when shell integration isn't working)

--- a/src/commands/select/mod.rs
+++ b/src/commands/select/mod.rs
@@ -227,7 +227,8 @@ pub fn handle_select(
         execute!(stderr(), crossterm::cursor::MoveTo(0, 0))?;
 
         // Show success message; emit cd directive if shell integration is active
-        handle_switch_output(&result, &branch_info)?;
+        // Interactive picker always performs cd (change_dir: true)
+        handle_switch_output(&result, &branch_info, true)?;
     }
 
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -732,6 +732,7 @@ fn main() {
             execute_args,
             yes,
             clobber,
+            no_cd,
             verify,
         } => UserConfig::load()
             .context("Failed to load config")
@@ -786,6 +787,7 @@ fn main() {
                         execute_args: &execute_args,
                         yes,
                         clobber,
+                        change_dir: !no_cd,
                         verify,
                     },
                     &mut config,

--- a/tests/snapshots/integration__integration_tests__directives__switch_no_cd_create_suppresses_directive.snap
+++ b/tests/snapshots/integration__integration_tests__directives__switch_no_cd_create_suppresses_directive.snap
@@ -1,0 +1,45 @@
+---
+source: tests/integration_tests/directives.rs
+info:
+  program: wt
+  args:
+    - switch
+    - "--create"
+    - new-feature
+    - "--no-cd"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_DIRECTIVE_FILE: "[DIRECTIVE_FILE]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[32m✓[39m [32mCreated branch [1mnew-feature[22m from [1mmain[22m and worktree @ [1m_REPO_.new-feature[22m[39m
+[2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m

--- a/tests/snapshots/integration__integration_tests__directives__switch_no_cd_execute_runs_in_target_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__directives__switch_no_cd_execute_runs_in_target_worktree.snap
@@ -1,0 +1,49 @@
+---
+source: tests/integration_tests/directives.rs
+info:
+  program: wt
+  args:
+    - switch
+    - "--create"
+    - exec-test
+    - "--no-cd"
+    - "--execute"
+    - pwd
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_DIRECTIVE_FILE: "[DIRECTIVE_FILE]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[32m✓[39m [32mCreated branch [1mexec-test[22m from [1mmain[22m and worktree @ [1m_REPO_.exec-test[22m[39m
+[2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
+[36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.exec-test[22m:[39m
+[107m [0m [2m[0m[2m[34mpwd[0m[2m

--- a/tests/snapshots/integration__integration_tests__directives__switch_no_cd_hooks_show_path_annotation.snap
+++ b/tests/snapshots/integration__integration_tests__directives__switch_no_cd_hooks_show_path_annotation.snap
@@ -1,0 +1,47 @@
+---
+source: tests/integration_tests/directives.rs
+info:
+  program: wt
+  args:
+    - switch
+    - "--create"
+    - hook-test
+    - "--no-cd"
+    - "--yes"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_DIRECTIVE_FILE: "[DIRECTIVE_FILE]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[32m✓[39m [32mCreated branch [1mhook-test[22m from [1mmain[22m and worktree @ [1m_REPO_.hook-test[22m[39m
+[2m↳[22m [2mTo customize worktree locations, run [90mwt config create[39m[22m
+[36m◎[39m [36mRunning post-switch: [1mproject[22m @ [1m_REPO_.hook-test[22m[39m

--- a/tests/snapshots/integration__integration_tests__directives__switch_no_cd_suppresses_directive.snap
+++ b/tests/snapshots/integration__integration_tests__directives__switch_no_cd_suppresses_directive.snap
@@ -1,0 +1,43 @@
+---
+source: tests/integration_tests/directives.rs
+info:
+  program: wt
+  args:
+    - switch
+    - feature
+    - "--no-cd"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_DIRECTIVE_FILE: "[DIRECTIVE_FILE]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[2m○[22m Switched to worktree for [1mfeature[22m @ [1m_REPO_.feature[22m

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -81,6 +81,11 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
       [1m[36m--clobber[0m
           Remove stale paths at target
 
+      [1m[36m--no-cd[0m
+          Skip directory change after switching[0m
+          
+          Hooks still run normally. Useful when hooks handle navigation (e.g., tmux workflows) or for CI/automation.[0m
+
       [1m[36m--no-verify[0m
           Skip hooks
 

--- a/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
@@ -43,6 +43,7 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
   [1m[36m-x[0m, [1m[36m--execute[0m[36m [0m[36m<EXECUTE>[0m  Command to run after switch
   [1m[36m-y[0m, [1m[36m--yes[0m                Skip approval prompts
       [1m[36m--clobber[0m            Remove stale paths at target
+      [1m[36m--no-cd[0m              Skip directory change after switching
       [1m[36m--no-verify[0m          Skip hooks
   [1m[36m-h[0m, [1m[36m--help[0m               Print help (see more with '--help')
 


### PR DESCRIPTION
## Summary

- Add `--no-cd` flag to `wt switch` that prevents shell from changing directory after switching
- Hooks still run normally when `--no-cd` is used
- `--execute` commands still run in the target worktree
- Shows "@ path" annotation in hook output since user won't be in the worktree
- No shell integration warnings shown (user explicitly chose not to cd)

Closes #929

## Test plan

- [x] `test_switch_no_cd_suppresses_directive` — verifies no cd directive written
- [x] `test_switch_no_cd_create_suppresses_directive` — verifies --create with --no-cd works
- [x] `test_switch_no_cd_hooks_show_path_annotation` — verifies hooks show "@ path" annotation
- [x] `test_switch_no_cd_execute_runs_in_target_worktree` — verifies --execute runs in target worktree

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>