### PR TITLE
feat(select): run hooks after interactive switch

### DIFF
--- a/src/commands/worktree/mod.rs
+++ b/src/commands/worktree/mod.rs
@@ -95,6 +95,6 @@ pub use resolve::{
 };
 pub use switch::{execute_switch, plan_switch};
 pub use types::{
-    BranchDeletionMode, MergeOperations, OperationMode, RemoveResult, SwitchBranchInfo,
+    BranchDeletionMode, MergeOperations, OperationMode, RemoveResult, SwitchBranchInfo, SwitchPlan,
     SwitchResult,
 };


### PR DESCRIPTION
## Summary

- Interactive picker (`wt switch` / `wt select`) now runs the same hooks as `wt switch <branch>` — post-switch, post-start, and post-create with upfront approval
- Extracted three shared helpers (`approve_switch_hooks`, `switch_extra_vars`, `spawn_switch_background_hooks`) from `handle_switch` to eliminate duplication between the interactive and non-interactive paths

## Test plan

- [x] All 1004 integration tests pass
- [x] All 475 unit tests pass
- [x] Lints clean (`pre-commit run --all-files`)
- [ ] Manual: `wt switch` with post-switch hooks configured — verify hooks fire
- [ ] Manual: `wt switch` with `--create` via `alt-c` — verify post-create/post-start hooks fire
- [ ] Manual: decline approval prompt — verify "Commands declined" message and switch still works

> _This was written by Claude Code on behalf of @max-sixty_

🤖 Generated with [Claude Code](https://claude.com/claude-code)