### PR TITLE
Combine post-remove and post-switch hooks into single output line

### DIFF
--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -473,40 +473,6 @@ pub(crate) fn prepare_background_hooks(
     )
 }
 
-/// Spawn hook commands as background processes with automatic config lookup.
-///
-/// This is a convenience wrapper that:
-/// 1. Loads project config from the repository
-/// 2. Looks up user hooks from the config
-/// 3. Prepares and spawns background commands
-///
-/// For spawning multiple hook types in a single message, use `prepare_background_hooks`
-/// to collect hooks, then `spawn_background_hooks` to spawn them.
-pub fn spawn_hook_background(
-    ctx: &CommandContext,
-    hook_type: HookType,
-    extra_vars: &[(&str, &str)],
-    name_filter: Option<&str>,
-    display_path: Option<&Path>,
-) -> anyhow::Result<()> {
-    let project_config = ctx.repo.load_project_config()?;
-    let user_hooks = ctx.config.hooks(ctx.project_id().as_deref());
-    let (user_config, proj_config) =
-        lookup_hook_configs(&user_hooks, project_config.as_ref(), hook_type);
-
-    let commands = prepare_hook_commands(
-        ctx,
-        user_config,
-        proj_config,
-        hook_type,
-        extra_vars,
-        name_filter,
-        display_path,
-    )?;
-
-    spawn_background_hooks(ctx, commands)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/commands/worktree/hooks.rs
+++ b/src/commands/worktree/hooks.rs
@@ -9,7 +9,7 @@ use worktrunk::path::to_posix_path;
 
 use crate::commands::command_executor::CommandContext;
 use crate::commands::hooks::{
-    HookFailureStrategy, execute_hook, prepare_hook_commands, spawn_background_hooks,
+    HookFailureStrategy, SourcedCommand, execute_hook, prepare_hook_commands,
 };
 
 impl<'a> CommandContext<'a> {
@@ -31,23 +31,25 @@ impl<'a> CommandContext<'a> {
         )
     }
 
-    /// Spawn post-remove commands in parallel as background processes (non-blocking)
+    /// Prepare post-remove commands for background spawning.
     ///
-    /// Runs after worktree removal. Commands execute from the invoking worktree (where
-    /// the user ends up after removal), but template variables reflect the removed
-    /// worktree so hooks can reference paths and names correctly.
+    /// Returns prepared commands without spawning them, so the caller can batch
+    /// them with other hook types (e.g., post-switch) into a single output line.
+    ///
+    /// Template variables reflect the removed worktree (not where commands run from),
+    /// so hooks can reference the removed path and branch correctly.
     ///
     /// `removed_branch`: The branch that was removed (for `{{ branch }}`).
     /// `removed_worktree_path`: The removed worktree's path (for `{{ worktree_path }}`, etc.).
     /// `removed_commit`: The commit SHA of the removed worktree's HEAD (for `{{ commit }}`).
     /// `display_path`: When `Some`, shows the path in hook announcements.
-    pub fn spawn_post_remove_commands(
+    pub fn prepare_post_remove_commands(
         &self,
         removed_branch: &str,
         removed_worktree_path: &Path,
         removed_commit: Option<&str>,
         display_path: Option<&Path>,
-    ) -> anyhow::Result<()> {
+    ) -> anyhow::Result<Vec<SourcedCommand>> {
         let project_config = self.repo.load_project_config()?;
 
         // Template variables should reflect the removed worktree, not where we run from.
@@ -77,7 +79,7 @@ impl<'a> CommandContext<'a> {
         ];
 
         let user_hooks = self.config.hooks(self.project_id().as_deref());
-        let commands = prepare_hook_commands(
+        prepare_hook_commands(
             self,
             user_hooks.post_remove.as_ref(),
             project_config
@@ -87,8 +89,6 @@ impl<'a> CommandContext<'a> {
             &extra_vars,
             None,
             display_path,
-        )?;
-
-        spawn_background_hooks(self, commands)
+        )
     }
 }

--- a/src/output/global.rs
+++ b/src/output/global.rs
@@ -305,9 +305,6 @@ pub fn pre_hook_display_path(hooks_run_at: &std::path::Path) -> Option<&std::pat
 /// // Prepare and spawn hooks with display path:
 /// let hooks = prepare_background_hooks(&ctx, HookType::PostStart, &extra_vars, post_hook_display_path(&destination))?;
 /// spawn_background_hooks(&ctx, hooks)?;
-///
-/// // After remove when switching to main:
-/// spawn_hook_background(&ctx, HookType::PostSwitch, &[], None, post_hook_display_path(main_path))?;
 /// ```
 pub fn post_hook_display_path(destination: &std::path::Path) -> Option<&std::path::Path> {
     if is_shell_integration_active() {

--- a/tests/integration_tests/user_hooks.rs
+++ b/tests/integration_tests/user_hooks.rs
@@ -778,11 +778,10 @@ cleanup = "echo 'POST_REMOVE_DURING_MERGE' > ../merge_postremove_marker.txt"
     );
 }
 
-// Note: The `return Ok(())` path in spawn_post_remove_hooks when UserConfig::load()
-// fails (handlers.rs line 556) is defensive code for an extremely rare race condition
-// where config becomes invalid between command startup and hook execution. This is
-// not easily testable without complex timing manipulation and matches the existing
-// pattern in spawn_post_switch_after_remove (line 584).
+// Note: The `return Ok(())` path in spawn_hooks_after_remove when UserConfig::load()
+// fails is defensive code for an extremely rare race condition where config becomes
+// invalid between command startup and hook execution. This is not easily testable
+// without complex timing manipulation.
 
 #[rstest]
 fn test_standalone_hook_post_remove_invalid_template(repo: TestRepo) {


### PR DESCRIPTION
## Summary

- Combine post-remove and post-switch hooks into a single output line during worktree removal, matching how post-switch and post-start are already combined during creation
- Remove the now-unused `spawn_hook_background` convenience wrapper

Before:
```
◎ Running post-remove: project:docs
◎ Running post-switch: user:zellij-tab
```

After:
```
◎ Running post-remove: project:docs; post-switch: user:zellij-tab
```

## Test plan

- [x] All 1004 integration tests pass
- [x] All lints pass
- [x] Existing snapshot for post-remove hook output unchanged (only tests post-remove alone)

> _This was written by Claude Code on behalf of @max-sixty_