### PR TITLE
docs(hooks): add -sTCP:LISTEN to lsof in hook examples

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/hook.md
+++ b/.claude-plugin/skills/worktrunk/reference/hook.md
@@ -94,7 +94,7 @@ Cleanup tasks after worktree removal: stopping dev servers, removing containers,
 
 ```toml
 [post-remove]
-kill-server = "lsof -ti :{{ branch | hash_port }} | xargs kill 2>/dev/null || true"
+kill-server = "lsof -ti :{{ branch | hash_port }} -sTCP:LISTEN | xargs kill 2>/dev/null || true"
 remove-db = "docker stop {{ repo }}-{{ branch | sanitize }}-postgres 2>/dev/null || true"
 ```
 
@@ -309,7 +309,7 @@ Run a dev server per worktree on a deterministic port using `hash_port`:
 server = "npm run dev -- --port {{ branch | hash_port }}"
 
 [post-remove]
-server = "lsof -ti :{{ branch | hash_port }} | xargs kill 2>/dev/null || true"
+server = "lsof -ti :{{ branch | hash_port }} -sTCP:LISTEN | xargs kill 2>/dev/null || true"
 ```
 
 The port is stable across machines and restarts — `feature-api` always gets the same port. Show it in `wt list`:

--- a/.claude-plugin/skills/worktrunk/reference/tips-patterns.md
+++ b/.claude-plugin/skills/worktrunk/reference/tips-patterns.md
@@ -38,7 +38,7 @@ server = "npm run dev -- --port {{ branch | hash_port }}"
 url = "http://localhost:{{ branch | hash_port }}"
 
 [pre-remove]
-server = "lsof -ti :{{ branch | hash_port }} | xargs kill 2>/dev/null || true"
+server = "lsof -ti :{{ branch | hash_port }} -sTCP:LISTEN | xargs kill 2>/dev/null || true"
 ```
 
 The URL column in `wt list` shows each worktree's dev server:

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -19,4 +19,4 @@ doc = "RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps"
 url = "http://127.0.0.1:{{ branch | hash_port }}"
 
 [post-remove]
-docs = "lsof -ti :{{ branch | hash_port }} | xargs kill 2>/dev/null || true"
+docs = "lsof -ti :{{ branch | hash_port }} -sTCP:LISTEN | xargs kill 2>/dev/null || true"

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -102,7 +102,7 @@ Cleanup tasks after worktree removal: stopping dev servers, removing containers,
 
 ```toml
 [post-remove]
-kill-server = "lsof -ti :{{ branch | hash_port }} | xargs kill 2>/dev/null || true"
+kill-server = "lsof -ti :{{ branch | hash_port }} -sTCP:LISTEN | xargs kill 2>/dev/null || true"
 remove-db = "docker stop {{ repo }}-{{ branch | sanitize }}-postgres 2>/dev/null || true"
 ```
 
@@ -317,7 +317,7 @@ Run a dev server per worktree on a deterministic port using `hash_port`:
 server = "npm run dev -- --port {{ branch | hash_port }}"
 
 [post-remove]
-server = "lsof -ti :{{ branch | hash_port }} | xargs kill 2>/dev/null || true"
+server = "lsof -ti :{{ branch | hash_port }} -sTCP:LISTEN | xargs kill 2>/dev/null || true"
 ```
 
 The port is stable across machines and restarts — `feature-api` always gets the same port. Show it in `wt list`:

--- a/docs/content/tips-patterns.md
+++ b/docs/content/tips-patterns.md
@@ -44,7 +44,7 @@ server = "npm run dev -- --port {{ branch | hash_port }}"
 url = "http://localhost:{{ branch | hash_port }}"
 
 [pre-remove]
-server = "lsof -ti :{{ branch | hash_port }} | xargs kill 2>/dev/null || true"
+server = "lsof -ti :{{ branch | hash_port }} -sTCP:LISTEN | xargs kill 2>/dev/null || true"
 ```
 
 The URL column in `wt list` shows each worktree's dev server:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1129,7 +1129,7 @@ Cleanup tasks after worktree removal: stopping dev servers, removing containers,
 
 ```toml
 [post-remove]
-kill-server = "lsof -ti :{{ branch | hash_port }} | xargs kill 2>/dev/null || true"
+kill-server = "lsof -ti :{{ branch | hash_port }} -sTCP:LISTEN | xargs kill 2>/dev/null || true"
 remove-db = "docker stop {{ repo }}-{{ branch | sanitize }}-postgres 2>/dev/null || true"
 ```
 
@@ -1344,7 +1344,7 @@ Run a dev server per worktree on a deterministic port using `hash_port`:
 server = "npm run dev -- --port {{ branch | hash_port }}"
 
 [post-remove]
-server = "lsof -ti :{{ branch | hash_port }} | xargs kill 2>/dev/null || true"
+server = "lsof -ti :{{ branch | hash_port }} -sTCP:LISTEN | xargs kill 2>/dev/null || true"
 ```
 
 The port is stable across machines and restarts — `feature-api` always gets the same port. Show it in `wt list`:


### PR DESCRIPTION
After being surprised a couple of times by a random browser tab closing when removing a worktree, I tracked it down to the `lsof` invocation in the hook examples.

   Without `-sTCP:LISTEN`, `lsof -ti :PORT` matches **any** process with a connection to that port — including browsers with an open tab to `localhost:PORT`. So the `xargs kill` was taking out the browser process along with the dev server.

   Adding `-sTCP:LISTEN` restricts the match to processes that are actually **listening** on the port (i.e., the dev server itself), leaving clients alone.
   
   I can't think of a case where using `-sTCP:LISTEN` would be worse than the current behavior, but I might be missing some edge case

   ## Changes

   - Added `-sTCP:LISTEN` flag to all `lsof` invocations in hook examples and project config"