### PR TITLE
fix: require panel border in preview stability check

### DIFF
--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -222,6 +222,9 @@ fn wait_for_stable(
 /// If `expected_content` is provided, waits until the screen contains that string
 /// AND has stabilized. This is essential for async preview panels where the initial
 /// render may show placeholder content before the actual data loads.
+///
+/// Tip: include the panel border character (`│`) in `expected_content` to ensure
+/// the full TUI frame has rendered, not just the preview text content.
 fn wait_for_stable_with_content(
     rx: &mpsc::Receiver<Vec<u8>>,
     parser: &mut vt100::Parser,
@@ -451,7 +454,7 @@ fn test_switch_picker_preview_panel_uncommitted(mut repo: TestRepo) {
         &env_vars,
         &[
             ("feature", None),
-            ("1", Some("diff --git")), // Wait for diff to load
+            ("1", Some("│diff --git")), // Wait for diff to load (│ = border drawn)
             ("\x1b", None),
         ],
     );
@@ -508,7 +511,7 @@ fn test_switch_picker_preview_panel_log(mut repo: TestRepo) {
         &env_vars,
         &[
             ("feature", None),
-            ("2", Some("* ")), // Wait for git log output (starts with "* [hash]")
+            ("2", Some("│* ")), // Wait for git log output (│ = border drawn)
             ("\x1b", None),
         ],
     );
@@ -598,7 +601,7 @@ fn test_new_feature() {
         &env_vars,
         &[
             ("feature", None),
-            ("3", Some("diff --git")), // Wait for diff to load
+            ("3", Some("│diff --git")), // Wait for diff to load (│ = border drawn)
             ("\x1b", None),
         ],
     );


### PR DESCRIPTION
## Summary

- Include `│` border character in preview panel `expected_content` strings so the stability check waits for the full TUI frame (not just preview text) before sending Escape
- Prevents flaky snapshot failures under CI load where diff/log text arrives and stabilizes before the panel border is drawn
- Applies to all 3 preview panel tests: uncommitted, log, and main diff

## Test plan

- [x] All 3 preview panel tests pass locally
- [x] Full `wt hook pre-merge --yes` passes
- [ ] CI passes

> _This was written by Claude Code on behalf of @max-sixty_

🤖 Generated with [Claude Code](https://claude.com/claude-code)