### PR TITLE
test: add switch nonexistent-branch test

### DIFF
--- a/tests/integration_tests/switch.rs
+++ b/tests/integration_tests/switch.rs
@@ -261,13 +261,20 @@ fn test_switch_base_without_create_warning(repo: TestRepo) {
 
 #[rstest]
 fn test_switch_create_with_invalid_base(repo: TestRepo) {
-    // Issue #562: Error message should identify the invalid base branch,
+    // Issues #562, #977: Error message should identify the invalid base branch,
     // not the target branch being created
     snapshot_switch(
         "switch_create_invalid_base",
         &repo,
         &["--create", "new-feature", "--base", "nonexistent-base"],
     );
+}
+
+#[rstest]
+fn test_switch_nonexistent_branch(repo: TestRepo) {
+    // Switching to a nonexistent branch (without --create) should give a clear
+    // "branch not found" error, not fall through to a confusing git error.
+    snapshot_switch("switch_nonexistent_branch", &repo, &["nonexistent-branch"]);
 }
 
 #[rstest]

--- a/tests/snapshots/integration__integration_tests__switch__switch_nonexistent_branch.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_nonexistent_branch.snap
@@ -1,0 +1,42 @@
+---
+source: tests/integration_tests/switch.rs
+info:
+  program: wt
+  args:
+    - switch
+    - nonexistent-branch
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WT_TEST_DELAYED_STREAM_MS: "-1"
+    WT_TEST_EPOCH: "1735776000"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[31m✗[39m [31mNo branch named [1mnonexistent-branch[22m[39m
+[2m↳[22m [2mTo create a new branch, run [90mwt switch nonexistent-branch --create[39m; to list branches, run [90mwt list --branches --remotes[39m[22m


### PR DESCRIPTION
## Summary
- The fix for #977 (wrong error message on `--create --base missing_branch`) was already in place from #562/#569
- Added `test_switch_nonexistent_branch` — the analogous untested case for switching to a nonexistent branch without `--create`
- Updated existing `test_switch_create_with_invalid_base` comment to reference #977

Closes #977

> _This was written by Claude Code on behalf of @max-sixty_