### PR TITLE
fix: use symlink-preserved paths in display messages

### DIFF
--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -250,7 +250,8 @@ fn print_switch_message_if_changed(
         return Ok(());
     };
 
-    let path_display = format_path_for_display(main_path);
+    let logical_path = super::to_logical_path(main_path);
+    let path_display = format_path_for_display(&logical_path);
 
     if super::is_shell_integration_active() {
         // Shell integration active - cd will work
@@ -358,8 +359,10 @@ pub fn handle_switch_output(
         super::change_directory(&cd_target)?;
     }
 
-    let path = result.path();
-    let path_display = format_path_for_display(path);
+    // Translate to the user's logical (symlink-preserved) path for display messages.
+    // The cd directive (above) handles its own translation internally.
+    let path = super::to_logical_path(result.path());
+    let path_display = format_path_for_display(&path);
     let branch = &branch_info.branch;
 
     // Check if shell integration is active (directive file set)
@@ -433,7 +436,7 @@ pub fn handle_switch_output(
                 eprintln!(
                     "{}",
                     info_message(format_switch_message(
-                        branch, path, false, // worktree_created
+                        branch, &path, false, // worktree_created
                         false, // created_branch
                         None, None,
                     ))
@@ -457,7 +460,7 @@ pub fn handle_switch_output(
                 "{}",
                 success_message(format_switch_message(
                     branch,
-                    path,
+                    &path,
                     true, // worktree_created
                     *created_branch,
                     base_branch.as_deref(),

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -38,7 +38,7 @@ pub(crate) mod shell_integration;
 // Re-export the public API
 pub(crate) use global::{
     change_directory, execute, is_shell_integration_active, post_hook_display_path,
-    pre_hook_display_path, set_verbosity, terminate_output,
+    pre_hook_display_path, set_verbosity, terminate_output, to_logical_path,
 };
 // Re-export output handlers
 pub(crate) use handlers::{

--- a/tests/integration_tests/directives.rs
+++ b/tests/integration_tests/directives.rs
@@ -472,6 +472,21 @@ fn test_switch_preserves_symlink_path(#[from(repo_with_remote)] mut repo: TestRe
         real_prefix,
         directives
     );
+
+    // Display messages (stderr) should also use the logical path
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(&*symlink_prefix),
+        "Display message should contain logical path {}, got: {}",
+        symlink_prefix,
+        stderr
+    );
+    assert!(
+        !stderr.contains(&*real_prefix),
+        "Display message should NOT contain canonical path {}, got: {}",
+        real_prefix,
+        stderr
+    );
 }
 
 #[cfg(unix)]
@@ -509,6 +524,22 @@ fn test_switch_create_preserves_symlink_path(#[from(repo_with_remote)] repo: Tes
         "Directive should use symlink path (containing {}), got: {}",
         symlink_prefix,
         directives
+    );
+
+    // Display messages (stderr) should also use the logical path
+    let real_prefix = real_parent.to_string_lossy();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(&*symlink_prefix),
+        "Display message should contain logical path {}, got: {}",
+        symlink_prefix,
+        stderr
+    );
+    assert!(
+        !stderr.contains(&*real_prefix),
+        "Display message should NOT contain canonical path {}, got: {}",
+        real_prefix,
+        stderr
     );
 }
 


### PR DESCRIPTION
## Summary

- PR #976 fixed `cd` directives to preserve symlink paths, but status messages still showed canonical paths (e.g., `✓ Created branch feature1 from main and worktree @ /mnt/wsl/workspace/...` instead of `@ /workspace/...`)
- Extracts `to_logical_path()` from `change_directory()` into a reusable function, applies it in `handle_switch_output()` and `print_switch_message_if_changed()` so display messages match the `cd` directive
- Adds positive and negative test assertions on stderr to verify display messages use the logical path

Ref: https://github.com/max-sixty/worktrunk/issues/968#issuecomment-3881595335

## Test plan

- [x] Existing symlink integration tests pass with new stderr assertions (both positive: contains symlink path, and negative: doesn't contain canonical path)
- [x] Full test suite passes (2327 tests, 0 failures)
- [x] All lints pass

> _This was written by Claude Code on behalf of @max-sixty_