### PR TITLE
docs: deduplicate manual shell setup instructions

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/config.md
+++ b/.claude-plugin/skills/worktrunk/reference/config.md
@@ -305,18 +305,7 @@ Worktrunk needs shell integration to change directories when switching worktrees
 wt config shell install
 ```
 
-Or manually add to the shell config:
-
-```bash
-# For bash: add to ~/.bashrc
-eval "$(wt config shell init bash)"
-
-# For zsh: add to ~/.zshrc
-eval "$(wt config shell init zsh)"
-
-# For fish: add to ~/.config/fish/config.fish
-wt config shell init fish | source
-```
+For manual setup, see `wt config shell init --help`.
 
 Without shell integration, `wt switch` prints the target directory but cannot `cd` into it.
 

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -313,18 +313,7 @@ Worktrunk needs shell integration to change directories when switching worktrees
 wt config shell install
 ```
 
-Or manually add to the shell config:
-
-```bash
-# For bash: add to ~/.bashrc
-eval "$(wt config shell init bash)"
-
-# For zsh: add to ~/.zshrc
-eval "$(wt config shell init zsh)"
-
-# For fish: add to ~/.config/fish/config.fish
-wt config shell init fish | source
-```
+For manual setup, see `wt config shell init --help`.
 
 Without shell integration, `wt switch` prints the target directory but cannot `cd` into it.
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1756,18 +1756,7 @@ Worktrunk needs shell integration to change directories when switching worktrees
 wt config shell install
 ```
 
-Or manually add to the shell config:
-
-```console
-# For bash: add to ~/.bashrc
-eval "$(wt config shell init bash)"
-
-# For zsh: add to ~/.zshrc
-eval "$(wt config shell init zsh)"
-
-# For fish: add to ~/.config/fish/config.fish
-wt config shell init fish | source
-```
+For manual setup, see `wt config shell init --help`.
 
 Without shell integration, `wt switch` prints the target directory but cannot `cd` into it.
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -316,16 +316,7 @@ Worktrunk needs shell integration to change directories when switching worktrees
 
   [2mwt config shell install[0m
 
-Or manually add to the shell config:
-
-  [2m# For bash: add to ~/.bashrc[0m
-  [2meval "$(wt config shell init bash)"[0m
-  [2m[0m
-  [2m# For zsh: add to ~/.zshrc[0m
-  [2meval "$(wt config shell init zsh)"[0m
-  [2m[0m
-  [2m# For fish: add to ~/.config/fish/config.fish[0m
-  [2mwt config shell init fish | source[0m
+For manual setup, see [2mwt config shell init --help[0m.
 
 Without shell integration, [2mwt switch[0m prints the target directory but cannot [2mcd[0m into it.
 


### PR DESCRIPTION
## Summary

- Replace per-shell manual setup snippets in `wt config --help` with a reference to `wt config shell init --help`
- The manual instructions (bash/zsh/fish eval lines) were duplicated between the parent and subcommand help; now they live in one place

## Test plan

- [x] All 1019 integration tests pass
- [x] `pre-commit run --all-files` passes
- [x] Help snapshot updated and verified
- [x] Docs and skill reference auto-synced via `test_command_pages_and_skill_files_are_in_sync`

> _This was written by Claude Code on behalf of @max-sixty_