### PR TITLE
fix: instruct claude-mention bot to use collapsible details and neutral tone

### DIFF
--- a/.github/workflows/claude-mention.yaml
+++ b/.github/workflows/claude-mention.yaml
@@ -113,7 +113,16 @@ jobs:
 
             For PR review comments on specific lines (shown as '[Comment on path:line]' in <review_comments>),
             ALWAYS read that file and examine the code at that line before answering. The question is about
-            that specific code, not about the PR in general."
+            that specific code, not about the PR in general.
+
+            FORMATTING: Keep PR comments concise. Put detailed analysis (file-by-file breakdowns,
+            code snippets) inside <details> tags with a short summary. The top-level comment should be a brief
+            overview (a few sentences); all supporting detail belongs in collapsible sections. Example:
+            <details><summary>Detailed findings (6 files)</summary>\n\n...details here...\n\n</details>
+
+            TONE: You are a helpful reviewer raising observations, not a manager assigning work. Never create
+            checklists or task lists for the PR author. Instead, note what you found and let the author decide
+            what to act on."
 
       - name: 📋 Upload Claude Code session logs
         if: always()


### PR DESCRIPTION
## Summary

- Add formatting instructions to use `<details>` tags for lengthy analysis in PR comments
- Add tone instructions to raise observations rather than create prescriptive checklists

Triggered by [this wall-of-text comment](https://github.com/max-sixty/worktrunk/pull/964#issuecomment-3887033340) (now edited to demonstrate the collapsible format).

> _This was written by Claude Code on behalf of @max-sixty_