### PR TITLE
docs: add PowerShell diagnostic guidance to skill references

### DIFF
--- a/.claude-plugin/skills/worktrunk/reference/shell-integration.md
+++ b/.claude-plugin/skills/worktrunk/reference/shell-integration.md
@@ -152,6 +152,23 @@ type wt
 # If it shows a path like /usr/local/bin/wt, wrapper isn't loaded
 ```
 
+### 1b. Check if wrapper is installed (PowerShell)
+
+```powershell
+# PowerShell: should show Function, not just Application
+Get-Command wt -All
+
+# Expected output when wrapper is loaded:
+# CommandType  Name  Source
+# -----------  ----  ------
+# Function     wt
+# Application  wt    C:\Users\...\wt.exe
+
+# If only Application appears, wrapper isn't loaded (restart shell)
+# If Function appears but integration is still "not active", check the body:
+(Get-Command wt -CommandType Function).ScriptBlock | Select-String WORKTRUNK
+```
+
 ### 2. Check shell config file
 
 ```bash

--- a/.claude-plugin/skills/worktrunk/reference/troubleshooting.md
+++ b/.claude-plugin/skills/worktrunk/reference/troubleshooting.md
@@ -92,6 +92,25 @@ wt config shell install powershell
 
 Both profile files are created when installing from a Windows-native shell. This ensures shell integration works regardless of which PowerShell variant the user opens later. The profile files are small and harmless if unused.
 
+### Shell integration configured but not active
+
+When `wt config show` shows the profile line is configured but shell integration
+is "not active", ask the user to run these diagnostics in the same PowerShell
+session:
+
+1. `Get-Command git-wt -All` — shows whether the wrapper Function is loaded
+   alongside the Application (exe). If only Application appears, the profile
+   didn't define the function (restart shell, or profile load failed).
+
+2. `(Get-Command git-wt -CommandType Function).ScriptBlock | Select-String
+   WORKTRUNK` — verifies the wrapper function body sets
+   `WORKTRUNK_DIRECTIVE_FILE`. If this doesn't appear, the function is
+   incomplete or corrupted.
+
+3. `Get-Command git-wt -CommandType Application | Select-Object Source` — shows
+   what the wrapper resolves as `$wtBin`. If empty, the wrapper can't find the
+   binary and will fail silently.
+
 ### Detection logic
 
 Worktrunk detects Windows-native shells (cmd/PowerShell) by checking if the `SHELL` environment variable is **not** set:


### PR DESCRIPTION
## Summary

- Adds PowerShell-specific `Get-Command` checks to the shell-integration debugging checklist (step 1b alongside the existing bash/zsh `type wt`)
- Adds a "configured but not active" troubleshooting section under PowerShell with 3 diagnostic commands for the `git-wt` wrapper

Closes #885

## Test plan

- [x] `cargo test --test integration test_command_pages_and_skill_files_are_in_sync` passes
- [ ] CI green

> _This was written by Claude Code on behalf of @max-sixty_

🤖 Generated with [Claude Code](https://claude.com/claude-code)