### PR TITLE
refactor(ci): consolidate CI workflow prompts into running-in-ci skill

### DIFF
--- a/.claude/skills/running-in-ci/SKILL.md
+++ b/.claude/skills/running-in-ci/SKILL.md
@@ -1,0 +1,54 @@
+---
+name: running-in-ci
+description: CI environment rules for GitHub Actions workflows. Use when operating in CI — covers security, CI monitoring, and PR comment formatting.
+---
+
+# Running in CI
+
+## Security
+
+NEVER run commands that could expose secrets (`env`, `printenv`, `set`,
+`export`, `cat`/`echo` on config files containing credentials). NEVER include
+environment variables, API keys, tokens, or credentials in responses or
+comments.
+
+## CI Monitoring
+
+After pushing changes to a PR branch, monitor CI until all checks pass:
+
+1. Monitor with `gh pr checks` or `gh run list --branch <branch>`
+2. Wait for completion with `gh run watch`
+3. If CI fails, diagnose with `gh run view <run-id> --log-failed`
+4. Fix issues, commit, push, and repeat
+5. Do not return until CI is green — local tests alone are not sufficient (CI
+   runs on Linux, Windows, macOS)
+
+## PR Comment Formatting
+
+Keep PR comments concise. Put detailed analysis (file-by-file breakdowns, code
+snippets) inside `<details>` tags with a short summary. The top-level comment
+should be a brief overview (a few sentences); all supporting detail belongs in
+collapsible sections.
+
+Example:
+
+```
+<details><summary>Detailed findings (6 files)</summary>
+
+...details here...
+
+</details>
+```
+
+## Tone
+
+You are a helpful reviewer raising observations, not a manager assigning work.
+Never create checklists or task lists for the PR author. Instead, note what you
+found and let the author decide what to act on.
+
+## PR Review Comments
+
+For PR review comments on specific lines (shown as `[Comment on path:line]` in
+`<review_comments>`), ALWAYS read that file and examine the code at that line
+before answering. The question is about that specific code, not the PR in
+general.

--- a/.github/workflows/claude-ci-fix.yaml
+++ b/.github/workflows/claude-ci-fix.yaml
@@ -73,8 +73,6 @@ jobs:
 
           # Provide Claude with context about the failure and instructions
           prompt: |
-            SECURITY: NEVER run commands that could expose secrets (env, printenv, set, export, cat/echo on config files containing credentials). NEVER include environment variables, API keys, tokens, or credentials in responses or comments.
-
             CI has failed on main branch. Your job is to diagnose the root cause and fix it properly, then create a PR.
 
             ## Failed workflow information
@@ -104,12 +102,7 @@ jobs:
                - Look for similar code that might have the same issue
                - Ask: "If this broke here, could it break elsewhere for the same reason?"
 
-            4. **Reproduce locally**:
-               - Run the appropriate commands to reproduce the failure:
-                 - Tests: `cargo insta test --dnd --test-runner=nextest`
-                 - Lints: `cargo clippy --all-targets --all-features -- -D warnings`
-                 - Format: `cargo fmt --all --check`
-                 - Docs: `cargo doc --no-deps`
+            4. **Reproduce locally** using the test commands documented in CLAUDE.md
 
             5. **Fix at the right level**:
                - Fix the underlying cause, not just the immediate symptom
@@ -151,11 +144,10 @@ jobs:
                - Fix issues, commit, push, repeat
                - Don't return until CI passes or you've exhausted reasonable fixes
 
-            Follow the project guidelines in CLAUDE.md.
-
           claude_args: |
             --model opus
             --allowedTools Bash,Edit,Read,Write,Glob,Grep,WebSearch,WebFetch,Task,Skill
+            --append-system-prompt "You are operating in a GitHub Actions CI environment. Use /running-in-ci before starting work."
 
       - name: 📋 Upload Claude Code session logs
         if: always()

--- a/.github/workflows/claude-mention.yaml
+++ b/.github/workflows/claude-mention.yaml
@@ -89,48 +89,10 @@ jobs:
           additional_permissions: |
             actions: read
 
-          # Grant Claude full permissions to execute commands
-          # Also include system prompt with project context via claude_args
           claude_args: |
             --model opus
             --allowedTools Bash,Edit,Read,Write,Glob,Grep,WebSearch,WebFetch,Task,Skill
-            --system-prompt "You are helping with the worktrunk project in a GitHub Actions environment.
-            Follow the project guidelines in CLAUDE.md.
-
-            SECURITY: NEVER run commands that could expose secrets (env, printenv, set, export, cat/echo on config files containing credentials). NEVER include environment variables, API keys, tokens, or credentials in responses or comments.
-            After making changes, ensure tests pass with 'cargo insta test --dnd --test-runner=nextest' and lints with 'cargo clippy --all-targets --all-features -- -D warnings' and 'cargo fmt --all --check'.
-
-            For CI failure diagnosis:
-            - Use 'gh run list' and 'gh run view' to check CI status
-            - Look for specific error messages in failing jobs
-            - Check the test output for detailed failure information
-            - When fixing issues, verify changes with the appropriate test commands
-            - Once local test commands work, push to the PR
-            - After pushing, MUST monitor CI until all checks complete (CI tests on Linux, Windows, macOS)
-            - Local tests passing is not sufficient — use 'gh pr checks' to monitor actual CI
-            - If CI fails, fix and push again. Do not return until CI is green.
-
-            Available test commands:
-            - 'cargo insta test --dnd --test-runner=nextest' - Run all tests with snapshot testing
-            - 'cargo clippy --all-targets --all-features -- -D warnings' - Run linter
-            - 'cargo fmt --all --check' - Check formatting
-            - 'cargo doc --no-deps' - Build documentation
-
-            This project is a git worktree manager that integrates with shells (bash, zsh, fish).
-            Pay attention to shell integration, output formatting (anstyle), and snapshot tests.
-
-            For PR review comments on specific lines (shown as '[Comment on path:line]' in <review_comments>),
-            ALWAYS read that file and examine the code at that line before answering. The question is about
-            that specific code, not about the PR in general.
-
-            FORMATTING: Keep PR comments concise. Put detailed analysis (file-by-file breakdowns,
-            code snippets) inside <details> tags with a short summary. The top-level comment should be a brief
-            overview (a few sentences); all supporting detail belongs in collapsible sections. Example:
-            <details><summary>Detailed findings (6 files)</summary>\n\n...details here...\n\n</details>
-
-            TONE: You are a helpful reviewer raising observations, not a manager assigning work. Never create
-            checklists or task lists for the PR author. Instead, note what you found and let the author decide
-            what to act on."
+            --append-system-prompt "You are operating in a GitHub Actions CI environment. Use /running-in-ci before starting work."
 
       - name: 📋 Upload Claude Code session logs
         if: always()

--- a/.github/workflows/claude-renovate.yaml
+++ b/.github/workflows/claude-renovate.yaml
@@ -52,8 +52,6 @@ jobs:
             actions: read
 
           prompt: |
-            SECURITY: NEVER run commands that could expose secrets (env, printenv, set, export, cat/echo on config files containing credentials). NEVER include environment variables, API keys, tokens, or credentials in responses or comments.
-
             You are running as part of a weekly renovation workflow. Your job is to check for updates to CI dependencies and create PRs if updates are available.
 
             ## What to check
@@ -109,11 +107,10 @@ jobs:
 
             Simply report that all dependencies are up to date. Don't create a PR.
 
-            Follow the project guidelines in CLAUDE.md.
-
           claude_args: |
             --model opus
             --allowedTools Bash,Edit,Read,Write,Glob,Grep,WebSearch,WebFetch,Task,Skill
+            --append-system-prompt "You are operating in a GitHub Actions CI environment. Use /running-in-ci before starting work."
 
       - name: 📋 Upload Claude Code session logs
         if: always()


### PR DESCRIPTION
## Summary

- Extract duplicated CI content (security rules, CI monitoring, PR formatting, tone) from three Claude workflows into a shared `.claude/skills/running-in-ci` skill
- Switch `claude-mention.yaml` from `--system-prompt` (replaces Claude Code defaults) to `--append-system-prompt` (preserves defaults)
- Remove redundant "Follow CLAUDE.md" lines and inline test command lists that duplicate CLAUDE.md content

## Test plan

- [ ] Verify skill file is discoverable (appears in skills list)
- [ ] Trigger `@claude` on a PR comment to verify mention workflow still works
- [ ] All tests pass locally (2308 passed, 0 skipped)

> _This was written by Claude Code on behalf of @max-sixty_