### PR TITLE
fix(ci): remove secrets from job-level if in claude-mention workflow

### DIFF
--- a/.github/workflows/claude-mention.yaml
+++ b/.github/workflows/claude-mention.yaml
@@ -18,17 +18,15 @@ env:
 
 jobs:
   claude:
-    # Only run when body/comment contains @claude AND secrets are available.
-    # Review comments on fork PRs don't receive repository secrets (GitHub
-    # security restriction) so the job skips. Use a regular PR comment on the
-    # Conversation tab to trigger @claude on fork PRs instead.
+    # Only run when body/comment contains @claude.
+    # Note: secrets cannot be used in job-level `if:` (actions/runner#520) —
+    # doing so causes GitHub to fail the workflow on push validation. For review
+    # comments on fork PRs (which don't receive secrets), we detect forks via
+    # github.event context instead. Use a Conversation tab comment for fork PRs.
     if: |
-      secrets.CLAUDE_CODE_OAUTH_TOKEN != '' &&
-      (
-        (github.event_name == 'issues' && contains(github.event.issue.body, '@claude')) ||
-        (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-        (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude'))
-      )
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-24.04
     permissions:
       contents: write # Allow pushing commits


### PR DESCRIPTION
## Summary

- Remove `secrets.CLAUDE_CODE_OAUTH_TOKEN` from job-level `if:` in `claude-mention.yaml` — the `secrets` context isn't available there ([actions/runner#520](https://github.com/actions/runner/issues/520)), causing GitHub to fail workflow validation on every push to every branch
- Replace the fork-PR detection with `github.event.pull_request.head.repo.full_name == github.repository`, which uses the always-resolvable `github` context

## Test plan

- [ ] Push to branch triggers ci/release workflows but **not** a failed claude-mention run
- [ ] `@claude` mention on a same-repo PR still triggers the workflow
- [ ] `@claude` review comment on a fork PR is cleanly skipped (no red X)

> _This was written by Claude Code on behalf of @max-sixty_