### PR TITLE
fix(statusline): dim symbols invisible in Claude Code

### DIFF
--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -15,7 +15,9 @@ use dunce::canonicalize;
 use ansi_str::AnsiStr;
 use anyhow::{Context, Result};
 use worktrunk::git::Repository;
-use worktrunk::styling::{fix_dim_after_color_reset, get_terminal_width, truncate_visible};
+use worktrunk::styling::{
+    dim_to_bright_black, fix_dim_after_color_reset, get_terminal_width, truncate_visible,
+};
 
 use super::list::{self, CollectOptions, StatuslineSegment, json_output};
 use crate::cli::OutputFormat;
@@ -240,9 +242,18 @@ pub fn run(format: OutputFormat) -> Result<()> {
     // Join and apply final truncation as fallback
     let output = StatuslineSegment::join(&fitted_segments);
 
-    let reset = anstyle::Reset;
-    let output = fix_dim_after_color_reset(&output);
-    let output = truncate_visible(&format!("{reset} {output}"), max_width);
+    let output = if claude_code {
+        // CC's Ink renderer sets the base foreground to truecolor rgb(102,102,102).
+        // Dim (SGR 2) works on truecolor but the effect on this already-dark base is
+        // imperceptible. Convert standalone dim to bright-black for visible contrast.
+        // Skip the leading reset which would kill Ink's dimColor.
+        let output = dim_to_bright_black(&output);
+        truncate_visible(&format!(" {output}"), max_width)
+    } else {
+        let reset = anstyle::Reset;
+        let output = fix_dim_after_color_reset(&output);
+        truncate_visible(&format!("{reset} {output}"), max_width)
+    };
 
     println!("{}", output);
 

--- a/src/styling/mod.rs
+++ b/src/styling/mod.rs
@@ -162,13 +162,79 @@ pub fn visual_width(s: &str) -> usize {
     s.ansi_strip().width()
 }
 
-/// Fix dim rendering for terminals that don't handle \e[2m after \e[39m.
+/// Fix dim rendering for terminals that don't handle `\e[2m` after `\e[39m`.
 ///
-/// Claude Code's terminal doesn't render dim (\e[2m) correctly when it follows
-/// a foreground color reset (\e[39m). This function replaces that sequence with
-/// a full reset (\e[0m) before dim, which works correctly.
+/// Some terminals don't render dim (`\e[2m`) correctly when it follows a
+/// foreground color reset (`\e[39m`). This function replaces that sequence with
+/// a full reset (`\e[0m`) before dim, which works correctly.
+///
+/// Used in the standard (non-Claude Code) statusline path.
 pub fn fix_dim_after_color_reset(s: &str) -> String {
     s.replace("\x1b[39m\x1b[2m", "\x1b[0m\x1b[2m")
+}
+
+/// Replace standalone dim (SGR 2) with bright-black for Claude Code.
+///
+/// CC's Ink renderer applies `dimColor={true}` by setting the base foreground to
+/// a **truecolor** value (`\e[38;2;102;102;102m`), which is already quite dark
+/// (rgb(102,102,102)). SGR 2 from our output passes through CC's ANSI parser to
+/// the host terminal, where dim *does* reduce brightness — but the effect on an
+/// already-dark base is imperceptible. Empirically: dim on bright truecolor
+/// (rgb(200,200,200)) is visibly different, but dim on CC's dark base is not.
+/// Dim + a saturated 4-bit color (like `\e[31m` red) produces a very visible
+/// change because the color has far more room to darken.
+///
+/// This function converts **standalone dim** (no following foreground color) to
+/// bright-black (`\e[90m`), which the terminal renders as a distinct darker shade
+/// against CC's truecolor gray base. Dim + foreground color (e.g., dim red for
+/// `⇣11`) is left as-is — dim on saturated colors works correctly.
+///
+/// The corresponding "dim off" (`\e[22m`) after a standalone dim becomes a
+/// foreground reset (`\e[39m`) so the base inactive color takes over again.
+/// This assumes `\e[22m` only appears as dim-off (not bold-off); bold text in
+/// the statusline uses `\e[0m` via anstyle.
+pub fn dim_to_bright_black(s: &str) -> String {
+    let mut result = String::with_capacity(s.len());
+    let mut rest = s;
+
+    while let Some(pos) = rest.find('\x1b') {
+        // Copy text before this escape
+        result.push_str(&rest[..pos]);
+        rest = &rest[pos..];
+
+        if rest.starts_with("\x1b[2m") {
+            if starts_with_fg_color(&rest[4..]) {
+                // Dim + foreground color: keep dim, it works for colored text
+                result.push_str("\x1b[2m");
+            } else {
+                // Standalone dim: convert to bright-black for visible contrast
+                result.push_str("\x1b[90m");
+            }
+            rest = &rest[4..]; // consume \x1b[2m
+        } else if rest.starts_with("\x1b[22m") {
+            rest = &rest[5..]; // consume \x1b[22m
+            result.push_str("\x1b[39m");
+        } else {
+            // Other escape sequence — pass through one byte, loop will find the rest
+            result.push('\x1b');
+            rest = &rest[1..];
+        }
+    }
+
+    result.push_str(rest);
+    result
+}
+
+/// Check if string starts with a foreground color escape: `\x1b[30-37m` or `\x1b[90-97m`.
+fn starts_with_fg_color(s: &str) -> bool {
+    let b = s.as_bytes();
+    b.len() >= 5
+        && b[0] == b'\x1b'
+        && b[1] == b'['
+        && (b[2] == b'3' || b[2] == b'9')
+        && b[3] >= b'0'
+        && b[3] <= b'7'
+        && b[4] == b'm'
 }
 
 // ============================================================================
@@ -874,6 +940,51 @@ cp -cR {{ repo_root }}/target/debug/.fingerprint {{ repo_root }}/target/debug/bu
         assert_eq!(
             fix_dim_after_color_reset("\x1b[39m\x1b[1m"),
             "\x1b[39m\x1b[1m"
+        );
+    }
+
+    #[test]
+    fn test_dim_to_bright_black() {
+        // Standalone dim → bright-black
+        assert_eq!(dim_to_bright_black("\x1b[2m⊂\x1b[22m"), "\x1b[90m⊂\x1b[39m");
+
+        // Multiple standalone dim regions
+        assert_eq!(
+            dim_to_bright_black("\x1b[2m⊂\x1b[22m💬  \x1b[2m↓2\x1b[22m"),
+            "\x1b[90m⊂\x1b[39m💬  \x1b[90m↓2\x1b[39m"
+        );
+
+        // Dim + foreground color → keep dim (dim-red is visibly different from red)
+        assert_eq!(
+            dim_to_bright_black("\x1b[2m\x1b[31m⇣11\x1b[0m"),
+            "\x1b[2m\x1b[31m⇣11\x1b[0m"
+        );
+
+        // Dim + green (upstream ahead)
+        assert_eq!(
+            dim_to_bright_black("\x1b[2m\x1b[32m⇡3\x1b[0m"),
+            "\x1b[2m\x1b[32m⇡3\x1b[0m"
+        );
+
+        // Mixed: standalone dim → bright-black, dim+color → preserved
+        assert_eq!(
+            dim_to_bright_black("\x1b[2m⊂\x1b[22m  \x1b[2m\x1b[31m⇣11\x1b[0m"),
+            "\x1b[90m⊂\x1b[39m  \x1b[2m\x1b[31m⇣11\x1b[0m"
+        );
+
+        // color_print pattern: cyan then standalone dim (e.g., "?^")
+        assert_eq!(
+            dim_to_bright_black("\x1b[36m?\x1b[39m\x1b[2m^\x1b[22m"),
+            "\x1b[36m?\x1b[39m\x1b[90m^\x1b[39m"
+        );
+
+        // No dim codes — passthrough
+        assert_eq!(dim_to_bright_black("no escapes"), "no escapes");
+
+        // Other SGR codes preserved
+        assert_eq!(
+            dim_to_bright_black("\x1b[31mred\x1b[39m"),
+            "\x1b[31mred\x1b[39m"
         );
     }
 }

--- a/tests/integration_tests/statusline.rs
+++ b/tests/integration_tests/statusline.rs
@@ -171,7 +171,7 @@ fn test_statusline_claude_code_full_context(repo: TestRepo) {
 
     let output = run_statusline(&repo, &["--format=claude-code"], Some(&json));
     claude_code_snapshot_settings().bind(|| {
-        assert_snapshot!(output, @"[PATH]  main  [36m?[0m[2m^[22m[2m|[22m  | Opus");
+        assert_snapshot!(output, @" [PATH]  main  [36m?[39m[90m^[39m[90m|[39m  | Opus");
     });
 }
 
@@ -182,7 +182,7 @@ fn test_statusline_claude_code_minimal(repo: TestRepo) {
 
     let output = run_statusline(&repo, &["--format=claude-code"], Some(&json));
     claude_code_snapshot_settings().bind(|| {
-        assert_snapshot!(output, @"[PATH]  main  [2m^[22m[2m|[22m");
+        assert_snapshot!(output, @" [PATH]  main  [90m^[39m[90m|[39m");
     });
 }
 
@@ -198,7 +198,7 @@ fn test_statusline_claude_code_with_model(repo: TestRepo) {
 
     let output = run_statusline(&repo, &["--format=claude-code"], Some(&json));
     claude_code_snapshot_settings().bind(|| {
-        assert_snapshot!(output, @"[PATH]  main  [2m^[22m[2m|[22m  | Haiku");
+        assert_snapshot!(output, @" [PATH]  main  [90m^[39m[90m|[39m  | Haiku");
     });
 }
 
@@ -217,7 +217,7 @@ fn test_statusline_claude_code_with_context_gauge(repo: TestRepo) {
 
     let output = run_statusline(&repo, &["--format=claude-code"], Some(&json));
     claude_code_snapshot_settings().bind(|| {
-        assert_snapshot!(output, @"[PATH]  main  [2m^[22m[2m|[22m  | Opus  🌕 42%");
+        assert_snapshot!(output, @" [PATH]  main  [90m^[39m[90m|[39m  | Opus  🌕 42%");
     });
 }
 
@@ -234,7 +234,7 @@ fn test_statusline_claude_code_context_gauge_low(repo: TestRepo) {
 
     let output = run_statusline(&repo, &["--format=claude-code"], Some(&json));
     claude_code_snapshot_settings().bind(|| {
-        assert_snapshot!(output, @"[PATH]  main  [2m^[22m[2m|[22m  | Opus  🌕 5%");
+        assert_snapshot!(output, @" [PATH]  main  [90m^[39m[90m|[39m  | Opus  🌕 5%");
     });
 }
 
@@ -251,7 +251,7 @@ fn test_statusline_claude_code_context_gauge_high(repo: TestRepo) {
 
     let output = run_statusline(&repo, &["--format=claude-code"], Some(&json));
     claude_code_snapshot_settings().bind(|| {
-        assert_snapshot!(output, @"[PATH]  main  [2m^[22m[2m|[22m  | Opus  🌑 98%");
+        assert_snapshot!(output, @" [PATH]  main  [90m^[39m[90m|[39m  | Opus  🌑 98%");
     });
 }
 
@@ -277,7 +277,7 @@ fn test_statusline_claude_code_missing_context_window(repo: TestRepo) {
                 && !output.contains('●'),
             "No gauge should appear when context_window is missing: {output}"
         );
-        assert_snapshot!(output, @"[PATH]  main  [2m^[22m[2m|[22m  | Opus");
+        assert_snapshot!(output, @" [PATH]  main  [90m^[39m[90m|[39m  | Opus");
     });
 }
 


### PR DESCRIPTION
## Summary

- CC's Ink renderer sets the base foreground to truecolor rgb(102,102,102) — dim (SGR 2) on this already-dark base is imperceptible
- Add `dim_to_bright_black()` that converts standalone dim to bright-black (SGR 90) for visible contrast
- Preserve dim + saturated colors (e.g., dim red `⇣11`) since the perceptual effect is strong on those

## Test plan

- [x] 489 unit tests pass
- [x] 1019 integration tests pass (including 21 statusline-specific)
- [x] All lints pass
- [x] Empirically verified in CC: bright-black renders as a distinct shade against CC's truecolor gray base

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> _This was written by Claude Code on behalf of max-sixty_