### PR TITLE
fix(plugin): use "./" instead of "." for marketplace source path

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "worktrunk",
       "description": "Worktrunk is a git worktree management CLI that streamlines multi-branch development. This plugin provides Claude Code integration with two features: (1) A configuration skill guiding you through LLM-powered commit message generation, project automation hooks (post-create, pre-merge), and worktree path customization. (2) Automatic activity tracking that displays 🤖 (working) and 💬 (waiting) indicators in `wt list`, showing which branches have active Claude sessions. Use when setting up Worktrunk configuration, automating project workflows, or monitoring AI activity across branches.",
-      "source": ".",
+      "source": "./",
       "strict": false,
       "skills": [
         "./skills/worktrunk"


### PR DESCRIPTION
## Summary

- Claude Code's plugin schema requires relative paths to start with `./` or `../`. The bare `"."` introduced in 800b2af is valid POSIX but fails schema validation.
- Changes `"source": "."` to `"source": "./"` in `marketplace.json`.

## Test plan

- [ ] Plugin installs correctly via marketplace with the updated source path

> _This was written by Claude Code on behalf of max-sixty_