### PR TITLE
fix(plugin): remove duplicate skills declaration from marketplace.json

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,11 +12,7 @@
     {
       "name": "worktrunk",
       "description": "Worktrunk is a git worktree management CLI that streamlines multi-branch development. This plugin provides Claude Code integration with two features: (1) A configuration skill guiding you through LLM-powered commit message generation, project automation hooks (post-create, pre-merge), and worktree path customization. (2) Automatic activity tracking that displays 🤖 (working) and 💬 (waiting) indicators in `wt list`, showing which branches have active Claude sessions. Use when setting up Worktrunk configuration, automating project workflows, or monitoring AI activity across branches.",
-      "source": "./",
-      "strict": false,
-      "skills": [
-        "./skills/worktrunk"
-      ]
+      "source": "./"
     }
   ]
 }


### PR DESCRIPTION
- Removes `skills` and `strict` keys from the marketplace plugin entry, letting `plugin.json` be the single source of truth for component declarations
- Fixes Claude Code warning about conflicting manifests when installing via `claude plugin marketplace add`

Closes #1013