### PR TITLE
fix(docs): consistent ordering of blockquote and heading in overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,9 +78,9 @@ git branch -d feat</pre></td>
   </tbody>
 </table>
 
-**Workflow automation:**
-
 > Expand into the more advanced commands as needed
+
+**Workflow automation:**
 
 - **[Hooks](https://worktrunk.dev/hook/)** — run commands on create, pre-merge, post-merge, etc
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs

--- a/docs/content/worktrunk.md
+++ b/docs/content/worktrunk.md
@@ -75,9 +75,9 @@ git branch -d feat{% end %}</td>
   </tbody>
 </table>
 
-**Workflow automation:**
-
 > Expand into the more advanced commands as needed
+
+**Workflow automation:**
 
 - **[Hooks](@/hook.md)** — run commands on create, pre-merge, post-merge, etc
 - **[LLM commit messages](@/llm-commits.md)** — generate commit messages from diffs

--- a/skills/worktrunk/reference/worktrunk.md
+++ b/skills/worktrunk/reference/worktrunk.md
@@ -64,9 +64,9 @@ git branch -d feat{% end %}</td>
   </tbody>
 </table>
 
-**Workflow automation:**
-
 > Expand into the more advanced commands as needed
+
+**Workflow automation:**
 
 - **[Hooks](https://worktrunk.dev/hook/)** — run commands on create, pre-merge, post-merge, etc
 - **[LLM commit messages](https://worktrunk.dev/llm-commits/)** — generate commit messages from diffs


### PR DESCRIPTION
## Summary
- The two overview sections had inconsistent ordering — "Core commands" put the blockquote before the heading, while "Workflow automation" did the opposite
- Swapped "Workflow automation" to match

## Test plan
- [x] Doc sync tests pass (`test_command_pages_and_skill_files_are_in_sync`, `test_readme_examples_are_in_sync`)

> _This was written by Claude Code on behalf of @max-sixty_