### PR TITLE
fix(docs): correct status symbol descriptions in quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ $ wt list
 
 ```
 
-The `@` marks the current worktree. `+` means uncommitted changes, `↕` means unpushed commits.
+The `@` marks the current worktree. `+` means staged changes, `⇡` means unpushed commits.
 
 When done, either:
 

--- a/docs/content/worktrunk.md
+++ b/docs/content/worktrunk.md
@@ -158,7 +158,7 @@ This creates a new branch and worktree, then switches to it. Do your work, then 
 
 <!-- END AUTO-GENERATED -->
 
-The `@` marks the current worktree. `+` means uncommitted changes, `↕` means unpushed commits.
+The `@` marks the current worktree. `+` means staged changes, `⇡` means unpushed commits.
 
 When done, either:
 

--- a/skills/worktrunk/reference/worktrunk.md
+++ b/skills/worktrunk/reference/worktrunk.md
@@ -127,7 +127,7 @@ This creates a new branch and worktree, then switches to it. Do your work, then 
 
 <span class=d>○</span> <span class=d>Showing 2 worktrees, 1 with changes, 1 column hidden</span>
 
-The `@` marks the current worktree. `+` means uncommitted changes, `↕` means unpushed commits.
+The `@` marks the current worktree. `+` means staged changes, `⇡` means unpushed commits.
 
 When done, either:
 


### PR DESCRIPTION
## Summary

- Fix `↕` → `⇡`: the quick start claimed `↕` means unpushed commits, but `↕` means diverged from default branch; `⇡` is unpushed commits
- Fix "uncommitted changes" → "staged changes": `+` means staged specifically (`!` is modified, `?` is untracked)

> _This was written by Claude Code on behalf of @max-sixty_

🤖 Generated with [Claude Code](https://claude.com/claude-code)