### PR TITLE
fix(docs): unset CLAUDECODE in Claude Code commit command

### DIFF
--- a/docs/content/llm-commits.md
+++ b/docs/content/llm-commits.md
@@ -23,10 +23,10 @@ Any command that reads a prompt from stdin and outputs a commit message works. A
 
 ```toml
 [commit.generation]
-command = "MAX_THINKING_TOKENS=0 claude -p --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"
+command = "CLAUDECODE= MAX_THINKING_TOKENS=0 claude -p --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"
 ```
 
-The flags disable tools, skills, settings, and system prompt for fast text-only output. See [Claude Code docs](https://docs.anthropic.com/en/docs/build-with-claude/claude-code) for installation.
+`CLAUDECODE=` unsets the nesting guard so `claude -p` works from within a Claude Code session. The other flags disable tools, skills, settings, and system prompt for fast text-only output. See [Claude Code docs](https://docs.anthropic.com/en/docs/build-with-claude/claude-code) for installation.
 
 ### llm
 

--- a/skills/worktrunk/reference/llm-commits.md
+++ b/skills/worktrunk/reference/llm-commits.md
@@ -10,10 +10,10 @@ Any command that reads a prompt from stdin and outputs a commit message works. A
 
 ```toml
 [commit.generation]
-command = "MAX_THINKING_TOKENS=0 claude -p --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"
+command = "CLAUDECODE= MAX_THINKING_TOKENS=0 claude -p --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"
 ```
 
-The flags disable tools, skills, settings, and system prompt for fast text-only output. See [Claude Code docs](https://docs.anthropic.com/en/docs/build-with-claude/claude-code) for installation.
+`CLAUDECODE=` unsets the nesting guard so `claude -p` works from within a Claude Code session. The other flags disable tools, skills, settings, and system prompt for fast text-only output. See [Claude Code docs](https://docs.anthropic.com/en/docs/build-with-claude/claude-code) for installation.
 
 ### llm
 


### PR DESCRIPTION
## Summary

- Add `CLAUDECODE=` prefix to the Claude Code command example in LLM commit docs
- Claude Code sets `CLAUDECODE=1` in subprocess environments and blocks nested invocations, which breaks `wt step commit` / `wt merge` when run from within a Claude Code session
- `claude -p` is a non-interactive single-shot API call, so nesting is safe — the guard is a known false positive ([anthropics/claude-code#25803](https://github.com/anthropics/claude-code/issues/25803))

## Test plan

- [x] Doc sync test passes (`test_command_pages_and_skill_files_are_in_sync`)
- [ ] Verify `wt step commit` works from within Claude Code with the updated config

> _This was written by Claude Code on behalf of @max-sixty_