### PR TITLE
fix: unset CLAUDECODE env var for LLM subprocess

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -297,10 +297,17 @@ fn execute_llm_command(command: &str, prompt: &str) -> anyhow::Result<String> {
     }
 
     let shell = ShellConfig::get();
+    // TODO(claude-code-nesting): Claude Code sets CLAUDECODE=1 and blocks nested
+    // invocations, even non-interactive `claude -p`. Remove this env_remove if
+    // Claude Code relaxes the check for non-interactive mode. If they don't fix
+    // it, replace with a deprecation warning + config.new migration to have users
+    // add `CLAUDECODE=` to their command string themselves.
+    // https://github.com/anthropics/claude-code/issues/25803
     let output = Cmd::new(shell.executable.to_string_lossy())
         .args(&shell.args)
         .arg(command)
         .stdin_bytes(prompt)
+        .env_remove("CLAUDECODE")
         .run()
         .context("Failed to spawn LLM command")?;
 


### PR DESCRIPTION
## Summary

- Strip `CLAUDECODE` env var before spawning LLM commands in `execute_llm_command`
- Claude Code sets `CLAUDECODE=1` in all subprocesses and blocks nested invocations, even non-interactive `claude -p` — this breaks `wt step commit` / `wt merge` from within Claude Code
- Companion to #1020 (doc fix); this is the code fix that handles it for all users regardless of config

## Test plan

- [x] All unit and integration tests pass (1026 integration, 499 unit)
- [x] Pre-commit lints pass
- [ ] Verify `wt step commit` works from within Claude Code without `CLAUDECODE=` in config

> _This was written by Claude Code on behalf of @max-sixty_