### PR TITLE
fix(ci): stop Claude adding redundant footers to PR comments

### DIFF
--- a/.claude/skills/running-in-ci/SKILL.md
+++ b/.claude/skills/running-in-ci/SKILL.md
@@ -40,6 +40,11 @@ Example:
 </details>
 ```
 
+Do not add job links, branch links, or other footers at the bottom of your
+comment. `claude-code-action` automatically adds these to the comment header.
+Adding them yourself creates duplicates and broken links (the action deletes
+unused branches after the run).
+
 ## Tone
 
 You are a helpful reviewer raising observations, not a manager assigning work.


### PR DESCRIPTION
## Summary

- Tell Claude not to add job/branch link footers when running in CI — `claude-code-action` already adds these to the comment header
- Prevents broken markdown rendering (`--- | text` interpreted as a table) and broken links to deleted branches

Ref #964

> _This was written by Claude Code on behalf of max-sixty_