### PR TITLE
fix(docs): correct misleading comment about nested rayon parallelism

### DIFF
--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -612,9 +612,11 @@ pub fn collect(
     let mut errors: Vec<TaskError> = Vec::new();
 
     // Collect all work items upfront, then execute in a single Rayon pool.
-    // This avoids nested parallelism (Rayon par_iter → thread::scope per worktree)
-    // which could create 100+ threads. Instead, we have one pool with the configured
-    // thread count (default 2x CPU cores unless overridden by RAYON_NUM_THREADS).
+    // This avoids nested parallelism (Rayon par_iter → scope per worktree)
+    // which can deadlock when outer tasks block pool threads waiting for inner
+    // tasks that can't get scheduled. Instead, we have one flat pool with the
+    // configured thread count (default 2x CPU cores unless overridden by
+    // RAYON_NUM_THREADS).
     let sorted_worktrees_clone = sorted_worktrees.clone();
     let tx_worker = tx.clone();
     let expected_results_clone = expected_results.clone();


### PR DESCRIPTION
## Summary

- Corrects inaccurate comment in `collect/mod.rs` that claimed nested rayon parallelism "could create 100+ threads" — rayon's pool is fixed-size and doesn't spawn extra OS threads
- The actual risk with nested parallelism is deadlock/starvation: outer tasks block pool threads waiting for inner tasks that can't get scheduled

## Test plan

- [ ] Comment-only change — verify `cargo check` passes

> _This was written by Claude Code on behalf of @max-sixty_