### PR TITLE
feat(ci): add automated Claude PR review

### DIFF
--- a/.claude/skills/worktrunk-review/SKILL.md
+++ b/.claude/skills/worktrunk-review/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: worktrunk-review
+description: Reviews a pull request for idiomatic Rust, project conventions, and code quality. Use when asked to review a PR or when running as an automated PR reviewer.
+argument-hint: "[PR number]"
+---
+
+# Worktrunk PR Review
+
+Review a pull request to worktrunk, a Rust CLI tool for managing git worktrees.
+
+**PR to review:** $ARGUMENTS
+
+## Setup
+
+Load these skills first:
+
+1. `/reviewing-code` — systematic review checklist (design review, universal
+   principles, completeness)
+2. `/developing-rust` — Rust idioms and patterns
+
+Then read CLAUDE.md (project root) to understand project-specific conventions.
+
+## Instructions
+
+1. Read the PR diff with `gh pr diff <number>`.
+2. Read the changed files in full (not just the diff) to understand context.
+3. Follow the `reviewing-code` skill's structure: design review first, then
+   tactical checklist.
+
+## What to review
+
+**Idiomatic Rust and project conventions:**
+
+- Does the code follow Rust idioms? (Iterator chains over manual loops, `?` over
+  match-on-error, proper use of Option/Result, etc.)
+- Does it follow the project's conventions documented in CLAUDE.md? (Cmd for
+  shell commands, error handling with anyhow, accessor naming conventions, etc.)
+- Are there unnecessary allocations, clones, or owned types where borrows would
+  suffice?
+
+**Code quality:**
+
+- Is the code clear and well-structured?
+- Are there simpler ways to express the same logic?
+- Does it avoid unnecessary complexity, feature flags, or compatibility layers?
+
+**Correctness:**
+
+- Are there edge cases that aren't handled?
+- Could the changes break existing functionality?
+- Are error messages helpful and consistent with the project style?
+
+**Testing:**
+
+- Are the changes adequately tested?
+- Do the tests follow the project's testing conventions (see tests/CLAUDE.md)?
+
+## How to provide feedback
+
+- Use inline comments for specific code issues.
+- Use `gh pr comment` for a top-level summary.
+- Be constructive and explain *why* something should change, not just *what*.
+- Distinguish between suggestions (nice to have) and issues (should fix).
+- Don't nitpick formatting — that's what linters are for.

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -1,0 +1,70 @@
+name: claude-review
+# Runner versions pinned; see ci.yaml header comment for rationale.
+
+# Automatic code review on PRs from external contributors.
+# Uses pull_request_target so secrets are available for fork PRs.
+on:
+  pull_request_target:
+    types: [opened, synchronize, ready_for_review, reopened]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CLICOLOR_FORCE: 1
+
+jobs:
+  review:
+    # Skip draft PRs
+    # To skip PRs from repo members, uncomment the author_association conditions:
+    # github.event.pull_request.author_association != 'OWNER' &&
+    # github.event.pull_request.author_association != 'MEMBER' &&
+    if: >-
+      github.event.pull_request.draft == false
+    runs-on: ubuntu-24.04
+    # Scoped environment — only CLAUDE_CODE_OAUTH_TOKEN is needed.
+    # Publishing tokens etc. are not accessible.
+    environment: claude-review
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: 📂 Checkout code
+        uses: actions/checkout@v6
+        with:
+          ref: refs/pull/${{ github.event.pull_request.number }}/merge
+          fetch-depth: 0
+
+      - name: 🔧 Configure git for Claude
+        run: |
+          git config --global user.name "Claude Code"
+          git config --global user.email "claude@anthropic.com"
+
+      - name: 🤖 Review PR with Claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ github.token }}
+          additional_permissions: |
+            actions: read
+          use_sticky_comment: true
+          prompt: |
+            Use /worktrunk-review ${{ github.event.pull_request.number }}
+          claude_args: |
+            --model opus
+            --allowedTools Bash,Edit,Read,Write,Glob,Grep,WebSearch,WebFetch,Task,Skill
+            --append-system-prompt "You are operating in a GitHub Actions CI environment. Use /running-in-ci before starting work."
+
+      - name: 📋 Upload Claude Code session logs
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: claude-session-logs
+          path: ~/.claude/
+          retention-days: 30
+          if-no-files-found: warn


### PR DESCRIPTION
## Summary

- Adds a `claude-review` GitHub Actions workflow that automatically reviews all non-draft PRs
- Review instructions live in `.claude/skills/worktrunk-review/SKILL.md` — reusable locally via `/worktrunk-review <PR number>` or from CI
- Uses a scoped `claude-review` GitHub environment with only `CLAUDE_CODE_OAUTH_TOKEN` — publishing tokens etc. are not accessible
- Uses `GITHUB_TOKEN` for GitHub API (no bot PAT needed since this workflow only reads and comments)
- `pull_request_target` trigger so secrets are available for fork PRs

## Test plan

- [ ] Open a test PR from a fork or non-owner account to verify the workflow triggers
- [ ] Verify the review comment appears as a sticky comment
- [ ] Verify the `claude-review` environment secret works

> _This was written by Claude Code on behalf of max-sixty_