### PR TITLE
fix(ci): allow Claude review on external contributor PRs

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -50,6 +50,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ github.token }}
+          allowed_non_write_users: "*"
           additional_permissions: |
             actions: read
           use_sticky_comment: true


### PR DESCRIPTION
## Summary

- The `claude-review` workflow was failing on PRs from external contributors (like #1038) because `claude-code-action` requires the PR author to have write permissions by default
- Set `allowed_non_write_users: "*"` to allow the review workflow to run on all PRs, since reviewing external contributions is the workflow's purpose
- The `claude-review` environment already scopes secrets to only `CLAUDE_CODE_OAUTH_TOKEN`

## Test plan

- [ ] Verify CI passes on this PR
- [ ] Re-run the review job on #1038 or wait for the next external PR to confirm it works

> _This was written by Claude Code on behalf of max-sixty_