### PR TITLE
perf(select): parallelize preview pre-computation via rayon

### DIFF
--- a/src/commands/select/items.rs
+++ b/src/commands/select/items.rs
@@ -160,14 +160,12 @@ impl WorktreeSkimItem {
     fn preview_for_mode(&self, mode: PreviewMode, width: usize, height: usize) -> String {
         let cache_key = (self.branch_name.clone(), mode);
 
-        // Get from cache or compute
-        let result = if let Some(cached) = self.preview_cache.get(&cache_key) {
-            cached.clone()
-        } else {
-            let computed = Self::compute_preview(&self.item, mode, width, height);
-            self.preview_cache.insert(cache_key, computed.clone());
-            computed
-        };
+        let result = self
+            .preview_cache
+            .entry(cache_key)
+            .or_insert_with(|| Self::compute_preview(&self.item, mode, width, height))
+            .value()
+            .clone();
 
         // Apply pager at display time for diff modes (1, 3, 4)
         // Log mode (2) doesn't benefit from diff pagers


### PR DESCRIPTION
## Summary

- Replace the single sequential background thread for preview pre-computation
  with per-(worktree, mode) `rayon::spawn` tasks, leveraging the existing global
  rayon pool (2× CPU cores) to fill the preview cache in parallel
- Use `DashMap::entry().or_insert_with()` in both rayon tasks and skim's preview
  thread for atomic compute-once semantics, preventing redundant git command
  execution

## Test plan

- [x] All lints pass (`pre-commit run --all-files`)
- [x] All 512 unit tests pass
- [x] All 1032 integration tests pass
- [x] Manual testing: open picker with `wt switch`, press number keys to switch
  preview tabs, verify previews load faster than before

> _This was written by Claude Code on behalf of @max-sixty_