### PR TITLE
fix(docs): address review feedback from #1041 and #1040

### DIFF
--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -246,7 +246,6 @@ impl std::error::Error for TemplateExpandError {}
 
 /// Build a [`TemplateExpandError`] from a minijinja error, the original template
 /// source, the template name (for error messages), and the available variable names.
-/// the template name, and the available variable names.
 ///
 /// Message format: `Failed to expand {name}: {kind}[: {detail}] [@ line {n}]`
 ///


### PR DESCRIPTION
## Summary

- Remove duplicate doc comment line in `build_template_error` (flagged by multiple reviewers on #1041)
- Update stale PTY function references in `tests/CLAUDE.md` to current API after #1040's refactor (`exec_in_pty` → `build_pty_command` + `exec_cmd_in_pty` / `exec_cmd_in_pty_prompted`)

## Test plan

- [x] All lints pass (`pre-commit run --all-files`)
- [x] Unit tests pass (499)
- [x] Integration tests pass (1032)

> _This was written by Claude Code on behalf of @max-sixty_