### PR TITLE
fix(ci): improve Claude review workflow noise and quality

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -17,12 +17,13 @@ env:
 
 jobs:
   review:
-    # Skip draft PRs
+    # Skip draft PRs and bot PRs (e.g. Dependabot)
     # To skip PRs from repo members, uncomment the author_association conditions:
     # github.event.pull_request.author_association != 'OWNER' &&
     # github.event.pull_request.author_association != 'MEMBER' &&
     if: >-
-      github.event.pull_request.draft == false
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-24.04
     # Scoped environment — only CLAUDE_CODE_OAUTH_TOKEN is needed.
     # Publishing tokens etc. are not accessible.
@@ -49,8 +50,7 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ github.token }}
-          allowed_non_write_users: "*"
+          github_token: ${{ secrets.WORKTRUNK_REVIEW_TOKEN }}
           additional_permissions: |
             actions: read
           use_sticky_comment: true


### PR DESCRIPTION
## Summary

- **Skip bot PRs** — add `user.type != 'Bot'` condition so Dependabot PRs show as skipped, not failed
- **Dedicated token** — switch `github_token` from `github.token` to `WORKTRUNK_REVIEW_TOKEN` PAT; remove `allowed_non_write_users: "*"`
- **Review discipline** — one formal review per run, no `gh pr comment` (action manages sticky comment), skip redundant re-approvals
- **LGTM brevity** — brief 1-2 sentence approvals + thumbs-up reaction instead of essays
- **Inline suggestions** — `gh api` example for submitting reviews with GitHub suggestion format

## Test plan

- [ ] Verify Dependabot PRs (#1045, #1046, #1047) show as "skipped"
- [ ] Confirm sticky comment updates in place on subsequent push
- [ ] Verify reviews appear from the new token identity
- [ ] Meta: Claude reviews its own review improvements on this PR

> _This was written by Claude Code on behalf of @max-sixty_