### PR TITLE
fix(ci): cancel redundant CI runs on PR updates

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,6 +12,10 @@ on:
     branches: [ main ]
   workflow_dispatch:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_TERM_COLOR: always
   # Authenticate lychee requests to GitHub to avoid rate limiting


### PR DESCRIPTION
## Summary
- Add `concurrency` group to `ci.yaml` so pushing a new commit to a PR cancels the previous in-progress run, saving CI minutes
- Pushes to main always run to completion (`cancel-in-progress: false`) to ensure codecov and status checks are recorded for every merge

## Test plan
- [ ] Verify CI runs on this PR itself
- [ ] Push a follow-up commit quickly to confirm the first run gets cancelled

> _This was written by Claude Code on behalf of @max-sixty_