### PR TITLE
fix(ci): restructure review skill and fix dead sticky comment

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -50,6 +50,8 @@ jobs:
           github_token: ${{ secrets.WORKTRUNK_REVIEW_TOKEN }}
           additional_permissions: |
             actions: read
+          # TODO: sticky comment stopped appearing after switching to WORKTRUNK_REVIEW_TOKEN PAT.
+          # Bot now puts feedback in review bodies instead of stdout, so this may be a no-op.
           use_sticky_comment: true
           prompt: |
             Use /worktrunk-review ${{ github.event.pull_request.number }}


### PR DESCRIPTION
## Summary

- Restructure review skill as explicit numbered workflow with pre-flight checks
  before expensive diff analysis (prevents redundant approvals like the triple
  on #1053)
- Remove dead sticky comment references — mechanism stopped working after PAT
  switch in #1052; bot now uses review bodies/inline comments which is better
- Filter dedup check by bot identity so human approvals don't skip the bot's
  review
- Accept brief approval bodies to match actual behavior
- Replace `{owner}/{repo}` placeholders with `$REPO` derived from `gh repo view`

## Test plan

- [ ] Next Claude review run should check for prior approvals before analyzing
- [ ] Bot should not triple-approve the same SHA
- [ ] Inline suggestions should use `$REPO` correctly

> _This was written by Claude Code on behalf of @max-sixty_