### PR TITLE
fix(ci): use empty body for LGTM approvals

### DIFF
--- a/.claude/skills/worktrunk-review/SKILL.md
+++ b/.claude/skills/worktrunk-review/SKILL.md
@@ -100,9 +100,9 @@ times.
 
 When the PR has no issues worth raising:
 
-1. Approve (a brief one-line remark is fine):
+1. Approve with an empty body (no fluff — silence is the best compliment):
    ```bash
-   gh pr review <number> --approve -b "Clean change, no issues."
+   gh pr review <number> --approve -b ""
    ```
 2. Add a thumbs-up reaction:
    ```bash


### PR DESCRIPTION
## Summary

- LGTM approvals now use an empty body instead of generating summary prose
- The thumbs-up reaction remains as sufficient signal that the bot reviewed and approved

## Test plan

- [x] Next LGTM approval from the bot will be silent instead of "Clean hardening of..."

> _This was written by Claude Code on behalf of @max-sixty_

🤖 Generated with [Claude Code](https://claude.com/claude-code)