### PR TITLE
refactor: consolidate shell escaping on shell_escape, drop shlex

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3219,7 +3219,6 @@ dependencies = [
  "serde_json",
  "shell-escape",
  "shellexpand",
- "shlex",
  "signal-hook 0.4.3",
  "similar",
  "skim",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,7 +86,6 @@ serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 shell-escape = "0.1"
 shellexpand = "3.1"
-shlex = "1.3"
 strum = { version = "0.27", features = ["derive"] }
 synoptic = "2"
 terminal_size = "0.4"

--- a/src/commands/handle_switch.rs
+++ b/src/commands/handle_switch.rs
@@ -238,7 +238,7 @@ pub fn handle_switch(
                 .collect();
             let escaped_args: Vec<_> = expanded_args?
                 .iter()
-                .map(|arg| shlex::try_quote(arg).unwrap_or(arg.into()).into_owned())
+                .map(|arg| shell_escape::escape(arg.into()).into_owned())
                 .collect();
             format!("{} {}", expanded_cmd, escaped_args.join(" "))
         };

--- a/src/commands/select/mod.rs
+++ b/src/commands/select/mod.rs
@@ -139,9 +139,7 @@ pub fn handle_select(
 
     // Get state path for key bindings (shell-escaped for safety)
     let state_path_display = state.path.display().to_string();
-    let state_path_str = shlex::try_quote(&state_path_display)
-        .map(|s| s.into_owned())
-        .unwrap_or(state_path_display);
+    let state_path_str = shell_escape::escape(state_path_display.into()).into_owned();
 
     // Calculate half-page scroll: skim uses 90% of terminal height, half of that = 45%
     let half_page = terminal_size::terminal_size()

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_template_in_args.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_template_in_args.snap
@@ -35,6 +35,7 @@ info:
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -50,4 +51,4 @@ branch=args-test repo=repo
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [90mwt config shell install[39m[22m
 [36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.args-test[22m:[39m
-[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'branch=args-test'[0m[2m [0m[2m[32m'repo=repo'[0m[2m
+[107m [0m [2m[0m[2m[34mecho[0m[2m branch=args-test repo=repo


### PR DESCRIPTION
## Summary

- Removes `shlex` crate dependency, consolidating all shell quoting on `shell_escape` (the project's existing standard)
- `shlex` was only used in 2 call sites for `try_quote()`; replaced with `shell_escape::escape()`
- One dependency fewer, one canonical way to shell-quote

## Test plan

- [x] All 1036 integration tests pass
- [x] All 499 unit tests pass
- [x] All lints pass (`pre-commit run --all-files`)
- [x] Snapshot updated: `--execute` args no longer unnecessarily single-quoted (e.g., `branch=args-test` instead of `'branch=args-test'`)

> _This was written by Claude Code on behalf of @max-sixty_