### PR TITLE
fix: remove stray blank lines before hints in error output

### DIFF
--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -83,7 +83,8 @@ Shell integration: {{ shell_integration }}
 {{ worktree_list }}
 ```
 </details>
-{% if config_show %}
+{%- if config_show %}
+
 <details>
 <summary>Config</summary>
 
@@ -91,8 +92,9 @@ Shell integration: {{ shell_integration }}
 {{ config_show }}
 ```
 </details>
-{% endif %}
-{% if verbose_log %}
+{%- endif %}
+{%- if verbose_log %}
+
 <details>
 <summary>Verbose log</summary>
 
@@ -100,7 +102,7 @@ Shell integration: {{ shell_integration }}
 {{ verbose_log }}
 ```
 </details>
-{% endif %}
+{%- endif %}
 "#;
 
 /// Collected diagnostic information for issue reporting.

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -601,7 +601,7 @@ impl GitError {
                 )?;
                 if !files.is_empty() {
                     let joined_files = files.join("\n");
-                    write!(f, "\n{}\n", format_with_gutter(&joined_files, None))?;
+                    write!(f, "\n{}", format_with_gutter(&joined_files, None))?;
                 }
                 let path_display = format_path_for_display(worktree_path);
                 write!(
@@ -626,7 +626,7 @@ impl GitError {
                     ))
                 )?;
                 if !commits_formatted.is_empty() {
-                    write!(f, "\n{}\n", format_with_gutter(commits_formatted, None))?;
+                    write!(f, "\n{}", format_with_gutter(commits_formatted, None))?;
                 }
                 // Context-appropriate hint
                 let merge_cmd = suggest_command("merge", &[target_branch], &[]);

--- a/src/help.rs
+++ b/src/help.rs
@@ -71,7 +71,7 @@ pub fn maybe_handle_help_with_pager() -> bool {
                 .to_string()
                 .replace("```text\n", "```\n")
                 .replace("```console\n", "```bash\n");
-            println!("{output}");
+            print!("{output}");
             process::exit(0);
         }
         // Fall through if not a help request

--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -50,6 +50,7 @@ pub mod shell_integration_prompt;
 pub mod shell_integration_windows;
 pub mod shell_powershell;
 pub mod shell_wrapper;
+pub mod snapshot_formatting_guard;
 pub mod spacing_edge_cases;
 pub mod statusline;
 pub mod step_copy_ignored;

--- a/tests/integration_tests/snapshot_formatting_guard.rs
+++ b/tests/integration_tests/snapshot_formatting_guard.rs
@@ -1,0 +1,160 @@
+//! Guard test to catch formatting violations in snapshot files
+//!
+//! Snapshots capture real output and are approved by reviewers. Subtle formatting
+//! issues (stray blank lines, detached hints) can slip through review. This test
+//! scans all snapshot files to enforce output formatting rules.
+//!
+//! Rules enforced:
+//! - **Hints attach to their subject** — no blank line before `↳`
+//! - **No double blank lines** — one blank line maximum between elements
+//!
+//! When this test fails:
+//! 1. Fix the source code producing the bad output
+//! 2. Re-run the failing test to regenerate the snapshot
+//! 3. If the blank line is intentional (e.g., phase boundary before a status
+//!    item that uses `↳`), add the snapshot to the allowlist with a comment
+
+use ansi_str::AnsiStr;
+use std::fs;
+use std::path::Path;
+
+/// Snapshots where a blank line before `↳` is intentional (phase boundary, not
+/// a detached hint). Each entry needs a comment explaining why.
+const BLANK_BEFORE_HINT_ALLOWED: &[&str] = &[
+    // config show: blank line separates "Shell integration not active" diagnostic
+    // from per-shell status section. The `↳` here is a status item, not a hint.
+    "config_show__config_show_partial_shell_config_shows_hint",
+    "config_show__config_show_unmatched_candidate_warning",
+];
+
+#[test]
+fn test_no_blank_line_before_hint_in_snapshots() {
+    let project_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    let mut violations = Vec::new();
+
+    for_each_snapshot(project_root, |path, content| {
+        let stem = path.file_stem().and_then(|s| s.to_str()).unwrap_or("");
+        if BLANK_BEFORE_HINT_ALLOWED
+            .iter()
+            .any(|allowed| stem.contains(allowed))
+        {
+            return;
+        }
+
+        let clean = content.ansi_strip();
+        let lines: Vec<&str> = clean.lines().collect();
+
+        for (i, line) in lines.iter().enumerate() {
+            if line.trim().starts_with('↳') && i > 0 && lines[i - 1].trim().is_empty() {
+                let relative = path.strip_prefix(project_root).unwrap_or(path);
+                violations.push(format!(
+                    "{}:{}: blank line before hint\n  {}: {:?}\n  {}: {:?}",
+                    relative.display(),
+                    i + 1,
+                    i,
+                    lines[i - 1],
+                    i + 1,
+                    line,
+                ));
+            }
+        }
+    });
+
+    if !violations.is_empty() {
+        panic!(
+            "Blank line before hint (↳) in {} snapshot(s):\n\n{}\n\n\
+             Hints attach to their subject — no blank line between a message and its hint.\n\
+             Fix the source code, not the snapshot. If the blank line is intentional,\n\
+             add the snapshot to BLANK_BEFORE_HINT_ALLOWED with a comment.",
+            violations.len(),
+            violations.join("\n\n"),
+        );
+    }
+}
+
+#[test]
+fn test_no_double_blank_lines_in_snapshot_output() {
+    let project_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+
+    let mut violations = Vec::new();
+
+    for_each_snapshot(project_root, |path, content| {
+        // Extract output content, skipping YAML header.
+        // Two formats: stdout/stderr sections (insta_cmd) or expression
+        // content after closing `---`.
+        for (label, text) in extract_output_sections(content) {
+            let clean = text.ansi_strip();
+            if clean.contains("\n\n\n") {
+                let relative = path.strip_prefix(project_root).unwrap_or(path);
+                violations.push(format!("{}  ({label})", relative.display()));
+            }
+        }
+    });
+
+    if !violations.is_empty() {
+        panic!(
+            "Double blank lines in {} snapshot output section(s):\n\n{}\n\n\
+             One blank line maximum between output elements.",
+            violations.len(),
+            violations.join("\n"),
+        );
+    }
+}
+
+fn for_each_snapshot(project_root: &Path, mut f: impl FnMut(&Path, &str)) {
+    let snap_dirs = [
+        project_root.join("tests/snapshots"),
+        project_root.join("tests/integration_tests/snapshots"),
+    ];
+
+    for dir in &snap_dirs {
+        let Ok(entries) = fs::read_dir(dir) else {
+            continue;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("snap") {
+                continue;
+            }
+            let content = fs::read_to_string(&path).unwrap();
+            f(&path, &content);
+        }
+    }
+}
+
+/// Extract labeled output sections from a snapshot file.
+///
+/// Handles two formats:
+/// - **insta_cmd**: sections delimited by `----- stdout -----` / `----- stderr -----`
+/// - **expression**: content after the closing `---` YAML delimiter
+fn extract_output_sections(content: &str) -> Vec<(&str, &str)> {
+    let mut sections = Vec::new();
+
+    // Try stdout/stderr sections (insta_cmd format)
+    for section in ["stdout", "stderr"] {
+        let marker = format!("----- {section} -----");
+        let Some(start) = content.find(&marker) else {
+            continue;
+        };
+        let after_marker = &content[start + marker.len()..];
+        let end = after_marker
+            .find("----- stdout -----")
+            .or_else(|| after_marker.find("----- stderr -----"))
+            .unwrap_or(after_marker.len());
+        sections.push((section, &after_marker[..end]));
+    }
+
+    // If no stdout/stderr sections, try expression format (content after closing ---)
+    if sections.is_empty()
+        && let Some(first_delim) = content.find("---")
+    {
+        let after_first = &content[first_delim + 3..];
+        if let Some(second_delim) = after_first.find("---") {
+            let output = &after_first[second_delim + 3..];
+            sections.push(("expression", output));
+        }
+    }
+
+    sections
+}

--- a/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__conflicting_changes.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__conflicting_changes.snap
@@ -5,5 +5,4 @@ expression: err.to_string()
 [31m✗[39m [31mCan't push to local [1mmain[22m branch: conflicting uncommitted changes[39m
 [107m [0m src/main.rs
 [107m [0m src/lib.rs
-
 [2m↳[22m [2mCommit or stash these changes in /tmp/repo.main first[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__not_fast_forward.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__not_fast_forward.snap
@@ -5,5 +5,4 @@ expression: err.to_string()
 [31m✗[39m [31mCan't push to local [1mmain[22m branch: it has newer commits[39m
 [107m [0m abc1234 Fix bug
 [107m [0m def5678 Add feature
-
 [2m↳[22m [2mTo rebase onto [1mmain[22m, run [90mwt step rebase main[39m[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__not_fast_forward_merge_context.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__not_fast_forward_merge_context.snap
@@ -4,5 +4,4 @@ expression: err.to_string()
 ---
 [31m✗[39m [31mCan't push to local [1mmain[22m branch: it has newer commits[39m
 [107m [0m abc1234 New commit on main
-
 [2m↳[22m [2mTo incorporate these changes, run [90mwt merge main[39m again[22m

--- a/tests/snapshots/integration__integration_tests__diagnostic__diagnostic_file_format.snap
+++ b/tests/snapshots/integration__integration_tests__diagnostic__diagnostic_file_format.snap
@@ -55,7 +55,6 @@ Project config: _REPO_/.config/wt.toml
 ```
 </details>
 
-
 <details>
 <summary>Verbose log</summary>
 

--- a/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
@@ -15,10 +15,12 @@ info:
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
+    WORKTRUNK_APPROVALS_PATH: /nonexistent/test/approvals.toml
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
 ---
@@ -145,6 +147,5 @@ lint = "cargo clippy"
 - [`wt step`](@/step.md) — Run individual operations (commit, squash, rebase, push)
 - [`wt remove`](@/remove.md) — Remove worktrees without merging
 - [`wt switch`](@/switch.md) — Navigate to other worktrees
-
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_md_root.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_root.snap
@@ -14,10 +14,12 @@ info:
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
+    WORKTRUNK_APPROVALS_PATH: /nonexistent/test/approvals.toml
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
 ---
@@ -66,6 +68,5 @@ Run `wt config create` to customize worktree locations.
 
 Docs: https://worktrunk.dev
 GitHub: https://github.com/max-sixty/worktrunk
-
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__merge__merge_error_conflicting_changes_in_target.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_error_conflicting_changes_in_target.snap
@@ -25,10 +25,12 @@ info:
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -40,5 +42,4 @@ exit_code: 1
 ----- stderr -----
 [31m✗[39m [31mCan't push to local [1mmain[22m branch: conflicting uncommitted changes[39m
 [107m [0m shared.txt
-
 [2m↳[22m [2mCommit or stash these changes in _REPO_.main-wt first[22m

--- a/tests/snapshots/integration__integration_tests__push__push_dirty_target_overlap.snap
+++ b/tests/snapshots/integration__integration_tests__push__push_dirty_target_overlap.snap
@@ -26,10 +26,12 @@ info:
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -41,5 +43,4 @@ exit_code: 1
 ----- stderr -----
 [31m✗[39m [31mCan't push to local [1mmain[22m branch: conflicting uncommitted changes[39m
 [107m [0m conflict.txt
-
 [2m↳[22m [2mCommit or stash these changes in _REPO_ first[22m

--- a/tests/snapshots/integration__integration_tests__push__push_dirty_target_overlap_renamed_file.snap
+++ b/tests/snapshots/integration__integration_tests__push__push_dirty_target_overlap_renamed_file.snap
@@ -26,10 +26,12 @@ info:
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -41,5 +43,4 @@ exit_code: 1
 ----- stderr -----
 [31m✗[39m [31mCan't push to local [1mmain[22m branch: conflicting uncommitted changes[39m
 [107m [0m file.txt
-
 [2m↳[22m [2mCommit or stash these changes in _REPO_ first[22m

--- a/tests/snapshots/integration__integration_tests__push__push_error_not_fast_forward.snap
+++ b/tests/snapshots/integration__integration_tests__push__push_error_not_fast_forward.snap
@@ -26,10 +26,12 @@ info:
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -41,5 +43,4 @@ exit_code: 1
 ----- stderr -----
 [31m✗[39m [31mCan't push to local [1mmain[22m branch: it has newer commits[39m
 [107m [0m * [33m[HASH][m Main commit
-
 [2m↳[22m [2mTo rebase onto [1mmain[22m, run [90mwt step rebase main[39m[22m


### PR DESCRIPTION
## Summary

- Remove blank line between detail lines (file list / commit list) and hint in `ConflictingChanges` and `NotFastForward` error display — `"\n{detail}\n"` + `"\n{hint}"` produced a blank line violating "hints attach to their subject"
- Fix trailing double blanks in `--help-md` output (`print!` instead of `println!` since clap output already ends with `\n`)
- Fix double blank in diagnostic template between optional `<details>` sections (Jinja `{%-` whitespace control)
- Add `snapshot_formatting_guard` tests scanning all 726 snapshots for blank-line-before-hint and double-blank-line violations

## Test plan

- [x] All 1040 integration tests pass (including 10 updated snapshots)
- [x] All 530 unit tests pass
- [x] Pre-commit lints clean
- [x] New guard tests catch the specific patterns and pass after fixes

🤖 Generated with [Claude Code](https://claude.com/claude-code)