### PR TITLE
fix: use info message for migration file write notification

### DIFF
--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -647,8 +647,8 @@ pub fn check_and_migrate(
 
             eprintln!(
                 "{}",
-                hint_message(cformat!(
-                    "Wrote migrated <bright-black>{new_filename}</>. To apply:"
+                info_message(cformat!(
+                    "Wrote migrated <bold>{new_filename}</>. To apply:"
                 ))
             );
             eprintln!(
@@ -829,8 +829,8 @@ pub fn format_deprecation_details(info: &DeprecationInfo) -> String {
         let _ = writeln!(
             out,
             "{}",
-            hint_message(cformat!(
-                "Wrote migrated <bright-black>{new_filename}</>. To apply:"
+            info_message(cformat!(
+                "Wrote migrated <bold>{new_filename}</>. To apply:"
             ))
         );
         let _ = writeln!(

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
@@ -46,7 +46,7 @@ exit_code: 0
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
 [33m▲[39m [33mProject config uses deprecated template variables: [2mmain_worktree[22m → [1mrepo[22m[39m
-[2m↳[22m [2mWrote migrated [90mwt.toml.new[39m. To apply:[22m
+[2m○[22m Wrote migrated [1mwt.toml.new[22m. To apply:
 [107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m _REPO_/.config/wt.toml.new _REPO_/.config/wt.toml
 [2m○[22m Diff:
 [107m [0m [1mdiff --git a_REPO_/.config/wt.toml b_REPO_/.config/wt.toml.new[m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
@@ -43,7 +43,7 @@ exit_code: 0
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUser config uses deprecated template variables: [2mrepo_root[22m → [1mrepo_path[22m, [2mmain_worktree[22m → [1mrepo[22m[39m
-[2m↳[22m [2mWrote migrated [90mconfig.toml.new[39m. To apply:[22m
+[2m○[22m Wrote migrated [1mconfig.toml.new[22m. To apply:
 [107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEMP_HOME]/.config/worktrunk/config.toml.new [TEMP_HOME]/.config/worktrunk/config.toml
 [2m○[22m Diff:
 [107m [0m [1mdiff --git a[TEMP_HOME]/.config/worktrunk/config.toml b[TEMP_HOME]/.config/worktrunk/config.toml.new

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
@@ -43,7 +43,7 @@ exit_code: 0
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUser config uses deprecated config sections: [projects."github.com/example/repo".commit-generation] → [projects."github.com/example/repo".commit.generation][39m
-[2m↳[22m [2mWrote migrated [90mconfig.toml.new[39m. To apply:[22m
+[2m○[22m Wrote migrated [1mconfig.toml.new[22m. To apply:
 [107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEMP_HOME]/.config/worktrunk/config.toml.new [TEMP_HOME]/.config/worktrunk/config.toml
 [2m○[22m Diff:
 [107m [0m [1mdiff --git a[TEMP_HOME]/.config/worktrunk/config.toml b[TEMP_HOME]/.config/worktrunk/config.toml.new

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
@@ -47,7 +47,7 @@ exit_code: 0
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
 [33m▲[39m [33mProject config uses deprecated config sections: [commit-generation] → [commit.generation][39m
-[2m↳[22m [2mWrote migrated [90mwt.toml.new[39m. To apply:[22m
+[2m○[22m Wrote migrated [1mwt.toml.new[22m. To apply:
 [107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m _REPO_/.config/wt.toml.new _REPO_/.config/wt.toml
 [2m○[22m Diff:
 [107m [0m [1mdiff --git a_REPO_/.config/wt.toml b_REPO_/.config/wt.toml.new[m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_project_level_shows_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_project_level_shows_warning.snap
@@ -24,10 +24,13 @@ info:
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -45,5 +48,5 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mUser config has deprecated settings. To see details, run [1mwt config show[22m[39m
-[2m↳[22m [2mWrote migrated [90mtest-config.toml.new[39m. To apply:[22m
+[2m○[22m Wrote migrated [1mtest-config.toml.new[22m. To apply:
 [107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEST_CONFIG_NEW] [TEST_CONFIG]

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_section_shows_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_section_shows_warning.snap
@@ -24,10 +24,13 @@ info:
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -45,5 +48,5 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mUser config has deprecated settings. To see details, run [1mwt config show[22m[39m
-[2m↳[22m [2mWrote migrated [90mtest-config.toml.new[39m. To apply:[22m
+[2m○[22m Wrote migrated [1mtest-config.toml.new[22m. To apply:
 [107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEST_CONFIG_NEW] [TEST_CONFIG]

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_show_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_show_warning.snap
@@ -24,10 +24,13 @@ info:
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -45,5 +48,5 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mUser config has deprecated settings. To see details, run [1mwt config show[22m[39m
-[2m↳[22m [2mWrote migrated [90mtest-config.toml.new[39m. To apply:[22m
+[2m○[22m Wrote migrated [1mtest-config.toml.new[22m. To apply:
 [107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEST_CONFIG_NEW] [TEST_CONFIG]

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_verbose_shows_content.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_verbose_shows_content.snap
@@ -25,10 +25,13 @@ info:
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -46,7 +49,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mUser config has deprecated settings. To see details, run [1mwt config show[22m[39m
-[2m↳[22m [2mWrote migrated [90mtest-config.toml.new[39m. To apply:[22m
+[2m○[22m Wrote migrated [1mtest-config.toml.new[22m. To apply:
 [107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEST_CONFIG_NEW] [TEST_CONFIG]
 [2m○[22m Expanding [1mworktree-path[22m
 [107m [0m ../{{ main_worktree }}.{{ branch }} [2m→[22m ../repo.feature-a


### PR DESCRIPTION
## Summary

- Changed "Wrote migrated config.toml.new. To apply:" from `hint_message` (↳ dim) to `info_message` (○) so it stands out more as a state acknowledgment
- Updated inner styling from `<bright-black>` to `<bold>` to match info message conventions
- Both code paths updated: brief warning (inline during other commands) and `wt config show` detail output

## Test plan

- [x] All 1052 tests pass
- [x] 8 snapshot tests updated to reflect new symbol and styling
- [x] Lints pass

> _This was written by Claude Code on behalf of @max-sixty_