### PR TITLE
feat: add `wt config update` command

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -376,6 +376,7 @@ Usage: <b><span class=c>wt config</span></b> <span class=c>[OPTIONS]</span> <spa
   <b><span class=c>shell</span></b>   Shell integration setup
   <b><span class=c>create</span></b>  Create configuration file
   <b><span class=c>show</span></b>    Show configuration files &amp; locations
+  <b><span class=c>update</span></b>  Update deprecated config settings
   <b><span class=c>state</span></b>   Manage internal data and cache
 
 <b><span class=g>Options:</span></b>

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -367,6 +367,7 @@ Usage: <b><span class=c>wt config</span></b> <span class=c>[OPTIONS]</span> <spa
   <b><span class=c>shell</span></b>   Shell integration setup
   <b><span class=c>create</span></b>  Create configuration file
   <b><span class=c>show</span></b>    Show configuration files &amp; locations
+  <b><span class=c>update</span></b>  Update deprecated config settings
   <b><span class=c>state</span></b>   Manage internal data and cache
 
 <b><span class=g>Options:</span></b>

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -236,6 +236,29 @@ This tests:
         full: bool,
     },
 
+    /// Update deprecated config settings
+    #[command(
+        after_long_help = r#"Updates deprecated settings in user and project config files
+to their current equivalents. Shows a diff and asks for confirmation.
+
+## Examples
+
+Preview and apply updates:
+```console
+wt config update
+```
+
+Apply without confirmation:
+```console
+wt config update --yes
+```"#
+    )]
+    Update {
+        /// Skip confirmation prompt
+        #[arg(short, long)]
+        yes: bool,
+    },
+
     /// Manage internal data and cache
     #[command(
         after_long_help = r#"State is stored in `.git/` (config entries and log files), separate from configuration files.

--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -6,6 +6,7 @@ mod create;
 mod hints;
 mod show;
 mod state;
+mod update;
 
 // Re-export public functions
 pub use create::handle_config_create;
@@ -15,6 +16,7 @@ pub use state::{
     handle_logs_get, handle_state_clear, handle_state_clear_all, handle_state_get,
     handle_state_set, handle_state_show,
 };
+pub use update::handle_config_update;
 
 #[cfg(test)]
 mod tests {

--- a/src/commands/config/update.rs
+++ b/src/commands/config/update.rs
@@ -1,0 +1,189 @@
+//! Config update command.
+//!
+//! Updates deprecated settings in user and project config files.
+
+use std::fmt::Write as _;
+use std::path::PathBuf;
+
+use anyhow::Context;
+use worktrunk::config::{
+    DeprecationInfo, format_deprecation_warnings, format_migration_diff, get_config_path,
+};
+use worktrunk::git::Repository;
+use worktrunk::styling::{eprintln, info_message, success_message};
+
+use crate::output::prompt::{PromptResponse, prompt_yes_no_preview};
+
+/// A config file that needs updating.
+struct UpdateCandidate {
+    /// Path to the original config file
+    config_path: PathBuf,
+    /// Path to the generated .new file
+    new_path: PathBuf,
+    /// Deprecation info for display
+    info: DeprecationInfo,
+}
+
+/// Handle the `wt config update` command.
+pub fn handle_config_update(yes: bool) -> anyhow::Result<()> {
+    let mut candidates = Vec::new();
+
+    // Check user config
+    if let Some(candidate) = check_user_config()? {
+        candidates.push(candidate);
+    }
+
+    // Check project config (if in a git repo)
+    if let Some(candidate) = check_project_config()? {
+        candidates.push(candidate);
+    }
+
+    if candidates.is_empty() {
+        eprintln!("{}", info_message("No deprecated settings found"));
+        return Ok(());
+    }
+
+    // Show what will be updated (warnings + diffs)
+    for candidate in &candidates {
+        eprint!("{}", format_update_preview(&candidate.info));
+    }
+
+    // Confirm unless --yes
+    if !yes {
+        let prompt_text = "Apply updates?".to_string();
+        match prompt_yes_no_preview(&prompt_text, || {})? {
+            PromptResponse::Accepted => {}
+            PromptResponse::Declined => {
+                eprintln!("{}", info_message("Update cancelled"));
+                return Ok(());
+            }
+        }
+    }
+
+    // Apply updates
+    for candidate in &candidates {
+        std::fs::rename(&candidate.new_path, &candidate.config_path)
+            .with_context(|| format!("Failed to update {}", candidate.info.label))?;
+        eprintln!(
+            "{}",
+            success_message(format!("Updated {}", candidate.info.label.to_lowercase()))
+        );
+    }
+
+    // Clear deprecation hint if we're in a repo
+    if let Ok(repo) = Repository::current() {
+        let _ = repo.clear_hint("deprecated-config");
+    }
+
+    Ok(())
+}
+
+/// Format update preview for display.
+///
+/// Shows deprecation warnings and diff, but omits the "mv" apply hint
+/// since `config update` will apply automatically.
+fn format_update_preview(info: &DeprecationInfo) -> String {
+    let mut out = format_deprecation_warnings(info);
+
+    // Show diff (without the "mv" apply hint that format_deprecation_details adds)
+    if let Some(new_path) = &info.migration_path
+        && let Some(diff) = format_migration_diff(&info.config_path, new_path)
+    {
+        let _ = writeln!(out, "{diff}");
+    }
+
+    out
+}
+
+/// Check user config for deprecations and generate .new file if needed.
+fn check_user_config() -> anyhow::Result<Option<UpdateCandidate>> {
+    let config_path = match get_config_path() {
+        Some(path) => path,
+        None => return Ok(None),
+    };
+    if !config_path.exists() {
+        return Ok(None);
+    }
+
+    let content = std::fs::read_to_string(&config_path).context("Failed to read user config")?;
+
+    // Use check_and_migrate in silent mode (show_brief_warning=false) which:
+    // - Detects deprecations
+    // - Copies approved-commands to approvals.toml
+    // - Writes the .new migration file
+    let info = match worktrunk::config::check_and_migrate(
+        &config_path,
+        &content,
+        true, // warn_and_migrate (write .new file)
+        "User config",
+        None,  // no repo context for user config
+        false, // silent mode
+    )? {
+        Some(info) if info.has_deprecations() => info,
+        _ => return Ok(None),
+    };
+
+    let new_path = match &info.migration_path {
+        Some(path) => path.clone(),
+        None => anyhow::bail!("Failed to write migration file for user config"),
+    };
+
+    Ok(Some(UpdateCandidate {
+        config_path,
+        new_path,
+        info,
+    }))
+}
+
+/// Check project config for deprecations and generate .new file if needed.
+fn check_project_config() -> anyhow::Result<Option<UpdateCandidate>> {
+    let repo = match Repository::current() {
+        Ok(repo) => repo,
+        Err(_) => return Ok(None),
+    };
+
+    let root = match repo.current_worktree().root() {
+        Ok(root) => root,
+        Err(_) => return Ok(None),
+    };
+
+    let config_path = root.join(".config").join("wt.toml");
+    if !config_path.exists() {
+        return Ok(None);
+    }
+
+    // Only update from main worktree (linked worktrees share the config)
+    let is_linked = repo.current_worktree().is_linked().unwrap_or(true);
+    if is_linked {
+        eprintln!(
+            "{}",
+            info_message("Project config update must run from main worktree")
+        );
+        return Ok(None);
+    }
+
+    let content = std::fs::read_to_string(&config_path).context("Failed to read project config")?;
+
+    let info = match worktrunk::config::check_and_migrate(
+        &config_path,
+        &content,
+        true, // warn_and_migrate
+        "Project config",
+        Some(&repo),
+        false, // silent mode
+    )? {
+        Some(info) if info.has_deprecations() => info,
+        _ => return Ok(None),
+    };
+
+    let new_path = match &info.migration_path {
+        Some(path) => path.clone(),
+        None => anyhow::bail!("Failed to write migration file for project config"),
+    };
+
+    Ok(Some(UpdateCandidate {
+        config_path,
+        new_path,
+        info,
+    }))
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -24,9 +24,9 @@ pub(crate) mod step_commands;
 pub(crate) mod worktree;
 
 pub(crate) use config::{
-    handle_config_create, handle_config_show, handle_hints_clear, handle_hints_get,
-    handle_logs_get, handle_state_clear, handle_state_clear_all, handle_state_get,
-    handle_state_set, handle_state_show,
+    handle_config_create, handle_config_show, handle_config_update, handle_hints_clear,
+    handle_hints_get, handle_logs_get, handle_state_clear, handle_state_clear_all,
+    handle_state_get, handle_state_set, handle_state_show,
 };
 pub(crate) use configure_shell::{
     handle_configure_shell, handle_show_theme, handle_unconfigure_shell,

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -798,17 +798,15 @@ pub fn format_migration_diff(original_path: &Path, new_path: &Path) -> Option<St
     None
 }
 
-/// Format deprecation details for display (for use by wt config show)
+/// Format deprecation warning lines (without apply hints or diff).
 ///
-/// Returns formatted output including:
-/// - Warning message listing deprecated patterns
-/// - Migration hint with apply command
-/// - Inline diff showing the changes
-pub fn format_deprecation_details(info: &DeprecationInfo) -> String {
+/// Lists which deprecated patterns were found: template variables, config sections,
+/// approved-commands. Used by both `format_deprecation_details` (which adds the "mv"
+/// hint) and `config migrate` (which applies automatically).
+pub fn format_deprecation_warnings(info: &DeprecationInfo) -> String {
     use std::fmt::Write;
     let mut out = String::new();
 
-    // Warning message listing deprecated patterns
     if !info.deprecations.vars.is_empty() {
         let var_list: Vec<String> = info
             .deprecations
@@ -872,6 +870,19 @@ pub fn format_deprecation_details(info: &DeprecationInfo) -> String {
             );
         }
     }
+
+    out
+}
+
+/// Format deprecation details for display (for use by `wt config show`).
+///
+/// Returns formatted output including:
+/// - Warning message listing deprecated patterns
+/// - Migration hint with apply command
+/// - Inline diff showing the changes
+pub fn format_deprecation_details(info: &DeprecationInfo) -> String {
+    use std::fmt::Write;
+    let mut out = format_deprecation_warnings(info);
 
     // Migration hint with apply command
     if let Some(new_path) = &info.migration_path {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -79,6 +79,8 @@ pub use deprecation::check_and_migrate;
 pub use deprecation::detect_deprecations;
 pub use deprecation::format_brief_warning;
 pub use deprecation::format_deprecation_details;
+pub use deprecation::format_deprecation_warnings;
+pub use deprecation::format_migration_diff;
 pub use deprecation::normalize_template_vars;
 pub use deprecation::write_migration_file;
 pub use deprecation::{DEPRECATED_SECTION_KEYS, key_belongs_in, warn_unknown_fields};

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,9 +47,9 @@ use commands::worktree::handle_push;
 use commands::{
     MergeOptions, OperationMode, RebaseResult, SquashResult, SwitchOptions, add_approvals,
     clear_approvals, handle_completions, handle_config_create, handle_config_show,
-    handle_configure_shell, handle_hints_clear, handle_hints_get, handle_hook_show, handle_init,
-    handle_list, handle_logs_get, handle_merge, handle_rebase, handle_remove,
-    handle_remove_current, handle_show_theme, handle_squash, handle_state_clear,
+    handle_config_update, handle_configure_shell, handle_hints_clear, handle_hints_get,
+    handle_hook_show, handle_init, handle_list, handle_logs_get, handle_merge, handle_rebase,
+    handle_remove, handle_remove_current, handle_show_theme, handle_squash, handle_state_clear,
     handle_state_clear_all, handle_state_get, handle_state_set, handle_state_show, handle_switch,
     handle_unconfigure_shell, resolve_worktree_arg, run_hook, step_commit, step_copy_ignored,
     step_for_each, step_relocate,
@@ -430,6 +430,7 @@ fn main() {
             }
             ConfigCommand::Create { project } => handle_config_create(project),
             ConfigCommand::Show { full } => handle_config_show(full),
+            ConfigCommand::Update { yes } => handle_config_update(yes),
             ConfigCommand::State { action } => match action {
                 StateCommand::DefaultBranch { action } => match action {
                     Some(DefaultBranchAction::Get) | None => {

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -2442,6 +2442,147 @@ approved-commands = ["npm install", "npm test"]
     );
 }
 
+// ==================== config update tests ====================
+
+/// `wt config update` with no deprecated settings reports nothing to do
+#[rstest]
+fn test_config_update_no_deprecations(repo: TestRepo) {
+    // Write a clean config with no deprecated patterns
+    fs::write(
+        repo.test_config_path(),
+        r#"worktree-path = "../{{ repo }}.{{ branch }}"
+"#,
+    )
+    .unwrap();
+
+    let settings = setup_snapshot_settings(&repo);
+    settings.bind(|| {
+        let mut cmd = repo.wt_command();
+        cmd.args(["config", "update", "--yes"]);
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
+/// `wt config update --yes` applies template variable migration
+#[rstest]
+fn test_config_update_applies_template_var_migration(repo: TestRepo) {
+    let config_path = repo.test_config_path();
+    fs::write(
+        config_path,
+        r#"worktree-path = "../{{ main_worktree }}.{{ branch }}"
+post-create = "ln -sf {{ repo_root }}/node_modules {{ worktree }}/node_modules"
+"#,
+    )
+    .unwrap();
+
+    let settings = setup_snapshot_settings(&repo);
+    settings.bind(|| {
+        let mut cmd = repo.wt_command();
+        cmd.args(["config", "update", "--yes"]);
+
+        assert_cmd_snapshot!(cmd);
+    });
+
+    // Config file should now contain the updated variables
+    let updated = fs::read_to_string(config_path).unwrap();
+    assert!(
+        updated.contains("{{ repo }}"),
+        "Should replace main_worktree with repo"
+    );
+    assert!(
+        updated.contains("{{ repo_path }}"),
+        "Should replace repo_root with repo_path"
+    );
+    assert!(
+        updated.contains("{{ worktree_path }}"),
+        "Should replace worktree with worktree_path"
+    );
+
+    // Migration .new file should be gone (renamed over original)
+    assert!(
+        !config_path.with_extension("toml.new").exists(),
+        ".new file should be consumed by the update"
+    );
+}
+
+/// `wt config update --yes` applies commit-generation section rename
+#[rstest]
+fn test_config_update_applies_commit_generation_migration(repo: TestRepo) {
+    let config_path = repo.test_config_path();
+    fs::write(
+        config_path,
+        r#"worktree-path = "../{{ repo }}.{{ branch }}"
+
+[commit-generation]
+command = "llm"
+args = ["-m", "haiku"]
+"#,
+    )
+    .unwrap();
+
+    let settings = setup_snapshot_settings(&repo);
+    settings.bind(|| {
+        let mut cmd = repo.wt_command();
+        cmd.args(["config", "update", "--yes"]);
+
+        assert_cmd_snapshot!(cmd);
+    });
+
+    // Config file should have the renamed section and merged args
+    let updated = fs::read_to_string(config_path).unwrap();
+    assert!(
+        updated.contains("[commit.generation]"),
+        "Should rename section"
+    );
+    assert!(
+        updated.contains("command = \"llm -m haiku\""),
+        "Should merge args into command"
+    );
+    assert!(
+        !updated.contains("[commit-generation]"),
+        "Old section name should be gone"
+    );
+    assert!(!updated.contains("args ="), "Args field should be removed");
+}
+
+/// `wt config update --yes` handles approved-commands migration
+#[rstest]
+fn test_config_update_applies_approved_commands_migration(repo: TestRepo) {
+    let config_path = repo.test_config_path();
+    fs::write(
+        config_path,
+        r#"worktree-path = "../{{ repo }}.{{ branch }}"
+
+[projects."github.com/user/repo"]
+approved-commands = ["npm install", "npm test"]
+"#,
+    )
+    .unwrap();
+
+    let settings = setup_snapshot_settings(&repo);
+    settings.bind(|| {
+        let mut cmd = repo.wt_command();
+        cmd.args(["config", "update", "--yes"]);
+
+        assert_cmd_snapshot!(cmd);
+    });
+
+    // Config should no longer have approved-commands
+    let updated = fs::read_to_string(config_path).unwrap();
+    assert!(
+        !updated.contains("approved-commands"),
+        "approved-commands should be removed from config"
+    );
+
+    // Approvals should be in approvals.toml
+    let approvals_file = config_path.with_file_name("approvals.toml");
+    assert!(approvals_file.exists(), "approvals.toml should exist");
+    let approvals = fs::read_to_string(&approvals_file).unwrap();
+    assert!(approvals.contains("npm install"));
+    assert!(approvals.contains("npm test"));
+}
+
 /// Test that explicitly specified --config path that doesn't exist shows a warning
 #[rstest]
 fn test_explicit_config_path_not_found_shows_warning(repo: TestRepo) {

--- a/tests/integration_tests/config_update_pty.rs
+++ b/tests/integration_tests/config_update_pty.rs
@@ -1,0 +1,78 @@
+#![cfg(all(unix, feature = "shell-integration-tests"))]
+//! PTY-based tests for `wt config update` interactive prompt.
+//!
+//! Tests the accept/decline flow in a real TTY environment.
+
+use crate::common::pty::{build_pty_command, exec_cmd_in_pty_prompted};
+use crate::common::{TestRepo, add_pty_filters, repo, setup_snapshot_settings, wt_bin};
+use insta::assert_snapshot;
+use rstest::rstest;
+use std::fs;
+
+/// Execute `wt config update` in a PTY, waiting for the confirmation prompt.
+fn exec_config_update_in_pty(
+    repo: &TestRepo,
+    env_vars: &[(String, String)],
+    input: &str,
+) -> (String, i32) {
+    let cmd = build_pty_command(
+        wt_bin().to_str().unwrap(),
+        &["config", "update"],
+        repo.root_path(),
+        env_vars,
+        None,
+    );
+    exec_cmd_in_pty_prompted(cmd, &[input], "[y/N")
+}
+
+fn config_update_pty_settings(repo: &TestRepo) -> insta::Settings {
+    let mut settings = setup_snapshot_settings(repo);
+    add_pty_filters(&mut settings);
+    settings
+}
+
+#[rstest]
+fn test_config_update_prompt_accept(repo: TestRepo) {
+    let config_path = repo.test_config_path();
+    fs::write(
+        config_path,
+        r#"worktree-path = "../{{ main_worktree }}.{{ branch }}"
+post-create = "ln -sf {{ repo_root }}/node_modules"
+"#,
+    )
+    .unwrap();
+
+    let env_vars = repo.test_env_vars();
+    let (output, exit_code) = exec_config_update_in_pty(&repo, &env_vars, "y\n");
+
+    assert_eq!(exit_code, 0);
+    config_update_pty_settings(&repo).bind(|| {
+        assert_snapshot!("config_update_prompt_accept", &output);
+    });
+
+    // Verify config was actually updated
+    let updated = fs::read_to_string(config_path).unwrap();
+    assert!(updated.contains("{{ repo }}"));
+    assert!(updated.contains("{{ repo_path }}"));
+}
+
+#[rstest]
+fn test_config_update_prompt_decline(repo: TestRepo) {
+    let config_path = repo.test_config_path();
+    let original_content = r#"worktree-path = "../{{ main_worktree }}.{{ branch }}"
+post-create = "ln -sf {{ repo_root }}/node_modules"
+"#;
+    fs::write(config_path, original_content).unwrap();
+
+    let env_vars = repo.test_env_vars();
+    let (output, exit_code) = exec_config_update_in_pty(&repo, &env_vars, "n\n");
+
+    assert_eq!(exit_code, 0);
+    config_update_pty_settings(&repo).bind(|| {
+        assert_snapshot!("config_update_prompt_decline", &output);
+    });
+
+    // Verify config was NOT changed
+    let content = fs::read_to_string(config_path).unwrap();
+    assert_eq!(content, original_content, "Config should be unchanged");
+}

--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -21,6 +21,7 @@ pub mod config_init;
 pub mod config_show;
 pub mod config_show_theme;
 pub mod config_state;
+pub mod config_update_pty;
 pub mod configure_shell;
 pub mod default_branch;
 pub mod diagnostic;

--- a/tests/snapshots/integration__integration_tests__config_show__config_update_applies_approved_commands_migration.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_update_applies_approved_commands_migration.snap
@@ -1,0 +1,56 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - update
+    - "--yes"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[33m▲[39m [33mUser config has approved-commands in [projects] sections (moved to approvals.toml)[39m
+[2m↳[22m [2mCopied approved commands to [90mapprovals.toml[39m[22m
+[107m [0m [1mdiff --git a[TEST_CONFIG] b[TEST_CONFIG_NEW][m
+[107m [0m [1mindex 51f8ab1..a30ca31 100644[m
+[107m [0m [1m--- a[TEST_CONFIG][m
+[107m [0m [1m+++ b[TEST_CONFIG_NEW][m
+[107m [0m [36m@@ -1,4 +1 @@[m
+[107m [0m  worktree-path = "../{{ repo }}.{{ branch }}"[m
+[107m [0m [31m-[m
+[107m [0m [31m-[projects."github.com/user/repo"][m
+[107m [0m [31m-approved-commands = ["npm install", "npm test"][m
+[32m✓[39m [32mUpdated user config[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_update_applies_commit_generation_migration.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_update_applies_commit_generation_migration.snap
@@ -1,0 +1,58 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - update
+    - "--yes"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[33m▲[39m [33mUser config uses deprecated config sections: [commit-generation] → [commit.generation][39m
+[107m [0m [1mdiff --git a[TEST_CONFIG] b[TEST_CONFIG_NEW][m
+[107m [0m [1mindex 40d0385..bc7273c 100644[m
+[107m [0m [1m--- a[TEST_CONFIG][m
+[107m [0m [1m+++ b[TEST_CONFIG_NEW][m
+[107m [0m [36m@@ -1,5 +1,4 @@[m
+[107m [0m  worktree-path = "../{{ repo }}.{{ branch }}"[m
+[107m [0m  [m
+[107m [0m [31m-[commit-generation][m
+[107m [0m [31m-command = "llm"[m
+[107m [0m [31m-args = ["-m", "haiku"][m
+[107m [0m [32m+[m[32m[commit.generation][m
+[107m [0m [32m+[m[32mcommand = "llm -m haiku"[m
+[32m✓[39m [32mUpdated user config[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_update_applies_template_var_migration.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_update_applies_template_var_migration.snap
@@ -1,0 +1,55 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - update
+    - "--yes"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[33m▲[39m [33mUser config uses deprecated template variables: [2mrepo_root[22m → [1mrepo_path[22m, [2mworktree[22m → [1mworktree_path[22m, [2mmain_worktree[22m → [1mrepo[22m[39m
+[107m [0m [1mdiff --git a[TEST_CONFIG] b[TEST_CONFIG_NEW][m
+[107m [0m [1mindex 89b3165..0643e7d 100644[m
+[107m [0m [1m--- a[TEST_CONFIG][m
+[107m [0m [1m+++ b[TEST_CONFIG_NEW][m
+[107m [0m [36m@@ -1,2 +1,2 @@[m
+[107m [0m [31m-worktree-path = "../{{ main_worktree }}.{{ branch }}"[m
+[107m [0m [31m-post-create = "ln -sf {{ repo_root }}/node_modules {{ worktree }}/node_modules"[m
+[107m [0m [32m+[m[32mworktree-path = "../{{ repo }}.{{ branch }}"[m
+[107m [0m [32m+[m[32mpost-create = "ln -sf {{ repo_path }}/node_modules {{ worktree_path }}/node_modules"[m
+[32m✓[39m [32mUpdated user config[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_update_no_deprecations.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_update_no_deprecations.snap
@@ -1,0 +1,45 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - update
+    - "--yes"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[2m○[22m No deprecated settings found

--- a/tests/snapshots/integration__integration_tests__config_update_pty__config_update_prompt_accept.snap
+++ b/tests/snapshots/integration__integration_tests__config_update_pty__config_update_prompt_accept.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration_tests/config_update_pty.rs
+expression: "&output"
+---
+[33m▲[39m [33mUser config uses deprecated template variables: [2mrepo_root[22m → [1mrepo_path[22m, [2mmain_worktree[22m → [1mrepo[22m[39m
+[107m [0m [1mdiff --git a[TEST_CONFIG] b[TEST_CONFIG_NEW][m
+[107m [0m [1mindex d95d100..ceb381d 100644[m
+[107m [0m [1m--- a[TEST_CONFIG][m
+[107m [0m [1m+++ b[TEST_CONFIG_NEW][m
+[107m [0m [36m@@ -1,2 +1,2 @@[m
+[107m [0m [31m-worktree-path = "../{{ main_worktree }}.{{ branch }}"[m
+[107m [0m [31m-post-create = "ln -sf {{ repo_root }}/node_modules"[m
+[107m [0m [32m+[m[32mworktree-path = "../{{ repo }}.{{ branch }}"[m
+[107m [0m [32m+[m[32mpost-create = "ln -sf {{ repo_path }}/node_modules"[m
+
+[36m❯[39m Apply updates? [1m[y/N/?][22m y
+[32m✓[39m [32mUpdated user config[39m

--- a/tests/snapshots/integration__integration_tests__config_update_pty__config_update_prompt_decline.snap
+++ b/tests/snapshots/integration__integration_tests__config_update_pty__config_update_prompt_decline.snap
@@ -1,0 +1,17 @@
+---
+source: tests/integration_tests/config_update_pty.rs
+expression: "&output"
+---
+[33m▲[39m [33mUser config uses deprecated template variables: [2mrepo_root[22m → [1mrepo_path[22m, [2mmain_worktree[22m → [1mrepo[22m[39m
+[107m [0m [1mdiff --git a[TEST_CONFIG] b[TEST_CONFIG_NEW][m
+[107m [0m [1mindex d95d100..ceb381d 100644[m
+[107m [0m [1m--- a[TEST_CONFIG][m
+[107m [0m [1m+++ b[TEST_CONFIG_NEW][m
+[107m [0m [36m@@ -1,2 +1,2 @@[m
+[107m [0m [31m-worktree-path = "../{{ main_worktree }}.{{ branch }}"[m
+[107m [0m [31m-post-create = "ln -sf {{ repo_root }}/node_modules"[m
+[107m [0m [32m+[m[32mworktree-path = "../{{ repo }}.{{ branch }}"[m
+[107m [0m [32m+[m[32mpost-create = "ln -sf {{ repo_path }}/node_modules"[m
+
+[36m❯[39m Apply updates? [1m[y/N/?][22m n
+[2m○[22m Update cancelled

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -40,6 +40,7 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
   [1m[36mshell[0m   Shell integration setup
   [1m[36mcreate[0m  Create configuration file
   [1m[36mshow[0m    Show configuration files & locations
+  [1m[36mupdate[0m  Update deprecated config settings
   [1m[36mstate[0m   Manage internal data and cache
 
 [1m[32mOptions:[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_short.snap
@@ -15,10 +15,13 @@ info:
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
+    WORKTRUNK_APPROVALS_PATH: /nonexistent/test/approvals.toml
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_SYSTEM_CONFIG_PATH: /etc/xdg/worktrunk/config.toml
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
 ---
@@ -35,6 +38,7 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
   [1m[36mshell[0m   Shell integration setup
   [1m[36mcreate[0m  Create configuration file
   [1m[36mshow[0m    Show configuration files & locations
+  [1m[36mupdate[0m  Update deprecated config settings
   [1m[36mstate[0m   Manage internal data and cache
 
 [1m[32mOptions:[0m


### PR DESCRIPTION
## Summary

- Adds `wt config update` — detects deprecated config patterns, previews changes with a diff, and applies with confirmation (`--yes` to skip prompt)
- Extracts `format_deprecation_warnings()` as a shared helper to avoid duplicating warning formatting between `config show` and `config update`
- Uses `get_config_path()` (respects `WORKTRUNK_CONFIG_PATH` and `--config`) for user config resolution

## Test plan

- [x] 4 non-interactive snapshot tests: no deprecations, template vars, commit-generation, approved-commands
- [x] 2 PTY-based interactive tests: prompt accept and decline flows
- [x] 1057 integration tests pass, 530 unit tests pass
- [x] All lints clean (`pre-commit run --all-files`)

> _This was written by Claude Code on behalf of @max-sixty_