### PR TITLE
fix(ci): allow issue triage for external contributors

### DIFF
--- a/.github/workflows/claude-issue-triage.yaml
+++ b/.github/workflows/claude-issue-triage.yaml
@@ -74,6 +74,8 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Use bot token so pushed commits trigger CI workflows
           github_token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
+          # Triage runs for all new issues, including from external contributors
+          allowed_non_write_users: '*'
           additional_permissions: |
             actions: read
 


### PR DESCRIPTION
## Summary
- The `claude-issue-triage` workflow was failing for issues opened by users without write permissions (e.g., external contributor `jdb8` opening issues #1084 and #1085)
- Added `allowed_non_write_users: '*'` so triage runs for all new issues regardless of author permissions

## Test plan
- [ ] Verify CI passes on this PR
- [ ] After merge, confirm next issue opened by an external contributor triggers triage successfully

> _This was written by Claude Code on behalf of max-sixty_

🤖 Generated with [Claude Code](https://claude.com/claude-code)