### PR TITLE
Point deprecation warnings to `wt config update`

### DIFF
--- a/src/commands/config/update.rs
+++ b/src/commands/config/update.rs
@@ -85,7 +85,7 @@ pub fn handle_config_update(yes: bool) -> anyhow::Result<()> {
 fn format_update_preview(info: &DeprecationInfo) -> String {
     let mut out = format_deprecation_warnings(info);
 
-    // Show diff (without the "mv" apply hint that format_deprecation_details adds)
+    // Show diff (without the hint that format_deprecation_details adds)
     if let Some(new_path) = &info.migration_path
         && let Some(diff) = format_migration_diff(&info.config_path, new_path)
     {

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -29,10 +29,7 @@ use shell_escape::unix::escape;
 
 use crate::config::WorktrunkConfig;
 use crate::shell_exec::Cmd;
-use crate::styling::{
-    eprintln, format_bash_with_gutter, format_with_gutter, hint_message, info_message,
-    warning_message,
-};
+use crate::styling::{eprintln, format_with_gutter, hint_message, warning_message};
 
 /// Tracks which config paths have already shown deprecation warnings this process.
 /// Prevents repeated warnings when config is loaded multiple times.
@@ -678,29 +675,9 @@ pub fn check_and_migrate(
         }
 
         // Still write migration file if needed (first time only)
-        if !should_skip_write
-            && let Some(new_path) = write_migration_file(path, content, &info.deprecations, repo)
-        {
-            // Show apply hint for first-time migration file write
-            let new_filename = new_path
-                .file_name()
-                .map(|n| n.to_string_lossy())
-                .unwrap_or_default();
-            let new_path_str = escape(new_path.to_slash_lossy());
-            let path_str = escape(path.to_slash_lossy());
-
-            eprintln!(
-                "{}",
-                info_message(cformat!(
-                    "Wrote migrated <bold>{new_filename}</>. To apply:"
-                ))
-            );
-            eprintln!(
-                "{}",
-                format_bash_with_gutter(&format!("mv -- {} {}", new_path_str, path_str))
-            );
-
-            info.migration_path = Some(new_path);
+        // The file is needed for `wt config update` / `wt config show` to work
+        if !should_skip_write {
+            info.migration_path = write_migration_file(path, content, &info.deprecations, repo);
         }
 
         std::io::stderr().flush().ok();
@@ -722,7 +699,7 @@ pub fn check_and_migrate(
 /// caller is responsible for output.
 pub fn format_brief_warning(label: &str) -> String {
     warning_message(cformat!(
-        "{} has deprecated settings. To see details, run <bold>wt config show</>",
+        "{} has deprecated settings. Run <bold>wt config show</> for details or <bold>wt config update</> to apply updates",
         label
     ))
     .to_string()
@@ -801,8 +778,8 @@ pub fn format_migration_diff(original_path: &Path, new_path: &Path) -> Option<St
 /// Format deprecation warning lines (without apply hints or diff).
 ///
 /// Lists which deprecated patterns were found: template variables, config sections,
-/// approved-commands. Used by both `format_deprecation_details` (which adds the "mv"
-/// hint) and `config migrate` (which applies automatically).
+/// approved-commands. Used by both `format_deprecation_details` (which adds the
+/// `wt config update` hint and diff) and `wt config update` (which applies directly).
 pub fn format_deprecation_warnings(info: &DeprecationInfo) -> String {
     use std::fmt::Write;
     let mut out = String::new();
@@ -886,31 +863,15 @@ pub fn format_deprecation_details(info: &DeprecationInfo) -> String {
 
     // Migration hint with apply command
     if let Some(new_path) = &info.migration_path {
-        let new_filename = new_path
-            .file_name()
-            .map(|n| n.to_string_lossy())
-            .unwrap_or_default();
-        // Shell-escape paths for safe copy/paste
-        let new_path_str = escape(new_path.to_slash_lossy());
-        let path_str = escape(info.config_path.to_slash_lossy());
-
         let _ = writeln!(
             out,
             "{}",
-            info_message(cformat!(
-                "Wrote migrated <bold>{new_filename}</>. To apply:"
-            ))
-        );
-        let _ = writeln!(
-            out,
-            "{}",
-            format_bash_with_gutter(&format!("mv -- {} {}", new_path_str, path_str))
+            hint_message(cformat!("Run <bright-black>wt config update</> to apply"))
         );
 
-        // Inline diff with intro
+        // Inline diff — git diff header shows the file paths
         if let Some(diff) = format_migration_diff(&info.config_path, new_path) {
-            let _ = writeln!(out, "{}", info_message("Diff:"));
-            let _ = writeln!(out, "{}", diff);
+            let _ = writeln!(out, "{diff}");
         }
     } else if info.in_linked_worktree {
         // In linked worktree - migration file is written to main worktree
@@ -918,7 +879,7 @@ pub fn format_deprecation_details(info: &DeprecationInfo) -> String {
             out,
             "{}",
             hint_message(cformat!(
-                "To generate migration file, run <bright-black>wt config show</> from main worktree",
+                "Run <bright-black>wt config update</> from main worktree to apply",
             ))
         );
     }

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
@@ -46,9 +46,7 @@ exit_code: 0
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
 [33m▲[39m [33mProject config uses deprecated template variables: [2mmain_worktree[22m → [1mrepo[22m[39m
-[2m○[22m Wrote migrated [1mwt.toml.new[22m. To apply:
-[107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m _REPO_/.config/wt.toml.new _REPO_/.config/wt.toml
-[2m○[22m Diff:
+[2m↳[22m [2mRun [90mwt config update[39m to apply[22m
 [107m [0m [1mdiff --git a_REPO_/.config/wt.toml b_REPO_/.config/wt.toml.new[m
 [107m [0m [1mindex 8fcdb47..42cb136 100644[m
 [107m [0m [1m--- a_REPO_/.config/wt.toml[m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
@@ -43,9 +43,7 @@ exit_code: 0
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUser config uses deprecated template variables: [2mrepo_root[22m → [1mrepo_path[22m, [2mmain_worktree[22m → [1mrepo[22m[39m
-[2m○[22m Wrote migrated [1mconfig.toml.new[22m. To apply:
-[107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEMP_HOME]/.config/worktrunk/config.toml.new [TEMP_HOME]/.config/worktrunk/config.toml
-[2m○[22m Diff:
+[2m↳[22m [2mRun [90mwt config update[39m to apply[22m
 [107m [0m [1mdiff --git a[TEMP_HOME]/.config/worktrunk/config.toml b[TEMP_HOME]/.config/worktrunk/config.toml.new
 [107m [0m [1mindex d95d100..ceb381d 100644[m
 [107m [0m [1m--- a[TEMP_HOME]/.config/worktrunk/config.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
@@ -43,9 +43,7 @@ exit_code: 0
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUser config uses deprecated config sections: [projects."github.com/example/repo".commit-generation] → [projects."github.com/example/repo".commit.generation][39m
-[2m○[22m Wrote migrated [1mconfig.toml.new[22m. To apply:
-[107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEMP_HOME]/.config/worktrunk/config.toml.new [TEMP_HOME]/.config/worktrunk/config.toml
-[2m○[22m Diff:
+[2m↳[22m [2mRun [90mwt config update[39m to apply[22m
 [107m [0m [1mdiff --git a[TEMP_HOME]/.config/worktrunk/config.toml b[TEMP_HOME]/.config/worktrunk/config.toml.new
 [107m [0m [1mindex de80729..131a2fd 100644[m
 [107m [0m [1m--- a[TEMP_HOME]/.config/worktrunk/config.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
@@ -46,7 +46,7 @@ exit_code: 0
 
 [36mPROJECT CONFIG[39m  [PROJECT_ID]
 [33m▲[39m [33mProject config uses deprecated template variables: [2mmain_worktree[22m → [1mrepo[22m[39m
-[2m↳[22m [2mTo generate migration file, run [90mwt config show[39m from main worktree[22m
+[2m↳[22m [2mRun [90mwt config update[39m from main worktree to apply[22m
 [2m○[22m Current config:
 [107m [0m post-create = [32m"ln -sf {{ main_worktree }}/node_modules"
 

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
@@ -47,9 +47,7 @@ exit_code: 0
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
 [33m▲[39m [33mProject config uses deprecated config sections: [commit-generation] → [commit.generation][39m
-[2m○[22m Wrote migrated [1mwt.toml.new[22m. To apply:
-[107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m _REPO_/.config/wt.toml.new _REPO_/.config/wt.toml
-[2m○[22m Diff:
+[2m↳[22m [2mRun [90mwt config update[39m to apply[22m
 [107m [0m [1mdiff --git a_REPO_/.config/wt.toml b_REPO_/.config/wt.toml.new[m
 [107m [0m [1mindex 074c30f..bcaf404 100644[m
 [107m [0m [1m--- a_REPO_/.config/wt.toml[m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_approved_commands_copies_to_approvals_file.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_approved_commands_copies_to_approvals_file.snap
@@ -47,7 +47,5 @@ exit_code: 0
 [2m○[22m [2mShowing 4 worktrees, 3 ahead
 
 ----- stderr -----
-[33m▲[39m [33mUser config has deprecated settings. To see details, run [1mwt config show[22m[39m
+[33m▲[39m [33mUser config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
 [2m↳[22m [2mCopied approved commands to [90mapprovals.toml[39m[22m
-[2m○[22m Wrote migrated [1mtest-config.toml.new[22m. To apply:
-[107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEST_CONFIG_NEW] [TEST_CONFIG]

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_project_level_shows_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_project_level_shows_warning.snap
@@ -47,6 +47,4 @@ exit_code: 0
 [2m○[22m [2mShowing 4 worktrees, 3 ahead
 
 ----- stderr -----
-[33m▲[39m [33mUser config has deprecated settings. To see details, run [1mwt config show[22m[39m
-[2m○[22m Wrote migrated [1mtest-config.toml.new[22m. To apply:
-[107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEST_CONFIG_NEW] [TEST_CONFIG]
+[33m▲[39m [33mUser config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_section_shows_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_section_shows_warning.snap
@@ -47,6 +47,4 @@ exit_code: 0
 [2m○[22m [2mShowing 4 worktrees, 3 ahead
 
 ----- stderr -----
-[33m▲[39m [33mUser config has deprecated settings. To see details, run [1mwt config show[22m[39m
-[2m○[22m Wrote migrated [1mtest-config.toml.new[22m. To apply:
-[107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEST_CONFIG_NEW] [TEST_CONFIG]
+[33m▲[39m [33mUser config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_show_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_show_warning.snap
@@ -47,6 +47,4 @@ exit_code: 0
 [2m○[22m [2mShowing 4 worktrees, 3 ahead
 
 ----- stderr -----
-[33m▲[39m [33mUser config has deprecated settings. To see details, run [1mwt config show[22m[39m
-[2m○[22m Wrote migrated [1mtest-config.toml.new[22m. To apply:
-[107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEST_CONFIG_NEW] [TEST_CONFIG]
+[33m▲[39m [33mUser config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_verbose_shows_content.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_verbose_shows_content.snap
@@ -48,9 +48,7 @@ exit_code: 0
 [2m○[22m [2mShowing 4 worktrees, 3 ahead
 
 ----- stderr -----
-[33m▲[39m [33mUser config has deprecated settings. To see details, run [1mwt config show[22m[39m
-[2m○[22m Wrote migrated [1mtest-config.toml.new[22m. To apply:
-[107m [0m [2m[0m[2m[34mmv[0m[2m [0m[2m[36m--[0m[2m [TEST_CONFIG_NEW] [TEST_CONFIG]
+[33m▲[39m [33mUser config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
 [2m○[22m Expanding [1mworktree-path[22m
 [107m [0m ../{{ main_worktree }}.{{ branch }} [2m→[22m ../repo.feature-a
 [2m○[22m Expanding [1mworktree-path[22m

--- a/tests/snapshots/integration__integration_tests__config_show__wt_list_skips_migration_file_after_first_write.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__wt_list_skips_migration_file_after_first_write.snap
@@ -24,10 +24,13 @@ info:
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -44,4 +47,4 @@ exit_code: 0
 [2m○[22m [2mShowing 4 worktrees, 1 with changes, 3 ahead
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. To see details, run [1mwt config show[22m[39m
+[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m


### PR DESCRIPTION
## Summary

- Brief deprecation warning now mentions both `wt config show` (for details) and `wt config update` (to apply)
- `wt config show` suggests `wt config update` instead of showing `mv` command
- Linked worktree hint updated to suggest `wt config update` from main worktree
- Removed `○ Diff:` label — git diff header already shows the files, gutter attaches to the hint above

## Test plan

- [x] All 1057 tests pass
- [x] All lints pass
- [x] Snapshot tests updated for new message wording

> _This was written by Claude Code on behalf of maximilian_