### PR TITLE
fix(ci): fix artifact upload path and review skill quoting

### DIFF
--- a/.github/workflows/claude-ci-fix.yaml
+++ b/.github/workflows/claude-ci-fix.yaml
@@ -154,6 +154,6 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: claude-session-logs
-          path: ~/.claude/
+          path: ${{ env.HOME }}/.claude/
           retention-days: 30
           if-no-files-found: warn

--- a/.github/workflows/claude-issue-triage.yaml
+++ b/.github/workflows/claude-issue-triage.yaml
@@ -92,6 +92,6 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: claude-session-logs
-          path: ~/.claude/
+          path: ${{ env.HOME }}/.claude/
           retention-days: 30
           if-no-files-found: warn

--- a/.github/workflows/claude-mention.yaml
+++ b/.github/workflows/claude-mention.yaml
@@ -97,6 +97,6 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: claude-session-logs
-          path: ~/.claude/
+          path: ${{ env.HOME }}/.claude/
           retention-days: 30
           if-no-files-found: warn

--- a/.github/workflows/claude-renovate.yaml
+++ b/.github/workflows/claude-renovate.yaml
@@ -117,6 +117,6 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: claude-session-logs
-          path: ~/.claude/
+          path: ${{ env.HOME }}/.claude/
           retention-days: 30
           if-no-files-found: warn

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -65,6 +65,6 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: claude-session-logs
-          path: ~/.claude/
+          path: ${{ env.HOME }}/.claude/
           retention-days: 30
           if-no-files-found: warn


### PR DESCRIPTION
## Summary

- Fix `upload-artifact` path across all 5 `claude-*.yaml` workflows — `~` isn't expanded by the action, changed to `${{ env.HOME }}/.claude/`
- Fix GraphQL quoting in `worktrunk-review` skill step 4 — the `"'"$BOT_LOGIN"'"` quote-nesting pattern was consistently mangled by Claude, replaced with `jq --arg` piping

## Test plan

- [ ] Verify next claude-review run uploads artifacts successfully
- [ ] Verify thread resolution step in review skill doesn't produce GraphQL errors

> _This was written by Claude Code on behalf of @max-sixty_