### PR TITLE
fix: centralize shell quoting guidance for CI skills

### DIFF
--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -148,15 +148,8 @@ Always comment via `gh issue comment`. Keep it brief, polite, and specific. A
 maintainer will always review — never claim the issue is fully resolved by
 automation alone.
 
-**Use heredoc to avoid shell quoting issues** — inline `--body "..."` causes
-Claude to over-escape characters like `!`:
-
-```bash
-gh issue comment $ARGUMENTS --body "$(cat <<'EOF'
-Your comment here — no escaping needed inside heredoc.
-EOF
-)"
-```
+Use the heredoc pattern from `/running-in-ci` for `--body` arguments to avoid
+shell quoting issues (e.g., `!` getting escaped as `\!`).
 
 Choose the appropriate template:
 

--- a/.claude/skills/running-in-ci/SKILL.md
+++ b/.claude/skills/running-in-ci/SKILL.md
@@ -45,6 +45,37 @@ comment. `claude-code-action` automatically adds these to the comment header.
 Adding them yourself creates duplicates and broken links (the action deletes
 unused branches after the run).
 
+## Shell Quoting in `gh` Commands
+
+Claude tends to mangle shell quoting in CI. Two common failure modes:
+
+1. **`$` in GraphQL queries** — `gh api graphql -f query='...$var...'` fails
+   because Claude corrupts the `$` signs. Write queries to a temp file instead:
+
+   ```bash
+   cat > /tmp/query.graphql << 'GRAPHQL'
+   query($owner: String!, $repo: String!, $name: String!) {
+     repository(owner: $owner, name: $name) { ... }
+   }
+   GRAPHQL
+
+   gh api graphql -F query=@/tmp/query.graphql -f owner="$OWNER" -f name="$NAME"
+   ```
+
+2. **`!` in comment/body text** — `gh issue comment N --body "Thanks!"` gets
+   over-escaped to `Thanks\!` because `!` is a bash history expansion character.
+   Use a heredoc:
+
+   ```bash
+   gh issue comment N --body "$(cat <<'EOF'
+   Comment text here — no escaping needed.
+   EOF
+   )"
+   ```
+
+**General rule:** When a `gh` command argument contains `$` or `!`, use either
+a temp file (`-F field=@file`) or a heredoc with a quoted delimiter (`<<'EOF'`).
+
 ## Tone
 
 You are a helpful reviewer raising observations, not a manager assigning work.

--- a/.claude/skills/worktrunk-review/SKILL.md
+++ b/.claude/skills/worktrunk-review/SKILL.md
@@ -109,12 +109,10 @@ have been addressed. For each unresolved bot thread, you've already read the
 file during review — if the suggestion was applied or the issue was otherwise
 fixed, resolve the thread:
 
-**IMPORTANT: GraphQL queries with `$` variables fail when passed inline** —
-Claude mangles the quoting. Always write the query to a file first, then use
-`-F query=@file`.
+Use the file-based GraphQL pattern from `/running-in-ci` to avoid quoting
+issues with `$` variables:
 
 ```bash
-# Step 1: Write query to temp file (quoted heredoc delimiter prevents $ expansion)
 cat > /tmp/review-threads.graphql << 'GRAPHQL'
 query($owner: String!, $repo: String!, $number: Int!) {
   repository(owner: $owner, name: $repo) {
@@ -138,7 +136,6 @@ query($owner: String!, $repo: String!, $number: Int!) {
 }
 GRAPHQL
 
-# Step 2: Run query using -F query=@file (reads from file, no shell quoting issues)
 REPO=$(gh repo view --json nameWithOwner --jq '.nameWithOwner')
 BOT_LOGIN=$(gh api user --jq '.login')
 OWNER=$(echo "$REPO" | cut -d/ -f1)


### PR DESCRIPTION
## Summary

- Add "Shell Quoting in `gh` Commands" section to `running-in-ci` skill with patterns for `$` (file-based GraphQL) and `!` (heredoc for `--body`)
- Update `worktrunk-review` and `issue-triage` to reference the centralized guidance instead of duplicating it
- Fixes GraphQL `$` variable mangling and `\!` over-escaping in bot comments

## Test plan

- [x] Verified `-F query=@file` works locally against real PR
- [ ] Next claude-review and issue-triage CI runs should work without quoting errors

> _This was written by Claude Code on behalf of max-sixty_