### PR TITLE
fix: omnibus demo — session manager, LSP dialog

### DIFF
--- a/docs/demos/shared/lib.py
+++ b/docs/demos/shared/lib.py
@@ -456,6 +456,7 @@ def setup_claude_code_config(
                 },
                 "officialMarketplaceAutoInstalled": True,
                 "effortCalloutDismissed": True,
+                "lspRecommendationDisabled": True,
                 "tipsHistory": {
                     "new-user-warmup": 100,
                     "terminal-setup": 100,
@@ -573,6 +574,7 @@ keybinds clear-defaults=true {{
         bind "Ctrl Space" {{ SwitchToMode "tmux"; }}
     }}
     tmux {{
+        bind "o" {{ SwitchToMode "pane"; }}
         bind "p" {{ SwitchToMode "pane"; }}
         bind "t" {{ SwitchToMode "tab"; }}
         bind "q" {{ Quit; }}
@@ -585,6 +587,9 @@ keybinds clear-defaults=true {{
         bind "2" {{ GoToTab 2; SwitchToMode "Normal"; }}
         bind "3" {{ GoToTab 3; SwitchToMode "Normal"; }}
         bind "4" {{ GoToTab 4; SwitchToMode "Normal"; }}
+    }}
+    pane {{
+        bind "n" {{ NewPane; SwitchToMode "Normal"; }}
     }}
     shared_except "locked" {{
         bind "Ctrl t" {{ NewTab; }}

--- a/docs/demos/shared/validation.py
+++ b/docs/demos/shared/validation.py
@@ -28,16 +28,14 @@ from pathlib import Path
 # Forbidden patterns must ALL be absent (case-insensitive).
 
 TUI_CHECKPOINTS: dict[str, list[tuple[int, list[str], list[str]]]] = {
-    # Frame numbers calibrated with permissions cache fix (no permission dialog).
-    # At 30fps: frame 100 = ~3.3s, frame 500 = ~16.7s, frame 2060 = ~68.7s
+    # Frame numbers calibrated after removing initial wt list (demo starts with picker).
+    # At 30fps: frame 200 = ~6.7s, frame 1750 = ~58.3s
     "wt-zellij-omnibus": [
-        # Frame 100: After wt list - should see branch table, no permission dialog
-        (100, ["Branch", "Status", "main", "hooks"], ["Allow?", "permission"]),
-        # Frame 300: Claude UI visible on TAB 1 (api) - shows Opus model and task
-        (300, ["Opus", "acme", "Add a test"], ["command not found", "Unknown command"]),
-        # Frame 1980: Near end - wt list --full showing all worktrees
-        # (shifted ~75 frames earlier after removing wt list before wt remove)
-        (1980, ["Branch", "main", "feature", "billing"], ["CONFLICT", "error:", "failed"]),
+        # Frame 200: Claude UI visible on TAB 1 (api) - shows Opus model and task
+        (200, ["Opus", "acme", "Add a test"], ["command not found", "Unknown command"]),
+        # Frame 1750: Near end - wt list --full showing all worktrees
+        # (feature removed by wt remove in TAB 3)
+        (1750, ["Branch", "main", "billing"], ["CONFLICT", "error:", "failed"]),
     ],
 }
 

--- a/docs/demos/tapes/wt-zellij-omnibus.tape
+++ b/docs/demos/tapes/wt-zellij-omnibus.tape
@@ -13,15 +13,14 @@ Output "{{OUTPUT_GIF}}"
 # 4. Each Zellij tab shows a distinct workflow
 #
 # Tab structure:
-#   TAB 1: wt list → wt switch api → claude (simple task)
+#   TAB 1: wt switch (picker → api) → claude (simple task)
 #   TAB 2: [NEW TAB] wsl abbreviation (wt switch -x claude --create) → claude
-#   TAB 3: [NEW TAB] wt switch --create → wt step commit → git push
-#   TAB 4: [NEW TAB] wt switch (picker) → wt remove → wt list --full
+#   TAB 3: [NEW TAB] wt switch --create → wt step commit → git push → wt remove → wt list --full
 #   Then back to TAB 1: [NEW PANE] git diff → wt merge (on Claude's completed work)
 #
 # Features demonstrated:
 # - wt list / wt list --full (URLs, CI status, diff stats)
-# - wt switch (simple navigation + interactive picker)
+# - wt switch (interactive picker)
 # - wsl abbreviation (wt switch --execute=claude --create)
 # - wt switch --create (with post-start hooks)
 # - wt step commit (LLM commit message, standalone)
@@ -38,7 +37,7 @@ Env ANTHROPIC_API_KEY "{{ANTHROPIC_API_KEY}}"
 # Pre-install marketplace plugin before recording
 Type "claude plugin marketplace add anthropics/claude-plugins-official"
 Enter
-Sleep 5s
+Sleep 10s
 # Start Zellij before showing
 Type "zellij"
 Enter
@@ -56,28 +55,17 @@ Sleep 500ms
 Show
 Sleep 500ms
 
-# ==== TAB 1: Overview and simple navigation ====
-# Start with wt list to see all worktrees
-Type "wt list"
+# ==== TAB 1: Interactive picker and Claude agent ====
+# wt switch (no args) - opens interactive picker
+Type "wt switch"
 Enter
-Sleep 3s
+Sleep 1.5s
 
-# Simple switch with Tab completion - navigate to existing worktree
-# Inside Zellij, fish completion needs a moment to render after Tab.
-# - "wt switch a" + pause → let fish process input
-# - Tab → triggers completion menu (alpha/api/auth)
-# - 500ms pause → menu renders and viewer reads it
-# - Tab → cycles to api
-# - 300ms → see selection
-# - Enter → accepts (dismisses pager), 50ms, Enter → executes
-Type "wt switch a"
-Sleep 200ms
-Tab
-Sleep 500ms
-Tab
-Sleep 300ms
-Enter
-Sleep 50ms
+# Filter to api branch
+Type "api"
+Sleep 1s
+
+# Select it
 Enter
 Sleep 1.5s
 
@@ -88,8 +76,11 @@ Enter
 Sleep 5.5s
 
 # ==== TAB 2: wsl abbreviation (creates billing, launches Claude) ====
-# [NEW TAB] - Ctrl+t creates new Zellij tab (starts in demo repo via default_cwd)
-Ctrl+t
+# [NEW TAB] via session manager (Ctrl+Space → tab mode → new)
+# Direct Ctrl+t is intercepted by Claude Code's TUI, so use session manager.
+Ctrl+Space
+Sleep 200ms
+Type "tn"
 Sleep 2s
 
 # wsl abbreviation expands to: wt switch --execute=claude --create
@@ -102,10 +93,12 @@ Sleep 500ms
 Enter
 Sleep 6s
 
-# ==== TAB 3: Create, commit, push workflow ====
-# This tab shows wt step commit as a standalone feature
-# [NEW TAB]
-Ctrl+t
+# ==== TAB 3: Create, commit, push, remove workflow ====
+# This tab shows wt step commit as a standalone feature, then cleanup
+# [NEW TAB] via session manager
+Ctrl+Space
+Sleep 200ms
+Type "tn"
 Sleep 2s
 
 # wt switch --create - shows post-start hooks running
@@ -128,30 +121,12 @@ Type "git push -u origin feature"
 Enter
 Sleep 2s
 
-# ==== TAB 4: Interactive picker, list, and cleanup ====
-# [NEW TAB]
-Ctrl+t
-Sleep 2s
-
-# wt switch (no args) - opens interactive picker
-Type "wt switch"
-Enter
-Sleep 1.5s
-
-# Filter to auth branch
-Type "au"
-Sleep 1s
-
-# Select it
-Enter
-Sleep 1.5s
-
-# wt remove - delete current worktree (we're in auth)
+# wt remove - done with feature, clean up
 Type "wt remove"
 Enter
 Sleep 3s
 
-# wt list --full - shows what changed
+# wt list --full - show remaining worktrees
 Type "wt list --full"
 Enter
 Sleep 3.5s
@@ -164,7 +139,11 @@ Type "t1"
 Sleep 2s
 
 # Open new pane for git diff and merge (like original zellij demo)
-Ctrl+n
+# Use session manager (Ctrl+Space → pane mode → new) since Ctrl+n is
+# intercepted by Claude Code's TUI running in the active pane.
+Ctrl+Space
+Sleep 200ms
+Type "on"
 Sleep 1.2s
 
 # Show what Claude changed
@@ -187,19 +166,13 @@ Sleep 200ms
 Type "t2"
 Sleep 1.5s
 
-# TAB 3: feature branch (already pushed)
+# TAB 3: show final state with wt list --full
 Ctrl+Space
 Sleep 200ms
 Type "t3"
-Sleep 1.5s
-
-# TAB 4: show final state with wt list --full
-Ctrl+Space
-Sleep 200ms
-Type "t4"
 Sleep 1s
 
-# Show comprehensive list of all worktrees
+# Show comprehensive list of all worktrees (post-merge state)
 Type "wt list --full"
 Enter
 Sleep 3s


### PR DESCRIPTION
## Summary

- Replace `Ctrl+t`/`Ctrl+n` with Zellij session manager sequences (`Ctrl+Space` → `tn`/`on`) to avoid Claude Code TUI intercepting keystrokes
- Remove initial `wt list` — demo now starts directly with the interactive picker
- Increase marketplace install sleep (5s → 10s) for reliability
- Suppress LSP plugin recommendation dialog via `lspRecommendationDisabled`
- Update OCR validation checkpoints for new frame timing

## Test plan

- [x] Demo builds successfully (`./docs/demos/build docs --only wt-zellij-omnibus`)
- [x] OCR validation passes (both frame checkpoints)
- [x] Visual review of key frames confirms no errors

> _This was written by Claude Code on behalf of @max-sixty_