### PR TITLE
Rename worktrunk-review skill to pr-review

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: worktrunk-review
+name: pr-review
 description: Reviews a pull request for idiomatic Rust, project conventions, and code quality. Use when asked to review a PR or when running as an automated PR reviewer.
 argument-hint: "[PR number]"
 ---

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -54,7 +54,7 @@ jobs:
           # Bot now puts feedback in review bodies instead of stdout, so this may be a no-op.
           use_sticky_comment: true
           prompt: |
-            Use /worktrunk-review ${{ github.event.pull_request.number }}
+            Use /pr-review ${{ github.event.pull_request.number }}
           claude_args: |
             --model opus
             --allowedTools Bash,Edit,Read,Write,Glob,Grep,WebSearch,WebFetch,Task,Skill


### PR DESCRIPTION
## Summary

- Rename `.claude/skills/worktrunk-review/` to `.claude/skills/pr-review/` — the project name is redundant since the skill lives inside the project
- Update the GitHub Actions workflow to invoke `/pr-review` instead of `/worktrunk-review`

## Test plan

- [x] Verify skill appears as `pr-review` in the skills list
- [ ] CI passes

> _This was written by Claude Code on behalf of @max-sixty_

🤖 Generated with [Claude Code](https://claude.com/claude-code)