### PR TITLE
fix: upload session logs from correct path in claude-review CI

### DIFF
--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -65,6 +65,6 @@ jobs:
         uses: actions/upload-artifact@v6
         with:
           name: claude-session-logs
-          path: ${{ env.HOME }}/.claude/
+          path: /home/runner/.claude/projects/
           retention-days: 30
           if-no-files-found: warn


### PR DESCRIPTION
## Summary

- `${{ env.HOME }}` in the artifact upload path resolved to empty string (it looks up the workflow `env:` block, not shell `$HOME`), so session logs were never uploaded
- Hardcode `/home/runner/.claude/projects/` — correct for the pinned `ubuntu-24.04` runner, and narrows to just session transcripts instead of all of `~/.claude/`

## Test plan

- [ ] Next claude-review run uploads artifacts successfully (no "No files were found" warning)

> _This was written by Claude Code on behalf of @max-sixty_