### PR TITLE
feat: enable Summary column in all demo GIFs

### DIFF
--- a/docs/demos/build
+++ b/docs/demos/build
@@ -84,7 +84,7 @@ def _add_staged_validation(env: DemoEnv):
 
 
 def _write_user_config(
-    env: DemoEnv, approved_commands: list[str], commit_generation: bool = False
+    env: DemoEnv, approved_commands: list[str], commit_generation: bool = True
 ):
     """Write worktrunk user config and approvals."""
     config_dir = env.home / ".config" / "worktrunk"
@@ -97,8 +97,11 @@ def _write_user_config(
 command = "llm -m claude-haiku-4.5"
 
 """
-    if config_content:
-        (config_dir / "config.toml").write_text(config_content)
+    config_content += """[list]
+summary = true
+
+"""
+    (config_dir / "config.toml").write_text(config_content)
 
     # Approvals (machine-local trust state, separate from config)
     approvals_content = f'[projects."{project_id}"]\n'
@@ -230,19 +233,35 @@ url = "http://localhost:{{ branch | hash_port }}"
 
     # Override llm mock with different commit message for this demo
     llm_mock = env.home / ".local" / "bin" / "llm"
-    llm_mock.write_text("""#!/bin/bash
-sleep 0.5
-echo "feat: add user settings module"
-echo ""
-echo "Add placeholder module for user profile settings."
+    llm_mock.write_text(r"""#!/bin/bash
+input=$(cat)
+
+if echo "$input" | grep -qi "summary"; then
+    # Summary generation — return branch-appropriate one-liner
+    if echo "$input" | grep -q "utils\.rs"; then
+        echo "Add utility functions module with string and math helpers"
+    elif echo "$input" | grep -q "notes\.txt"; then
+        echo "Add TODO notes for caching improvements"
+    elif echo "$input" | grep -q "multiply\|subtract\|math"; then
+        echo "Add math operations and consolidate tests"
+    elif echo "$input" | grep -q "User settings"; then
+        echo "Add user settings module placeholder"
+    else
+        echo "Expand README with contributing and license sections"
+    fi
+else
+    # Commit message generation
+    sleep 0.5
+    echo "feat: add user settings module"
+    echo ""
+    echo "Add placeholder module for user profile settings."
+fi
 """)
     llm_mock.chmod(0o755)
 
-    # User config with LLM commit generation
     _write_user_config(
         env,
         ["npm run dev -- --port {{ branch | hash_port }}", "cargo nextest run"],
-        commit_generation=True,
     )
 
     # Zellij + Fish configs (with --create in wsl abbreviation)

--- a/docs/demos/shared/lib.py
+++ b/docs/demos/shared/lib.py
@@ -709,14 +709,33 @@ fi
 """)
     flyctl_mock.chmod(0o755)
 
-    # llm mock - simulates LLM commit message generation
+    # llm mock - simulates both commit message and summary generation.
+    # Reads stdin to detect prompt type: summary prompts contain "summary",
+    # commit prompts don't. For summaries, returns branch-appropriate one-liners
+    # based on filenames in the diff.
     llm_mock = bin_dir / "llm"
-    llm_mock.write_text("""#!/bin/bash
-sleep 0.5
-echo "feat(validation): add input validation utilities"
-echo ""
-echo "Add validation module with is_positive and is_non_empty helpers"
-echo "for validating user input. Includes comprehensive test coverage."
+    llm_mock.write_text(r"""#!/bin/bash
+input=$(cat)
+
+if echo "$input" | grep -qi "summary"; then
+    # Summary generation — return branch-appropriate one-liner
+    if echo "$input" | grep -q "utils\.rs"; then
+        echo "Add utility functions module with string and math helpers"
+    elif echo "$input" | grep -q "notes\.txt"; then
+        echo "Add TODO notes for caching improvements"
+    elif echo "$input" | grep -q "multiply\|subtract\|math"; then
+        echo "Add math operations and consolidate tests"
+    else
+        echo "Expand README with contributing and license sections"
+    fi
+else
+    # Commit message generation
+    sleep 0.5
+    echo "feat(validation): add input validation utilities"
+    echo ""
+    echo "Add validation module with is_positive and is_non_empty helpers"
+    echo "for validating user input. Includes comprehensive test coverage."
+fi
 """)
     llm_mock.chmod(0o755)
 


### PR DESCRIPTION
## Summary

- LLM mock handles both commit messages and summary generation via stdin branching
- `_write_user_config` defaults to `commit_generation=True` and always writes `[list] summary = true`
- All demos showing `wt list --full` (wt-core, wt-list, wt-zellij-omnibus) now display the Summary column

## Test plan

- [ ] `./docs/demos/build docs --only wt-list` — verify Summary column in `wt list --full`
- [ ] `./docs/demos/build docs --only wt-core` — same
- [ ] Demos without `wt list --full` unaffected (extra config is harmless)

> _This was written by Claude Code on behalf of @max-sixty_