### PR TITLE
refactor: unify LLM mock — remove omnibus override

### DIFF
--- a/docs/demos/build
+++ b/docs/demos/build
@@ -231,34 +231,6 @@ url = "http://localhost:{{ branch | hash_port }}"
     # Enable git colors for non-TTY environments (VHS)
     git(["-C", str(env.repo), "config", "color.ui", "always"])
 
-    # Override llm mock with different commit message for this demo
-    llm_mock = env.home / ".local" / "bin" / "llm"
-    llm_mock.write_text(r"""#!/bin/bash
-input=$(cat)
-
-if echo "$input" | grep -qi "summary"; then
-    # Summary generation — return branch-appropriate one-liner
-    if echo "$input" | grep -q "utils\.rs"; then
-        echo "Add utility functions module with string and math helpers"
-    elif echo "$input" | grep -q "notes\.txt"; then
-        echo "Add TODO notes for caching improvements"
-    elif echo "$input" | grep -q "multiply\|subtract\|math"; then
-        echo "Add math operations and consolidate tests"
-    elif echo "$input" | grep -q "User settings"; then
-        echo "Add user settings module placeholder"
-    else
-        echo "Expand README with contributing and license sections"
-    fi
-else
-    # Commit message generation
-    sleep 0.5
-    echo "feat: add user settings module"
-    echo ""
-    echo "Add placeholder module for user profile settings."
-fi
-""")
-    llm_mock.chmod(0o755)
-
     _write_user_config(
         env,
         ["npm run dev -- --port {{ branch | hash_port }}", "cargo nextest run"],

--- a/docs/demos/shared/lib.py
+++ b/docs/demos/shared/lib.py
@@ -725,16 +725,17 @@ if echo "$input" | grep -qi "summary"; then
         echo "Add TODO notes for caching improvements"
     elif echo "$input" | grep -q "multiply\|subtract\|math"; then
         echo "Add math operations and consolidate tests"
+    elif echo "$input" | grep -q "User settings"; then
+        echo "Add user settings module placeholder"
     else
         echo "Expand README with contributing and license sections"
     fi
 else
     # Commit message generation
     sleep 0.5
-    echo "feat(validation): add input validation utilities"
+    echo "feat: add user settings module"
     echo ""
-    echo "Add validation module with is_positive and is_non_empty helpers"
-    echo "for validating user input. Includes comprehensive test coverage."
+    echo "Add placeholder module for user profile settings."
 fi
 """)
     llm_mock.chmod(0o755)


### PR DESCRIPTION
## Summary

- Remove the omnibus-specific LLM mock override from `build`
- Use the shared mock from `lib.py` for all demos (same commit message, same summary branches)
- Net -27 lines

## Test plan

- [ ] `./docs/demos/build docs --only wt-zellij-omnibus --text` builds without error

> _This was written by Claude Code on behalf of @max-sixty_