### PR TITLE
fix: prevent panic in statusline when no LLM command configured

### DIFF
--- a/src/commands/list/collect/tasks.rs
+++ b/src/commands/list/collect/tasks.rs
@@ -664,10 +664,12 @@ impl Task for SummaryGenerateTask {
     const KIND: TaskKind = TaskKind::SummaryGenerate;
 
     fn compute(ctx: TaskContext) -> Result<TaskResult, TaskError> {
-        let llm_command = ctx
-            .llm_command
-            .as_deref()
-            .expect("SummaryGenerateTask requires llm_command");
+        let Some(ref llm_command) = ctx.llm_command else {
+            return Err(ctx.error(
+                Self::KIND,
+                &anyhow::anyhow!("SummaryGenerateTask requires llm_command"),
+            ));
+        };
 
         let branch = ctx.branch_ref.branch.as_deref().unwrap_or("(detached)");
         let worktree_path = ctx.branch_ref.worktree_path.as_deref();


### PR DESCRIPTION
## Summary

- `wt list statusline` panicked when `SummaryGenerateTask` ran without an LLM command configured
- The statusline path (`populate_item`) bypasses `collect()` where the `SummaryGenerate` skip guard lived, so the task hit an `.expect()` with `llm_command: None`
- Added guards in `work_items_for_worktree` and `work_items_for_branch` to skip `SummaryGenerate` when `llm_command` is `None`, and converted the `.expect()` to a proper `TaskError` return

## Test plan

- [x] Reproduced the panic with `wt list statusline`
- [x] Verified fix: statusline now renders without panic
- [x] Added `test_no_llm_command_skips_summary_generate` unit test
- [x] All 550 unit tests pass
- [x] All 1077 integration tests pass
- [x] All lints pass

> _This was written by Claude Code on behalf of @max-sixty_