### PR TITLE
fix: stabilize flaky test_switch_picker_respects_list_config

### DIFF
--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -831,6 +831,12 @@ fn test_switch_picker_preview_panel_summary(mut repo: TestRepo) {
 
 #[rstest]
 fn test_switch_picker_respects_list_config(mut repo: TestRepo) {
+    // Use the same reliable setup as test_switch_picker_with_branches:
+    // remove fixture worktrees (which use relative gitdir paths that can fail
+    // to resolve under concurrent operations) and origin (to avoid remote branch noise)
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["remote", "remove", "origin"]);
+
     repo.add_worktree("active-worktree");
     // Create a branch without a worktree
     let output = repo


### PR DESCRIPTION
## Summary

- Remove fixture worktrees and origin remote before test setup in `test_switch_picker_respects_list_config`, matching the pattern used by every other PTY-based switch picker test
- Fixture worktrees use relative gitdir paths that can fail to resolve under concurrent test operations, causing intermittent failures (~10-20% of runs showing 4 items instead of expected 6)

## Test plan

- [x] Test passes consistently: 20/20 loop runs (previously ~10-20% failure rate)
- [x] Full integration test suite: 1211 passed, 0 failed
- [x] All lints pass

> _This was written by Claude Code on behalf of @max-sixty_