### PR TITLE
docs: add guidelines to prevent panics in fallible code

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -96,6 +96,9 @@ tactical checklist.
 - Are there edge cases that aren't handled?
 - Could the changes break existing functionality?
 - Are error messages helpful and consistent with the project style?
+- Does new code use `.expect()` or `.unwrap()` in functions returning `Result`?
+  These should use `?` or `bail!` instead — panics in fallible code bypass error
+  handling.
 
 **Testing:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -331,6 +331,7 @@ if worktree.is_dirty() {
 
 - **Use `bail!`** for business logic errors (dirty worktree, missing branch, invalid state)
 - **Use `.context()`** for wrapping I/O and external command failures
+- **Never `.expect()` or `.unwrap()` in functions returning `Result`** — use `?`, `bail!`, or return an error. Panics in fallible code bypass error handling.
 - **Don't `logger.error` before raising** — include context in the error message itself
 - **Let errors propagate** — don't catch and re-raise without adding information
 


### PR DESCRIPTION
## Summary

- Post-incident improvements from the statusline panic (#1107)
- Add error handling rule to CLAUDE.md: never `.expect()`/`.unwrap()` in functions returning `Result`
- Add correctness check to pr-review skill: flag panics in fallible code during review
- Document in `work_items_for_worktree`/`work_items_for_branch` docstrings that task preconditions are enforced here (the decision point), not in callers

## Test plan

- [x] `cargo test --lib --bins` — 550 passed
- [x] `pre-commit run --all-files` — all passed
- [x] Changes are documentation/comments only; no behavior change

> _This was written by Claude Code on behalf of @max-sixty_