### PR TITLE
docs: automate version bump in release skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -13,7 +13,7 @@ description: Worktrunk release workflow. Use when user asks to "do a release", "
 4. **Credit contributors**: Check for external PR authors and issue reporters (see "Credit External Contributors" and "Credit Issue Reporters" below)
 5. **Confirm release type with user**: Present changes summary and ask user to confirm patch/minor/major (see below)
 6. **Update CHANGELOG**: Add `## X.Y.Z` section at top with changes (see MANDATORY verification below)
-7. **Bump version**: Update `version` in `Cargo.toml`, run `cargo check` to update `Cargo.lock`
+7. **Bump version**: `cargo release X.Y.Z -p worktrunk -x --no-publish --no-push --no-tag --no-verify --no-confirm && cargo check`
 8. **Commit**: `git add -A && git commit -m "Release vX.Y.Z"`
 9. **Merge to main**: `wt merge --no-remove` (rebases onto main, pushes, keeps worktree)
 10. **Tag and push**: `git tag vX.Y.Z && git push origin vX.Y.Z`


### PR DESCRIPTION
## Summary

- Replace manual "edit Cargo.toml" instruction in release skill step 7 with `cargo release X.Y.Z -p worktrunk -x --no-publish --no-push --no-tag --no-verify --no-confirm`
- Single command bumps version in `Cargo.toml` and applies `pre-release-replacements` (updating the skill version marker in `skills/worktrunk/SKILL.md`)
- Matches the pattern used by [PRQL](https://github.com/PRQL/prql), which switched from the two-step approach (`cargo release version` + `cargo release replace`) to the combined command for `prev_version` template variable support

## Test plan

- [ ] Verify next release uses the new command successfully

> _This was written by Claude Code on behalf of @max-sixty_