### PR TITLE
demos: set IS_DEMO env var in shared tape commands

### DIFF
--- a/docs/demos/tapes/shared-commands.tape
+++ b/docs/demos/tapes/shared-commands.tape
@@ -3,6 +3,7 @@ Require wt
 Require git
 
 Env CLAUDECODE ""
+Env IS_DEMO "1"
 Env GIT_TERMINAL_PROMPT "0"
 Env DEMO_REPO "{{DEMO_REPO}}"
 Env RUSTUP_HOME "{{REAL_HOME}}/.rustup"


### PR DESCRIPTION
## Summary
- Add `IS_DEMO=1` to `shared-commands.tape` so all demo recordings hide email/org from the Claude Code UI

## Test plan
- [ ] Rebuild a demo that launches Claude Code (e.g., `wt-switch`) and verify no account info in header

> _This was written by Claude Code on behalf of @max-sixty_