### PR TITLE
ci: review Dependabot PRs and enable fix handoff

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -249,6 +249,30 @@ fixed line content here
   direct suggestion.
 - Multi-line suggestions: set `start_line` and `line` to define the range.
 
+### 6. Request fixes on bot PRs
+
+The review workflow is read-only (`contents: read`) and cannot push fixes. For
+bot PRs (Dependabot, renovate, etc.), request fixes via the `@claude` mention
+workflow, which has write access and can push commits to the PR branch.
+
+**When to use:** The review found concrete, fixable issues (CI failures, missing
+test updates, small code problems) on a bot-authored PR. Don't use this for
+human PRs — leave suggestions for the author instead.
+
+After submitting the review, post a separate comment:
+
+```bash
+gh pr comment <number> --body "@claude The review found issues on this Dependabot PR. Please fix:
+
+- [specific issue 1]
+- [specific issue 2]
+
+See the review comments for details."
+```
+
+This triggers the `claude-mention` workflow, which checks out the PR branch,
+applies fixes, and pushes. CI reruns automatically.
+
 ## How to provide feedback
 
 - Use inline review comments for specific code issues. Prefer suggestion format

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -1,7 +1,7 @@
 name: claude-review
 # Runner versions pinned; see ci.yaml header comment for rationale.
 
-# Automatic code review on PRs from external contributors.
+# Automatic code review on non-draft PRs.
 # Uses pull_request_target so secrets are available for fork PRs.
 on:
   pull_request_target:
@@ -17,13 +17,12 @@ env:
 
 jobs:
   review:
-    # Skip draft PRs and bot PRs (e.g. Dependabot)
+    # Skip draft PRs.
     # To skip PRs from repo members, uncomment the author_association conditions:
     # github.event.pull_request.author_association != 'OWNER' &&
     # github.event.pull_request.author_association != 'MEMBER' &&
     if: >-
-      github.event.pull_request.draft == false &&
-      github.event.pull_request.user.type != 'Bot'
+      github.event.pull_request.draft == false
     runs-on: ubuntu-24.04
     permissions:
       contents: read # Read-only: review workflow should not push code


### PR DESCRIPTION
## Summary

- Remove bot-author filter from `claude-review` workflow so Dependabot PRs get Claude review
- Add step 6 to pr-review skill: when the reviewer finds fixable issues on a bot PR, post `@claude` comment to trigger the mention workflow for fixes

The mention workflow already has write access and can push commits to PR branches. This gives Dependabot PRs the same review coverage as human PRs, and a path to automated fixes without giving any bot merge permissions.

## Test plan

- [ ] Verify next Dependabot PR triggers `claude-review` workflow (previously skipped)
- [ ] Verify `@claude` comment on a Dependabot PR triggers `claude-mention` and can push fixes

> _This was written by Claude Code on behalf of @max-sixty_