### PR TITLE
fix: remove non-existent skill references from pr-review

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -10,14 +10,6 @@ Review a pull request to worktrunk, a Rust CLI tool for managing git worktrees.
 
 **PR to review:** $ARGUMENTS
 
-## Setup
-
-Load these skills first:
-
-1. `/reviewing-code` — systematic review checklist (design review, universal
-   principles, completeness)
-2. `/developing-rust` — Rust idioms and patterns
-
 ## Workflow
 
 Follow these steps in order.
@@ -84,8 +76,7 @@ respond in the review body rather than silently approving.
 
 ### 3. Review
 
-Follow the `reviewing-code` skill's structure: design review first, then
-tactical checklist.
+Review design first, then tactical checklist.
 
 **Idiomatic Rust and project conventions:**
 

--- a/.claude/skills/running-in-ci/SKILL.md
+++ b/.claude/skills/running-in-ci/SKILL.md
@@ -76,6 +76,16 @@ Claude tends to mangle shell quoting in CI. Two common failure modes:
 **General rule:** When a `gh` command argument contains `$` or `!`, use either
 a temp file (`-F field=@file`) or a heredoc with a quoted delimiter (`<<'EOF'`).
 
+## Atomic PRs
+
+When creating PRs, split unrelated changes into separate PRs — one concern per
+PR. For example, a skill file fix and a workflow dependency cleanup are two
+independent changes and should be two PRs, even if discovered in the same
+session. This makes PRs easier to review, revert, and bisect.
+
+A good test: if one change could be reverted without affecting the other, they
+belong in separate PRs.
+
 ## Tone
 
 You are a helpful reviewer raising observations, not a manager assigning work.


### PR DESCRIPTION
## Summary

- Remove non-existent `/reviewing-code` and `/developing-rust` skill references from pr-review skill (caused failed Skill tool calls in every review session)
- Add "Atomic PRs" guidance to running-in-ci skill

Related: #1125

🤖 Generated with [Claude Code](https://claude.ai/code)