### PR TITLE
fix: instruct CI Claude to create PRs directly when asked

### DIFF
--- a/.claude/skills/running-in-ci/SKILL.md
+++ b/.claude/skills/running-in-ci/SKILL.md
@@ -12,6 +12,12 @@ NEVER run commands that could expose secrets (`env`, `printenv`, `set`,
 environment variables, API keys, tokens, or credentials in responses or
 comments.
 
+## PR Creation
+
+When the triggering comment asks for a PR (e.g., "make a new PR", "open a PR",
+"create a PR"), create it directly with `gh pr create`. The comment is the
+user's explicit request — don't downgrade it to a compare link.
+
 ## CI Monitoring
 
 After pushing changes to a PR branch, monitor CI until all checks pass:


### PR DESCRIPTION
## Summary

- Add "PR Creation" guidance to the `running-in-ci` skill so CI Claude uses `gh pr create` instead of providing a compare link when the triggering comment asks for a PR

Context: https://github.com/max-sixty/worktrunk/pull/1125 — the final `@claude` comment asked to "make a new PR", but Claude pushed a branch and posted a compare link instead of creating the PR directly. The global CLAUDE.md lists PR creation under "High-Confidence Actions" requiring explicit request, but in CI the `@claude` comment *is* the explicit request.

## Test plan

- [x] Doc sync test passes (`test_command_pages_and_skill_files_are_in_sync`)
- [ ] Next CI `@claude` comment requesting a PR should use `gh pr create`

> _This was written by Claude Code on behalf of @max-sixty_