### PR TITLE
fix: use gutter for config update hint and add -C for linked worktrees

### DIFF
--- a/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
@@ -46,7 +46,8 @@ exit_code: 0
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
 [33m▲[39m [33mProject config uses deprecated template variables: [2mmain_worktree[22m → [1mrepo[22m[39m
-[2m↳[22m [2mRun [90mwt config update[39m to apply[22m
+[2m↳[22m [2mTo apply:[22m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config update
 [107m [0m [1mdiff --git a_REPO_/.config/wt.toml b_REPO_/.config/wt.toml.new[m
 [107m [0m [1mindex 8fcdb47..42cb136 100644[m
 [107m [0m [1m--- a_REPO_/.config/wt.toml[m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
@@ -43,7 +43,8 @@ exit_code: 0
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUser config uses deprecated template variables: [2mrepo_root[22m → [1mrepo_path[22m, [2mmain_worktree[22m → [1mrepo[22m[39m
-[2m↳[22m [2mRun [90mwt config update[39m to apply[22m
+[2m↳[22m [2mTo apply:[22m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config update
 [107m [0m [1mdiff --git a[TEMP_HOME]/.config/worktrunk/config.toml b[TEMP_HOME]/.config/worktrunk/config.toml.new
 [107m [0m [1mindex d95d100..ceb381d 100644[m
 [107m [0m [1m--- a[TEMP_HOME]/.config/worktrunk/config.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
@@ -43,7 +43,8 @@ exit_code: 0
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUser config uses deprecated config sections: [projects."github.com/example/repo".commit-generation] → [projects."github.com/example/repo".commit.generation][39m
-[2m↳[22m [2mRun [90mwt config update[39m to apply[22m
+[2m↳[22m [2mTo apply:[22m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config update
 [107m [0m [1mdiff --git a[TEMP_HOME]/.config/worktrunk/config.toml b[TEMP_HOME]/.config/worktrunk/config.toml.new
 [107m [0m [1mindex de80729..131a2fd 100644[m
 [107m [0m [1m--- a[TEMP_HOME]/.config/worktrunk/config.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
@@ -46,7 +46,8 @@ exit_code: 0
 
 [36mPROJECT CONFIG[39m  [PROJECT_ID]
 [33m▲[39m [33mProject config uses deprecated template variables: [2mmain_worktree[22m → [1mrepo[22m[39m
-[2m↳[22m [2mRun [90mwt config update[39m from main worktree to apply[22m
+[2m↳[22m [2mTo apply:[22m
+[107m [0m [2m[0m[2m[34mwt[0m[2m [0m[2m[36m-C[0m[2m _REPO_ config update
 [2m○[22m Current config:
 [107m [0m post-create = [32m"ln -sf {{ main_worktree }}/node_modules"
 

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
@@ -47,7 +47,8 @@ exit_code: 0
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
 [33m▲[39m [33mProject config uses deprecated config sections: [commit-generation] → [commit.generation][39m
-[2m↳[22m [2mRun [90mwt config update[39m to apply[22m
+[2m↳[22m [2mTo apply:[22m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config update
 [107m [0m [1mdiff --git a_REPO_/.config/wt.toml b_REPO_/.config/wt.toml.new[m
 [107m [0m [1mindex 074c30f..bcaf404 100644[m
 [107m [0m [1m--- a_REPO_/.config/wt.toml[m


### PR DESCRIPTION
## Summary

- Show the `wt config update` command in a gutter block so it's easy to copy-paste from the terminal
- For linked worktrees, inject `-C <main_worktree>` so the command works from any worktree
- Replace `DeprecationInfo.in_linked_worktree: bool` with `main_worktree_path: Option<PathBuf>` to carry the actual path needed for the hint
- Fix `wt config update` to only show the linked-worktree hint when there are actual deprecations (previously showed unconditionally)

## Test plan

- [x] All 1084 integration tests pass
- [x] 5 snapshots updated to reflect new gutter formatting
- [x] Lints clean

> _This was written by Claude Code on behalf of @max-sixty_