### PR TITLE
feat: respond to comments on bot PRs without @claude

### DIFF
--- a/.claude/skills/running-in-ci/SKILL.md
+++ b/.claude/skills/running-in-ci/SKILL.md
@@ -5,6 +5,28 @@ description: CI environment rules for GitHub Actions workflows. Use when operati
 
 # Running in CI
 
+## First Steps — Read Context
+
+When triggered by a comment or issue, read the full context before responding.
+The prompt provides a URL — extract the PR/issue number from it.
+
+For PRs:
+
+```bash
+gh pr view <number> --json title,body,comments,reviews,state,statusCheckRollup
+gh pr diff <number>
+gh pr checks <number>
+```
+
+For issues:
+
+```bash
+gh issue view <number> --json title,body,comments,state
+```
+
+Read the triggering comment, the PR/issue description, the diff (for PRs), and
+recent comments to understand the full conversation before taking action.
+
 ## Security
 
 NEVER run commands that could expose secrets (`env`, `printenv`, `set`,

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -96,7 +96,7 @@ The review workflow is the only one where these paths diverge: checkout uses the
 |----------|-------------------|-------------------|-------------|
 | **review** | PR diff content | Full (any external PR) | Fixed prompt, merge restriction, `contents: read` on checkout |
 | **triage** | Issue body | Partial (structured skill) | Fixed prompt, merge restriction, environment protection |
-| **mention** | Comment body | Full | Restricted to write-access users |
+| **mention** | Comment body | Full | Fixed prompt, merge restriction, fork check on inline review comments |
 | **ci-fix** | Failed CI logs | Minimal (must break CI on main) | Fixed prompt, automatic trigger |
 | **renovate** | None | None | Fixed prompt, scheduled trigger |
 
@@ -132,7 +132,7 @@ These two workflows explicitly exclude each other to avoid double-processing:
 - Issue body contains `@claude` → triage skips, mention handles it
 - Issue body does not contain `@claude` → triage handles it, mention ignores it
 
-Consequence: external users (no write access) who open issues with `@claude` get **neither** triage nor a mention response. This is the accepted trade-off — `@claude` is a maintainer tool.
+The mention workflow runs for any user who includes `@claude` — the merge restriction (ruleset) is the safety boundary, not access control on the workflow itself.
 
 ## GitHub API: issue_comment vs pull_request_review_comment
 
@@ -145,6 +145,7 @@ The `claude-mention` workflow handles both with separate checkout steps.
 
 ## Rules for modifying workflows
 
+- **No role-based gating**: Workflows should not check `author_association` (OWNER, MEMBER, etc.) to decide whether to run. The merge restriction (ruleset) is the security boundary — Claude cannot merge regardless of who triggers it. Use technical criteria instead: fork detection, loop prevention (exclude the bot's own comments), `@claude` trigger phrase.
 - **Adding `allowed_non_write_users`** to a workflow with user-controlled prompts requires security review.
 - **All Claude workflows** must include `--append-system-prompt "You are operating in a GitHub Actions CI environment. Use /running-in-ci before starting work."`.
 - **Token choice**: All Claude workflows use `BOT_TOKEN` for consistent identity. The merge restriction (ruleset) is the security boundary.

--- a/.github/workflows/claude-mention.yaml
+++ b/.github/workflows/claude-mention.yaml
@@ -18,7 +18,13 @@ env:
 
 jobs:
   claude:
-    # Only run when body/comment contains @claude.
+    # Run for:
+    # 1. @claude mentions in issues/PRs/comments
+    # 2. Any comment on worktrunk-bot PRs (loop prevention: exclude bot's own comments)
+    #
+    # Always runs in agent mode (prompt). The prompt tells Claude what happened
+    # and where to look; Claude reads the full context itself via gh/skills.
+    #
     # Note: secrets cannot be used in job-level `if:` (actions/runner#520) —
     # doing so causes GitHub to fail the workflow on push validation. For review
     # comments on fork PRs (which don't receive secrets), we detect forks via
@@ -26,7 +32,9 @@ jobs:
     if: |
       (github.event_name == 'issues' && contains(github.event.issue.body, '@claude')) ||
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.pull_request.head.repo.full_name == github.repository)
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.issue.user.login == 'worktrunk-bot' && github.event.comment.user.login != 'worktrunk-bot') ||
+      (github.event_name == 'pull_request_review_comment' && github.event.pull_request.user.login == 'worktrunk-bot' && github.event.comment.user.login != 'worktrunk-bot' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-24.04
     permissions:
       contents: write # Allow pushing commits
@@ -47,6 +55,18 @@ jobs:
         run: |
           git config --global user.name "Claude Code"
           git config --global user.email "claude@anthropic.com"
+
+      - name: 👀 React to comment
+        if: github.event.comment
+        run: |
+          # Try issue comment endpoint first, then review comment endpoint.
+          # One will match depending on the comment type.
+          gh api "repos/$REPO/issues/comments/$COMMENT_ID/reactions" -f content=eyes 2>/dev/null || \
+          gh api "repos/$REPO/pulls/comments/$COMMENT_ID/reactions" -f content=eyes 2>/dev/null || true
+        env:
+          REPO: ${{ github.repository }}
+          COMMENT_ID: ${{ github.event.comment.id }}
+          GH_TOKEN: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
 
       - name: 📌 Check out PR branch (conversation comment)
         if: github.event.issue.pull_request
@@ -101,9 +121,21 @@ jobs:
           # Use bot token so pushed commits trigger CI workflows
           github_token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
 
-          # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read
+
+          # Always agent mode. The prompt tells Claude what happened; the
+          # /running-in-ci skill instructs it to read full context via gh.
+          prompt: >-
+            ${{ github.event.comment.html_url
+              && format(
+                'A user commented ({0}). Read the full issue or PR (description, diff, recent comments, CI status) and respond to their feedback. If they''re requesting changes, make the changes, commit, and push. If they''re asking a question, answer it.',
+                github.event.comment.html_url
+              )
+              || format(
+                'An issue was opened or updated ({0}). Read it and respond.',
+                github.event.issue.html_url
+              ) }}
 
           claude_args: |
             --model opus


### PR DESCRIPTION
## Summary

The `claude-mention` workflow now fires on any comment on `worktrunk-bot` PRs — no `@claude` required. Claude behaves like a reliable colleague: eyes reaction for acknowledgment, reads full context via `gh`, responds naturally.

- Always agent mode (no dual tag/agent switching)
- Bot-PR comment triggers with loop prevention (`!= 'worktrunk-bot'`)
- Eyes reaction right after checkout for fast feedback
- `running-in-ci` skill teaches Claude to read PR/issue context in agent mode
- Security docs fixed: mention was never restricted to write-access users
- Added no-role-gating rule to workflow modification guidelines

## Test plan

- [ ] Comment on a `worktrunk-bot` PR without `@claude` — workflow should trigger
- [ ] Comment with `@claude` on any issue/PR — workflow should still trigger
- [ ] Verify eyes reaction appears on the comment
- [ ] Verify Claude reads PR context (description, diff, comments) before responding

> _This was written by Claude Code on behalf of @max-sixty_