### PR TITLE
feat: change CI bot trigger from @claude to @worktrunk-bot

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -316,7 +316,7 @@ fixed line content here
 ### 6. Request fixes on bot PRs
 
 The review workflow is read-only (`contents: read`) and cannot push fixes. For
-bot PRs (Dependabot, renovate, etc.), request fixes via the `@claude` mention
+bot PRs (Dependabot, renovate, etc.), request fixes via the `@worktrunk-bot` mention
 workflow, which has write access and can push commits to the PR branch.
 
 **When to use:** The review found concrete, fixable issues (CI failures, missing
@@ -326,7 +326,7 @@ human PRs — leave suggestions for the author instead.
 After submitting the review, post a separate comment:
 
 ```bash
-gh pr comment <number> --body "@claude The review found issues on this Dependabot PR. Please fix:
+gh pr comment <number> --body "@worktrunk-bot The review found issues on this Dependabot PR. Please fix:
 
 - [specific issue 1]
 - [specific issue 2]

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -1,6 +1,6 @@
 # CI Automation Security Model
 
-Five Claude-powered workflows automate issue triage, PR review, CI fixes, dependency updates, and `@claude` mentions.
+Five Claude-powered workflows automate issue triage, PR review, CI fixes, dependency updates, and `@worktrunk-bot` mentions.
 
 ## Security layers
 
@@ -129,10 +129,10 @@ This is why release secrets must be in a protected environment, not repo-level s
 ## Triage ↔ mention handoff
 
 These two workflows explicitly exclude each other to avoid double-processing:
-- Issue body contains `@claude` → triage skips, mention handles it
-- Issue body does not contain `@claude` → triage handles it, mention ignores it
+- Issue body contains `@worktrunk-bot` → triage skips, mention handles it
+- Issue body does not contain `@worktrunk-bot` → triage handles it, mention ignores it
 
-The mention workflow runs for any user who includes `@claude` — the merge restriction (ruleset) is the safety boundary, not access control on the workflow itself.
+The mention workflow runs for any user who includes `@worktrunk-bot` — the merge restriction (ruleset) is the safety boundary, not access control on the workflow itself.
 
 ## GitHub API: issue_comment vs pull_request_review_comment
 
@@ -145,7 +145,7 @@ The `claude-mention` workflow handles both with separate checkout steps.
 
 ## Rules for modifying workflows
 
-- **No role-based gating**: Workflows should not check `author_association` (OWNER, MEMBER, etc.) to decide whether to run. The merge restriction (ruleset) is the security boundary — Claude cannot merge regardless of who triggers it. Use technical criteria instead: fork detection, loop prevention (exclude the bot's own comments), `@claude` trigger phrase.
+- **No role-based gating**: Workflows should not check `author_association` (OWNER, MEMBER, etc.) to decide whether to run. The merge restriction (ruleset) is the security boundary — Claude cannot merge regardless of who triggers it. Use technical criteria instead: fork detection, loop prevention (exclude the bot's own comments), `@worktrunk-bot` trigger phrase.
 - **Adding `allowed_non_write_users`** to a workflow with user-controlled prompts requires security review.
 - **All Claude workflows** must include `--append-system-prompt "You are operating in a GitHub Actions CI environment. Use /running-in-ci before starting work."`.
 - **Token choice**: All Claude workflows use `BOT_TOKEN` for consistent identity. The merge restriction (ruleset) is the security boundary.

--- a/.github/workflows/claude-issue-triage.yaml
+++ b/.github/workflows/claude-issue-triage.yaml
@@ -19,7 +19,7 @@ env:
 
 jobs:
   triage:
-    # Skip bot-created issues, @claude mentions (handled by claude-mention.yaml),
+    # Skip bot-created issues, @worktrunk-bot mentions (handled by claude-mention.yaml),
     # and issues from worktrunk-bot (nightly workflows, ci-fix, etc.). Nightly
     # workflows handle their own remediation because they have richer context
     # (session logs, aggregate diffs) that would be lost if the triager
@@ -27,8 +27,8 @@ jobs:
     if: >-
       github.event.issue.user.type != 'Bot' &&
       github.event.issue.user.login != 'worktrunk-bot' &&
-      !contains(github.event.issue.body, '@claude') &&
-      !contains(github.event.issue.title, '@claude')
+      !contains(github.event.issue.body, '@worktrunk-bot') &&
+      !contains(github.event.issue.title, '@worktrunk-bot')
     runs-on: ubuntu-24.04
     permissions:
       contents: write

--- a/.github/workflows/claude-mention.yaml
+++ b/.github/workflows/claude-mention.yaml
@@ -19,7 +19,7 @@ env:
 jobs:
   claude:
     # Run for:
-    # 1. @claude mentions in issues/PRs/comments
+    # 1. @worktrunk-bot mentions in issues/PRs/comments
     # 2. Any comment on worktrunk-bot PRs (loop prevention: exclude bot's own comments)
     #
     # Always runs in agent mode (prompt). The prompt tells Claude what happened
@@ -30,9 +30,9 @@ jobs:
     # comments on fork PRs (which don't receive secrets), we detect forks via
     # github.event context instead. Use a Conversation tab comment for fork PRs.
     if: |
-      (github.event_name == 'issues' && contains(github.event.issue.body, '@claude')) ||
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude') && github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'issues' && contains(github.event.issue.body, '@worktrunk-bot')) ||
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@worktrunk-bot')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@worktrunk-bot') && github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'issue_comment' && github.event.issue.pull_request && github.event.issue.user.login == 'worktrunk-bot' && github.event.comment.user.login != 'worktrunk-bot') ||
       (github.event_name == 'pull_request_review_comment' && github.event.pull_request.user.login == 'worktrunk-bot' && github.event.comment.user.login != 'worktrunk-bot' && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

- Changes the mention trigger in `claude-mention.yaml` from `@claude` to `@worktrunk-bot`
- Updates the exclusion filter in `claude-issue-triage.yaml` to match
- Updates `.github/CLAUDE.md` security docs and `pr-review` skill to reference `@worktrunk-bot`

The bot's GitHub username was already `worktrunk-bot` — this aligns the trigger with the actual account.

## Test plan

- [ ] Verify CI passes (no Rust code changes, only workflow YAML and docs)
- [ ] After merge, test by commenting `@worktrunk-bot` on an issue or PR

> _This was written by Claude Code on behalf of @max-sixty_

🤖 Generated with [Claude Code](https://claude.com/claude-code)