### PR TITLE
fix: support SSH URLs with ports in remote matching

### DIFF
--- a/src/git/repository/remotes.rs
+++ b/src/git/repository/remotes.rs
@@ -171,17 +171,8 @@ impl Repository {
                     if let Some(parsed) = GitRemoteUrl::parse(url.trim()) {
                         return Ok(parsed.project_identifier());
                     }
-                    // Fallback for URLs that don't fit host/owner/repo model (e.g., with ports)
+                    // Fallback for URLs that don't fit host/owner/repo model
                     let url = url.strip_suffix(".git").unwrap_or(url.as_str());
-                    // Handle ssh:// format with port: ssh://git@host:port/path -> host/port/path
-                    if let Some(ssh_part) = url.strip_prefix("ssh://") {
-                        let ssh_part = ssh_part.strip_prefix("git@").unwrap_or(ssh_part);
-                        if let Some(colon_pos) = ssh_part.find(':') {
-                            let (host, rest) = ssh_part.split_at(colon_pos);
-                            return Ok(format!("{}{}", host, rest.replacen(':', "/", 1)));
-                        }
-                        return Ok(ssh_part.to_string());
-                    }
                     return Ok(url.to_string());
                 }
 

--- a/tests/integration_tests/repository.rs
+++ b/tests/integration_tests/repository.rs
@@ -282,8 +282,8 @@ fn test_project_identifier_ssh_protocol_with_port() {
 
     let repository = Repository::at(repo.root_path().to_path_buf()).unwrap();
     let id = repository.project_identifier().unwrap();
-    // The port colon gets converted to /
-    assert_eq!(id, "gitlab.example.com/2222/team/project");
+    // Port is stripped — irrelevant to project identity
+    assert_eq!(id, "gitlab.example.com/team/project");
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- `GitRemoteUrl::parse()` now strips the port from SSH URLs instead of rejecting them, fixing remote matching for URLs like `ssh://git@host:2222/owner/repo.git`
- Removed the dead SSH port fallback in `project_identifier()` that was only needed because the parser rejected ported URLs
- Added unit tests covering SSH URLs with ports (standard, no-user, nested groups, port equivalence)

Closes #1156

## Test plan

- [x] New unit tests for SSH URLs with ports pass
- [x] Updated integration test `test_project_identifier_ssh_protocol_with_port` passes
- [x] Full test suite (1110 integration + 556 unit) passes
- [x] Lints clean

> _This was written by Claude Code on behalf of @max-sixty_

🤖 Generated with [Claude Code](https://claude.com/claude-code)