### PR TITLE
feat: allow non-write users to trigger mention workflow

### DIFF
--- a/.github/workflows/claude-mention.yaml
+++ b/.github/workflows/claude-mention.yaml
@@ -120,6 +120,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           # Use bot token so pushed commits trigger CI workflows
           github_token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
+          allowed_non_write_users: '*'
 
           additional_permissions: |
             actions: read


### PR DESCRIPTION
## Summary

- Add `allowed_non_write_users: '*'` to the mention workflow so external contributors can use `@worktrunk-bot` in comments
- The merge restriction (ruleset) is the security boundary, not access control on the workflow — same permissions already existed via issue-triage

## Test plan

- [ ] External contributor comments `@worktrunk-bot` on an issue — workflow triggers
- [ ] Verify merge restriction still prevents unauthorized merges

> _This was written by Claude Code on behalf of @max-sixty_