### PR TITLE
feat: hide Message column when Summary is below 40 chars

### DIFF
--- a/src/commands/list/layout.rs
+++ b/src/commands/list/layout.rs
@@ -1643,11 +1643,11 @@ mod tests {
         let mut found_below = false;
         for width in 80..200 {
             let l = layout_at_width(width, &full_skip_tasks());
-            if let Some(s) = find_column(&l, ColumnKind::Summary) {
-                if s.width < 40 {
-                    found_below = true;
-                    assert!(find_column(&l, ColumnKind::Message).is_none());
-                }
+            if let Some(s) = find_column(&l, ColumnKind::Summary)
+                && s.width < 40
+            {
+                found_below = true;
+                assert!(find_column(&l, ColumnKind::Message).is_none());
             }
         }
         assert!(found_below, "no width produced Summary < 40");


### PR DESCRIPTION
## Summary

- When Summary can't reach 40 characters of width, Message is dropped entirely and its space reclaimed for Summary
- Prevents both columns being truncated to ~10 chars where neither is readable
- Above the threshold, behavior is unchanged — Summary expands first, then Message gets leftovers

## Test plan

- [x] New test `test_message_hidden_when_summary_below_threshold` — probes widths 80–200, asserts Message absent when Summary < 40
- [x] New test `test_message_shown_when_summary_reaches_threshold` — confirms both columns appear at width 200
- [x] All 24 layout tests pass
- [x] All 1115 integration tests pass
- [x] Clippy + pre-commit clean

> _This was written by Claude Code on behalf of @max-sixty_

🤖 Generated with [Claude Code](https://claude.com/claude-code)