### PR TITLE
fix: shell-escape paths in -C flag hints

### DIFF
--- a/src/commands/config/update.rs
+++ b/src/commands/config/update.rs
@@ -12,6 +12,7 @@ use worktrunk::config::{
 use worktrunk::git::Repository;
 use worktrunk::styling::{
     eprintln, format_bash_with_gutter, hint_message, info_message, success_message,
+    suggest_command_in_dir,
 };
 
 use crate::output::prompt::{PromptResponse, prompt_yes_no_preview};
@@ -172,12 +173,9 @@ fn check_project_config() -> anyhow::Result<Option<UpdateCandidate>> {
 
     // Linked worktrees can't apply the update — suggest -C to main worktree
     if is_linked {
-        let display_path = worktrunk::path::format_path_for_display(repo.repo_path());
+        let cmd = suggest_command_in_dir(repo.repo_path(), "config", &["update"], &[]);
         eprintln!("{}", hint_message("To update project config:"));
-        eprintln!(
-            "{}",
-            format_bash_with_gutter(&format!("wt -C {display_path} config update"))
-        );
+        eprintln!("{}", format_bash_with_gutter(&cmd));
         return Ok(None);
     }
 

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -30,7 +30,8 @@ use shell_escape::unix::escape;
 use crate::config::WorktrunkConfig;
 use crate::shell_exec::Cmd;
 use crate::styling::{
-    eprintln, format_bash_with_gutter, format_with_gutter, hint_message, warning_message,
+    eprintln, format_bash_with_gutter, format_with_gutter, hint_message, suggest_command_in_dir,
+    warning_message,
 };
 
 /// Tracks which config paths have already shown deprecation warnings this process.
@@ -980,13 +981,9 @@ pub fn format_deprecation_details(info: &DeprecationInfo) -> String {
         }
     } else if let Some(main_path) = &info.main_worktree_path {
         // In linked worktree — include -C so the command works from here
-        let display_path = crate::path::format_path_for_display(main_path);
+        let cmd = suggest_command_in_dir(main_path, "config", &["update"], &[]);
         let _ = writeln!(out, "{}", hint_message("To apply:"));
-        let _ = writeln!(
-            out,
-            "{}",
-            format_bash_with_gutter(&format!("wt -C {display_path} config update"))
-        );
+        let _ = writeln!(out, "{}", format_bash_with_gutter(&cmd));
     }
 
     out

--- a/src/styling/mod.rs
+++ b/src/styling/mod.rs
@@ -37,7 +37,7 @@ pub use format::{GUTTER_OVERHEAD, format_bash_with_gutter, format_with_gutter, w
 pub use highlighting::format_toml;
 pub use hyperlink::{Stream, hyperlink_stdout, strip_osc8_hyperlinks, supports_hyperlinks};
 pub use line::{StyledLine, StyledString, truncate_visible};
-pub use suggest::suggest_command;
+pub use suggest::{suggest_command, suggest_command_in_dir};
 
 // ============================================================================
 // Verbosity


### PR DESCRIPTION
## Summary

- Add `suggest_command_in_dir()` to build shell commands with `-C <path>` prefix, routing through `format_path_for_display()` for tilde shortening and POSIX shell escaping
- Update both `-C` hint sites (`config/update.rs`, `config/deprecation.rs`) to use it instead of manual string interpolation

Closes #1143

> _This was written by Claude Code on behalf of @max-sixty_