### PR TITLE
fix: remove global state mutation from recover test

### DIFF
--- a/src/git/recover.rs
+++ b/src/git/recover.rs
@@ -303,9 +303,6 @@ mod tests {
 
     #[test]
     fn test_recover_from_path_finds_deleted_worktree() {
-        // Enable debug logging so log::debug! format args are evaluated for coverage
-        log::set_max_level(log::LevelFilter::Debug);
-
         let tmp = tempfile::tempdir().unwrap();
         let base = dunce::canonicalize(tmp.path()).unwrap();
         let repo_dir = base.join("repo");


### PR DESCRIPTION
## Summary

- Remove `log::set_max_level(log::LevelFilter::Debug)` from
  `test_recover_from_path_finds_deleted_worktree` — it mutates process-global
  state that leaks across parallel tests and produces non-deterministic behavior
- Add "No Global State Mutations in Tests" section to `tests/CLAUDE.md`
  documenting why `set_max_level`, `set_var`, and unsynchronized global statics
  are forbidden in tests

## Test plan

- [x] `cargo test --lib -- recover` — all 15 tests pass
- [ ] CI green

> _This was written by Claude Code on behalf of @max-sixty_