### PR TITLE
fix: nudge bot to respond on its own PRs/issues

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -134,7 +134,7 @@ The mention workflow runs for any user who includes `@worktrunk-bot` — the mer
 - Formal review submitted on a `worktrunk-bot`-authored PR, with body or non-approval → `claude-review` responds
 - `@worktrunk-bot` mentioned in an issue body → `claude-mention` responds
 - `@worktrunk-bot` mentioned in any comment (issue or PR) → `claude-mention` responds
-- Any comment on a PR or issue that `worktrunk-bot` has engaged with (authored, reviewed, or commented on) → `claude-mention` runs (verify step confirms engagement via API), but the prompt instructs Claude to only respond if the comment needs bot input — otherwise exit silently
+- Any comment on a PR or issue that `worktrunk-bot` has engaged with (authored, reviewed, or commented on) → `claude-mention` runs (verify step confirms engagement via API), but the prompt instructs Claude to only respond if the comment needs bot input — otherwise exit silently. When the bot authored the PR/issue, it leans toward responding since commenters expect the author to engage.
 - Editing a comment or issue body re-triggers the same response
 
 **Does not trigger:**

--- a/.github/workflows/claude-mention.yaml
+++ b/.github/workflows/claude-mention.yaml
@@ -203,7 +203,7 @@ jobs:
                   github.event.comment.html_url
                 )
                 || format(
-                  'A user commented on an issue/PR where you previously participated ({0}). Read the full context (description, recent comments, CI status). Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. If the conversation is between humans and doesn''t need your input, exit silently without commenting.',
+                  'A user commented on an issue/PR where you previously participated ({0}). Read the full context (description, recent comments, CI status). Only respond if the comment is directed at you, asks a question you can help with, or requests changes you can make. If the conversation is between humans and doesn''t need your input, exit silently without commenting. Note: if you are the author of the PR or issue, commenters are probably expecting the author to engage — lean toward responding.',
                   github.event.comment.html_url
                 ))
               || format(


### PR DESCRIPTION
## Summary

- When someone comments on a bot-authored PR/issue without `@worktrunk-bot`, the bot was silently exiting — the prompt said "only respond if helpful"
- Adds a nudge: "if you are the author of the PR or issue, commenters are probably expecting the author to engage — lean toward responding"
- Updates `.github/CLAUDE.md` docs to reflect the new behavior

Ref #1196

## Test plan

- [x] Verify prompt change in workflow YAML
- [ ] Next comment on a bot-authored PR without `@worktrunk-bot` should get a response

> _This was written by Claude Code on behalf of @max-sixty_