### PR TITLE
feat: add explicit issue-closing step to nightly cleaner

### DIFF
--- a/.github/workflows/claude-nightly-cleaner.yaml
+++ b/.github/workflows/claude-nightly-cleaner.yaml
@@ -2,7 +2,8 @@ name: claude-nightly-cleaner
 # Runner versions pinned; see ci.yaml header comment for rationale.
 
 # Nightly code quality sweep — reviews all commits merged to main in the past
-# 24 hours for bugs, inconsistencies, and improvement opportunities.
+# 24 hours for bugs, inconsistencies, and improvement opportunities. Also closes
+# open issues that have been resolved by recent (or earlier unlinked) merges.
 on:
   schedule:
     # Run at 6:17 AM UTC daily (off-peak minute, 30 min after review-reviewers)
@@ -126,7 +127,19 @@ jobs:
             gh pr list --state open --json number,title,headRefName
             ```
 
-            ## Step 5: Report findings
+            ## Step 5: Close resolved issues
+
+            For each open issue found in Step 4, check whether the recent commits (or earlier
+            unlinked merges) already resolve it. An issue is resolved when the code change it
+            describes has landed on main — look at the diff, linked PRs, and commit messages.
+
+            For each resolved issue:
+            - Comment briefly explaining which commit or PR resolved it
+            - Close the issue with `gh issue close <number>`
+
+            Skip issues that are feature requests, discussions, or still partially unresolved.
+
+            ## Step 6: Report findings
 
             For each finding:
 
@@ -143,7 +156,7 @@ jobs:
                - Create a PR referencing the issue(s)
                - Monitor CI with `gh run watch`
 
-            ## Step 6: Summary
+            ## Step 7: Summary
 
             If the codebase looks clean, report a brief summary:
             - Number of commits reviewed


### PR DESCRIPTION
## Summary

The nightly cleaner was already closing resolved issues ad hoc (it closed #1187
without being told to), but the prompt didn't explicitly instruct it to. This
adds a new Step 5 that:

- Checks each open issue against recent commits and earlier unlinked merges
- Comments briefly explaining which commit or PR resolved it
- Closes the issue
- Skips feature requests, discussions, and partially-resolved issues

Closes #1187

> _This was written by Claude Code on behalf of @max-sixty_