### PR TITLE
fix: include worktree path in detached HEAD removal messages

### DIFF
--- a/.claude/skills/writing-user-outputs/SKILL.md
+++ b/.claude/skills/writing-user-outputs/SKILL.md
@@ -130,9 +130,9 @@ values) by reflecting those choices in the message text.
 ```rust
 // User runs: wt switch --create feature --base=main
 // GOOD - acknowledges the base branch
-"Created new worktree for feature from main at /path/to/worktree"
+"Created new worktree for feature from main @ /path/to/worktree"
 // BAD - ignores the base argument
-"Created new worktree for feature at /path/to/worktree"
+"Created new worktree for feature @ /path/to/worktree"
 ```
 
 **Avoid "you/your" pronouns:** Messages should refer to things directly, not
@@ -834,12 +834,28 @@ regular users.
 `worktrunk::path`. This function replaces home directory prefixes with `~` for
 readability (e.g., `/Users/alex/projects/repo` → `~/projects/repo`).
 
+**Use `@` (not "at") before paths in status messages.** This is the codebase
+convention for associating an entity with a location:
+
+```rust
+// GOOD - @ before path
+"Created worktree for feature @ ~/code/repo.feature"
+"Squashed @ a1b2c3d"
+"Worktree for feature @ ~/repo.feature, but cannot change directory..."
+
+// BAD - "at" before path
+"Created worktree for feature at ~/code/repo.feature"
+```
+
+**Exception:** Prose contexts (error descriptions, doc comments, help text) use
+"at" — `@` is for terse status messages only.
+
 ```rust
 use worktrunk::path::format_path_for_display;
 
 // GOOD - uses format_path_for_display
 eprintln!("{}", success_message(cformat!(
-    "Created worktree at {}",
+    "Created worktree @ {}",
     format_path_for_display(&worktree_path)
 )));
 
@@ -848,7 +864,7 @@ eprintln!("{}", success_message(cformat!(
 
 // BAD - raw path.display()
 eprintln!("{}", success_message(format!(
-    "Created worktree at {}",
+    "Created worktree @ {}",
     worktree_path.display()  // Shows /Users/alex/... instead of ~/...
 )));
 ```

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -1020,11 +1020,12 @@ fn handle_removed_worktree_output(
     let Some(branch_name) = branch_name else {
         // No branch associated - just remove the worktree
         if background {
+            let path_display = format_path_for_display(worktree_path);
             eprintln!(
                 "{}",
-                progress_message(
-                    "Removing worktree in background (detached HEAD, no branch to delete)",
-                )
+                progress_message(cformat!(
+                    "Removing worktree @ <bold>{path_display}</> in background (detached HEAD, no branch to delete)"
+                ))
             );
 
             // Stop fsmonitor daemon BEFORE rename (must happen while path still exists)
@@ -1047,7 +1048,10 @@ fn handle_removed_worktree_output(
             // Progress message after pre-remove hooks, before actual removal
             eprintln!(
                 "{}",
-                progress_message("Removing worktree (detached HEAD, no branch to delete)...",)
+                progress_message(cformat!(
+                    "Removing worktree @ <bold>{}</>... (detached HEAD, no branch to delete)",
+                    format_path_for_display(worktree_path)
+                ))
             );
             let _ = repo
                 .worktree_at(worktree_path)
@@ -1063,7 +1067,10 @@ fn handle_removed_worktree_output(
             }
             eprintln!(
                 "{}",
-                success_message("Removed worktree (detached HEAD, no branch to delete)",)
+                success_message(cformat!(
+                    "Removed worktree @ <bold>{}</> (detached HEAD, no branch to delete)",
+                    format_path_for_display(worktree_path)
+                ))
             );
         }
         // Post-remove hooks for detached HEAD use "HEAD" as the branch identifier

--- a/tests/snapshots/integration__integration_tests__remove__pre_remove_hook_runs_for_detached_head.snap
+++ b/tests/snapshots/integration__integration_tests__remove__pre_remove_hook_runs_for_detached_head.snap
@@ -25,10 +25,13 @@ info:
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -40,5 +43,5 @@ exit_code: 0
 ----- stderr -----
 [36m◎[39m [36mRunning pre-remove project hook[39m
 [107m [0m [2m[0m[2m[34mtouch[0m[2m _REPO_/m.txt
-[0m[36m◎[39m [36mRemoving worktree (detached HEAD, no branch to delete)...[39m
-[32m✓[39m [32mRemoved worktree (detached HEAD, no branch to delete)[39m
+[0m[36m◎[39m [36mRemoving worktree @ [1m_REPO_.feature-detached-hook[22m... (detached HEAD, no branch to delete)[39m
+[32m✓[39m [32mRemoved worktree @ [1m_REPO_.feature-detached-hook[22m (detached HEAD, no branch to delete)[39m

--- a/tests/snapshots/integration__integration_tests__remove__pre_remove_hook_runs_for_detached_head_background.snap
+++ b/tests/snapshots/integration__integration_tests__remove__pre_remove_hook_runs_for_detached_head_background.snap
@@ -24,10 +24,13 @@ info:
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -39,4 +42,4 @@ exit_code: 0
 ----- stderr -----
 [36m◎[39m [36mRunning pre-remove project hook[39m
 [107m [0m [2m[0m[2m[34mtouch[0m[2m _REPO_/detached-bg-hook-marker.txt
-[0m[36m◎[39m [36mRemoving worktree in background (detached HEAD, no branch to delete)[39m
+[0m[36m◎[39m [36mRemoving worktree @ [1m_REPO_.feature-detached-bg[22m in background (detached HEAD, no branch to delete)[39m

--- a/tests/snapshots/integration__integration_tests__remove__remove_at_from_detached_head_in_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_at_from_detached_head_in_worktree.snap
@@ -25,10 +25,13 @@ info:
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -38,4 +41,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRemoving worktree in background (detached HEAD, no branch to delete)[39m
+[36m◎[39m [36mRemoving worktree @ [1m_REPO_.feature-detached-at[22m in background (detached HEAD, no branch to delete)[39m

--- a/tests/snapshots/integration__integration_tests__remove__remove_foreground_detached_head.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_foreground_detached_head.snap
@@ -25,10 +25,13 @@ info:
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -38,5 +41,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRemoving worktree (detached HEAD, no branch to delete)...[39m
-[32m✓[39m [32mRemoved worktree (detached HEAD, no branch to delete)[39m
+[36m◎[39m [36mRemoving worktree @ [1m_REPO_.feature-detached-fg[22m... (detached HEAD, no branch to delete)[39m
+[32m✓[39m [32mRemoved worktree @ [1m_REPO_.feature-detached-fg[22m (detached HEAD, no branch to delete)[39m

--- a/tests/snapshots/integration__integration_tests__remove__remove_from_detached_head_in_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_from_detached_head_in_worktree.snap
@@ -24,10 +24,13 @@ info:
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -37,4 +40,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRemoving worktree in background (detached HEAD, no branch to delete)[39m
+[36m◎[39m [36mRemoving worktree @ [1m_REPO_.feature-detached[22m in background (detached HEAD, no branch to delete)[39m


### PR DESCRIPTION
## Summary
- Detached HEAD removal messages now show the worktree path (`Removing worktree @ ~/code/repo.feature...`) instead of anonymous `Removing worktree (detached HEAD, ...)`
- Uses `format_path_for_display` with `@` convention, consistent with named-branch messages
- Documents `@` vs `at` convention in writing-user-outputs skill

## Test plan
- [x] All 1120 integration tests pass
- [x] All 5 affected snapshots updated and verified
- [x] Pre-commit lints pass

> _This was written by Claude Code on behalf of @max-sixty_

🤖 Generated with [Claude Code](https://claude.com/claude-code)