### PR TITLE
fix: prevent claude-review from polling its own CI check

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -293,11 +293,17 @@ description: new text here
 
 ### 5. Monitor CI
 
-After approving, check whether CI has finished:
+After approving, check whether CI has finished. Exclude the current workflow's
+own check to avoid a circular wait (Claude polling itself):
 
 ```bash
+# $GITHUB_WORKFLOW is set in CI; when unset, no checks are excluded.
 gh pr view <number> --json statusCheckRollup \
-  --jq '.statusCheckRollup[] | {name: .name, status: .status, conclusion: .conclusion}'
+  --jq '[.statusCheckRollup[]
+    | select(env.GITHUB_WORKFLOW == null
+             or (.workflowName == env.GITHUB_WORKFLOW | not))]
+    | .[]
+    | {name, status, conclusion}'
 ```
 
 - **All checks passed** → done, no further action.

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -30,6 +30,7 @@ jobs:
         github.event.review.user.login != 'worktrunk-bot' &&
         (github.event.review.state != 'approved' || github.event.review.body))
     runs-on: ubuntu-24.04
+    timeout-minutes: 60
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary

- The pr-review skill's "Monitor CI" step polls `statusCheckRollup` until all checks pass, but the `claude-review` job itself appears as a check — creating a circular wait where Claude polls itself indefinitely (observed hanging for 3+ hours on #1206)
- Filter out the current workflow's checks using `env.GITHUB_WORKFLOW` in the jq query (set by GitHub Actions; null locally so no checks are excluded outside CI)
- Add `timeout-minutes: 60` to the workflow as a safety net for the separate MCP server deadlock bug ([claude-code-action#865](https://github.com/anthropics/claude-code-action/issues/865))

## Test plan

- [x] Verified `env.GITHUB_WORKFLOW` filtering with `gh` CLI locally — correctly excludes 2 `claude-review` checks when set, includes all 25 checks when unset
- [ ] Verify next claude-review run completes without hanging

> _This was written by Claude Code on behalf of @max-sixty_