### PR TITLE
feat: add nushell tab completions

### DIFF
--- a/src/completion.rs
+++ b/src/completion.rs
@@ -56,7 +56,7 @@ pub(crate) fn maybe_handle_env_completion() -> bool {
 
     // Determine the index of the word being completed.
     // - Bash/Zsh: Pass `_CLAP_COMPLETE_INDEX` env var with the cursor position
-    // - Fish: Appends the current token as the last argument, so index = len - 1
+    // - Fish/Nushell: Append the current token as the last argument, so index = len - 1
     let index: usize = std::env::var("_CLAP_COMPLETE_INDEX")
         .ok()
         .and_then(|i| i.parse().ok())

--- a/src/shell/snapshots/worktrunk__shell__tests__init_nu.snap
+++ b/src/shell/snapshots/worktrunk__shell__tests__init_nu.snap
@@ -4,6 +4,41 @@ expression: output
 ---
 # worktrunk shell integration for nushell
 
+# Tab completions: calls binary with COMPLETE=nu to get candidates.
+# Note: nushell's completion engine bypasses custom completers when the current
+# token starts with `-`, so flag completions (e.g. `wt switch --<TAB>`) don't
+# appear. Subcommand and value completions work. (nushell/nushell#14504)
+def "nu-complete wt" [context: string] {
+    let worktrunk_bin = if ($env.WORKTRUNK_BIN? | is-not-empty) {
+        $env.WORKTRUNK_BIN
+    } else {
+        let external = (which -a wt | where type == "external")
+        if ($external | is-empty) { return [] }
+        ($external | get 0.path)
+    }
+
+    let tokens = ($context | split row " " | where {|t| $t != "" })
+    let tokens = if ($context | str ends-with " ") {
+        $tokens | append ""
+    } else {
+        $tokens
+    }
+
+    let result = (do {
+        with-env { COMPLETE: nu } { ^$worktrunk_bin -- ...$tokens }
+    } | complete)
+    if $result.exit_code != 0 { return [] }
+
+    $result.stdout | lines | each {|line|
+        let parts = ($line | split row "\t")
+        if ($parts | length) >= 2 {
+            { value: ($parts | get 0), description: ($parts | get 1) }
+        } else {
+            { value: ($parts | get 0) }
+        }
+    }
+}
+
 # Override wt command with file-based directive passing.
 # Creates a temp file, passes path via WORKTRUNK_DIRECTIVE_FILE, executes directives after.
 # WORKTRUNK_BIN can override the binary path (for testing dev builds).
@@ -34,7 +69,7 @@ expression: output
 #   Stderr flows to the terminal in real-time. The binary sees non-TTY stdout
 #   and uses buffered mode, but commands other than `list` don't benefit from
 #   progressive rendering anyway.
-def --env --wrapped wt [...args: string] {
+def --env --wrapped wt [...args: string@"nu-complete wt"] {
     let worktrunk_bin = if ($env.WORKTRUNK_BIN? | is-not-empty) {
         $env.WORKTRUNK_BIN
     } else {

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -653,9 +653,10 @@ pub fn configure_completion_invocation_for_shell(cmd: &mut Command, words: &[&st
             let index = words.len().saturating_sub(1);
             cmd.env("_CLAP_COMPLETE_INDEX", index.to_string());
         }
-        "fish" => {
-            // Fish doesn't set _CLAP_COMPLETE_INDEX - it appends the current token
-            // as the last argument, so the completion handler uses args.len() - 1
+        "fish" | "nu" => {
+            // Fish and Nushell don't set _CLAP_COMPLETE_INDEX - they append the
+            // current token as the last argument, so the completion handler uses
+            // args.len() - 1
         }
         _ => {}
     }

--- a/tests/integration_tests/completion.rs
+++ b/tests/integration_tests/completion.rs
@@ -1052,7 +1052,7 @@ fn test_complete_switch_single_dash_shows_options_not_branches(repo: TestRepo) {
 fn test_complete_help_flag_all_shells(repo: TestRepo) {
     repo.commit("initial");
 
-    for shell in ["bash", "zsh", "fish"] {
+    for shell in ["bash", "zsh", "fish", "nu"] {
         // Test: wt --help<cursor> - should complete --help
         let output = repo
             .completion_cmd_for_shell(&["wt", "--help"], shell)
@@ -1084,7 +1084,7 @@ fn test_complete_help_flag_all_shells(repo: TestRepo) {
 fn test_complete_version_flag_all_shells(repo: TestRepo) {
     repo.commit("initial");
 
-    for shell in ["bash", "zsh", "fish"] {
+    for shell in ["bash", "zsh", "fish", "nu"] {
         // Test: wt --version<cursor> - should complete --version
         let output = repo
             .completion_cmd_for_shell(&["wt", "--version"], shell)
@@ -1107,7 +1107,7 @@ fn test_complete_version_flag_all_shells(repo: TestRepo) {
 fn test_complete_single_dash_shows_both_short_and_long_flags(repo: TestRepo) {
     repo.commit("initial");
 
-    for shell in ["bash", "zsh", "fish"] {
+    for shell in ["bash", "zsh", "fish", "nu"] {
         // Test: wt -<cursor> - should show both -h and --help
         let output = repo
             .completion_cmd_for_shell(&["wt", "-"], shell)
@@ -1162,7 +1162,7 @@ fn test_complete_excludes_deprecated_args(repo: TestRepo) {
     // Deprecated args that should never appear
     let deprecated = ["--no-background"];
 
-    for shell in ["bash", "zsh", "fish"] {
+    for shell in ["bash", "zsh", "fish", "nu"] {
         // Test: wt remove --<cursor> - should NOT show --no-background
         let output = repo
             .completion_cmd_for_shell(&["wt", "remove", "--"], shell)
@@ -1278,6 +1278,10 @@ fn test_static_completions_for_all_shells() {
                 assert!(
                     stdout.contains("def --wrapped") || stdout.contains("def --env"),
                     "{shell}: should contain nushell function markers"
+                );
+                assert!(
+                    stdout.contains("nu-complete wt"),
+                    "{shell}: should contain nushell completer function"
                 );
             }
             "powershell" => {

--- a/tests/integration_tests/shell_wrapper.rs
+++ b/tests/integration_tests/shell_wrapper.rs
@@ -3114,6 +3114,29 @@ for c in "${{COMPREPLY[@]}}"; do echo "${{c%%	*}}"; done
         assert_snapshot!(completions);
     }
 
+    /// Black-box test: nushell completion produces correct subcommands.
+    ///
+    /// Nushell completions call binary with COMPLETE=nu (same protocol as fish).
+    #[test]
+    fn test_nushell_completion_subcommands() {
+        let wt_bin = wt_bin();
+
+        let output = std::process::Command::new(&wt_bin)
+            .args(["--", "wt", ""])
+            .env("COMPLETE", "nu")
+            .output()
+            .unwrap();
+
+        // Nushell format is "value\tdescription" - extract just values
+        let completions: String = String::from_utf8_lossy(&output.stdout)
+            .lines()
+            .map(|line| line.split('\t').next().unwrap_or(line))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        assert_snapshot!(completions);
+    }
+
     // ========================================================================
     // Stderr/Stdout Redirection Tests
     // ========================================================================

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__nushell_completion_subcommands.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__nushell_completion_subcommands.snap
@@ -1,0 +1,11 @@
+---
+source: tests/integration_tests/shell_wrapper.rs
+expression: completions
+---
+switch
+list
+remove
+merge
+step
+hook
+config


### PR DESCRIPTION
## Summary

- Add `nu-complete wt` completer function to the nushell init template, wiring it to the wrapper's rest parameter via `@"nu-complete wt"`
- The completer calls the binary with `COMPLETE=nu` and parses tab-separated output into nushell's `{value, description}` record format
- Add `"nu"` to multi-shell completion test loops (help, version, single-dash, deprecated flags) and a dedicated subcommand snapshot test

Thanks to @omerxx for reporting in #1215.

Closes #1215

## Limitations

Nushell's completion engine bypasses custom completers when the current token starts with `-`, so flag completions (e.g. `wt switch --<TAB>`) don't appear. Subcommand and value completions work correctly. This is a nushell engine limitation (nushell/nushell#14504), not something we can fix in our template.

## Test plan

- [x] Unit tests pass (`cargo test --lib --bins`) — snapshot updated
- [x] Integration tests pass (`cargo test --test integration`) — 1121 tests
- [x] Shell integration test (`cargo test --test integration --features shell-integration-tests -- test_nushell_completion_subcommands`)
- [x] Lints pass (`pre-commit run --all-files`)
- [x] Manual verification in nushell 0.110.0: `wt <TAB>` shows subcommands, `wt switch <TAB>` shows branches with descriptions

> _This was written by Claude Code on behalf of @max-sixty_

🤖 Generated with [Claude Code](https://claude.com/claude-code)