### PR TITLE
fix: propagate error from `is_bare()` instead of panicking

### DIFF
--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -1073,7 +1073,7 @@ pub fn handle_promote(branch: Option<&str>) -> anyhow::Result<PromoteResult> {
 
     // For normal repos, worktrees[0] is the main worktree
     // For bare repos, there's no main worktree - we don't support promote there
-    if repo.is_bare() {
+    if repo.is_bare()? {
         anyhow::bail!("wt step promote is not supported in bare repositories");
     }
 

--- a/src/commands/worktree/resolve.rs
+++ b/src/commands/worktree/resolve.rs
@@ -82,7 +82,7 @@ pub fn compute_worktree_path(
 ) -> anyhow::Result<PathBuf> {
     let repo_root = repo.repo_path();
     let default_branch = repo.default_branch().unwrap_or_default();
-    let is_bare = repo.is_bare();
+    let is_bare = repo.is_bare()?;
 
     // Default branch lives at repo root (main worktree), not a templated path.
     // Exception: bare repos have no main worktree, so all branches use templated paths.

--- a/src/git/repository/config.rs
+++ b/src/git/repository/config.rs
@@ -292,7 +292,7 @@ impl Repository {
         // - Empty repos: No branches exist yet, but HEAD tells us the intended default
         // - Linked worktrees: HEAD points to CURRENT branch, so skip this heuristic
         // - Normal repos: HEAD points to CURRENT branch, so skip this heuristic
-        let is_bare = self.is_bare();
+        let is_bare = self.is_bare()?;
         let in_linked_worktree = self.current_worktree().is_linked()?;
         if ((is_bare && !in_linked_worktree) || branches.is_empty())
             && let Ok(head_ref) = self.run_command(&["symbolic-ref", "HEAD"])

--- a/src/git/repository/worktrees.rs
+++ b/src/git/repository/worktrees.rs
@@ -88,7 +88,7 @@ impl Repository {
     /// Used as the default source for `copy-ignored` and the `{{ primary_worktree_path }}` template.
     /// Returns `None` for bare repos when no worktree has the default branch.
     pub fn primary_worktree(&self) -> anyhow::Result<Option<PathBuf>> {
-        if self.is_bare() {
+        if self.is_bare()? {
             let Some(branch) = self.default_branch() else {
                 return Ok(None);
             };


### PR DESCRIPTION
`is_bare()` panics when `git rev-parse --is-bare-repository` times out because it uses `.expect()` on the `Cmd::run()` result. This changes the return type to `Result<bool>` so the error propagates instead.

I don't know why `git` was slow in this case, but it was:

```
thread '<unnamed>' (84001037) panicked at src/git/repository/mod.rs:459:18:
git rev-parse failed on valid repo: Custom { kind: TimedOut, error: "command timed out" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Rayon: detected unexpected panic; aborting
```

## Changes

- `is_bare()` returns `Result<bool>` using `get_or_try_init` (doesn't cache errors, so transient timeouts retry on next call)
- `repo_path()` uses `unwrap_or(false)` since it returns `&Path` via `OnceCell<PathBuf>` with many callers. Cascading `Result` would be disproportionate, and the non-bare fallback handles normal repos correctly
- All other callers already return `Result`, so they just add `?`
