### PR TITLE
feat(nushell): add tab completion support

### DIFF
--- a/templates/nushell.nu
+++ b/templates/nushell.nu
@@ -177,4 +177,3 @@ def --env --wrapped {{ cmd }} [...args: string@{{ cmd }}-completer] {
         }
     }
 }
-


### PR DESCRIPTION
Add a wt-completer function that calls the binary with clap's COMPLETE=nu protocol and attach it to the wt wrapper via @completer annotation.

Nushell's external completer only applies to external commands, not custom functions. Since the wt wrapper is a custom command (def --env --wrapped), completions must be wired via the parameter annotation instead.