### PR TITLE
perf: copy index in `step diff` for faster diffs

### DIFF
--- a/src/cli/step.rs
+++ b/src/cli/step.rs
@@ -196,12 +196,12 @@ wt step diff | delta
 Equivalent to:
 
 ```console
-GIT_INDEX_FILE=/tmp/idx git read-tree --empty
+cp "$(git rev-parse --git-dir)/index" /tmp/idx
 GIT_INDEX_FILE=/tmp/idx git add --intent-to-add .
 GIT_INDEX_FILE=/tmp/idx git diff $(git merge-base HEAD $(wt config state default-branch))
 ```
 
-`git diff` ignores untracked files. `git add --intent-to-add .` registers them in the index without staging their content, making them visible to `git diff`. This runs against a temporary empty index so the real one is never modified.
+`git diff` ignores untracked files. `git add --intent-to-add .` registers them in the index without staging their content, making them visible to `git diff`. This runs against a copy of the real index so the original is never modified.
 "#
     )]
     Diff {


### PR DESCRIPTION
## Summary

- Copy the real git index instead of creating an empty one in `wt step diff`
- Preserves git's stat cache so `git diff` skips re-reading unchanged tracked files
- Eliminates the `git read-tree --empty` subprocess — one fewer process spawn

## Test plan

- [x] All 7 `step_diff` integration tests pass (including `test_step_diff_index_unchanged`)
- [x] Tests run in linked worktrees, exercising the `wt.git_dir()` path resolution
- [x] Doc sync test passes
- [x] Lints pass

> _This was written by Claude Code on behalf of @max-sixty_