### PR TITLE
fix: color status symbols and inline code in help text tables

### DIFF
--- a/src/md_help.rs
+++ b/src/md_help.rs
@@ -1,7 +1,8 @@
 //! Minimal markdown rendering for CLI help text.
 
 use anstyle::{AnsiColor, Color, Color as AnsiStyleColor, Style};
-use termimad::{MadSkin, TableBorderChars};
+use crossterm::style::Attribute;
+use termimad::{CompoundStyle, MadSkin, TableBorderChars};
 use unicode_width::UnicodeWidthStr;
 
 use worktrunk::styling::{DEFAULT_HELP_WIDTH, wrap_styled_text};
@@ -27,6 +28,10 @@ static HELP_TABLE_BORDERS: TableBorderChars = TableBorderChars {
 fn help_table_skin() -> MadSkin {
     let mut skin = MadSkin::no_style();
     skin.table_border_chars = &HELP_TABLE_BORDERS;
+    // Render backtick-enclosed text as dimmed, matching render_inline_formatting().
+    // This is needed for colorize_status_symbols() to find and recolor symbols
+    // like `●` that appear in table cells.
+    skin.inline_code = CompoundStyle::with_attr(Attribute::Dim);
     skin
 }
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -79,8 +79,8 @@ Show current configuration and file locations:
 
         File                 Location                                Contains                     Committed & shared 
    ────────────── ─────────────────────────────── ─────────────────────────────────────────────── ────────────────── 
-   User config    ~/.config/worktrunk/config.toml Worktree path template, LLM commit configs, etc ✗                  
-   Project config .config/wt.toml                 Project hooks, dev server URL                   ✓                  
+   User config    [2m~/.config/worktrunk/config.toml[0m Worktree path template, LLM commit configs, etc ✗                  
+   Project config [2m.config/wt.toml[0m                 Project hooks, dev server URL                   ✓                  
 
 Organizations can also deploy a system-wide config file for shared defaults — run [2mwt config show[0m for the platform-specific location.
 
@@ -339,9 +339,9 @@ For nested config sections, use double underscores to separate levels:
 
             Config                   Environment Variable          
    ───────────────────────── ───────────────────────────────────── 
-   worktree-path             WORKTRUNK_WORKTREE_PATH               
-   commit.generation.command WORKTRUNK_COMMIT__GENERATION__COMMAND 
-   commit.stage              WORKTRUNK_COMMIT__STAGE               
+   [2mworktree-path[0m             [2mWORKTRUNK_WORKTREE_PATH[0m               
+   [2mcommit.generation.command[0m [2mWORKTRUNK_COMMIT__GENERATION__COMMAND[0m 
+   [2mcommit.stage[0m              [2mWORKTRUNK_COMMIT__STAGE[0m               
 
 Note the single underscore after [2mWORKTRUNK[0m and double underscores between nested keys.
 
@@ -355,12 +355,12 @@ Override the LLM command in CI to use a mock:
 
                Variable                                                   Purpose                                      
    ───────────────────────────────── ───────────────────────────────────────────────────────────────────────────────── 
-   WORKTRUNK_BIN                     Override binary path for shell wrappers (useful for testing dev builds)           
-   WORKTRUNK_CONFIG_PATH             Override user config file location                                                
-   WORKTRUNK_SYSTEM_CONFIG_PATH      Override system config file location                                              
-   XDG_CONFIG_DIRS                   Colon-separated system config directories (default: /etc/xdg)                     
-   WORKTRUNK_DIRECTIVE_FILE          Internal: set by shell wrappers to enable directory changes                       
-   WORKTRUNK_SHELL                   Internal: set by shell wrappers to indicate shell type (e.g., powershell)         
-   WORKTRUNK_MAX_CONCURRENT_COMMANDS Max parallel git commands (default: 32). Lower if hitting file descriptor limits. 
-   NO_COLOR                          Disable colored output (standard)                                                 
-   CLICOLOR_FORCE                    Force colored output even when not a TTY
+   [2mWORKTRUNK_BIN[0m                     Override binary path for shell wrappers (useful for testing dev builds)           
+   [2mWORKTRUNK_CONFIG_PATH[0m             Override user config file location                                                
+   [2mWORKTRUNK_SYSTEM_CONFIG_PATH[0m      Override system config file location                                              
+   [2mXDG_CONFIG_DIRS[0m                   Colon-separated system config directories (default: [2m/etc/xdg[0m)                     
+   [2mWORKTRUNK_DIRECTIVE_FILE[0m          Internal: set by shell wrappers to enable directory changes                       
+   [2mWORKTRUNK_SHELL[0m                   Internal: set by shell wrappers to indicate shell type (e.g., [2mpowershell[0m)         
+   [2mWORKTRUNK_MAX_CONCURRENT_COMMANDS[0m Max parallel git commands (default: 32). Lower if hitting file descriptor limits. 
+   [2mNO_COLOR[0m                          Disable colored output (standard)                                                 
+   [2mCLICOLOR_FORCE[0m                    Force colored output even when not a TTY

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
@@ -17,10 +17,13 @@ info:
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
+    WORKTRUNK_APPROVALS_PATH: /nonexistent/test/approvals.toml
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_SYSTEM_CONFIG_PATH: /etc/xdg/worktrunk/config.toml
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
 ---
@@ -63,12 +66,12 @@ Results cache for 30-60 seconds. Indicators dim when local changes haven't been 
 
     Status                   Meaning                 
    ───────── ─────────────────────────────────────── 
-   passed    All checks passed                       
-   running   Checks in progress                      
-   failed    Checks failed                           
-   conflicts PR has merge conflicts                  
-   no-ci     No checks configured                    
-   error     Fetch error (rate limit, network, auth) 
+   [2mpassed[0m    All checks passed                       
+   [2mrunning[0m   Checks in progress                      
+   [2mfailed[0m    Checks failed                           
+   [2mconflicts[0m PR has merge conflicts                  
+   [2mno-ci[0m     No checks configured                    
+   [2merror[0m     Fetch error (rate limit, network, auth) 
 
 See [2mwt list[0m CI status for display symbols and colors.
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
@@ -68,8 +68,8 @@ All hook executions and LLM commands are recorded automatically — one JSON obj
 
        Operation                     Log file                 
    ────────────────── ─────────────────────────────────────── 
-   post-start hooks   {branch}-{source}-post-start-{name}.log 
-   Background removal {branch}-remove.log                     
+   post-start hooks   [2m{branch}-{source}-post-start-{name}.log[0m 
+   Background removal [2m{branch}-remove.log[0m                     
 
 Source is [2muser[0m or [2mproject[0m depending on where the hook is defined.
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -101,10 +101,10 @@ Output as JSON for scripting:
    Status  Compact symbols (see below)                                                                       
    HEAD±   Uncommitted changes: +added -deleted lines                                                        
    main↕   Commits ahead/behind default branch                                                               
-   main…±  Line diffs since the merge-base with the default branch (--full)                                  
-   Summary LLM-generated branch summary (--full + summary = true, requires commit.generation) (experimental) 
+   main…±  Line diffs since the merge-base with the default branch ([2m--full[0m)                                  
+   Summary LLM-generated branch summary ([2m--full[0m + [2msummary = true[0m, requires [2mcommit.generation[0m) (experimental) 
    Remote⇅ Commits ahead/behind tracking branch                                                              
-   CI      Pipeline status (--full)                                                                          
+   CI      Pipeline status ([2m--full[0m)                                                                          
    Path    Worktree directory                                                                                
    URL     Dev server URL from project config (dimmed if port not listening)                                 
    Commit  Short hash (8 chars)                                                                              
@@ -119,12 +119,12 @@ The CI column shows GitHub/GitLab pipeline status:
 
    Indicator              Meaning              
    ───────── ───────────────────────────────── 
-   ● green   All checks passed                 
-   ● blue    Checks running                    
-   ● red     Checks failed                     
-   ● yellow  Merge conflicts with base         
-   ● gray    No checks configured              
-   ⚠ yellow  Fetch error (rate limit, network) 
+   [32m●[0m green   All checks passed                 
+   [34m●[0m blue    Checks running                    
+   [31m●[0m red     Checks failed                     
+   [33m●[0m yellow  Merge conflicts with base         
+   [90m●[0m gray    No checks configured              
+   [33m⚠[0m yellow  Fetch error (rate limit, network) 
    (blank)   No upstream or no PR/MR           
 
 CI indicators are clickable links to the PR or pipeline page. Any CI dot appears dimmed when there are unpushed local changes (stale status). PRs/MRs are checked first, then branch workflows/pipelines for branches with an upstream. Local-only branches show blank; remote-only branches (visible with [2m--remotes[0m) get CI status detection. Results are cached for 30-60 seconds; use [2mwt config state[0m to view or clear.
@@ -141,29 +141,29 @@ The Status column has multiple subcolumns. Within each, only the first matching 
 
       Subcolumn     Symbol                                          Meaning                                           
    ──────────────── ────── ────────────────────────────────────────────────────────────────────────────────────────── 
-   Working tree (1) +      Staged files                                                                               
-   Working tree (2) !      Modified files (unstaged)                                                                  
-   Working tree (3) ?      Untracked files                                                                            
-   Worktree         ✘      Merge conflicts                                                                            
-                    ⤴      Rebase in progress                                                                         
-                    ⤵      Merge in progress                                                                          
-                    /      Branch without worktree                                                                    
-                    ⚑      Branch-worktree mismatch (branch name doesn't match worktree path)                         
-                    ⊟      Prunable (directory missing)                                                               
-                    ⊞      Locked worktree                                                                            
-   Default branch   ^      Is the default branch                                                                      
-                    ∅      Orphan branch (no common ancestor with the default branch)                                 
-                    ✗      Would conflict if merged to the default branch (with --full, includes uncommitted changes) 
-                    _      Same commit as the default branch, clean                                                   
-                    –      Same commit as the default branch, uncommitted changes                                     
-                    ⊂      Content integrated into the default branch or target                                       
-                    ↕      Diverged from the default branch                                                           
-                    ↑      Ahead of the default branch                                                                
-                    ↓      Behind the default branch                                                                  
-   Remote           |      In sync with remote                                                                        
-                    ⇅      Diverged from remote                                                                       
-                    ⇡      Ahead of remote                                                                            
-                    ⇣      Behind remote                                                                              
+   Working tree (1) [36m+[0m      Staged files                                                                               
+   Working tree (2) [36m![0m      Modified files (unstaged)                                                                  
+   Working tree (3) [36m?[0m      Untracked files                                                                            
+   Worktree         [31m✘[0m      Merge conflicts                                                                            
+                    [33m⤴[0m      Rebase in progress                                                                         
+                    [33m⤵[0m      Merge in progress                                                                          
+                    [2m/[0m      Branch without worktree                                                                    
+                    [31m⚑[0m      Branch-worktree mismatch (branch name doesn't match worktree path)                         
+                    [33m⊟[0m      Prunable (directory missing)                                                               
+                    [33m⊞[0m      Locked worktree                                                                            
+   Default branch   [2m^[0m      Is the default branch                                                                      
+                    [2m∅[0m      Orphan branch (no common ancestor with the default branch)                                 
+                    [33m✗[0m      Would conflict if merged to the default branch (with [2m--full[0m, includes uncommitted changes) 
+                    [2m_[0m      Same commit as the default branch, clean                                                   
+                    [2m–[0m      Same commit as the default branch, uncommitted changes                                     
+                    [2m⊂[0m      Content integrated into the default branch or target                                       
+                    [2m↕[0m      Diverged from the default branch                                                           
+                    [2m↑[0m      Ahead of the default branch                                                                
+                    [2m↓[0m      Behind the default branch                                                                  
+   Remote           [2m|[0m      In sync with remote                                                                        
+                    [2m⇅[0m      Diverged from remote                                                                       
+                    [2m⇡[0m      Ahead of remote                                                                            
+                    [2m⇣[0m      Behind remote                                                                              
 
 Rows are dimmed when safe to delete ([2m_[0m same commit with clean working tree or [2m⊂[0m content integrated).
 
@@ -201,79 +201,79 @@ Query structured data with [2m--format=json[0m:
 
          Field           Type                                 Description                             
    ────────────────── ─────────── ─────────────────────────────────────────────────────────────────── 
-   branch             string/null Branch name (null for detached HEAD)                                
-   path               string      Worktree path (absent for branches without worktrees)               
-   kind               string      "worktree" or "branch"                                              
-   commit             object      Commit info (see below)                                             
-   working_tree       object      Working tree state (see below)                                      
-   main_state         string      Relation to the default branch (see below)                          
-   integration_reason string      Why branch is integrated (see below)                                
-   operation_state    string      "conflicts", "rebase", or "merge" (absent when clean)               
-   main               object      Relationship to the default branch (see below, absent when is_main) 
-   remote             object      Tracking branch info (see below, absent when no tracking)           
-   worktree           object      Worktree metadata (see below)                                       
-   is_main            boolean     Is the main worktree                                                
-   is_current         boolean     Is the current worktree                                             
-   is_previous        boolean     Previous worktree from wt switch                                    
-   ci                 object      CI status (see below, absent when no CI)                            
-   url                string      Dev server URL from project config (absent when not configured)     
-   url_active         boolean     Whether the URL's port is listening (absent when not configured)    
-   statusline         string      Pre-formatted status with ANSI colors                               
-   symbols            string      Raw status symbols without colors (e.g., "!?↓")                     
+   [2mbranch[0m             string/null Branch name (null for detached HEAD)                                
+   [2mpath[0m               string      Worktree path (absent for branches without worktrees)               
+   [2mkind[0m               string      [2m"worktree"[0m or [2m"branch"[0m                                              
+   [2mcommit[0m             object      Commit info (see below)                                             
+   [2mworking_tree[0m       object      Working tree state (see below)                                      
+   [2mmain_state[0m         string      Relation to the default branch (see below)                          
+   [2mintegration_reason[0m string      Why branch is integrated (see below)                                
+   [2moperation_state[0m    string      [2m"conflicts"[0m, [2m"rebase"[0m, or [2m"merge"[0m (absent when clean)               
+   [2mmain[0m               object      Relationship to the default branch (see below, absent when is_main) 
+   [2mremote[0m             object      Tracking branch info (see below, absent when no tracking)           
+   [2mworktree[0m           object      Worktree metadata (see below)                                       
+   [2mis_main[0m            boolean     Is the main worktree                                                
+   [2mis_current[0m         boolean     Is the current worktree                                             
+   [2mis_previous[0m        boolean     Previous worktree from wt switch                                    
+   [2mci[0m                 object      CI status (see below, absent when no CI)                            
+   [2murl[0m                string      Dev server URL from project config (absent when not configured)     
+   [2murl_active[0m         boolean     Whether the URL's port is listening (absent when not configured)    
+   [2mstatusline[0m         string      Pre-formatted status with ANSI colors                               
+   [2msymbols[0m            string      Raw status symbols without colors (e.g., [2m"!?↓"[0m)                     
 
 [32mCommit object[0m
 
      Field    Type          Description         
    ───────── ────── ─────────────────────────── 
-   sha       string Full commit SHA (40 chars)  
-   short_sha string Short commit SHA (7 chars)  
-   message   string Commit message (first line) 
-   timestamp number Unix timestamp              
+   [2msha[0m       string Full commit SHA (40 chars)  
+   [2mshort_sha[0m string Short commit SHA (7 chars)  
+   [2mmessage[0m   string Commit message (first line) 
+   [2mtimestamp[0m number Unix timestamp              
 
 [32mworking_tree object[0m
 
      Field    Type                 Description               
    ───────── ─────── ─────────────────────────────────────── 
-   staged    boolean Has staged files                        
-   modified  boolean Has modified files (unstaged)           
-   untracked boolean Has untracked files                     
-   renamed   boolean Has renamed files                       
-   deleted   boolean Has deleted files                       
-   diff      object  Lines changed vs HEAD: {added, deleted} 
+   [2mstaged[0m    boolean Has staged files                        
+   [2mmodified[0m  boolean Has modified files (unstaged)           
+   [2muntracked[0m boolean Has untracked files                     
+   [2mrenamed[0m   boolean Has renamed files                       
+   [2mdeleted[0m   boolean Has deleted files                       
+   [2mdiff[0m      object  Lines changed vs HEAD: [2m{added, deleted}[0m 
 
 [32mmain object[0m
 
    Field   Type                       Description                      
    ────── ────── ───────────────────────────────────────────────────── 
-   ahead  number Commits ahead of the default branch                   
-   behind number Commits behind the default branch                     
-   diff   object Lines changed vs the default branch: {added, deleted} 
+   [2mahead[0m  number Commits ahead of the default branch                   
+   [2mbehind[0m number Commits behind the default branch                     
+   [2mdiff[0m   object Lines changed vs the default branch: [2m{added, deleted}[0m 
 
 [32mremote object[0m
 
    Field   Type          Description          
    ────── ────── ──────────────────────────── 
-   name   string Remote name (e.g., "origin") 
-   branch string Remote branch name           
-   ahead  number Commits ahead of remote      
-   behind number Commits behind remote        
+   [2mname[0m   string Remote name (e.g., [2m"origin"[0m) 
+   [2mbranch[0m string Remote branch name           
+   [2mahead[0m  number Commits ahead of remote      
+   [2mbehind[0m number Commits behind remote        
 
 [32mworktree object[0m
 
     Field    Type                                       Description                                      
    ──────── ─────── ──────────────────────────────────────────────────────────────────────────────────── 
-   state    string  "no_worktree", "branch_worktree_mismatch", "prunable", "locked" (absent when normal) 
-   reason   string  Reason for locked/prunable state                                                     
-   detached boolean HEAD is detached                                                                     
+   [2mstate[0m    string  [2m"no_worktree"[0m, [2m"branch_worktree_mismatch"[0m, [2m"prunable"[0m, [2m"locked"[0m (absent when normal) 
+   [2mreason[0m   string  Reason for locked/prunable state                                                     
+   [2mdetached[0m boolean HEAD is detached                                                                     
 
 [32mci object[0m
 
    Field   Type                      Description                    
    ────── ─────── ───────────────────────────────────────────────── 
-   status string  CI status (see below)                             
-   source string  "pr" (PR/MR) or "branch" (branch workflow)        
-   stale  boolean Local HEAD differs from remote (unpushed changes) 
-   url    string  URL to the PR/MR page                             
+   [2mstatus[0m string  CI status (see below)                             
+   [2msource[0m string  [2m"pr"[0m (PR/MR) or [2m"branch"[0m (branch workflow)        
+   [2mstale[0m  boolean Local HEAD differs from remote (unpushed changes) 
+   [2murl[0m    string  URL to the PR/MR page                             
 
 [32mmain_state values[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -107,11 +107,11 @@ Output as JSON for scripting:
    Status  Compact symbols (see below)                                          
    HEAD±   Uncommitted changes: +added -deleted lines                           
    main↕   Commits ahead/behind default branch                                  
-   main…±  Line diffs since the merge-base with the default branch (--full)     
-   Summary LLM-generated branch summary (--full + summary = true, requires      
-           commit.generation) (experimental)                                    
+   main…±  Line diffs since the merge-base with the default branch ([2m--full[0m)     
+   Summary LLM-generated branch summary ([2m--full[0m + [2msummary = true[0m, requires      
+           [2mcommit.generation[0m) (experimental)                                    
    Remote⇅ Commits ahead/behind tracking branch                                 
-   CI      Pipeline status (--full)                                             
+   CI      Pipeline status ([2m--full[0m)                                             
    Path    Worktree directory                                                   
    URL     Dev server URL from project config (dimmed if port not listening)    
    Commit  Short hash (8 chars)                                                 
@@ -127,12 +127,12 @@ The CI column shows GitHub/GitLab pipeline status:
 
    Indicator              Meaning              
    ───────── ───────────────────────────────── 
-   ● green   All checks passed                 
-   ● blue    Checks running                    
-   ● red     Checks failed                     
-   ● yellow  Merge conflicts with base         
-   ● gray    No checks configured              
-   ⚠ yellow  Fetch error (rate limit, network) 
+   [32m●[0m green   All checks passed                 
+   [34m●[0m blue    Checks running                    
+   [31m●[0m red     Checks failed                     
+   [33m●[0m yellow  Merge conflicts with base         
+   [90m●[0m gray    No checks configured              
+   [33m⚠[0m yellow  Fetch error (rate limit, network) 
    (blank)   No upstream or no PR/MR           
 
 CI indicators are clickable links to the PR or pipeline page. Any CI dot appears
@@ -158,33 +158,33 @@ symbol is shown (listed in priority order):
 
       Subcolumn     Symbol                       Meaning                        
    ──────────────── ────── ──────────────────────────────────────────────────── 
-   Working tree (1) +      Staged files                                         
-   Working tree (2) !      Modified files (unstaged)                            
-   Working tree (3) ?      Untracked files                                      
-   Worktree         ✘      Merge conflicts                                      
-                    ⤴      Rebase in progress                                   
-                    ⤵      Merge in progress                                    
-                    /      Branch without worktree                              
-                    ⚑      Branch-worktree mismatch (branch name doesn't match  
+   Working tree (1) [36m+[0m      Staged files                                         
+   Working tree (2) [36m![0m      Modified files (unstaged)                            
+   Working tree (3) [36m?[0m      Untracked files                                      
+   Worktree         [31m✘[0m      Merge conflicts                                      
+                    [33m⤴[0m      Rebase in progress                                   
+                    [33m⤵[0m      Merge in progress                                    
+                    [2m/[0m      Branch without worktree                              
+                    [31m⚑[0m      Branch-worktree mismatch (branch name doesn't match  
                            worktree path)                                       
-                    ⊟      Prunable (directory missing)                         
-                    ⊞      Locked worktree                                      
-   Default branch   ^      Is the default branch                                
-                    ∅      Orphan branch (no common ancestor with the default   
+                    [33m⊟[0m      Prunable (directory missing)                         
+                    [33m⊞[0m      Locked worktree                                      
+   Default branch   [2m^[0m      Is the default branch                                
+                    [2m∅[0m      Orphan branch (no common ancestor with the default   
                            branch)                                              
-                    ✗      Would conflict if merged to the default branch (with 
-                           --full, includes uncommitted changes)                
-                    _      Same commit as the default branch, clean             
-                    –      Same commit as the default branch, uncommitted       
+                    [33m✗[0m      Would conflict if merged to the default branch (with 
+                           [2m--full[0m, includes uncommitted changes)                
+                    [2m_[0m      Same commit as the default branch, clean             
+                    [2m–[0m      Same commit as the default branch, uncommitted       
                            changes                                              
-                    ⊂      Content integrated into the default branch or target 
-                    ↕      Diverged from the default branch                     
-                    ↑      Ahead of the default branch                          
-                    ↓      Behind the default branch                            
-   Remote           |      In sync with remote                                  
-                    ⇅      Diverged from remote                                 
-                    ⇡      Ahead of remote                                      
-                    ⇣      Behind remote                                        
+                    [2m⊂[0m      Content integrated into the default branch or target 
+                    [2m↕[0m      Diverged from the default branch                     
+                    [2m↑[0m      Ahead of the default branch                          
+                    [2m↓[0m      Behind the default branch                            
+   Remote           [2m|[0m      In sync with remote                                  
+                    [2m⇅[0m      Diverged from remote                                 
+                    [2m⇡[0m      Ahead of remote                                      
+                    [2m⇣[0m      Behind remote                                        
 
 Rows are dimmed when safe to delete ([2m_[0m same commit with clean working tree or [2m⊂[0m 
 content integrated).
@@ -223,87 +223,87 @@ Query structured data with [2m--format=json[0m:
 
          Field           Type                      Description                  
    ────────────────── ─────────── ───────────────────────────────────────────── 
-   branch             string/null Branch name (null for detached HEAD)          
-   path               string      Worktree path (absent for branches without    
+   [2mbranch[0m             string/null Branch name (null for detached HEAD)          
+   [2mpath[0m               string      Worktree path (absent for branches without    
                                   worktrees)                                    
-   kind               string      "worktree" or "branch"                        
-   commit             object      Commit info (see below)                       
-   working_tree       object      Working tree state (see below)                
-   main_state         string      Relation to the default branch (see below)    
-   integration_reason string      Why branch is integrated (see below)          
-   operation_state    string      "conflicts", "rebase", or "merge" (absent     
+   [2mkind[0m               string      [2m"worktree"[0m or [2m"branch"[0m                        
+   [2mcommit[0m             object      Commit info (see below)                       
+   [2mworking_tree[0m       object      Working tree state (see below)                
+   [2mmain_state[0m         string      Relation to the default branch (see below)    
+   [2mintegration_reason[0m string      Why branch is integrated (see below)          
+   [2moperation_state[0m    string      [2m"conflicts"[0m, [2m"rebase"[0m, or [2m"merge"[0m (absent     
                                   when clean)                                   
-   main               object      Relationship to the default branch (see       
+   [2mmain[0m               object      Relationship to the default branch (see       
                                   below, absent when is_main)                   
-   remote             object      Tracking branch info (see below, absent when  
+   [2mremote[0m             object      Tracking branch info (see below, absent when  
                                   no tracking)                                  
-   worktree           object      Worktree metadata (see below)                 
-   is_main            boolean     Is the main worktree                          
-   is_current         boolean     Is the current worktree                       
-   is_previous        boolean     Previous worktree from wt switch              
-   ci                 object      CI status (see below, absent when no CI)      
-   url                string      Dev server URL from project config (absent    
+   [2mworktree[0m           object      Worktree metadata (see below)                 
+   [2mis_main[0m            boolean     Is the main worktree                          
+   [2mis_current[0m         boolean     Is the current worktree                       
+   [2mis_previous[0m        boolean     Previous worktree from wt switch              
+   [2mci[0m                 object      CI status (see below, absent when no CI)      
+   [2murl[0m                string      Dev server URL from project config (absent    
                                   when not configured)                          
-   url_active         boolean     Whether the URL's port is listening (absent   
+   [2murl_active[0m         boolean     Whether the URL's port is listening (absent   
                                   when not configured)                          
-   statusline         string      Pre-formatted status with ANSI colors         
-   symbols            string      Raw status symbols without colors (e.g.,      
-                                  "!?↓")                                        
+   [2mstatusline[0m         string      Pre-formatted status with ANSI colors         
+   [2msymbols[0m            string      Raw status symbols without colors (e.g.,      
+                                  [2m"!?↓"[0m)                                        
 
 [32mCommit object[0m
 
      Field    Type          Description         
    ───────── ────── ─────────────────────────── 
-   sha       string Full commit SHA (40 chars)  
-   short_sha string Short commit SHA (7 chars)  
-   message   string Commit message (first line) 
-   timestamp number Unix timestamp              
+   [2msha[0m       string Full commit SHA (40 chars)  
+   [2mshort_sha[0m string Short commit SHA (7 chars)  
+   [2mmessage[0m   string Commit message (first line) 
+   [2mtimestamp[0m number Unix timestamp              
 
 [32mworking_tree object[0m
 
      Field    Type                 Description               
    ───────── ─────── ─────────────────────────────────────── 
-   staged    boolean Has staged files                        
-   modified  boolean Has modified files (unstaged)           
-   untracked boolean Has untracked files                     
-   renamed   boolean Has renamed files                       
-   deleted   boolean Has deleted files                       
-   diff      object  Lines changed vs HEAD: {added, deleted} 
+   [2mstaged[0m    boolean Has staged files                        
+   [2mmodified[0m  boolean Has modified files (unstaged)           
+   [2muntracked[0m boolean Has untracked files                     
+   [2mrenamed[0m   boolean Has renamed files                       
+   [2mdeleted[0m   boolean Has deleted files                       
+   [2mdiff[0m      object  Lines changed vs HEAD: [2m{added, deleted}[0m 
 
 [32mmain object[0m
 
    Field   Type                       Description                      
    ────── ────── ───────────────────────────────────────────────────── 
-   ahead  number Commits ahead of the default branch                   
-   behind number Commits behind the default branch                     
-   diff   object Lines changed vs the default branch: {added, deleted} 
+   [2mahead[0m  number Commits ahead of the default branch                   
+   [2mbehind[0m number Commits behind the default branch                     
+   [2mdiff[0m   object Lines changed vs the default branch: [2m{added, deleted}[0m 
 
 [32mremote object[0m
 
    Field   Type          Description          
    ────── ────── ──────────────────────────── 
-   name   string Remote name (e.g., "origin") 
-   branch string Remote branch name           
-   ahead  number Commits ahead of remote      
-   behind number Commits behind remote        
+   [2mname[0m   string Remote name (e.g., [2m"origin"[0m) 
+   [2mbranch[0m string Remote branch name           
+   [2mahead[0m  number Commits ahead of remote      
+   [2mbehind[0m number Commits behind remote        
 
 [32mworktree object[0m
 
     Field    Type                           Description                         
    ──────── ─────── ─────────────────────────────────────────────────────────── 
-   state    string  "no_worktree", "branch_worktree_mismatch", "prunable",      
-                    "locked" (absent when normal)                               
-   reason   string  Reason for locked/prunable state                            
-   detached boolean HEAD is detached                                            
+   [2mstate[0m    string  [2m"no_worktree"[0m, [2m"branch_worktree_mismatch"[0m, [2m"prunable"[0m,      
+                    [2m"locked"[0m (absent when normal)                               
+   [2mreason[0m   string  Reason for locked/prunable state                            
+   [2mdetached[0m boolean HEAD is detached                                            
 
 [32mci object[0m
 
    Field   Type                      Description                    
    ────── ─────── ───────────────────────────────────────────────── 
-   status string  CI status (see below)                             
-   source string  "pr" (PR/MR) or "branch" (branch workflow)        
-   stale  boolean Local HEAD differs from remote (unpushed changes) 
-   url    string  URL to the PR/MR page                             
+   [2mstatus[0m string  CI status (see below)                             
+   [2msource[0m string  [2m"pr"[0m (PR/MR) or [2m"branch"[0m (branch workflow)        
+   [2mstale[0m  boolean Local HEAD differs from remote (unpushed changes) 
+   [2murl[0m    string  URL to the PR/MR page                             
 
 [32mmain_state values[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
@@ -15,10 +15,13 @@ info:
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
+    WORKTRUNK_APPROVALS_PATH: /nonexistent/test/approvals.toml
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_SYSTEM_CONFIG_PATH: /etc/xdg/worktrunk/config.toml
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
 ---
@@ -112,8 +115,8 @@ Worktrunk has two force flags for different situations:
 
           Flag          Scope                          When to use                         
    ─────────────────── ──────── ────────────────────────────────────────────────────────── 
-   --force (-f)        Worktree Worktree has untracked files (build artifacts, IDE config) 
-   --force-delete (-D) Branch   Branch has unmerged commits                                
+   [2m--force[0m ([2m-f[0m)        Worktree Worktree has untracked files (build artifacts, IDE config) 
+   [2m--force-delete[0m ([2m-D[0m) Branch   Branch has unmerged commits                                
 
   [2mwt remove feature --force       # Remove worktree with untracked files[0m
   [2mwt remove feature -D            # Delete unmerged branch[0m

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -141,11 +141,11 @@ When creating a worktree, worktrunk:
 
    Shortcut            Meaning            
    ──────── ───────────────────────────── 
-   ^        Default branch (main/master)  
-   @        Current branch/worktree       
-   -        Previous worktree (like cd -) 
-   pr:{N}   GitHub PR #N's branch         
-   mr:{N}   GitLab MR !N's branch         
+   [2m^[0m        Default branch ([2mmain[0m/[2mmaster[0m)  
+   [2m@[0m        Current branch/worktree       
+   [2m-[0m        Previous worktree (like [2mcd -[0m) 
+   [2mpr:{N}[0m   GitHub PR #N's branch         
+   [2mmr:{N}[0m   GitLab MR !N's branch         
 
   [2mwt switch -                      # Back to previous[0m
   [2mwt switch ^                      # Default branch worktree[0m
@@ -161,14 +161,14 @@ When called without arguments, [2mwt switch[0m opens an interactive picker to 
 
         Key                  Action             
    ───────────── ────────────────────────────── 
-   ↑/↓           Navigate worktree list         
+   [2m↑[0m/[2m↓[0m           Navigate worktree list         
    (type)        Filter worktrees               
-   Enter         Switch to selected worktree    
-   Alt-c         Create new worktree from query 
-   Esc           Cancel                         
-   1–5           Switch preview tab             
-   Alt-p         Toggle preview panel           
-   Ctrl-u/Ctrl-d Scroll preview up/down         
+   [2mEnter[0m         Switch to selected worktree    
+   [2mAlt-c[0m         Create new worktree from query 
+   [2mEsc[0m           Cancel                         
+   [2m1[0m–[2m5[0m           Switch preview tab             
+   [2mAlt-p[0m         Toggle preview panel           
+   [2mCtrl-u[0m/[2mCtrl-d[0m Scroll preview up/down         
 
 [1mPreview tabs[0m (toggle with number keys):
 


### PR DESCRIPTION
## Summary

- Fix missing colors in `--help` table content (CI status dots, status symbols, inline code)
- Root cause: `MadSkin::no_style()` stripped backticks without adding ANSI codes, so `colorize_status_symbols()` couldn't find the dimmed patterns it expected
- Set `inline_code` to dimmed in the table skin, matching what `render_inline_formatting()` does for prose

## Test plan

- [x] All 1137 tests pass
- [x] 7 help snapshots updated to reflect new ANSI codes in table content
- [x] Lints pass (`pre-commit run --all-files`)
- [x] Verified CI status dots render green/blue/red/yellow/gray
- [x] Verified status symbols render in correct colors (cyan, red, yellow, dim)
- [x] Verified other backtick-enclosed text in tables (e.g. `--full`) renders dimmed

> _This was written by Claude Code on behalf of @max-sixty_