### PR TITLE
fix: show "Outdated" instead of "Not configured" for nushell in `config show`

### DIFF
--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -805,16 +805,16 @@ fn render_shell_status(out: &mut String) -> anyhow::Result<()> {
                             "To migrate to <bright-black>{canonical_path}</>, run <bright-black>{cmd} config shell install fish</>"
                         ))
                     )?;
-                } else if matches!(shell, Shell::Fish)
+                } else if matches!(shell, Shell::Fish | Shell::Nushell)
                     && matches!(result.action, ConfigAction::WouldAdd)
                 {
-                    // Fish file exists but has different content (e.g. outdated version)
+                    // File exists but has different content (e.g. outdated version)
                     any_not_configured = true;
                     let warning = warning_message(cformat!(
                         "<bold>{shell}</>: Outdated shell extension @ {path}"
                     ));
                     let hint = hint_message(cformat!(
-                        "To update, run <bright-black>{cmd} config shell install fish</>"
+                        "To update, run <bright-black>{cmd} config shell install {shell}</>"
                     ));
                     writeln!(out, "{warning}\n{hint}")?;
                 } else {

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_nushell_outdated_wrapper.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_nushell_outdated_wrapper.snap
@@ -1,0 +1,71 @@
+---
+source: tests/integration_tests/config_show.rs
+assertion_line: 799
+info:
+  program: wt
+  args:
+    - config
+    - show
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[2m↳[22m [2mEmpty file (using defaults)[22m
+
+[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[2m↳[22m [2mNot found[22m
+
+[36mSHELL INTEGRATION[39m
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+
+[33m▲[39m [33m[1mnu[22m: Outdated shell extension @ ~/.config/nushell/vendor/autoload/wt.nu[39m
+[2m↳[22m [2mTo update, run [90mwt config shell install nu[39m[22m
+[2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
+[2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
+[2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
+[2m↳[22m [2mTo configure, run [90mwt config shell install[39m[22m
+[33m▲[39m [33mFound [1mwt[22m in [1m~/.config/nushell/vendor/autoload/wt.nu:2[22m but not detected as integration:[39m
+[107m [0m [2m[0m[2m[34mdef[0m[2m [0m[2m[36m--wrapped[0m[2m wt [...args] {
+[2m↳[22m [2mIf `def --wrapped wt [...args] {` is shell integration, report a false negative: https://github.com/max-sixty/worktrunk/issues/new?title=Shell%20integration%20detection%20false%20negative&body=Shell%20integration%20not%20detected%20despite%20config%20containing%20%60wt%60.%0A%0A%2A%2AUnmatched%20lines%3A%2A%2A%0A%60%60%60%0Adef%20--wrapped%20wt%20%5B...args%5D%20%7B%0A%60%60%60%0A%0A%2A%2AExpected%20behavior%3A%2A%2A%20These%20lines%20should%20be%20detected%20as%20shell%20integration.[22m
+
+[36mCLAUDE CODE[39m
+[2m○[22m [1mclaude[22m CLI not installed
+
+[36mOTHER[39m
+[2m○[22m wt: [1m[VERSION][22m
+[2m○[22m git: [1m[VERSION][22m
+[2m○[22m Hyperlinks: [1minactive[22m


### PR DESCRIPTION
## Summary

When a nushell user's `wt.nu` wrapper was outdated (e.g. after upgrading the binary), `wt config show` displayed the misleading `nu: Not configured shell extension & completions` instead of the helpful outdated message that Fish already shows. This extends the Fish-only outdated detection to also cover Nushell — both use file-based wrappers where `WouldAdd` means "exists but content differs".

**Before:** `nu: Not configured shell extension & completions`
**After:** `nu: Outdated shell extension @ ~/.config/nushell/vendor/autoload/wt.nu` with hint `To update, run wt config shell install nu`

Part of #1229

## Test plan

- [x] New snapshot test `test_config_show_nushell_outdated_wrapper` mirrors existing Fish test
- [x] All 68 config_show tests pass
- [x] Full pre-merge suite green

> _This was written by Claude Code on behalf of @max-sixty_