### PR TITLE
fix: fail fast when ffmpeg lacks libass for demo GIF builds

### DIFF
--- a/docs/demos/CLAUDE.md
+++ b/docs/demos/CLAUDE.md
@@ -92,6 +92,12 @@ Currently `wt-zellij-omnibus` has checkpoints; other TUI demos are skipped until
 
 **Requires Go** — The VHS fork is built from source ([install Go](https://go.dev/dl/)).
 
+**Requires ffmpeg with libass** — The keystroke overlay uses ASS subtitles. The build script checks for this and exits with install instructions if missing. Homebrew's API-sourced bottle omits `libass`; install from the tap formula instead:
+
+```bash
+HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source ffmpeg
+```
+
 External dependencies are downloaded/built automatically on first run:
 - **VHS** — Custom fork with keystroke overlay (cloned and built from source)
 - **Claude Code binary** — Downloaded from Anthropic's release bucket

--- a/docs/demos/build
+++ b/docs/demos/build
@@ -38,6 +38,7 @@ from shared import (  # noqa: E402
     setup_zellij_config,
     setup_fish_config,
     check_dependencies,
+    check_ffmpeg_libass,
     setup_demo_output,
     record_all_themes,
     SIZE_DOCS,
@@ -487,6 +488,8 @@ Examples:
     # Check dependencies (VHS is built from source, not required in PATH)
     deps = ["wt", "starship", "zellij"]
     check_dependencies(deps)
+    if not args.text and not args.snapshot:
+        check_ffmpeg_libass()
 
     # Ensure VHS is built (requires Go)
     vhs_binary = str(ensure_vhs_binary())

--- a/docs/demos/shared/__init__.py
+++ b/docs/demos/shared/__init__.py
@@ -22,6 +22,7 @@ from .lib import (
     prepare_demo_repo,
     # Demo recording infrastructure
     check_dependencies,
+    check_ffmpeg_libass,
     setup_demo_output,
     record_all_themes,
     # Text output recording
@@ -59,6 +60,7 @@ __all__ = [
     "format_theme_for_vhs",
     # Demo recording infrastructure
     "check_dependencies",
+    "check_ffmpeg_libass",
     "setup_demo_output",
     "record_all_themes",
     # Text output recording


### PR DESCRIPTION
## Summary

- Add early `check_ffmpeg_libass()` at demo build startup — exits with install
  instructions when ffmpeg lacks libass (required for keystroke overlay ASS
  subtitles)
- Add output verification in `record_vhs()` — catches silent failures where VHS
  exits 0 but produces no GIF
- Document the Homebrew API-bottle vs tap-formula issue in demos CLAUDE.md

Homebrew's API-sourced formula strips `libass`; the tap formula includes it.
The fix is `HOMEBREW_NO_INSTALL_FROM_API=1 brew install --build-from-source ffmpeg`.

## Test plan

- [x] Verified `check_ffmpeg_libass()` passes with correct ffmpeg
- [x] Verified full demo build succeeds with `--only wt-switch-picker`
- [x] Lints pass (`pre-commit run --all-files`)

> _This was written by Claude Code on behalf of @max-sixty_