### PR TITLE
fix: bump Zola to 0.22.1 for syntax highlighting

### DIFF
--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Setup Zola
         uses: taiki-e/install-action@v2.68.16
         with:
-          tool: zola@0.21.0
+          tool: zola@0.22.1
 
       - name: Fetch assets
         env:


### PR DESCRIPTION
The docs config was migrated to the Zola 0.22 format (`[markdown.highlighting]`
section) in #1080, but the deploy workflow still installed `zola@0.21.0`. Zola
0.21 silently ignores the new config section, so worktrunk.dev has had no syntax
highlighting on any code blocks.

Note: since `publish-docs.yaml` isn't under the `docs/**` path filter, a
`workflow_dispatch` trigger will be needed after merge to redeploy.

> _This was written by Claude Code on behalf of @max-sixty_