### PR TITLE
Investigate existing functionality when triaging feature requests

### DIFF
--- a/.claude/skills/issue-triage/SKILL.md
+++ b/.claude/skills/issue-triage/SKILL.md
@@ -32,11 +32,9 @@ Classify into one of:
 - **Question** — asks how to do something or how something works
 - **Other** — doesn't fit the above categories
 
-If not a bug report, skip to step 6 (comment only).
-
 ## Step 3: Check for duplicates
 
-Before doing any work, check if this issue is already being addressed:
+*Skip for questions and other.*
 
 ```bash
 # Search open issues for similar problems
@@ -50,12 +48,28 @@ git branch -r --list 'origin/repro/issue-*'
 gh pr list --state open --json number,title,headRefName --limit 50
 ```
 
-If a duplicate or existing fix is found, note it for the comment in step 6.
+If a duplicate or existing fix is found, note it for the comment in step 7.
 Don't create a duplicate fix.
 
-## Step 4: Reproduce the bug
+## Step 4: Investigate existing functionality
 
-Follow the AD FONTES principle — reproduce before fixing:
+*Feature requests only.*
+
+Search the codebase to check whether the requested feature already exists.
+
+1. **Extract the core ask** — What specific behavior does the requester want?
+2. **Search for implementations** — Grep for relevant function names, config
+   keys, CLI flags, and domain terms in `src/`, `src/cli/`, `docs/`, and config.
+3. **Read key files** — If searches find hits, read the relevant source to
+   understand what already exists and how it works.
+4. **Check docs and help text** — Look for user-facing documentation of the
+   feature (`--help`, `docs/content/`, config reference).
+
+Record what you found (or didn't find) for use in step 7.
+
+## Step 5: Reproduce the bug
+
+*Bug reports only.*
 
 1. **Understand the report** — What command was run? What was expected? What
    actually happened?
@@ -72,9 +86,11 @@ Follow the AD FONTES principle — reproduce before fixing:
 If the test passes (bug may already be fixed), note this for the comment.
 
 If you cannot reproduce the bug (unclear steps, environment-specific, etc.),
-note what you tried and skip to step 6.
+note what you tried and skip to step 7.
 
-## Step 5: Fix (conservative)
+## Step 6: Fix (conservative)
+
+*Bug reports only.*
 
 **Only attempt a fix if ALL of these conditions are met:**
 
@@ -142,7 +158,7 @@ Automated triage for #<issue-number>"
 
 Note the PR number for the comment.
 
-## Step 6: Comment on the issue
+## Step 7: Comment on the issue
 
 Always comment via `gh issue comment`. Keep it brief, polite, and specific. A
 maintainer will always review — never claim the issue is fully resolved by
@@ -193,9 +209,21 @@ Choose the appropriate template:
 > on an older release, updating should resolve this. A maintainer will
 > confirm.
 
-### Feature request
+### Feature may already exist
 
-> Thanks for the suggestion! This is a feature request rather than a bug, so
+> Thanks for the suggestion! It's possible that [existing feature — specific
+> behavior, config/flag] already does what you're looking for: [brief
+> description of how it works].
+>
+> If that's not quite what you had in mind, could you clarify what additional
+> behavior you're looking for? A maintainer will take a look either way.
+
+### Feature does not exist
+
+> Thanks for the suggestion! I searched the codebase and didn't find an
+> existing implementation of this. [Optionally: the closest related
+> functionality is X, which does Y.]
+>
 > I'll leave it for a maintainer to evaluate and prioritize.
 
 ### Question


### PR DESCRIPTION
The issue triager now searches the codebase before commenting on feature
requests, checking whether the requested functionality already exists.

Motivated by #1264 — the user asked for dynamic layout switching in the
picker, which is already implemented via `PreviewLayout::auto_detect()`.
The triager would have just said "I'll leave it for a maintainer" without
investigating.

Changes:
- Add step 4 (investigate existing functionality) for feature requests —
  grep for relevant terms in source, CLI, docs, and config
- Split feature request comment template into "may already exist" (with
  open-minded framing) and "does not exist" variants
- Restructure step numbering for linear flow — each step states which
  issue types it applies to instead of routing instructions in step 2

Ref #1264

> _This was written by Claude Code on behalf of @max-sixty_