### PR TITLE
fix(prune): use plumbing command for branch listing

### DIFF
--- a/src/git/repository/branches.rs
+++ b/src/git/repository/branches.rs
@@ -24,12 +24,13 @@ impl Repository {
             .is_ok())
     }
 
-    /// Get all branch names (local branches only).
+    /// List all local branch names, sorted by most recent commit first.
     pub fn all_branches(&self) -> anyhow::Result<Vec<String>> {
         let stdout = self.run_command(&[
-            "branch",
+            "for-each-ref",
             "--sort=-committerdate",
             "--format=%(refname:lstrip=2)",
+            "refs/heads/",
         ])?;
         Ok(stdout
             .lines()
@@ -37,14 +38,6 @@ impl Repository {
             .filter(|s| !s.is_empty())
             .map(str::to_owned)
             .collect())
-    }
-
-    /// List all local branches.
-    pub(super) fn local_branches(&self) -> anyhow::Result<Vec<String>> {
-        // Use lstrip=2 instead of refname:short - git adds "heads/" prefix to short
-        // names when disambiguation is needed (e.g., branch "foo" + remote "foo").
-        let stdout = self.run_command(&["branch", "--format=%(refname:lstrip=2)"])?;
-        Ok(stdout.lines().map(|s| s.trim().to_string()).collect())
     }
 
     /// List all local branches with their HEAD commit SHA.

--- a/src/git/repository/config.rs
+++ b/src/git/repository/config.rs
@@ -282,7 +282,7 @@ impl Repository {
     /// 5. Fail if none of the above work
     fn infer_default_branch_locally(&self) -> anyhow::Result<String> {
         // 1. If there's only one local branch, use it
-        let branches = self.local_branches()?;
+        let branches = self.all_branches()?;
         if branches.len() == 1 {
             return Ok(branches[0].clone());
         }
@@ -336,7 +336,7 @@ impl Repository {
             .ok()
             .and_then(|s| s.trim().strip_prefix("refs/heads/").map(String::from))
             .is_some_and(|head_branch| head_branch == branch)
-            && self.local_branches().is_ok_and(|b| b.is_empty())
+            && self.all_branches().is_ok_and(|b| b.is_empty())
     }
 
     fn get_local_default_branch(&self, remote: &str) -> anyhow::Result<String> {

--- a/tests/integration_tests/step_prune.rs
+++ b/tests/integration_tests/step_prune.rs
@@ -407,6 +407,44 @@ fn test_prune_dry_run_mixed_worktrees_and_branches(mut repo: TestRepo) {
     assert_cmd_snapshot!(cmd);
 }
 
+/// Prune works when the current worktree is mid-rebase.
+///
+/// During an interactive rebase, the worktree is in detached HEAD state.
+/// `git branch --format=%(refname:lstrip=2)` includes a synthetic entry like
+/// `(no branch, rebasing feature)` which isn't a valid ref. The orphan branch
+/// scan must not pass this to `integration_reason`.
+#[rstest]
+fn test_prune_during_rebase(mut repo: TestRepo) {
+    repo.commit("initial");
+
+    // Create a merged worktree (same commit as main)
+    repo.add_worktree("merged-wt");
+
+    // Create a feature worktree with commits to rebase
+    let feature_path = repo.add_worktree_with_commit("rebasing", "r.txt", "v1", "commit 1");
+    repo.commit_in_worktree(&feature_path, "r.txt", "v2", "commit 2");
+
+    // Start an interactive rebase that pauses (exec false fails)
+    let git_status = repo
+        .git_command()
+        .args(["rebase", "-i", "--exec", "false", "main"])
+        .current_dir(&feature_path)
+        .env("GIT_SEQUENCE_EDITOR", "true")
+        .output()
+        .unwrap();
+    // The rebase should pause (exec false fails), leaving us in rebase state
+    assert!(!git_status.status.success(), "rebase should be paused");
+
+    // Run prune from the rebasing worktree — should succeed, not error on
+    // "(no branch, rebasing ...)" being used as a git revision
+    assert_cmd_snapshot!(make_snapshot_cmd(
+        &repo,
+        "step",
+        &["prune", "--yes", "--min-age=0s"],
+        Some(&feature_path)
+    ));
+}
+
 /// Stale candidate + young worktrees: shows both the candidate and skipped count.
 ///
 /// A stale worktree (directory deleted) bypasses the age check because it goes

--- a/tests/snapshots/integration__integration_tests__step_prune__prune_during_rebase.snap
+++ b/tests/snapshots/integration__integration_tests__step_prune__prune_during_rebase.snap
@@ -1,0 +1,48 @@
+---
+source: tests/integration_tests/step_prune.rs
+info:
+  program: wt
+  args:
+    - step
+    - prune
+    - "--yes"
+    - "--min-age=0s"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎ Removing [1mmerged-wt[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m
+[32m✓[39m [32mPruned 1 worktree (with branch)[39m


### PR DESCRIPTION
During an interactive rebase, `git branch --format=%(refname:lstrip=2)` includes
a synthetic `(no branch, rebasing <name>)` entry. The orphan branch scan in
`step prune` passed this to `integration_reason()`, which tried to resolve it as
a git revision and crashed.

Switch `all_branches()` from `git branch` (porcelain) to `git for-each-ref
refs/heads/` (plumbing), which only iterates actual refs. Delete the
near-duplicate `local_branches()` — it was identical minus sorting, and neither
caller needed a specific order.

> _This was written by Claude Code on behalf of @max-sixty_