### PR TITLE
fix(list): add missing summary field to JSON output

### DIFF
--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -205,6 +205,7 @@ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 | `ci` | object | CI status (see below, absent when no CI) |
 | `url` | string | Dev server URL from project config (absent when not configured) |
 | `url_active` | boolean | Whether the URL's port is listening (absent when not configured) |
+| `summary` | string | LLM-generated branch summary (absent when not configured or no summary) |
 | `statusline` | string | Pre-formatted status with ANSI colors |
 | `symbols` | string | Raw status symbols without colors (e.g., `"!?↓"`) |
 

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -177,6 +177,7 @@ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 | `ci` | object | CI status (see below, absent when no CI) |
 | `url` | string | Dev server URL from project config (absent when not configured) |
 | `url_active` | boolean | Whether the URL's port is listening (absent when not configured) |
+| `summary` | string | LLM-generated branch summary (absent when not configured or no summary) |
 | `statusline` | string | Pre-formatted status with ANSI colors |
 | `symbols` | string | Raw status symbols without colors (e.g., `"!?↓"`) |
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -626,6 +626,7 @@ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 | `ci` | object | CI status (see below, absent when no CI) |
 | `url` | string | Dev server URL from project config (absent when not configured) |
 | `url_active` | boolean | Whether the URL's port is listening (absent when not configured) |
+| `summary` | string | LLM-generated branch summary (absent when not configured or no summary) |
 | `statusline` | string | Pre-formatted status with ANSI colors |
 | `symbols` | string | Raw status symbols without colors (e.g., `"!?↓"`) |
 

--- a/src/commands/list/collect/tasks.rs
+++ b/src/commands/list/collect/tasks.rs
@@ -657,7 +657,7 @@ impl Task for UrlStatusTask {
     }
 }
 
-/// Task 14: LLM-generated branch summary (--full only, requires LLM command)
+/// Task 14: LLM-generated branch summary (`--full` + `[list] summary = true` + LLM command)
 pub struct SummaryGenerateTask;
 
 impl Task for SummaryGenerateTask {

--- a/src/commands/list/collect/types.rs
+++ b/src/commands/list/collect/types.rs
@@ -154,7 +154,7 @@ pub(crate) enum TaskResult {
         /// Whether the port is listening (None if no URL or couldn't parse port)
         active: Option<bool>,
     },
-    /// LLM-generated branch summary (--full only, requires LLM command configured)
+    /// LLM-generated branch summary (`--full` + `[list] summary = true` + LLM command)
     SummaryGenerate {
         item_idx: usize,
         summary: Option<String>,

--- a/src/commands/list/json_output.rs
+++ b/src/commands/list/json_output.rs
@@ -91,6 +91,10 @@ pub struct JsonItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url_active: Option<bool>,
 
+    /// LLM-generated branch summary (requires `[list] summary = true`)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub summary: Option<String>,
+
     /// Pre-formatted statusline for statusline tools (tmux, starship)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub statusline: Option<String>,
@@ -325,6 +329,9 @@ impl JsonItem {
             .map(format_raw_symbols)
             .filter(|s| !s.is_empty());
 
+        // Summary: flatten Option<Option<String>> → Option<String>
+        let summary = item.summary.as_ref().and_then(|s| s.clone());
+
         JsonItem {
             branch: item.branch.clone(),
             path,
@@ -343,6 +350,7 @@ impl JsonItem {
             ci,
             url: item.url.clone(),
             url_active: item.url_active,
+            summary,
             statusline,
             symbols,
         }
@@ -879,6 +887,24 @@ mod tests {
         let json = serde_json::to_string(&wt).unwrap();
         assert!(json.contains("\"state\":\"locked\""));
         assert!(json.contains("\"reason\":\"manual\""));
+    }
+
+    #[test]
+    fn test_json_item_summary_present() {
+        let mut item = ListItem::new_branch("abc1234".into(), "feature".into());
+        item.summary = Some(Some("Add login page".to_string()));
+        let json_item = JsonItem::from_list_item(&item);
+        assert_eq!(json_item.summary, Some("Add login page".to_string()));
+    }
+
+    #[test]
+    fn test_json_item_summary_absent() {
+        let mut item = ListItem::new_branch("abc1234".into(), "feature".into());
+        // None = not loaded, Some(None) = loaded but no summary — both should be absent in JSON
+        assert!(JsonItem::from_list_item(&item).summary.is_none());
+
+        item.summary = Some(None);
+        assert!(JsonItem::from_list_item(&item).summary.is_none());
     }
 
     #[test]

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -11,6 +11,7 @@ info:
     GIT_EDITOR: ""
     LANG: C
     LC_ALL: C
+    NO_COLOR: ""
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
@@ -199,27 +200,28 @@ Query structured data with [2m--format=json[0m:
 
 [1mFields:[0m
 
-         Field           Type                                 Description                             
-   ────────────────── ─────────── ─────────────────────────────────────────────────────────────────── 
-   [2mbranch[0m             string/null Branch name (null for detached HEAD)                                
-   [2mpath[0m               string      Worktree path (absent for branches without worktrees)               
-   [2mkind[0m               string      [2m"worktree"[0m or [2m"branch"[0m                                              
-   [2mcommit[0m             object      Commit info (see below)                                             
-   [2mworking_tree[0m       object      Working tree state (see below)                                      
-   [2mmain_state[0m         string      Relation to the default branch (see below)                          
-   [2mintegration_reason[0m string      Why branch is integrated (see below)                                
-   [2moperation_state[0m    string      [2m"conflicts"[0m, [2m"rebase"[0m, or [2m"merge"[0m (absent when clean)               
-   [2mmain[0m               object      Relationship to the default branch (see below, absent when is_main) 
-   [2mremote[0m             object      Tracking branch info (see below, absent when no tracking)           
-   [2mworktree[0m           object      Worktree metadata (see below)                                       
-   [2mis_main[0m            boolean     Is the main worktree                                                
-   [2mis_current[0m         boolean     Is the current worktree                                             
-   [2mis_previous[0m        boolean     Previous worktree from wt switch                                    
-   [2mci[0m                 object      CI status (see below, absent when no CI)                            
-   [2murl[0m                string      Dev server URL from project config (absent when not configured)     
-   [2murl_active[0m         boolean     Whether the URL's port is listening (absent when not configured)    
-   [2mstatusline[0m         string      Pre-formatted status with ANSI colors                               
-   [2msymbols[0m            string      Raw status symbols without colors (e.g., [2m"!?↓"[0m)                     
+         Field           Type                                   Description                               
+   ────────────────── ─────────── ─────────────────────────────────────────────────────────────────────── 
+   [2mbranch[0m             string/null Branch name (null for detached HEAD)                                    
+   [2mpath[0m               string      Worktree path (absent for branches without worktrees)                   
+   [2mkind[0m               string      [2m"worktree"[0m or [2m"branch"[0m                                                  
+   [2mcommit[0m             object      Commit info (see below)                                                 
+   [2mworking_tree[0m       object      Working tree state (see below)                                          
+   [2mmain_state[0m         string      Relation to the default branch (see below)                              
+   [2mintegration_reason[0m string      Why branch is integrated (see below)                                    
+   [2moperation_state[0m    string      [2m"conflicts"[0m, [2m"rebase"[0m, or [2m"merge"[0m (absent when clean)                   
+   [2mmain[0m               object      Relationship to the default branch (see below, absent when is_main)     
+   [2mremote[0m             object      Tracking branch info (see below, absent when no tracking)               
+   [2mworktree[0m           object      Worktree metadata (see below)                                           
+   [2mis_main[0m            boolean     Is the main worktree                                                    
+   [2mis_current[0m         boolean     Is the current worktree                                                 
+   [2mis_previous[0m        boolean     Previous worktree from wt switch                                        
+   [2mci[0m                 object      CI status (see below, absent when no CI)                                
+   [2murl[0m                string      Dev server URL from project config (absent when not configured)         
+   [2murl_active[0m         boolean     Whether the URL's port is listening (absent when not configured)        
+   [2msummary[0m            string      LLM-generated branch summary (absent when not configured or no summary) 
+   [2mstatusline[0m         string      Pre-formatted status with ANSI colors                                   
+   [2msymbols[0m            string      Raw status symbols without colors (e.g., [2m"!?↓"[0m)                         
 
 [32mCommit object[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -11,6 +11,7 @@ info:
     GIT_EDITOR: ""
     LANG: C
     LC_ALL: C
+    NO_COLOR: ""
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
@@ -246,6 +247,8 @@ Query structured data with [2m--format=json[0m:
                                   when not configured)                          
    [2murl_active[0m         boolean     Whether the URL's port is listening (absent   
                                   when not configured)                          
+   [2msummary[0m            string      LLM-generated branch summary (absent when not 
+                                  configured or no summary)                     
    [2mstatusline[0m         string      Pre-formatted status with ANSI colors         
    [2msymbols[0m            string      Raw status symbols without colors (e.g.,      
                                   [2m"!?↓"[0m)                                        


### PR DESCRIPTION
The `summary` field was wired up in the table UI but never added to `JsonItem`, so `wt list --format=json` never included LLM summaries even when configured. Also improves doc comments to mention all three requirements for summary generation.

> _This was written by Claude Code on behalf of @max-sixty_