### PR TITLE
Group picker options under separate help heading in wt switch

### DIFF
--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -176,12 +176,6 @@ Usage: <b><span class=c>wt switch</span></b> <span class=c>[OPTIONS]</span> <spa
           is expanded for templates, then POSIX shell-escaped.
 
 <b><span class=g>Options:</span></b>
-      <b><span class=c>--branches</span></b>
-          Include branches without worktrees (interactive picker)
-
-      <b><span class=c>--remotes</span></b>
-          Include remote branches (interactive picker)
-
   <b><span class=c>-c</span></b>, <b><span class=c>--create</span></b>
           Create a new branch
 
@@ -231,6 +225,13 @@ Usage: <b><span class=c>wt switch</span></b> <span class=c>[OPTIONS]</span> <spa
 
   <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
           Print help (see a summary with &#39;-h&#39;)
+
+<b><span class=g>Picker Options:</span></b>
+      <b><span class=c>--branches</span></b>
+          Include branches without worktrees
+
+      <b><span class=c>--remotes</span></b>
+          Include remote branches
 
 <b><span class=g>Global Options:</span></b>
   <b><span class=c>-C</span></b><span class=c> &lt;path&gt;</span>

--- a/skills/worktrunk/reference/switch.md
+++ b/skills/worktrunk/reference/switch.md
@@ -146,12 +146,6 @@ Usage: <b><span class=c>wt switch</span></b> <span class=c>[OPTIONS]</span> <spa
           is expanded for templates, then POSIX shell-escaped.
 
 <b><span class=g>Options:</span></b>
-      <b><span class=c>--branches</span></b>
-          Include branches without worktrees (interactive picker)
-
-      <b><span class=c>--remotes</span></b>
-          Include remote branches (interactive picker)
-
   <b><span class=c>-c</span></b>, <b><span class=c>--create</span></b>
           Create a new branch
 
@@ -201,6 +195,13 @@ Usage: <b><span class=c>wt switch</span></b> <span class=c>[OPTIONS]</span> <spa
 
   <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
           Print help (see a summary with &#39;-h&#39;)
+
+<b><span class=g>Picker Options:</span></b>
+      <b><span class=c>--branches</span></b>
+          Include branches without worktrees
+
+      <b><span class=c>--remotes</span></b>
+          Include remote branches
 
 <b><span class=g>Global Options:</span></b>
   <b><span class=c>-C</span></b><span class=c> &lt;path&gt;</span>

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -389,12 +389,12 @@ To change which branch a worktree is on, use `git switch` inside that worktree.
         #[arg(add = crate::completion::worktree_branch_completer())]
         branch: Option<String>,
 
-        /// Include branches without worktrees (interactive picker)
-        #[arg(long, conflicts_with_all = ["create", "base", "execute", "execute_args", "clobber"])]
+        /// Include branches without worktrees
+        #[arg(long, help_heading = "Picker Options", conflicts_with_all = ["create", "base", "execute", "execute_args", "clobber"])]
         branches: bool,
 
-        /// Include remote branches (interactive picker)
-        #[arg(long, conflicts_with_all = ["create", "base", "execute", "execute_args", "clobber"])]
+        /// Include remote branches
+        #[arg(long, help_heading = "Picker Options", conflicts_with_all = ["create", "base", "execute", "execute_args", "clobber"])]
         remotes: bool,
 
         /// Create a new branch

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -47,12 +47,6 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
           Arguments after [1m--[0m are appended to the execute command. Each argument is expanded for templates, then POSIX shell-escaped.[0m
 
 [1m[32mOptions:[0m
-      [1m[36m--branches[0m
-          Include branches without worktrees (interactive picker)
-
-      [1m[36m--remotes[0m
-          Include remote branches (interactive picker)
-
   [1m[36m-c[0m, [1m[36m--create[0m
           Create a new branch
 
@@ -93,6 +87,13 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
 
   [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
+
+[1m[32mPicker Options:[0m
+      [1m[36m--branches[0m
+          Include branches without worktrees
+
+      [1m[36m--remotes[0m
+          Include remote branches
 
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m

--- a/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
@@ -11,6 +11,7 @@ info:
     GIT_EDITOR: ""
     LANG: C
     LC_ALL: C
+    NO_COLOR: ""
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
@@ -39,8 +40,6 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
   [36m[EXECUTE_ARGS]...[0m  Additional arguments for --execute command (after --)
 
 [1m[32mOptions:[0m
-      [1m[36m--branches[0m           Include branches without worktrees (interactive picker)
-      [1m[36m--remotes[0m            Include remote branches (interactive picker)
   [1m[36m-c[0m, [1m[36m--create[0m             Create a new branch
   [1m[36m-b[0m, [1m[36m--base[0m[36m [0m[36m<BASE>[0m        Base branch
   [1m[36m-x[0m, [1m[36m--execute[0m[36m [0m[36m<EXECUTE>[0m  Command to run after switch
@@ -49,6 +48,10 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
       [1m[36m--no-cd[0m              Skip directory change after switching
       [1m[36m--no-verify[0m          Skip hooks
   [1m[36m-h[0m, [1m[36m--help[0m               Print help (see more with '--help')
+
+[1m[32mPicker Options:[0m
+      [1m[36m--branches[0m  Include branches without worktrees
+      [1m[36m--remotes[0m   Include remote branches
 
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command


### PR DESCRIPTION
Move `--branches` and `--remotes` into a "Picker Options" section in `wt switch --help`, since they only apply to the interactive picker mode and conflict with all direct-switch flags.

> _This was written by Claude Code on behalf of @max-sixty_