### PR TITLE
Remove redundant "(background)" from hook help table

### DIFF
--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -18,14 +18,14 @@ Hooks are shell commands that run at key points in the worktree lifecycle — au
 | Hook | When | Blocking | Fail-fast |
 |------|------|----------|-----------|
 | `pre-switch` | Before every switch | Yes | Yes |
-| `post-start` | After worktree created | No (background) | No |
+| `post-start` | After worktree created | No | No |
 | `post-create` | After worktree created | Yes | No |
-| `post-switch` | After every switch | No (background) | No |
+| `post-switch` | After every switch | No | No |
 | `pre-commit` | Before commit during merge | Yes | Yes |
 | `pre-merge` | Before merging to target | Yes | Yes |
 | `post-merge` | After successful merge | Yes | No |
 | `pre-remove` | Before worktree removed | Yes | Yes |
-| `post-remove` | After worktree removed | No (background) | No |
+| `post-remove` | After worktree removed | No | No |
 
 **Blocking**: Command waits for hook to complete before continuing.
 **Fail-fast**: First failure aborts the operation.

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -9,14 +9,14 @@ Hooks are shell commands that run at key points in the worktree lifecycle — au
 | Hook | When | Blocking | Fail-fast |
 |------|------|----------|-----------|
 | `pre-switch` | Before every switch | Yes | Yes |
-| `post-start` | After worktree created | No (background) | No |
+| `post-start` | After worktree created | No | No |
 | `post-create` | After worktree created | Yes | No |
-| `post-switch` | After every switch | No (background) | No |
+| `post-switch` | After every switch | No | No |
 | `pre-commit` | Before commit during merge | Yes | Yes |
 | `pre-merge` | Before merging to target | Yes | Yes |
 | `post-merge` | After successful merge | Yes | No |
 | `pre-remove` | Before worktree removed | Yes | Yes |
-| `post-remove` | After worktree removed | No (background) | No |
+| `post-remove` | After worktree removed | No | No |
 
 **Blocking**: Command waits for hook to complete before continuing.
 **Fail-fast**: First failure aborts the operation.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1082,14 +1082,14 @@ Alias names that match a built-in step command (`commit`, `squash`, etc.) are sh
 | Hook | When | Blocking | Fail-fast |
 |------|------|----------|-----------|
 | `pre-switch` | Before every switch | Yes | Yes |
-| `post-start` | After worktree created | No (background) | No |
+| `post-start` | After worktree created | No | No |
 | `post-create` | After worktree created | Yes | No |
-| `post-switch` | After every switch | No (background) | No |
+| `post-switch` | After every switch | No | No |
 | `pre-commit` | Before commit during merge | Yes | Yes |
 | `pre-merge` | Before merging to target | Yes | Yes |
 | `post-merge` | After successful merge | Yes | No |
 | `pre-remove` | Before worktree removed | Yes | Yes |
-| `post-remove` | After worktree removed | No (background) | No |
+| `post-remove` | After worktree removed | No | No |
 
 **Blocking**: Command waits for hook to complete before continuing.
 **Fail-fast**: First failure aborts the operation.


### PR DESCRIPTION
The Blocking column's "No (background)" was overspecified — the column header
and footer definition already explain what "No" means.

> _This was written by Claude Code on behalf of max-sixty_