### PR TITLE
docs: fix home page SEO — canonical dedup and consistent tagline

### DIFF
--- a/docs/content/worktrunk.md
+++ b/docs/content/worktrunk.md
@@ -1,7 +1,10 @@
 +++
 title = "Worktrunk"
-description = "Git worktree management for parallel AI agents. Core commands, install guide, and quick start."
+description = "CLI for Git worktree management, designed for parallel AI agent workflows."
 weight = 1
+
+[extra]
+canonical = "/"
 +++
 
 Worktrunk is a CLI for git worktree management, designed for running AI agents

--- a/docs/templates/base.html
+++ b/docs/templates/base.html
@@ -76,12 +76,18 @@
     <meta name="view-transition" content="same-origin">
     {% set page_description = page.description | default(value=config.extra.site_description) %}
     <meta name="description" content="{{ page_description }}">
+    {% if page.extra.canonical %}
+    <link rel="canonical" href="{{ config.base_url | trim_end_matches(pat='/') }}{{ page.extra.canonical }}">
+    {% else %}
     <link rel="canonical" href="{{ current_url | default(value=config.base_url) }}">
+    {% endif %}
 
     <!-- OpenGraph -->
+    {% set og_title = page.title | default(value="") %}
     <meta property="og:type" content="website">
-    <meta property="og:url" content="{{ current_url | default(value=config.base_url) }}">
-    <meta property="og:title" content="{% if page.title %}{{ page.title }} | {{ config.title }}{% else %}{{ config.title }}{% endif %}">
+    <meta property="og:url" content="{% if page.extra.canonical %}{{ config.base_url | trim_end_matches(pat='/') }}{{ page.extra.canonical }}{% else %}{{ current_url | default(value=config.base_url) }}{% endif %}">
+    {% if og_title %}{% set og_title_full = og_title ~ " | " ~ config.title %}{% else %}{% set og_title_full = config.title ~ " — " ~ config.extra.site_description %}{% endif %}
+    <meta property="og:title" content="{{ og_title_full }}">
     <meta property="og:description" content="{{ page_description }}">
     <meta property="og:image" content="{{ config.base_url }}assets/social/social-card.png">
     <meta property="og:image:width" content="1200">
@@ -89,7 +95,7 @@
 
     <!-- Twitter Card -->
     <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="{% if page.title %}{{ page.title }} | {{ config.title }}{% else %}{{ config.title }}{% endif %}">
+    <meta name="twitter:title" content="{{ og_title_full }}">
     <meta name="twitter:description" content="{{ page_description }}">
     <meta name="twitter:image" content="{{ config.base_url }}assets/social/social-card.png">
 


### PR DESCRIPTION
The home page (`/`) and `/worktrunk/` serve identical content (the index
template renders `worktrunk.content` directly), but each declared its own
canonical URL. Google saw two competing pages and wasn't indexing either as
the home page result.

- Set canonical + og:url on `/worktrunk/` to point to `/`
- Fix home page og:title/twitter:title — was just "Worktrunk", now uses the
  full tagline from `config.extra.site_description`
- Align `worktrunk.md` description with `site_description`

> _This was written by Claude Code on behalf of @max-sixty_