### PR TITLE
Simplify: cache regexes, remove TOCTOU, fix silent wrong results

### DIFF
--- a/src/commands/configure_shell.rs
+++ b/src/commands/configure_shell.rs
@@ -598,12 +598,8 @@ fn configure_wrapper_file(
     // - Nushell: vendor/autoload/{cmd}.nu is autoloaded automatically at startup
 
     // Check if it already exists and has our integration
-    // Use .ok() for read errors - treat as "not configured" rather than failing
-    if let Some(existing_content) = path
-        .exists()
-        .then(|| fs::read_to_string(path).ok())
-        .flatten()
-    {
+    // Read errors (including not-found) fall through to "not configured"
+    if let Ok(existing_content) = fs::read_to_string(path) {
         // Compare only non-comment lines so that comment changes (e.g. updated
         // URLs) don't cause existing installations to appear unconfigured.
         if fish_code_lines(&existing_content) == fish_code_lines(content) {
@@ -864,11 +860,8 @@ pub fn process_shell_completions(
             .map_err(|e| format!("Failed to get completion path for {shell}: {e}"))?;
 
         // Check if completions already exist with correct content
-        // Use .ok() for read errors - treat as "not configured" rather than failing
-        if let Some(existing) = completion_path
-            .exists()
-            .then(|| fs::read_to_string(&completion_path).ok())
-            .flatten()
+        // Read errors (including not-found) fall through to "not configured"
+        if let Ok(existing) = fs::read_to_string(&completion_path)
             && existing == fish_completion
         {
             results.push(CompletionResult {

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -39,6 +39,18 @@ use crate::styling::{
 static WARNED_DEPRECATED_PATHS: LazyLock<Mutex<HashSet<PathBuf>>> =
     LazyLock::new(|| Mutex::new(HashSet::new()));
 
+/// Pre-compiled regexes for deprecated variable word-boundary matching.
+/// Compiled once on first use, shared across all calls to normalize/replace.
+static DEPRECATED_VAR_REGEXES: LazyLock<Vec<(Regex, &'static str)>> = LazyLock::new(|| {
+    DEPRECATED_VARS
+        .iter()
+        .map(|&(old, new)| {
+            let re = Regex::new(&format!(r"\b{}\b", regex::escape(old))).unwrap();
+            (re, new)
+        })
+        .collect()
+});
+
 /// Tracks which config paths have already shown unknown field warnings this process.
 /// Prevents repeated warnings when config is loaded multiple times.
 static WARNED_UNKNOWN_PATHS: LazyLock<Mutex<HashSet<PathBuf>>> =
@@ -76,9 +88,8 @@ pub fn normalize_template_vars(template: &str) -> Cow<'_, str> {
     }
 
     let mut result = template.to_string();
-    for &(old, new) in DEPRECATED_VARS {
-        let re = Regex::new(&format!(r"\b{}\b", regex::escape(old))).unwrap();
-        result = re.replace_all(&result, new).into_owned();
+    for (re, new) in DEPRECATED_VAR_REGEXES.iter() {
+        result = re.replace_all(&result, *new).into_owned();
     }
     Cow::Owned(result)
 }
@@ -147,9 +158,8 @@ pub fn replace_deprecated_vars(content: &str) -> String {
 
     for original in strings {
         let mut modified = original.clone();
-        for &(old, new) in DEPRECATED_VARS {
-            let re = Regex::new(&format!(r"\b{}\b", regex::escape(old))).unwrap();
-            modified = re.replace_all(&modified, new).into_owned();
+        for (re, new) in DEPRECATED_VAR_REGEXES.iter() {
+            modified = re.replace_all(&modified, *new).into_owned();
         }
         if modified != original {
             result = result.replace(&original, &modified);

--- a/src/git/repository/integration.rs
+++ b/src/git/repository/integration.rs
@@ -3,6 +3,8 @@
 //! Methods for determining if a branch has been integrated into the target
 //! (same commit, ancestor, trees match, etc.).
 
+use anyhow::Context;
+
 use super::Repository;
 use crate::git::{IntegrationReason, check_integration, compute_integration_lazy};
 
@@ -42,8 +44,11 @@ impl Repository {
         // Parse both refs in a single git command
         let output = self.run_command(&["rev-parse", &ref1, &ref2])?;
         let mut lines = output.lines();
-        let sha1 = lines.next().unwrap_or_default().trim();
-        let sha2 = lines.next().unwrap_or_default().trim();
+        let sha1 = lines.next().context("rev-parse returned no output")?.trim();
+        let sha2 = lines
+            .next()
+            .context("rev-parse returned only one line")?
+            .trim();
         Ok(sha1 == sha2)
     }
 
@@ -84,8 +89,11 @@ impl Repository {
             &format!("{ref2}^{{tree}}"),
         ])?;
         let mut lines = output.lines();
-        let tree1 = lines.next().unwrap_or_default().trim();
-        let tree2 = lines.next().unwrap_or_default().trim();
+        let tree1 = lines.next().context("rev-parse returned no output")?.trim();
+        let tree2 = lines
+            .next()
+            .context("rev-parse returned only one line")?
+            .trim();
         Ok(tree1 == tree2)
     }
 


### PR DESCRIPTION
Cache deprecated-variable regexes in a `LazyLock` static instead of compiling
4 regexes per call. Remove redundant `path.exists()` checks before
`read_to_string()` (TOCTOU). Replace `unwrap_or_default()` with error
propagation in `same_commit()`/`trees_match()` — previously malformed git
output would silently compare `"" == ""` and return `true`.

> _This was written by Claude Code on behalf of @max-sixty_