### PR TITLE
fix(output): use bash formatting for verbose expansion gutter

### DIFF
--- a/.claude/skills/writing-user-outputs/SKILL.md
+++ b/.claude/skills/writing-user-outputs/SKILL.md
@@ -817,13 +817,17 @@ Shows template expansions and other details users might need for debugging confi
 Format for template expansion:
 ```
 ○ Expanding name
- ┃ template → result
+ ┃ template (bash-highlighted)
+ ┃ → (dim)
+ ┃ result (bash-highlighted)
 ```
 
 - **Info message** for header (`○` symbol, "Expanding" + bold name)
-- **Gutter** for quoted content (template → result)
-- Arrow `→` is dim
-- For multiline: template lines, dim `→` on its own line, result lines
+- **Bash gutter** for template and result (dim + syntax highlighting via
+  `format_bash_with_gutter`)
+- **Plain gutter** for dim `→` separator (bypasses syntax highlighter)
+- Template and result are always on separate gutter blocks from the arrow,
+  because the `→` can't go through the bash syntax highlighter
 
 **`-vv` (debug):** Developer-facing logging output. MAY violate these guidelines.
 Uses `log::debug!()` with structured format for deep debugging. Not intended for

--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -18,7 +18,8 @@ use shell_escape::escape;
 use crate::git::Repository;
 use crate::path::to_posix_path;
 use crate::styling::{
-    eprintln, error_message, format_with_gutter, hint_message, info_message, verbosity,
+    eprintln, error_message, format_bash_with_gutter, format_with_gutter, hint_message,
+    info_message, verbosity,
 };
 
 /// Known template variables available in hook commands.
@@ -419,15 +420,12 @@ pub fn expand_template(
     // Single atomic write to avoid interleaving in multi-threaded execution
     if verbose == 1 {
         let header = info_message(cformat!("Expanding <bold>{name}</>"));
-        let content = if template.contains('\n') || result.contains('\n') {
-            // Multiline: template lines, dim →, result lines
-            cformat!("{template}\n<dim>→</>\n{result}")
-        } else {
-            // Single line: template → result
-            cformat!("{template} <dim>→</> {result}")
-        };
-        let gutter = format_with_gutter(&content, None);
-        eprintln!("{header}\n{gutter}");
+        // Format template and result as bash (dim + syntax highlighting),
+        // with a dim → separator that bypasses the syntax highlighter
+        let template_gutter = format_bash_with_gutter(template);
+        let arrow = format_with_gutter(&cformat!("<dim>→</>"), None);
+        let result_gutter = format_bash_with_gutter(&result);
+        eprintln!("{header}\n{template_gutter}\n{arrow}\n{result_gutter}");
     }
     Ok(result)
 }

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_verbose_shows_content.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_verbose_shows_content.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -50,8 +51,14 @@ exit_code: 0
 ----- stderr -----
 [33m▲[39m [33mUser config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
 [2m○[22m Expanding [1mworktree-path[22m
-[107m [0m ../{{ main_worktree }}.{{ branch }} [2m→[22m ../repo.feature-a
+[107m [0m [2m[0m[2m[34m../[0m[2m[32m{{[0m[2m[34m[0m[2m main_worktree [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[32m}}[0m[2m
+[107m [0m [2m→[22m
+[107m [0m [2m[0m[2m[34m../repo.feature-a[0m[2m
 [2m○[22m Expanding [1mworktree-path[22m
-[107m [0m ../{{ main_worktree }}.{{ branch }} [2m→[22m ../repo.feature-b
+[107m [0m [2m[0m[2m[34m../[0m[2m[32m{{[0m[2m[34m[0m[2m main_worktree [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[32m}}[0m[2m
+[107m [0m [2m→[22m
+[107m [0m [2m[0m[2m[34m../repo.feature-b[0m[2m
 [2m○[22m Expanding [1mworktree-path[22m
-[107m [0m ../{{ main_worktree }}.{{ branch }} [2m→[22m ../repo.feature-c
+[107m [0m [2m[0m[2m[34m../[0m[2m[32m{{[0m[2m[34m[0m[2m main_worktree [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[32m}}[0m[2m
+[107m [0m [2m→[22m
+[107m [0m [2m[0m[2m[34m../repo.feature-c[0m[2m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_verbose_template_expansion.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_verbose_template_expansion.snap
@@ -45,9 +45,13 @@ exit_code: 0
 
 ----- stderr -----
 [2m○[22m Expanding [1mworktree-path[22m
-[107m [0m ../{{ repo }}.{{ branch | sanitize }} [2m→[22m ../repo.verbose-hooks
+[107m [0m [2m[0m[2m[34m../[0m[2m[32m{{[0m[2m[34m[0m[2m repo [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34msanitize[0m[2m [0m[2m[32m}}[0m[2m
+[107m [0m [2m→[22m
+[107m [0m [2m[0m[2m[34m../repo.verbose-hooks[0m[2m
 [2m○[22m Expanding [1mproject:setup[22m
-[107m [0m echo 'Setting up {{ branch | sanitize }} in {{ worktree_path }}' [2m→[22m echo 'Setting up verbose-hooks in _REPO_.verbose-hooks'
+[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setting up {{ branch | sanitize }} in {{ worktree_path }}'[0m[2m
+[107m [0m [2m→[22m
+[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setting up verbose-hooks in _REPO_.verbose-hooks'[0m[2m
 [36m◎[39m [36mRunning post-create [1mproject:setup[22m @ [1m_REPO_.verbose-hooks[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setting up verbose-hooks in _REPO_.verbose-hooks'[0m[2m
 [0mSetting up verbose-hooks in _REPO_.verbose-hooks

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_verbose_output.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_verbose_output.snap
@@ -45,12 +45,16 @@ exit_code: 0
 
 ----- stderr -----
 [2m○[22m Expanding [1mworktree-path[22m
-[107m [0m {{ repo_path }}/../{{ repo }}.{{ branch | sanitize }} [2m→[22m _REPO_/../repo.feature
+[107m [0m [2m[0m[2m[32m{{[0m[2m[0m[2m repo_path [0m[2m[32m}}[0m[2m/../[0m[2m[32m{{[0m[2m repo [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34msanitize[0m[2m [0m[2m[32m}}[0m[2m
+[107m [0m [2m→[22m
+[107m [0m [2m[0m[2m[34m_REPO_/../repo.feature[0m[2m
 [32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
 [2m○[22m Expanding [1mproject:setup[22m
-[107m [0m echo 'verbose test' > verbose.txt [2m→[22m echo 'verbose test' > verbose.txt
+[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'verbose test'[0m[2m [0m[2m[36m>[0m[2m verbose.txt
+[107m [0m [2m→[22m
+[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'verbose test'[0m[2m [0m[2m[36m>[0m[2m verbose.txt
 [36m◎[39m [36mRunning post-start [1mproject:setup[22m @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'verbose test'[0m[2m [0m[2m[36m>[0m[2m verbose.txt

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_verbose_multiline_template.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_verbose_multiline_template.snap
@@ -49,20 +49,22 @@ repo=repo
 
 ----- stderr -----
 [2m○[22m Expanding [1mworktree-path[22m
-[107m [0m {{ repo_path }}/../{{ repo }}.{{ branch | sanitize }} [2m→[22m _REPO_/../repo.multiline-test
+[107m [0m [2m[0m[2m[32m{{[0m[2m[0m[2m repo_path [0m[2m[32m}}[0m[2m/../[0m[2m[32m{{[0m[2m repo [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34msanitize[0m[2m [0m[2m[32m}}[0m[2m
+[107m [0m [2m→[22m
+[107m [0m [2m[0m[2m[34m_REPO_/../repo.multiline-test[0m[2m
 [32m✓[39m [32mCreated branch [1mmultiline-test[22m from [1mmain[22m and worktree @ [1m_REPO_.multiline-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
 [2m○[22m Expanding [1m--execute command[22m
-[107m [0m {% if branch %}
-[107m [0m echo 'branch={{ branch }}'
-[107m [0m echo 'repo={{ repo }}'
-[107m [0m {% endif %}
+[107m [0m [2m{[0m[2m[34m%[0m[2m if branch %}
+[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'branch={{ branch }}'[0m[2m
+[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'repo={{ repo }}'[0m[2m
+[107m [0m [2m{[0m[2m[34m%[0m[2m endif %}
 [107m [0m [2m→[22m
-[107m [0m 
-[107m [0m echo 'branch=multiline-test'
-[107m [0m echo 'repo=repo'
+[107m [0m [2m
+[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'branch=multiline-test'[0m[2m
+[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'repo=repo'[0m[2m
 [36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.multiline-test[22m:[39m
 [107m [0m [2m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'branch=multiline-test'[0m[2m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_verbose_template.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_verbose_template.snap
@@ -48,12 +48,16 @@ branch=verbose-test
 
 ----- stderr -----
 [2m○[22m Expanding [1mworktree-path[22m
-[107m [0m {{ repo_path }}/../{{ repo }}.{{ branch | sanitize }} [2m→[22m _REPO_/../repo.verbose-test
+[107m [0m [2m[0m[2m[32m{{[0m[2m[0m[2m repo_path [0m[2m[32m}}[0m[2m/../[0m[2m[32m{{[0m[2m repo [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34msanitize[0m[2m [0m[2m[32m}}[0m[2m
+[107m [0m [2m→[22m
+[107m [0m [2m[0m[2m[34m_REPO_/../repo.verbose-test[0m[2m
 [32m✓[39m [32mCreated branch [1mverbose-test[22m from [1mmain[22m and worktree @ [1m_REPO_.verbose-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
 [2m○[22m Expanding [1m--execute command[22m
-[107m [0m echo 'branch={{ branch }}' [2m→[22m echo 'branch=verbose-test'
+[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'branch={{ branch }}'[0m[2m
+[107m [0m [2m→[22m
+[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'branch=verbose-test'[0m[2m
 [36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.verbose-test[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'branch=verbose-test'[0m[2m


### PR DESCRIPTION
The `-v` template expansion output was using `format_with_gutter` (plain text)
instead of `format_bash_with_gutter` (dim + syntax highlighting) for shell
commands. Now template and result render with proper bash styling, matching
how commands appear elsewhere in the output.

Template and result are formatted as separate bash gutter blocks with a dim
`→` arrow between them, since the arrow can't go through the syntax
highlighter.

> _This was written by Claude Code on behalf of @max-sixty_