### PR TITLE
feat(hook): make hook_type and hook_name available as template variables

### DIFF
--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -214,11 +214,13 @@ Hooks can use template variables that expand at runtime:
 | `{{ remote }}` | Primary remote name |
 | `{{ remote_url }}` | Remote URL |
 | `{{ upstream }}` | Upstream tracking branch (if set) |
+| `{{ hook_type }}` | Hook type being run (e.g. `post-create`, `pre-merge`) |
+| `{{ hook_name }}` | Hook command name (if named) |
 | `{{ target }}` | Target branch (merge hooks only) |
 | `{{ base }}` | Base branch (creation hooks only) |
 | `{{ base_worktree_path }}` | Base branch worktree (creation hooks only) |
 
-Some variables may not be defined: `upstream` is only set when the branch tracks a remote; `target`, `base`, and `base_worktree_path` are hook-specific. Using an undefined variable directly errors — use conditionals for optional behavior:
+Some variables may not be defined: `upstream` is only set when the branch tracks a remote; `hook_name` is only set for named commands; `target`, `base`, and `base_worktree_path` are hook-specific. Using an undefined variable directly errors — use conditionals for optional behavior:
 
 ```toml
 [post-create]
@@ -280,7 +282,7 @@ if ctx['branch'].startswith('feature/') and 'backend' in ctx['repo']:
     subprocess.run(['make', 'seed-db'])
 ```
 
-The JSON includes all template variables plus `hook_type` and `hook_name`.
+The JSON includes all template variables.
 
 ## Running hooks manually
 

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -205,11 +205,13 @@ Hooks can use template variables that expand at runtime:
 | `{{ remote }}` | Primary remote name |
 | `{{ remote_url }}` | Remote URL |
 | `{{ upstream }}` | Upstream tracking branch (if set) |
+| `{{ hook_type }}` | Hook type being run (e.g. `post-create`, `pre-merge`) |
+| `{{ hook_name }}` | Hook command name (if named) |
 | `{{ target }}` | Target branch (merge hooks only) |
 | `{{ base }}` | Base branch (creation hooks only) |
 | `{{ base_worktree_path }}` | Base branch worktree (creation hooks only) |
 
-Some variables may not be defined: `upstream` is only set when the branch tracks a remote; `target`, `base`, and `base_worktree_path` are hook-specific. Using an undefined variable directly errors — use conditionals for optional behavior:
+Some variables may not be defined: `upstream` is only set when the branch tracks a remote; `hook_name` is only set for named commands; `target`, `base`, and `base_worktree_path` are hook-specific. Using an undefined variable directly errors — use conditionals for optional behavior:
 
 ```toml
 [post-create]
@@ -271,7 +273,7 @@ if ctx['branch'].startswith('feature/') and 'backend' in ctx['repo']:
     subprocess.run(['make', 'seed-db'])
 ```
 
-The JSON includes all template variables plus `hook_type` and `hook_name`.
+The JSON includes all template variables.
 
 ## Running hooks manually
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1278,11 +1278,13 @@ Hooks can use template variables that expand at runtime:
 | `{{ remote }}` | Primary remote name |
 | `{{ remote_url }}` | Remote URL |
 | `{{ upstream }}` | Upstream tracking branch (if set) |
+| `{{ hook_type }}` | Hook type being run (e.g. `post-create`, `pre-merge`) |
+| `{{ hook_name }}` | Hook command name (if named) |
 | `{{ target }}` | Target branch (merge hooks only) |
 | `{{ base }}` | Base branch (creation hooks only) |
 | `{{ base_worktree_path }}` | Base branch worktree (creation hooks only) |
 
-Some variables may not be defined: `upstream` is only set when the branch tracks a remote; `target`, `base`, and `base_worktree_path` are hook-specific. Using an undefined variable directly errors — use conditionals for optional behavior:
+Some variables may not be defined: `upstream` is only set when the branch tracks a remote; `hook_name` is only set for named commands; `target`, `base`, and `base_worktree_path` are hook-specific. Using an undefined variable directly errors — use conditionals for optional behavior:
 
 ```toml
 [post-create]
@@ -1344,7 +1346,7 @@ if ctx['branch'].startswith('feature/') and 'backend' in ctx['repo']:
     subprocess.run(['make', 'seed-db'])
 ```
 
-The JSON includes all template variables plus `hook_type` and `hook_name`.
+The JSON includes all template variables.
 
 ## Running hooks manually
 

--- a/src/commands/command_executor.rs
+++ b/src/commands/command_executor.rs
@@ -157,29 +157,31 @@ fn expand_commands(
         return Ok(Vec::new());
     }
 
-    let base_context = build_hook_context(ctx, extra_vars)?;
+    let mut base_context = build_hook_context(ctx, extra_vars)?;
 
-    // Convert to &str references for expand_template
-    let vars: HashMap<&str, &str> = base_context
-        .iter()
-        .map(|(k, v)| (k.as_str(), v.as_str()))
-        .collect();
+    // hook_type is always available as a template variable and in JSON context
+    base_context.insert("hook_type".into(), hook_type.to_string());
 
     let mut result = Vec::new();
 
     for cmd in commands {
+        // hook_name is per-command: available as template variable and in JSON context
+        let mut cmd_context = base_context.clone();
+        if let Some(ref name) = cmd.name {
+            cmd_context.insert("hook_name".into(), name.clone());
+        }
+
+        let vars: HashMap<&str, &str> = cmd_context
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect();
+
         let template_name = match &cmd.name {
             Some(name) => format!("{}:{}", source, name),
             None => format!("{} {} hook", source, hook_type),
         };
         let expanded_str = expand_template(&cmd.template, &vars, true, ctx.repo, &template_name)?;
 
-        // Build per-command JSON with hook_type and hook_name
-        let mut cmd_context = base_context.clone();
-        cmd_context.insert("hook_type".into(), hook_type.to_string());
-        if let Some(ref name) = cmd.name {
-            cmd_context.insert("hook_name".into(), name.clone());
-        }
         let context_json = serde_json::to_string(&cmd_context)
             .expect("HashMap<String, String> serialization should never fail");
 

--- a/src/commands/hook_commands.rs
+++ b/src/commands/hook_commands.rs
@@ -592,7 +592,7 @@ fn render_hook_commands(
         // Show template or expanded command
         let command_text = if let Some(command_ctx) = ctx {
             // Expand template with current context
-            expand_command_template(&cmd.template, command_ctx, hook_type)?
+            expand_command_template(&cmd.template, command_ctx, hook_type, cmd.name.as_deref())?
         } else {
             cmd.template.clone()
         };
@@ -608,6 +608,7 @@ fn expand_command_template(
     template: &str,
     ctx: &CommandContext,
     hook_type: HookType,
+    hook_name: Option<&str>,
 ) -> anyhow::Result<String> {
     // Build extra vars based on hook type (same logic as run_hook approval)
     let default_branch = ctx.repo.default_branch();
@@ -626,7 +627,11 @@ fn expand_command_template(
         }
         _ => Vec::new(),
     };
-    let template_ctx = build_hook_context(ctx, &extra_vars)?;
+    let mut template_ctx = build_hook_context(ctx, &extra_vars)?;
+    template_ctx.insert("hook_type".into(), hook_type.to_string());
+    if let Some(name) = hook_name {
+        template_ctx.insert("hook_name".into(), name.into());
+    }
     let vars: HashMap<&str, &str> = template_ctx
         .iter()
         .map(|(k, v)| (k.as_str(), v.as_str()))

--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -40,8 +40,10 @@ pub const TEMPLATE_VARS: &[&str] = &[
     "remote",
     "remote_url",
     "upstream",
-    "target",             // Added by merge/rebase hooks via extra_vars
-    "base",               // Added by creation hooks via extra_vars
+    "hook_type",          // Added by expand_commands / expand_command_template
+    "hook_name", // Added by expand_commands / expand_command_template (named commands only)
+    "target",    // Added by merge/rebase hooks via extra_vars
+    "base",      // Added by creation hooks via extra_vars
     "base_worktree_path", // Added by creation hooks via extra_vars
 ];
 

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_upstream_template.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_upstream_template.snap
@@ -46,4 +46,4 @@ exit_code: 1
 ----- stderr -----
 [31m✗[39m [31mFailed to expand project post-create hook: undefined value @ line 1[39m
 [107m [0m echo 'Upstream: {{ upstream }}' > upstream.txt
-[2m↳[22m [2mAvailable variables: [4mbase, base_worktree_path, branch, commit, default_branch, main_worktree, main_worktree_path, primary_worktree_path, remote, remote_url, repo, repo_path, repo_root, short_commit, worktree, worktree_name, worktree_path[24m[22m
+[2m↳[22m [2mAvailable variables: [4mbase, base_worktree_path, branch, commit, default_branch, hook_type, main_worktree, main_worktree_path, primary_worktree_path, remote, remote_url, repo, repo_path, repo_root, short_commit, worktree, worktree_name, worktree_path[24m[22m


### PR DESCRIPTION
These were already included in the JSON context piped to stdin but couldn't be used as `{{ hook_type }}` or `{{ hook_name }}` in templates — the values were inserted into `cmd_context` *after* template expansion.

Now both code paths (`expand_commands` for execution, `expand_command_template` for `wt hook show --expanded`) include them before rendering. Also added to `TEMPLATE_VARS` so `--var hook_type=...` works for testing.

> _This was written by Claude Code on behalf of @max-sixty_