### PR TITLE
feat(help): syntax-highlight code blocks in --help

### DIFF
--- a/src/md_help.rs
+++ b/src/md_help.rs
@@ -5,7 +5,9 @@ use crossterm::style::Attribute;
 use termimad::{CompoundStyle, MadSkin, TableBorderChars};
 use unicode_width::UnicodeWidthStr;
 
-use worktrunk::styling::{DEFAULT_HELP_WIDTH, wrap_styled_text};
+use worktrunk::styling::{
+    DEFAULT_HELP_WIDTH, format_bash_with_gutter, format_toml, format_with_gutter, wrap_styled_text,
+};
 
 /// Table border style matching our help text format:
 /// - Horizontal lines under headers with spaces between column segments
@@ -41,10 +43,11 @@ fn help_table_skin() -> MadSkin {
 /// and headers are never wrapped (tables need full-width rows for alignment).
 pub(crate) fn render_markdown_in_help_with_width(help: &str, width: Option<usize>) -> String {
     let green = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Green)));
-    let dimmed = Style::new().dimmed();
 
     let mut result = String::new();
     let mut in_code_block = false;
+    let mut code_block_lang = String::new();
+    let mut code_block_lines: Vec<&str> = Vec::new();
     let mut table_lines: Vec<&str> = Vec::new();
 
     let lines: Vec<&str> = help.lines().collect();
@@ -61,15 +64,41 @@ pub(crate) fn render_markdown_in_help_with_width(help: &str, width: Option<usize
         }
 
         // Handle code fences
-        if trimmed.starts_with("```") {
-            in_code_block = !in_code_block;
+        if let Some(after_fence) = trimmed.strip_prefix("```") {
+            if !in_code_block {
+                // Opening fence — extract language identifier
+                code_block_lang = after_fence.trim().to_string();
+                code_block_lines.clear();
+                in_code_block = true;
+            } else {
+                // Closing fence — render collected code block with gutter
+                let content = code_block_lines.join("\n");
+                let formatted = match code_block_lang.as_str() {
+                    "toml" => format_toml(&content),
+                    "console" | "bash" | "sh" => format_bash_with_gutter(&content),
+                    _ => {
+                        // Dim the content before adding gutter (format_with_gutter
+                        // doesn't style text; bash/toml formatters handle their own)
+                        let dim = Style::new().dimmed();
+                        let dimmed = code_block_lines
+                            .iter()
+                            .map(|l| format!("{dim}{l}{dim:#}"))
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        format_with_gutter(&dimmed, None)
+                    }
+                };
+                result.push_str(&formatted);
+                result.push('\n');
+                in_code_block = false;
+            }
             i += 1;
             continue;
         }
 
-        // Inside code blocks, render dimmed with indent
+        // Inside code blocks, collect lines for deferred rendering
         if in_code_block {
-            result.push_str(&format!("  {dimmed}{line}{dimmed:#}\n"));
+            code_block_lines.push(line);
             i += 1;
             continue;
         }
@@ -150,9 +179,9 @@ pub(crate) fn render_markdown_in_help_with_width(help: &str, width: Option<usize
     colorize_status_symbols(&result)
 }
 
-/// Render a markdown table using termimad (for help text, adds 2-space indent)
+/// Render a markdown table using termimad (for help text, no indent)
 fn render_table(lines: &[&str], max_width: Option<usize>) -> String {
-    render_table_with_termimad(lines, "  ", max_width)
+    render_table_with_termimad(lines, "", max_width)
 }
 
 /// Render a markdown table from markdown source string (no indent)
@@ -561,6 +590,17 @@ mod tests {
         // Code is dimmed with indent
         assert!(result.contains("code here"));
         assert!(result.contains("after"));
+    }
+
+    #[test]
+    fn test_render_markdown_in_help_toml_code_block() {
+        let md = "```toml\n[section]\nkey = \"value\"\n```\nafter";
+        let result = render_markdown_in_help(md);
+        // TOML blocks get syntax highlighting with gutter
+        assert!(result.contains("section"));
+        assert!(result.contains("after"));
+        // Should have gutter (BrightWhite background = SGR 107)
+        assert!(result.contains("\u{1b}[107m"));
     }
 
     #[test]

--- a/src/styling/highlighting.rs
+++ b/src/styling/highlighting.rs
@@ -94,6 +94,7 @@ pub fn format_toml(content: &str) -> String {
     // synoptic has built-in TOML support, so this always succeeds
     let mut highlighter = from_extension("toml", 4).expect("synoptic supports TOML");
     let gutter = super::GUTTER;
+    let dim = Style::new().dimmed();
     let lines: Vec<String> = content.lines().map(|s| s.to_string()).collect();
 
     // Process all lines through the highlighter
@@ -116,7 +117,8 @@ pub fn format_toml(content: &str) -> String {
                 if let Some(s) = style {
                     line_output.push_str(&format!("{s}{text}{s:#}"));
                 } else {
-                    line_output.push_str(&text);
+                    // Unstyled tokens (keys, operators, whitespace) rendered dim
+                    line_output.push_str(&format!("{dim}{text}{dim:#}"));
                 }
             }
 
@@ -136,24 +138,35 @@ pub fn format_toml(content: &str) -> String {
 /// - "table": table headers [...]
 /// - "digit": numeric values
 fn toml_token_style(kind: &str) -> Option<Style> {
+    // All styles include .dimmed() so highlighted tokens match the dim base text,
+    // consistent with bash_token_style(). We do NOT use .bold() because bold (SGR 1)
+    // and dim (SGR 2) are mutually exclusive in some terminals like Alacritty.
     match kind {
-        // Strings (quoted values)
-        "string" => Some(Style::new().fg_color(Some(Color::Ansi(AnsiColor::Green)))),
+        // Strings (quoted values) - dim green
+        "string" => Some(
+            Style::new()
+                .fg_color(Some(Color::Ansi(AnsiColor::Green)))
+                .dimmed(),
+        ),
 
-        // Comments (hash-prefixed)
+        // Comments (hash-prefixed) - dim (no color, just subdued)
         "comment" => Some(Style::new().dimmed()),
 
-        // Table headers [table] and [[array]]
+        // Table headers [table] and [[array]] - dim cyan
         "table" => Some(
             Style::new()
                 .fg_color(Some(Color::Ansi(AnsiColor::Cyan)))
-                .bold(),
+                .dimmed(),
         ),
 
-        // Booleans and numbers
-        "boolean" | "digit" => Some(Style::new().fg_color(Some(Color::Ansi(AnsiColor::Yellow)))),
+        // Booleans and numbers - dim yellow
+        "boolean" | "digit" => Some(
+            Style::new()
+                .fg_color(Some(Color::Ansi(AnsiColor::Yellow)))
+                .dimmed(),
+        ),
 
-        // Everything else (operators, punctuation, keys)
+        // Everything else (operators, punctuation, keys) - no styling (will use base dim)
         _ => None,
     }
 }

--- a/tests/integration_tests/snapshots/integration__integration_tests__config_show_theme__show_theme.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__config_show_theme__show_theme.snap
@@ -43,8 +43,8 @@ exit_code: 0
 [107m [0m expected `=`, found newline at line 3 column 1
 
 [2m○[22m Gutter formatting (config):
-[107m [0m [1m[36m[commit.generation][0m
-[107m [0m command = [32m"llm --model claude"[0m
+[107m [0m [2m[36m[commit.generation][0m
+[107m [0m [2mcommand = [0m[2m[32m"llm --model claude"[0m
 
 [2m○[22m Gutter formatting (shell code):
 [107m [0m [2m[0m[2m[34meval[0m[2m [0m[2m[32m"$([0m[2m[34mwt[0m[2m config shell init bash)"[0m[2m[0m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
@@ -57,7 +57,7 @@ exit_code: 0
 [107m [0m [31m-post-create = "ln -sf {{ main_worktree }}/node_modules"[m
 [107m [0m [32m+[m[32mpost-create = "ln -sf {{ repo }}/node_modules"[m
 [2m○[22m Current config:
-[107m [0m post-create = [32m"ln -sf {{ main_worktree }}/node_modules"
+[107m [0m [2mpost-create = [0m[2m[32m"ln -sf {{ main_worktree }}/node_modules"
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_claude_available_plugin_not_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_claude_available_plugin_not_installed.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -42,7 +43,7 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -55,8 +56,8 @@ exit_code: 0
 [107m [0m [32m+[m[32mworktree-path = "../{{ repo }}.{{ branch }}"[m
 [107m [0m [32m+[m[32mpost-create = "ln -sf {{ repo_path }}/node_modules"[m
 [2m○[22m Current config:
-[107m [0m worktree-path = [32m"../{{ main_worktree }}.{{ branch }}"
-[107m [0m post-create = [32m"ln -sf {{ repo_root }}/node_modules"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ main_worktree }}.{{ branch }}"
+[107m [0m [2mpost-create = [0m[2m[32m"ln -sf {{ repo_root }}/node_modules"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -56,10 +57,10 @@ exit_code: 0
 [107m [0m [32m+[m[32m[projects."github.com/example/repo".commit.generation][m
 [107m [0m  command = "llm -m gpt-4"[m
 [2m○[22m Current config:
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [107m [0m 
-[107m [0m [1m[36m[projects."github.com/example/repo".commit-generation]
-[107m [0m command = [32m"llm -m gpt-4"
+[107m [0m [2m[36m[projects."github.com/example/repo".commit-generation]
+[107m [0m [2mcommand = [0m[2m[32m"llm -m gpt-4"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_empty_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_empty_project_config.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -42,7 +43,7 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
@@ -50,7 +50,7 @@ exit_code: 0
 [2m↳[22m [2mTo apply:[22m
 [107m [0m [2m[0m[2m[34mwt[0m[2m [0m[2m[36m-C[0m[2m _REPO_ config update
 [2m○[22m Current config:
-[107m [0m post-create = [32m"ln -sf {{ main_worktree }}/node_modules"
+[107m [0m [2mpost-create = [0m[2m[32m"ln -sf {{ main_worktree }}/node_modules"
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_command_not_found.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_command_not_found.snap
@@ -20,6 +20,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -32,7 +33,7 @@ info:
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
-    WORKTRUNK_TEST_LATEST_VERSION: 0.24.1
+    WORKTRUNK_TEST_LATEST_VERSION: 0.28.2
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -44,10 +45,10 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [107m [0m 
-[107m [0m [1m[36m[commit.generation]
-[107m [0m command = [32m"nonexistent-llm-command-12345 -m test-model"
+[107m [0m [2m[36m[commit.generation]
+[107m [0m [2mcommand = [0m[2m[32m"nonexistent-llm-command-12345 -m test-model"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_not_configured.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_not_configured.snap
@@ -20,6 +20,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -32,7 +33,7 @@ info:
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
-    WORKTRUNK_TEST_LATEST_VERSION: 0.24.1
+    WORKTRUNK_TEST_LATEST_VERSION: 0.28.2
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -44,7 +45,7 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_update_available.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_update_available.snap
@@ -20,6 +20,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -44,7 +45,7 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_version_check_unavailable.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_version_check_unavailable.snap
@@ -20,6 +20,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -44,7 +45,7 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_github_remote.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_github_remote.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -42,7 +43,7 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_gitlab_remote.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_gitlab_remote.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -42,7 +43,7 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_project_toml.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_project_toml.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -42,7 +43,7 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
@@ -52,7 +53,7 @@ exit_code: 0
 [107m [0m 1 | invalid = [unclosed bracket
 [107m [0m   |                            ^
 [107m [0m unclosed array, expected `]`
-[107m [0m invalid = [unclosed bracket
+[107m [0m [2minvalid = [unclosed bracket
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_system_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_system_config.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -48,7 +49,7 @@ exit_code: 0
 [107m [0m 1 | invalid = [toml
 [107m [0m   |                 ^
 [107m [0m unclosed array, expected `]`
-[107m [0m invalid = [toml
+[107m [0m [2minvalid = [toml
 
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_user_toml.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_user_toml.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -48,7 +49,7 @@ exit_code: 0
 [107m [0m 1 | this is not valid toml {{{
 [107m [0m   |      ^
 [107m [0m key with no value, expected `=`
-[107m [0m this is not valid toml {{{
+[107m [0m [2mthis is not valid toml {{{
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_no_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_no_project_config.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -42,7 +43,7 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_outside_git_repo.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_outside_git_repo.snap
@@ -14,6 +14,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -37,7 +38,7 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [2m[36mPROJECT CONFIG[39m  Not in a git repository[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_plugin_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_plugin_installed.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -42,7 +43,7 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_shell_integration_active.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_shell_integration_active.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -43,7 +44,7 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_statusline_configured.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_statusline_configured.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -42,7 +43,7 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_project_config_for_ci.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_project_config_for_ci.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -43,10 +44,10 @@ exit_code: 0
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
 [33m▲[39m [33mKey [1mci[22m belongs in project config (will be ignored)[39m
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [107m [0m 
-[107m [0m [1m[36m[ci]
-[107m [0m platform = [32m"github"
+[107m [0m [2m[36m[ci]
+[107m [0m [2mplatform = [0m[2m[32m"github"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -42,7 +43,7 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
@@ -61,8 +62,8 @@ exit_code: 0
 [107m [0m [32m+[m[32mcommand = "claude"[m
 [33m▲[39m [33mKey [1mcommit-generation[22m belongs in user config (will be ignored)[39m
 [2m○[22m Current config:
-[107m [0m [1m[36m[commit-generation]
-[107m [0m command = [32m"claude"
+[107m [0m [2m[36m[commit-generation]
+[107m [0m [2mcommand = [0m[2m[32m"claude"
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_project_keys.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_project_keys.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -42,13 +43,13 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
 [33m▲[39m [33mUnknown key [1mpost-merge-command[22m will be ignored[39m
-[107m [0m [1m[36m[post-merge-command]
-[107m [0m deploy = [32m"task deploy"
+[107m [0m [2m[36m[post-merge-command]
+[107m [0m [2mdeploy = [0m[2m[32m"task deploy"
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_user_keys.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_user_keys.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -43,10 +44,10 @@ exit_code: 0
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUnknown key [1mcommit-gen[22m will be ignored[39m
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [107m [0m 
-[107m [0m [1m[36m[commit-gen]
-[107m [0m command = [32m"llm"
+[107m [0m [2m[36m[commit-gen]
+[107m [0m [2mcommand = [0m[2m[32m"llm"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_whitespace_only_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_whitespace_only_project_config.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -42,7 +43,7 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_with_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_with_project_config.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -42,14 +43,14 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
-[107m [0m post-create = [32m"npm install"
+[107m [0m [2mpost-create = [0m[2m[32m"npm install"
 [107m [0m 
-[107m [0m [1m[36m[post-start]
-[107m [0m server = [32m"npm run dev"
+[107m [0m [2m[36m[post-start]
+[107m [0m [2mserver = [0m[2m[32m"npm run dev"
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_with_system_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_with_system_config.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -42,15 +43,15 @@ exit_code: 0
 
 ----- stderr -----
 [36mSYSTEM CONFIG[39m  [PROJECT_ID]
-[107m [0m [1m[36m[merge]
-[107m [0m squash = [33mtrue
-[107m [0m verify = [33mtrue
+[107m [0m [2m[36m[merge]
+[107m [0m [2msquash = [0m[2m[33mtrue
+[107m [0m [2mverify = [0m[2m[33mtrue
 [107m [0m 
-[107m [0m [1m[36m[commit.generation]
-[107m [0m command = [32m"company-llm-tool"
+[107m [0m [2m[36m[commit.generation]
+[107m [0m [2mcommand = [0m[2m[32m"company-llm-tool"
 
 [36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
-[107m [0m worktree-path = [32m"../{{ repo }}.{{ branch }}"
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 
 [36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -57,323 +57,323 @@ Usage: [1m[36mwt config create[0m [36m[OPTIONS][0m
 
 Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 
-  [2m# # User Configuration[0m
-  [2m#[0m
-  [2m# Create with `wt config create`.[0m
-  [2m#[0m
-  [2m# Location:[0m
-  [2m#[0m
-  [2m# - macOS/Linux: `~/.config/worktrunk/config.toml` (or `$XDG_CONFIG_HOME` if set)[0m
-  [2m# - Windows: `%APPDATA%\worktrunk\config.toml`[0m
-  [2m#[0m
-  [2m# ## Worktree path template[0m
-  [2m#[0m
-  [2m# Controls where new worktrees are created.[0m
-  [2m#[0m
-  [2m# **Variables:**[0m
-  [2m#[0m
-  [2m# - `{{ repo_path }}` — absolute path to the repository (e.g., `/Users/me/code/myproject`)[0m
-  [2m# - `{{ repo }}` — repository directory name (e.g., `myproject`)[0m
-  [2m# - `{{ branch }}` — raw branch name (e.g., `feature/auth`)[0m
-  [2m# - `{{ branch | sanitize }}` — filesystem-safe: `/` and `\` become `-` (e.g., `feature-auth`)[0m
-  [2m# - `{{ branch | sanitize_db }}` — database-safe: lowercase, underscores, hash suffix (e.g., `feature_auth_x7k`)[0m
-  [2m#[0m
-  [2m# **Examples** for repo at `~/code/myproject`, branch `feature/auth`:[0m
-  [2m#[0m
-  [2m# # Default — sibling directory[0m
-  [2m# # Creates: ~/code/myproject.feature-auth[0m
-  [2m# # worktree-path = "{{ repo_path }}/../{{ repo }}.{{ branch | sanitize }}"[0m
-  [2m#[0m
-  [2m# # Inside the repository[0m
-  [2m# # Creates: ~/code/myproject/.worktrees/feature-auth[0m
-  [2m# worktree-path = "{{ repo_path }}/.worktrees/{{ branch | sanitize }}"[0m
-  [2m#[0m
-  [2m# # Centralized worktrees directory[0m
-  [2m# # Creates: ~/worktrees/myproject/feature-auth[0m
-  [2m# worktree-path = "~/worktrees/{{ repo }}/{{ branch | sanitize }}"[0m
-  [2m#[0m
-  [2m# `~` expands to the home directory. Relative paths are relative to the repository root.[0m
-  [2m#[0m
-  [2m# ## LLM commit messages[0m
-  [2m#[0m
-  [2m# Generate commit messages automatically during merge. Requires an external CLI tool.[0m
-  [2m#[0m
-  [2m# See LLM commits docs (https://worktrunk.dev/llm-commits/) for setup and Custom prompt templates (#custom-prompt-templates) for template customization.[0m
-  [2m#[0m
-  [2m# ## Command config[0m
-  [2m#[0m
-  [2m# ### List[0m
-  [2m#[0m
-  [2m# Persistent flag values for `wt list`. Override on command line as needed.[0m
-  [2m#[0m
-  [2m# [list][0m
-  [2m# summary = false    # Enable LLM branch summaries (requires [commit.generation])[0m
-  [2m#[0m
-  [2m# full = false       # Show CI, main…± diffstat, and LLM summaries (--full)[0m
-  [2m# branches = false   # Include branches without worktrees (--branches)[0m
-  [2m# remotes = false    # Include remote-only branches (--remotes)[0m
-  [2m#[0m
-  [2m# ### Commit[0m
-  [2m#[0m
-  [2m# Shared by `wt step commit`, `wt step squash`, and `wt merge`.[0m
-  [2m#[0m
-  [2m# [commit][0m
-  [2m# stage = "all"      # What to stage before commit: "all", "tracked", or "none"[0m
-  [2m#[0m
-  [2m# ### Merge[0m
-  [2m#[0m
-  [2m# All flags are on by default. Set to false to change default behavior.[0m
-  [2m#[0m
-  [2m# [merge][0m
-  [2m# squash = true      # Squash commits into one (--no-squash to preserve history)[0m
-  [2m# commit = true      # Commit uncommitted changes first (--no-commit to skip)[0m
-  [2m# rebase = true      # Rebase onto target before merge (--no-rebase to skip)[0m
-  [2m# remove = true      # Remove worktree after merge (--no-remove to keep)[0m
-  [2m# verify = true      # Run project hooks (--no-verify to skip)[0m
-  [2m#[0m
-  [2m# ### Switch picker[0m
-  [2m#[0m
-  [2m# Configuration for `wt switch` interactive picker.[0m
-  [2m#[0m
-  [2m# [switch.picker][0m
-  [2m# # Pager command for diff preview (overrides git's core.pager)[0m
-  [2m# # pager = "delta --paging=never"[0m
-  [2m#[0m
-  [2m# # Timeout (ms) for git commands during picker loading (default: 200)[0m
-  [2m# # Lower values show the TUI faster; 0 disables timeouts[0m
-  [2m# # timeout-ms = 200[0m
-  [2m#[0m
-  [2m# ### Aliases[0m
-  [2m#[0m
-  [2m# Command templates that run with `wt step <name>`. See `wt step` aliases (https://worktrunk.dev/step/#aliases) for usage and flags.[0m
-  [2m#[0m
-  [2m# [aliases][0m
-  [2m# greet = "echo Hello from {{ branch }}"[0m
-  [2m# url = "echo http://localhost:{{ branch | hash_port }}"[0m
-  [2m#[0m
-  [2m# Aliases defined here apply to all projects. For project-specific aliases, use the project config (https://worktrunk.dev/config/#project-configuration) `[aliases]` section instead.[0m
-  [2m#[0m
-  [2m# ### User project-specific settings[0m
-  [2m#[0m
-  [2m# For context:[0m
-  [2m#[0m
-  [2m# - Project config (https://worktrunk.dev/config/#project-configuration) settings are shared with teammates.[0m
-  [2m# - User configs generally apply to all projects.[0m
-  [2m# - User configs _also_ has a `[projects]` table which holds project-specific settings for the user, such as worktree layout and setting overrides. That's what this section covers.[0m
-  [2m#[0m
-  [2m# Entries are keyed by project identifier (e.g., `github.com/user/repo`).[0m
-  [2m#[0m
-  [2m# #### Setting overrides (Experimental)[0m
-  [2m#[0m
-  [2m# Override global user config for a specific project. Scalar values (like `worktree-path`) replace the global value. Hooks append — both global and per-project hooks run. Aliases merge — per-project aliases override global aliases on name collision.[0m
-  [2m#[0m
-  [2m# [projects."github.com/user/repo"][0m
-  [2m# worktree-path = ".worktrees/{{ branch | sanitize }}"[0m
-  [2m# list.full = true[0m
-  [2m# merge.squash = false[0m
-  [2m# post-create.env = "cp .env.example .env"[0m
-  [2m# aliases.deploy = "make deploy BRANCH={{ branch }}"[0m
-  [2m#[0m
-  [2m# ### Custom prompt templates[0m
-  [2m#[0m
-  [2m# Templates use minijinja (https://docs.rs/minijinja/) syntax.[0m
-  [2m#[0m
-  [2m# #### Commit template[0m
-  [2m#[0m
-  [2m# Available variables:[0m
-  [2m#[0m
-  [2m# - `{{ git_diff }}`, `{{ git_diff_stat }}` — diff content[0m
-  [2m# - `{{ branch }}`, `{{ repo }}` — context[0m
-  [2m# - `{{ recent_commits }}` — recent commit messages[0m
-  [2m#[0m
-  [2m# Default template:[0m
-  [2m#[0m
-  [2m# <!-- DEFAULT_TEMPLATE_START -->[0m
-  [2m# [commit.generation][0m
-  [2m# template = """[0m
-  [2m# Write a commit message for the staged changes below.[0m
-  [2m#[0m
-  [2m# <format>[0m
-  [2m# - Subject line under 50 chars[0m
-  [2m# - For material changes, add a blank line then a body paragraph explaining the change[0m
-  [2m# - Output only the commit message, no quotes or code blocks[0m
-  [2m# </format>[0m
-  [2m#[0m
-  [2m# <style>[0m
-  [2m# - Imperative mood: "Add feature" not "Added feature"[0m
-  [2m# - Match recent commit style (conventional commits if used)[0m
-  [2m# - Describe the change, not the intent or benefit[0m
-  [2m# </style>[0m
-  [2m#[0m
-  [2m# <diffstat>[0m
-  [2m# {{ git_diff_stat }}[0m
-  [2m# </diffstat>[0m
-  [2m#[0m
-  [2m# <diff>[0m
-  [2m# {{ git_diff }}[0m
-  [2m# </diff>[0m
-  [2m#[0m
-  [2m# <context>[0m
-  [2m# Branch: {{ branch }}[0m
-  [2m# {% if recent_commits %}<recent_commits>[0m
-  [2m# {% for commit in recent_commits %}- {{ commit }}[0m
-  [2m# {% endfor %}</recent_commits>{% endif %}[0m
-  [2m# </context>[0m
-  [2m#[0m
-  [2m# """[0m
-  [2m# <!-- DEFAULT_TEMPLATE_END -->[0m
-  [2m#[0m
-  [2m# #### Squash template[0m
-  [2m#[0m
-  [2m# Available variables (in addition to commit template variables):[0m
-  [2m#[0m
-  [2m# - `{{ commits }}` — list of commits being squashed[0m
-  [2m# - `{{ target_branch }}` — merge target branch[0m
-  [2m#[0m
-  [2m# Default template:[0m
-  [2m#[0m
-  [2m# <!-- DEFAULT_SQUASH_TEMPLATE_START -->[0m
-  [2m# [commit.generation][0m
-  [2m# squash-template = """[0m
-  [2m# Combine these commits into a single commit message.[0m
-  [2m#[0m
-  [2m# <format>[0m
-  [2m# - Subject line under 50 chars[0m
-  [2m# - For material changes, add a blank line then a body paragraph explaining the change[0m
-  [2m# - Output only the commit message, no quotes or code blocks[0m
-  [2m# </format>[0m
-  [2m#[0m
-  [2m# <style>[0m
-  [2m# - Imperative mood: "Add feature" not "Added feature"[0m
-  [2m# - Match the style of commits being squashed (conventional commits if used)[0m
-  [2m# - Describe the change, not the intent or benefit[0m
-  [2m# </style>[0m
-  [2m#[0m
-  [2m# <commits branch="{{ branch }}" target="{{ target_branch }}">[0m
-  [2m# {% for commit in commits %}- {{ commit }}[0m
-  [2m# {% endfor %}</commits>[0m
-  [2m#[0m
-  [2m# <diffstat>[0m
-  [2m# {{ git_diff_stat }}[0m
-  [2m# </diffstat>[0m
-  [2m#[0m
-  [2m# <diff>[0m
-  [2m# {{ git_diff }}[0m
-  [2m# </diff>[0m
-  [2m#[0m
-  [2m# """[0m
-  [2m# <!-- DEFAULT_SQUASH_TEMPLATE_END -->[0m
+[107m [0m [2m# # User Configuration[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Create with `wt config create`.[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Location:[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# - macOS/Linux: `~/.config/worktrunk/config.toml` (or `$XDG_CONFIG_HOME` if set)[0m
+[107m [0m [2m# - Windows: `%APPDATA%\worktrunk\config.toml`[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# ## Worktree path template[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Controls where new worktrees are created.[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# **Variables:**[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# - `{{ repo_path }}` — absolute path to the repository (e.g., `/Users/me/code/myproject`)[0m
+[107m [0m [2m# - `{{ repo }}` — repository directory name (e.g., `myproject`)[0m
+[107m [0m [2m# - `{{ branch }}` — raw branch name (e.g., `feature/auth`)[0m
+[107m [0m [2m# - `{{ branch | sanitize }}` — filesystem-safe: `/` and `\` become `-` (e.g., `feature-auth`)[0m
+[107m [0m [2m# - `{{ branch | sanitize_db }}` — database-safe: lowercase, underscores, hash suffix (e.g., `feature_auth_x7k`)[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# **Examples** for repo at `~/code/myproject`, branch `feature/auth`:[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# # Default — sibling directory[0m
+[107m [0m [2m# # Creates: ~/code/myproject.feature-auth[0m
+[107m [0m [2m# # worktree-path = "{{ repo_path }}/../{{ repo }}.{{ branch | sanitize }}"[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# # Inside the repository[0m
+[107m [0m [2m# # Creates: ~/code/myproject/.worktrees/feature-auth[0m
+[107m [0m [2m# worktree-path = "{{ repo_path }}/.worktrees/{{ branch | sanitize }}"[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# # Centralized worktrees directory[0m
+[107m [0m [2m# # Creates: ~/worktrees/myproject/feature-auth[0m
+[107m [0m [2m# worktree-path = "~/worktrees/{{ repo }}/{{ branch | sanitize }}"[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# `~` expands to the home directory. Relative paths are relative to the repository root.[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# ## LLM commit messages[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Generate commit messages automatically during merge. Requires an external CLI tool.[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# See LLM commits docs (https://worktrunk.dev/llm-commits/) for setup and Custom prompt templates (#custom-prompt-templates) for template customization.[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# ## Command config[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# ### List[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Persistent flag values for `wt list`. Override on command line as needed.[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# [list][0m
+[107m [0m [2m# summary = false    # Enable LLM branch summaries (requires [commit.generation])[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# full = false       # Show CI, main…± diffstat, and LLM summaries (--full)[0m
+[107m [0m [2m# branches = false   # Include branches without worktrees (--branches)[0m
+[107m [0m [2m# remotes = false    # Include remote-only branches (--remotes)[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# ### Commit[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Shared by `wt step commit`, `wt step squash`, and `wt merge`.[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# [commit][0m
+[107m [0m [2m# stage = "all"      # What to stage before commit: "all", "tracked", or "none"[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# ### Merge[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# All flags are on by default. Set to false to change default behavior.[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# [merge][0m
+[107m [0m [2m# squash = true      # Squash commits into one (--no-squash to preserve history)[0m
+[107m [0m [2m# commit = true      # Commit uncommitted changes first (--no-commit to skip)[0m
+[107m [0m [2m# rebase = true      # Rebase onto target before merge (--no-rebase to skip)[0m
+[107m [0m [2m# remove = true      # Remove worktree after merge (--no-remove to keep)[0m
+[107m [0m [2m# verify = true      # Run project hooks (--no-verify to skip)[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# ### Switch picker[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Configuration for `wt switch` interactive picker.[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# [switch.picker][0m
+[107m [0m [2m# # Pager command for diff preview (overrides git's core.pager)[0m
+[107m [0m [2m# # pager = "delta --paging=never"[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# # Timeout (ms) for git commands during picker loading (default: 200)[0m
+[107m [0m [2m# # Lower values show the TUI faster; 0 disables timeouts[0m
+[107m [0m [2m# # timeout-ms = 200[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# ### Aliases[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Command templates that run with `wt step <name>`. See `wt step` aliases (https://worktrunk.dev/step/#aliases) for usage and flags.[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# [aliases][0m
+[107m [0m [2m# greet = "echo Hello from {{ branch }}"[0m
+[107m [0m [2m# url = "echo http://localhost:{{ branch | hash_port }}"[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Aliases defined here apply to all projects. For project-specific aliases, use the project config (https://worktrunk.dev/config/#project-configuration) `[aliases]` section instead.[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# ### User project-specific settings[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# For context:[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# - Project config (https://worktrunk.dev/config/#project-configuration) settings are shared with teammates.[0m
+[107m [0m [2m# - User configs generally apply to all projects.[0m
+[107m [0m [2m# - User configs _also_ has a `[projects]` table which holds project-specific settings for the user, such as worktree layout and setting overrides. That's what this section covers.[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Entries are keyed by project identifier (e.g., `github.com/user/repo`).[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# #### Setting overrides (Experimental)[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Override global user config for a specific project. Scalar values (like `worktree-path`) replace the global value. Hooks append — both global and per-project hooks run. Aliases merge — per-project aliases override global aliases on name collision.[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# [projects."github.com/user/repo"][0m
+[107m [0m [2m# worktree-path = ".worktrees/{{ branch | sanitize }}"[0m
+[107m [0m [2m# list.full = true[0m
+[107m [0m [2m# merge.squash = false[0m
+[107m [0m [2m# post-create.env = "cp .env.example .env"[0m
+[107m [0m [2m# aliases.deploy = "make deploy BRANCH={{ branch }}"[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# ### Custom prompt templates[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Templates use minijinja (https://docs.rs/minijinja/) syntax.[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# #### Commit template[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Available variables:[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# - `{{ git_diff }}`, `{{ git_diff_stat }}` — diff content[0m
+[107m [0m [2m# - `{{ branch }}`, `{{ repo }}` — context[0m
+[107m [0m [2m# - `{{ recent_commits }}` — recent commit messages[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Default template:[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# <!-- DEFAULT_TEMPLATE_START -->[0m
+[107m [0m [2m# [commit.generation][0m
+[107m [0m [2m# template = """[0m
+[107m [0m [2m# Write a commit message for the staged changes below.[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# <format>[0m
+[107m [0m [2m# - Subject line under 50 chars[0m
+[107m [0m [2m# - For material changes, add a blank line then a body paragraph explaining the change[0m
+[107m [0m [2m# - Output only the commit message, no quotes or code blocks[0m
+[107m [0m [2m# </format>[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# <style>[0m
+[107m [0m [2m# - Imperative mood: "Add feature" not "Added feature"[0m
+[107m [0m [2m# - Match recent commit style (conventional commits if used)[0m
+[107m [0m [2m# - Describe the change, not the intent or benefit[0m
+[107m [0m [2m# </style>[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# <diffstat>[0m
+[107m [0m [2m# {{ git_diff_stat }}[0m
+[107m [0m [2m# </diffstat>[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# <diff>[0m
+[107m [0m [2m# {{ git_diff }}[0m
+[107m [0m [2m# </diff>[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# <context>[0m
+[107m [0m [2m# Branch: {{ branch }}[0m
+[107m [0m [2m# {% if recent_commits %}<recent_commits>[0m
+[107m [0m [2m# {% for commit in recent_commits %}- {{ commit }}[0m
+[107m [0m [2m# {% endfor %}</recent_commits>{% endif %}[0m
+[107m [0m [2m# </context>[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# """[0m
+[107m [0m [2m# <!-- DEFAULT_TEMPLATE_END -->[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# #### Squash template[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Available variables (in addition to commit template variables):[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# - `{{ commits }}` — list of commits being squashed[0m
+[107m [0m [2m# - `{{ target_branch }}` — merge target branch[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Default template:[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# <!-- DEFAULT_SQUASH_TEMPLATE_START -->[0m
+[107m [0m [2m# [commit.generation][0m
+[107m [0m [2m# squash-template = """[0m
+[107m [0m [2m# Combine these commits into a single commit message.[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# <format>[0m
+[107m [0m [2m# - Subject line under 50 chars[0m
+[107m [0m [2m# - For material changes, add a blank line then a body paragraph explaining the change[0m
+[107m [0m [2m# - Output only the commit message, no quotes or code blocks[0m
+[107m [0m [2m# </format>[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# <style>[0m
+[107m [0m [2m# - Imperative mood: "Add feature" not "Added feature"[0m
+[107m [0m [2m# - Match the style of commits being squashed (conventional commits if used)[0m
+[107m [0m [2m# - Describe the change, not the intent or benefit[0m
+[107m [0m [2m# </style>[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# <commits branch="{{ branch }}" target="{{ target_branch }}">[0m
+[107m [0m [2m# {% for commit in commits %}- {{ commit }}[0m
+[107m [0m [2m# {% endfor %}</commits>[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# <diffstat>[0m
+[107m [0m [2m# {{ git_diff_stat }}[0m
+[107m [0m [2m# </diffstat>[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# <diff>[0m
+[107m [0m [2m# {{ git_diff }}[0m
+[107m [0m [2m# </diff>[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# """[0m
+[107m [0m [2m# <!-- DEFAULT_SQUASH_TEMPLATE_END -->[0m
 
 [1m[32mProject config[0m
 
 With [2m--project[0m, creates [2m.config/wt.toml[0m in the current repository:
 
-  [2m# Worktrunk Project Configuration[0m
-  [2m# Copy to: <repo>/.config/wt.toml[0m
-  [2m#[0m
-  [2m# Project-specific hooks that run automatically during worktree operations.[0m
-  [2m# Check this file into git to share hooks across all developers.[0m
-  [2m[0m
-  [2m# ============================================================================[0m
-  [2m# Hook Formats[0m
-  [2m# ============================================================================[0m
-  [2m# All hooks support two formats:[0m
-  [2m#[0m
-  [2m# Single command:[0m
-  [2m#   post-create = "npm install"[0m
-  [2m#[0m
-  [2m# Named table (multiple commands):[0m
-  [2m#   [post-create][0m
-  [2m#   deps = "npm install"[0m
-  [2m#   build = "npm run build"[0m
-  [2m#[0m
-  [2m# Named commands appear in output, making it easier to identify failures.[0m
-  [2m[0m
-  [2m# ============================================================================[0m
-  [2m# Template Variables — see https://worktrunk.dev/hook/#template-variables[0m
-  [2m# ============================================================================[0m
-  [2m# Common variables:[0m
-  [2m#   {{ repo }}               - Repository directory name (e.g., "myproject")[0m
-  [2m#   {{ branch }}             - Branch name (e.g., "feature/auth")[0m
-  [2m#   {{ worktree_path }}      - Absolute path to worktree[0m
-  [2m#   {{ primary_worktree_path }} - Main worktree (or default branch worktree for bare repos)[0m
-  [2m#   {{ default_branch }}     - Default branch name (e.g., "main")[0m
-  [2m#   {{ target }}             - Target branch (merge hooks only)[0m
-  [2m#[0m
-  [2m# Filters:[0m
-  [2m#   {{ branch | sanitize }}     - Replace / and \ with - (e.g., "feature-auth")[0m
-  [2m#   {{ branch | sanitize_db }}  - Database-safe identifier with hash suffix (e.g., "feature_auth_x7k")[0m
-  [2m#   {{ branch | hash_port }}    - Deterministic port 10000-19999[0m
-  [2m[0m
-  [2m# ============================================================================[0m
-  [2m# Hooks[0m
-  [2m# ============================================================================[0m
-  [2m[0m
-  [2m# Post-Create: Runs after worktree creation, BLOCKS until complete[0m
-  [2m# Use for: installing dependencies, setting up databases, copying configs[0m
-  [2m#[0m
-  [2m# [post-create][0m
-  [2m# deps = "npm ci"[0m
-  [2m# env = "cp .env.example .env"[0m
-  [2m[0m
-  [2m# Post-Start: Runs in BACKGROUND after worktree creation (parallel)[0m
-  [2m# Use for: dev servers, file watchers, background builds[0m
-  [2m# Output logged to .git/wt-logs/{branch}-project-post-start-{name}.log[0m
-  [2m#[0m
-  [2m# [post-start][0m
-  [2m# server = "npm run dev -- --port {{ branch | hash_port }}"[0m
-  [2m# watch = "npm run watch"[0m
-  [2m[0m
-  [2m# Post-Switch: Runs in BACKGROUND after every switch (parallel)[0m
-  [2m# Use for: terminal tab naming, tmux window titles, IDE notifications[0m
-  [2m#[0m
-  [2m# post-switch = "echo -ne '\\033]0;{{ branch }}\\007'"[0m
-  [2m[0m
-  [2m# Pre-Commit: Runs before committing during merge, BLOCKS (fail-fast)[0m
-  [2m# Use for: formatters, linters, quick checks[0m
-  [2m#[0m
-  [2m# [pre-commit][0m
-  [2m# format = "npm run format:check"[0m
-  [2m# lint = "npm run lint"[0m
-  [2m[0m
-  [2m# Pre-Merge: Runs before merging to target, BLOCKS (fail-fast)[0m
-  [2m# Use for: tests, build verification[0m
-  [2m#[0m
-  [2m# [pre-merge][0m
-  [2m# test = "npm test"[0m
-  [2m# build = "npm run build"[0m
-  [2m[0m
-  [2m# Post-Merge: Runs after successful merge, BLOCKS[0m
-  [2m# Use for: deployment, notifications[0m
-  [2m#[0m
-  [2m# post-merge = "echo 'Merged {{ branch }} to {{ target }}'"[0m
-  [2m[0m
-  [2m# Pre-Remove: Runs before worktree removal, BLOCKS (fail-fast)[0m
-  [2m# Use for: cleanup, stopping services[0m
-  [2m#[0m
-  [2m# pre-remove = "docker compose down"[0m
-  [2m[0m
-  [2m# ============================================================================[0m
-  [2m# Aliases (experimental) — run with `wt step <name>`[0m
-  [2m# ============================================================================[0m
-  [2m# Command templates that support the same variables as hooks.[0m
-  [2m# Project-config aliases require command approval on first run.[0m
-  [2m#[0m
-  [2m# [aliases][0m
-  [2m# deploy = "make deploy BRANCH={{ branch }}"[0m
-  [2m# url = "echo http://localhost:{{ branch | hash_port }}"[0m
-  [2m[0m
-  [2m# ============================================================================[0m
-  [2m# Dev Server URL (shown in `wt list`)[0m
-  [2m# ============================================================================[0m
-  [2m# [list][0m
-  [2m# url = "http://localhost:{{ branch | hash_port }}"[0m
-  [2m[0m
-  [2m# ============================================================================[0m
-  [2m# CI Platform Override[0m
-  [2m# ============================================================================[0m
-  [2m# Override CI platform detection for GitHub Enterprise or self-hosted GitLab[0m
-  [2m# with custom domains where URL detection fails.[0m
-  [2m#[0m
-  [2m# [ci][0m
-  [2m# platform = "github"  # or "gitlab"[0m
+[107m [0m [2m# Worktrunk Project Configuration[0m
+[107m [0m [2m# Copy to: <repo>/.config/wt.toml[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Project-specific hooks that run automatically during worktree operations.[0m
+[107m [0m [2m# Check this file into git to share hooks across all developers.[0m
+[107m [0m [2m[0m
+[107m [0m [2m# ============================================================================[0m
+[107m [0m [2m# Hook Formats[0m
+[107m [0m [2m# ============================================================================[0m
+[107m [0m [2m# All hooks support two formats:[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Single command:[0m
+[107m [0m [2m#   post-create = "npm install"[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Named table (multiple commands):[0m
+[107m [0m [2m#   [post-create][0m
+[107m [0m [2m#   deps = "npm install"[0m
+[107m [0m [2m#   build = "npm run build"[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Named commands appear in output, making it easier to identify failures.[0m
+[107m [0m [2m[0m
+[107m [0m [2m# ============================================================================[0m
+[107m [0m [2m# Template Variables — see https://worktrunk.dev/hook/#template-variables[0m
+[107m [0m [2m# ============================================================================[0m
+[107m [0m [2m# Common variables:[0m
+[107m [0m [2m#   {{ repo }}               - Repository directory name (e.g., "myproject")[0m
+[107m [0m [2m#   {{ branch }}             - Branch name (e.g., "feature/auth")[0m
+[107m [0m [2m#   {{ worktree_path }}      - Absolute path to worktree[0m
+[107m [0m [2m#   {{ primary_worktree_path }} - Main worktree (or default branch worktree for bare repos)[0m
+[107m [0m [2m#   {{ default_branch }}     - Default branch name (e.g., "main")[0m
+[107m [0m [2m#   {{ target }}             - Target branch (merge hooks only)[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Filters:[0m
+[107m [0m [2m#   {{ branch | sanitize }}     - Replace / and \ with - (e.g., "feature-auth")[0m
+[107m [0m [2m#   {{ branch | sanitize_db }}  - Database-safe identifier with hash suffix (e.g., "feature_auth_x7k")[0m
+[107m [0m [2m#   {{ branch | hash_port }}    - Deterministic port 10000-19999[0m
+[107m [0m [2m[0m
+[107m [0m [2m# ============================================================================[0m
+[107m [0m [2m# Hooks[0m
+[107m [0m [2m# ============================================================================[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Post-Create: Runs after worktree creation, BLOCKS until complete[0m
+[107m [0m [2m# Use for: installing dependencies, setting up databases, copying configs[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# [post-create][0m
+[107m [0m [2m# deps = "npm ci"[0m
+[107m [0m [2m# env = "cp .env.example .env"[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Post-Start: Runs in BACKGROUND after worktree creation (parallel)[0m
+[107m [0m [2m# Use for: dev servers, file watchers, background builds[0m
+[107m [0m [2m# Output logged to .git/wt-logs/{branch}-project-post-start-{name}.log[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# [post-start][0m
+[107m [0m [2m# server = "npm run dev -- --port {{ branch | hash_port }}"[0m
+[107m [0m [2m# watch = "npm run watch"[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Post-Switch: Runs in BACKGROUND after every switch (parallel)[0m
+[107m [0m [2m# Use for: terminal tab naming, tmux window titles, IDE notifications[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# post-switch = "echo -ne '\\033]0;{{ branch }}\\007'"[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Pre-Commit: Runs before committing during merge, BLOCKS (fail-fast)[0m
+[107m [0m [2m# Use for: formatters, linters, quick checks[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# [pre-commit][0m
+[107m [0m [2m# format = "npm run format:check"[0m
+[107m [0m [2m# lint = "npm run lint"[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Pre-Merge: Runs before merging to target, BLOCKS (fail-fast)[0m
+[107m [0m [2m# Use for: tests, build verification[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# [pre-merge][0m
+[107m [0m [2m# test = "npm test"[0m
+[107m [0m [2m# build = "npm run build"[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Post-Merge: Runs after successful merge, BLOCKS[0m
+[107m [0m [2m# Use for: deployment, notifications[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# post-merge = "echo 'Merged {{ branch }} to {{ target }}'"[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Pre-Remove: Runs before worktree removal, BLOCKS (fail-fast)[0m
+[107m [0m [2m# Use for: cleanup, stopping services[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# pre-remove = "docker compose down"[0m
+[107m [0m [2m[0m
+[107m [0m [2m# ============================================================================[0m
+[107m [0m [2m# Aliases (experimental) — run with `wt step <name>`[0m
+[107m [0m [2m# ============================================================================[0m
+[107m [0m [2m# Command templates that support the same variables as hooks.[0m
+[107m [0m [2m# Project-config aliases require command approval on first run.[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# [aliases][0m
+[107m [0m [2m# deploy = "make deploy BRANCH={{ branch }}"[0m
+[107m [0m [2m# url = "echo http://localhost:{{ branch | hash_port }}"[0m
+[107m [0m [2m[0m
+[107m [0m [2m# ============================================================================[0m
+[107m [0m [2m# Dev Server URL (shown in `wt list`)[0m
+[107m [0m [2m# ============================================================================[0m
+[107m [0m [2m# [list][0m
+[107m [0m [2m# url = "http://localhost:{{ branch | hash_port }}"[0m
+[107m [0m [2m[0m
+[107m [0m [2m# ============================================================================[0m
+[107m [0m [2m# CI Platform Override[0m
+[107m [0m [2m# ============================================================================[0m
+[107m [0m [2m# Override CI platform detection for GitHub Enterprise or self-hosted GitLab[0m
+[107m [0m [2m# with custom domains where URL detection fails.[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# [ci][0m
+[107m [0m [2m# platform = "github"  # or "gitlab"[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -62,45 +62,45 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 
 Install shell integration (required for directory switching):
 
-  [2mwt config shell install[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config shell install[0m
 
 Create user config file with documented examples:
 
-  [2mwt config create[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config create[0m
 
 Create project config file ([2m.config/wt.toml[0m) for hooks:
 
-  [2mwt config create --project[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config create [0m[2m[36m--project[0m[2m[0m
 
 Show current configuration and file locations:
 
-  [2mwt config show[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config show[0m
 
 [1m[32mConfiguration files[0m
 
-        File                 Location                                Contains                     Committed & shared 
-   ────────────── ─────────────────────────────── ─────────────────────────────────────────────── ────────────────── 
-   User config    [2m~/.config/worktrunk/config.toml[0m Worktree path template, LLM commit configs, etc ✗                  
-   Project config [2m.config/wt.toml[0m                 Project hooks, dev server URL                   ✓                  
+      File                 Location                                Contains                     Committed & shared 
+ ────────────── ─────────────────────────────── ─────────────────────────────────────────────── ────────────────── 
+ User config    [2m~/.config/worktrunk/config.toml[0m Worktree path template, LLM commit configs, etc ✗                  
+ Project config [2m.config/wt.toml[0m                 Project hooks, dev server URL                   ✓                  
 
 Organizations can also deploy a system-wide config file for shared defaults — run [2mwt config show[0m for the platform-specific location.
 
 [1mUser config[0m — personal preferences:
 
-  [2m# ~/.config/worktrunk/config.toml[0m
-  [2mworktree-path = ".worktrees/{{ branch | sanitize }}"[0m
-  [2m[0m
-  [2m[commit.generation][0m
-  [2mcommand = "MAX_THINKING_TOKENS=0 claude -p --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"[0m
+[107m [0m [2m# ~/.config/worktrunk/config.toml[0m
+[107m [0m [2mworktree-path = [0m[2m[32m".worktrees/{{ branch | sanitize }}"[0m
+[107m [0m 
+[107m [0m [2m[36m[commit.generation][0m
+[107m [0m [2mcommand = [0m[2m[32m"MAX_THINKING_TOKENS=0 claude -p --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"[0m
 
 [1mProject config[0m — shared team settings:
 
-  [2m# .config/wt.toml[0m
-  [2m[post-create][0m
-  [2mdeps = "npm ci"[0m
-  [2m[0m
-  [2m[pre-merge][0m
-  [2mtest = "npm test"[0m
+[107m [0m [2m# .config/wt.toml[0m
+[107m [0m [2m[36m[post-create][0m
+[107m [0m [2mdeps = [0m[2m[32m"npm ci"[0m
+[107m [0m 
+[107m [0m [2m[36m[pre-merge][0m
+[107m [0m [2mtest = [0m[2m[32m"npm test"[0m
 
 [32mUSER CONFIGURATION[0m
 
@@ -125,17 +125,17 @@ Controls where new worktrees are created.
 
 [1mExamples[0m for repo at [2m~/code/myproject[0m, branch [2mfeature/auth[0m:
 
-  [2m# Default — sibling directory[0m
-  [2m# Creates: ~/code/myproject.feature-auth[0m
-  [2m# worktree-path = "{{ repo_path }}/../{{ repo }}.{{ branch | sanitize }}"[0m
-  [2m[0m
-  [2m# Inside the repository[0m
-  [2m# Creates: ~/code/myproject/.worktrees/feature-auth[0m
-  [2mworktree-path = "{{ repo_path }}/.worktrees/{{ branch | sanitize }}"[0m
-  [2m[0m
-  [2m# Centralized worktrees directory[0m
-  [2m# Creates: ~/worktrees/myproject/feature-auth[0m
-  [2mworktree-path = "~/worktrees/{{ repo }}/{{ branch | sanitize }}"[0m
+[107m [0m [2m# Default — sibling directory[0m
+[107m [0m [2m# Creates: ~/code/myproject.feature-auth[0m
+[107m [0m [2m# worktree-path = "{{ repo_path }}/../{{ repo }}.{{ branch | sanitize }}"[0m
+[107m [0m 
+[107m [0m [2m# Inside the repository[0m
+[107m [0m [2m# Creates: ~/code/myproject/.worktrees/feature-auth[0m
+[107m [0m [2mworktree-path = [0m[2m[32m"{{ repo_path }}/.worktrees/{{ branch | sanitize }}"[0m
+[107m [0m 
+[107m [0m [2m# Centralized worktrees directory[0m
+[107m [0m [2m# Creates: ~/worktrees/myproject/feature-auth[0m
+[107m [0m [2mworktree-path = [0m[2m[32m"~/worktrees/{{ repo }}/{{ branch | sanitize }}"[0m
 
 [2m~[0m expands to the home directory. Relative paths are relative to the repository root.
 
@@ -151,50 +151,50 @@ See LLM commits docs for setup and Custom prompt templates for template customiz
 
 Persistent flag values for [2mwt list[0m. Override on command line as needed.
 
-  [2m[list][0m
-  [2msummary = false    # Enable LLM branch summaries (requires [commit.generation])[0m
-  [2m[0m
-  [2mfull = false       # Show CI, main…± diffstat, and LLM summaries (--full)[0m
-  [2mbranches = false   # Include branches without worktrees (--branches)[0m
-  [2mremotes = false    # Include remote-only branches (--remotes)[0m
+[107m [0m [2m[36m[list][0m
+[107m [0m [2msummary = [0m[2m[33mfalse[0m[2m    [0m[2m# Enable LLM branch summaries (requires [commit.generation])[0m
+[107m [0m 
+[107m [0m [2mfull = [0m[2m[33mfalse[0m[2m       [0m[2m# Show CI, main…± diffstat, and LLM summaries (--full)[0m
+[107m [0m [2mbranches = [0m[2m[33mfalse[0m[2m   [0m[2m# Include branches without worktrees (--branches)[0m
+[107m [0m [2mremotes = [0m[2m[33mfalse[0m[2m    [0m[2m# Include remote-only branches (--remotes)[0m
 
 [32mCommit[0m
 
 Shared by [2mwt step commit[0m, [2mwt step squash[0m, and [2mwt merge[0m.
 
-  [2m[commit][0m
-  [2mstage = "all"      # What to stage before commit: "all", "tracked", or "none"[0m
+[107m [0m [2m[36m[commit][0m
+[107m [0m [2mstage = [0m[2m[32m"all"[0m[2m      [0m[2m# What to stage before commit: "all", "tracked", or "none"[0m
 
 [32mMerge[0m
 
 All flags are on by default. Set to false to change default behavior.
 
-  [2m[merge][0m
-  [2msquash = true      # Squash commits into one (--no-squash to preserve history)[0m
-  [2mcommit = true      # Commit uncommitted changes first (--no-commit to skip)[0m
-  [2mrebase = true      # Rebase onto target before merge (--no-rebase to skip)[0m
-  [2mremove = true      # Remove worktree after merge (--no-remove to keep)[0m
-  [2mverify = true      # Run project hooks (--no-verify to skip)[0m
+[107m [0m [2m[36m[merge][0m
+[107m [0m [2msquash = [0m[2m[33mtrue[0m[2m      [0m[2m# Squash commits into one (--no-squash to preserve history)[0m
+[107m [0m [2mcommit = [0m[2m[33mtrue[0m[2m      [0m[2m# Commit uncommitted changes first (--no-commit to skip)[0m
+[107m [0m [2mrebase = [0m[2m[33mtrue[0m[2m      [0m[2m# Rebase onto target before merge (--no-rebase to skip)[0m
+[107m [0m [2mremove = [0m[2m[33mtrue[0m[2m      [0m[2m# Remove worktree after merge (--no-remove to keep)[0m
+[107m [0m [2mverify = [0m[2m[33mtrue[0m[2m      [0m[2m# Run project hooks (--no-verify to skip)[0m
 
 [32mSwitch picker[0m
 
 Configuration for [2mwt switch[0m interactive picker.
 
-  [2m[switch.picker][0m
-  [2m# Pager command for diff preview (overrides git's core.pager)[0m
-  [2m# pager = "delta --paging=never"[0m
-  [2m[0m
-  [2m# Timeout (ms) for git commands during picker loading (default: 200)[0m
-  [2m# Lower values show the TUI faster; 0 disables timeouts[0m
-  [2m# timeout-ms = 200[0m
+[107m [0m [2m[36m[switch.picker][0m
+[107m [0m [2m# Pager command for diff preview (overrides git's core.pager)[0m
+[107m [0m [2m# pager = "delta --paging=never"[0m
+[107m [0m 
+[107m [0m [2m# Timeout (ms) for git commands during picker loading (default: 200)[0m
+[107m [0m [2m# Lower values show the TUI faster; 0 disables timeouts[0m
+[107m [0m [2m# timeout-ms = 200[0m
 
 [32mAliases[0m
 
 Command templates that run with [2mwt step <name>[0m. See [2mwt step[0m aliases for usage and flags.
 
-  [2m[aliases][0m
-  [2mgreet = "echo Hello from {{ branch }}"[0m
-  [2murl = "echo http://localhost:{{ branch | hash_port }}"[0m
+[107m [0m [2m[36m[aliases][0m
+[107m [0m [2mgreet = [0m[2m[32m"echo Hello from {{ branch }}"[0m
+[107m [0m [2murl = [0m[2m[32m"echo http://localhost:{{ branch | hash_port }}"[0m
 
 Aliases defined here apply to all projects. For project-specific aliases, use the project config [2m[aliases][0m section instead.
 
@@ -212,12 +212,12 @@ Entries are keyed by project identifier (e.g., [2mgithub.com/user/repo[0m).
 
 Override global user config for a specific project. Scalar values (like [2mworktree-path[0m) replace the global value. Hooks append — both global and per-project hooks run. Aliases merge — per-project aliases override global aliases on name collision.
 
-  [2m[projects."github.com/user/repo"][0m
-  [2mworktree-path = ".worktrees/{{ branch | sanitize }}"[0m
-  [2mlist.full = true[0m
-  [2mmerge.squash = false[0m
-  [2mpost-create.env = "cp .env.example .env"[0m
-  [2maliases.deploy = "make deploy BRANCH={{ branch }}"[0m
+[107m [0m [2m[36m[projects."github.com/user/repo"][0m
+[107m [0m [2mworktree-path = [0m[2m[32m".worktrees/{{ branch | sanitize }}"[0m
+[107m [0m [2mlist.full = [0m[2m[33mtrue[0m
+[107m [0m [2mmerge.squash = [0m[2m[33mfalse[0m
+[107m [0m [2mpost-create.env = [0m[2m[32m"cp .env.example .env"[0m
+[107m [0m [2maliases.deploy = [0m[2m[32m"make deploy BRANCH={{ branch }}"[0m
 
 [32mCustom prompt templates[0m
 
@@ -233,38 +233,38 @@ Available variables:
 
 Default template:
 
-  [2m[commit.generation][0m
-  [2mtemplate = """[0m
-  [2mWrite a commit message for the staged changes below.[0m
-  [2m[0m
-  [2m<format>[0m
-  [2m- Subject line under 50 chars[0m
-  [2m- For material changes, add a blank line then a body paragraph explaining the change[0m
-  [2m- Output only the commit message, no quotes or code blocks[0m
-  [2m</format>[0m
-  [2m[0m
-  [2m<style>[0m
-  [2m- Imperative mood: "Add feature" not "Added feature"[0m
-  [2m- Match recent commit style (conventional commits if used)[0m
-  [2m- Describe the change, not the intent or benefit[0m
-  [2m</style>[0m
-  [2m[0m
-  [2m<diffstat>[0m
-  [2m{{ git_diff_stat }}[0m
-  [2m</diffstat>[0m
-  [2m[0m
-  [2m<diff>[0m
-  [2m{{ git_diff }}[0m
-  [2m</diff>[0m
-  [2m[0m
-  [2m<context>[0m
-  [2mBranch: {{ branch }}[0m
-  [2m{% if recent_commits %}<recent_commits>[0m
-  [2m{% for commit in recent_commits %}- {{ commit }}[0m
-  [2m{% endfor %}</recent_commits>{% endif %}[0m
-  [2m</context>[0m
-  [2m[0m
-  [2m"""[0m
+[107m [0m [2m[36m[commit.generation][0m
+[107m [0m [2mtemplate = [0m[2m[32m""[0m[2m[32m"[0m
+[107m [0m [2m[32mWrite a commit message for the staged changes below.[0m
+[107m [0m 
+[107m [0m [2m[32m<format>[0m
+[107m [0m [2m[32m- Subject line under 50 chars[0m
+[107m [0m [2m[32m- For material changes, add a blank line then a body paragraph explaining the change[0m
+[107m [0m [2m[32m- Output only the commit message, no quotes or code blocks[0m
+[107m [0m [2m[32m</format>[0m
+[107m [0m 
+[107m [0m [2m[32m<style>[0m
+[107m [0m [2m[32m- Imperative mood: "[0m[2mAdd feature[0m[2m[32m" not "[0m[2mAdded feature[0m[2m[32m"[0m
+[107m [0m [2m[32m- Match recent commit style (conventional commits if used)[0m
+[107m [0m [2m[32m- Describe the change, not the intent or benefit[0m
+[107m [0m [2m[32m</style>[0m
+[107m [0m 
+[107m [0m [2m[32m<diffstat>[0m
+[107m [0m [2m[32m{{ git_diff_stat }}[0m
+[107m [0m [2m[32m</diffstat>[0m
+[107m [0m 
+[107m [0m [2m[32m<diff>[0m
+[107m [0m [2m[32m{{ git_diff }}[0m
+[107m [0m [2m[32m</diff>[0m
+[107m [0m 
+[107m [0m [2m[32m<context>[0m
+[107m [0m [2m[32mBranch: {{ branch }}[0m
+[107m [0m [2m[32m{% if recent_commits %}<recent_commits>[0m
+[107m [0m [2m[32m{% for commit in recent_commits %}- {{ commit }}[0m
+[107m [0m [2m[32m{% endfor %}</recent_commits>{% endif %}[0m
+[107m [0m [2m[32m</context>[0m
+[107m [0m 
+[107m [0m [2m[32m"[0m[2m[32m""[0m
 
 [1mSquash template[0m
 
@@ -275,35 +275,35 @@ Available variables (in addition to commit template variables):
 
 Default template:
 
-  [2m[commit.generation][0m
-  [2msquash-template = """[0m
-  [2mCombine these commits into a single commit message.[0m
-  [2m[0m
-  [2m<format>[0m
-  [2m- Subject line under 50 chars[0m
-  [2m- For material changes, add a blank line then a body paragraph explaining the change[0m
-  [2m- Output only the commit message, no quotes or code blocks[0m
-  [2m</format>[0m
-  [2m[0m
-  [2m<style>[0m
-  [2m- Imperative mood: "Add feature" not "Added feature"[0m
-  [2m- Match the style of commits being squashed (conventional commits if used)[0m
-  [2m- Describe the change, not the intent or benefit[0m
-  [2m</style>[0m
-  [2m[0m
-  [2m<commits branch="{{ branch }}" target="{{ target_branch }}">[0m
-  [2m{% for commit in commits %}- {{ commit }}[0m
-  [2m{% endfor %}</commits>[0m
-  [2m[0m
-  [2m<diffstat>[0m
-  [2m{{ git_diff_stat }}[0m
-  [2m</diffstat>[0m
-  [2m[0m
-  [2m<diff>[0m
-  [2m{{ git_diff }}[0m
-  [2m</diff>[0m
-  [2m[0m
-  [2m"""[0m
+[107m [0m [2m[36m[commit.generation][0m
+[107m [0m [2msquash-template = [0m[2m[32m""[0m[2m[32m"[0m
+[107m [0m [2m[32mCombine these commits into a single commit message.[0m
+[107m [0m 
+[107m [0m [2m[32m<format>[0m
+[107m [0m [2m[32m- Subject line under 50 chars[0m
+[107m [0m [2m[32m- For material changes, add a blank line then a body paragraph explaining the change[0m
+[107m [0m [2m[32m- Output only the commit message, no quotes or code blocks[0m
+[107m [0m [2m[32m</format>[0m
+[107m [0m 
+[107m [0m [2m[32m<style>[0m
+[107m [0m [2m[32m- Imperative mood: "[0m[2mAdd feature[0m[2m[32m" not "[0m[2mAdded feature[0m[2m[32m"[0m
+[107m [0m [2m[32m- Match the style of commits being squashed (conventional commits if used)[0m
+[107m [0m [2m[32m- Describe the change, not the intent or benefit[0m
+[107m [0m [2m[32m</style>[0m
+[107m [0m 
+[107m [0m [2m[32m<commits branch="[0m[2m{{ branch }}[0m[2m[32m" target="[0m[2m{{ target_branch }}[0m[2m[32m">[0m
+[107m [0m [2m[32m{% for commit in commits %}- {{ commit }}[0m
+[107m [0m [2m[32m{% endfor %}</commits>[0m
+[107m [0m 
+[107m [0m [2m[32m<diffstat>[0m
+[107m [0m [2m[32m{{ git_diff_stat }}[0m
+[107m [0m [2m[32m</diffstat>[0m
+[107m [0m 
+[107m [0m [2m[32m<diff>[0m
+[107m [0m [2m[32m{{ git_diff }}[0m
+[107m [0m [2m[32m</diff>[0m
+[107m [0m 
+[107m [0m [2m[32m"[0m[2m[32m""[0m
 
 [32mPROJECT CONFIGURATION[0m
 
@@ -313,26 +313,26 @@ See [2mwt hook[0m for hook types, execution order, template variables, and exa
 
 [32mNon-hook settings[0m
 
-  [2m# .config/wt.toml[0m
-  [2m[0m
-  [2m# URL column in wt list (dimmed when port not listening)[0m
-  [2m[list][0m
-  [2murl = "http://localhost:{{ branch | hash_port }}"[0m
-  [2m[0m
-  [2m# Override CI platform detection for self-hosted instances[0m
-  [2m[ci][0m
-  [2mplatform = "github"  # or "gitlab"[0m
-  [2m[0m
-  [2m# Command aliases (run with wt step <name>)[0m
-  [2m[aliases][0m
-  [2mdeploy = "make deploy BRANCH={{ branch }}"[0m
-  [2mtest = "cargo test"[0m
+[107m [0m [2m# .config/wt.toml[0m
+[107m [0m 
+[107m [0m [2m# URL column in wt list (dimmed when port not listening)[0m
+[107m [0m [2m[36m[list][0m
+[107m [0m [2murl = [0m[2m[32m"http://localhost:{{ branch | hash_port }}"[0m
+[107m [0m 
+[107m [0m [2m# Override CI platform detection for self-hosted instances[0m
+[107m [0m [2m[36m[ci][0m
+[107m [0m [2mplatform = [0m[2m[32m"github"[0m[2m  [0m[2m# or "gitlab"[0m
+[107m [0m 
+[107m [0m [2m# Command aliases (run with wt step <name>)[0m
+[107m [0m [2m[36m[aliases][0m
+[107m [0m [2mdeploy = [0m[2m[32m"make deploy BRANCH={{ branch }}"[0m
+[107m [0m [2mtest = [0m[2m[32m"cargo test"[0m
 
 [32mSHELL INTEGRATION[0m
 
 Worktrunk needs shell integration to change directories when switching worktrees. Install with:
 
-  [2mwt config shell install[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config shell install[0m
 
 For manual setup, see [2mwt config shell init --help[0m.
 
@@ -354,11 +354,11 @@ Config keys use kebab-case ([2mworktree-path[0m), while env vars use SCREAMING
 
 For nested config sections, use double underscores to separate levels:
 
-            Config                   Environment Variable          
-   ───────────────────────── ───────────────────────────────────── 
-   [2mworktree-path[0m             [2mWORKTRUNK_WORKTREE_PATH[0m               
-   [2mcommit.generation.command[0m [2mWORKTRUNK_COMMIT__GENERATION__COMMAND[0m 
-   [2mcommit.stage[0m              [2mWORKTRUNK_COMMIT__STAGE[0m               
+          Config                   Environment Variable          
+ ───────────────────────── ───────────────────────────────────── 
+ [2mworktree-path[0m             [2mWORKTRUNK_WORKTREE_PATH[0m               
+ [2mcommit.generation.command[0m [2mWORKTRUNK_COMMIT__GENERATION__COMMAND[0m 
+ [2mcommit.stage[0m              [2mWORKTRUNK_COMMIT__STAGE[0m               
 
 Note the single underscore after [2mWORKTRUNK[0m and double underscores between nested keys.
 
@@ -366,18 +366,18 @@ Note the single underscore after [2mWORKTRUNK[0m and double underscores betwee
 
 Override the LLM command in CI to use a mock:
 
-  [2mWORKTRUNK_COMMIT__GENERATION__COMMAND="echo 'test: automated commit'" wt merge[0m
+[107m [0m [2mWORKTRUNK_COMMIT__GENERATION__COMMAND=[0m[2m[32m"echo 'test: automated commit'"[0m[2m [0m[2m[34mwt[0m[2m merge[0m
 
 [32mOther environment variables[0m
 
-               Variable                                                   Purpose                                      
-   ───────────────────────────────── ───────────────────────────────────────────────────────────────────────────────── 
-   [2mWORKTRUNK_BIN[0m                     Override binary path for shell wrappers (useful for testing dev builds)           
-   [2mWORKTRUNK_CONFIG_PATH[0m             Override user config file location                                                
-   [2mWORKTRUNK_SYSTEM_CONFIG_PATH[0m      Override system config file location                                              
-   [2mXDG_CONFIG_DIRS[0m                   Colon-separated system config directories (default: [2m/etc/xdg[0m)                     
-   [2mWORKTRUNK_DIRECTIVE_FILE[0m          Internal: set by shell wrappers to enable directory changes                       
-   [2mWORKTRUNK_SHELL[0m                   Internal: set by shell wrappers to indicate shell type (e.g., [2mpowershell[0m)         
-   [2mWORKTRUNK_MAX_CONCURRENT_COMMANDS[0m Max parallel git commands (default: 32). Lower if hitting file descriptor limits. 
-   [2mNO_COLOR[0m                          Disable colored output (standard)                                                 
-   [2mCLICOLOR_FORCE[0m                    Force colored output even when not a TTY
+             Variable                                                   Purpose                                      
+ ───────────────────────────────── ───────────────────────────────────────────────────────────────────────────────── 
+ [2mWORKTRUNK_BIN[0m                     Override binary path for shell wrappers (useful for testing dev builds)           
+ [2mWORKTRUNK_CONFIG_PATH[0m             Override user config file location                                                
+ [2mWORKTRUNK_SYSTEM_CONFIG_PATH[0m      Override system config file location                                              
+ [2mXDG_CONFIG_DIRS[0m                   Colon-separated system config directories (default: [2m/etc/xdg[0m)                     
+ [2mWORKTRUNK_DIRECTIVE_FILE[0m          Internal: set by shell wrappers to enable directory changes                       
+ [2mWORKTRUNK_SHELL[0m                   Internal: set by shell wrappers to indicate shell type (e.g., [2mpowershell[0m)         
+ [2mWORKTRUNK_MAX_CONCURRENT_COMMANDS[0m Max parallel git commands (default: 32). Lower if hitting file descriptor limits. 
+ [2mNO_COLOR[0m                          Disable colored output (standard)                                                 
+ [2mCLICOLOR_FORCE[0m                    Force colored output even when not a TTY

--- a/tests/snapshots/integration__integration_tests__help__help_config_show.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_show.snap
@@ -12,15 +12,18 @@ info:
     GIT_EDITOR: ""
     LANG: C
     LC_ALL: C
+    NO_COLOR: ""
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
+    WORKTRUNK_APPROVALS_PATH: /nonexistent/test/approvals.toml
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
     WORKTRUNK_SYSTEM_CONFIG_PATH: /etc/xdg/worktrunk/config.toml
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
 ---
@@ -59,7 +62,7 @@ If a config file doesn't exist, shows defaults that would be used.
 
 Use [2m--full[0m to run diagnostic checks:
 
-  [2mwt config show --full[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config show [0m[2m[36m--full[0m[2m[0m
 
 This tests:
 - [1mCI tool status[0m — Whether [2mgh[0m (GitHub) or [2mglab[0m (GitLab) is installed and authenticated

--- a/tests/snapshots/integration__integration_tests__help__help_config_state.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state.snap
@@ -12,14 +12,18 @@ info:
     GIT_EDITOR: ""
     LANG: C
     LC_ALL: C
+    NO_COLOR: ""
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
+    WORKTRUNK_APPROVALS_PATH: /nonexistent/test/approvals.toml
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_SYSTEM_CONFIG_PATH: /etc/xdg/worktrunk/config.toml
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
 ---
@@ -70,19 +74,19 @@ Use [2mwt config show[0m to view file-based configuration.
 [1m[32mExamples[0m
 
 Get the default branch:
-  [2mwt config state default-branch[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config state default-branch[0m
 
 Set the default branch manually:
-  [2mwt config state default-branch set main[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config state default-branch set main[0m
 
 Set a marker for current branch:
-  [2mwt config state marker set "🚧 WIP"[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config state marker set [0m[2m[32m"🚧 WIP"[0m[2m[0m
 
 Clear all CI status cache:
-  [2mwt config state ci-status clear --all[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config state ci-status clear [0m[2m[36m--all[0m[2m[0m
 
 Show all stored state:
-  [2mwt config state get[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config state get[0m
 
 Clear all stored state:
-  [2mwt config state clear[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config state clear[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
@@ -13,6 +13,7 @@ info:
     GIT_EDITOR: ""
     LANG: C
     LC_ALL: C
+    NO_COLOR: ""
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
@@ -64,14 +65,14 @@ Results cache for 30-60 seconds. Indicators dim when local changes haven't been 
 
 [1m[32mStatus values[0m
 
-    Status                   Meaning                 
-   ───────── ─────────────────────────────────────── 
-   [2mpassed[0m    All checks passed                       
-   [2mrunning[0m   Checks in progress                      
-   [2mfailed[0m    Checks failed                           
-   [2mconflicts[0m PR has merge conflicts                  
-   [2mno-ci[0m     No checks configured                    
-   [2merror[0m     Fetch error (rate limit, network, auth) 
+  Status                   Meaning                 
+ ───────── ─────────────────────────────────────── 
+ [2mpassed[0m    All checks passed                       
+ [2mrunning[0m   Checks in progress                      
+ [2mfailed[0m    Checks failed                           
+ [2mconflicts[0m PR has merge conflicts                  
+ [2mno-ci[0m     No checks configured                    
+ [2merror[0m     Fetch error (rate limit, network, auth) 
 
 See [2mwt list[0m CI status for display symbols and colors.
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
@@ -13,14 +13,18 @@ info:
     GIT_EDITOR: ""
     LANG: C
     LC_ALL: C
+    NO_COLOR: ""
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
+    WORKTRUNK_APPROVALS_PATH: /nonexistent/test/approvals.toml
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_SYSTEM_CONFIG_PATH: /etc/xdg/worktrunk/config.toml
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
 ---
@@ -54,7 +58,7 @@ Usage: [1m[36mwt config state default-branch[0m [36m[OPTIONS][0m [36m[COMM
 
 Useful in scripts to avoid hardcoding [2mmain[0m or [2mmaster[0m:
 
-  [2mgit rebase $(wt config state default-branch)[0m
+[107m [0m [2m[0m[2m[34mgit[0m[2m rebase $([0m[2m[34mwt[0m[2m config state default-branch)[0m
 
 Without a subcommand, runs [2mget[0m. Use [2mset[0m to override, or [2mclear[0m then [2mget[0m to re-detect.
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
@@ -13,6 +13,7 @@ info:
     GIT_EDITOR: ""
     LANG: C
     LC_ALL: C
+    NO_COLOR: ""
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
@@ -66,10 +67,10 @@ All hook executions and LLM commands are recorded automatically — one JSON obj
 
 [32mHook output logs[0m
 
-       Operation                     Log file                 
-   ────────────────── ─────────────────────────────────────── 
-   post-start hooks   [2m{branch}-{source}-post-start-{name}.log[0m 
-   Background removal [2m{branch}-remove.log[0m                     
+     Operation                     Log file                 
+ ────────────────── ─────────────────────────────────────── 
+ post-start hooks   [2m{branch}-{source}-post-start-{name}.log[0m 
+ Background removal [2m{branch}-remove.log[0m                     
 
 Source is [2muser[0m or [2mproject[0m depending on where the hook is defined.
 
@@ -86,13 +87,13 @@ All logs are stored in [2m.git/wt-logs/[0m (in the main worktree's git directo
 [1m[32mExamples[0m
 
 List all log files:
-  [2mwt config state logs get[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config state logs get[0m
 
 Query the command log:
-  [2mtail -5 .git/wt-logs/commands.jsonl | jq .[0m
+[107m [0m [2m[0m[2m[34mtail[0m[2m [0m[2m[36m-5[0m[2m .git/wt-logs/commands.jsonl [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m .[0m
 
 View a specific hook log:
-  [2mcat "$(git rev-parse --git-dir)/wt-logs/feature-project-post-start-build.log"[0m
+[107m [0m [2m[0m[2m[34mcat[0m[2m [0m[2m[32m"$([0m[2m[34mgit[0m[2m rev-parse [0m[2m[36m--git-dir[0m[2m)/wt-logs/feature-project-post-start-build.log"[0m[2m[0m
 
 Clear all logs:
-  [2mwt config state logs clear[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config state logs clear[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
@@ -13,14 +13,18 @@ info:
     GIT_EDITOR: ""
     LANG: C
     LC_ALL: C
+    NO_COLOR: ""
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
+    WORKTRUNK_APPROVALS_PATH: /nonexistent/test/approvals.toml
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_SYSTEM_CONFIG_PATH: /etc/xdg/worktrunk/config.toml
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
 ---
@@ -58,10 +62,10 @@ Custom status text or emoji shown in the [2mwt list[0m Status column.
 
 Markers appear at the start of the Status column:
 
-  [2mBranch    Status   Path[0m
-  [2mmain      ^        ~/code/myproject[0m
-  [2mfeature   🚧↑      ~/code/myproject.feature[0m
-  [2mbugfix    🤖!↑⇡    ~/code/myproject.bugfix[0m
+[107m [0m [2mBranch    Status   Path[0m
+[107m [0m [2mmain      ^        ~/code/myproject[0m
+[107m [0m [2mfeature   🚧↑      ~/code/myproject.feature[0m
+[107m [0m [2mbugfix    🤖!↑⇡    ~/code/myproject.bugfix[0m
 
 [1m[32mUse cases[0m
 
@@ -73,6 +77,6 @@ Markers appear at the start of the Status column:
 
 Stored in git config as [2mworktrunk.state.<branch>.marker[0m. Set directly with:
 
-  [2mgit config worktrunk.state.feature.marker '{"marker":"🚧","set_at":0}'[0m
+[107m [0m [2m[0m[2m[34mgit[0m[2m config worktrunk.state.feature.marker [0m[2m[32m'{"marker":"🚧","set_at":0}'[0m[2m[0m
 
 Without a subcommand, runs [2mget[0m for the current branch. For [2m--branch[0m, use [2mget --branch=NAME[0m.

--- a/tests/snapshots/integration__integration_tests__help__help_hook_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_approvals.snap
@@ -12,12 +12,14 @@ info:
     GIT_EDITOR: ""
     LANG: C
     LC_ALL: C
+    NO_COLOR: ""
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     WORKTRUNK_APPROVALS_PATH: /nonexistent/test/approvals.toml
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_SYSTEM_CONFIG_PATH: /etc/xdg/worktrunk/config.toml
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
@@ -57,13 +59,13 @@ Project hooks require approval on first run to prevent untrusted projects from r
 [1m[32mExamples[0m
 
 Pre-approve all commands for current project:
-  [2mwt hook approvals add[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m hook approvals add[0m
 
 Clear approvals for current project:
-  [2mwt hook approvals clear[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m hook approvals clear[0m
 
 Clear global approvals:
-  [2mwt hook approvals clear --global[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m hook approvals clear [0m[2m[36m--global[0m[2m[0m
 
 [1m[32mHow approvals work[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -80,37 +80,37 @@ The table renders progressively: branch names, paths, and commit hashes appear i
 
 List all worktrees:
 
-  [2m$ wt list[0m
+[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list[0m
 
 Include CI status, line diffs, and LLM summaries:
 
-  [2m$ wt list --full[0m
+[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--full[0m[2m[0m
 
 Include branches that don't have worktrees:
 
-  [2m$ wt list --branches --full[0m
+[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--branches[0m[2m [0m[2m[36m--full[0m[2m[0m
 
 Output as JSON for scripting:
 
-  [2m$ wt list --format=json[0m
+[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m[0m
 
 [1m[32mColumns[0m
 
-   Column                                                Shows                                               
-   ─────── ───────────────────────────────────────────────────────────────────────────────────────────────── 
-   Branch  Branch name                                                                                       
-   Status  Compact symbols (see below)                                                                       
-   HEAD±   Uncommitted changes: +added -deleted lines                                                        
-   main↕   Commits ahead/behind default branch                                                               
-   main…±  Line diffs since the merge-base with the default branch ([2m--full[0m)                                  
-   Summary LLM-generated branch summary ([2m--full[0m + [2msummary = true[0m, requires [2mcommit.generation[0m) (experimental) 
-   Remote⇅ Commits ahead/behind tracking branch                                                              
-   CI      Pipeline status ([2m--full[0m)                                                                          
-   Path    Worktree directory                                                                                
-   URL     Dev server URL from project config (dimmed if port not listening)                                 
-   Commit  Short hash (8 chars)                                                                              
-   Age     Time since last commit                                                                            
-   Message Last commit message (truncated)                                                                   
+ Column                                                Shows                                               
+ ─────── ───────────────────────────────────────────────────────────────────────────────────────────────── 
+ Branch  Branch name                                                                                       
+ Status  Compact symbols (see below)                                                                       
+ HEAD±   Uncommitted changes: +added -deleted lines                                                        
+ main↕   Commits ahead/behind default branch                                                               
+ main…±  Line diffs since the merge-base with the default branch ([2m--full[0m)                                  
+ Summary LLM-generated branch summary ([2m--full[0m + [2msummary = true[0m, requires [2mcommit.generation[0m) (experimental) 
+ Remote⇅ Commits ahead/behind tracking branch                                                              
+ CI      Pipeline status ([2m--full[0m)                                                                          
+ Path    Worktree directory                                                                                
+ URL     Dev server URL from project config (dimmed if port not listening)                                 
+ Commit  Short hash (8 chars)                                                                              
+ Age     Time since last commit                                                                            
+ Message Last commit message (truncated)                                                                   
 
 Note: [2mmain↕[0m and [2mmain…±[0m refer to the default branch (header label stays [2mmain[0m for compactness). [2mmain…±[0m uses a merge-base (three-dot) diff.
 
@@ -118,15 +118,15 @@ Note: [2mmain↕[0m and [2mmain…±[0m refer to the default branch (header 
 
 The CI column shows GitHub/GitLab pipeline status:
 
-   Indicator              Meaning              
-   ───────── ───────────────────────────────── 
-   [32m●[0m green   All checks passed                 
-   [34m●[0m blue    Checks running                    
-   [31m●[0m red     Checks failed                     
-   [33m●[0m yellow  Merge conflicts with base         
-   [90m●[0m gray    No checks configured              
-   [33m⚠[0m yellow  Fetch error (rate limit, network) 
-   (blank)   No upstream or no PR/MR           
+ Indicator              Meaning              
+ ───────── ───────────────────────────────── 
+ [32m●[0m green   All checks passed                 
+ [34m●[0m blue    Checks running                    
+ [31m●[0m red     Checks failed                     
+ [33m●[0m yellow  Merge conflicts with base         
+ [90m●[0m gray    No checks configured              
+ [33m⚠[0m yellow  Fetch error (rate limit, network) 
+ (blank)   No upstream or no PR/MR           
 
 CI indicators are clickable links to the PR or pipeline page. Any CI dot appears dimmed when there are unpushed local changes (stale status). PRs/MRs are checked first, then branch workflows/pipelines for branches with an upstream. Local-only branches show blank; remote-only branches (visible with [2m--remotes[0m) get CI status detection. Results are cached for 30-60 seconds; use [2mwt config state[0m to view or clear.
 
@@ -140,31 +140,31 @@ Disabled by default — when enabled, each branch's diff is sent to the configur
 
 The Status column has multiple subcolumns. Within each, only the first matching symbol is shown (listed in priority order):
 
-      Subcolumn     Symbol                                          Meaning                                           
-   ──────────────── ────── ────────────────────────────────────────────────────────────────────────────────────────── 
-   Working tree (1) [36m+[0m      Staged files                                                                               
-   Working tree (2) [36m![0m      Modified files (unstaged)                                                                  
-   Working tree (3) [36m?[0m      Untracked files                                                                            
-   Worktree         [31m✘[0m      Merge conflicts                                                                            
-                    [33m⤴[0m      Rebase in progress                                                                         
-                    [33m⤵[0m      Merge in progress                                                                          
-                    [2m/[0m      Branch without worktree                                                                    
-                    [31m⚑[0m      Branch-worktree mismatch (branch name doesn't match worktree path)                         
-                    [33m⊟[0m      Prunable (directory missing)                                                               
-                    [33m⊞[0m      Locked worktree                                                                            
-   Default branch   [2m^[0m      Is the default branch                                                                      
-                    [2m∅[0m      Orphan branch (no common ancestor with the default branch)                                 
-                    [33m✗[0m      Would conflict if merged to the default branch (with [2m--full[0m, includes uncommitted changes) 
-                    [2m_[0m      Same commit as the default branch, clean                                                   
-                    [2m–[0m      Same commit as the default branch, uncommitted changes                                     
-                    [2m⊂[0m      Content integrated into the default branch or target                                       
-                    [2m↕[0m      Diverged from the default branch                                                           
-                    [2m↑[0m      Ahead of the default branch                                                                
-                    [2m↓[0m      Behind the default branch                                                                  
-   Remote           [2m|[0m      In sync with remote                                                                        
-                    [2m⇅[0m      Diverged from remote                                                                       
-                    [2m⇡[0m      Ahead of remote                                                                            
-                    [2m⇣[0m      Behind remote                                                                              
+    Subcolumn     Symbol                                          Meaning                                           
+ ──────────────── ────── ────────────────────────────────────────────────────────────────────────────────────────── 
+ Working tree (1) [36m+[0m      Staged files                                                                               
+ Working tree (2) [36m![0m      Modified files (unstaged)                                                                  
+ Working tree (3) [36m?[0m      Untracked files                                                                            
+ Worktree         [31m✘[0m      Merge conflicts                                                                            
+                  [33m⤴[0m      Rebase in progress                                                                         
+                  [33m⤵[0m      Merge in progress                                                                          
+                  [2m/[0m      Branch without worktree                                                                    
+                  [31m⚑[0m      Branch-worktree mismatch (branch name doesn't match worktree path)                         
+                  [33m⊟[0m      Prunable (directory missing)                                                               
+                  [33m⊞[0m      Locked worktree                                                                            
+ Default branch   [2m^[0m      Is the default branch                                                                      
+                  [2m∅[0m      Orphan branch (no common ancestor with the default branch)                                 
+                  [33m✗[0m      Would conflict if merged to the default branch (with [2m--full[0m, includes uncommitted changes) 
+                  [2m_[0m      Same commit as the default branch, clean                                                   
+                  [2m–[0m      Same commit as the default branch, uncommitted changes                                     
+                  [2m⊂[0m      Content integrated into the default branch or target                                       
+                  [2m↕[0m      Diverged from the default branch                                                           
+                  [2m↑[0m      Ahead of the default branch                                                                
+                  [2m↓[0m      Behind the default branch                                                                  
+ Remote           [2m|[0m      In sync with remote                                                                        
+                  [2m⇅[0m      Diverged from remote                                                                       
+                  [2m⇡[0m      Ahead of remote                                                                            
+                  [2m⇣[0m      Behind remote                                                                              
 
 Rows are dimmed when safe to delete ([2m_[0m same commit with clean working tree or [2m⊂[0m content integrated).
 
@@ -174,108 +174,108 @@ Rows are dimmed when safe to delete ([2m_[0m same commit with clean working tr
 
 Query structured data with [2m--format=json[0m:
 
-  [2m# Current worktree path (for scripts)[0m
-  [2mwt list --format=json | jq -r '.[] | select(.is_current) | .path'[0m
-  [2m[0m
-  [2m# Branches with uncommitted changes[0m
-  [2mwt list --format=json | jq '.[] | select(.working_tree.modified)'[0m
-  [2m[0m
-  [2m# Worktrees with merge conflicts[0m
-  [2mwt list --format=json | jq '.[] | select(.operation_state == "conflicts")'[0m
-  [2m[0m
-  [2m# Branches ahead of main (needs merging)[0m
-  [2mwt list --format=json | jq '.[] | select(.main.ahead > 0) | .branch'[0m
-  [2m[0m
-  [2m# Integrated branches (safe to remove)[0m
-  [2mwt list --format=json | jq '.[] | select(.main_state == "integrated" or .main_state == "empty") | .branch'[0m
-  [2m[0m
-  [2m# Branches without worktrees[0m
-  [2mwt list --format=json --branches | jq '.[] | select(.kind == "branch") | .branch'[0m
-  [2m[0m
-  [2m# Worktrees ahead of remote (needs pushing)[0m
-  [2mwt list --format=json | jq '.[] | select(.remote.ahead > 0) | {branch, ahead: .remote.ahead}'[0m
-  [2m[0m
-  [2m# Stale CI (local changes not reflected in CI)[0m
-  [2mwt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'[0m
+[107m [0m [2m# Current worktree path (for scripts)[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[36m-r[0m[2m [0m[2m[32m'.[] | select(.is_current) | .path'[0m[2m[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Branches with uncommitted changes[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.working_tree.modified)'[0m[2m[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Worktrees with merge conflicts[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.operation_state == "conflicts")'[0m[2m[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Branches ahead of main (needs merging)[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.main.ahead > 0) | .branch'[0m[2m[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Integrated branches (safe to remove)[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.main_state == "integrated" or .main_state == "empty") | .branch'[0m[2m[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Branches without worktrees[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m--branches[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.kind == "branch") | .branch'[0m[2m[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Worktrees ahead of remote (needs pushing)[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.remote.ahead > 0) | {branch, ahead: .remote.ahead}'[0m[2m[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Stale CI (local changes not reflected in CI)[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m--full[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.ci.stale) | .branch'[0m[2m[0m
 
 [1mFields:[0m
 
-         Field           Type                                   Description                               
-   ────────────────── ─────────── ─────────────────────────────────────────────────────────────────────── 
-   [2mbranch[0m             string/null Branch name (null for detached HEAD)                                    
-   [2mpath[0m               string      Worktree path (absent for branches without worktrees)                   
-   [2mkind[0m               string      [2m"worktree"[0m or [2m"branch"[0m                                                  
-   [2mcommit[0m             object      Commit info (see below)                                                 
-   [2mworking_tree[0m       object      Working tree state (see below)                                          
-   [2mmain_state[0m         string      Relation to the default branch (see below)                              
-   [2mintegration_reason[0m string      Why branch is integrated (see below)                                    
-   [2moperation_state[0m    string      [2m"conflicts"[0m, [2m"rebase"[0m, or [2m"merge"[0m (absent when clean)                   
-   [2mmain[0m               object      Relationship to the default branch (see below, absent when is_main)     
-   [2mremote[0m             object      Tracking branch info (see below, absent when no tracking)               
-   [2mworktree[0m           object      Worktree metadata (see below)                                           
-   [2mis_main[0m            boolean     Is the main worktree                                                    
-   [2mis_current[0m         boolean     Is the current worktree                                                 
-   [2mis_previous[0m        boolean     Previous worktree from wt switch                                        
-   [2mci[0m                 object      CI status (see below, absent when no CI)                                
-   [2murl[0m                string      Dev server URL from project config (absent when not configured)         
-   [2murl_active[0m         boolean     Whether the URL's port is listening (absent when not configured)        
-   [2msummary[0m            string      LLM-generated branch summary (absent when not configured or no summary) 
-   [2mstatusline[0m         string      Pre-formatted status with ANSI colors                                   
-   [2msymbols[0m            string      Raw status symbols without colors (e.g., [2m"!?↓"[0m)                         
+       Field           Type                                   Description                               
+ ────────────────── ─────────── ─────────────────────────────────────────────────────────────────────── 
+ [2mbranch[0m             string/null Branch name (null for detached HEAD)                                    
+ [2mpath[0m               string      Worktree path (absent for branches without worktrees)                   
+ [2mkind[0m               string      [2m"worktree"[0m or [2m"branch"[0m                                                  
+ [2mcommit[0m             object      Commit info (see below)                                                 
+ [2mworking_tree[0m       object      Working tree state (see below)                                          
+ [2mmain_state[0m         string      Relation to the default branch (see below)                              
+ [2mintegration_reason[0m string      Why branch is integrated (see below)                                    
+ [2moperation_state[0m    string      [2m"conflicts"[0m, [2m"rebase"[0m, or [2m"merge"[0m (absent when clean)                   
+ [2mmain[0m               object      Relationship to the default branch (see below, absent when is_main)     
+ [2mremote[0m             object      Tracking branch info (see below, absent when no tracking)               
+ [2mworktree[0m           object      Worktree metadata (see below)                                           
+ [2mis_main[0m            boolean     Is the main worktree                                                    
+ [2mis_current[0m         boolean     Is the current worktree                                                 
+ [2mis_previous[0m        boolean     Previous worktree from wt switch                                        
+ [2mci[0m                 object      CI status (see below, absent when no CI)                                
+ [2murl[0m                string      Dev server URL from project config (absent when not configured)         
+ [2murl_active[0m         boolean     Whether the URL's port is listening (absent when not configured)        
+ [2msummary[0m            string      LLM-generated branch summary (absent when not configured or no summary) 
+ [2mstatusline[0m         string      Pre-formatted status with ANSI colors                                   
+ [2msymbols[0m            string      Raw status symbols without colors (e.g., [2m"!?↓"[0m)                         
 
 [32mCommit object[0m
 
-     Field    Type          Description         
-   ───────── ────── ─────────────────────────── 
-   [2msha[0m       string Full commit SHA (40 chars)  
-   [2mshort_sha[0m string Short commit SHA (7 chars)  
-   [2mmessage[0m   string Commit message (first line) 
-   [2mtimestamp[0m number Unix timestamp              
+   Field    Type          Description         
+ ───────── ────── ─────────────────────────── 
+ [2msha[0m       string Full commit SHA (40 chars)  
+ [2mshort_sha[0m string Short commit SHA (7 chars)  
+ [2mmessage[0m   string Commit message (first line) 
+ [2mtimestamp[0m number Unix timestamp              
 
 [32mworking_tree object[0m
 
-     Field    Type                 Description               
-   ───────── ─────── ─────────────────────────────────────── 
-   [2mstaged[0m    boolean Has staged files                        
-   [2mmodified[0m  boolean Has modified files (unstaged)           
-   [2muntracked[0m boolean Has untracked files                     
-   [2mrenamed[0m   boolean Has renamed files                       
-   [2mdeleted[0m   boolean Has deleted files                       
-   [2mdiff[0m      object  Lines changed vs HEAD: [2m{added, deleted}[0m 
+   Field    Type                 Description               
+ ───────── ─────── ─────────────────────────────────────── 
+ [2mstaged[0m    boolean Has staged files                        
+ [2mmodified[0m  boolean Has modified files (unstaged)           
+ [2muntracked[0m boolean Has untracked files                     
+ [2mrenamed[0m   boolean Has renamed files                       
+ [2mdeleted[0m   boolean Has deleted files                       
+ [2mdiff[0m      object  Lines changed vs HEAD: [2m{added, deleted}[0m 
 
 [32mmain object[0m
 
-   Field   Type                       Description                      
-   ────── ────── ───────────────────────────────────────────────────── 
-   [2mahead[0m  number Commits ahead of the default branch                   
-   [2mbehind[0m number Commits behind the default branch                     
-   [2mdiff[0m   object Lines changed vs the default branch: [2m{added, deleted}[0m 
+ Field   Type                       Description                      
+ ────── ────── ───────────────────────────────────────────────────── 
+ [2mahead[0m  number Commits ahead of the default branch                   
+ [2mbehind[0m number Commits behind the default branch                     
+ [2mdiff[0m   object Lines changed vs the default branch: [2m{added, deleted}[0m 
 
 [32mremote object[0m
 
-   Field   Type          Description          
-   ────── ────── ──────────────────────────── 
-   [2mname[0m   string Remote name (e.g., [2m"origin"[0m) 
-   [2mbranch[0m string Remote branch name           
-   [2mahead[0m  number Commits ahead of remote      
-   [2mbehind[0m number Commits behind remote        
+ Field   Type          Description          
+ ────── ────── ──────────────────────────── 
+ [2mname[0m   string Remote name (e.g., [2m"origin"[0m) 
+ [2mbranch[0m string Remote branch name           
+ [2mahead[0m  number Commits ahead of remote      
+ [2mbehind[0m number Commits behind remote        
 
 [32mworktree object[0m
 
-    Field    Type                                       Description                                      
-   ──────── ─────── ──────────────────────────────────────────────────────────────────────────────────── 
-   [2mstate[0m    string  [2m"no_worktree"[0m, [2m"branch_worktree_mismatch"[0m, [2m"prunable"[0m, [2m"locked"[0m (absent when normal) 
-   [2mreason[0m   string  Reason for locked/prunable state                                                     
-   [2mdetached[0m boolean HEAD is detached                                                                     
+  Field    Type                                       Description                                      
+ ──────── ─────── ──────────────────────────────────────────────────────────────────────────────────── 
+ [2mstate[0m    string  [2m"no_worktree"[0m, [2m"branch_worktree_mismatch"[0m, [2m"prunable"[0m, [2m"locked"[0m (absent when normal) 
+ [2mreason[0m   string  Reason for locked/prunable state                                                     
+ [2mdetached[0m boolean HEAD is detached                                                                     
 
 [32mci object[0m
 
-   Field   Type                      Description                    
-   ────── ─────── ───────────────────────────────────────────────── 
-   [2mstatus[0m string  CI status (see below)                             
-   [2msource[0m string  [2m"pr"[0m (PR/MR) or [2m"branch"[0m (branch workflow)        
-   [2mstale[0m  boolean Local HEAD differs from remote (unpushed changes) 
-   [2murl[0m    string  URL to the PR/MR page                             
+ Field   Type                      Description                    
+ ────── ─────── ───────────────────────────────────────────────── 
+ [2mstatus[0m string  CI status (see below)                             
+ [2msource[0m string  [2m"pr"[0m (PR/MR) or [2m"branch"[0m (branch workflow)        
+ [2mstale[0m  boolean Local HEAD differs from remote (unpushed changes) 
+ [2murl[0m    string  URL to the PR/MR page                             
 
 [32mmain_state values[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -86,38 +86,38 @@ results arrive.
 
 List all worktrees:
 
-  [2m$ wt list[0m
+[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list[0m
 
 Include CI status, line diffs, and LLM summaries:
 
-  [2m$ wt list --full[0m
+[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--full[0m[2m[0m
 
 Include branches that don't have worktrees:
 
-  [2m$ wt list --branches --full[0m
+[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--branches[0m[2m [0m[2m[36m--full[0m[2m[0m
 
 Output as JSON for scripting:
 
-  [2m$ wt list --format=json[0m
+[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m[0m
 
 [1m[32mColumns[0m
 
-   Column                                 Shows                                 
-   ─────── ──────────────────────────────────────────────────────────────────── 
-   Branch  Branch name                                                          
-   Status  Compact symbols (see below)                                          
-   HEAD±   Uncommitted changes: +added -deleted lines                           
-   main↕   Commits ahead/behind default branch                                  
-   main…±  Line diffs since the merge-base with the default branch ([2m--full[0m)     
-   Summary LLM-generated branch summary ([2m--full[0m + [2msummary = true[0m, requires      
-           [2mcommit.generation[0m) (experimental)                                    
-   Remote⇅ Commits ahead/behind tracking branch                                 
-   CI      Pipeline status ([2m--full[0m)                                             
-   Path    Worktree directory                                                   
-   URL     Dev server URL from project config (dimmed if port not listening)    
-   Commit  Short hash (8 chars)                                                 
-   Age     Time since last commit                                               
-   Message Last commit message (truncated)                                      
+ Column                                  Shows                                  
+ ─────── ────────────────────────────────────────────────────────────────────── 
+ Branch  Branch name                                                            
+ Status  Compact symbols (see below)                                            
+ HEAD±   Uncommitted changes: +added -deleted lines                             
+ main↕   Commits ahead/behind default branch                                    
+ main…±  Line diffs since the merge-base with the default branch ([2m--full[0m)       
+ Summary LLM-generated branch summary ([2m--full[0m + [2msummary = true[0m, requires        
+         [2mcommit.generation[0m) (experimental)                                      
+ Remote⇅ Commits ahead/behind tracking branch                                   
+ CI      Pipeline status ([2m--full[0m)                                               
+ Path    Worktree directory                                                     
+ URL     Dev server URL from project config (dimmed if port not listening)      
+ Commit  Short hash (8 chars)                                                   
+ Age     Time since last commit                                                 
+ Message Last commit message (truncated)                                        
 
 Note: [2mmain↕[0m and [2mmain…±[0m refer to the default branch (header label stays [2mmain[0m for 
 compactness). [2mmain…±[0m uses a merge-base (three-dot) diff.
@@ -126,15 +126,15 @@ compactness). [2mmain…±[0m uses a merge-base (three-dot) diff.
 
 The CI column shows GitHub/GitLab pipeline status:
 
-   Indicator              Meaning              
-   ───────── ───────────────────────────────── 
-   [32m●[0m green   All checks passed                 
-   [34m●[0m blue    Checks running                    
-   [31m●[0m red     Checks failed                     
-   [33m●[0m yellow  Merge conflicts with base         
-   [90m●[0m gray    No checks configured              
-   [33m⚠[0m yellow  Fetch error (rate limit, network) 
-   (blank)   No upstream or no PR/MR           
+ Indicator              Meaning              
+ ───────── ───────────────────────────────── 
+ [32m●[0m green   All checks passed                 
+ [34m●[0m blue    Checks running                    
+ [31m●[0m red     Checks failed                     
+ [33m●[0m yellow  Merge conflicts with base         
+ [90m●[0m gray    No checks configured              
+ [33m⚠[0m yellow  Fetch error (rate limit, network) 
+ (blank)   No upstream or no PR/MR           
 
 CI indicators are clickable links to the PR or pipeline page. Any CI dot appears
  dimmed when there are unpushed local changes (stale status). PRs/MRs are 
@@ -157,35 +157,34 @@ Disabled by default — when enabled, each branch's diff is sent to the configur
 The Status column has multiple subcolumns. Within each, only the first matching 
 symbol is shown (listed in priority order):
 
-      Subcolumn     Symbol                       Meaning                        
-   ──────────────── ────── ──────────────────────────────────────────────────── 
-   Working tree (1) [36m+[0m      Staged files                                         
-   Working tree (2) [36m![0m      Modified files (unstaged)                            
-   Working tree (3) [36m?[0m      Untracked files                                      
-   Worktree         [31m✘[0m      Merge conflicts                                      
-                    [33m⤴[0m      Rebase in progress                                   
-                    [33m⤵[0m      Merge in progress                                    
-                    [2m/[0m      Branch without worktree                              
-                    [31m⚑[0m      Branch-worktree mismatch (branch name doesn't match  
-                           worktree path)                                       
-                    [33m⊟[0m      Prunable (directory missing)                         
-                    [33m⊞[0m      Locked worktree                                      
-   Default branch   [2m^[0m      Is the default branch                                
-                    [2m∅[0m      Orphan branch (no common ancestor with the default   
-                           branch)                                              
-                    [33m✗[0m      Would conflict if merged to the default branch (with 
-                           [2m--full[0m, includes uncommitted changes)                
-                    [2m_[0m      Same commit as the default branch, clean             
-                    [2m–[0m      Same commit as the default branch, uncommitted       
-                           changes                                              
-                    [2m⊂[0m      Content integrated into the default branch or target 
-                    [2m↕[0m      Diverged from the default branch                     
-                    [2m↑[0m      Ahead of the default branch                          
-                    [2m↓[0m      Behind the default branch                            
-   Remote           [2m|[0m      In sync with remote                                  
-                    [2m⇅[0m      Diverged from remote                                 
-                    [2m⇡[0m      Ahead of remote                                      
-                    [2m⇣[0m      Behind remote                                        
+    Subcolumn     Symbol                        Meaning                         
+ ──────────────── ────── ────────────────────────────────────────────────────── 
+ Working tree (1) [36m+[0m      Staged files                                           
+ Working tree (2) [36m![0m      Modified files (unstaged)                              
+ Working tree (3) [36m?[0m      Untracked files                                        
+ Worktree         [31m✘[0m      Merge conflicts                                        
+                  [33m⤴[0m      Rebase in progress                                     
+                  [33m⤵[0m      Merge in progress                                      
+                  [2m/[0m      Branch without worktree                                
+                  [31m⚑[0m      Branch-worktree mismatch (branch name doesn't match    
+                         worktree path)                                         
+                  [33m⊟[0m      Prunable (directory missing)                           
+                  [33m⊞[0m      Locked worktree                                        
+ Default branch   [2m^[0m      Is the default branch                                  
+                  [2m∅[0m      Orphan branch (no common ancestor with the default     
+                         branch)                                                
+                  [33m✗[0m      Would conflict if merged to the default branch (with   
+                         [2m--full[0m, includes uncommitted changes)                  
+                  [2m_[0m      Same commit as the default branch, clean               
+                  [2m–[0m      Same commit as the default branch, uncommitted changes 
+                  [2m⊂[0m      Content integrated into the default branch or target   
+                  [2m↕[0m      Diverged from the default branch                       
+                  [2m↑[0m      Ahead of the default branch                            
+                  [2m↓[0m      Behind the default branch                              
+ Remote           [2m|[0m      In sync with remote                                    
+                  [2m⇅[0m      Diverged from remote                                   
+                  [2m⇡[0m      Ahead of remote                                        
+                  [2m⇣[0m      Behind remote                                          
 
 Rows are dimmed when safe to delete ([2m_[0m same commit with clean working tree or [2m⊂[0m 
 content integrated).
@@ -196,117 +195,119 @@ content integrated).
 
 Query structured data with [2m--format=json[0m:
 
-  [2m# Current worktree path (for scripts)[0m
-  [2mwt list --format=json | jq -r '.[] | select(.is_current) | .path'[0m
-  [2m[0m
-  [2m# Branches with uncommitted changes[0m
-  [2mwt list --format=json | jq '.[] | select(.working_tree.modified)'[0m
-  [2m[0m
-  [2m# Worktrees with merge conflicts[0m
-  [2mwt list --format=json | jq '.[] | select(.operation_state == "conflicts")'[0m
-  [2m[0m
-  [2m# Branches ahead of main (needs merging)[0m
-  [2mwt list --format=json | jq '.[] | select(.main.ahead > 0) | .branch'[0m
-  [2m[0m
-  [2m# Integrated branches (safe to remove)[0m
-  [2mwt list --format=json | jq '.[] | select(.main_state == "integrated" or .main_state == "empty") | .branch'[0m
-  [2m[0m
-  [2m# Branches without worktrees[0m
-  [2mwt list --format=json --branches | jq '.[] | select(.kind == "branch") | .branch'[0m
-  [2m[0m
-  [2m# Worktrees ahead of remote (needs pushing)[0m
-  [2mwt list --format=json | jq '.[] | select(.remote.ahead > 0) | {branch, ahead: .remote.ahead}'[0m
-  [2m[0m
-  [2m# Stale CI (local changes not reflected in CI)[0m
-  [2mwt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'[0m
+[107m [0m [2m# Current worktree path (for scripts)[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[36m-r[0m[2m [0m[2m[32m'.[] | select(.is_current) | .path'[0m[2m[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Branches with uncommitted changes[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.working_tree.modified)'[0m[2m[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Worktrees with merge conflicts[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.operation_state == "conflicts")'[0m[2m[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Branches ahead of main (needs merging)[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.main.ahead > 0) | .branch'[0m[2m[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Integrated branches (safe to remove)[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.main_state == "integrated" or [0m
+[107m [0m [2m[32m.main_state == "empty") | .branch'[0m[2m[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Branches without worktrees[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m--branches[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.kind == "branch") | [0m
+[107m [0m [2m[32m.branch'[0m[2m[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Worktrees ahead of remote (needs pushing)[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.remote.ahead > 0) | {branch, ahead: [0m
+[107m [0m [2m[32m.remote.ahead}'[0m[2m[0m
+[107m [0m [2m[0m
+[107m [0m [2m# Stale CI (local changes not reflected in CI)[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m--full[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.ci.stale) | .branch'[0m[2m[0m
 
 [1mFields:[0m
 
-         Field           Type                      Description                  
-   ────────────────── ─────────── ───────────────────────────────────────────── 
-   [2mbranch[0m             string/null Branch name (null for detached HEAD)          
-   [2mpath[0m               string      Worktree path (absent for branches without    
-                                  worktrees)                                    
-   [2mkind[0m               string      [2m"worktree"[0m or [2m"branch"[0m                        
-   [2mcommit[0m             object      Commit info (see below)                       
-   [2mworking_tree[0m       object      Working tree state (see below)                
-   [2mmain_state[0m         string      Relation to the default branch (see below)    
-   [2mintegration_reason[0m string      Why branch is integrated (see below)          
-   [2moperation_state[0m    string      [2m"conflicts"[0m, [2m"rebase"[0m, or [2m"merge"[0m (absent     
-                                  when clean)                                   
-   [2mmain[0m               object      Relationship to the default branch (see       
-                                  below, absent when is_main)                   
-   [2mremote[0m             object      Tracking branch info (see below, absent when  
-                                  no tracking)                                  
-   [2mworktree[0m           object      Worktree metadata (see below)                 
-   [2mis_main[0m            boolean     Is the main worktree                          
-   [2mis_current[0m         boolean     Is the current worktree                       
-   [2mis_previous[0m        boolean     Previous worktree from wt switch              
-   [2mci[0m                 object      CI status (see below, absent when no CI)      
-   [2murl[0m                string      Dev server URL from project config (absent    
-                                  when not configured)                          
-   [2murl_active[0m         boolean     Whether the URL's port is listening (absent   
-                                  when not configured)                          
-   [2msummary[0m            string      LLM-generated branch summary (absent when not 
-                                  configured or no summary)                     
-   [2mstatusline[0m         string      Pre-formatted status with ANSI colors         
-   [2msymbols[0m            string      Raw status symbols without colors (e.g.,      
-                                  [2m"!?↓"[0m)                                        
+       Field           Type                       Description                   
+ ────────────────── ─────────── ─────────────────────────────────────────────── 
+ [2mbranch[0m             string/null Branch name (null for detached HEAD)            
+ [2mpath[0m               string      Worktree path (absent for branches without      
+                                worktrees)                                      
+ [2mkind[0m               string      [2m"worktree"[0m or [2m"branch"[0m                          
+ [2mcommit[0m             object      Commit info (see below)                         
+ [2mworking_tree[0m       object      Working tree state (see below)                  
+ [2mmain_state[0m         string      Relation to the default branch (see below)      
+ [2mintegration_reason[0m string      Why branch is integrated (see below)            
+ [2moperation_state[0m    string      [2m"conflicts"[0m, [2m"rebase"[0m, or [2m"merge"[0m (absent when  
+                                clean)                                          
+ [2mmain[0m               object      Relationship to the default branch (see below,  
+                                absent when is_main)                            
+ [2mremote[0m             object      Tracking branch info (see below, absent when no 
+                                tracking)                                       
+ [2mworktree[0m           object      Worktree metadata (see below)                   
+ [2mis_main[0m            boolean     Is the main worktree                            
+ [2mis_current[0m         boolean     Is the current worktree                         
+ [2mis_previous[0m        boolean     Previous worktree from wt switch                
+ [2mci[0m                 object      CI status (see below, absent when no CI)        
+ [2murl[0m                string      Dev server URL from project config (absent when 
+                                not configured)                                 
+ [2murl_active[0m         boolean     Whether the URL's port is listening (absent     
+                                when not configured)                            
+ [2msummary[0m            string      LLM-generated branch summary (absent when not   
+                                configured or no summary)                       
+ [2mstatusline[0m         string      Pre-formatted status with ANSI colors           
+ [2msymbols[0m            string      Raw status symbols without colors (e.g., [2m"!?↓"[0m) 
 
 [32mCommit object[0m
 
-     Field    Type          Description         
-   ───────── ────── ─────────────────────────── 
-   [2msha[0m       string Full commit SHA (40 chars)  
-   [2mshort_sha[0m string Short commit SHA (7 chars)  
-   [2mmessage[0m   string Commit message (first line) 
-   [2mtimestamp[0m number Unix timestamp              
+   Field    Type          Description         
+ ───────── ────── ─────────────────────────── 
+ [2msha[0m       string Full commit SHA (40 chars)  
+ [2mshort_sha[0m string Short commit SHA (7 chars)  
+ [2mmessage[0m   string Commit message (first line) 
+ [2mtimestamp[0m number Unix timestamp              
 
 [32mworking_tree object[0m
 
-     Field    Type                 Description               
-   ───────── ─────── ─────────────────────────────────────── 
-   [2mstaged[0m    boolean Has staged files                        
-   [2mmodified[0m  boolean Has modified files (unstaged)           
-   [2muntracked[0m boolean Has untracked files                     
-   [2mrenamed[0m   boolean Has renamed files                       
-   [2mdeleted[0m   boolean Has deleted files                       
-   [2mdiff[0m      object  Lines changed vs HEAD: [2m{added, deleted}[0m 
+   Field    Type                 Description               
+ ───────── ─────── ─────────────────────────────────────── 
+ [2mstaged[0m    boolean Has staged files                        
+ [2mmodified[0m  boolean Has modified files (unstaged)           
+ [2muntracked[0m boolean Has untracked files                     
+ [2mrenamed[0m   boolean Has renamed files                       
+ [2mdeleted[0m   boolean Has deleted files                       
+ [2mdiff[0m      object  Lines changed vs HEAD: [2m{added, deleted}[0m 
 
 [32mmain object[0m
 
-   Field   Type                       Description                      
-   ────── ────── ───────────────────────────────────────────────────── 
-   [2mahead[0m  number Commits ahead of the default branch                   
-   [2mbehind[0m number Commits behind the default branch                     
-   [2mdiff[0m   object Lines changed vs the default branch: [2m{added, deleted}[0m 
+ Field   Type                       Description                      
+ ────── ────── ───────────────────────────────────────────────────── 
+ [2mahead[0m  number Commits ahead of the default branch                   
+ [2mbehind[0m number Commits behind the default branch                     
+ [2mdiff[0m   object Lines changed vs the default branch: [2m{added, deleted}[0m 
 
 [32mremote object[0m
 
-   Field   Type          Description          
-   ────── ────── ──────────────────────────── 
-   [2mname[0m   string Remote name (e.g., [2m"origin"[0m) 
-   [2mbranch[0m string Remote branch name           
-   [2mahead[0m  number Commits ahead of remote      
-   [2mbehind[0m number Commits behind remote        
+ Field   Type          Description          
+ ────── ────── ──────────────────────────── 
+ [2mname[0m   string Remote name (e.g., [2m"origin"[0m) 
+ [2mbranch[0m string Remote branch name           
+ [2mahead[0m  number Commits ahead of remote      
+ [2mbehind[0m number Commits behind remote        
 
 [32mworktree object[0m
 
-    Field    Type                           Description                         
-   ──────── ─────── ─────────────────────────────────────────────────────────── 
-   [2mstate[0m    string  [2m"no_worktree"[0m, [2m"branch_worktree_mismatch"[0m, [2m"prunable"[0m,      
-                    [2m"locked"[0m (absent when normal)                               
-   [2mreason[0m   string  Reason for locked/prunable state                            
-   [2mdetached[0m boolean HEAD is detached                                            
+  Field    Type                            Description                          
+ ──────── ─────── ───────────────────────────────────────────────────────────── 
+ [2mstate[0m    string  [2m"no_worktree"[0m, [2m"branch_worktree_mismatch"[0m, [2m"prunable"[0m,        
+                  [2m"locked"[0m (absent when normal)                                 
+ [2mreason[0m   string  Reason for locked/prunable state                              
+ [2mdetached[0m boolean HEAD is detached                                              
 
 [32mci object[0m
 
-   Field   Type                      Description                    
-   ────── ─────── ───────────────────────────────────────────────── 
-   [2mstatus[0m string  CI status (see below)                             
-   [2msource[0m string  [2m"pr"[0m (PR/MR) or [2m"branch"[0m (branch workflow)        
-   [2mstale[0m  boolean Local HEAD differs from remote (unpushed changes) 
-   [2murl[0m    string  URL to the PR/MR page                             
+ Field   Type                      Description                    
+ ────── ─────── ───────────────────────────────────────────────── 
+ [2mstatus[0m string  CI status (see below)                             
+ [2msource[0m string  [2m"pr"[0m (PR/MR) or [2m"branch"[0m (branch workflow)        
+ [2mstale[0m  boolean Local HEAD differs from remote (unpushed changes) 
+ [2murl[0m    string  URL to the PR/MR page                             
 
 [32mmain_state values[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
@@ -11,14 +11,18 @@ info:
     GIT_EDITOR: ""
     LANG: C
     LC_ALL: C
+    NO_COLOR: ""
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
+    WORKTRUNK_APPROVALS_PATH: /nonexistent/test/approvals.toml
     WORKTRUNK_CONFIG_PATH: /nonexistent/test/config.toml
+    WORKTRUNK_SYSTEM_CONFIG_PATH: /etc/xdg/worktrunk/config.toml
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
 ---
@@ -85,23 +89,23 @@ Unlike [2mgit merge[0m, this merges current into target (not target into curre
 
 Merge to the default branch:
 
-  [2mwt merge[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m merge[0m
 
 Merge to a different branch:
 
-  [2mwt merge develop[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m merge develop[0m
 
 Keep the worktree after merging:
 
-  [2mwt merge --no-remove[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m merge [0m[2m[36m--no-remove[0m[2m[0m
 
 Preserve commit history (no squash):
 
-  [2mwt merge --no-squash[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m merge [0m[2m[36m--no-squash[0m[2m[0m
 
 Skip committing/squashing (rebase still runs unless --no-rebase):
 
-  [2mwt merge --no-commit[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m merge [0m[2m[36m--no-commit[0m[2m[0m
 
 [1m[32mPipeline[0m
 
@@ -125,9 +129,9 @@ Historically, ensuring tests ran before merging was difficult to enforce locally
 
 The full workflow: start an agent (one of many) on a task, work elsewhere, return when it's ready. Review the diff, run [2mwt merge[0m, move on. Pre-merge hooks validate before merging — if they pass, the branch goes to the default branch and the worktree cleans up.
 
-  [2m[pre-merge][0m
-  [2mtest = "cargo test"[0m
-  [2mlint = "cargo clippy"[0m
+[107m [0m [2m[36m[pre-merge][0m
+[107m [0m [2mtest = [0m[2m[32m"cargo test"[0m
+[107m [0m [2mlint = [0m[2m[32m"cargo clippy"[0m
 
 [1m[32mSee also[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
@@ -11,6 +11,7 @@ info:
     GIT_EDITOR: ""
     LANG: C
     LC_ALL: C
+    NO_COLOR: ""
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
@@ -78,20 +79,20 @@ Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...[0m
 
 Remove current worktree:
 
-  [2mwt remove[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m remove[0m
 
 Remove specific worktrees:
 
-  [2mwt remove feature-branch[0m
-  [2mwt remove old-feature another-branch[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m remove feature-branch[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m remove old-feature another-branch[0m
 
 Keep the branch:
 
-  [2mwt remove --no-delete-branch feature-branch[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m remove [0m[2m[36m--no-delete-branch[0m[2m feature-branch[0m
 
 Force-delete an unmerged branch:
 
-  [2mwt remove -D experimental[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m remove [0m[2m[36m-D[0m[2m experimental[0m
 
 [1m[32mBranch cleanup[0m
 
@@ -113,14 +114,14 @@ Branches showing [2m_[0m or [2m⊂[0m are dimmed as safe to delete.
 
 Worktrunk has two force flags for different situations:
 
-          Flag          Scope                          When to use                         
-   ─────────────────── ──────── ────────────────────────────────────────────────────────── 
-   [2m--force[0m ([2m-f[0m)        Worktree Worktree has untracked files (build artifacts, IDE config) 
-   [2m--force-delete[0m ([2m-D[0m) Branch   Branch has unmerged commits                                
+        Flag          Scope                          When to use                         
+ ─────────────────── ──────── ────────────────────────────────────────────────────────── 
+ [2m--force[0m ([2m-f[0m)        Worktree Worktree has untracked files (build artifacts, IDE config) 
+ [2m--force-delete[0m ([2m-D[0m) Branch   Branch has unmerged commits                                
 
-  [2mwt remove feature --force       # Remove worktree with untracked files[0m
-  [2mwt remove feature -D            # Delete unmerged branch[0m
-  [2mwt remove feature --force -D    # Both[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m remove feature [0m[2m[36m--force[0m[2m       # Remove worktree with untracked files[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m remove feature [0m[2m[36m-D[0m[2m            # Delete unmerged branch[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m remove feature [0m[2m[36m--force[0m[2m [0m[2m[36m-D[0m[2m    # Both[0m[2m[0m
 
 Without [2m--force[0m, removal fails if the worktree contains untracked files. Without [2m-D[0m, removal keeps branches with unmerged changes. Use [2m--no-delete-branch[0m to keep the branch regardless of merge status.
 

--- a/tests/snapshots/integration__integration_tests__help__help_step_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_long.snap
@@ -67,14 +67,14 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 
 Commit with LLM-generated message:
 
-  [2mwt step commit[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step commit[0m
 
 Manual merge workflow with review between steps:
 
-  [2mwt step commit[0m
-  [2mwt step squash[0m
-  [2mwt step rebase[0m
-  [2mwt step push[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step commit[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step squash[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step rebase[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step push[0m
 
 [1m[32mOperations[0m
 
@@ -94,15 +94,15 @@ Manual merge workflow with review between steps:
 
 Custom command templates configured in user config ([2m~/.config/worktrunk/config.toml[0m) or project config ([2m.config/wt.toml[0m). Aliases support the same template variables as hooks.
 
-  [2m# .config/wt.toml[0m
-  [2m[aliases][0m
-  [2mdeploy = "make deploy BRANCH={{ branch }}"[0m
-  [2mport = "echo http://localhost:{{ branch | hash_port }}"[0m
+[107m [0m [2m# .config/wt.toml[0m
+[107m [0m [2m[36m[aliases][0m
+[107m [0m [2mdeploy = [0m[2m[32m"make deploy BRANCH={{ branch }}"[0m
+[107m [0m [2mport = [0m[2m[32m"echo http://localhost:{{ branch | hash_port }}"[0m
 
-  [2mwt step deploy                            # run the alias[0m
-  [2mwt step deploy --dry-run                  # show expanded command[0m
-  [2mwt step deploy --var env=staging          # pass extra template variables[0m
-  [2mwt step deploy --yes                      # skip approval prompt[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step deploy                            # run the alias[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step deploy [0m[2m[36m--dry-run[0m[2m                  # show expanded command[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step deploy [0m[2m[36m--var[0m[2m env=staging          # pass extra template variables[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step deploy [0m[2m[36m--yes[0m[2m                      # skip approval prompt[0m[2m[0m
 
 When defined in both user and project config, user aliases take precedence. Project-config aliases require command approval on first run (same as project hooks). User-config aliases are trusted.
 

--- a/tests/snapshots/integration__integration_tests__help__help_step_promote.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_promote.snap
@@ -12,6 +12,7 @@ info:
     GIT_EDITOR: ""
     LANG: C
     LC_ALL: C
+    NO_COLOR: ""
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
@@ -61,20 +62,20 @@ Usage: [1m[36mwt step promote[0m [36m[OPTIONS][0m [36m[BRANCH][0m
 
 [1m[32mExample[0m
 
-  [2m# from ~/project (main worktree)[0m
-  [2m$ wt step promote feature[0m
+[107m [0m [2m# from ~/project (main worktree)[0m[2m[0m
+[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m step promote feature[0m
 
 Before:
 
-  [2m  Branch   Path[0m
-  [2m@ main     ~/project[0m
-  [2m+ feature  ~/project.feature[0m
+[107m [0m [2m  Branch   Path[0m
+[107m [0m [2m@ main     ~/project[0m
+[107m [0m [2m+ feature  ~/project.feature[0m
 
 After:
 
-  [2m  Branch   Path[0m
-  [2m@ feature  ~/project[0m
-  [2m+ main     ~/project.feature[0m
+[107m [0m [2m  Branch   Path[0m
+[107m [0m [2m@ feature  ~/project[0m
+[107m [0m [2m+ main     ~/project.feature[0m
 
 To restore: [2mwt step promote main[0m from anywhere, or just [2mwt step promote[0m from the main worktree.
 

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -109,11 +109,11 @@ Worktrees are addressed by branch name; paths are computed from a configurable t
 
 [1m[32mExamples[0m
 
-  [2mwt switch feature-auth           # Switch to worktree[0m
-  [2mwt switch -                      # Previous worktree (like cd -)[0m
-  [2mwt switch --create new-feature   # Create new branch and worktree[0m
-  [2mwt switch --create hotfix --base production[0m
-  [2mwt switch pr:123                 # Switch to PR #123's branch[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch feature-auth           # Switch to worktree[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch [0m[2m[36m-[0m[2m                      # Previous worktree (like cd -)[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch [0m[2m[36m--create[0m[2m new-feature   # Create new branch and worktree[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch [0m[2m[36m--create[0m[2m hotfix [0m[2m[36m--base[0m[2m production[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch pr:123                 # Switch to PR #123's branch[0m[2m[0m
 
 [1m[32mCreating a branch[0m
 
@@ -134,26 +134,26 @@ When creating a worktree, worktrunk:
 3. Runs post-create hooks (blocking)
 4. Spawns post-start hooks (background)
 
-  [2mwt switch feature                        # Existing branch → creates worktree[0m
-  [2mwt switch --create feature               # New branch and worktree[0m
-  [2mwt switch --create fix --base release    # New branch from release[0m
-  [2mwt switch --create temp --no-verify      # Skip hooks[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch feature                        # Existing branch → creates worktree[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch [0m[2m[36m--create[0m[2m feature               # New branch and worktree[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch [0m[2m[36m--create[0m[2m fix [0m[2m[36m--base[0m[2m release    # New branch from release[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch [0m[2m[36m--create[0m[2m temp [0m[2m[36m--no-verify[0m[2m      # Skip hooks[0m[2m[0m
 
 [1m[32mShortcuts[0m
 
-   Shortcut            Meaning            
-   ──────── ───────────────────────────── 
-   [2m^[0m        Default branch ([2mmain[0m/[2mmaster[0m)  
-   [2m@[0m        Current branch/worktree       
-   [2m-[0m        Previous worktree (like [2mcd -[0m) 
-   [2mpr:{N}[0m   GitHub PR #N's branch         
-   [2mmr:{N}[0m   GitLab MR !N's branch         
+ Shortcut            Meaning            
+ ──────── ───────────────────────────── 
+ [2m^[0m        Default branch ([2mmain[0m/[2mmaster[0m)  
+ [2m@[0m        Current branch/worktree       
+ [2m-[0m        Previous worktree (like [2mcd -[0m) 
+ [2mpr:{N}[0m   GitHub PR #N's branch         
+ [2mmr:{N}[0m   GitLab MR !N's branch         
 
-  [2mwt switch -                      # Back to previous[0m
-  [2mwt switch ^                      # Default branch worktree[0m
-  [2mwt switch --create fix --base=@  # Branch from current HEAD[0m
-  [2mwt switch pr:123                 # PR #123's branch[0m
-  [2mwt switch mr:101                 # MR !101's branch[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch [0m[2m[36m-[0m[2m                      # Back to previous[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch ^                      # Default branch worktree[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch [0m[2m[36m--create[0m[2m fix [0m[2m[36m--base=@[0m[2m  # Branch from current HEAD[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch pr:123                 # PR #123's branch[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch mr:101                 # MR !101's branch[0m[2m[0m
 
 [1m[32mInteractive picker[0m
 
@@ -161,17 +161,17 @@ When called without arguments, [2mwt switch[0m opens an interactive picker to 
 
 [1mKeybindings:[0m
 
-        Key                  Action             
-   ───────────── ────────────────────────────── 
-   [2m↑[0m/[2m↓[0m           Navigate worktree list         
-   (type)        Filter worktrees               
-   [2mEnter[0m         Switch to selected worktree    
-   [2mAlt-c[0m         Create new worktree from query 
-   [2mAlt-r[0m         Remove selected worktree       
-   [2mEsc[0m           Cancel                         
-   [2m1[0m–[2m5[0m           Switch preview tab             
-   [2mAlt-p[0m         Toggle preview panel           
-   [2mCtrl-u[0m/[2mCtrl-d[0m Scroll preview up/down         
+      Key                  Action             
+ ───────────── ────────────────────────────── 
+ [2m↑[0m/[2m↓[0m           Navigate worktree list         
+ (type)        Filter worktrees               
+ [2mEnter[0m         Switch to selected worktree    
+ [2mAlt-c[0m         Create new worktree from query 
+ [2mAlt-r[0m         Remove selected worktree       
+ [2mEsc[0m           Cancel                         
+ [2m1[0m–[2m5[0m           Switch preview tab             
+ [2mAlt-p[0m         Toggle preview panel           
+ [2mCtrl-u[0m/[2mCtrl-d[0m Scroll preview up/down         
 
 [1mPreview tabs[0m (toggle with number keys):
 
@@ -183,8 +183,8 @@ When called without arguments, [2mwt switch[0m opens an interactive picker to 
 
 [1mPager configuration:[0m The preview panel pipes diff output through git's pager. Override in user config:
 
-  [2m[switch.picker][0m
-  [2mpager = "delta --paging=never --width=$COLUMNS"[0m
+[107m [0m [2m[36m[switch.picker][0m
+[107m [0m [2mpager = [0m[2m[32m"delta --paging=never --width=$COLUMNS"[0m
 
 Available on Unix only (macOS, Linux). On Windows, use [2mwt list[0m or [2mwt switch <branch>[0m directly.
 
@@ -192,7 +192,7 @@ Available on Unix only (macOS, Linux). On Windows, use [2mwt list[0m or [2mwt
 
 The [2mpr:<number>[0m syntax resolves the branch for a GitHub pull request. For same-repo PRs, it switches to the branch directly. For fork PRs, it fetches [2mrefs/pull/N/head[0m and configures [2mpushRemote[0m to the fork URL.
 
-  [2mwt switch pr:101                 # Checkout PR #101[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch pr:101                 # Checkout PR #101[0m[2m[0m
 
 Requires [2mgh[0m CLI to be installed and authenticated. The [2m--create[0m flag cannot be used with [2mpr:[0m syntax since the branch already exists.
 
@@ -202,7 +202,7 @@ Requires [2mgh[0m CLI to be installed and authenticated. The [2m--create[0m 
 
 The [2mmr:<number>[0m syntax resolves the branch for a GitLab merge request. For same-project MRs, it switches to the branch directly. For fork MRs, it fetches [2mrefs/merge-requests/N/head[0m and configures [2mpushRemote[0m to the fork URL.
 
-  [2mwt switch mr:101                 # Checkout MR !101[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch mr:101                 # Checkout MR !101[0m[2m[0m
 
 Requires [2mglab[0m CLI to be installed and authenticated. The [2m--create[0m flag cannot be used with [2mmr:[0m syntax since the branch already exists.
 


### PR DESCRIPTION
Code blocks in `--help` were rendered as plain dimmed text — the markdown
language identifier (` ```toml `, ` ```console `) was discarded. Now they use
the existing gutter formatting with language-aware syntax highlighting:

- **TOML** blocks get synoptic highlighting (table headers cyan, strings green,
  comments dimmed)
- **console/bash/sh** blocks get tree-sitter-bash highlighting (commands blue,
  flags cyan, strings green)
- **Other** languages get dimmed text with gutter

Also makes TOML highlighting consistently dimmed (matching bash style) and
removes the 2-space indent from help tables so block elements are flush-left.

> _This was written by Claude Code on behalf of @max-sixty_