### PR TITLE
fix(output): replace quoted names with bold styling in error messages

### DIFF
--- a/src/commands/repository_ext.rs
+++ b/src/commands/repository_ext.rs
@@ -313,12 +313,12 @@ impl RepositoryCliExt for Repository {
         // Stash entry not found. Verify the worktree is now clean — if it's still
         // dirty, stashing may have failed silently or our lookup missed the entry.
         if wt.is_dirty()? {
-            bail!(
+            bail!(cformat!(
                 "Failed to stash changes in {}; worktree still has uncommitted changes. \
-                 Expected stash entry: '{}'. Check 'git stash list'.",
+                 Expected stash entry: <bold>{}</>. Check <bold>git stash list</>.",
                 format_path_for_display(wt_path),
                 stash_name
-            );
+            ));
         }
 
         // Worktree is clean and no stash entry — nothing needed to be stashed

--- a/src/commands/worktree/switch.rs
+++ b/src/commands/worktree/switch.rs
@@ -317,7 +317,7 @@ fn resolve_same_repo_ref(
     let refspec = format!("+refs/heads/{branch}:refs/remotes/{remote}/{branch}");
     // Use -- to prevent branch names starting with - from being interpreted as flags
     repo.run_command(&["fetch", "--", &remote, &refspec])
-        .with_context(|| format!("Failed to fetch branch '{}' from {}", branch, remote))?;
+        .with_context(|| cformat!("Failed to fetch branch <bold>{}</> from {}", branch, remote))?;
 
     Ok(ResolvedTarget {
         branch: info.source_branch.clone(),
@@ -532,7 +532,13 @@ fn setup_fork_branch(
     // Create local branch from FETCH_HEAD
     // Use -- to prevent branch names starting with - from being interpreted as flags
     repo.run_command(&["branch", "--", branch, "FETCH_HEAD"])
-        .with_context(|| format!("Failed to create local branch '{}' from {}", branch, label))?;
+        .with_context(|| {
+            cformat!(
+                "Failed to create local branch <bold>{}</> from {}",
+                branch,
+                label
+            )
+        })?;
 
     // Configure branch tracking for pull and push
     let branch_remote_key = format!("branch.{}.remote", branch);


### PR DESCRIPTION
Replace single-quoted command and branch names with `cformat!` bold styling
in `bail!`/`.with_context()` error messages, per the output guidelines
("Never quote commands or branch names. Use styling to make them stand out").

Three call sites fixed:
- `switch.rs` — "Failed to fetch branch **{branch}**" (was `'{branch}'`)
- `switch.rs` — "Failed to create local branch **{branch}**" (was `'{branch}'`)
- `repository_ext.rs` — "Expected stash entry: **{name}**. Check **git stash list**." (was `'{name}'` and `'git stash list'`)

> _This was written by Claude Code on behalf of @max-sixty_