### PR TITLE
Use @ before paths in all section headings

### DIFF
--- a/.claude/skills/writing-user-outputs/SKILL.md
+++ b/.claude/skills/writing-user-outputs/SKILL.md
@@ -84,8 +84,8 @@ use worktrunk::styling::format_heading;
 format_heading("BINARIES", None)  // => "BINARIES" (cyan)
 
 // Heading with suffix
-format_heading("USER CONFIG", Some("~/.config/wt.toml"))
-// => "USER CONFIG  ~/.config/wt.toml" (title cyan, suffix plain)
+format_heading("USER CONFIG", Some("@ ~/.config/wt.toml"))
+// => "USER CONFIG @ ~/.config/wt.toml" (title cyan, suffix plain)
 ```
 
 ## stdout vs stderr
@@ -839,21 +839,25 @@ regular users.
 `worktrunk::path`. This function replaces home directory prefixes with `~` for
 readability (e.g., `/Users/alex/projects/repo` → `~/projects/repo`).
 
-**Use `@` (not "at") before paths in status messages.** This is the codebase
-convention for associating an entity with a location:
+**Use `@` (not "at") before paths in all user-facing output.** This is the
+codebase convention for associating an entity with a location — in status
+messages, section headings, hints, and everywhere else:
 
 ```rust
 // GOOD - @ before path
 "Created worktree for feature @ ~/code/repo.feature"
 "Squashed @ a1b2c3d"
 "Worktree for feature @ ~/repo.feature, but cannot change directory..."
+format_heading("USER HOOKS", Some(&format!("@ {}", format_path_for_display(p))))
 
 // BAD - "at" before path
 "Created worktree for feature at ~/code/repo.feature"
+// BAD - heading without @
+format_heading("USER HOOKS", Some(&format_path_for_display(p)))
 ```
 
-**Exception:** Prose contexts (error descriptions, doc comments, help text) use
-"at" — `@` is for terse status messages only.
+**Exception:** Prose contexts (doc comments, help text) use "at" — `@` is for
+terse output only.
 
 ```rust
 use worktrunk::path::format_path_for_display;
@@ -876,6 +880,7 @@ eprintln!("{}", success_message(format!(
 
 **Applies to:**
 - Success/info/warning/error messages
+- Section headings (`format_heading` with path suffix)
 - Hints suggesting paths
 - Progress messages
 - Dry-run previews

--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -358,7 +358,7 @@ fn render_system_config(out: &mut String) -> anyhow::Result<bool> {
         "{}",
         format_heading(
             "SYSTEM CONFIG",
-            Some(&format_path_for_display(&system_path))
+            Some(&format!("@ {}", format_path_for_display(&system_path)))
         )
     )?;
 
@@ -394,7 +394,10 @@ fn render_user_config(out: &mut String, has_system_config: bool) -> anyhow::Resu
     writeln!(
         out,
         "{}",
-        format_heading("USER CONFIG", Some(&format_path_for_display(&config_path)))
+        format_heading(
+            "USER CONFIG",
+            Some(&format!("@ {}", format_path_for_display(&config_path)))
+        )
     )?;
 
     // Check if file exists
@@ -537,7 +540,7 @@ fn render_project_config(out: &mut String) -> anyhow::Result<()> {
         "{}",
         format_heading(
             "PROJECT CONFIG",
-            Some(&format_path_for_display(&config_path))
+            Some(&format!("@ {}", format_path_for_display(&config_path)))
         )
     )?;
 

--- a/src/commands/hook_commands.rs
+++ b/src/commands/hook_commands.rs
@@ -448,7 +448,7 @@ fn render_user_hooks(
             Some(
                 &config_path
                     .as_ref()
-                    .map(|p| format_path_for_display(p))
+                    .map(|p| format!("@ {}", format_path_for_display(p)))
                     .unwrap_or_else(|| "(not found)".to_string())
             )
         )
@@ -509,7 +509,7 @@ fn render_project_hooks(
         "{}",
         format_heading(
             "PROJECT HOOKS",
-            Some(&format_path_for_display(&config_path))
+            Some(&format!("@ {}", format_path_for_display(&config_path)))
         )
     )?;
 

--- a/src/styling/constants.rs
+++ b/src/styling/constants.rs
@@ -223,12 +223,12 @@ pub fn prompt_message(content: impl AsRef<str>) -> FormattedMessage {
 /// // => "BINARIES"
 ///
 /// // Heading with suffix
-/// let h = format_heading("USER CONFIG", Some("~/.config/wt.toml"));
-/// // => "USER CONFIG  ~/.config/wt.toml"
+/// let h = format_heading("USER CONFIG", Some("@ ~/.config/wt.toml"));
+/// // => "USER CONFIG @ ~/.config/wt.toml"
 /// ```
 pub fn format_heading(title: &str, suffix: Option<&str>) -> String {
     match suffix {
-        Some(s) => cformat!("<cyan>{}</>  {}", title, s),
+        Some(s) => cformat!("<cyan>{}</> {}", title, s),
         None => cformat!("<cyan>{}</>", title),
     }
 }
@@ -357,11 +357,11 @@ mod tests {
 
     #[test]
     fn test_format_heading_with_suffix() {
-        let heading = format_heading("USER CONFIG", Some("~/.config/wt.toml"));
+        let heading = format_heading("USER CONFIG", Some("@ ~/.config/wt.toml"));
         assert!(heading.contains("USER CONFIG"));
-        assert!(heading.contains("~/.config/wt.toml"));
-        // Should have double-space separator
-        assert!(heading.contains("  "));
+        assert!(heading.contains("@ ~/.config/wt.toml"));
+        // Title and suffix separated by single space (plus ANSI reset between them)
+        assert!(!heading.contains("  "));
     }
 
     #[test]

--- a/tests/integration_tests/config_state.rs
+++ b/tests/integration_tests/config_state.rs
@@ -695,10 +695,10 @@ fn test_state_get_empty(repo: TestRepo) {
         [36mHINTS[39m
         [107m [0m (none)
 
-        [36mCOMMAND LOG[39m  @ <PATH>
+        [36mCOMMAND LOG[39m @ <PATH>
         [107m [0m (none)
 
-        [36mHOOK OUTPUT[39m  @ <PATH>
+        [36mHOOK OUTPUT[39m @ <PATH>
         [107m [0m (none)
         ");
     });

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
@@ -42,10 +42,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mNot found; to create one, run [4mwt config create[24m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [33m▲[39m [33mProject config uses deprecated template variables: [2mmain_worktree[22m → [1mrepo[22m[39m
 [2m↳[22m [2mTo apply:[22m
 [107m [0m [2m[0m[2m[34mwt[0m[2m config update

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_claude_available_plugin_not_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_claude_available_plugin_not_installed.snap
@@ -42,11 +42,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
@@ -42,7 +42,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUser config uses deprecated template variables: [2mrepo_root[22m → [1mrepo_path[22m, [2mmain_worktree[22m → [1mrepo[22m[39m
 [2m↳[22m [2mTo apply:[22m
 [107m [0m [2m[0m[2m[34mwt[0m[2m config update
@@ -60,7 +60,7 @@ exit_code: 0
 [107m [0m [2mpost-create = [0m[2m[32m"ln -sf {{ repo_root }}/node_modules"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
@@ -42,7 +42,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUser config uses deprecated config sections: [projects."github.com/example/repo".commit-generation] → [projects."github.com/example/repo".commit.generation][39m
 [2m↳[22m [2mTo apply:[22m
 [107m [0m [2m[0m[2m[34mwt[0m[2m config update
@@ -63,7 +63,7 @@ exit_code: 0
 [107m [0m [2mcommand = [0m[2m[32m"llm -m gpt-4"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_empty_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_empty_project_config.snap
@@ -42,11 +42,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mEmpty file[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_empty_system_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_empty_system_config.snap
@@ -19,6 +19,7 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
@@ -41,13 +42,13 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mSYSTEM CONFIG[39m  [PROJECT_ID]
+[36mSYSTEM CONFIG[39m @ [PROJECT_ID]
 [2m↳[22m [2mEmpty file (no system defaults)[22m
 
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_fish_outdated_wrapper.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_fish_outdated_wrapper.snap
@@ -42,10 +42,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_fish_with_completions.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_fish_with_completions.snap
@@ -42,10 +42,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_fish_without_completions.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_fish_without_completions.snap
@@ -42,10 +42,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
@@ -42,10 +42,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mNot found; to create one, run [4mwt config create[24m[22m
 
-[36mPROJECT CONFIG[39m  [PROJECT_ID]
+[36mPROJECT CONFIG[39m @ [PROJECT_ID]
 [33m▲[39m [33mProject config uses deprecated template variables: [2mmain_worktree[22m → [1mrepo[22m[39m
 [2m↳[22m [2mTo apply:[22m
 [107m [0m [2m[0m[2m[34mwt[0m[2m [0m[2m[36m-C[0m[2m _REPO_ config update

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_command_not_found.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_command_not_found.snap
@@ -44,14 +44,14 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [107m [0m 
 [107m [0m [2m[36m[commit.generation]
 [107m [0m [2mcommand = [0m[2m[32m"nonexistent-llm-command-12345 -m test-model"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_not_configured.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_not_configured.snap
@@ -44,11 +44,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_update_available.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_update_available.snap
@@ -44,11 +44,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_version_check_unavailable.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_version_check_unavailable.snap
@@ -44,11 +44,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_github_remote.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_github_remote.snap
@@ -42,11 +42,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_gitlab_remote.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_gitlab_remote.snap
@@ -42,11 +42,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_project_toml.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_project_toml.snap
@@ -42,11 +42,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [31m✗[39m [31mInvalid config[39m
 [107m [0m TOML parse error at line 1, column 28
 [107m [0m   |

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_system_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_system_config.snap
@@ -42,7 +42,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mSYSTEM CONFIG[39m  [PROJECT_ID]
+[36mSYSTEM CONFIG[39m @ [PROJECT_ID]
 [31m✗[39m [31mInvalid config[39m
 [107m [0m TOML parse error at line 1, column 17
 [107m [0m   |
@@ -51,10 +51,10 @@ exit_code: 0
 [107m [0m unclosed array, expected `]`
 [107m [0m [2minvalid = [toml
 
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_user_toml.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_user_toml.snap
@@ -42,7 +42,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [31m✗[39m [31mInvalid config[39m
 [107m [0m TOML parse error at line 1, column 6
 [107m [0m   |
@@ -52,7 +52,7 @@ exit_code: 0
 [107m [0m [2mthis is not valid toml {{{
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_no_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_no_project_config.snap
@@ -42,11 +42,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_no_user_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_no_user_config.snap
@@ -42,10 +42,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mNot found; to create one, run [4mwt config create[24m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_nushell_outdated_wrapper.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_nushell_outdated_wrapper.snap
@@ -42,10 +42,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_outside_git_repo.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_outside_git_repo.snap
@@ -37,11 +37,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[2m[36mPROJECT CONFIG[39m  Not in a git repository[22m
+[2m[36mPROJECT CONFIG[39m Not in a git repository[22m
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_partial_shell_config_shows_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_partial_shell_config_shows_hint.snap
@@ -43,10 +43,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_plugin_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_plugin_installed.snap
@@ -42,11 +42,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_powershell_detected_via_psmodulepath.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_powershell_detected_via_psmodulepath.snap
@@ -42,10 +42,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_shell_integration_active.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_shell_integration_active.snap
@@ -43,11 +43,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_statusline_configured.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_statusline_configured.snap
@@ -42,11 +42,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_project_config_for_ci.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_project_config_for_ci.snap
@@ -42,7 +42,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [33m▲[39m [33mKey [1mci[22m belongs in project config (will be ignored)[39m
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [107m [0m 
@@ -50,7 +50,7 @@ exit_code: 0
 [107m [0m [2mplatform = [0m[2m[32m"github"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
@@ -42,11 +42,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [33m▲[39m [33mProject config uses deprecated config sections: [commit-generation] → [commit.generation][39m
 [2m↳[22m [2mTo apply:[22m
 [107m [0m [2m[0m[2m[34mwt[0m[2m config update

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_warning.snap
@@ -43,10 +43,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_project_keys.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_project_keys.snap
@@ -42,11 +42,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [33m▲[39m [33mUnknown key [1mpost-merge-command[22m will be ignored[39m
 [107m [0m [2m[36m[post-merge-command]
 [107m [0m [2mdeploy = [0m[2m[32m"task deploy"

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_user_keys.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_user_keys.snap
@@ -42,7 +42,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUnknown key [1mcommit-gen[22m will be ignored[39m
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [107m [0m 
@@ -50,7 +50,7 @@ exit_code: 0
 [107m [0m [2mcommand = [0m[2m[32m"llm"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_whitespace_only_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_whitespace_only_project_config.snap
@@ -42,11 +42,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mEmpty file[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_with_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_with_project_config.snap
@@ -42,11 +42,11 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [107m [0m [2mpost-create = [0m[2m[32m"npm install"
 [107m [0m 
 [107m [0m [2m[36m[post-start]

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_with_system_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_with_system_config.snap
@@ -42,7 +42,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mSYSTEM CONFIG[39m  [PROJECT_ID]
+[36mSYSTEM CONFIG[39m @ [PROJECT_ID]
 [107m [0m [2m[36m[merge]
 [107m [0m [2msquash = [0m[2m[33mtrue
 [107m [0m [2mverify = [0m[2m[33mtrue
@@ -50,10 +50,10 @@ exit_code: 0
 [107m [0m [2m[36m[commit.generation]
 [107m [0m [2mcommand = [0m[2m[32m"company-llm-tool"
 
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_correct_order.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_correct_order.snap
@@ -43,10 +43,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_warning.snap
@@ -43,10 +43,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__config_state__state_get_comprehensive.snap
+++ b/tests/snapshots/integration__integration_tests__config_state__state_get_comprehensive.snap
@@ -22,10 +22,10 @@ expression: "String::from_utf8_lossy(&output.stderr)"
 [36mHINTS[39m
 [107m [0m (none)
 
-[36mCOMMAND LOG[39m  @ <PATH>
+[36mCOMMAND LOG[39m @ <PATH>
 [107m [0m (none)
 
-[36mHOOK OUTPUT[39m  @ <PATH>
+[36mHOOK OUTPUT[39m @ <PATH>
             File            Size  Age   
  ────────────────────────── ──── ────── 
  bugfix-remove.log          13B  future 

--- a/tests/snapshots/integration__integration_tests__config_state__state_get_with_ci_entries.snap
+++ b/tests/snapshots/integration__integration_tests__config_state__state_get_with_ci_entries.snap
@@ -21,8 +21,8 @@ expression: "String::from_utf8_lossy(&output.stderr)"
 [36mHINTS[39m
 [107m [0m (none)
 
-[36mCOMMAND LOG[39m  @ <PATH>
+[36mCOMMAND LOG[39m @ <PATH>
 [107m [0m (none)
 
-[36mHOOK OUTPUT[39m  @ <PATH>
+[36mHOOK OUTPUT[39m @ <PATH>
 [107m [0m (none)

--- a/tests/snapshots/integration__integration_tests__configure_shell__config_show_detects_fish_legacy_conf_d.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__config_show_detects_fish_legacy_conf_d.snap
@@ -42,10 +42,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mNot found; to create one, run [4mwt config create[24m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__configure_shell__config_show_fish_legacy_with_functions_dir.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__config_show_fish_legacy_with_functions_dir.snap
@@ -42,10 +42,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER CONFIG[39m  ~/.config/worktrunk/config.toml
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mNot found; to create one, run [4mwt config create[24m[22m
 
-[36mPROJECT CONFIG[39m  _REPO_/.config/wt.toml
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_approval_status.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_approval_status.snap
@@ -19,16 +19,20 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -38,10 +42,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER HOOKS[39m  ~/.config/worktrunk/config.toml
+[36mUSER HOOKS[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2m(none configured)[22m
 
-[36mPROJECT HOOKS[39m  _REPO_/.config/wt.toml
+[36mPROJECT HOOKS[39m @ _REPO_/.config/wt.toml
 [2m○[22m pre-merge [1mbuild[22m:
 [107m [0m [2m[0m[2m[34mcargo[0m[2m build
 [36m❯[39m pre-merge [1mtest[22m: [2m(requires approval)[22m

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_expanded_syntax_error.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_expanded_syntax_error.snap
@@ -21,16 +21,20 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -40,10 +44,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER HOOKS[39m  [TEST_CONFIG]
+[36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
-[36mPROJECT HOOKS[39m  _REPO_/.config/wt.toml
+[36mPROJECT HOOKS[39m @ _REPO_/.config/wt.toml
 [36m❯[39m pre-commit [1mbroken[22m: [2m(requires approval)[22m
 [107m [0m [2m# Failed to expand hook preview: syntax error: unexpected end of input, expected end of variable block @ line 1[0m[2m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m{{[0m[2m branch

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_expanded_undefined_var.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_expanded_undefined_var.snap
@@ -21,16 +21,20 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -40,10 +44,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER HOOKS[39m  [TEST_CONFIG]
+[36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
-[36mPROJECT HOOKS[39m  _REPO_/.config/wt.toml
+[36mPROJECT HOOKS[39m @ _REPO_/.config/wt.toml
 [36m❯[39m pre-commit [1moptional-var[22m: [2m(requires approval)[22m
 [107m [0m [2m# Failed to expand hook preview: undefined value @ line 1[0m[2m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m{{[0m[2m base [0m[2m[32m}}[0m[2m

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_expanded_valid_template.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_expanded_valid_template.snap
@@ -21,16 +21,20 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -40,9 +44,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER HOOKS[39m  [TEST_CONFIG]
+[36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
-[36mPROJECT HOOKS[39m  _REPO_/.config/wt.toml
+[36mPROJECT HOOKS[39m @ _REPO_/.config/wt.toml
 [36m❯[39m pre-commit [1mvalid[22m: [2m(requires approval)[22m
 [107m [0m [2m[0m[2m[34mecho[0m[2m branch=main repo=repo

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_filter_by_type.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_filter_by_type.snap
@@ -20,16 +20,20 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -39,10 +43,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER HOOKS[39m  [TEST_CONFIG]
+[36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
-[36mPROJECT HOOKS[39m  _REPO_/.config/wt.toml
+[36mPROJECT HOOKS[39m @ _REPO_/.config/wt.toml
 [36m❯[39m pre-merge [1mbuild[22m: [2m(requires approval)[22m
 [107m [0m [2m[0m[2m[34mcargo[0m[2m build
 [36m❯[39m pre-merge [1mtest[22m: [2m(requires approval)[22m

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_filter_post_merge.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_filter_post_merge.snap
@@ -20,16 +20,20 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -39,9 +43,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER HOOKS[39m  [TEST_CONFIG]
+[36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
-[36mPROJECT HOOKS[39m  _REPO_/.config/wt.toml
+[36mPROJECT HOOKS[39m @ _REPO_/.config/wt.toml
 [36m❯[39m post-merge [1mdeploy[22m: [2m(requires approval)[22m
 [107m [0m [2m[0m[2m[34mscripts/deploy.sh[0m[2m

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_filter_post_remove.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_filter_post_remove.snap
@@ -20,16 +20,20 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -39,9 +43,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER HOOKS[39m  [TEST_CONFIG]
+[36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
-[36mPROJECT HOOKS[39m  _REPO_/.config/wt.toml
+[36mPROJECT HOOKS[39m @ _REPO_/.config/wt.toml
 [36m❯[39m post-remove [1mnotify[22m: [2m(requires approval)[22m
 [107m [0m [2m[0m[2m[34mecho[0m[2m removed

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_filter_pre_remove.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_filter_pre_remove.snap
@@ -20,16 +20,20 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -39,9 +43,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER HOOKS[39m  [TEST_CONFIG]
+[36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
-[36mPROJECT HOOKS[39m  _REPO_/.config/wt.toml
+[36mPROJECT HOOKS[39m @ _REPO_/.config/wt.toml
 [36m❯[39m pre-remove [1mcleanup[22m: [2m(requires approval)[22m
 [107m [0m [2m[0m[2m[34mecho[0m[2m cleanup

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_no_hooks.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_no_hooks.snap
@@ -19,16 +19,20 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -38,8 +42,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER HOOKS[39m  [TEST_CONFIG]
+[36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
-[36mPROJECT HOOKS[39m  _REPO_/.config/wt.toml
+[36mPROJECT HOOKS[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2m(not found)[22m

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_project_config_no_hooks.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_project_config_no_hooks.snap
@@ -19,16 +19,20 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -38,8 +42,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER HOOKS[39m  [TEST_CONFIG]
+[36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
-[36mPROJECT HOOKS[39m  _REPO_/.config/wt.toml
+[36mPROJECT HOOKS[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2m(none configured)[22m

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_with_both_configs.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_with_both_configs.snap
@@ -19,16 +19,20 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -38,10 +42,10 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36mUSER HOOKS[39m  [TEST_CONFIG]
+[36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
-[36mPROJECT HOOKS[39m  _REPO_/.config/wt.toml
+[36mPROJECT HOOKS[39m @ _REPO_/.config/wt.toml
 [36m❯[39m post-start [1mdeps[22m: [2m(requires approval)[22m
 [107m [0m [2m[0m[2m[34mnpm[0m[2m install
 [36m❯[39m pre-merge [1mbuild[22m: [2m(requires approval)[22m


### PR DESCRIPTION
Unify the `@ path` convention across all user-facing output. Previously
headings (`USER CONFIG`, `PROJECT HOOKS`, etc.) showed bare paths while
status messages used `@ path`. Now everything uses `@ path` consistently.

Also changes `format_heading` separator from double-space to single-space.

> _This was written by Claude Code on behalf of @max-sixty_