### PR TITLE
Show actual path in branch-worktree mismatch warning

### DIFF
--- a/.claude/skills/writing-user-outputs/SKILL.md
+++ b/.claude/skills/writing-user-outputs/SKILL.md
@@ -321,7 +321,7 @@ When a command evaluates state, discovers something unexpected, and proceeds
 anyway, the warning should come first:
 
 ```
-▲ Branch-worktree mismatch; expected feature @ ~/workspace/project.feature ⚑
+▲ Branch-worktree mismatch: feature @ ~/workspace/project.alias, expected @ ~/workspace/project.feature ⚑
 ◎ Removing feature worktree & branch in background (same commit as main, _)
 ```
 
@@ -329,7 +329,7 @@ Not:
 
 ```
 ◎ Removing feature worktree & branch in background (same commit as main, _)
-▲ Branch-worktree mismatch; expected feature @ ~/workspace/project.feature ⚑
+▲ Branch-worktree mismatch: feature @ ~/workspace/project.alias, expected @ ~/workspace/project.feature ⚑
 ```
 
 Warnings that result from the action itself (something failed during execution)

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -168,10 +168,16 @@ fn format_switch_message(
 /// Format a branch-worktree mismatch warning message.
 ///
 /// Shows when a worktree is at a path that doesn't match the config template.
-fn format_path_mismatch_warning(branch: &str, expected_path: &Path) -> FormattedMessage {
+/// Displays both the actual location and the expected location.
+fn format_path_mismatch_warning(
+    branch: &str,
+    actual_path: &Path,
+    expected_path: &Path,
+) -> FormattedMessage {
+    let actual_display = format_path_for_display(actual_path);
     let expected_display = format_path_for_display(expected_path);
     warning_message(cformat!(
-        "Branch-worktree mismatch; expected <bold>{branch}</> @ <bold>{expected_display}</> <red>⚑</>"
+        "Branch-worktree mismatch: <bold>{branch}</> @ <bold>{actual_display}</>, expected @ <bold>{expected_display}</> <red>⚑</>"
     ))
 }
 
@@ -479,7 +485,7 @@ pub fn handle_switch_output(
     let branch_worktree_mismatch_warning = branch_info
         .expected_path
         .as_ref()
-        .map(|expected| format_path_mismatch_warning(&branch_info.branch, expected));
+        .map(|expected| format_path_mismatch_warning(&branch_info.branch, &path, expected));
 
     let display_path_for_hooks = match result {
         SwitchResult::AlreadyAt(_) => {
@@ -1162,7 +1168,10 @@ fn handle_removed_worktree_output(ctx: RemovedWorktreeOutputContext<'_>) -> anyh
     if background {
         // Background mode: show warning before decision announcement
         if let Some(expected) = expected_path {
-            eprintln!("{}", format_path_mismatch_warning(branch_name, expected));
+            eprintln!(
+                "{}",
+                format_path_mismatch_warning(branch_name, worktree_path, expected)
+            );
         }
 
         // Background mode: spawn detached process
@@ -1221,7 +1230,10 @@ fn handle_removed_worktree_output(ctx: RemovedWorktreeOutputContext<'_>) -> anyh
 
         // Foreground mode: show warning after progress (contextual info during operation)
         if let Some(expected) = expected_path {
-            eprintln!("{}", format_path_mismatch_warning(branch_name, expected));
+            eprintln!(
+                "{}",
+                format_path_mismatch_warning(branch_name, worktree_path, expected)
+            );
         }
 
         // Stop fsmonitor daemon first (best effort - ignore errors)

--- a/tests/snapshots/integration__integration_tests__remove__remove_path_mismatch_warning.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_path_mismatch_warning.snap
@@ -19,16 +19,20 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -38,5 +42,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mBranch-worktree mismatch; expected [1mfeature[22m @ [1m_REPO_.feature[22m [31m⚑[39m[39m
+[33m▲[39m [33mBranch-worktree mismatch: [1mfeature[22m @ [1m_PARENT_/weird-path-for-feature[22m, expected @ [1m_REPO_.feature[22m [31m⚑[39m[39m
 [36m◎ Removing [1mfeature[22m worktree & branch in background (same commit as [1mmain[22m,[39m [2m_[22m[36m)[39m

--- a/tests/snapshots/integration__integration_tests__remove__remove_path_mismatch_warning_foreground.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_path_mismatch_warning_foreground.snap
@@ -20,16 +20,20 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -40,5 +44,5 @@ exit_code: 0
 
 ----- stderr -----
 [36m◎[39m [36mRemoving [1mfeature-fg[22m worktree...[39m
-[33m▲[39m [33mBranch-worktree mismatch; expected [1mfeature-fg[22m @ [1m_REPO_.feature-fg[22m [31m⚑[39m[39m
+[33m▲[39m [33mBranch-worktree mismatch: [1mfeature-fg[22m @ [1m_PARENT_/another-weird-path[22m, expected @ [1m_REPO_.feature-fg[22m [31m⚑[39m[39m
 [32m✓ Removed [1mfeature-fg[22m worktree & branch (same commit as [1mmain[22m,[39m [2m_[22m[32m)[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_already_at_branch_worktree_mismatch.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_already_at_branch_worktree_mismatch.snap
@@ -42,6 +42,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mBranch-worktree mismatch; expected [1mfeature-already[22m @ [1m_REPO_.feature-already[22m [31m⚑[39m[39m
+[33m▲[39m [33mBranch-worktree mismatch: [1mfeature-already[22m @ [1m_PARENT_/wrong-path-already[22m, expected @ [1m_REPO_.feature-already[22m [31m⚑[39m[39m
 [2m○[22m Already on worktree for [1mfeature-already[22m @ [1m_PARENT_/wrong-path-already[22m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_branch_worktree_mismatch_no_shell.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_branch_worktree_mismatch_no_shell.snap
@@ -42,6 +42,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mBranch-worktree mismatch; expected [1mfeature-mismatch[22m @ [1m_REPO_.feature-mismatch[22m [31m⚑[39m[39m
+[33m▲[39m [33mBranch-worktree mismatch: [1mfeature-mismatch[22m @ [1m_PARENT_/wrong-path-no-shell[22m, expected @ [1m_REPO_.feature-mismatch[22m [31m⚑[39m[39m
 [33m▲[39m [33mWorktree for [1mfeature-mismatch[22m @ [1m_PARENT_/wrong-path-no-shell[22m, but cannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_branch_worktree_mismatch_shows_hint.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_branch_worktree_mismatch_shows_hint.snap
@@ -19,17 +19,21 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_DIRECTIVE_FILE: "[DIRECTIVE_FILE]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -39,5 +43,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mBranch-worktree mismatch; expected [1mfeature[22m @ [1m_REPO_.feature[22m [31m⚑[39m[39m
+[33m▲[39m [33mBranch-worktree mismatch: [1mfeature[22m @ [1m_PARENT_/wrong-path[22m, expected @ [1m_REPO_.feature[22m [31m⚑[39m[39m
 [2m○[22m Switched to worktree for [1mfeature[22m @ [1m_PARENT_/wrong-path[22m


### PR DESCRIPTION
The mismatch warning previously only showed the expected path, leaving users
guessing what the actual location was. Now shows both.

Before: `▲ Branch-worktree mismatch; expected feature @ ~/workspace/project.feature ⚑`
After: `▲ Branch-worktree mismatch: feature @ ~/w/project.alias, expected @ ~/workspace/project.feature ⚑`

> _This was written by Claude Code on behalf of @max-sixty_