### PR TITLE
fix(output): use cformat! for GitError action strings

### DIFF
--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -340,7 +340,7 @@ impl GitError {
 
             GitError::DetachedHead { action } => {
                 let message = match action {
-                    Some(action) => format!("Cannot {action}: not on a branch (detached HEAD)"),
+                    Some(action) => cformat!("Cannot {action}: not on a branch (detached HEAD)"),
                     None => "Not on a branch (detached HEAD)".to_string(),
                 };
                 write!(
@@ -434,7 +434,7 @@ impl GitError {
 
             GitError::NotInWorktree { action } => {
                 let message = match action {
-                    Some(action) => format!("Cannot {action}: not in a worktree"),
+                    Some(action) => cformat!("Cannot {action}: not in a worktree"),
                     None => "Not in a worktree".to_string(),
                 };
                 write!(


### PR DESCRIPTION
Switches `format!` → `cformat!` in the Display impl for `DetachedHead` and
`NotInWorktree`, so action strings can include color-print styling tags. All
other GitError variants already use `cformat!` — these two were the only
holdouts.

Follow-up to #1380.

> _This was written by Claude Code on behalf of @max-sixty_