### PR TITLE
Replace negated boolean variables with positive-polarity names

### DIFF
--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -17,7 +17,7 @@ pub use worktrunk::config::StageMode;
 pub struct CommitOptions<'a> {
     pub ctx: &'a CommandContext<'a>,
     pub target_branch: Option<&'a str>,
-    pub no_verify: bool,
+    pub verify: bool,
     pub stage_mode: StageMode,
     pub warn_about_untracked: bool,
     pub show_no_squash_note: bool,
@@ -29,7 +29,7 @@ impl<'a> CommitOptions<'a> {
         Self {
             ctx,
             target_branch: None,
-            no_verify: false,
+            verify: true,
             stage_mode: StageMode::All,
             warn_about_untracked: true,
             show_no_squash_note: false,
@@ -165,14 +165,14 @@ impl CommitOptions<'_> {
         let any_hooks_exist = user_hooks_exist || project_hooks_exist;
 
         // Show skip message
-        if self.no_verify && any_hooks_exist {
+        if !self.verify && any_hooks_exist {
             eprintln!(
                 "{}",
                 info_message("Skipping pre-commit hooks (--no-verify)")
             );
         }
 
-        if !self.no_verify {
+        if self.verify {
             let extra_vars: Vec<(&str, &str)> = self
                 .target_branch
                 .into_iter()

--- a/src/commands/handle_switch.rs
+++ b/src/commands/handle_switch.rs
@@ -212,10 +212,10 @@ pub fn handle_switch(
     // "Approve at the Gate": collect and approve hooks upfront
     // This ensures approval happens once at the command entry point
     // If user declines, skip hooks but continue with worktree operation
-    let skip_hooks = !approve_switch_hooks(&repo, config, &plan, yes, verify)?;
+    let hooks_approved = approve_switch_hooks(&repo, config, &plan, yes, verify)?;
 
     // Execute the validated plan
-    let (result, branch_info) = execute_switch(&repo, plan, config, yes, skip_hooks)?;
+    let (result, branch_info) = execute_switch(&repo, plan, config, yes, hooks_approved)?;
 
     // Early exit for benchmarking time-to-first-output
     if std::env::var_os("WORKTRUNK_FIRST_OUTPUT").is_some() {
@@ -264,7 +264,7 @@ pub fn handle_switch(
     // - post-switch: runs on ALL switches (shows "@ path" when shell won't be there)
     // - post-start: runs only when creating a NEW worktree
     // Batch hooks into a single message when both types are present
-    if !skip_hooks {
+    if hooks_approved {
         spawn_switch_background_hooks(
             &repo,
             config,

--- a/src/commands/list/layout.rs
+++ b/src/commands/list/layout.rs
@@ -724,8 +724,8 @@ fn allocate_columns_with_priority(
             continue;
         };
 
-        let skip_spacing = !needs_spacing(&pending);
-        let allocated = try_allocate(&mut remaining, ideal_width, spacing, skip_spacing);
+        let is_first = !needs_spacing(&pending);
+        let allocated = try_allocate(&mut remaining, ideal_width, spacing, is_first);
         if allocated > 0 {
             pending.push(PendingColumn {
                 spec,

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -163,7 +163,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
             let ctx = env.context(yes);
             let mut options = CommitOptions::new(&ctx);
             options.target_branch = Some(&target_branch);
-            options.no_verify = !verify;
+            options.verify = verify;
             options.stage_mode = stage_mode;
             options.warn_about_untracked = stage_mode == super::commit::StageMode::All;
             options.show_no_squash_note = true;
@@ -181,7 +181,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
             super::step_commands::handle_squash(
                 Some(&target_branch),
                 yes,
-                !verify, // skip_pre_commit when !verify
+                verify,
                 Some(stage_mode)
             )?,
             super::step_commands::SquashResult::Squashed

--- a/src/commands/select/mod.rs
+++ b/src/commands/select/mod.rs
@@ -370,8 +370,9 @@ pub fn handle_select(
 
                 // Switch to existing worktree or create new one
                 let plan = plan_switch(&repo, &identifier, should_create, None, false, config)?;
-                let skip_hooks = !approve_switch_hooks(&repo, config, &plan, false, true)?;
-                let (result, branch_info) = execute_switch(&repo, plan, config, false, skip_hooks)?;
+                let hooks_approved = approve_switch_hooks(&repo, config, &plan, false, true)?;
+                let (result, branch_info) =
+                    execute_switch(&repo, plan, config, false, hooks_approved)?;
 
                 // Compute path mismatch lazily (deferred from plan_switch for existing worktrees)
                 let branch_info = match &result {
@@ -400,7 +401,7 @@ pub fn handle_select(
                 )?;
 
                 // Spawn background hooks after success message
-                if !skip_hooks {
+                if hooks_approved {
                     let extra_vars = switch_extra_vars(&result);
                     spawn_switch_background_hooks(
                         &repo,

--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -43,7 +43,7 @@ use worktrunk::shell_exec::Cmd;
 /// `stage` is the CLI-provided stage mode. If None, uses the effective config default.
 pub fn step_commit(
     yes: bool,
-    no_verify: bool,
+    verify: bool,
     stage: Option<StageMode>,
     show_prompt: bool,
 ) -> anyhow::Result<()> {
@@ -70,24 +70,24 @@ pub fn step_commit(
     let stage_mode = stage.unwrap_or(env.resolved().commit.stage());
 
     // "Approve at the Gate": approve pre-commit hooks upfront (unless --no-verify)
-    // Shadow no_verify: if user declines approval, skip hooks but continue commit
-    let no_verify = if !no_verify {
+    // Shadow verify: if user declines approval, skip hooks but continue commit
+    let verify = if verify {
         let approved = approve_hooks(&ctx, &[HookType::PreCommit])?;
         if !approved {
             eprintln!(
                 "{}",
                 info_message("Commands declined, committing without hooks",)
             );
-            true // Skip hooks
+            false
         } else {
-            false // Run hooks
+            true
         }
     } else {
-        true // --no-verify was passed
+        false // --no-verify was passed
     };
 
     let mut options = CommitOptions::new(&ctx);
-    options.no_verify = no_verify;
+    options.verify = verify;
     options.stage_mode = stage_mode;
     options.show_no_squash_note = false;
     // Only warn about untracked if we're staging all
@@ -112,12 +112,12 @@ pub enum SquashResult {
 /// Handle shared squash workflow (used by `wt step squash` and `wt merge`)
 ///
 /// # Arguments
-/// * `no_verify` - If true, skip all pre-commit hooks (from --no-verify flag)
+/// * `verify` - If true, run pre-commit hooks (false when --no-verify flag is passed)
 /// * `stage` - CLI-provided stage mode. If None, uses the effective config default.
 pub fn handle_squash(
     target: Option<&str>,
     yes: bool,
-    no_verify: bool,
+    verify: bool,
     stage: Option<StageMode>,
 ) -> anyhow::Result<SquashResult> {
     // Load config once, run LLM setup prompt, then reuse config
@@ -145,17 +145,17 @@ pub fn handle_squash(
             .is_some_and(|c| c.hooks.pre_commit.is_some());
 
     // "Approve at the Gate": approve pre-commit hooks upfront (unless --no-verify)
-    // Shadow no_verify: if user declines approval, skip hooks but continue squash
-    let no_verify = if !no_verify {
+    // Shadow verify: if user declines approval, skip hooks but continue squash
+    let verify = if verify {
         let approved = approve_hooks(&ctx, &[HookType::PreCommit])?;
         if !approved {
             eprintln!(
                 "{}",
                 info_message("Commands declined, squashing without hooks")
             );
-            true // Skip hooks
+            false
         } else {
-            false // Run hooks
+            true
         }
     } else {
         // Show skip message when --no-verify was passed and hooks exist
@@ -165,7 +165,7 @@ pub fn handle_squash(
                 info_message("Skipping pre-commit hooks (--no-verify)")
             );
         }
-        true // --no-verify was passed
+        false // --no-verify was passed
     };
 
     // Get and validate target ref (any commit-ish for merge-base calculation)
@@ -188,7 +188,7 @@ pub fn handle_squash(
     }
 
     // Run pre-commit hooks (user first, then project)
-    if !no_verify {
+    if verify {
         let extra_vars = [("target", integration_target.as_str())];
         run_hook_with_filter(
             &ctx,

--- a/src/commands/worktree/switch.rs
+++ b/src/commands/worktree/switch.rs
@@ -648,7 +648,7 @@ pub fn execute_switch(
     plan: SwitchPlan,
     config: &UserConfig,
     force: bool,
-    no_verify: bool,
+    run_hooks: bool,
 ) -> anyhow::Result<(SwitchResult, SwitchBranchInfo)> {
     match plan {
         SwitchPlan::Existing {
@@ -861,7 +861,7 @@ pub fn execute_switch(
                 .map(|p| worktrunk::path::to_posix_path(&p.to_string_lossy()));
 
             // Execute post-create commands
-            if !no_verify {
+            if run_hooks {
                 let ctx = CommandContext::new(repo, config, Some(&branch), &worktree_path, force);
 
                 match &method {

--- a/src/main.rs
+++ b/src/main.rs
@@ -638,7 +638,7 @@ fn main() {
                 verify,
                 stage,
                 show_prompt,
-            } => step_commit(yes, !verify, stage, show_prompt),
+            } => step_commit(yes, verify, stage, show_prompt),
             StepCommand::Squash {
                 target,
                 yes,
@@ -651,24 +651,25 @@ fn main() {
                     commands::step_show_squash_prompt(target.as_deref())
                 } else {
                     // Approval is handled inside handle_squash (like step_commit)
-                    handle_squash(target.as_deref(), yes, !verify, stage).map(|result| match result
-                    {
-                        SquashResult::Squashed | SquashResult::NoNetChanges => {}
-                        SquashResult::NoCommitsAhead(branch) => {
-                            eprintln!(
-                                "{}",
-                                info_message(format!(
-                                    "Nothing to squash; no commits ahead of {branch}"
-                                ))
-                            );
-                        }
-                        SquashResult::AlreadySingleCommit => {
-                            eprintln!(
-                                "{}",
-                                info_message("Nothing to squash; already a single commit")
-                            );
-                        }
-                    })
+                    handle_squash(target.as_deref(), yes, verify, stage).map(
+                        |result| match result {
+                            SquashResult::Squashed | SquashResult::NoNetChanges => {}
+                            SquashResult::NoCommitsAhead(branch) => {
+                                eprintln!(
+                                    "{}",
+                                    info_message(format!(
+                                        "Nothing to squash; no commits ahead of {branch}"
+                                    ))
+                                );
+                            }
+                            SquashResult::AlreadySingleCommit => {
+                                eprintln!(
+                                    "{}",
+                                    info_message("Nothing to squash; already a single commit")
+                                );
+                            }
+                        },
+                    )
                 }
             }
             StepCommand::Push { target } => handle_push(target.as_deref(), "Pushed to", None),


### PR DESCRIPTION
Extends the pattern from #1381 (`foreground` over `!background`) to three
remaining negation patterns in the codebase:

- **`no_verify` → `verify`** in `CommitOptions`, `step_commit`, `handle_squash`, `merge.rs` — removes `!verify` inversions at the CLI boundary and double-negation checks like `if !self.no_verify`
- **`skip_hooks` → `hooks_approved`** / **`no_verify` → `run_hooks`** in `handle_switch`, `select`, `execute_switch` — eliminates `!skip_hooks` double negation
- **`skip_spacing` → `is_first`** in `layout.rs` — aligns variable name with `try_allocate`'s parameter

No behavior changes — pure rename with polarity flip.

> _This was written by Claude Code on behalf of maximilian_