### PR TITLE
Increase drain timeout from 30s to 120s to fix flaky CI

### DIFF
--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -874,7 +874,10 @@ pub fn collect(
     } = drain_outcome
     {
         // Warning: what happened + gutter showing which results are missing
-        let mut diag = format!("wt list timed out after 30s ({received_count} results received)");
+        let mut diag = format!(
+            "wt list timed out after {}s ({received_count} results received)",
+            results::DRAIN_TIMEOUT.as_secs()
+        );
 
         if !items_with_missing.is_empty() {
             let missing_lines: Vec<String> = items_with_missing
@@ -1207,7 +1210,10 @@ pub fn populate_item(
 
     // Handle timeout (silent for statusline - just log it)
     if let DrainOutcome::TimedOut { received_count, .. } = drain_outcome {
-        log::warn!("populate_item timed out after 30s ({received_count} results received)");
+        log::warn!(
+            "populate_item timed out after {}s ({received_count} results received)",
+            results::DRAIN_TIMEOUT.as_secs()
+        );
     }
 
     // Log errors silently (statusline shouldn't spam warnings)

--- a/src/commands/list/collect/results.rs
+++ b/src/commands/list/collect/results.rs
@@ -9,6 +9,10 @@ use std::time::{Duration, Instant};
 use crossbeam_channel as chan;
 use worktrunk::git::LineDiff;
 
+/// Deadline for the entire drain operation. Generous to avoid flaky timeouts
+/// under CI load where process spawning for ~70 work items can be slow.
+pub(super) const DRAIN_TIMEOUT: Duration = Duration::from_secs(120);
+
 use super::super::model::{CommitDetails, ItemKind, ListItem, UpstreamStatus, WorkingTreeStatus};
 use super::execution::ExpectedResults;
 use super::types::{DrainOutcome, MissingResult, StatusContext, TaskError, TaskKind, TaskResult};
@@ -100,7 +104,7 @@ pub(super) fn apply_default(
 /// item index and a reference to the updated item, allowing progressive mode
 /// to update the live table while buffered mode does nothing.
 ///
-/// Uses a 30-second deadline to prevent infinite hangs if git commands stall.
+/// Uses [`DRAIN_TIMEOUT`] to prevent infinite hangs if git commands stall.
 /// When timeout occurs, returns `DrainOutcome::TimedOut` with diagnostic info.
 ///
 /// Errors are collected in the `errors` vec for display after rendering.
@@ -116,8 +120,7 @@ pub(super) fn drain_results(
     expected_results: &ExpectedResults,
     mut on_result: impl FnMut(usize, &mut ListItem, &StatusContext),
 ) -> DrainOutcome {
-    // Deadline for the entire drain operation (30 seconds should be more than enough)
-    let deadline = Instant::now() + Duration::from_secs(30);
+    let deadline = Instant::now() + DRAIN_TIMEOUT;
 
     // Track which result kinds we've received per item (for timeout diagnostics)
     let mut received_by_item: Vec<Vec<TaskKind>> = vec![Vec::new(); items.len()];


### PR DESCRIPTION
The drain deadline in `wt list` was 30 seconds — too tight for CI environments
where process spawning for ~70 work items (5 worktrees × ~14 tasks) can be
slow under load. When the deadline fires, a timeout warning goes to stderr,
breaking snapshot comparisons for tests like `test_list_full_with_no_ci_checks`
and `test_list_full_with_status_context::case_1_pending`.

Increased to 120s and extracted a `DRAIN_TIMEOUT` constant so the value and
diagnostic messages stay in sync.

> _This was written by Claude Code on behalf of @max-sixty_