### PR TITLE
fix(docs): broken anchor link in step.md

### DIFF
--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -60,7 +60,7 @@ wt step deploy --var env=staging          # pass extra template variables
 wt step deploy --yes                      # skip approval prompt
 ```
 
-When defined in both user and project config, user aliases take precedence. Project-config aliases require [command approval](@/hook.md#command-approval) on first run (same as project hooks). User-config aliases are trusted.
+When defined in both user and project config, user aliases take precedence. Project-config aliases require [command approval](@/hook.md#security) on first run (same as project hooks). User-config aliases are trusted.
 
 Alias names that match a built-in step command (`commit`, `squash`, etc.) are shadowed by the built-in and will never run.
 

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -51,7 +51,7 @@ wt step deploy --var env=staging          # pass extra template variables
 wt step deploy --yes                      # skip approval prompt
 ```
 
-When defined in both user and project config, user aliases take precedence. Project-config aliases require [command approval](https://worktrunk.dev/hook/#command-approval) on first run (same as project hooks). User-config aliases are trusted.
+When defined in both user and project config, user aliases take precedence. Project-config aliases require [command approval](https://worktrunk.dev/hook/#security) on first run (same as project hooks). User-config aliases are trusted.
 
 Alias names that match a built-in step command (`commit`, `squash`, etc.) are shadowed by the built-in and will never run.
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1053,7 +1053,7 @@ wt step deploy --var env=staging          # pass extra template variables
 wt step deploy --yes                      # skip approval prompt
 ```
 
-When defined in both user and project config, user aliases take precedence. Project-config aliases require [command approval](@/hook.md#command-approval) on first run (same as project hooks). User-config aliases are trusted.
+When defined in both user and project config, user aliases take precedence. Project-config aliases require [command approval](@/hook.md#security) on first run (same as project hooks). User-config aliases are trusted.
 
 Alias names that match a built-in step command (`commit`, `squash`, etc.) are shadowed by the built-in and will never run.
 


### PR DESCRIPTION
The `@/hook.md#command-approval` anchor in step.md doesn't exist, causing
the `publish-docs` workflow to fail (`zola build` rejects broken internal
anchors). The approval docs live under the `# Security` heading, so the
correct anchor is `#security`.

> _This was written by Claude Code on behalf of @max-sixty_