### PR TITLE
refactor(tests): consolidate and delete trivial tests

### DIFF
--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -280,55 +280,113 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_name_only() {
-        let opts = parse(&["deploy"]).unwrap();
-        assert_eq!(opts.name, "deploy");
-        assert!(!opts.dry_run);
-        assert!(!opts.yes);
-        assert!(opts.vars.is_empty());
-    }
-
-    #[test]
-    fn test_parse_dry_run() {
-        let opts = parse(&["deploy", "--dry-run"]).unwrap();
-        assert!(opts.dry_run);
-    }
-
-    #[test]
-    fn test_parse_yes_long() {
-        let opts = parse(&["deploy", "--yes"]).unwrap();
-        assert!(opts.yes);
-    }
-
-    #[test]
-    fn test_parse_yes_short() {
-        let opts = parse(&["deploy", "-y"]).unwrap();
-        assert!(opts.yes);
-    }
-
-    #[test]
-    fn test_parse_var_separate() {
-        let opts = parse(&["deploy", "--var", "key=value"]).unwrap();
-        assert_eq!(opts.vars, vec![("key".into(), "value".into())]);
-    }
-
-    #[test]
-    fn test_parse_var_equals() {
-        let opts = parse(&["deploy", "--var=key=value"]).unwrap();
-        assert_eq!(opts.vars, vec![("key".into(), "value".into())]);
-    }
-
-    #[test]
-    fn test_parse_var_value_with_equals() {
-        let opts = parse(&["deploy", "--var", "url=http://host?a=1"]).unwrap();
-        assert_eq!(opts.vars[0], ("url".into(), "http://host?a=1".into()));
-    }
-
-    #[test]
-    fn test_parse_multiple_vars() {
-        let opts = parse(&["deploy", "--var", "a=1", "--var", "b=2", "--dry-run"]).unwrap();
-        assert_eq!(opts.vars.len(), 2);
-        assert!(opts.dry_run);
+    fn test_parse() {
+        use insta::assert_debug_snapshot;
+        assert_debug_snapshot!(parse(&["deploy"]).unwrap(), @r#"
+        AliasOptions {
+            name: "deploy",
+            dry_run: false,
+            yes: false,
+            vars: [],
+        }
+        "#);
+        assert_debug_snapshot!(parse(&["deploy", "--dry-run"]).unwrap(), @r#"
+        AliasOptions {
+            name: "deploy",
+            dry_run: true,
+            yes: false,
+            vars: [],
+        }
+        "#);
+        assert_debug_snapshot!(parse(&["deploy", "--yes"]).unwrap(), @r#"
+        AliasOptions {
+            name: "deploy",
+            dry_run: false,
+            yes: true,
+            vars: [],
+        }
+        "#);
+        assert_debug_snapshot!(parse(&["deploy", "-y"]).unwrap(), @r#"
+        AliasOptions {
+            name: "deploy",
+            dry_run: false,
+            yes: true,
+            vars: [],
+        }
+        "#);
+        assert_debug_snapshot!(parse(&["deploy", "--var", "key=value"]).unwrap(), @r#"
+        AliasOptions {
+            name: "deploy",
+            dry_run: false,
+            yes: false,
+            vars: [
+                (
+                    "key",
+                    "value",
+                ),
+            ],
+        }
+        "#);
+        // --var=key=value (equals form)
+        assert_debug_snapshot!(parse(&["deploy", "--var=key=value"]).unwrap(), @r#"
+        AliasOptions {
+            name: "deploy",
+            dry_run: false,
+            yes: false,
+            vars: [
+                (
+                    "key",
+                    "value",
+                ),
+            ],
+        }
+        "#);
+        // Value containing equals sign
+        assert_debug_snapshot!(parse(&["deploy", "--var", "url=http://host?a=1"]).unwrap(), @r#"
+        AliasOptions {
+            name: "deploy",
+            dry_run: false,
+            yes: false,
+            vars: [
+                (
+                    "url",
+                    "http://host?a=1",
+                ),
+            ],
+        }
+        "#);
+        // Multiple vars + flags
+        assert_debug_snapshot!(parse(&["deploy", "--var", "a=1", "--var", "b=2", "--dry-run"]).unwrap(), @r#"
+        AliasOptions {
+            name: "deploy",
+            dry_run: true,
+            yes: false,
+            vars: [
+                (
+                    "a",
+                    "1",
+                ),
+                (
+                    "b",
+                    "2",
+                ),
+            ],
+        }
+        "#);
+        // Empty value accepted
+        assert_debug_snapshot!(parse(&["deploy", "--var", "key="]).unwrap(), @r#"
+        AliasOptions {
+            name: "deploy",
+            dry_run: false,
+            yes: false,
+            vars: [
+                (
+                    "key",
+                    "",
+                ),
+            ],
+        }
+        "#);
     }
 
     #[test]
@@ -343,34 +401,16 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_var_empty_value_accepted() {
-        let opts = parse(&["deploy", "--var", "key="]).unwrap();
-        assert_eq!(opts.vars, vec![("key".into(), String::new())]);
-    }
-
-    #[test]
-    fn test_find_closest_match_typo() {
+    fn test_find_closest_match() {
         assert_eq!(
             find_closest_match("deplyo", &["deploy", "hello"]),
-            Some("deploy"),
+            Some("deploy")
         );
-    }
-
-    #[test]
-    fn test_find_closest_match_missing_letter() {
         assert_eq!(
             find_closest_match("comit", &["commit", "squash", "push", "rebase"]),
-            Some("commit"),
+            Some("commit")
         );
-    }
-
-    #[test]
-    fn test_find_closest_match_no_match() {
         assert_eq!(find_closest_match("zzz", &["deploy", "hello"]), None);
-    }
-
-    #[test]
-    fn test_find_closest_match_empty_candidates() {
         assert_eq!(find_closest_match("deploy", &[]), None);
     }
 

--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -258,25 +258,4 @@ mod tests {
         let result = generator.format_message_for_display("");
         assert_eq!(result, "");
     }
-
-    #[test]
-    fn test_commit_options_new() {
-        // CommitOptions::new requires a CommandContext, which requires a Repository.
-        // Instead, test the struct fields directly
-        let stage_mode = StageMode::default();
-        assert!(matches!(stage_mode, StageMode::All));
-    }
-
-    #[test]
-    fn test_stage_mode_variants() {
-        // Test that all StageMode variants can be matched
-        let modes = [StageMode::All, StageMode::Tracked, StageMode::None];
-        for mode in modes {
-            match mode {
-                StageMode::All => assert_eq!(format!("{:?}", mode), "All"),
-                StageMode::Tracked => assert_eq!(format!("{:?}", mode), "Tracked"),
-                StageMode::None => assert_eq!(format!("{:?}", mode), "None"),
-            }
-        }
-    }
 }

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -512,52 +512,39 @@ mod tests {
     }
 
     #[test]
-    fn test_parsed_filter_no_prefix() {
-        let filter = ParsedFilter::parse("foo");
-        assert!(filter.source.is_none());
-        assert_eq!(filter.name, "foo");
-        assert!(filter.matches_source(HookSource::User));
-        assert!(filter.matches_source(HookSource::Project));
-    }
+    fn test_parsed_filter() {
+        // No prefix — matches all sources
+        let f = ParsedFilter::parse("foo");
+        assert!(f.source.is_none());
+        assert_eq!(f.name, "foo");
+        assert!(f.matches_source(HookSource::User));
+        assert!(f.matches_source(HookSource::Project));
 
-    #[test]
-    fn test_parsed_filter_user_prefix() {
-        let filter = ParsedFilter::parse("user:foo");
-        assert_eq!(filter.source, Some(HookSource::User));
-        assert_eq!(filter.name, "foo");
-        assert!(filter.matches_source(HookSource::User));
-        assert!(!filter.matches_source(HookSource::Project));
-    }
+        // user: prefix
+        let f = ParsedFilter::parse("user:foo");
+        assert_eq!(f.source, Some(HookSource::User));
+        assert_eq!(f.name, "foo");
+        assert!(f.matches_source(HookSource::User));
+        assert!(!f.matches_source(HookSource::Project));
 
-    #[test]
-    fn test_parsed_filter_project_prefix() {
-        let filter = ParsedFilter::parse("project:bar");
-        assert_eq!(filter.source, Some(HookSource::Project));
-        assert_eq!(filter.name, "bar");
-        assert!(!filter.matches_source(HookSource::User));
-        assert!(filter.matches_source(HookSource::Project));
-    }
+        // project: prefix
+        let f = ParsedFilter::parse("project:bar");
+        assert_eq!(f.source, Some(HookSource::Project));
+        assert_eq!(f.name, "bar");
+        assert!(!f.matches_source(HookSource::User));
+        assert!(f.matches_source(HookSource::Project));
 
-    #[test]
-    fn test_parsed_filter_colon_in_name() {
-        // A name like "my:hook" without valid prefix should be parsed as-is
-        let filter = ParsedFilter::parse("my:hook");
-        assert!(filter.source.is_none());
-        assert_eq!(filter.name, "my:hook");
-    }
+        // Unknown prefix treated as name (colon in name)
+        let f = ParsedFilter::parse("my:hook");
+        assert!(f.source.is_none());
+        assert_eq!(f.name, "my:hook");
 
-    #[test]
-    fn test_parsed_filter_source_only() {
-        // "user:" means all user hooks (empty name)
-        let filter = ParsedFilter::parse("user:");
-        assert_eq!(filter.source, Some(HookSource::User));
-        assert_eq!(filter.name, "");
-        assert!(filter.matches_source(HookSource::User));
-        assert!(!filter.matches_source(HookSource::Project));
-
-        // "project:" means all project hooks
-        let filter = ParsedFilter::parse("project:");
-        assert_eq!(filter.source, Some(HookSource::Project));
-        assert_eq!(filter.name, "");
+        // Source-only (empty name matches all hooks from source)
+        let f = ParsedFilter::parse("user:");
+        assert_eq!(f.source, Some(HookSource::User));
+        assert_eq!(f.name, "");
+        let f = ParsedFilter::parse("project:");
+        assert_eq!(f.source, Some(HookSource::Project));
+        assert_eq!(f.name, "");
     }
 }

--- a/src/commands/list/columns.rs
+++ b/src/commands/list/columns.rs
@@ -179,21 +179,6 @@ mod tests {
     }
 
     #[test]
-    fn test_column_spec_new() {
-        let spec = ColumnSpec::new(ColumnKind::Branch, 1, None);
-        assert_eq!(spec.kind, ColumnKind::Branch);
-        assert_eq!(spec.base_priority, 1);
-        assert!(spec.requires_task.is_none());
-    }
-
-    #[test]
-    fn test_column_spec_with_required_task() {
-        let spec = ColumnSpec::new(ColumnKind::BranchDiff, 5, Some(TaskKind::BranchDiff));
-        assert_eq!(spec.kind, ColumnKind::BranchDiff);
-        assert_eq!(spec.requires_task, Some(TaskKind::BranchDiff));
-    }
-
-    #[test]
     fn test_column_specs_priorities_are_unique() {
         // Each column should have a unique base_priority
         let priorities: Vec<u8> = COLUMN_SPECS.iter().map(|c| c.base_priority).collect();

--- a/src/commands/list/model/state.rs
+++ b/src/commands/list/model/state.rs
@@ -648,14 +648,9 @@ mod tests {
     // ============================================================================
 
     #[test]
-    fn test_git_operation_state_default() {
-        let state = ActiveGitOperation::default();
-        assert_eq!(state, ActiveGitOperation::None);
-    }
-
-    #[test]
     fn test_git_operation_state_is_none() {
         assert!(ActiveGitOperation::None.is_none());
+        assert!(ActiveGitOperation::default().is_none());
         assert!(!ActiveGitOperation::Rebase.is_none());
         assert!(!ActiveGitOperation::Merge.is_none());
     }

--- a/src/commands/list/model/stats.rs
+++ b/src/commands/list/model/stats.rs
@@ -60,26 +60,6 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_ahead_behind_default() {
-        let ab = AheadBehind::default();
-        assert_eq!(ab.ahead, 0);
-        assert_eq!(ab.behind, 0);
-    }
-
-    #[test]
-    fn test_branch_diff_totals_default() {
-        let diff = BranchDiffTotals::default();
-        assert!(diff.diff.is_empty());
-    }
-
-    #[test]
-    fn test_commit_details_default() {
-        let details = CommitDetails::default();
-        assert_eq!(details.timestamp, 0);
-        assert_eq!(details.commit_message, "");
-    }
-
-    #[test]
     fn test_upstream_status_active_with_remote() {
         let status = UpstreamStatus {
             remote: Some("origin".to_string()),

--- a/src/commands/list/model/status_symbols.rs
+++ b/src/commands/list/model/status_symbols.rs
@@ -467,13 +467,4 @@ mod tests {
         assert_eq!(mask.width(PositionMask::UPSTREAM_DIVERGENCE), 1);
         assert_eq!(mask.width(PositionMask::USER_MARKER), 2);
     }
-
-    #[test]
-    fn test_position_mask_default() {
-        let mask = PositionMask::default();
-        // Default has all widths at 0
-        for i in 0..7 {
-            assert_eq!(mask.width(i), 0);
-        }
-    }
 }

--- a/src/config/commands.rs
+++ b/src/config/commands.rs
@@ -170,38 +170,6 @@ mod tests {
     // ============================================================================
 
     #[test]
-    fn test_command_new() {
-        let cmd = Command::new(Some("build".to_string()), "cargo build".to_string());
-        assert_eq!(cmd.name, Some("build".to_string()));
-        assert_eq!(cmd.template, "cargo build");
-        assert_eq!(cmd.expanded, "cargo build"); // Same as template when not expanded
-    }
-
-    #[test]
-    fn test_command_new_unnamed() {
-        let cmd = Command::new(None, "npm install".to_string());
-        assert_eq!(cmd.name, None);
-        assert_eq!(cmd.template, "npm install");
-        assert_eq!(cmd.expanded, "npm install");
-    }
-
-    #[test]
-    fn test_command_with_expansion() {
-        let cmd = Command::with_expansion(
-            Some("test".to_string()),
-            "cargo test --package {{ repo }}".to_string(),
-            "cargo test --package myrepo".to_string(),
-        );
-        assert_eq!(cmd.name, Some("test".to_string()));
-        assert_eq!(cmd.template, "cargo test --package {{ repo }}");
-        assert_eq!(cmd.expanded, "cargo test --package myrepo");
-    }
-
-    // ============================================================================
-    // CommandConfig Deserialization Tests
-    // ============================================================================
-
-    #[test]
     fn test_deserialize_single_string() {
         let toml_str = r#"command = "npm install""#;
 

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -1464,31 +1464,6 @@ command = "llm -m opus"
     }
 
     #[test]
-    fn test_migrate_commit_generation_simple() {
-        let content = r#"
-[commit-generation]
-command = "llm -m haiku"
-"#;
-        let result = migrate_commit_generation_sections(content);
-        assert!(result.contains("[commit.generation]"));
-        assert!(result.contains("command = \"llm -m haiku\""));
-        assert!(!result.contains("[commit-generation]"));
-    }
-
-    #[test]
-    fn test_migrate_commit_generation_with_args() {
-        let content = r#"
-[commit-generation]
-command = "llm"
-args = ["-m", "haiku"]
-"#;
-        let result = migrate_commit_generation_sections(content);
-        assert!(result.contains("[commit.generation]"));
-        assert!(result.contains("command = \"llm -m haiku\""));
-        assert!(!result.contains("args"));
-    }
-
-    #[test]
     fn test_migrate_commit_generation_args_with_spaces() {
         let content = r#"
 [commit-generation]
@@ -1496,21 +1471,11 @@ command = "llm"
 args = ["-m", "claude haiku 4.5"]
 "#;
         let result = migrate_commit_generation_sections(content);
-        assert!(result.contains("[commit.generation]"));
-        // Args with spaces should be quoted
-        assert!(result.contains("command = \"llm -m 'claude haiku 4.5'\""));
-    }
+        insta::assert_snapshot!(result, @r#"
 
-    #[test]
-    fn test_migrate_commit_generation_project_level() {
-        let content = r#"
-[projects."github.com/user/repo".commit-generation]
-command = "llm -m gpt-4"
-"#;
-        let result = migrate_commit_generation_sections(content);
-        assert!(result.contains("[projects.\"github.com/user/repo\".commit.generation]"));
-        assert!(result.contains("command = \"llm -m gpt-4\""));
-        assert!(!result.contains("commit-generation"));
+        [commit.generation]
+        command = "llm -m 'claude haiku 4.5'"
+        "#);
     }
 
     #[test]
@@ -1521,25 +1486,12 @@ command = "llm -m haiku"
 template = "Write commit: {{ diff }}"
 "#;
         let result = migrate_commit_generation_sections(content);
-        assert!(result.contains("[commit.generation]"));
-        assert!(result.contains("command = \"llm -m haiku\""));
-        assert!(result.contains("template = \"Write commit: {{ diff }}\""));
-    }
+        insta::assert_snapshot!(result, @r#"
 
-    #[test]
-    fn test_migrate_commit_generation_preserves_existing_commit_section() {
-        let content = r#"
-[commit]
-stage = "all"
-
-[commit-generation]
-command = "llm -m haiku"
-"#;
-        let result = migrate_commit_generation_sections(content);
-        assert!(result.contains("[commit]"));
-        assert!(result.contains("stage = \"all\""));
-        assert!(result.contains("[commit.generation]"));
-        assert!(result.contains("command = \"llm -m haiku\""));
+        [commit.generation]
+        command = "llm -m haiku"
+        template = "Write commit: {{ diff }}"
+        "#);
     }
 
     #[test]
@@ -1549,14 +1501,11 @@ command = "llm -m haiku"
 command = "llm -m haiku"
 "#;
         let result = migrate_commit_generation_sections(content);
-        // Should return unchanged content
         assert_eq!(result, content);
     }
 
     #[test]
     fn test_migrate_skips_when_new_section_exists() {
-        // When both old and new sections exist, migration should NOT overwrite
-        // the new section (new takes precedence)
         let content = r#"
 [commit.generation]
 command = "new-command"
@@ -1565,16 +1514,15 @@ command = "new-command"
 command = "old-command"
 "#;
         let result = migrate_commit_generation_sections(content);
-        // New section should be preserved, old section should be removed but not migrated
-        assert!(
-            result.contains("command = \"new-command\""),
-            "New command should be preserved"
-        );
-        // Old section is left alone (not migrated since new exists)
-        assert!(
-            result.contains("[commit-generation]"),
-            "Old section is left as-is since new already exists"
-        );
+        // Old section left as-is since new already exists
+        insta::assert_snapshot!(result, @r#"
+
+        [commit.generation]
+        command = "new-command"
+
+        [commit-generation]
+        command = "old-command"
+        "#);
     }
 
     #[test]
@@ -1624,8 +1572,6 @@ command = "old-command"
 
     #[test]
     fn test_combined_migrations_template_vars_and_section_rename() {
-        // Test that both deprecated template variables AND deprecated
-        // [commit-generation] section are migrated in a single pass
         let content = r#"
 worktree-path = "../{{ main_worktree }}.{{ branch }}"
 
@@ -1633,22 +1579,15 @@ worktree-path = "../{{ main_worktree }}.{{ branch }}"
 command = "llm"
 args = ["-m", "haiku"]
 "#;
-        // First apply template var replacements
         let step1 = replace_deprecated_vars(content);
-        assert!(step1.contains("{{ repo }}"), "main_worktree → repo");
-
-        // Then apply section migration
         let step2 = migrate_commit_generation_sections(&step1);
-        assert!(step2.contains("[commit.generation]"), "Section renamed");
-        assert!(
-            step2.contains("command = \"llm -m haiku\""),
-            "Args merged into command"
-        );
-        assert!(
-            !step2.contains("[commit-generation]"),
-            "Old section removed"
-        );
-        assert!(!step2.contains("args"), "Args field removed");
+        insta::assert_snapshot!(step2, @r#"
+
+        worktree-path = "../{{ repo }}.{{ branch }}"
+
+        [commit.generation]
+        command = "llm -m haiku"
+        "#);
     }
 
     // Tests for inline table handling
@@ -1737,28 +1676,6 @@ commit-generation = { command = "llm", args = ["-m", "gpt-4"] }
     }
 
     #[test]
-    fn test_migrate_preserves_existing_commit_stage() {
-        // When [commit] section already exists with other fields, preserve them
-        let content = r#"
-[commit]
-stage = "all"
-
-[commit-generation]
-command = "llm -m haiku"
-"#;
-        let result = migrate_commit_generation_sections(content);
-        assert!(result.contains("stage = \"all\""), "Should preserve stage");
-        assert!(
-            result.contains("[commit.generation]"),
-            "Should add generation subsection"
-        );
-        assert!(
-            result.contains("command = \"llm -m haiku\""),
-            "Should migrate command"
-        );
-    }
-
-    #[test]
     fn test_find_deprecations_empty_inline_table() {
         // Empty inline table should not be flagged
         let content = r#"
@@ -1773,76 +1690,51 @@ commit-generation = {}
 
     #[test]
     fn test_migrate_args_without_command_preserved() {
-        // When args exists but command doesn't, args should be preserved
-        // (merge_args_into_command won't run without a command)
+        // Args preserved when no command to merge into
         let content = r#"
 [commit-generation]
 args = ["-m", "haiku"]
 template = "some template"
 "#;
         let result = migrate_commit_generation_sections(content);
-        assert!(
-            result.contains("[commit.generation]"),
-            "Section should be renamed"
-        );
-        // Args should be preserved since there's no command to merge into
-        assert!(
-            result.contains("args ="),
-            "Args should be preserved when no command exists"
-        );
+        insta::assert_snapshot!(result, @r#"
+
+        [commit.generation]
+        args = ["-m", "haiku"]
+        template = "some template"
+        "#);
     }
 
     #[test]
     fn test_migrate_args_with_non_string_command() {
-        // When command is not a string (e.g., integer), args should be preserved
+        // Args preserved when command is not a string
         let content = r#"
 [commit-generation]
 command = 123
 args = ["-m", "haiku"]
 "#;
         let result = migrate_commit_generation_sections(content);
-        // Args should be preserved since command is not a string
-        assert!(
-            result.contains("args ="),
-            "Args should be preserved when command is not a string"
-        );
-    }
+        insta::assert_snapshot!(result, @r#"
 
-    #[test]
-    fn test_migrate_command_only_no_args() {
-        // When only command exists (no args), it should migrate cleanly
-        let content = r#"
-[commit-generation]
-command = "llm -m haiku"
-"#;
-        let result = migrate_commit_generation_sections(content);
-        assert!(result.contains("[commit.generation]"));
-        assert!(result.contains("command = \"llm -m haiku\""));
-        assert!(!result.contains("args"));
+        [commit.generation]
+        command = 123
+        args = ["-m", "haiku"]
+        "#);
     }
 
     #[test]
     fn test_migrate_empty_command_with_args() {
-        // When command is empty string but args exist, args become the command
         let content = r#"
 [commit-generation]
 command = ""
 args = ["-m", "haiku"]
 "#;
         let result = migrate_commit_generation_sections(content);
-        assert!(
-            result.contains("[commit.generation]"),
-            "Section should be renamed"
-        );
-        // Empty command + args should produce just args as command
-        assert!(
-            result.contains("command = \"-m haiku\""),
-            "Empty command should be replaced with args"
-        );
-        assert!(
-            !result.contains("args"),
-            "Args field should be removed after merge"
-        );
+        insta::assert_snapshot!(result, @r#"
+
+        [commit.generation]
+        command = "-m haiku"
+        "#);
     }
 
     #[test]
@@ -2036,31 +1928,6 @@ worktree-path = ".worktrees/{{ branch | sanitize }}"
     // Tests for remove_approved_commands_from_config
 
     #[test]
-    fn test_remove_approved_commands_simple() {
-        let content = r#"
-[projects."github.com/user/repo"]
-approved-commands = ["npm install", "npm test"]
-"#;
-        let result = remove_approved_commands_from_config(content);
-        assert!(!result.contains("approved-commands"));
-        // Empty project section and empty projects table should be removed
-        assert!(!result.contains("[projects"));
-    }
-
-    #[test]
-    fn test_remove_approved_commands_preserves_other_fields() {
-        let content = r#"
-[projects."github.com/user/repo"]
-approved-commands = ["npm install"]
-worktree-path = ".worktrees/{{ branch | sanitize }}"
-"#;
-        let result = remove_approved_commands_from_config(content);
-        assert!(!result.contains("approved-commands"));
-        assert!(result.contains("worktree-path"));
-        assert!(result.contains("projects"));
-    }
-
-    #[test]
     fn test_remove_approved_commands_multiple_projects() {
         let content = r#"
 [projects."github.com/user/repo1"]
@@ -2071,12 +1938,11 @@ approved-commands = ["cargo test"]
 worktree-path = ".worktrees/{{ branch | sanitize }}"
 "#;
         let result = remove_approved_commands_from_config(content);
-        assert!(!result.contains("approved-commands"));
-        // repo1 had only approved-commands, so its section should be removed
-        assert!(!result.contains("repo1"));
-        // repo2 has other fields, so its section should remain
-        assert!(result.contains("repo2"));
-        assert!(result.contains("worktree-path"));
+        insta::assert_snapshot!(result, @r#"
+
+        [projects."github.com/user/repo2"]
+        worktree-path = ".worktrees/{{ branch | sanitize }}"
+        "#);
     }
 
     #[test]

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -221,82 +221,6 @@ pub fn find_unknown_keys(contents: &str) -> std::collections::HashMap<String, to
 mod tests {
     use super::*;
 
-    // ============================================================================
-    // ProjectConfig Default Tests
-    // ============================================================================
-
-    #[test]
-    fn test_project_config_default() {
-        let config = ProjectConfig::default();
-        assert!(config.hooks.post_create.is_none());
-        assert!(config.hooks.post_start.is_none());
-        assert!(config.hooks.post_switch.is_none());
-        assert!(config.hooks.pre_commit.is_none());
-        assert!(config.hooks.pre_merge.is_none());
-        assert!(config.hooks.post_merge.is_none());
-        assert!(config.hooks.pre_remove.is_none());
-        assert!(config.list.is_none());
-        assert!(config.ci.is_none());
-    }
-
-    // ============================================================================
-    // Deserialization Tests
-    // ============================================================================
-
-    #[test]
-    fn test_deserialize_empty_config() {
-        let contents = "";
-        let config: ProjectConfig = toml::from_str(contents).unwrap();
-        assert!(config.hooks.post_create.is_none());
-        assert!(config.hooks.pre_merge.is_none());
-    }
-
-    #[test]
-    fn test_deserialize_post_create_string() {
-        let contents = r#"post-create = "npm install""#;
-        let config: ProjectConfig = toml::from_str(contents).unwrap();
-        assert!(config.hooks.post_create.is_some());
-    }
-
-    #[test]
-    fn test_deserialize_post_start_table() {
-        let contents = r#"
-[post-start]
-build = "cargo build"
-test = "cargo test"
-"#;
-        let config: ProjectConfig = toml::from_str(contents).unwrap();
-        assert!(config.hooks.post_start.is_some());
-    }
-
-    #[test]
-    fn test_deserialize_pre_merge() {
-        let contents = r#"pre-merge = "cargo test""#;
-        let config: ProjectConfig = toml::from_str(contents).unwrap();
-        assert!(config.hooks.pre_merge.is_some());
-    }
-
-    #[test]
-    fn test_deserialize_post_merge() {
-        let contents = r#"post-merge = "git push origin main""#;
-        let config: ProjectConfig = toml::from_str(contents).unwrap();
-        assert!(config.hooks.post_merge.is_some());
-    }
-
-    #[test]
-    fn test_deserialize_pre_remove() {
-        let contents = r#"pre-remove = "echo cleaning up""#;
-        let config: ProjectConfig = toml::from_str(contents).unwrap();
-        assert!(config.hooks.pre_remove.is_some());
-    }
-
-    #[test]
-    fn test_deserialize_pre_commit() {
-        let contents = r#"pre-commit = "cargo fmt --check""#;
-        let config: ProjectConfig = toml::from_str(contents).unwrap();
-        assert!(config.hooks.pre_commit.is_some());
-    }
-
     #[test]
     fn test_deserialize_all_hooks() {
         let contents = r#"
@@ -348,13 +272,6 @@ url = "http://localhost:{{ branch | hash_port }}"
         let list = config.list.unwrap();
         assert!(list.url.is_none());
         assert!(!list.is_configured());
-    }
-
-    #[test]
-    fn test_list_config_default() {
-        let config = ProjectListConfig::default();
-        assert!(config.url.is_none());
-        assert!(!config.is_configured());
     }
 
     // ============================================================================

--- a/src/git/diff.rs
+++ b/src/git/diff.rs
@@ -126,52 +126,36 @@ mod tests {
     // ============================================================================
 
     #[test]
-    fn test_line_diff_default() {
-        let diff = LineDiff::default();
-        assert_eq!(diff.added, 0);
-        assert_eq!(diff.deleted, 0);
+    fn test_line_diff_is_empty() {
+        assert!(LineDiff::default().is_empty());
+        assert!(
+            LineDiff {
+                added: 0,
+                deleted: 0
+            }
+            .is_empty()
+        );
+        assert!(
+            !LineDiff {
+                added: 5,
+                deleted: 0
+            }
+            .is_empty()
+        );
+        assert!(
+            !LineDiff {
+                added: 0,
+                deleted: 5
+            }
+            .is_empty()
+        );
     }
 
     #[test]
-    fn test_line_diff_is_empty_true() {
-        let diff = LineDiff {
-            added: 0,
-            deleted: 0,
-        };
-        assert!(diff.is_empty());
-    }
-
-    #[test]
-    fn test_line_diff_is_empty_false_added() {
-        let diff = LineDiff {
-            added: 5,
-            deleted: 0,
-        };
-        assert!(!diff.is_empty());
-    }
-
-    #[test]
-    fn test_line_diff_is_empty_false_deleted() {
-        let diff = LineDiff {
-            added: 0,
-            deleted: 5,
-        };
-        assert!(!diff.is_empty());
-    }
-
-    #[test]
-    fn test_line_diff_from_tuple() {
+    fn test_line_diff_tuple_roundtrip() {
         let diff: LineDiff = (10, 5).into();
         assert_eq!(diff.added, 10);
         assert_eq!(diff.deleted, 5);
-    }
-
-    #[test]
-    fn test_tuple_from_line_diff() {
-        let diff = LineDiff {
-            added: 10,
-            deleted: 5,
-        };
         let tuple: (usize, usize) = diff.into();
         assert_eq!(tuple, (10, 5));
     }

--- a/src/shell/paths.rs
+++ b/src/shell/paths.rs
@@ -254,31 +254,19 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_parse_nu_config_output_valid_path() {
-        let stdout = b"/home/user/.config/nushell\n";
+    fn test_parse_nu_config_output() {
         assert_eq!(
-            parse_nu_config_output(stdout),
+            parse_nu_config_output(b"/home/user/.config/nushell\n"),
             Some(PathBuf::from("/home/user/.config/nushell"))
         );
-    }
-
-    #[test]
-    fn test_parse_nu_config_output_trims_whitespace() {
-        let stdout = b"  /home/user/.config/nushell  \n";
+        // Trims whitespace
         assert_eq!(
-            parse_nu_config_output(stdout),
+            parse_nu_config_output(b"  /home/user/.config/nushell  \n"),
             Some(PathBuf::from("/home/user/.config/nushell"))
         );
-    }
-
-    #[test]
-    fn test_parse_nu_config_output_empty() {
+        // Empty / whitespace-only / invalid UTF-8
         assert_eq!(parse_nu_config_output(b""), None);
         assert_eq!(parse_nu_config_output(b"  \n"), None);
-    }
-
-    #[test]
-    fn test_parse_nu_config_output_invalid_utf8() {
         assert_eq!(parse_nu_config_output(&[0xFF, 0xFE]), None);
     }
 


### PR DESCRIPTION
Continuation of #1382. Deletes constructor/Default tests that only verify
struct fields initialize to None/0/empty, consolidates one-test-per-input
into single tests with debug snapshots, and converts remaining `contains()`
chains to inline snapshots.

12 files, net -320 lines.

> _This was written by Claude Code on behalf of max-sixty_