### PR TITLE
Rename no_delete_branch to keep_branch, add approval-declined tests

### DIFF
--- a/src/commands/select/mod.rs
+++ b/src/commands/select/mod.rs
@@ -325,7 +325,7 @@ pub fn handle_select(
                 // Safe removal: no force-delete (-D), no force-worktree (-f)
                 let result = handle_remove(
                     &branch_name,
-                    false, // no_delete_branch: delete branch (default behavior)
+                    false, // keep_branch: delete branch (default behavior)
                     false, // force_delete: no -D
                     false, // force_worktree: no -f
                     config,

--- a/src/commands/worktree/remove.rs
+++ b/src/commands/worktree/remove.rs
@@ -9,7 +9,7 @@ use crate::commands::repository_ext::{RemoveTarget, RepositoryCliExt};
 /// Remove a worktree by branch name.
 pub fn handle_remove(
     worktree_name: &str,
-    no_delete_branch: bool,
+    keep_branch: bool,
     force_delete: bool,
     force_worktree: bool,
     config: &UserConfig,
@@ -19,7 +19,7 @@ pub fn handle_remove(
     // Progress message is shown in handle_removed_worktree_output() after pre-remove hooks run
     repo.prepare_worktree_removal(
         RemoveTarget::Branch(worktree_name),
-        BranchDeletionMode::from_flags(no_delete_branch, force_delete),
+        BranchDeletionMode::from_flags(keep_branch, force_delete),
         force_worktree,
         config,
     )
@@ -30,7 +30,7 @@ pub fn handle_remove(
 /// This is the path-based removal that handles the "@" shorthand, including
 /// when HEAD is detached.
 pub fn handle_remove_current(
-    no_delete_branch: bool,
+    keep_branch: bool,
     force_delete: bool,
     force_worktree: bool,
     config: &UserConfig,
@@ -40,7 +40,7 @@ pub fn handle_remove_current(
     // Progress message is shown in handle_removed_worktree_output() after pre-remove hooks run
     repo.prepare_worktree_removal(
         RemoveTarget::Current,
-        BranchDeletionMode::from_flags(no_delete_branch, force_delete),
+        BranchDeletionMode::from_flags(keep_branch, force_delete),
         force_worktree,
         config,
     )

--- a/src/commands/worktree/types.rs
+++ b/src/commands/worktree/types.rs
@@ -137,7 +137,7 @@ impl SwitchPlan {
 
 /// How the branch should be handled after worktree removal.
 ///
-/// This enum replaces the previous `no_delete_branch: bool, force_delete: bool` pattern,
+/// This enum replaces the previous boolean flag pair,
 /// making the three valid states explicit and preventing invalid combinations.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BranchDeletionMode {
@@ -153,8 +153,8 @@ impl BranchDeletionMode {
     /// Create from CLI flags.
     ///
     /// `--no-delete-branch` takes precedence over `-D` (force delete).
-    pub fn from_flags(no_delete_branch: bool, force_delete: bool) -> Self {
-        if no_delete_branch {
+    pub fn from_flags(keep_branch: bool, force_delete: bool) -> Self {
+        if keep_branch {
             Self::Keep
         } else if force_delete {
             Self::ForceDelete

--- a/tests/integration_tests/approval_pty.rs
+++ b/tests/integration_tests/approval_pty.rs
@@ -12,6 +12,7 @@ use crate::common::pty::{build_pty_command, exec_cmd_in_pty_prompted};
 use crate::common::{TestRepo, add_pty_binary_path_filters, add_pty_filters, repo, wt_bin};
 use insta::assert_snapshot;
 use rstest::rstest;
+use std::path::Path;
 
 /// Execute wt in a PTY, waiting for the approval prompt before sending input.
 fn exec_wt_in_pty(
@@ -20,13 +21,17 @@ fn exec_wt_in_pty(
     env_vars: &[(String, String)],
     input: &str,
 ) -> (String, i32) {
-    let cmd = build_pty_command(
-        wt_bin().to_str().unwrap(),
-        args,
-        repo.root_path(),
-        env_vars,
-        None,
-    );
+    exec_wt_in_pty_cwd(repo.root_path(), args, env_vars, input)
+}
+
+/// Execute wt in a PTY from a specific directory.
+fn exec_wt_in_pty_cwd(
+    cwd: &Path,
+    args: &[&str],
+    env_vars: &[(String, String)],
+    input: &str,
+) -> (String, i32) {
+    let cmd = build_pty_command(wt_bin().to_str().unwrap(), args, cwd, env_vars, None);
     exec_cmd_in_pty_prompted(cmd, &[input], "[y/N")
 }
 
@@ -407,4 +412,89 @@ fn test_approval_prompt_remove_decline(repo: TestRepo) {
     approval_pty_settings(&repo).bind(|| {
         assert_snapshot!("approval_prompt_remove_decline", &output);
     });
+}
+
+#[rstest]
+fn test_approval_prompt_step_commit_decline(mut repo: TestRepo) {
+    // Remove origin so worktrunk uses directory name as project identifier
+    repo.run_git(&["remote", "remove", "origin"]);
+
+    // Add pre-commit hook to project config and commit it
+    repo.write_project_config(r#"pre-commit = "echo 'pre-commit hook'""#);
+    repo.commit("Add pre-commit config");
+
+    // Create a feature worktree
+    let feature_wt = repo.add_worktree("feature-commit");
+
+    // Make dirty changes in the feature worktree
+    std::fs::write(feature_wt.join("new-file.txt"), "new content").unwrap();
+
+    // Configure LLM commit generation
+    repo.write_test_config(
+        r#"
+[commit.generation]
+command = "cat >/dev/null && echo 'feat: test commit message'"
+"#,
+    );
+
+    let env_vars = test_env_vars_with_shell(&repo);
+
+    // Decline the pre-commit hook approval prompt
+    let (output, exit_code) =
+        exec_wt_in_pty_cwd(&feature_wt, &["step", "commit"], &env_vars, "n\n");
+
+    assert_eq!(
+        exit_code, 0,
+        "Commit should succeed even when hooks declined. Output:\n{output}"
+    );
+    assert!(
+        output.contains("Commands declined"),
+        "Should show 'Commands declined' message. Output:\n{output}"
+    );
+    assert!(
+        output.contains("committing without hooks"),
+        "Should indicate commit proceeds without hooks. Output:\n{output}"
+    );
+}
+
+#[rstest]
+fn test_approval_prompt_step_squash_decline(mut repo: TestRepo) {
+    // Remove origin so worktrunk uses directory name as project identifier
+    repo.run_git(&["remote", "remove", "origin"]);
+
+    // Add pre-commit hook to project config and commit it
+    repo.write_project_config(r#"pre-commit = "echo 'pre-commit hook'""#);
+    repo.commit("Add pre-commit config");
+
+    // Create a feature worktree with multiple commits ahead of main
+    let feature_wt = repo.add_worktree("feature-squash");
+    repo.commit_in_worktree(&feature_wt, "file1.txt", "content 1", "feat: first change");
+    repo.commit_in_worktree(&feature_wt, "file2.txt", "content 2", "feat: second change");
+
+    // Configure LLM commit generation
+    repo.write_test_config(
+        r#"
+[commit.generation]
+command = "cat >/dev/null && echo 'feat: squashed commit message'"
+"#,
+    );
+
+    let env_vars = test_env_vars_with_shell(&repo);
+
+    // Decline the pre-commit hook approval prompt
+    let (output, exit_code) =
+        exec_wt_in_pty_cwd(&feature_wt, &["step", "squash"], &env_vars, "n\n");
+
+    assert_eq!(
+        exit_code, 0,
+        "Squash should succeed even when hooks declined. Output:\n{output}"
+    );
+    assert!(
+        output.contains("Commands declined"),
+        "Should show 'Commands declined' message. Output:\n{output}"
+    );
+    assert!(
+        output.contains("squashing without hooks"),
+        "Should indicate squash proceeds without hooks. Output:\n{output}"
+    );
 }


### PR DESCRIPTION
Follow-up to #1388. Renames the negated `no_delete_branch` parameter to
positive `keep_branch` at function boundaries (`handle_remove`,
`handle_remove_current`, `BranchDeletionMode::from_flags`). Call sites in
`main.rs` continue passing `!delete_branch` — the CLI field name is tied
to clap's `--no-delete-branch` flag.

Adds PTY tests for the approval-declined code paths in `step_commit` and
`handle_squash` that were flagged as uncovered by codecov in #1388. These
cover the `if !approved { false }` branches where users decline hook
approval prompts.

> _This was written by Claude Code on behalf of @max-sixty_