### PR TITLE
ci: add Zola docs validation to PR checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -151,6 +151,7 @@ jobs:
       pull-requests: read
     outputs:
       cargo: ${{ steps.filter.outputs.cargo }}
+      docs: ${{ steps.filter.outputs.docs }}
     steps:
     - name: 📂 Checkout code
       uses: actions/checkout@v6
@@ -163,6 +164,9 @@ jobs:
             - 'Cargo.lock'
             - 'rust-toolchain.toml'
             - '.github/workflows/ci.yaml'
+          docs:
+            - 'docs/**'
+            - 'src/cli/mod.rs'
 
   msrv:
     runs-on: ubuntu-24.04
@@ -206,6 +210,23 @@ jobs:
       with:
         command: udeps
         args: --all-targets
+
+  check-docs:
+    runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.docs == 'true' || github.event_name == 'workflow_dispatch'
+    steps:
+    - name: 📂 Checkout code
+      uses: actions/checkout@v6
+
+    - name: Setup Zola
+      uses: taiki-e/install-action@v2.68.22
+      with:
+        tool: zola@0.22.1
+
+    - name: 🕷️ Build docs
+      run: zola build
+      working-directory: docs
 
   benchmarks:
     runs-on: ubuntu-24.04

--- a/.github/workflows/claude-ci-fix.yaml
+++ b/.github/workflows/claude-ci-fix.yaml
@@ -1,10 +1,10 @@
 name: claude-ci-fix
 # Runner versions pinned; see ci.yaml header comment for rationale.
 
-# Trigger when CI workflow fails on main
+# Trigger when CI or docs workflow fails on main
 on:
   workflow_run:
-    workflows: [ci]
+    workflows: [ci, publish-docs]
     types: [completed]
     branches: [main]
 

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -7,6 +7,7 @@ on:
       - main
     paths:
       - 'docs/**'
+      - 'src/cli/mod.rs'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
Broken internal anchor links in docs (like the `#command-approval` → `#security` fix in #1391) were only caught post-merge by `publish-docs`. This adds pre-merge validation and extends the auto-fix safety net.

**Changes:**
- New `check-docs` CI job runs `zola build` on PRs when `docs/**` or `src/cli/mod.rs` changes, catching broken anchors before merge
- `claude-ci-fix` now watches `publish-docs` failures in addition to `ci`, so docs build failures on main get auto-fixed
- `publish-docs` path filter extended to include `src/cli/mod.rs` (CLI help text is the source of truth for docs content)

> _This was written by Claude Code on behalf of @max-sixty_