### PR TITLE
feat: add github enterprise hostname parsing to wt switch logic

### DIFF
--- a/src/commands/worktree/switch.rs
+++ b/src/commands/worktree/switch.rs
@@ -75,8 +75,7 @@ fn resolve_remote_ref(
         progress_message(cformat!("Fetching {} {symbol}{number}...", ref_type.name()))
     );
 
-    let repo_root = repo.repo_path()?;
-    let info = provider.fetch_info(number, repo_root)?;
+    let info = provider.fetch_info(number, repo)?;
 
     // Display context with URL (as gutter under fetch progress)
     eprintln!("{}", format_with_gutter(&format_ref_context(&info), None));

--- a/src/git/remote_ref/github.rs
+++ b/src/git/remote_ref/github.rs
@@ -3,14 +3,13 @@
 //! Implements `RemoteRefProvider` for GitHub Pull Requests using the `gh` CLI.
 
 use std::io::ErrorKind;
-use std::path::Path;
 
 use anyhow::{Context, bail};
 use serde::Deserialize;
 
 use super::{PlatformData, RemoteRefInfo, RemoteRefProvider};
 use crate::git::error::GitError;
-use crate::git::{self, RefType};
+use crate::git::{self, RefType, Repository};
 use crate::shell_exec::Cmd;
 
 /// GitHub Pull Request provider.
@@ -22,8 +21,8 @@ impl RemoteRefProvider for GitHubProvider {
         RefType::Pr
     }
 
-    fn fetch_info(&self, number: u32, repo_root: &Path) -> anyhow::Result<RemoteRefInfo> {
-        fetch_pr_info(number, repo_root)
+    fn fetch_info(&self, number: u32, repo: &Repository) -> anyhow::Result<RemoteRefInfo> {
+        fetch_pr_info(number, repo)
     }
 
     fn ref_path(&self, number: u32) -> String {
@@ -77,12 +76,13 @@ struct GhOwner {
 }
 
 /// Fetch PR information from GitHub using the `gh` CLI.
-fn fetch_pr_info(pr_number: u32, repo_root: &Path) -> anyhow::Result<RemoteRefInfo> {
+fn fetch_pr_info(pr_number: u32, repo: &Repository) -> anyhow::Result<RemoteRefInfo> {
+    let repo_root = repo.repo_path()?;
+
     // Best-effort hostname extraction for GitHub Enterprise support.
     // Falls back to gh's default (github.com) if the remote URL can't be parsed.
-    let hostname = git::Repository::at(repo_root)
-        .ok()
-        .and_then(|repo| repo.primary_remote_url())
+    let hostname = repo
+        .primary_remote_url()
         .and_then(|url| git::GitRemoteUrl::parse(&url))
         .map(|parsed| parsed.host().to_string())
         .unwrap_or_else(|| "github.com".to_string());

--- a/src/git/remote_ref/gitlab.rs
+++ b/src/git/remote_ref/gitlab.rs
@@ -28,8 +28,8 @@ use anyhow::{Context, bail};
 use serde::Deserialize;
 
 use super::{PlatformData, RemoteRefInfo, RemoteRefProvider};
-use crate::git::RefType;
 use crate::git::error::GitError;
+use crate::git::{RefType, Repository};
 use crate::shell_exec::Cmd;
 
 /// GitLab Merge Request provider.
@@ -41,7 +41,8 @@ impl RemoteRefProvider for GitLabProvider {
         RefType::Mr
     }
 
-    fn fetch_info(&self, number: u32, repo_root: &Path) -> anyhow::Result<RemoteRefInfo> {
+    fn fetch_info(&self, number: u32, repo: &Repository) -> anyhow::Result<RemoteRefInfo> {
+        let repo_root = repo.repo_path()?;
         fetch_mr_info(number, repo_root)
     }
 

--- a/src/git/remote_ref/mod.rs
+++ b/src/git/remote_ref/mod.rs
@@ -40,7 +40,7 @@ pub use info::{PlatformData, RemoteRefInfo};
 
 use std::path::Path;
 
-use crate::git::RefType;
+use crate::git::{RefType, Repository};
 
 /// Provider trait for platform-specific PR/MR operations.
 ///
@@ -58,7 +58,7 @@ pub trait RemoteRefProvider {
     /// - The CLI tool is not installed or not authenticated
     /// - The ref doesn't exist
     /// - The JSON response is malformed
-    fn fetch_info(&self, number: u32, repo_root: &Path) -> anyhow::Result<RemoteRefInfo>;
+    fn fetch_info(&self, number: u32, repo: &Repository) -> anyhow::Result<RemoteRefInfo>;
 
     /// Get the git ref path for this ref (e.g., "pull/123/head" or "merge-requests/42/head").
     fn ref_path(&self, number: u32) -> String;


### PR DESCRIPTION
## Summary
- Fix `wt switch pr:<number>` for repositories hosted on GitHub Enterprise (or other non-`github.com` hosts) by passing `--hostname` to the `gh` CLI
- Extract the hostname from the repository's primary remote URL using the existing `GitRemoteUrl::parse()` utility, falling back to `github.com` if the URL can't be parsed
## Problem
When checking out a PR in a repository hosted on a GitHub Enterprise instance (e.g., `github.example.com`), the `gh api` call in `fetch_pr_info` did not specify which host to authenticate against. The `gh` CLI defaults to `github.com`, so PR checkout silently failed for any other GitHub host.
The `gh api` command accepts a `--hostname` flag to target a specific GitHub host, but it was not being used.
## Solution
This PR extracts the hostname from the repository's configured remote URL and passes it to `gh api --hostname`. The extraction is best-effort so if the remote URL can't be parsed for any reason, it falls back to `"github.com"`, preserving the existing behavior.
The hostname parsing reuses the existing `GitRemoteUrl::parse()` to support all remote URL formats (`https://`, `ssh://`, `git@`, `git://`, `http://`).
## Notes
I'm not that experienced in Rust, so I'm happy to implement any PR feedback and add tests if necessary.