### PR TITLE
docs: add Xcode DerivedData cleanup recipe

### DIFF
--- a/docs/content/tips-patterns.md
+++ b/docs/content/tips-patterns.md
@@ -267,6 +267,26 @@ To create a worktree and immediately attach:
 wt switch --create feature -x 'tmux attach -t {{ branch | sanitize }}'
 ```
 
+## Xcode DerivedData cleanup
+
+Clean up Xcode's DerivedData when removing a worktree. Each DerivedData directory contains an `info.plist` recording its project path — grep for the worktree path to find and remove the matching build cache:
+
+```toml
+# ~/.config/worktrunk/config.toml
+[post-remove]
+clean-derived = """
+  grep -rl {{ worktree_path }} \
+    ~/Library/Developer/Xcode/DerivedData/*/info.plist 2>/dev/null \
+  | while read plist; do
+      derived_dir=$(dirname "$plist")
+      rm -rf "$derived_dir"
+      echo "Cleaned DerivedData: $derived_dir"
+    done
+"""
+```
+
+This precisely targets only the DerivedData for the removed worktree, leaving caches for other worktrees and the main repository intact.
+
 ## Subdomain routing with Caddy
 <!-- Hand-tested 2026-03-07 -->
 

--- a/skills/worktrunk/reference/tips-patterns.md
+++ b/skills/worktrunk/reference/tips-patterns.md
@@ -256,6 +256,26 @@ To create a worktree and immediately attach:
 wt switch --create feature -x 'tmux attach -t {{ branch | sanitize }}'
 ```
 
+## Xcode DerivedData cleanup
+
+Clean up Xcode's DerivedData when removing a worktree. Each DerivedData directory contains an `info.plist` recording its project path — grep for the worktree path to find and remove the matching build cache:
+
+```toml
+# ~/.config/worktrunk/config.toml
+[post-remove]
+clean-derived = """
+  grep -rl {{ worktree_path }} \
+    ~/Library/Developer/Xcode/DerivedData/*/info.plist 2>/dev/null \
+  | while read plist; do
+      derived_dir=$(dirname "$plist")
+      rm -rf "$derived_dir"
+      echo "Cleaned DerivedData: $derived_dir"
+    done
+"""
+```
+
+This precisely targets only the DerivedData for the removed worktree, leaving caches for other worktrees and the main repository intact.
+
 ## Subdomain routing with Caddy
 <!-- Hand-tested 2026-03-07 -->
 


### PR DESCRIPTION
## Summary

- Add a `post-remove` hook recipe to Tips & Patterns that cleans up Xcode's DerivedData when removing a worktree
- Uses `grep -rl` on `info.plist` files to precisely match the removed worktree's build cache, avoiding collateral deletion of other worktrees' caches

## Context

Xcode's DerivedData directory names are hashed from the `.xcodeproj` path, making them hard to match by name alone. Each DerivedData directory contains an `info.plist` with a `WorkspacePath` field that records the original project path. This recipe leverages that to find and remove only the matching cache.

## Test plan

- [ ] Verify `test_command_pages_and_skill_files_are_in_sync` passes
- [ ] Verify the new section renders correctly on the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)