### PR TITLE
docs: add Xcode DerivedData cleanup recipe

### DIFF
--- a/docs/content/tips-patterns.md
+++ b/docs/content/tips-patterns.md
@@ -275,7 +275,7 @@ Clean up Xcode's DerivedData when removing a worktree. Each DerivedData director
 # ~/.config/worktrunk/config.toml
 [post-remove]
 clean-derived = """
-  grep -rl {{ worktree_path }} \
+  grep -Fl {{ worktree_path }} \
     ~/Library/Developer/Xcode/DerivedData/*/info.plist 2>/dev/null \
   | while read plist; do
       derived_dir=$(dirname "$plist")

--- a/skills/worktrunk/reference/tips-patterns.md
+++ b/skills/worktrunk/reference/tips-patterns.md
@@ -264,7 +264,7 @@ Clean up Xcode's DerivedData when removing a worktree. Each DerivedData director
 # ~/.config/worktrunk/config.toml
 [post-remove]
 clean-derived = """
-  grep -rl {{ worktree_path }} \
+  grep -Fl {{ worktree_path }} \
     ~/Library/Developer/Xcode/DerivedData/*/info.plist 2>/dev/null \
   | while read plist; do
       derived_dir=$(dirname "$plist")


### PR DESCRIPTION
## Summary

For iOS developers, this PR add a `post-remove` hook recipe to Tips & Patterns that cleans up Xcode's DerivedData when removing a worktree.

## Context

Xcode's DerivedData directory names are hashed from the `.xcodeproj` path, making them hard to match by name alone. Each DerivedData directory contains an `info.plist` with a `WorkspacePath` field that records the original project path. This recipe leverages that to find and remove only the matching cache.