### PR TITLE
fix: replace std::process::exit() with error returns in Windows paths

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -467,9 +467,10 @@ fn handle_select_command(branches: bool, remotes: bool) -> anyhow::Result<()> {
 
 #[cfg(not(unix))]
 fn handle_select_command(_branches: bool, _remotes: bool) -> anyhow::Result<()> {
+    use worktrunk::git::WorktrunkError;
     warn_select_deprecated();
     print_windows_picker_unavailable();
-    std::process::exit(1);
+    Err(WorktrunkError::AlreadyDisplayed { exit_code: 1 }.into())
 }
 
 struct SwitchCommandArgs {
@@ -499,11 +500,12 @@ fn handle_switch_command(spec: SwitchCommandArgs) -> anyhow::Result<()> {
 
                 #[cfg(not(unix))]
                 {
+                    use worktrunk::git::WorktrunkError;
                     // Suppress unused variable warnings on Windows
                     let _ = (spec.branches, spec.remotes);
 
                     print_windows_picker_unavailable();
-                    std::process::exit(2);
+                    return Err(WorktrunkError::AlreadyDisplayed { exit_code: 2 }.into());
                 }
             };
 


### PR DESCRIPTION
The two Windows-only code paths (`handle_select_command` and `handle_switch_command`) called `std::process::exit()` directly, bypassing destructors, cleanup, and the centralized error handling in `main()`. Replace with `WorktrunkError::AlreadyDisplayed` returns — the established pattern for "message already printed, just exit with this code". Exit codes (1 and 2) are preserved.

> _This was written by Claude Code on behalf of @max-sixty_