### PR TITLE
docs(list): rewrite LLM summaries section

### DIFF
--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -119,10 +119,7 @@ CI indicators are clickable links to the PR or pipeline page. Any CI dot appears
 
 ### LLM summaries (experimental)
 
-With `--full`, `summary = true`, and a [`commit.generation`](@/config.md#commit) command configured, the Summary column shows an LLM-generated one-line description of each branch's changes relative to the default branch.
-
-Disabled by default — when enabled, each branch's diff is sent to the configured LLM for summarization. Results are cached until the diff changes.
-<!-- TODO: promote this feature more prominently once it's been tested in the wild -->
+Reuses the [`commit.generation`](@/config.md#commit) command — the same LLM that generates commit messages. Enable with `summary = true` in `[list]` config. Results are cached until the branch's diff changes.
 
 ## Status symbols
 

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -91,10 +91,7 @@ CI indicators are clickable links to the PR or pipeline page. Any CI dot appears
 
 ### LLM summaries (experimental)
 
-With `--full`, `summary = true`, and a [`commit.generation`](https://worktrunk.dev/config/#commit) command configured, the Summary column shows an LLM-generated one-line description of each branch's changes relative to the default branch.
-
-Disabled by default — when enabled, each branch's diff is sent to the configured LLM for summarization. Results are cached until the diff changes.
-<!-- TODO: promote this feature more prominently once it's been tested in the wild -->
+Reuses the [`commit.generation`](https://worktrunk.dev/config/#commit) command — the same LLM that generates commit messages. Enable with `summary = true` in `[list]` config. Results are cached until the branch's diff changes.
 
 ## Status symbols
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -547,10 +547,7 @@ CI indicators are clickable links to the PR or pipeline page. Any CI dot appears
 
 ### LLM summaries (experimental)
 
-With `--full`, `summary = true`, and a [`commit.generation`](@/config.md#commit) command configured, the Summary column shows an LLM-generated one-line description of each branch's changes relative to the default branch.
-
-Disabled by default — when enabled, each branch's diff is sent to the configured LLM for summarization. Results are cached until the diff changes.
-<!-- TODO: promote this feature more prominently once it's been tested in the wild -->
+Reuses the [`commit.generation`](@/config.md#commit) command — the same LLM that generates commit messages. Enable with `summary = true` in `[list]` config. Results are cached until the branch's diff changes.
 
 ## Status symbols
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -136,9 +136,7 @@ CI indicators are clickable links to the PR or pipeline page. Any CI dot appears
 
 [32mLLM summaries (experimental)[0m
 
-With [2m--full[0m, [2msummary = true[0m, and a [2mcommit.generation[0m command configured, the Summary column shows an LLM-generated one-line description of each branch's changes relative to the default branch.
-
-Disabled by default — when enabled, each branch's diff is sent to the configured LLM for summarization. Results are cached until the diff changes.
+Reuses the [2mcommit.generation[0m command — the same LLM that generates commit messages. Enable with [2msummary = true[0m in [2m[list][0m config. Results are cached until the branch's diff changes.
 
 [1m[32mStatus symbols[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -151,12 +151,9 @@ get CI status detection. Results are cached for 30-60 seconds; use [2mwt config
 
 [32mLLM summaries (experimental)[0m
 
-With [2m--full[0m, [2msummary = true[0m, and a [2mcommit.generation[0m command configured, the 
-Summary column shows an LLM-generated one-line description of each branch's 
-changes relative to the default branch.
-
-Disabled by default — when enabled, each branch's diff is sent to the configured
- LLM for summarization. Results are cached until the diff changes.
+Reuses the [2mcommit.generation[0m command — the same LLM that generates commit 
+messages. Enable with [2msummary = true[0m in [2m[list][0m config. Results are cached until 
+the branch's diff changes.
 
 [1m[32mStatus symbols[0m
 


### PR DESCRIPTION
Remove the TODO ("promote this feature more prominently once it's been tested in the wild") since LLM summaries are now on the homepage. Tighten the subsection — the prerequisites are already in the Columns table above, so the text now focuses on the mechanism (reuses `commit.generation`), how to enable (`summary = true`), and caching behavior.

> _This was written by Claude Code on behalf of @max-sixty_