### PR TITLE
Unify timeout model for list and switch picker

### DIFF
--- a/benches/list.rs
+++ b/benches/list.rs
@@ -372,54 +372,12 @@ fn bench_real_repo_many_branches(c: &mut Criterion) {
     group.finish();
 }
 
-/// Benchmark the effect of command timeout on GH #461 scenario.
-///
-/// Compares `wt list --branches` with and without the 500ms timeout.
-/// The timeout kills slow git commands (merge-tree, rev-list) that would
-/// otherwise block the TUI for seconds.
-fn bench_timeout_effect(c: &mut Criterion) {
-    let mut group = c.benchmark_group("timeout_effect");
-    group.measurement_time(std::time::Duration::from_secs(60));
-    group.sample_size(10);
-
-    let binary = get_release_binary();
-
-    // Set up workspace once for both benchmarks
-    let temp = tempfile::tempdir().unwrap();
-    let workspace_main = setup_rust_workspace_with_branches(&temp, 50);
-
-    // Without timeout (baseline)
-    group.bench_function("no_timeout", |b| {
-        b.iter(|| {
-            Command::new(binary)
-                .args(["list", "--branches"])
-                .current_dir(&workspace_main)
-                .output()
-                .unwrap();
-        });
-    });
-
-    // With 500ms timeout (GH #461 fix)
-    group.bench_function("timeout_500ms", |b| {
-        b.iter(|| {
-            Command::new(binary)
-                .args(["list", "--branches"])
-                .env("WORKTRUNK_COMMAND_TIMEOUT_MS", "500")
-                .current_dir(&workspace_main)
-                .output()
-                .unwrap();
-        });
-    });
-
-    group.finish();
-}
-
 criterion_group! {
     name = benches;
     config = Criterion::default()
         .sample_size(30)
         .measurement_time(std::time::Duration::from_secs(15))
         .warm_up_time(std::time::Duration::from_secs(3));
-    targets = bench_skeleton, bench_complete, bench_worktree_scaling, bench_real_repo, bench_many_branches, bench_divergent_branches, bench_real_repo_many_branches, bench_timeout_effect
+    targets = bench_skeleton, bench_complete, bench_worktree_scaling, bench_real_repo, bench_many_branches, bench_divergent_branches, bench_real_repo_many_branches
 }
 criterion_main!(benches);

--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -54,6 +54,9 @@
 # branches = false   # Include branches without worktrees (--branches)
 # remotes = false    # Include remote-only branches (--remotes)
 #
+# task-timeout-ms = 0   # Kill individual git commands after N ms; 0 disables
+# timeout-ms = 0        # Wall-clock budget for the entire collect phase; 0 disables
+#
 # ### Commit
 #
 # Shared by `wt step commit`, `wt step squash`, and `wt merge`.
@@ -81,9 +84,9 @@
 # # Pager command for diff preview (overrides git's core.pager)
 # # pager = "delta --paging=never"
 #
-# # Timeout (ms) for git commands during picker loading (default: 200)
-# # Lower values show the TUI faster; 0 disables timeouts
-# # timeout-ms = 200
+# # Wall-clock budget (ms) for picker data collection (default: 500)
+# # Tasks still running when the budget expires are abandoned; 0 disables
+# # timeout-ms = 500
 #
 # ### Aliases
 #

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -126,6 +126,9 @@ summary = false    # Enable LLM branch summaries (requires [commit.generation])
 full = false       # Show CI, main…± diffstat, and LLM summaries (--full)
 branches = false   # Include branches without worktrees (--branches)
 remotes = false    # Include remote-only branches (--remotes)
+
+task-timeout-ms = 0   # Kill individual git commands after N ms; 0 disables
+timeout-ms = 0        # Wall-clock budget for the entire collect phase; 0 disables
 ```
 
 ### Commit
@@ -160,9 +163,9 @@ no-cd = true       # Skip directory change after switching (--cd to override)
 # Pager command for diff preview (overrides git's core.pager)
 # pager = "delta --paging=never"
 
-# Timeout (ms) for git commands during picker loading (default: 200)
-# Lower values show the TUI faster; 0 disables timeouts
-# timeout-ms = 200
+# Wall-clock budget (ms) for picker data collection (default: 500)
+# Tasks still running when the budget expires are abandoned; 0 disables
+# timeout-ms = 500
 ```
 
 ### Aliases

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -117,6 +117,9 @@ summary = false    # Enable LLM branch summaries (requires [commit.generation])
 full = false       # Show CI, main…± diffstat, and LLM summaries (--full)
 branches = false   # Include branches without worktrees (--branches)
 remotes = false    # Include remote-only branches (--remotes)
+
+task-timeout-ms = 0   # Kill individual git commands after N ms; 0 disables
+timeout-ms = 0        # Wall-clock budget for the entire collect phase; 0 disables
 ```
 
 ### Commit
@@ -151,9 +154,9 @@ no-cd = true       # Skip directory change after switching (--cd to override)
 # Pager command for diff preview (overrides git's core.pager)
 # pager = "delta --paging=never"
 
-# Timeout (ms) for git commands during picker loading (default: 200)
-# Lower values show the TUI faster; 0 disables timeouts
-# timeout-ms = 200
+# Wall-clock budget (ms) for picker data collection (default: 500)
+# Tasks still running when the budget expires are abandoned; 0 disables
+# timeout-ms = 500
 ```
 
 ### Aliases

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1636,6 +1636,9 @@ summary = false    # Enable LLM branch summaries (requires [commit.generation])
 full = false       # Show CI, main…± diffstat, and LLM summaries (--full)
 branches = false   # Include branches without worktrees (--branches)
 remotes = false    # Include remote-only branches (--remotes)
+
+task-timeout-ms = 0   # Kill individual git commands after N ms; 0 disables
+timeout-ms = 0        # Wall-clock budget for the entire collect phase; 0 disables
 ```
 
 ### Commit
@@ -1670,9 +1673,9 @@ no-cd = true       # Skip directory change after switching (--cd to override)
 # Pager command for diff preview (overrides git's core.pager)
 # pager = "delta --paging=never"
 
-# Timeout (ms) for git commands during picker loading (default: 200)
-# Lower values show the TUI faster; 0 disables timeouts
-# timeout-ms = 200
+# Wall-clock budget (ms) for picker data collection (default: 500)
+# Tasks still running when the budget expires are abandoned; 0 disables
+# timeout-ms = 500
 ```
 
 ### Aliases

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -208,9 +208,13 @@ pub enum ShowConfig {
         show_remotes: bool,
         skip_tasks: HashSet<TaskKind>,
         command_timeout: Option<std::time::Duration>,
+        /// Wall-clock deadline for the collect phase. `None` uses the default
+        /// [`DRAIN_TIMEOUT`](results::DRAIN_TIMEOUT) and shows a warning on timeout.
+        collect_deadline: Option<std::time::Instant>,
     },
     /// Raw CLI flags; config resolution deferred to collect's parallel phase
     /// so project_identifier runs concurrently with other git operations.
+    /// Timeouts are resolved from config internally.
     DeferredToParallel {
         cli_branches: bool,
         cli_remotes: bool,
@@ -229,16 +233,12 @@ pub enum ShowConfig {
 /// skipping expensive merge-base operations for branches far behind the default branch.
 /// This dramatically improves performance for repos with many stale branches.
 ///
-/// When `collect_deadline` is `Some`, drain stops at the deadline and returns partial data
-/// silently (budget-based truncation is expected). When `None`, uses the default
-/// [`DRAIN_TIMEOUT`](results::DRAIN_TIMEOUT) and shows a user-facing warning on timeout.
 pub fn collect(
     repo: &Repository,
     show_config: ShowConfig,
     show_progress: bool,
     render_table: bool,
     skip_expensive_for_stale: bool,
-    collect_deadline: Option<std::time::Instant>,
 ) -> anyhow::Result<Option<super::model::ListData>> {
     use super::progressive_table::ProgressiveTable;
     worktrunk::shell_exec::trace_instant("List collect started");
@@ -330,47 +330,59 @@ pub fn collect(
     let url_template = url_template_cell.into_inner().unwrap();
 
     // Resolve show flags: merge CLI overrides with config (warmed in parallel phase)
-    let (show_branches, show_remotes, skip_tasks, command_timeout) = match show_config {
-        ShowConfig::Resolved {
-            show_branches,
-            show_remotes,
-            skip_tasks,
-            command_timeout,
-        } => (show_branches, show_remotes, skip_tasks, command_timeout),
-        ShowConfig::DeferredToParallel {
-            cli_branches,
-            cli_remotes,
-            cli_full,
-        } => {
-            let config = repo.config();
-            let show_branches = cli_branches || config.list.branches();
-            let show_remotes = cli_remotes || config.list.remotes();
-            let show_full = cli_full || config.list.full();
-            let skip_tasks: HashSet<TaskKind> = if show_full {
-                HashSet::new()
-            } else {
-                [
-                    TaskKind::BranchDiff,
-                    TaskKind::CiStatus,
-                    TaskKind::WorkingTreeConflicts,
-                    TaskKind::SummaryGenerate,
-                ]
-                .into_iter()
-                .collect()
-            };
-            // Resolve timeout from merged config (--full disables timeout)
-            let command_timeout = if show_full {
-                None
-            } else {
-                config
-                    .list
-                    .timeout_ms()
-                    .filter(|&ms| ms > 0) // 0 means "no timeout" (explicit disable)
-                    .map(std::time::Duration::from_millis)
-            };
-            (show_branches, show_remotes, skip_tasks, command_timeout)
-        }
-    };
+    let (show_branches, show_remotes, skip_tasks, command_timeout, collect_deadline) =
+        match show_config {
+            ShowConfig::Resolved {
+                show_branches,
+                show_remotes,
+                skip_tasks,
+                command_timeout,
+                collect_deadline,
+            } => (
+                show_branches,
+                show_remotes,
+                skip_tasks,
+                command_timeout,
+                collect_deadline,
+            ),
+            ShowConfig::DeferredToParallel {
+                cli_branches,
+                cli_remotes,
+                cli_full,
+            } => {
+                let config = repo.config();
+                let show_branches = cli_branches || config.list.branches();
+                let show_remotes = cli_remotes || config.list.remotes();
+                let show_full = cli_full || config.list.full();
+                let skip_tasks: HashSet<TaskKind> = if show_full {
+                    HashSet::new()
+                } else {
+                    [
+                        TaskKind::BranchDiff,
+                        TaskKind::CiStatus,
+                        TaskKind::WorkingTreeConflicts,
+                        TaskKind::SummaryGenerate,
+                    ]
+                    .into_iter()
+                    .collect()
+                };
+                // Resolve timeouts from merged config (--full disables both)
+                let (command_timeout, collect_deadline) = if show_full {
+                    (None, None)
+                } else {
+                    let task_timeout = config.list.task_timeout();
+                    let deadline = config.list.timeout().map(|d| std::time::Instant::now() + d);
+                    (task_timeout, deadline)
+                };
+                (
+                    show_branches,
+                    show_remotes,
+                    skip_tasks,
+                    command_timeout,
+                    collect_deadline,
+                )
+            }
+        };
 
     // Filter local branches to those without worktrees (CPU-only, no git commands)
     let branches_without_worktrees = if show_branches {

--- a/src/commands/list/mod.rs
+++ b/src/commands/list/mod.rs
@@ -178,7 +178,6 @@ pub fn handle_list(
         show_progress,
         render_table,
         skip_expensive_for_stale,
-        None, // no deadline — wt list waits for all results
     )?;
 
     let Some(ListData { items, .. }) = list_data else {

--- a/src/commands/select/mod.rs
+++ b/src/commands/select/mod.rs
@@ -10,7 +10,7 @@ mod summary;
 
 use std::io::IsTerminal;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 use anyhow::Context;
 use dashmap::DashMap;
@@ -70,19 +70,11 @@ pub fn handle_select(
     .into_iter()
     .collect();
 
-    // Configurable timeout for git commands to show TUI faster on large repos.
-    // Operations that timeout fail silently (data not shown), but TUI stays responsive.
-    let command_timeout = config.switch_picker.picker_command_timeout();
+    // Per-task command timeout from shared [list] config.
+    let command_timeout = config.list.task_timeout();
 
-    // Wall-clock budget for the entire collect phase. Tasks that complete within
-    // the budget contribute data; tasks still running when it expires are abandoned.
-    // This caps total latency regardless of worktree count or filesystem speed.
-    const DEFAULT_COLLECT_BUDGET_MS: u64 = 500;
-    let budget_ms: u64 = std::env::var("WORKTRUNK_PICKER_BUDGET_MS")
-        .ok()
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(DEFAULT_COLLECT_BUDGET_MS);
-    let collect_deadline = Some(Instant::now() + Duration::from_millis(budget_ms));
+    // Wall-clock budget for the entire collect phase (default: 500ms).
+    let collect_deadline = config.switch_picker.timeout().map(|d| Instant::now() + d);
 
     let Some(list_data) = collect::collect(
         &repo,
@@ -91,11 +83,11 @@ pub fn handle_select(
             show_remotes,
             skip_tasks: skip_tasks.clone(),
             command_timeout,
+            collect_deadline,
         },
         false, // show_progress (no progress bars)
         false, // render_table (select renders its own UI)
         true,  // skip_expensive_for_stale (faster for repos with many stale branches)
-        collect_deadline,
     )?
     else {
         return Ok(());

--- a/src/config/user/resolved.rs
+++ b/src/config/user/resolved.rs
@@ -21,7 +21,7 @@ use super::sections::{
 /// let squash = resolved.merge.squash();                     // bool, default applied
 /// let stage = resolved.commit.stage();                      // StageMode, default applied
 /// let pager = resolved.switch_picker.pager();               // Option<&str>
-/// let timeout = resolved.switch_picker.picker_command_timeout(); // Option<Duration>
+/// let timeout = resolved.switch_picker.timeout();               // Option<Duration>
 /// let no_cd = resolved.switch.no_cd();                       // bool, default applied
 /// ```
 #[derive(Debug, Clone, PartialEq)]

--- a/src/config/user/sections.rs
+++ b/src/config/user/sections.rs
@@ -135,10 +135,17 @@ pub struct ListConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub summary: Option<bool>,
 
-    /// (Experimental) Per-task timeout in milliseconds.
-    /// When set to a positive value, git operations that exceed this timeout are terminated.
-    /// Timed-out tasks show defaults in the table. Set to 0 to explicitly disable timeout
+    /// Per-task timeout in milliseconds.
+    /// Kills individual git commands that exceed this duration. Applies to both
+    /// `wt list` and the `wt switch` picker. Set to 0 to explicitly disable
     /// (useful to override a global setting). Disabled when --full is used.
+    #[serde(rename = "task-timeout-ms", skip_serializing_if = "Option::is_none")]
+    pub task_timeout_ms: Option<u64>,
+
+    /// Wall-clock budget for the entire collect phase in milliseconds.
+    /// Tasks that complete within the budget contribute data; tasks still
+    /// running when it expires are abandoned silently. Set to 0 to disable.
+    /// Disabled when --full is used. Default: no budget (wait for all results).
     #[serde(rename = "timeout-ms", skip_serializing_if = "Option::is_none")]
     pub timeout_ms: Option<u64>,
 }
@@ -164,9 +171,20 @@ impl ListConfig {
         self.summary.unwrap_or(false)
     }
 
-    /// Per-task timeout in milliseconds (default: None)
-    pub fn timeout_ms(&self) -> Option<u64> {
+    /// Per-task command timeout (default: None — no per-command timeout).
+    /// Returns `None` when disabled (task_timeout_ms = 0 or unset).
+    pub fn task_timeout(&self) -> Option<std::time::Duration> {
+        self.task_timeout_ms
+            .filter(|&ms| ms > 0)
+            .map(std::time::Duration::from_millis)
+    }
+
+    /// Wall-clock budget for the collect phase (default: None — no budget).
+    /// Returns `None` when disabled (timeout_ms = 0 or unset).
+    pub fn timeout(&self) -> Option<std::time::Duration> {
         self.timeout_ms
+            .filter(|&ms| ms > 0)
+            .map(std::time::Duration::from_millis)
     }
 }
 
@@ -177,6 +195,7 @@ impl Merge for ListConfig {
             branches: other.branches.or(self.branches),
             remotes: other.remotes.or(self.remotes),
             summary: other.summary.or(self.summary),
+            task_timeout_ms: other.task_timeout_ms.or(self.task_timeout_ms),
             timeout_ms: other.timeout_ms.or(self.timeout_ms),
         }
     }
@@ -320,14 +339,14 @@ pub struct SwitchPickerConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pager: Option<String>,
 
-    /// Picker command timeout in milliseconds.
+    /// Wall-clock budget for picker data collection in milliseconds.
     ///
-    /// Controls how long to wait for git commands when populating the picker.
-    /// Commands that exceed this timeout fail silently (data not shown).
+    /// Controls how long the picker waits for git data before displaying.
+    /// Tasks still running when the budget expires are abandoned.
     ///
-    /// - Unset: 200ms default
-    /// - `0`: No timeout
-    /// - Positive value: Custom timeout in milliseconds
+    /// - Unset: 500ms default
+    /// - `0`: No budget (wait for all results)
+    /// - Positive value: Custom budget in milliseconds
     #[serde(rename = "timeout-ms", skip_serializing_if = "Option::is_none")]
     pub timeout_ms: Option<u64>,
 }
@@ -338,17 +357,13 @@ impl SwitchPickerConfig {
         self.pager.as_deref()
     }
 
-    /// Command timeout for the picker.
-    ///
-    /// Returns `None` when timeout is disabled (timeout_ms = 0),
-    /// the configured timeout, or the 200ms default. The 200ms default
-    /// aggressively cuts tail latency so the TUI appears near-instantly;
-    /// users on large repos can raise it via `timeout-ms`.
-    pub fn picker_command_timeout(&self) -> Option<std::time::Duration> {
+    /// Wall-clock budget for picker data collection (default: 500ms).
+    /// Returns `None` when disabled (timeout_ms = 0).
+    pub fn timeout(&self) -> Option<std::time::Duration> {
         match self.timeout_ms {
             Some(0) => None,
             Some(ms) => Some(std::time::Duration::from_millis(ms)),
-            None => Some(std::time::Duration::from_millis(200)),
+            None => Some(std::time::Duration::from_millis(500)),
         }
     }
 }

--- a/src/config/user/tests.rs
+++ b/src/config/user/tests.rs
@@ -309,7 +309,8 @@ fn test_list_config_serde() {
         branches: Some(false),
         remotes: None,
         summary: None,
-        timeout_ms: Some(500),
+        task_timeout_ms: Some(500),
+        timeout_ms: None,
     };
     let json = serde_json::to_string(&config).unwrap();
     let parsed: ListConfig = serde_json::from_str(&json).unwrap();
@@ -317,7 +318,8 @@ fn test_list_config_serde() {
     assert_eq!(parsed.branches, Some(false));
     assert_eq!(parsed.remotes, None);
     assert_eq!(parsed.summary, None);
-    assert_eq!(parsed.timeout_ms, Some(500));
+    assert_eq!(parsed.task_timeout_ms, Some(500));
+    assert_eq!(parsed.timeout_ms, None);
 }
 
 #[test]
@@ -522,14 +524,16 @@ fn test_merge_list_config() {
         branches: Some(false),
         remotes: None,
         summary: Some(true),
-        timeout_ms: Some(1000),
+        task_timeout_ms: Some(1000),
+        timeout_ms: Some(2000),
     };
     let override_config = ListConfig {
-        full: None,           // Should fall back to base
-        branches: Some(true), // Should override
-        remotes: Some(true),  // Should override (base was None)
-        summary: None,        // Should fall back to base
-        timeout_ms: None,     // Should fall back to base
+        full: None,            // Should fall back to base
+        branches: Some(true),  // Should override
+        remotes: Some(true),   // Should override (base was None)
+        summary: None,         // Should fall back to base
+        task_timeout_ms: None, // Should fall back to base
+        timeout_ms: None,      // Should fall back to base
     };
 
     let merged = base.merge_with(&override_config);
@@ -537,7 +541,8 @@ fn test_merge_list_config() {
     assert_eq!(merged.branches, Some(true)); // From override
     assert_eq!(merged.remotes, Some(true)); // From override
     assert_eq!(merged.summary, Some(true)); // From base
-    assert_eq!(merged.timeout_ms, Some(1000)); // From base
+    assert_eq!(merged.task_timeout_ms, Some(1000)); // From base
+    assert_eq!(merged.timeout_ms, Some(2000)); // From base
 }
 
 #[test]
@@ -956,7 +961,8 @@ fn test_list_config_accessor_methods_defaults() {
     assert!(!config.full());
     assert!(!config.branches());
     assert!(!config.remotes());
-    assert!(config.timeout_ms().is_none());
+    assert!(config.task_timeout().is_none());
+    assert!(config.timeout().is_none());
 }
 
 #[test]
@@ -966,13 +972,21 @@ fn test_list_config_accessor_methods_with_values() {
         branches: Some(true),
         remotes: Some(false),
         summary: Some(true),
-        timeout_ms: Some(5000),
+        task_timeout_ms: Some(5000),
+        timeout_ms: Some(3000),
     };
     assert!(config.full());
     assert!(config.branches());
     assert!(!config.remotes());
     assert!(config.summary());
-    assert_eq!(config.timeout_ms(), Some(5000));
+    assert_eq!(
+        config.task_timeout(),
+        Some(std::time::Duration::from_millis(5000))
+    );
+    assert_eq!(
+        config.timeout(),
+        Some(std::time::Duration::from_millis(3000))
+    );
 }
 
 #[test]
@@ -1035,20 +1049,20 @@ fn test_switch_picker_config_accessor_methods() {
 
     let config = SwitchPickerConfig::default();
     assert!(config.pager().is_none());
-    // Default timeout is 200ms
+    // Default wall-clock budget is 500ms
     assert_eq!(
-        config.picker_command_timeout(),
-        Some(std::time::Duration::from_millis(200))
+        config.timeout(),
+        Some(std::time::Duration::from_millis(500))
     );
 
     let config = SwitchPickerConfig {
         pager: Some("delta --paging=never".to_string()),
-        timeout_ms: Some(500),
+        timeout_ms: Some(1000),
     };
     assert_eq!(config.pager(), Some("delta --paging=never"));
     assert_eq!(
-        config.picker_command_timeout(),
-        Some(std::time::Duration::from_millis(500))
+        config.timeout(),
+        Some(std::time::Duration::from_millis(1000))
     );
 }
 
@@ -1060,7 +1074,7 @@ fn test_switch_picker_timeout_zero_disables() {
         timeout_ms: Some(0),
         ..Default::default()
     };
-    assert!(config.picker_command_timeout().is_none());
+    assert!(config.timeout().is_none());
 }
 
 #[test]
@@ -1069,8 +1083,8 @@ fn test_switch_picker_timeout_none_uses_default() {
 
     let config = SwitchPickerConfig::default();
     assert_eq!(
-        config.picker_command_timeout(),
-        Some(std::time::Duration::from_millis(200))
+        config.timeout(),
+        Some(std::time::Duration::from_millis(500))
     );
 }
 
@@ -1243,8 +1257,8 @@ fn test_switch_picker_fallback_from_select() {
     // timeout_ms not available from select, so default applies
     assert_eq!(picker.timeout_ms, None);
     assert_eq!(
-        picker.picker_command_timeout(),
-        Some(std::time::Duration::from_millis(200))
+        picker.timeout(),
+        Some(std::time::Duration::from_millis(500))
     );
 }
 

--- a/tests/integration_tests/list_config.rs
+++ b/tests/integration_tests/list_config.rs
@@ -376,11 +376,11 @@ url = "http://localhost:8080/{{ branch }}"
     assert_eq!(url, "http://localhost:8080/main");
 }
 
-/// Test that timeout-ms config option is parsed correctly.
+/// Test that task-timeout-ms config option is parsed correctly.
 /// We use a very short timeout (1ms) to trigger timeouts.
 #[rstest]
 fn test_list_config_timeout_triggers_timeouts(repo: TestRepo, temp_home: TempDir) {
-    // Create user config with a very short timeout
+    // Create user config with a very short per-task timeout
     let global_config_dir = temp_home.path().join(".config").join("worktrunk");
     fs::create_dir_all(&global_config_dir).unwrap();
     fs::write(
@@ -388,7 +388,7 @@ fn test_list_config_timeout_triggers_timeouts(repo: TestRepo, temp_home: TempDir
         r#"worktree-path = "../{{ repo }}.{{ branch }}"
 
 [projects."repo".list]
-timeout-ms = 1
+task-timeout-ms = 1
 "#,
     )
     .unwrap();
@@ -409,10 +409,10 @@ timeout-ms = 1
     );
 }
 
-/// Test that timeout-ms = 0 explicitly disables timeout.
+/// Test that task-timeout-ms = 0 explicitly disables timeout.
 #[rstest]
 fn test_list_config_timeout_zero_means_no_timeout(repo: TestRepo, temp_home: TempDir) {
-    // Create user config with timeout-ms = 0
+    // Create user config with task-timeout-ms = 0
     let global_config_dir = temp_home.path().join(".config").join("worktrunk");
     fs::create_dir_all(&global_config_dir).unwrap();
     fs::write(
@@ -420,7 +420,7 @@ fn test_list_config_timeout_zero_means_no_timeout(repo: TestRepo, temp_home: Tem
         r#"worktree-path = "../{{ repo }}.{{ branch }}"
 
 [projects."repo".list]
-timeout-ms = 0
+task-timeout-ms = 0
 "#,
     )
     .unwrap();
@@ -433,18 +433,18 @@ timeout-ms = 0
     let output = cmd.output().unwrap();
     let stderr = String::from_utf8_lossy(&output.stderr);
 
-    // With timeout-ms = 0, there should be no timeout
+    // With task-timeout-ms = 0, there should be no timeout
     assert!(
         !stderr.contains("timed out"),
-        "Expected no timeout message with timeout-ms = 0, but got: {}",
+        "Expected no timeout message with task-timeout-ms = 0, but got: {}",
         stderr
     );
 }
 
-/// Test that --full disables the timeout.
+/// Test that --full disables the task timeout.
 #[rstest]
 fn test_list_config_timeout_disabled_with_full(repo: TestRepo, temp_home: TempDir) {
-    // Create user config with a very short timeout
+    // Create user config with a very short per-task timeout
     let global_config_dir = temp_home.path().join(".config").join("worktrunk");
     fs::create_dir_all(&global_config_dir).unwrap();
     fs::write(
@@ -452,7 +452,7 @@ fn test_list_config_timeout_disabled_with_full(repo: TestRepo, temp_home: TempDi
         r#"worktree-path = "../{{ repo }}.{{ branch }}"
 
 [projects."repo".list]
-timeout-ms = 1
+task-timeout-ms = 1
 "#,
     )
     .unwrap();

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -113,6 +113,9 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# branches = false   # Include branches without worktrees (--branches)[0m
 [107m [0m [2m# remotes = false    # Include remote-only branches (--remotes)[0m
 [107m [0m [2m#[0m
+[107m [0m [2m# task-timeout-ms = 0   # Kill individual git commands after N ms; 0 disables[0m
+[107m [0m [2m# timeout-ms = 0        # Wall-clock budget for the entire collect phase; 0 disables[0m
+[107m [0m [2m#[0m
 [107m [0m [2m# ### Commit[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# Shared by `wt step commit`, `wt step squash`, and `wt merge`.[0m
@@ -140,9 +143,9 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# # Pager command for diff preview (overrides git's core.pager)[0m
 [107m [0m [2m# # pager = "delta --paging=never"[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# # Timeout (ms) for git commands during picker loading (default: 200)[0m
-[107m [0m [2m# # Lower values show the TUI faster; 0 disables timeouts[0m
-[107m [0m [2m# # timeout-ms = 200[0m
+[107m [0m [2m# # Wall-clock budget (ms) for picker data collection (default: 500)[0m
+[107m [0m [2m# # Tasks still running when the budget expires are abandoned; 0 disables[0m
+[107m [0m [2m# # timeout-ms = 500[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# ### Aliases[0m
 [107m [0m [2m#[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -157,6 +157,9 @@ Persistent flag values for [2mwt list[0m. Override on command line as needed.
 [107m [0m [2mfull = [0m[2m[33mfalse[0m[2m       [0m[2m# Show CI, main…± diffstat, and LLM summaries (--full)[0m
 [107m [0m [2mbranches = [0m[2m[33mfalse[0m[2m   [0m[2m# Include branches without worktrees (--branches)[0m
 [107m [0m [2mremotes = [0m[2m[33mfalse[0m[2m    [0m[2m# Include remote-only branches (--remotes)[0m
+[107m [0m 
+[107m [0m [2mtask-timeout-ms = [0m[2m[33m0[0m[2m   [0m[2m# Kill individual git commands after N ms; 0 disables[0m
+[107m [0m [2mtimeout-ms = [0m[2m[33m0[0m[2m        [0m[2m# Wall-clock budget for the entire collect phase; 0 disables[0m
 
 [32mCommit[0m
 
@@ -185,9 +188,9 @@ All flags are on by default. Set to false to change default behavior.
 [107m [0m [2m# Pager command for diff preview (overrides git's core.pager)[0m
 [107m [0m [2m# pager = "delta --paging=never"[0m
 [107m [0m 
-[107m [0m [2m# Timeout (ms) for git commands during picker loading (default: 200)[0m
-[107m [0m [2m# Lower values show the TUI faster; 0 disables timeouts[0m
-[107m [0m [2m# timeout-ms = 200[0m
+[107m [0m [2m# Wall-clock budget (ms) for picker data collection (default: 500)[0m
+[107m [0m [2m# Tasks still running when the budget expires are abandoned; 0 disables[0m
+[107m [0m [2m# timeout-ms = 500[0m
 
 [32mAliases[0m
 


### PR DESCRIPTION
The picker had its own hardcoded 200ms per-command timeout default plus a `WORKTRUNK_PICKER_BUDGET_MS` env var escape hatch, while `wt list` had a separate experimental `[list] timeout-ms` for per-task timeouts. This consolidates into a shared config model with clear separation between per-task and wall-clock timeouts.

**New config model:**
- `[list] task-timeout-ms` — per-task command timeout, shared by both list and picker (default: disabled)
- `[list] timeout-ms` — wall-clock budget for list's collect phase (default: disabled)
- `[switch.picker] timeout-ms` — wall-clock budget for picker (default: 500ms, was 200ms per-command)

The picker's old per-command timeout goes away — the wall-clock budget is sufficient. `collect_deadline` moves from a `collect()` parameter into `ShowConfig::Resolved` where it belongs. Removes the `WORKTRUNK_PICKER_BUDGET_MS` env var and a dead benchmark that tested a non-functional env var.

Note: `[list] timeout-ms` changes semantics from per-task to wall-clock budget. The old field was marked "(Experimental)" and not shown in user-facing docs.

> _This was written by Claude Code on behalf of max-sixty_