### PR TITLE
docs: fix stale function name in docs CLAUDE.md

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -242,7 +242,7 @@ The `--help-page` generator in `src/main.rs` applies post-processing to transfor
 | `` `●` yellow `` | `<span style='color:#a60'>●</span> yellow` |
 | `` `●` gray `` | `<span style='color:#888'>●</span> gray` |
 
-To add web-only styling for new content, edit `colorize_ci_status_for_html()` in `src/main.rs` — not the markdown files.
+To add web-only styling for new content, edit `post_process_for_html()` in `src/help.rs` — not the markdown files.
 
 Similarly, `md_help::colorize_status_symbols()` applies ANSI colors for terminal `--help` output.
 


### PR DESCRIPTION
\`colorize_ci_status_for_html\` was renamed to \`post_process_for_html\` and moved from \`src/main.rs\` to \`src/help.rs\` in #1499. The docs CLAUDE.md reference was stale.

> _This was written by Claude Code on behalf of @max-sixty_