### PR TITLE
fix(config): remove extra blank line in `config create` output

### DIFF
--- a/src/commands/config/create.rs
+++ b/src/commands/config/create.rs
@@ -131,7 +131,6 @@ fn create_config_file(
             format_path_for_display(&path)
         ))
     );
-    eprintln!();
     for hint in success_hints {
         eprintln!("{}", hint_message(*hint));
     }

--- a/tests/integration_tests/config_init.rs
+++ b/tests/integration_tests/config_init.rs
@@ -58,7 +58,6 @@ fn test_config_init_creates_file(temp_home: TempDir) {
 
         ----- stderr -----
         [32m✓[39m [32mCreated user config: [1m~/.config/worktrunk/config.toml[22m[39m
-
         [2m↳[22m [2mEdit this file to customize worktree paths and LLM settings[22m
         ");
     });
@@ -80,7 +79,6 @@ fn test_config_create_project_creates_file(repo: TestRepo) {
 
         ----- stderr -----
         [32m✓[39m [32mCreated project config: [1m_REPO_/.config/wt.toml[22m[39m
-
         [2m↳[22m [2mEdit this file to configure hooks for this repository[22m
         [2m↳[22m [2mSee https://worktrunk.dev/hook/ for hook documentation[22m
         ");


### PR DESCRIPTION
The success path in `wt config create` printed a blank line between the success message and hint lines, inconsistent with the "already exists" path.

> _This was written by Claude Code on behalf of @max-sixty_