### PR TITLE
docs: add experimental badge to post-processing table

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -241,6 +241,7 @@ The `--help-page` generator in `src/main.rs` applies post-processing to transfor
 | `` `●` red `` | `<span style='color:#a00'>●</span> red` |
 | `` `●` yellow `` | `<span style='color:#a60'>●</span> yellow` |
 | `` `●` gray `` | `<span style='color:#888'>●</span> gray` |
+| `[experimental]` | `<span class="badge-experimental"></span>` (text via CSS `::after`) |
 
 To add web-only styling for new content, edit `post_process_for_html()` in `src/help.rs` — not the markdown files.
 


### PR DESCRIPTION
Add the `[experimental]` → empty `<span>` mapping to the post-processing table in docs CLAUDE.md, which was missing after the badge-to-heading change in #1523.

> _This was written by Claude Code on behalf of @max-sixty_