### PR TITLE
Add opencode, llm, and aichat to example config

### DIFF
--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -49,6 +49,21 @@
 # # [commit.generation]
 # # command = "codex exec -m gpt-5.1-codex-mini -c model_reasoning_effort='low' -c system_prompt='' --sandbox=read-only --json - | jq -sr '[.[] | select(.item.type? == \"agent_message\")] | last.item.text'"
 #
+# ### opencode
+#
+# # [commit.generation]
+# # command = "opencode run -m anthropic/claude-haiku-4.5 --variant fast"
+#
+# ### llm
+#
+# # [commit.generation]
+# # command = "llm -m claude-haiku-4.5"
+#
+# ### aichat
+#
+# # [commit.generation]
+# # command = "aichat -m claude:claude-haiku-4.5"
+#
 # See LLM commits docs (https://worktrunk.dev/llm-commits/) for setup and Custom prompt templates (#custom-prompt-templates) for template customization.
 #
 # ## Command config

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -125,6 +125,27 @@ Generate commit messages automatically during merge. Requires an external CLI to
 # command = "codex exec -m gpt-5.1-codex-mini -c model_reasoning_effort='low' -c system_prompt='' --sandbox=read-only --json - | jq -sr '[.[] | select(.item.type? == \"agent_message\")] | last.item.text'"
 ```
 
+### opencode
+
+```toml
+# [commit.generation]
+# command = "opencode run -m anthropic/claude-haiku-4.5 --variant fast"
+```
+
+### llm
+
+```toml
+# [commit.generation]
+# command = "llm -m claude-haiku-4.5"
+```
+
+### aichat
+
+```toml
+# [commit.generation]
+# command = "aichat -m claude:claude-haiku-4.5"
+```
+
 See [LLM commits docs](@/llm-commits.md) for setup and [Custom prompt templates](#custom-prompt-templates) for template customization.
 
 ## Command config

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -116,6 +116,27 @@ Generate commit messages automatically during merge. Requires an external CLI to
 # command = "codex exec -m gpt-5.1-codex-mini -c model_reasoning_effort='low' -c system_prompt='' --sandbox=read-only --json - | jq -sr '[.[] | select(.item.type? == \"agent_message\")] | last.item.text'"
 ```
 
+### opencode
+
+```toml
+# [commit.generation]
+# command = "opencode run -m anthropic/claude-haiku-4.5 --variant fast"
+```
+
+### llm
+
+```toml
+# [commit.generation]
+# command = "llm -m claude-haiku-4.5"
+```
+
+### aichat
+
+```toml
+# [commit.generation]
+# command = "aichat -m claude:claude-haiku-4.5"
+```
+
 See [LLM commits docs](https://worktrunk.dev/llm-commits/) for setup and [Custom prompt templates](#custom-prompt-templates) for template customization.
 
 ## Command config

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1647,6 +1647,27 @@ Generate commit messages automatically during merge. Requires an external CLI to
 # command = "codex exec -m gpt-5.1-codex-mini -c model_reasoning_effort='low' -c system_prompt='' --sandbox=read-only --json - | jq -sr '[.[] | select(.item.type? == \"agent_message\")] | last.item.text'"
 ```
 
+### opencode
+
+```toml
+# [commit.generation]
+# command = "opencode run -m anthropic/claude-haiku-4.5 --variant fast"
+```
+
+### llm
+
+```toml
+# [commit.generation]
+# command = "llm -m claude-haiku-4.5"
+```
+
+### aichat
+
+```toml
+# [commit.generation]
+# command = "aichat -m claude:claude-haiku-4.5"
+```
+
 See [LLM commits docs](@/llm-commits.md) for setup and [Custom prompt templates](#custom-prompt-templates) for template customization.
 
 ## Command config

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -108,6 +108,21 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# # [commit.generation][0m
 [107m [0m [2m# # command = "codex exec -m gpt-5.1-codex-mini -c model_reasoning_effort='low' -c system_prompt='' --sandbox=read-only --json - | jq -sr '[.[] | select(.item.type? == \"agent_message\")] | last.item.text'"[0m
 [107m [0m [2m#[0m
+[107m [0m [2m# ### opencode[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# # [commit.generation][0m
+[107m [0m [2m# # command = "opencode run -m anthropic/claude-haiku-4.5 --variant fast"[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# ### llm[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# # [commit.generation][0m
+[107m [0m [2m# # command = "llm -m claude-haiku-4.5"[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# ### aichat[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# # [commit.generation][0m
+[107m [0m [2m# # command = "aichat -m claude:claude-haiku-4.5"[0m
+[107m [0m [2m#[0m
 [107m [0m [2m# See LLM commits docs (https://worktrunk.dev/llm-commits/) for setup and Custom prompt templates (#custom-prompt-templates) for template customization.[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# ## Command config[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -153,6 +153,21 @@ Generate commit messages automatically during merge. Requires an external CLI to
 [107m [0m [2m# [commit.generation][0m
 [107m [0m [2m# command = "codex exec -m gpt-5.1-codex-mini -c model_reasoning_effort='low' -c system_prompt='' --sandbox=read-only --json - | jq -sr '[.[] | select(.item.type? == \"agent_message\")] | last.item.text'"[0m
 
+[32mopencode[0m
+
+[107m [0m [2m# [commit.generation][0m
+[107m [0m [2m# command = "opencode run -m anthropic/claude-haiku-4.5 --variant fast"[0m
+
+[32mllm[0m
+
+[107m [0m [2m# [commit.generation][0m
+[107m [0m [2m# command = "llm -m claude-haiku-4.5"[0m
+
+[32maichat[0m
+
+[107m [0m [2m# [commit.generation][0m
+[107m [0m [2m# command = "aichat -m claude:claude-haiku-4.5"[0m
+
 See LLM commits docs for setup and Custom prompt templates for template customization.
 
 [1m[32mCommand config[0m


### PR DESCRIPTION
Follow-up to #1531. These three tools were only documented in `llm-commits.md` — adding them as double-commented entries in the config example makes them discoverable via `wt config create` and keeps all tool commands in one place, verified by the existing sync test.

> _This was written by Claude Code on behalf of @max-sixty_