### PR TITLE
fix(git): use raw config value for remote URL to avoid insteadOf rewrites

### DIFF
--- a/src/git/repository/remotes.rs
+++ b/src/git/repository/remotes.rs
@@ -59,7 +59,7 @@ impl Repository {
 
     /// Get the URL for a remote, if configured.
     pub fn remote_url(&self, remote: &str) -> Option<String> {
-        self.run_command(&["remote", "get-url", remote])
+        self.run_command(&["config", &format!("remote.{}.url", remote)])
             .ok()
             .map(|url| url.trim().to_string())
             .filter(|url| !url.is_empty())


### PR DESCRIPTION
## Problem

`wt switch pr:<number>` fails when `url.insteadOf` rewrites are configured in `~/.gitconfig` to redirect git operations through an SSH host alias.

For example, a common GitHub Enterprise setup:

```gitconfig
[url "git@github-internal:my-org/"]
    insteadOf = git@github.com:my-org/
```

This means:
- `.git/config` stores: `git@github.com:my-org/repo.git`
- `git remote get-url origin` returns: `git@github-internal:my-org/repo.git` (rewrite applied)

`wt` extracts the hostname from `git remote get-url` and passes it to `gh api --hostname`. With the rewrite applied, it passes `--hostname github-internal` — a hostname that only exists as an SSH alias, not as a registered `gh` account. This causes `gh api` to fail with a connection error.

## Fix

Use `git config remote.<name>.url` instead of `git remote get-url <name>`.

`git config` reads the raw stored value — no `insteadOf` rewrites applied — returning the canonical hostname (`github.com`) that `gh` knows about.

## Backward compatibility

Without any `insteadOf` rewrites configured, both commands return identical values. This change only affects users with SSH host alias rewrites, and for them it fixes a broken workflow.

## Reproduction

1. Configure `~/.gitconfig` with a `url.insteadOf` rewrite that changes the hostname (e.g., `github.com` → `github-internal`)
2. Clone a repo — `.git/config` stores `github.com`, but `git remote get-url` returns `github-internal`
3. Run `wt switch pr:<number>` → fails with `error connecting to github-internal`
4. With this fix → works correctly
