### PR TITLE
fix: treat SIGPIPE as success in Cmd::stream()

### DIFF
--- a/src/shell_exec.rs
+++ b/src/shell_exec.rs
@@ -1235,6 +1235,25 @@ mod tests {
 
     #[test]
     #[cfg(unix)]
+    fn test_cmd_stream_other_signals_are_errors() {
+        use crate::git::WorktrunkError;
+
+        // Non-SIGPIPE signals (like SIGTERM) should still be treated as errors.
+        let result = Cmd::new("sh").args(["-c", "kill -TERM $$"]).stream();
+        assert!(result.is_err());
+
+        let err = result.unwrap_err();
+        let wt_err = err.downcast_ref::<WorktrunkError>().unwrap();
+        match wt_err {
+            WorktrunkError::ChildProcessExited { code, .. } => {
+                assert_eq!(*code, 128 + 15); // SIGTERM = 15
+            }
+            _ => panic!("Expected ChildProcessExited error"),
+        }
+    }
+
+    #[test]
+    #[cfg(unix)]
     fn test_cmd_shell_stream_with_stdin() {
         // cat should echo stdin content (output goes to inherited stdout, we can't capture it,
         // but we can verify no error)


### PR DESCRIPTION
When `wt step diff` pipes through a pager and the user quits with `q`, git gets SIGPIPE (signal 13) and exits. `Cmd::stream()` was treating all signal exits as errors, showing "terminated by signal 13". SIGPIPE from a pager quit is normal Unix behavior — not an error condition.

The fix checks for SIGPIPE specifically in the `ExitStatusExt::signal()` path of `stream()` and returns `Ok(())` instead of an error. The `seen_signal` path (for forwarded SIGINT/SIGTERM) is unaffected since it only listens for those two signals.

> _This was written by Claude Code on behalf of @max-sixty_