### PR TITLE
fix: use syntax-highlighted formatter for alias dry-run output

### DIFF
--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -15,7 +15,7 @@ use color_print::cformat;
 use worktrunk::config::{ProjectConfig, UserConfig, expand_template};
 use worktrunk::git::{Repository, WorktrunkError};
 use worktrunk::styling::{
-    eprintln, format_with_gutter, info_message, progress_message, warning_message,
+    eprintln, format_bash_with_gutter, info_message, progress_message, warning_message,
 };
 
 use crate::commands::command_approval::approve_alias;
@@ -269,7 +269,7 @@ pub fn step_alias(opts: AliasOptions) -> anyhow::Result<()> {
             info_message(cformat!(
                 "Alias <bold>{}</> would run:\n{}",
                 opts.name,
-                format_with_gutter(&command, None)
+                format_bash_with_gutter(&command)
             ))
         );
         return Ok(());

--- a/tests/snapshots/integration__integration_tests__step_alias__project_alias.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__project_alias.snap
@@ -6,6 +6,7 @@ info:
     - step
     - project-cmd
     - "--dry-run"
+    - "--yes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -44,4 +45,4 @@ exit_code: 0
 
 ----- stderr -----
 [2m○[22m Alias [1mproject-cmd[22m would run:
-[107m [0m echo from-project
+[107m [0m [2m[0m[2m[34mecho[0m[2m from-project

--- a/tests/snapshots/integration__integration_tests__step_alias__step_alias_dry_run.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_alias_dry_run.snap
@@ -44,4 +44,4 @@ exit_code: 0
 
 ----- stderr -----
 [2m○[22m Alias [1mhello[22m would run:
-[107m [0m echo Hello from feature
+[107m [0m [2m[0m[2m[34mecho[0m[2m Hello from feature

--- a/tests/snapshots/integration__integration_tests__step_alias__step_alias_with_var.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_alias_with_var.snap
@@ -8,6 +8,7 @@ info:
     - "--dry-run"
     - "--var"
     - name=World
+    - "--yes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -46,4 +47,4 @@ exit_code: 0
 
 ----- stderr -----
 [2m○[22m Alias [1mgreet[22m would run:
-[107m [0m echo Hello World from feature
+[107m [0m [2m[0m[2m[34mecho[0m[2m Hello World from feature

--- a/tests/snapshots/integration__integration_tests__step_alias__user_alias.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__user_alias.snap
@@ -44,4 +44,4 @@ exit_code: 0
 
 ----- stderr -----
 [2m○[22m Alias [1muser-cmd[22m would run:
-[107m [0m echo from-user
+[107m [0m [2m[0m[2m[34mecho[0m[2m from-user

--- a/tests/snapshots/integration__integration_tests__step_alias__user_overrides_project.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__user_overrides_project.snap
@@ -44,4 +44,4 @@ exit_code: 0
 
 ----- stderr -----
 [2m○[22m Alias [1mshared[22m would run:
-[107m [0m echo user-version
+[107m [0m [2m[0m[2m[34mecho[0m[2m user-version


### PR DESCRIPTION
Alias dry-run was using `format_with_gutter` (plain text) while hook dry-run uses `format_bash_with_gutter` (syntax-highlighted bash). Both display expanded shell commands in `--dry-run` mode — they should use the same formatter.

Two-line change (import + call site) plus snapshot updates.

> _This was written by Claude Code on behalf of max-sixty_