### PR TITLE
fix: prevent `wt list` hang from fsmonitor daemon pipe inheritance

### DIFF
--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -527,26 +527,34 @@ impl Repository {
             .unwrap_or(false)
     }
 
-    /// Start the fsmonitor daemon for this worktree.
+    /// Start the fsmonitor daemon at a worktree path.
     ///
-    /// This is idempotent - if the daemon is already running, this is a no-op.
+    /// Idempotent — if the daemon is already running, this is a no-op.
     /// Used to avoid auto-start races when running many parallel git commands.
-    pub fn start_fsmonitor_daemon(&self) {
-        // Best effort - log errors at debug level for troubleshooting
-        if let Err(e) = self.run_command(&["fsmonitor--daemon", "start"]) {
-            log::debug!("fsmonitor daemon start failed (usually fine): {e}");
-        }
-    }
-
-    /// Start fsmonitor daemon at a specific worktree path.
     ///
-    /// Like `start_fsmonitor_daemon` but runs the command in the specified worktree.
+    /// Uses `Command::status()` with null stdio instead of `Cmd::run()` to avoid
+    /// pipe inheritance: the daemon process (`git fsmonitor--daemon run --detach`)
+    /// inherits pipe file descriptors from its parent, keeping them open
+    /// indefinitely. `read_to_end()` in `Command::output()` then blocks forever
+    /// waiting for EOF that never comes.
     pub fn start_fsmonitor_daemon_at(&self, path: &Path) {
-        if let Err(e) = self
-            .worktree_at(path)
-            .run_command(&["fsmonitor--daemon", "start"])
-        {
-            log::debug!("fsmonitor daemon start failed (usually fine): {e}");
+        log::debug!("$ git fsmonitor--daemon start [{}]", path.display());
+        let result = std::process::Command::new("git")
+            .args(["fsmonitor--daemon", "start"])
+            .current_dir(path)
+            .env_remove(crate::shell_exec::DIRECTIVE_FILE_ENV_VAR)
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+        match result {
+            Ok(status) if !status.success() => {
+                log::debug!("fsmonitor daemon start exited {status} (usually fine)");
+            }
+            Err(e) => {
+                log::debug!("fsmonitor daemon start failed (usually fine): {e}");
+            }
+            _ => {}
         }
     }
 


### PR DESCRIPTION
`git fsmonitor--daemon start` forks a long-lived daemon that inherits piped stdio file descriptors from `Command::output()`. The daemon holds the write end of the pipe open indefinitely, so `read_to_end()` blocks forever waiting for EOF that never comes. This causes `wt list` to hang at the "(loading...)" stage on macOS with builtin fsmonitor enabled.

Confirmed via `sample` — one rayon worker thread stuck in `start_fsmonitor_daemon_at` → `Cmd::run` → `Command::output` → `read` syscall. The specific daemon (PID 33559, watching `worktrunk.jj-struct`) held the same pipe FD (`0x33a071def7d89bb5`) as the frozen `wt` process.

Fix: use `Command::status()` with `Stdio::null()` instead of `Cmd::run()`. No pipes = nothing to inherit. Also removes the unused `start_fsmonitor_daemon()` wrapper — only `start_fsmonitor_daemon_at` had callers.

> _This was written by Claude Code on behalf of @max-sixty_