### PR TITLE
fix(ci): set trigger_phrase and provide review-response prompt

### DIFF
--- a/.github/workflows/claude-mention.yaml
+++ b/.github/workflows/claude-mention.yaml
@@ -204,6 +204,7 @@ jobs:
           bot_name: "worktrunk-bot"
           allowed_non_write_users: '*'
 
+          trigger_phrase: "@worktrunk-bot"
           additional_permissions: |
             actions: read
 

--- a/.github/workflows/claude-review.yaml
+++ b/.github/workflows/claude-review.yaml
@@ -81,8 +81,16 @@ jobs:
           allowed_non_write_users: "*"
           additional_permissions: |
             actions: read
+          trigger_phrase: "@worktrunk-bot"
           use_sticky_comment: ${{ github.event_name == 'pull_request_target' }}
-          prompt: ${{ github.event_name == 'pull_request_target' && format('/review-pr {0}', github.event.pull_request.number) || '' }}
+          prompt: >-
+            ${{ github.event_name == 'pull_request_target'
+              && format('/review-pr {0}', github.event.pull_request.number)
+              || format(
+                'A review was submitted on your PR #{0} ({1}). Read the review and full PR context (description, diff, comments, CI status), then respond appropriately. If changes were requested, make them, commit, and push. If questions were asked, answer them.',
+                github.event.pull_request.number,
+                github.event.review.html_url
+              ) }}
           claude_args: |
             --model opus
             --allowedTools Bash,Edit,Read,Write,Glob,Grep,WebSearch,WebFetch,Task,Skill


### PR DESCRIPTION
The `claude-code-action` defaults `trigger_phrase` to `@claude`. When `claude-review.yaml` handled `pull_request_review` events on bot-authored PRs, it passed an empty prompt (`''`), causing the action to fall back to trigger detection — which looked for `@claude` in the review text. Since nobody writes `@claude` in reviews, the action always skipped. This meant formal reviews on bot-authored PRs were silently ignored by `claude-review` (only handled incidentally via `claude-mention`'s `pull_request_review_comment` path when inline comments were present).

Two fixes:
- Set `trigger_phrase: "@worktrunk-bot"` in both interactive workflows (`claude-review`, `claude-mention`) so the action never defaults to `@claude`
- Provide a non-empty prompt for the `pull_request_review` path in `claude-review.yaml`, so the action runs the prompt directly instead of falling back to trigger detection

The five automated workflows (ci-fix, hourly, nightly, renovate, triage) are unchanged — they all provide explicit prompts, making `trigger_phrase` irrelevant.

Evidence from PR #1557: run 23132865052 logged `No trigger was met for @claude` / `Context prompt: NO PROMPT` / `No trigger found, skipping remaining steps` despite the workflow's `if:` condition correctly selecting the event.

> _This was written by Claude Code on behalf of @max-sixty_