### PR TITLE
fix(select): use stale placeholder for all picker items

### DIFF
--- a/src/commands/select/mod.rs
+++ b/src/commands/select/mod.rs
@@ -127,16 +127,11 @@ pub fn handle_select(
         .map(|item| {
             let branch_name = item.branch_name().to_string();
 
-            // status_symbols is None only when no task results arrived for this item
-            // (budget truncation). collect() sets it for all other items: via drain
-            // callbacks for items that received results, and the post-drain loop for
-            // prunable worktrees. Each column also shows the placeholder independently
-            // when its own data field is None.
-            let rendered_line = if item.status_symbols.is_none() {
-                layout.render_list_item_stale(&item)
-            } else {
-                layout.render_list_item_line(&item)
-            };
+            // The picker doesn't update progressively, so any column whose data
+            // didn't arrive in time won't fill in later. Use the stale placeholder
+            // ("·") for all items — it signals "data not available" rather than the
+            // ellipsis ("⋯") which implies data is still loading.
+            let rendered_line = layout.render_list_item_stale(&item);
             let display_text_with_ansi = rendered_line.render();
             let display_text = rendered_line.plain_text();
 


### PR DESCRIPTION
The picker renders items once — it doesn't update progressively like `wt list`. Using the ellipsis placeholder (`⋯`) for items where some tasks completed but others (like Summary) didn't was misleading: it implied data was still loading when it wouldn't arrive.

Now all picker items use the stale placeholder (`·`) which correctly signals "data not available". Items where all data arrived render identically — the placeholder only appears for `None` fields.

> _This was written by Claude Code on behalf of @max-sixty_