### PR TITLE
chore: remove stale TODO about default_branch indicator

### DIFF
--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -433,7 +433,6 @@ pub fn collect(
     // Main worktree is the primary worktree (for sorting and is_main display).
     // - Normal repos: the main worktree (repo root)
     // - Bare repos: the default branch's worktree
-    // TODO: show ellipsis or indicator when default_branch is None and columns are empty
     let primary_path = repo.primary_worktree()?;
     let main_worktree = primary_path
         .as_ref()


### PR DESCRIPTION
When `default_branch` is None (rare — detection has multiple fallback strategies), dependent columns like AheadBehind and BranchDiff render blank, which is acceptable. The configured-but-invalid case already shows a warning with a hint to clear the config.

> _This was written by Claude Code on behalf of @max-sixty_