### PR TITLE
refactor: rename `select-test` perf config to `picker-test`

### DIFF
--- a/benches/CLAUDE.md
+++ b/benches/CLAUDE.md
@@ -78,7 +78,7 @@ cargo run -p wt-perf -- setup typical-8 --persist
 #   branches-N      - N branches, 1 commit each
 #   branches-N-M    - N branches, M commits each
 #   divergent       - 200 branches × 20 commits (GH #461 scenario)
-#   select-test     - Config for wt switch interactive picker testing
+#   picker-test     - Config for wt switch interactive picker testing
 
 # Invalidate caches for cold run
 cargo run -p wt-perf -- invalidate /tmp/wt-perf-typical-8/main

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -7,10 +7,10 @@ When debugging TUI commands like `wt switch` (interactive picker), use the `tmux
 ### 1. Create Test Environment
 
 ```bash
-cargo run -p wt-perf -- setup select-test
+cargo run -p wt-perf -- setup picker-test
 ```
 
-This creates a reproducible test repo at `/tmp/wt-perf-select-test/`.
+This creates a reproducible test repo at `/tmp/wt-perf-picker-test/`.
 
 ### 2. Test Interactively
 
@@ -21,7 +21,7 @@ Load the `tmux-cli` skill, then use the `tmux-cli` tool. Install if needed: `uv 
 ```bash
 # Launch shell in test repo
 pane=$(tmux-cli launch "zsh")
-tmux-cli send "cd /tmp/wt-perf-select-test" --pane=$pane
+tmux-cli send "cd /tmp/wt-perf-picker-test" --pane=$pane
 tmux-cli wait_idle --pane=$pane
 
 # Run with debug logging
@@ -43,7 +43,7 @@ MCP terminals use pseudo-TTY, not real terminals. If tests pass in MCP but users
 ```typescript
 // Create terminal and navigate to test repo
 mcp__node-terminal__terminal_create({ sessionId: "test" })
-mcp__node-terminal__terminal_write({ sessionId: "test", input: "cd /tmp/wt-perf-select-test" })
+mcp__node-terminal__terminal_write({ sessionId: "test", input: "cd /tmp/wt-perf-picker-test" })
 mcp__node-terminal__terminal_send_key({ sessionId: "test", key: "enter" })
 
 // Run with debug logging

--- a/tests/helpers/wt-perf/src/lib.rs
+++ b/tests/helpers/wt-perf/src/lib.rs
@@ -101,7 +101,7 @@ impl RepoConfig {
     }
 
     /// Config for testing `wt switch` interactive picker (6 worktrees with varying commits).
-    pub const fn select_test() -> Self {
+    pub const fn picker_test() -> Self {
         Self {
             commits_on_main: 3,
             files: 3,
@@ -417,7 +417,7 @@ pub fn canonicalize(path: &Path) -> std::io::Result<PathBuf> {
 /// - `branches-N` - N branches with 1 commit each
 /// - `branches-N-M` - N branches with M commits each
 /// - `divergent` - many divergent branches (GH #461)
-/// - `select-test` - config for wt switch interactive picker testing
+/// - `picker-test` - config for wt switch interactive picker testing
 pub fn parse_config(s: &str) -> Option<RepoConfig> {
     if let Some(n) = s.strip_prefix("typical-") {
         let worktrees: usize = n.parse().ok()?;
@@ -442,7 +442,7 @@ pub fn parse_config(s: &str) -> Option<RepoConfig> {
 
     match s {
         "divergent" => Some(RepoConfig::many_divergent_branches()),
-        "select-test" => Some(RepoConfig::select_test()),
+        "picker-test" => Some(RepoConfig::picker_test()),
         _ => None,
     }
 }

--- a/tests/helpers/wt-perf/src/main.rs
+++ b/tests/helpers/wt-perf/src/main.rs
@@ -12,8 +12,8 @@
 //! # Parse trace logs (pipe from wt command)
 //! RUST_LOG=debug wt list 2>&1 | grep wt-trace | wt-perf trace > trace.json
 //!
-//! # Set up select test environment
-//! wt-perf setup select-test
+//! # Set up picker test environment
+//! wt-perf setup picker-test
 //! ```
 
 use std::io::{IsTerminal, Read, Write};
@@ -34,7 +34,7 @@ struct Cli {
 enum Commands {
     /// Set up a benchmark repository
     Setup {
-        /// Config name: typical-N, branches-N, branches-N-M, divergent, select-test
+        /// Config name: typical-N, branches-N, branches-N-M, divergent, picker-test
         config: String,
 
         /// Directory to create repo in (default: temp directory)
@@ -92,7 +92,7 @@ fn main() {
                 eprintln!("  branches-N      - N branches with 1 commit each");
                 eprintln!("  branches-N-M    - N branches with M commits each");
                 eprintln!("  divergent       - 200 branches × 20 commits (GH #461 scenario)");
-                eprintln!("  select-test     - Config for wt switch interactive picker testing");
+                eprintln!("  picker-test     - Config for wt switch interactive picker testing");
                 std::process::exit(1);
             });
 


### PR DESCRIPTION
Follow-up to #1650 — renames the `wt-perf` config name (`select-test` → `picker-test`), constructor (`select_test()` → `picker_test()`), and references in `src/commands/CLAUDE.md` and `benches/CLAUDE.md`.

> _This was written by Claude Code on behalf of @max-sixty_