### PR TITLE
docs: add template variable detection guideline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -310,6 +310,7 @@ Never hand-roll utilities that already exist as crate dependencies. Check `Cargo
 | Path normalization | `path_slash::PathExt::to_slash_lossy()` | `.to_string_lossy().replace('\\', "/")` |
 | Shell escaping | `shell_escape::unix::escape()` | Manual quoting |
 | ANSI colors | `color_print::cformat!()` | Raw escape codes |
+| Template variable detection | `minijinja::undeclared_variables(false)` | Regex or substring matching for `{{ var }}` |
 
 ### Don't Suppress Warnings
 


### PR DESCRIPTION
## Summary

- Adds `minijinja::undeclared_variables(false)` to the "Use Existing Dependencies" table in CLAUDE.md
- Prevents hand-rolled regex/substring matching for detecting template variables

Audited the codebase — no remaining instances of hand-rolled template variable detection (the `resolve.rs` fix landed in the `bare-path` branch). Other template-related string ops (layout width estimation, deprecated var rewriting, syntax highlighting) are categorically different and don't need refactoring.

## Test plan

- [ ] CLAUDE.md renders correctly

> _This was written by Claude Code on behalf of maximilian_

🤖 Generated with [Claude Code](https://claude.com/claude-code)