### PR TITLE
docs: changelog and migration note for template variable redesign

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## Unreleased
+
+### Breaking
+
+- **Hook template variable `worktree_path` changed meaning** in two hook types: in **pre-switch** (existing worktrees), `{{ worktree_path }}` now points to the destination worktree instead of the source; in **post-merge**, it now points to the feature worktree (active) instead of the merge target. Use `{{ base_worktree_path }}` or `{{ cwd }}` for the previous behavior. ([#1655](https://github.com/max-sixty/worktrunk/pull/1655), [#1660](https://github.com/max-sixty/worktrunk/pull/1660))
+
+### Improved
+
+- **Directional template variables for hooks**: New `{{ base }}`, `{{ base_worktree_path }}`, `{{ target }}`, `{{ target_worktree_path }}`, and `{{ cwd }}` variables give hooks explicit access to both sides of two-worktree operations (switch, merge, remove). Bare variables (`branch`, `worktree_path`, `commit`) consistently point to the active branch — the destination for switch/create, the source for merge/remove. ([#1655](https://github.com/max-sixty/worktrunk/pull/1655), [#1660](https://github.com/max-sixty/worktrunk/pull/1660), [#1663](https://github.com/max-sixty/worktrunk/pull/1663))
+
 ## 0.30.1
 
 ### Fixed

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -240,6 +240,15 @@ Some variables are conditional: `upstream` requires remote tracking; `base`/`tar
 sync = "{% if upstream %}git fetch && git rebase {{ upstream }}{% endif %}"
 ```
 
+### Migration from earlier versions
+
+`worktree_path` changed meaning in two hook types:
+
+- **pre-switch** (existing worktrees): previously the source worktree, now the destination. Use `{{ base_worktree_path }}` or `{{ cwd }}` for the source.
+- **post-merge**: previously the merge target worktree, now the feature worktree (active). Use `{{ target_worktree_path }}` or `{{ cwd }}` for where code landed.
+
+New variables `cwd`, `target_worktree_path`, `base`, and `base_worktree_path` are available in more hook types than before.
+
 ## Worktrunk filters
 
 Templates support Jinja2 filters for transforming values:

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -231,6 +231,15 @@ Some variables are conditional: `upstream` requires remote tracking; `base`/`tar
 sync = "{% if upstream %}git fetch && git rebase {{ upstream }}{% endif %}"
 ```
 
+### Migration from earlier versions
+
+`worktree_path` changed meaning in two hook types:
+
+- **pre-switch** (existing worktrees): previously the source worktree, now the destination. Use `{{ base_worktree_path }}` or `{{ cwd }}` for the source.
+- **post-merge**: previously the merge target worktree, now the feature worktree (active). Use `{{ target_worktree_path }}` or `{{ cwd }}` for where code landed.
+
+New variables `cwd`, `target_worktree_path`, `base`, and `base_worktree_path` are available in more hook types than before.
+
 ## Worktrunk filters
 
 Templates support Jinja2 filters for transforming values:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1327,6 +1327,15 @@ Some variables are conditional: `upstream` requires remote tracking; `base`/`tar
 sync = "{% if upstream %}git fetch && git rebase {{ upstream }}{% endif %}"
 ```
 
+### Migration from earlier versions
+
+`worktree_path` changed meaning in two hook types:
+
+- **pre-switch** (existing worktrees): previously the source worktree, now the destination. Use `{{ base_worktree_path }}` or `{{ cwd }}` for the source.
+- **post-merge**: previously the merge target worktree, now the feature worktree (active). Use `{{ target_worktree_path }}` or `{{ cwd }}` for where code landed.
+
+New variables `cwd`, `target_worktree_path`, `base`, and `base_worktree_path` are available in more hook types than before.
+
 ## Worktrunk filters
 
 Templates support Jinja2 filters for transforming values:


### PR DESCRIPTION
Adds changelog entry for the template variable redesign (breaking + improved) and a migration section in the hook docs explaining what changed and how to update existing hooks.

Ref #1633

> _This was written by Claude Code on behalf of @max-sixty_