### PR TITLE
fix: hide alt-r remove from picker legend and docs

### DIFF
--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -91,7 +91,6 @@ When called without arguments, `wt switch` opens an interactive picker to browse
 | (type) | Filter worktrees |
 | `Enter` | Switch to selected worktree |
 | `Alt-c` | Create new worktree from query |
-| `Alt-r` | Remove selected worktree |
 | `Esc` | Cancel |
 | `1`–`5` | Switch preview tab |
 | `Alt-p` | Toggle preview panel |

--- a/skills/worktrunk/reference/switch.md
+++ b/skills/worktrunk/reference/switch.md
@@ -68,7 +68,6 @@ When called without arguments, `wt switch` opens an interactive picker to browse
 | (type) | Filter worktrees |
 | `Enter` | Switch to selected worktree |
 | `Alt-c` | Create new worktree from query |
-| `Alt-r` | Remove selected worktree |
 | `Esc` | Cancel |
 | `1`–`5` | Switch preview tab |
 | `Alt-p` | Toggle preview panel |

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -317,7 +317,6 @@ When called without arguments, `wt switch` opens an interactive picker to browse
 | (type) | Filter worktrees |
 | `Enter` | Switch to selected worktree |
 | `Alt-c` | Create new worktree from query |
-| `Alt-r` | Remove selected worktree |
 | `Esc` | Cancel |
 | `1`–`5` | Switch preview tab |
 | `Alt-p` | Toggle preview panel |

--- a/src/commands/picker/items.rs
+++ b/src/commands/picker/items.rs
@@ -145,7 +145,7 @@ impl WorktreeSkimItem {
 
         // Controls use dim yellow to distinguish from dimmed (white) tabs
         let controls = cformat!(
-            "<dim,yellow>Enter: switch | alt-c: create | alt-r: remove | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle</>"
+            "<dim,yellow>Enter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle</>"
         );
 
         // End each tab and controls with full reset to prevent style bleeding

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__branch_diff.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__branch_diff.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::render_preview_tabs(mode)"
 ---
 [2m1: HEAD±[22m[0m | [2m2: log[22m[0m | [1m3: main…±[22m[0m | [2m4: remote⇅[22m[0m | [2m5: summary[22m[0m
-[33m[2mEnter: switch | alt-c: create | alt-r: remove | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m
+[33m[2mEnter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__log.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__log.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::render_preview_tabs(mode)"
 ---
 [2m1: HEAD±[22m[0m | [1m2: log[22m[0m | [2m3: main…±[22m[0m | [2m4: remote⇅[22m[0m | [2m5: summary[22m[0m
-[33m[2mEnter: switch | alt-c: create | alt-r: remove | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m
+[33m[2mEnter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__summary.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__summary.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::render_preview_tabs(mode)"
 ---
 [2m1: HEAD±[22m[0m | [2m2: log[22m[0m | [2m3: main…±[22m[0m | [2m4: remote⇅[22m[0m | [1m5: summary[22m[0m
-[33m[2mEnter: switch | alt-c: create | alt-r: remove | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m
+[33m[2mEnter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__upstream_diff.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__upstream_diff.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::render_preview_tabs(mode)"
 ---
 [2m1: HEAD±[22m[0m | [2m2: log[22m[0m | [2m3: main…±[22m[0m | [1m4: remote⇅[22m[0m | [2m5: summary[22m[0m
-[33m[2mEnter: switch | alt-c: create | alt-r: remove | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m
+[33m[2mEnter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__working_tree.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__working_tree.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::render_preview_tabs(mode)"
 ---
 [1m1: HEAD±[22m[0m | [2m2: log[22m[0m | [2m3: main…±[22m[0m | [2m4: remote⇅[22m[0m | [2m5: summary[22m[0m
-[33m[2mEnter: switch | alt-c: create | alt-r: remove | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m
+[33m[2mEnter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -168,7 +168,6 @@ When called without arguments, [2mwt switch[0m opens an interactive picker to 
  (type)        Filter worktrees               
  [2mEnter[0m         Switch to selected worktree    
  [2mAlt-c[0m         Create new worktree from query 
- [2mAlt-r[0m         Remove selected worktree       
  [2mEsc[0m           Cancel                         
  [2m1[0m–[2m5[0m           Switch preview tab             
  [2mAlt-p[0m         Toggle preview panel           

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_abort_escape_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_abort_escape_preview.snap
@@ -3,6 +3,6 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± | 2: log | 3: main…± | 4: remote⇅ | 5: summary [N/M]
-Enter: switch | alt-c: create | alt-r: remove | Esc: cancel
+Enter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scr
 
 ○ main has no uncommitted changes

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_multiple_worktrees_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_multiple_worktrees_preview.snap
@@ -3,6 +3,6 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± | 2: log | 3: main…± | 4: remote⇅ | 5: summary [N/M]
-Enter: switch | alt-c: create | alt-r: remove | Esc: cancel
+Enter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scr
 
 ○ main has no uncommitted changes

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_log_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_log_preview.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± | 2: log | 3: main…± | 4: remote⇅ | 5: summary [N/M]
-Enter: switch | alt-c: create | alt-r: remove | Esc: cancel
+Enter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scr
 
 * [HASH]   +1        [TIME] (feature) Add file 5 with content
 * [HASH]   +1        [TIME] Add file 4 with content

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_main_diff_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_main_diff_preview.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± | 2: log | 3: main…± | 4: remote⇅ | 5: summary [N/M]
-Enter: switch | alt-c: create | alt-r: remove | Esc: cancel
+Enter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scr
 
  feature_code.rs | 6 ++++++
  tests.rs        | 4 ++++

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_summary_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_summary_preview.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± | 2: log | 3: main…± | 4: remote⇅ | 5: summary [N/M]
-Enter: switch | alt-c: create | alt-r: remove | Esc: cancel
+Enter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scr
 
 Configure [commit.generation] command to enable LLM summari
 

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_uncommitted_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_uncommitted_preview.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± | 2: log | 3: main…± | 4: remote⇅ | 5: summary [N/M]
-Enter: switch | alt-c: create | alt-r: remove | Esc: cancel
+Enter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scr
 
  tracked.txt | 4 +++-
  1 file changed, 3 insertions(+), 1 deletion(-)

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_with_branches_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_with_branches_preview.snap
@@ -3,6 +3,6 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± | 2: log | 3: main…± | 4: remote⇅ | 5: summary [N/M]
-Enter: switch | alt-c: create | alt-r: remove | Esc: cancel
+Enter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scr
 
 ○ main has no uncommitted changes


### PR DESCRIPTION
The alt-r keybinding for in-place worktree removal has poor UX — cursor resets to the top after each removal due to a skim 0.20 limitation (#1695). This hides the feature from the picker legend and documentation so users don't discover it until fixed. The keybinding itself remains functional for power users who already know about it.

Ref #1695

> _This was written by Claude Code on behalf of @max-sixty_