### PR TITLE
refactor: replace remaining Command::new("git") with Cmd::new in tests

### DIFF
--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -492,6 +492,7 @@ mod tests {
     use insta::assert_snapshot;
 
     use super::*;
+    use crate::shell_exec::Cmd;
 
     /// Test fixture that creates a real temporary git repository.
     struct TestRepo {
@@ -502,10 +503,10 @@ mod tests {
     impl TestRepo {
         fn new() -> Self {
             let dir = tempfile::tempdir().unwrap();
-            std::process::Command::new("git")
+            Cmd::new("git")
                 .args(["init"])
                 .current_dir(dir.path())
-                .output()
+                .run()
                 .unwrap();
             let repo = Repository::at(dir.path()).unwrap();
             Self { _dir: dir, repo }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -106,6 +106,7 @@ mod tests {
 
     use super::*;
     use crate::git::Repository;
+    use crate::shell_exec::Cmd;
 
     /// Test fixture that creates a real temporary git repository.
     struct TestRepo {
@@ -116,10 +117,10 @@ mod tests {
     impl TestRepo {
         fn new() -> Self {
             let dir = tempfile::tempdir().unwrap();
-            std::process::Command::new("git")
+            Cmd::new("git")
                 .args(["init"])
                 .current_dir(dir.path())
-                .output()
+                .run()
                 .unwrap();
             let repo = Repository::at(dir.path()).unwrap();
             Self { _dir: dir, repo }

--- a/src/config/test.rs
+++ b/src/config/test.rs
@@ -5,6 +5,7 @@
 
 use super::expand_template;
 use crate::git::Repository;
+use crate::shell_exec::Cmd;
 use std::collections::HashMap;
 
 /// Test fixture that creates a real temporary git repository.
@@ -16,10 +17,10 @@ struct TestRepo {
 impl TestRepo {
     fn new() -> Self {
         let dir = tempfile::tempdir().unwrap();
-        std::process::Command::new("git")
+        Cmd::new("git")
             .args(["init"])
             .current_dir(dir.path())
-            .output()
+            .run()
             .unwrap();
         let repo = Repository::at(dir.path()).unwrap();
         Self { _dir: dir, repo }

--- a/src/config/user/tests.rs
+++ b/src/config/user/tests.rs
@@ -1,6 +1,7 @@
 use super::*;
 use crate::config::HooksConfig;
 use crate::git::{HookType, Repository};
+use crate::shell_exec::Cmd;
 
 /// Test fixture that creates a real temporary git repository.
 struct TestRepo {
@@ -11,10 +12,10 @@ struct TestRepo {
 impl TestRepo {
     fn new() -> Self {
         let dir = tempfile::tempdir().unwrap();
-        std::process::Command::new("git")
+        Cmd::new("git")
             .args(["init"])
             .current_dir(dir.path())
-            .output()
+            .run()
             .unwrap();
         let repo = Repository::at(dir.path()).unwrap();
         Self { _dir: dir, repo }

--- a/tests/helpers/wt-perf/src/lib.rs
+++ b/tests/helpers/wt-perf/src/lib.rs
@@ -32,9 +32,9 @@
 //! ```
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
 use std::sync::OnceLock;
 use tempfile::TempDir;
+use worktrunk::shell_exec::Cmd;
 
 /// Lazy-initialized rust repo path.
 static RUST_REPO: OnceLock<PathBuf> = OnceLock::new();
@@ -116,12 +116,12 @@ impl RepoConfig {
 
 /// Run a git command in the given directory.
 pub fn run_git(path: &Path, args: &[&str]) {
-    let output = Command::new("git")
-        .args(args)
+    let output = Cmd::new("git")
+        .args(args.iter().copied())
         .current_dir(path)
         .env("GIT_CONFIG_GLOBAL", "/dev/null")
         .env("GIT_CONFIG_SYSTEM", "/dev/null")
-        .output()
+        .run()
         .unwrap();
     assert!(
         output.status.success(),
@@ -237,10 +237,10 @@ pub fn add_worktrees(config: &RepoConfig, repo_path: &Path) {
         let branch = format!("feature-wt-{wt_num}");
         let wt_path = parent_dir.join(format!("{repo_name}.{branch}"));
 
-        let head_output = Command::new("git")
+        let head_output = Cmd::new("git")
             .args(["rev-parse", "HEAD"])
             .current_dir(repo_path)
-            .output()
+            .run()
             .unwrap();
         let base_commit = String::from_utf8_lossy(&head_output.stdout)
             .trim()
@@ -280,10 +280,10 @@ pub fn setup_fake_remote(repo_path: &Path) {
     let refs_dir = repo_path.join(".git/refs/remotes/origin");
     std::fs::create_dir_all(&refs_dir).unwrap();
     std::fs::write(refs_dir.join("HEAD"), "ref: refs/remotes/origin/main\n").unwrap();
-    let head_sha = Command::new("git")
+    let head_sha = Cmd::new("git")
         .args(["rev-parse", "HEAD"])
         .current_dir(repo_path)
-        .output()
+        .run()
         .unwrap();
     std::fs::write(refs_dir.join("main"), head_sha.stdout).unwrap();
 }
@@ -324,10 +324,10 @@ pub fn ensure_rust_repo() -> PathBuf {
             let rust_repo = cache_dir.join("rust");
 
             if rust_repo.exists() {
-                let output = Command::new("git")
+                let output = Cmd::new("git")
                     .args(["rev-parse", "HEAD"])
                     .current_dir(&rust_repo)
-                    .output();
+                    .run();
 
                 if output.is_ok_and(|o| o.status.success()) {
                     eprintln!("Using cached rust repo at {}", rust_repo.display());
@@ -340,13 +340,13 @@ pub fn ensure_rust_repo() -> PathBuf {
             std::fs::create_dir_all(&cache_dir).unwrap();
             eprintln!("Cloning rust-lang/rust (this will take several minutes)...");
 
-            let clone_output = Command::new("git")
+            let clone_output = Cmd::new("git")
                 .args([
                     "clone",
                     "https://github.com/rust-lang/rust.git",
                     rust_repo.to_str().unwrap(),
                 ])
-                .output()
+                .run()
                 .unwrap();
 
             assert!(clone_output.status.success(), "Failed to clone rust repo");
@@ -364,14 +364,14 @@ pub fn clone_rust_repo(temp: &TempDir) -> PathBuf {
     let rust_repo = ensure_rust_repo();
     let workspace_main = temp.path().join("repo");
 
-    let clone_output = Command::new("git")
+    let clone_output = Cmd::new("git")
         .args([
             "clone",
             "--local",
             rust_repo.to_str().unwrap(),
             workspace_main.to_str().unwrap(),
         ])
-        .output()
+        .run()
         .unwrap();
     assert!(
         clone_output.status.success(),
@@ -390,10 +390,10 @@ pub fn clone_rust_repo(temp: &TempDir) -> PathBuf {
 /// creates `feature-NNN` branches pointing at them. This reproduces the
 /// GH #461 scenario where branch divergence depth (not count) drives cost.
 pub fn add_history_spread_branches(repo_path: &Path, count: usize) {
-    let log_output = Command::new("git")
+    let log_output = Cmd::new("git")
         .args(["log", "--oneline", "-n", "5000", "--format=%H"])
         .current_dir(repo_path)
-        .output()
+        .run()
         .unwrap();
     let log_str = String::from_utf8_lossy(&log_output.stdout);
     let step = 5000 / count;

--- a/tests/integration_tests/repository.rs
+++ b/tests/integration_tests/repository.rs
@@ -3,6 +3,7 @@
 use std::fs;
 
 use worktrunk::git::Repository;
+use worktrunk::shell_exec::Cmd;
 
 use crate::common::TestRepo;
 
@@ -570,37 +571,28 @@ fn test_repo_path_in_submodule() {
     fs::create_dir(&parent_path).unwrap();
 
     // Initialize parent repo with git config
-    let mut cmd = std::process::Command::new("git");
-    cmd.args(["init", "-q"])
+    Cmd::new("git")
+        .args(["init", "-q"])
         .current_dir(&parent_path)
         .env("GIT_CONFIG_SYSTEM", "/dev/null")
-        .env("GIT_CONFIG_GLOBAL", "/dev/null");
-    let output = cmd.output().unwrap();
-    assert!(output.status.success(), "git init failed for parent");
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .run()
+        .unwrap();
 
     // Configure git user for commits
-    std::process::Command::new("git")
-        .args(["config", "user.email", "test@example.com"])
-        .current_dir(&parent_path)
-        .output()
+    let parent_repo = Repository::at(&parent_path).unwrap();
+    parent_repo
+        .run_command(&["config", "user.email", "test@example.com"])
         .unwrap();
-    std::process::Command::new("git")
-        .args(["config", "user.name", "Test User"])
-        .current_dir(&parent_path)
-        .output()
+    parent_repo
+        .run_command(&["config", "user.name", "Test User"])
         .unwrap();
 
     // Create initial commit in parent
     fs::write(parent_path.join("README.md"), "# Parent").unwrap();
-    std::process::Command::new("git")
-        .args(["add", "."])
-        .current_dir(&parent_path)
-        .output()
-        .unwrap();
-    std::process::Command::new("git")
-        .args(["commit", "-m", "Initial commit"])
-        .current_dir(&parent_path)
-        .output()
+    parent_repo.run_command(&["add", "."]).unwrap();
+    parent_repo
+        .run_command(&["commit", "-m", "Initial commit"])
         .unwrap();
 
     // Create submodule repository (as a separate repo first)
@@ -608,45 +600,33 @@ fn test_repo_path_in_submodule() {
     let sub_origin_path = sub_temp.path().join("submodule-origin");
     fs::create_dir(&sub_origin_path).unwrap();
 
-    let mut cmd = std::process::Command::new("git");
-    cmd.args(["init", "-q"])
+    Cmd::new("git")
+        .args(["init", "-q"])
         .current_dir(&sub_origin_path)
         .env("GIT_CONFIG_SYSTEM", "/dev/null")
-        .env("GIT_CONFIG_GLOBAL", "/dev/null");
-    let output = cmd.output().unwrap();
-    assert!(
-        output.status.success(),
-        "git init failed for submodule origin"
-    );
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .run()
+        .unwrap();
 
     // Configure git user for submodule
-    std::process::Command::new("git")
-        .args(["config", "user.email", "test@example.com"])
-        .current_dir(&sub_origin_path)
-        .output()
+    let sub_repo = Repository::at(&sub_origin_path).unwrap();
+    sub_repo
+        .run_command(&["config", "user.email", "test@example.com"])
         .unwrap();
-    std::process::Command::new("git")
-        .args(["config", "user.name", "Test User"])
-        .current_dir(&sub_origin_path)
-        .output()
+    sub_repo
+        .run_command(&["config", "user.name", "Test User"])
         .unwrap();
 
     // Create initial commit in submodule origin
     fs::write(sub_origin_path.join("README.md"), "# Submodule").unwrap();
-    std::process::Command::new("git")
-        .args(["add", "."])
-        .current_dir(&sub_origin_path)
-        .output()
-        .unwrap();
-    std::process::Command::new("git")
-        .args(["commit", "-m", "Submodule initial commit"])
-        .current_dir(&sub_origin_path)
-        .output()
+    sub_repo.run_command(&["add", "."]).unwrap();
+    sub_repo
+        .run_command(&["commit", "-m", "Submodule initial commit"])
         .unwrap();
 
     // Add submodule to parent (using local path directly, with file transport allowed)
-    let output = std::process::Command::new("git")
-        .args([
+    parent_repo
+        .run_command(&[
             "-c",
             "protocol.file.allow=always",
             "submodule",
@@ -654,20 +634,11 @@ fn test_repo_path_in_submodule() {
             sub_origin_path.to_str().unwrap(),
             "sub",
         ])
-        .current_dir(&parent_path)
-        .output()
         .unwrap();
-    assert!(
-        output.status.success(),
-        "git submodule add failed: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
 
     // Commit the submodule addition
-    std::process::Command::new("git")
-        .args(["commit", "-m", "Add submodule"])
-        .current_dir(&parent_path)
-        .output()
+    parent_repo
+        .run_command(&["commit", "-m", "Add submodule"])
         .unwrap();
 
     // Now test: create Repository from inside the submodule


### PR DESCRIPTION
Follow-up to #1714. Converts remaining `std::process::Command::new("git")` calls to `Cmd::new("git")` so all git commands in tests get consistent debug logging and timing traces.

**Changed:**
- `src/config/{mod,expansion,test,user/tests}.rs` — `TestRepo::new()` init calls
- `tests/integration_tests/repository.rs` — `test_repo_path_in_submodule` uses `Cmd` for init (with `.env()` isolation) and `repo.run_command()` for post-init operations
- `tests/helpers/wt-perf/src/lib.rs` — All 7 `Command::new("git")` calls converted to `Cmd`

**Not changed (bigger refactor):**
- `tests/common/mod.rs` — `git_command()` returns `Command` to callers; changing return type would touch many integration test files
- `tests/integration_tests/bare_repository.rs` — uses `configure_git_cmd(&mut Command)` helper

> _This was written by Claude Code on behalf of @max-sixty_