### PR TITLE
refactor: change test git_command() to return Cmd instead of Command

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -49,11 +49,11 @@ let output = wt_command()
 
 ### Method reference
 
-| Method | Use when |
-|--------|----------|
-| `repo.wt_command()` | Running wt commands with a TestRepo |
-| `wt_command()` | Running wt without a TestRepo (free function) |
-| `repo.git_command()` | Running git commands |
+| Method | Returns | Use when |
+|--------|---------|----------|
+| `repo.wt_command()` | `Command` | Running wt commands with a TestRepo |
+| `wt_command()` | `Command` | Running wt without a TestRepo (free function) |
+| `repo.git_command()` | `Cmd` | Running git commands (use `.run()` not `.output()`) |
 
 ## Timing Tests: Long Timeouts with Fast Polling
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -22,7 +22,7 @@
 //!
 //! ## Environment Isolation
 //!
-//! Git commands are run with isolated environments using `Command::env()` to ensure:
+//! Git commands are run with isolated environments using `Cmd::env()` to ensure:
 //! - No interference from global git config
 //! - Deterministic commit timestamps
 //! - Consistent locale settings
@@ -409,6 +409,7 @@ pub fn wt_bin() -> PathBuf {
 use tempfile::TempDir;
 use worktrunk::config::sanitize_branch_name;
 use worktrunk::path::to_posix_path;
+use worktrunk::shell_exec::Cmd;
 
 /// Path to the standard fixture (relative to crate root).
 /// Contains repo/, repo.feature-a/, repo.feature-b/, repo.feature-c/, origin_git/.
@@ -764,10 +765,25 @@ pub fn configure_git_cmd(cmd: &mut Command, git_config_path: &Path) {
     cmd.env("GIT_TERMINAL_PROMPT", "0");
 }
 
+/// Configure a `Cmd`-based git command with isolated environment for testing.
+///
+/// This is the `Cmd` equivalent of [`configure_git_cmd`]. Use this when building
+/// git commands via the builder pattern (`Cmd::new("git")`).
+pub fn configure_git_env(cmd: Cmd, git_config_path: &Path) -> Cmd {
+    cmd.env("GIT_CONFIG_GLOBAL", git_config_path.to_str().unwrap())
+        .env("GIT_CONFIG_SYSTEM", NULL_DEVICE)
+        .env("GIT_AUTHOR_DATE", "2025-01-01T00:00:00Z")
+        .env("GIT_COMMITTER_DATE", "2025-01-01T00:00:00Z")
+        .env("LC_ALL", "C")
+        .env("LANG", "C")
+        .env("WORKTRUNK_TEST_EPOCH", TEST_EPOCH.to_string())
+        .env("GIT_TERMINAL_PROMPT", "0")
+}
+
 /// Shared interface for test repository fixtures.
 ///
-/// Provides `configure_git_cmd()`, `git_command()`, and `run_git_in()` with consistent
-/// environment isolation.
+/// Provides `configure_git_cmd()` (for `Command`), `git_command()` (returns `Cmd`),
+/// and `run_git_in()` with consistent environment isolation.
 pub trait TestRepoBase {
     /// Path to the git config file for this test.
     fn git_config_path(&self) -> &Path;
@@ -778,16 +794,17 @@ pub trait TestRepoBase {
     }
 
     /// Create a git command for the given directory.
-    fn git_command(&self, dir: &Path) -> Command {
-        let mut cmd = Command::new("git");
-        cmd.current_dir(dir);
-        self.configure_git_cmd(&mut cmd);
-        cmd
+    fn git_command(&self, dir: &Path) -> Cmd {
+        configure_git_env(Cmd::new("git"), self.git_config_path()).current_dir(dir)
     }
 
     /// Run a git command in a specific directory, panicking on failure.
     fn run_git_in(&self, dir: &Path, args: &[&str]) {
-        let output = self.git_command(dir).args(args).output().unwrap();
+        let output = self
+            .git_command(dir)
+            .args(args.iter().copied())
+            .run()
+            .unwrap();
         check_git_status(&output, &args.join(" "));
     }
 
@@ -801,7 +818,7 @@ pub trait TestRepoBase {
         let output = self
             .git_command(dir)
             .args(["commit", "-m", message])
-            .output()
+            .run()
             .unwrap();
 
         if !output.status.success() {
@@ -1010,11 +1027,11 @@ pub fn set_xdg_config_path(cmd: &mut Command, home: &Path) {
 
 /// Check that a git command succeeded, panicking with diagnostics if not.
 ///
-/// Use this after `git_command().output()` to ensure the command succeeded.
+/// Use this after `git_command().run()` to ensure the command succeeded.
 ///
 /// # Example
 /// ```ignore
-/// let output = repo.git_command().args(["add", "."]).current_dir(&dir).output().unwrap();
+/// let output = repo.git_command().args(["add", "."]).current_dir(&dir).run().unwrap();
 /// check_git_status(&output, "add");
 /// ```
 pub fn check_git_status(output: &std::process::Output, cmd_desc: &str) {
@@ -1229,28 +1246,25 @@ impl TestRepo {
 
     /// Create a `git` command pre-configured for this test repo.
     ///
-    /// Returns an isolated Command with test-specific git config.
-    /// Chain `.args()` to add arguments.
+    /// Returns an isolated `Cmd` with test-specific git config.
+    /// Chain `.args()` to add arguments, then `.run()` to execute.
     ///
     /// # Example
     /// ```ignore
     /// repo.git_command()
     ///     .args(["status", "--porcelain"])
-    ///     .output()?;
+    ///     .run()?;
     /// ```
     #[must_use]
-    pub fn git_command(&self) -> Command {
-        let mut cmd = Command::new("git");
-        self.configure_git_cmd(&mut cmd);
-        cmd.current_dir(&self.root);
-        cmd
+    pub fn git_command(&self) -> Cmd {
+        configure_git_env(Cmd::new("git"), &self.git_config_path).current_dir(&self.root)
     }
 
     /// Run a git command in the repo root, panicking on failure.
     ///
     /// Thin wrapper around `git_command()` that runs the command and checks status.
     pub fn run_git(&self, args: &[&str]) {
-        let output = self.git_command().args(args).output().unwrap();
+        let output = self.git_command().args(args.iter().copied()).run().unwrap();
         check_git_status(&output, &args.join(" "));
     }
 
@@ -1260,9 +1274,9 @@ impl TestRepo {
     pub fn run_git_in(&self, dir: &Path, args: &[&str]) {
         let output = self
             .git_command()
-            .args(args)
+            .args(args.iter().copied())
             .current_dir(dir)
-            .output()
+            .run()
             .unwrap();
         check_git_status(&output, &args.join(" "));
     }
@@ -1271,7 +1285,7 @@ impl TestRepo {
     ///
     /// Thin wrapper around `git_command()` for commands that return output.
     pub fn git_output(&self, args: &[&str]) -> String {
-        let output = self.git_command().args(args).output().unwrap();
+        let output = self.git_command().args(args.iter().copied()).run().unwrap();
         check_git_status(&output, &args.join(" "));
         String::from_utf8_lossy(&output.stdout).trim().to_string()
     }
@@ -1297,10 +1311,10 @@ impl TestRepo {
                         "--force",
                         worktree_path.to_str().unwrap(),
                     ])
-                    .output();
+                    .run();
             }
             // Delete the branch after removing the worktree
-            let _ = self.git_command().args(["branch", "-D", branch]).output();
+            let _ = self.git_command().args(["branch", "-D", branch]).run();
             // Remove from worktrees map so add_worktree() can recreate if needed
             self.worktrees.remove(*branch);
         }
@@ -1316,7 +1330,7 @@ impl TestRepo {
         let output = self
             .git_command()
             .args(["rev-parse", "HEAD"])
-            .output()
+            .run()
             .unwrap();
         check_git_status(&output, "rev-parse HEAD");
         String::from_utf8_lossy(&output.stdout).trim().to_string()
@@ -1328,7 +1342,7 @@ impl TestRepo {
             .git_command()
             .args(["rev-parse", "HEAD"])
             .current_dir(dir)
-            .output()
+            .run()
             .unwrap();
         check_git_status(&output, "rev-parse HEAD");
         String::from_utf8_lossy(&output.stdout).trim().to_string()
@@ -1483,11 +1497,11 @@ impl TestRepo {
         let file_path = self.root.join("file.txt");
         std::fs::write(&file_path, message).unwrap();
 
-        self.git_command().args(["add", "."]).output().unwrap();
+        self.git_command().args(["add", "."]).run().unwrap();
 
         self.git_command()
             .args(["commit", "-m", message])
-            .output()
+            .run()
             .unwrap();
     }
 
@@ -1503,11 +1517,11 @@ impl TestRepo {
         let file_path = self.root.join(format!("file-{}.txt", sanitized));
         std::fs::write(&file_path, message).unwrap();
 
-        self.git_command().args(["add", "."]).output().unwrap();
+        self.git_command().args(["add", "."]).run().unwrap();
 
         self.git_command()
             .args(["commit", "-m", message])
-            .output()
+            .run()
             .unwrap();
     }
 
@@ -1535,14 +1549,14 @@ impl TestRepo {
         let file_path = self.root.join("file.txt");
         std::fs::write(&file_path, message).unwrap();
 
-        self.git_command().args(["add", "."]).output().unwrap();
+        self.git_command().args(["add", "."]).run().unwrap();
 
         // Create commit with custom timestamp
         self.git_command()
             .env("GIT_AUTHOR_DATE", &timestamp)
             .env("GIT_COMMITTER_DATE", &timestamp)
             .args(["commit", "-m", message])
-            .output()
+            .run()
             .unwrap();
     }
 
@@ -1567,7 +1581,7 @@ impl TestRepo {
             .env("GIT_COMMITTER_DATE", &timestamp)
             .args(["commit", "-m", message])
             .current_dir(dir)
-            .output()
+            .run()
             .unwrap();
     }
 
@@ -1816,7 +1830,7 @@ impl TestRepo {
     pub fn has_origin_head(&self) -> bool {
         self.git_command()
             .args(["rev-parse", "--abbrev-ref", "origin/HEAD"])
-            .output()
+            .run()
             .unwrap()
             .status
             .success()
@@ -2151,7 +2165,7 @@ impl TestRepo {
         let json_value = format!(r#"{{"marker":"{}","set_at":{}}}"#, marker, TEST_EPOCH);
         self.git_command()
             .args(["config", &config_key, &json_value])
-            .output()
+            .run()
             .unwrap();
     }
 }
@@ -2206,11 +2220,11 @@ impl BareRepoTest {
         };
 
         // Create bare repository
-        let mut cmd = Command::new("git");
-        cmd.args(["init", "--bare", "--initial-branch", "main"])
-            .arg(&test.bare_repo_path);
-        test.configure_git_cmd(&mut cmd);
-        let output = cmd.output().unwrap();
+        let output = configure_git_env(Cmd::new("git"), &test.git_config_path)
+            .args(["init", "--bare", "--initial-branch", "main"])
+            .arg(test.bare_repo_path.to_str().unwrap())
+            .run()
+            .unwrap();
 
         if !output.status.success() {
             panic!(
@@ -2260,7 +2274,7 @@ impl BareRepoTest {
                 branch,
                 worktree_path.to_str().unwrap(),
             ])
-            .output()
+            .run()
             .unwrap();
 
         if !output.status.success() {
@@ -3272,7 +3286,7 @@ pub fn wait_for_valid_json(path: &Path) -> serde_json::Value {
 /// wait_for("git to detect dirty working tree", || {
 ///     repo.git_command()
 ///         .args(["status", "--porcelain"])
-///         .output()
+///         .run()
 ///         .map(|o| !o.stdout.is_empty())
 ///         .unwrap_or(false)
 /// });
@@ -3374,11 +3388,7 @@ mod tests {
         repo.commit_with_age("Ten minutes ago", 10 * MINUTE);
 
         // Verify commits were created (1 from fixture + 4 = 5 commits)
-        let output = repo
-            .git_command()
-            .args(["log", "--oneline"])
-            .output()
-            .unwrap();
+        let output = repo.git_command().args(["log", "--oneline"]).run().unwrap();
         let log = String::from_utf8_lossy(&output.stdout);
         assert_eq!(log.lines().count(), 5);
     }

--- a/tests/integration_tests/bare_repository.rs
+++ b/tests/integration_tests/bare_repository.rs
@@ -1,7 +1,7 @@
 use crate::common::{
     BareRepoTest, TestRepo, TestRepoBase, canonicalize, configure_directive_file,
-    configure_git_cmd, directive_file, repo, setup_temp_snapshot_settings, wait_for,
-    wait_for_file_content, wait_for_file_count, wt_command,
+    configure_git_cmd, configure_git_env, directive_file, repo, setup_temp_snapshot_settings,
+    wait_for, wait_for_file_content, wait_for_file_count, wt_command,
 };
 use insta_cmd::assert_cmd_snapshot;
 use rstest::rstest;
@@ -10,6 +10,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::thread;
 use std::time::Duration;
+use worktrunk::shell_exec::Cmd;
 
 #[test]
 fn test_bare_repo_list_worktrees() {
@@ -93,7 +94,7 @@ fn test_bare_repo_switch_creates_worktree() {
     let output = test
         .git_command(test.bare_repo_path())
         .args(["worktree", "list"])
-        .output()
+        .run()
         .unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
 
@@ -303,7 +304,7 @@ fn test_bare_repo_equivalent_to_normal_repo(repo: TestRepo) {
                     "--force",
                     worktree_path.to_str().unwrap(),
                 ])
-                .output()
+                .run()
                 .unwrap();
         }
     }
@@ -426,7 +427,7 @@ fn test_bare_repo_merge_workflow() {
     let log_output = test
         .git_command(&main_worktree)
         .args(["log", "--oneline"])
-        .output()
+        .run()
         .unwrap();
 
     let log = String::from_utf8_lossy(&log_output.stdout);
@@ -530,7 +531,7 @@ fn test_bare_repo_project_config_found_from_bare_root() {
     let output = test
         .git_command(&main_worktree)
         .args(["add", ".config/wt.toml"])
-        .output()
+        .run()
         .unwrap();
     assert!(output.status.success());
     test.commit_in(&main_worktree, "Add project config");
@@ -592,7 +593,7 @@ fn test_bare_repo_project_config_found_with_dash_c_flag() {
     let output = test
         .git_command(&main_worktree)
         .args(["add", ".config/wt.toml"])
-        .output()
+        .run()
         .unwrap();
     assert!(output.status.success());
     test.commit_in(&main_worktree, "Add project config");
@@ -734,7 +735,7 @@ fn test_bare_repo_slashed_branch_with_sanitize() {
     let branch_output = test
         .git_command(&expected_path)
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
-        .output()
+        .run()
         .unwrap();
     assert_eq!(
         String::from_utf8_lossy(&branch_output.stdout).trim(),
@@ -787,11 +788,11 @@ impl NestedBareRepoTest {
         };
 
         // Create bare repository at project/.git
-        let mut cmd = Command::new("git");
-        cmd.args(["init", "--bare", "--initial-branch", "main"])
-            .arg(&test.bare_repo_path);
-        test.configure_git_cmd(&mut cmd);
-        let output = cmd.output().unwrap();
+        let output = configure_git_env(Cmd::new("git"), &test.git_config_path)
+            .args(["init", "--bare", "--initial-branch", "main"])
+            .arg(test.bare_repo_path.to_str().unwrap())
+            .run()
+            .unwrap();
 
         if !output.status.success() {
             panic!(
@@ -1078,7 +1079,7 @@ fn test_bare_repo_bootstrap_first_worktree() {
     let output = test
         .git_command(test.bare_repo_path())
         .args(["worktree", "list"])
-        .output()
+        .run()
         .unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
 
@@ -1111,10 +1112,11 @@ fn test_clone_bare_repo_list_no_status_errors() {
     fs::write(&test_config_path, "").unwrap();
 
     let run_git = |dir: &Path, args: &[&str]| {
-        let mut cmd = Command::new("git");
-        cmd.args(args).current_dir(dir);
-        configure_git_cmd(&mut cmd, &git_config_path);
-        let output = cmd.output().unwrap();
+        let output = configure_git_env(Cmd::new("git"), &git_config_path)
+            .args(args.iter().copied())
+            .current_dir(dir)
+            .run()
+            .unwrap();
         assert!(
             output.status.success(),
             "git {} failed: {}",
@@ -1386,11 +1388,14 @@ mod bare_repo_prompt_pty {
         });
 
         // Verify skip flag was saved in git config
-        let git_config_output = Command::new("git")
+        let git_config_output = Cmd::new("git")
             .args(["config", "worktrunk.skip-bare-repo-prompt"])
             .current_dir(&main_worktree)
-            .env("GIT_CONFIG_GLOBAL", test.git_config_path())
-            .output()
+            .env(
+                "GIT_CONFIG_GLOBAL",
+                test.git_config_path().to_str().unwrap(),
+            )
+            .run()
             .unwrap();
         let value = String::from_utf8_lossy(&git_config_output.stdout);
         assert_eq!(

--- a/tests/integration_tests/completion.rs
+++ b/tests/integration_tests/completion.rs
@@ -523,7 +523,7 @@ fn test_complete_excludes_remote_branches(repo: TestRepo) {
     let remote_dir = repo.root_path().parent().unwrap().join("remote.git");
     repo.git_command()
         .args(["init", "--bare", remote_dir.to_str().unwrap()])
-        .output()
+        .run()
         .unwrap();
 
     // Update origin URL to point to our bare repo

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -1304,7 +1304,7 @@ fn test_config_show_github_remote(mut repo: TestRepo, temp_home: TempDir) {
             "origin",
             "https://github.com/example/repo.git",
         ])
-        .output()
+        .run()
         .unwrap();
 
     // Create fake global config
@@ -1343,7 +1343,7 @@ fn test_config_show_gitlab_remote(mut repo: TestRepo, temp_home: TempDir) {
             "origin",
             "https://gitlab.com/example/repo.git",
         ])
-        .output()
+        .run()
         .unwrap();
 
     // Create fake global config

--- a/tests/integration_tests/config_state.rs
+++ b/tests/integration_tests/config_state.rs
@@ -104,10 +104,10 @@ fn test_state_get_default_branch_fails_when_undetermined(repo: TestRepo) {
     // Rename main to something non-standard so default branch can't be determined
     repo.git_command()
         .args(["branch", "-m", "main", "xyz"])
-        .status()
+        .run()
         .unwrap();
-    repo.git_command().args(["branch", "abc"]).status().unwrap();
-    repo.git_command().args(["branch", "def"]).status().unwrap();
+    repo.git_command().args(["branch", "abc"]).run().unwrap();
+    repo.git_command().args(["branch", "def"]).run().unwrap();
 
     // Now we have: xyz, abc, def - no common names, no init.defaultBranch
     // wt config state default-branch get should fail with an error
@@ -138,7 +138,7 @@ fn test_state_set_default_branch(repo: TestRepo) {
     let output = repo
         .git_command()
         .args(["config", "--get", "worktrunk.default-branch"])
-        .output()
+        .run()
         .unwrap();
     assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "develop");
 }
@@ -163,7 +163,7 @@ fn test_state_clear_default_branch(mut repo: TestRepo) {
     let output = repo
         .git_command()
         .args(["config", "--get", "worktrunk.default-branch"])
-        .output()
+        .run()
         .unwrap();
     assert!(!output.status.success());
 }
@@ -257,7 +257,7 @@ fn test_state_get_ci_status(repo: TestRepo) {
 fn test_state_get_ci_status_specific_branch(repo: TestRepo) {
     repo.git_command()
         .args(["branch", "feature"])
-        .status()
+        .run()
         .unwrap();
 
     // Without any CI configured, should return "no-ci"
@@ -296,7 +296,7 @@ fn test_state_clear_ci_status_branch(repo: TestRepo) {
         "worktrunk.state.main.ci-status",
         &format!(r#"{{"status":{{"ci_status":"passed","source":"pull-request","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"abc12345"}}"#),
     ])
-    .status()
+    .run()
     .unwrap();
 
     let output = wt_state_cmd(&repo, "ci-status", "clear", &[])
@@ -342,7 +342,7 @@ fn test_state_get_marker_empty(repo: TestRepo) {
 fn test_state_get_marker_specific_branch(repo: TestRepo) {
     repo.git_command()
         .args(["branch", "feature"])
-        .status()
+        .run()
         .unwrap();
 
     // Set a marker for feature branch (using JSON format)
@@ -373,7 +373,7 @@ fn test_state_set_marker_branch_default(repo: TestRepo) {
 fn test_state_set_marker_branch_specific(repo: TestRepo) {
     repo.git_command()
         .args(["branch", "feature"])
-        .status()
+        .run()
         .unwrap();
 
     let output = wt_state_cmd(&repo, "marker", "set", &["🔧", "--branch", "feature"])
@@ -404,7 +404,7 @@ fn test_state_clear_marker_branch_default(repo: TestRepo) {
     let output = repo
         .git_command()
         .args(["config", "--get", "worktrunk.state.main.marker"])
-        .output()
+        .run()
         .unwrap();
     assert!(!output.status.success());
 }
@@ -424,7 +424,7 @@ fn test_state_clear_marker_branch_specific(repo: TestRepo) {
     let output = repo
         .git_command()
         .args(["config", "--get", "worktrunk.state.feature.marker"])
-        .output()
+        .run()
         .unwrap();
     assert!(!output.status.success());
 }
@@ -446,7 +446,7 @@ fn test_state_clear_marker_all(repo: TestRepo) {
     let output = repo
         .git_command()
         .args(["config", "--get-regexp", r"^worktrunk\.state\..+\.marker$"])
-        .output()
+        .run()
         .unwrap();
     assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "");
 }
@@ -608,7 +608,7 @@ fn test_state_clear_all_comprehensive(repo: TestRepo) {
     // Previous branch
     repo.git_command()
         .args(["config", "worktrunk.history", "feature"])
-        .status()
+        .run()
         .unwrap();
 
     // Marker (using JSON format)
@@ -635,7 +635,7 @@ fn test_state_clear_all_comprehensive(repo: TestRepo) {
     assert!(
         repo.git_command()
             .args(["config", "--get", "worktrunk.history"])
-            .output()
+            .run()
             .unwrap()
             .status
             .code()
@@ -644,7 +644,7 @@ fn test_state_clear_all_comprehensive(repo: TestRepo) {
     assert!(
         repo.git_command()
             .args(["config", "--get", "worktrunk.state.main.marker"])
-            .output()
+            .run()
             .unwrap()
             .status
             .code()
@@ -743,7 +743,7 @@ fn test_state_get_comprehensive(repo: TestRepo) {
     // Set up previous branch
     repo.git_command()
         .args(["config", "worktrunk.history", "feature"])
-        .status()
+        .run()
         .unwrap();
 
     // Set up branch markers (JSON format with timestamps for deterministic age)
@@ -753,7 +753,7 @@ fn test_state_get_comprehensive(repo: TestRepo) {
             "worktrunk.state.feature.marker",
             &format!(r#"{{"marker":"🚧 WIP","set_at":{TEST_EPOCH}}}"#),
         ])
-        .status()
+        .run()
         .unwrap();
     repo.git_command()
         .args([
@@ -761,7 +761,7 @@ fn test_state_get_comprehensive(repo: TestRepo) {
             "worktrunk.state.bugfix.marker",
             &format!(r#"{{"marker":"🐛 debugging","set_at":{TEST_EPOCH}}}"#),
         ])
-        .status()
+        .run()
         .unwrap();
 
     // Set up CI cache (file-based)
@@ -809,7 +809,7 @@ fn test_state_get_json_comprehensive(repo: TestRepo) {
     // Set up previous branch
     repo.git_command()
         .args(["config", "worktrunk.history", "feature"])
-        .status()
+        .run()
         .unwrap();
 
     // Set up branch markers (JSON format with timestamps)
@@ -819,7 +819,7 @@ fn test_state_get_json_comprehensive(repo: TestRepo) {
             "worktrunk.state.feature.marker",
             &format!(r#"{{"marker":"🚧 WIP","set_at":{TEST_EPOCH}}}"#),
         ])
-        .status()
+        .run()
         .unwrap();
 
     // Set up CI cache (file-based)
@@ -947,7 +947,7 @@ fn test_state_clear_ci_status_specific_branch(repo: TestRepo) {
     // Create a feature branch
     repo.git_command()
         .args(["branch", "feature"])
-        .status()
+        .run()
         .unwrap();
 
     // Add CI cache via git config for the specific branch
@@ -956,7 +956,7 @@ fn test_state_clear_ci_status_specific_branch(repo: TestRepo) {
         "worktrunk.state.feature.ci-status",
         &format!(r#"{{"status":{{"ci_status":"passed","source":"pull-request","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"abc12345"}}"#),
     ])
-    .status()
+    .run()
     .unwrap();
 
     let output = wt_state_cmd(&repo, "ci-status", "clear", &["--branch", "feature"])
@@ -971,7 +971,7 @@ fn test_state_clear_ci_status_specific_branch_not_cached(repo: TestRepo) {
     // Create a feature branch without any CI cache
     repo.git_command()
         .args(["branch", "feature"])
-        .status()
+        .run()
         .unwrap();
 
     let output = wt_state_cmd(&repo, "ci-status", "clear", &["--branch", "feature"])
@@ -986,7 +986,7 @@ fn test_state_clear_marker_specific_branch(repo: TestRepo) {
     // Create a feature branch and set marker
     repo.git_command()
         .args(["branch", "feature"])
-        .status()
+        .run()
         .unwrap();
     repo.set_marker("feature", "🔧");
 
@@ -1002,7 +1002,7 @@ fn test_state_clear_marker_specific_branch_not_set(repo: TestRepo) {
     // Create a feature branch without any marker
     repo.git_command()
         .args(["branch", "feature"])
-        .status()
+        .run()
         .unwrap();
 
     let output = wt_state_cmd(&repo, "marker", "clear", &["--branch", "feature"])
@@ -1050,11 +1050,11 @@ fn test_state_hints_get_with_hints(repo: TestRepo) {
     // Set hints via git config (as the code stores them)
     repo.git_command()
         .args(["config", "worktrunk.hints.worktree-path", "true"])
-        .status()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["config", "worktrunk.hints.another-hint", "true"])
-        .status()
+        .run()
         .unwrap();
 
     let output = wt_state_cmd(&repo, "hints", "get", &[]).output().unwrap();
@@ -1077,11 +1077,11 @@ fn test_state_hints_clear_all(repo: TestRepo) {
     // Set hints
     repo.git_command()
         .args(["config", "worktrunk.hints.worktree-path", "true"])
-        .status()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["config", "worktrunk.hints.another-hint", "true"])
-        .status()
+        .run()
         .unwrap();
 
     let output = wt_state_cmd(&repo, "hints", "clear", &[]).output().unwrap();
@@ -1092,7 +1092,7 @@ fn test_state_hints_clear_all(repo: TestRepo) {
     let output = repo
         .git_command()
         .args(["config", "--get-regexp", r"^worktrunk\.hints\."])
-        .output()
+        .run()
         .unwrap();
     assert!(!output.status.success()); // No matches
 }
@@ -1102,7 +1102,7 @@ fn test_state_hints_clear_single(repo: TestRepo) {
     // Set a single hint
     repo.git_command()
         .args(["config", "worktrunk.hints.worktree-path", "true"])
-        .status()
+        .run()
         .unwrap();
 
     let output = wt_state_cmd(&repo, "hints", "clear", &[]).output().unwrap();
@@ -1115,11 +1115,11 @@ fn test_state_hints_clear_specific(repo: TestRepo) {
     // Set hints
     repo.git_command()
         .args(["config", "worktrunk.hints.worktree-path", "true"])
-        .status()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["config", "worktrunk.hints.another-hint", "true"])
-        .status()
+        .run()
         .unwrap();
 
     let output = wt_state_cmd(&repo, "hints", "clear", &["worktree-path"])
@@ -1132,14 +1132,14 @@ fn test_state_hints_clear_specific(repo: TestRepo) {
     let output = repo
         .git_command()
         .args(["config", "--get", "worktrunk.hints.worktree-path"])
-        .output()
+        .run()
         .unwrap();
     assert!(!output.status.success()); // Cleared
 
     let output = repo
         .git_command()
         .args(["config", "--get", "worktrunk.hints.another-hint"])
-        .output()
+        .run()
         .unwrap();
     assert!(output.status.success()); // Still there
 }
@@ -1304,7 +1304,7 @@ fn test_state_logs_get_hook_with_branch_flag(repo: TestRepo) {
     // Create log file for a different branch
     repo.git_command()
         .args(["branch", "feature"])
-        .status()
+        .run()
         .unwrap();
 
     let git_dir = repo.root_path().join(".git");

--- a/tests/integration_tests/default_branch.rs
+++ b/tests/integration_tests/default_branch.rs
@@ -32,7 +32,7 @@ fn test_get_default_branch_without_origin_head(#[from(repo_with_remote)] repo: T
     let cached = repo
         .git_command()
         .args(["config", "--get", "worktrunk.default-branch"])
-        .output()
+        .run()
         .unwrap();
     assert_eq!(String::from_utf8_lossy(&cached.stdout).trim(), "main");
 }
@@ -44,7 +44,7 @@ fn test_get_default_branch_caches_result(#[from(repo_with_remote)] repo: TestRep
     let _ = repo
         .git_command()
         .args(["config", "--unset", "worktrunk.default-branch"])
-        .output();
+        .run();
 
     // First call queries remote and caches to worktrunk config
     Repository::at(repo.root_path())
@@ -54,7 +54,7 @@ fn test_get_default_branch_caches_result(#[from(repo_with_remote)] repo: TestRep
     let cached = repo
         .git_command()
         .args(["config", "--get", "worktrunk.default-branch"])
-        .output()
+        .run()
         .unwrap();
     assert!(cached.status.success());
 
@@ -134,12 +134,9 @@ fn test_get_default_branch_no_remote_common_names_fallback(repo: TestRepo) {
     // Create additional branches (no remote configured)
     repo.git_command()
         .args(["branch", "feature"])
-        .status()
+        .run()
         .unwrap();
-    repo.git_command()
-        .args(["branch", "bugfix"])
-        .status()
-        .unwrap();
+    repo.git_command().args(["branch", "bugfix"]).run().unwrap();
 
     // Now we have multiple branches: main, feature, bugfix
     // Should detect "main" from the common names list
@@ -158,16 +155,13 @@ fn test_get_default_branch_no_remote_master_fallback(repo: TestRepo) {
     // Rename main to master, then create other branches
     repo.git_command()
         .args(["branch", "-m", "main", "master"])
-        .status()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["branch", "feature"])
-        .status()
+        .run()
         .unwrap();
-    repo.git_command()
-        .args(["branch", "bugfix"])
-        .status()
-        .unwrap();
+    repo.git_command().args(["branch", "bugfix"]).run().unwrap();
 
     // Now we have: master, feature, bugfix (no "main")
     // Should detect "master" from the common names list
@@ -186,17 +180,17 @@ fn test_default_branch_no_remote_uses_init_config(repo: TestRepo) {
     // Rename main to something non-standard, create the configured default
     repo.git_command()
         .args(["branch", "-m", "main", "primary"])
-        .status()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["branch", "feature"])
-        .status()
+        .run()
         .unwrap();
 
     // Set init.defaultBranch - this should be checked before common names
     repo.git_command()
         .args(["config", "init.defaultBranch", "primary"])
-        .status()
+        .run()
         .unwrap();
 
     // Now we have: primary, feature (no common names like main/master)
@@ -213,7 +207,7 @@ fn test_configured_default_branch_does_not_exist_returns_none(repo: TestRepo) {
     // Configure a non-existent branch
     repo.git_command()
         .args(["config", "worktrunk.default-branch", "nonexistent-branch"])
-        .status()
+        .run()
         .unwrap();
 
     // Should return None when configured branch doesn't exist locally
@@ -230,7 +224,7 @@ fn test_invalid_default_branch_config_returns_configured_value(repo: TestRepo) {
     // Configure a non-existent branch
     repo.git_command()
         .args(["config", "worktrunk.default-branch", "nonexistent-branch"])
-        .status()
+        .run()
         .unwrap();
 
     // Should report the invalid configuration
@@ -245,7 +239,7 @@ fn test_invalid_default_branch_config_returns_none_when_valid(repo: TestRepo) {
     // Configure the existing "main" branch
     repo.git_command()
         .args(["config", "worktrunk.default-branch", "main"])
-        .status()
+        .run()
         .unwrap();
 
     // Should return None since the configured branch exists
@@ -267,10 +261,10 @@ fn test_get_default_branch_no_remote_fails_when_no_match(repo: TestRepo) {
     // Rename main to something non-standard
     repo.git_command()
         .args(["branch", "-m", "main", "xyz"])
-        .status()
+        .run()
         .unwrap();
-    repo.git_command().args(["branch", "abc"]).status().unwrap();
-    repo.git_command().args(["branch", "def"]).status().unwrap();
+    repo.git_command().args(["branch", "abc"]).run().unwrap();
+    repo.git_command().args(["branch", "def"]).run().unwrap();
 
     // Now we have: xyz, abc, def - no common names, no init.defaultBranch
     // In normal repos (not bare), symbolic-ref HEAD isn't used because HEAD
@@ -292,10 +286,10 @@ fn test_resolve_caret_fails_when_default_branch_unavailable(repo: TestRepo) {
     // Rename main to something non-standard so default branch can't be determined
     repo.git_command()
         .args(["branch", "-m", "main", "xyz"])
-        .status()
+        .run()
         .unwrap();
-    repo.git_command().args(["branch", "abc"]).status().unwrap();
-    repo.git_command().args(["branch", "def"]).status().unwrap();
+    repo.git_command().args(["branch", "abc"]).run().unwrap();
+    repo.git_command().args(["branch", "def"]).run().unwrap();
 
     // Now resolving "^" should fail with an error
     let git_repo = Repository::at(repo.root_path()).unwrap();

--- a/tests/integration_tests/for_each.rs
+++ b/tests/integration_tests/for_each.rs
@@ -102,7 +102,7 @@ fn test_for_each_skips_prunable_worktrees(mut repo: TestRepo) {
     let output = repo
         .git_command()
         .args(["worktree", "list", "--porcelain"])
-        .output()
+        .run()
         .unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(

--- a/tests/integration_tests/list.rs
+++ b/tests/integration_tests/list.rs
@@ -35,7 +35,7 @@ fn setup_timestamped_worktrees(repo: &mut TestRepo) -> std::path::PathBuf {
             .env("GIT_COMMITTER_DATE", time)
             .args(["add", "."])
             .current_dir(path)
-            .output()
+            .run()
             .unwrap();
 
         repo.git_command()
@@ -43,7 +43,7 @@ fn setup_timestamped_worktrees(repo: &mut TestRepo) -> std::path::PathBuf {
             .env("GIT_COMMITTER_DATE", time)
             .args(["commit", "-m", &format!("Commit at {}", time_short)])
             .current_dir(path)
-            .output()
+            .run()
             .unwrap();
     }
 
@@ -434,7 +434,7 @@ fn test_list_with_orphaned_remote_ref(#[from(repo_with_remote)] repo: TestRepo) 
     let head_sha = repo
         .git_command()
         .args(["rev-parse", "HEAD"])
-        .output()
+        .run()
         .unwrap()
         .stdout;
     let head_sha = String::from_utf8_lossy(&head_sha);
@@ -446,7 +446,7 @@ fn test_list_with_orphaned_remote_ref(#[from(repo_with_remote)] repo: TestRepo) 
     ]);
 
     // Verify the ref exists but the remote doesn't
-    let remotes = repo.git_command().args(["remote"]).output().unwrap().stdout;
+    let remotes = repo.git_command().args(["remote"]).run().unwrap().stdout;
     let remotes = String::from_utf8_lossy(&remotes);
     assert!(
         !remotes.contains("deleted-remote"),
@@ -619,10 +619,10 @@ fn test_list_with_user_marker(mut repo: TestRepo) {
                     "--force",
                     worktree_path.to_str().unwrap(),
                 ])
-                .output();
+                .run();
         }
         // Delete the branch after removing the worktree
-        let _ = repo.git_command().args(["branch", "-D", branch]).output();
+        let _ = repo.git_command().args(["branch", "-D", branch]).run();
     }
 
     repo.commit_with_age("Initial commit", DAY);
@@ -710,7 +710,7 @@ fn test_list_json_with_git_operation(mut repo: TestRepo) {
         .git_command()
         .current_dir(&feature)
         .args(["rebase", "main"])
-        .output()
+        .run()
         .unwrap();
 
     // Rebase should fail with conflicts - verify we're in rebase state
@@ -785,9 +785,9 @@ fn remove_fixture_worktrees(repo: &mut TestRepo) {
                     "--force",
                     worktree_path.to_str().unwrap(),
                 ])
-                .output();
+                .run();
         }
-        let _ = repo.git_command().args(["branch", "-D", branch]).output();
+        let _ = repo.git_command().args(["branch", "-D", branch]).run();
     }
 }
 
@@ -1651,7 +1651,7 @@ impl SubscriptionRoot {
         let output = repo
             .git_command()
             .args(["rev-parse", "HEAD"])
-            .output()
+            .run()
             .unwrap();
         String::from_utf8_lossy(&output.stdout).trim().to_string()
     };
@@ -1731,7 +1731,7 @@ fn mock_ci_status(repo: &TestRepo, branch: &str, status: &str, source: &str, is_
     let output = repo
         .git_command()
         .args(["rev-parse", branch])
-        .output()
+        .run()
         .unwrap();
     let head = String::from_utf8_lossy(&output.stdout).trim().to_string();
 
@@ -1753,7 +1753,7 @@ fn mock_ci_status(repo: &TestRepo, branch: &str, status: &str, source: &str, is_
     let output = repo
         .git_command()
         .args(["rev-parse", "--git-common-dir"])
-        .output()
+        .run()
         .unwrap();
     let git_dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
 
@@ -2449,7 +2449,7 @@ fn test_list_maximum_status_with_git_operation(mut repo: TestRepo) {
         .git_command()
         .args(["rebase", "main"])
         .current_dir(&feature)
-        .output()
+        .run()
         .unwrap();
 
     // Rebase should fail with conflicts - verify we're in rebase state
@@ -2516,7 +2516,7 @@ fn test_list_maximum_status_symbols(mut repo: TestRepo) {
             .git_command()
             .args(["rev-parse", "HEAD"])
             .current_dir(&feature)
-            .output()
+            .run()
             .unwrap();
         String::from_utf8_lossy(&output.stdout).trim().to_string()
     };
@@ -2526,19 +2526,19 @@ fn test_list_maximum_status_symbols(mut repo: TestRepo) {
     repo.git_command()
         .args(["add", "remote-file.txt"])
         .current_dir(&feature)
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["commit", "-m", "Remote commit"])
         .current_dir(&feature)
-        .output()
+        .run()
         .unwrap();
     let remote_sha = {
         let output = repo
             .git_command()
             .args(["rev-parse", "HEAD"])
             .current_dir(&feature)
-            .output()
+            .run()
             .unwrap();
         String::from_utf8_lossy(&output.stdout).trim().to_string()
     };
@@ -2547,7 +2547,7 @@ fn test_list_maximum_status_symbols(mut repo: TestRepo) {
     repo.git_command()
         .args(["reset", "--hard", &base_sha])
         .current_dir(&feature)
-        .output()
+        .run()
         .unwrap();
 
     // Local-only commit (divergence on the local side)
@@ -2555,24 +2555,24 @@ fn test_list_maximum_status_symbols(mut repo: TestRepo) {
     repo.git_command()
         .args(["add", "local-file.txt"])
         .current_dir(&feature)
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["commit", "-m", "Local commit"])
         .current_dir(&feature)
-        .output()
+        .run()
         .unwrap();
 
     // Wire up upstream tracking deterministically: point origin/feature at the remote-only commit
     repo.git_command()
         .args(["update-ref", "refs/remotes/origin/feature", &remote_sha])
         .current_dir(&feature)
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["branch", "--set-upstream-to=origin/feature", "feature"])
         .current_dir(&feature)
-        .output()
+        .run()
         .unwrap();
 
     // Make main advance with conflicting change (so feature is behind with conflicts)
@@ -2722,32 +2722,26 @@ fn test_list_handles_orphan_branch(repo: TestRepo) {
     // Create an orphan branch (no common ancestor with main)
     repo.git_command()
         .args(["checkout", "--orphan", "assets"])
-        .output()
+        .run()
         .unwrap();
 
     // Clear working tree and create new content
-    repo.git_command()
-        .args(["rm", "-rf", "."])
-        .output()
-        .unwrap();
+    repo.git_command().args(["rm", "-rf", "."]).run().unwrap();
     std::fs::write(repo.root_path().join("asset.txt"), "asset content\n").unwrap();
-    repo.git_command().args(["add", "."]).output().unwrap();
+    repo.git_command().args(["add", "."]).run().unwrap();
     repo.git_command()
         .args(["commit", "-m", "Add asset"])
-        .output()
+        .run()
         .unwrap();
 
     // Go back to main
-    repo.git_command()
-        .args(["checkout", "main"])
-        .output()
-        .unwrap();
+    repo.git_command().args(["checkout", "main"]).run().unwrap();
 
     // Verify no merge base exists (this confirms we have a true orphan branch)
     let output = repo
         .git_command()
         .args(["merge-base", "main", "assets"])
-        .output()
+        .run()
         .unwrap();
     assert!(
         !output.status.success(),
@@ -2776,7 +2770,7 @@ fn test_list_skips_operations_for_prunable_worktrees(mut repo: TestRepo) {
     let output = repo
         .git_command()
         .args(["worktree", "list", "--porcelain"])
-        .output()
+        .run()
         .unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
@@ -2807,12 +2801,12 @@ fn test_list_skips_expensive_for_stale_branches(mut repo: TestRepo) {
     repo.git_command()
         .args(["add", "feature.txt"])
         .current_dir(&feature_path)
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["commit", "-m", "Feature work"])
         .current_dir(&feature_path)
-        .output()
+        .run()
         .unwrap();
 
     // With threshold=1, feature branch (2 behind) should skip expensive tasks

--- a/tests/integration_tests/list_config.rs
+++ b/tests/integration_tests/list_config.rs
@@ -278,10 +278,10 @@ fn test_list_url_with_branches_flag(repo: TestRepo, temp_home: TempDir) {
                     "--force",
                     worktree_path.to_str().unwrap(),
                 ])
-                .output();
+                .run();
         }
         // Delete the branch after removing the worktree
-        let _ = repo.git_command().args(["branch", "-D", branch]).output();
+        let _ = repo.git_command().args(["branch", "-D", branch]).run();
     }
 
     // Create a branch without a worktree

--- a/tests/integration_tests/merge.rs
+++ b/tests/integration_tests/merge.rs
@@ -170,7 +170,7 @@ fn test_merge_no_commit_not_fast_forward(repo: TestRepo) {
         &repo
             .git_command()
             .args(["rev-parse", "HEAD"])
-            .output()
+            .run()
             .unwrap()
             .stdout,
     )
@@ -226,7 +226,7 @@ fn test_merge_rebase_conflict(repo: TestRepo) {
         &repo
             .git_command()
             .args(["rev-parse", "HEAD~1"])
-            .output()
+            .run()
             .unwrap()
             .stdout,
     )
@@ -1395,7 +1395,7 @@ fn test_merge_primary_on_different_branch_dirty(mut repo: TestRepo) {
         &repo
             .git_command()
             .args(["rev-parse", "HEAD~1"])
-            .output()
+            .run()
             .unwrap()
             .stdout,
     )
@@ -1455,7 +1455,7 @@ fn test_merge_race_condition_commit_after_push(mut repo_with_feature_worktree: T
     let output = repo
         .git_command()
         .args(["branch", "-d", "feature"])
-        .output()
+        .run()
         .unwrap();
 
     // Verify the deletion failed (non-zero exit code)
@@ -1476,7 +1476,7 @@ fn test_merge_race_condition_commit_after_push(mut repo_with_feature_worktree: T
     let output = repo
         .git_command()
         .args(["branch", "--list", "feature"])
-        .output()
+        .run()
         .unwrap();
 
     let stdout = String::from_utf8_lossy(&output.stdout);
@@ -1499,7 +1499,7 @@ fn test_merge_to_non_default_target(repo: TestRepo) {
         &repo
             .git_command()
             .args(["rev-parse", "HEAD~1"])
-            .output()
+            .run()
             .unwrap()
             .stdout,
     )
@@ -1585,7 +1585,7 @@ fn test_merge_squash_with_working_tree_creates_backup(mut repo_with_main_worktre
     let output = repo
         .git_command()
         .args(["reflog", "show", "refs/wt-backup/feature"])
-        .output()
+        .run()
         .unwrap();
 
     let reflog = String::from_utf8_lossy(&output.stdout);
@@ -1627,7 +1627,7 @@ fn test_merge_doesnt_set_receive_deny_current_branch(merge_scenario: (TestRepo, 
     let after = repo
         .git_command()
         .args(["config", "receive.denyCurrentBranch"])
-        .output()
+        .run()
         .unwrap();
     let after_value = String::from_utf8_lossy(&after.stdout).trim().to_string();
 
@@ -1982,7 +1982,7 @@ fn test_step_rebase_with_merge_commit(mut repo: TestRepo) {
         .git_command()
         .current_dir(&feature_wt)
         .args(["merge", "main", "-m", "Merge main into feature"])
-        .output()
+        .run()
         .unwrap();
     assert!(
         output.status.success(),
@@ -2359,7 +2359,7 @@ fn test_merge_no_ff_syncs_target_worktree(mut repo_with_main_worktree: TestRepo)
         .git_command()
         .args(["rev-parse", "HEAD"])
         .current_dir(&main_wt)
-        .output()
+        .run()
         .unwrap();
     let wt_head = String::from_utf8_lossy(&wt_head_output.stdout)
         .trim()
@@ -2401,7 +2401,7 @@ fn test_merge_no_ff_dirty_target_autostash(mut repo_with_main_worktree: TestRepo
     );
 
     // Verify autostash cleaned up (no leftover stash entries)
-    let stash_list = repo.git_command().args(["stash", "list"]).output().unwrap();
+    let stash_list = repo.git_command().args(["stash", "list"]).run().unwrap();
     assert!(
         String::from_utf8_lossy(&stash_list.stdout)
             .trim()
@@ -2450,7 +2450,7 @@ fn test_merge_no_ff_dirty_target_conflict(mut repo_with_main_worktree: TestRepo)
     );
 
     // Verify no stash was created
-    let stash_list = repo.git_command().args(["stash", "list"]).output().unwrap();
+    let stash_list = repo.git_command().args(["stash", "list"]).run().unwrap();
     assert!(
         String::from_utf8_lossy(&stash_list.stdout)
             .trim()

--- a/tests/integration_tests/post_start_commands.rs
+++ b/tests/integration_tests/post_start_commands.rs
@@ -280,7 +280,7 @@ fn test_post_create_git_variables_template(#[from(repo_with_remote)] repo: TestR
     // Set up an upstream tracking branch
     repo.git_command()
         .args(["push", "-u", "origin", "main"])
-        .output()
+        .run()
         .expect("failed to push");
 
     // Create project config with git-related template variables
@@ -353,7 +353,7 @@ fn test_post_create_upstream_template(#[from(repo_with_remote)] repo: TestRepo) 
     // Push main to set up tracking
     repo.git_command()
         .args(["push", "-u", "origin", "main"])
-        .output()
+        .run()
         .expect("failed to push main");
 
     // Create project config with upstream template variable
@@ -387,7 +387,7 @@ fn test_post_create_upstream_conditional(#[from(repo_with_remote)] repo: TestRep
     // Push main to set up tracking
     repo.git_command()
         .args(["push", "-u", "origin", "main"])
-        .output()
+        .run()
         .expect("failed to push main");
 
     // Create project config with conditional upstream check

--- a/tests/integration_tests/push.rs
+++ b/tests/integration_tests/push.rs
@@ -81,7 +81,7 @@ fn test_push_with_dirty_target(mut repo: TestRepo) {
     let main_contents = std::fs::read_to_string(repo.root_path().join("conflict.txt")).unwrap();
     assert_eq!(main_contents, "old content");
 
-    let stash_list = repo.git_command().args(["stash", "list"]).output().unwrap();
+    let stash_list = repo.git_command().args(["stash", "list"]).run().unwrap();
     assert!(
         String::from_utf8_lossy(&stash_list.stdout)
             .trim()
@@ -109,7 +109,7 @@ fn test_push_dirty_target_autostash(mut repo: TestRepo) {
     assert_eq!(notes, "temporary notes");
 
     // Autostash should clean up after itself
-    let stash_list = repo.git_command().args(["stash", "list"]).output().unwrap();
+    let stash_list = repo.git_command().args(["stash", "list"]).run().unwrap();
     assert!(
         String::from_utf8_lossy(&stash_list.stdout)
             .trim()
@@ -162,7 +162,7 @@ fn test_push_dirty_target_overlap_renamed_file(mut repo: TestRepo) {
     let main_contents = std::fs::read_to_string(repo.root_path().join("file.txt")).unwrap();
     assert_eq!(main_contents, "modified in target");
 
-    let stash_list = repo.git_command().args(["stash", "list"]).output().unwrap();
+    let stash_list = repo.git_command().args(["stash", "list"]).run().unwrap();
     assert!(
         String::from_utf8_lossy(&stash_list.stdout)
             .trim()

--- a/tests/integration_tests/remove.rs
+++ b/tests/integration_tests/remove.rs
@@ -212,7 +212,7 @@ fn test_remove_nonexistent_worktree(repo: TestRepo) {
 #[rstest]
 fn test_remove_branch_no_worktree_path_occupied(mut repo: TestRepo) {
     // Create branch `npm` without a worktree
-    repo.git_command().args(["branch", "npm"]).output().unwrap();
+    repo.git_command().args(["branch", "npm"]).run().unwrap();
 
     // Create a worktree for a different branch at the path where `npm` worktree would be
     // (the path template puts worktrees at ../repo.branch, so ../repo.npm would be npm's path)
@@ -237,7 +237,7 @@ fn test_remove_branch_no_worktree_path_occupied(mut repo: TestRepo) {
             "--force",
             other_path.to_str().unwrap(),
         ])
-        .output()
+        .run()
         .unwrap();
 
     // Create worktree at npm's expected path but for the "other" branch
@@ -248,7 +248,7 @@ fn test_remove_branch_no_worktree_path_occupied(mut repo: TestRepo) {
             npm_expected_path.to_str().unwrap(),
             "other",
         ])
-        .output()
+        .run()
         .unwrap();
 
     // Now: branch `npm` exists, no worktree for it, but npm's expected path has `other` branch
@@ -337,7 +337,7 @@ fn test_remove_force_with_untracked_files(mut repo: TestRepo) {
         .git_command()
         .args(["status", "--porcelain"])
         .current_dir(&worktree_path)
-        .output()
+        .run()
         .unwrap();
     let status_output = String::from_utf8_lossy(&status.stdout);
     assert!(
@@ -365,12 +365,12 @@ fn test_remove_force_with_modified_files(mut repo: TestRepo) {
     repo.git_command()
         .args(["add", "tracked.txt"])
         .current_dir(&worktree_path)
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["commit", "-m", "Add tracked file"])
         .current_dir(&worktree_path)
-        .output()
+        .run()
         .unwrap();
 
     // Now modify the tracked file
@@ -396,7 +396,7 @@ fn test_remove_force_with_staged_files(mut repo: TestRepo) {
     repo.git_command()
         .args(["add", "staged.txt"])
         .current_dir(&worktree_path)
-        .output()
+        .run()
         .unwrap();
 
     // --force passes through to git, which allows this
@@ -417,7 +417,7 @@ fn test_remove_force_with_force_delete(mut repo: TestRepo) {
     repo.git_command()
         .args(["commit", "--allow-empty", "-m", "feature commit"])
         .current_dir(&worktree_path)
-        .output()
+        .run()
         .unwrap();
 
     // Add untracked file to make the worktree dirty
@@ -442,7 +442,7 @@ fn test_remove_force_actually_deletes_directory_with_untracked(mut repo: TestRep
     repo.git_command()
         .args(["commit", "--allow-empty", "-m", "feature commit"])
         .current_dir(&worktree_path)
-        .output()
+        .run()
         .unwrap();
 
     // Create untracked files (the scenario from issue #839)
@@ -489,7 +489,7 @@ fn test_remove_force_actually_deletes_directory_with_untracked(mut repo: TestRep
     let branch_list = repo
         .git_command()
         .args(["branch", "--list", "feature-untracked-delete"])
-        .output()
+        .run()
         .unwrap();
     assert!(
         String::from_utf8_lossy(&branch_list.stdout)
@@ -541,12 +541,12 @@ fn test_remove_branch_not_fully_merged(mut repo: TestRepo) {
     repo.git_command()
         .args(["add", "feature.txt"])
         .current_dir(&worktree_path)
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["commit", "-m", "Add feature"])
         .current_dir(&worktree_path)
-        .output()
+        .run()
         .unwrap();
 
     // Try to remove it from the main repo
@@ -596,12 +596,12 @@ fn test_remove_foreground_unmerged(mut repo: TestRepo) {
     repo.git_command()
         .args(["add", "feature.txt"])
         .current_dir(&worktree_path)
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["commit", "-m", "Add feature"])
         .current_dir(&worktree_path)
-        .output()
+        .run()
         .unwrap();
 
     // Remove it with --foreground flag from main repo
@@ -642,19 +642,16 @@ fn test_remove_foreground_no_delete_branch_unmerged(mut repo: TestRepo) {
     repo.git_command()
         .args(["add", "feature.txt"])
         .current_dir(&worktree_path)
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["commit", "-m", "Add feature"])
         .current_dir(&worktree_path)
-        .output()
+        .run()
         .unwrap();
 
     // Go back to main
-    repo.git_command()
-        .args(["checkout", "main"])
-        .output()
-        .unwrap();
+    repo.git_command().args(["checkout", "main"]).run().unwrap();
 
     // Remove with both --foreground and --no-delete-branch
     // No hint because:
@@ -697,19 +694,16 @@ fn test_remove_no_delete_branch_unmerged(mut repo: TestRepo) {
     repo.git_command()
         .args(["add", "feature.txt"])
         .current_dir(&worktree_path)
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["commit", "-m", "Add feature"])
         .current_dir(&worktree_path)
-        .output()
+        .run()
         .unwrap();
 
     // Go back to main before removing
-    repo.git_command()
-        .args(["checkout", "main"])
-        .output()
-        .unwrap();
+    repo.git_command().args(["checkout", "main"]).run().unwrap();
 
     // Remove worktree with --no-delete-branch flag
     // Since branch is unmerged, the flag has no effect - no hint shown
@@ -726,7 +720,7 @@ fn test_remove_branch_only_merged(repo: TestRepo) {
     // Create a branch from main without a worktree (already merged)
     repo.git_command()
         .args(["branch", "feature-merged"])
-        .output()
+        .run()
         .unwrap();
 
     // Remove the branch (no worktree exists)
@@ -743,27 +737,24 @@ fn test_remove_branch_only_unmerged(repo: TestRepo) {
     // Create a branch with a unique commit (not in main)
     repo.git_command()
         .args(["branch", "feature-unmerged"])
-        .output()
+        .run()
         .unwrap();
 
     // Add a commit to the branch that's not in main
     repo.git_command()
         .args(["checkout", "feature-unmerged"])
-        .output()
+        .run()
         .unwrap();
     std::fs::write(repo.root_path().join("feature.txt"), "new feature").unwrap();
     repo.git_command()
         .args(["add", "feature.txt"])
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["commit", "-m", "Add feature"])
-        .output()
+        .run()
         .unwrap();
-    repo.git_command()
-        .args(["checkout", "main"])
-        .output()
-        .unwrap();
+    repo.git_command().args(["checkout", "main"]).run().unwrap();
 
     // Try to remove the branch (no worktree exists, branch not merged)
     // Branch deletion should fail but not error
@@ -780,27 +771,24 @@ fn test_remove_branch_only_force_delete(repo: TestRepo) {
     // Create a branch with a unique commit (not in main)
     repo.git_command()
         .args(["branch", "feature-force"])
-        .output()
+        .run()
         .unwrap();
 
     // Add a commit to the branch that's not in main
     repo.git_command()
         .args(["checkout", "feature-force"])
-        .output()
+        .run()
         .unwrap();
     std::fs::write(repo.root_path().join("feature.txt"), "new feature").unwrap();
     repo.git_command()
         .args(["add", "feature.txt"])
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["commit", "-m", "Add feature"])
-        .output()
+        .run()
         .unwrap();
-    repo.git_command()
-        .args(["checkout", "main"])
-        .output()
-        .unwrap();
+    repo.git_command().args(["checkout", "main"]).run().unwrap();
 
     // Force delete the branch (no worktree exists)
     assert_cmd_snapshot!(make_snapshot_cmd(
@@ -882,44 +870,41 @@ fn test_remove_branch_matching_tree_content(repo: TestRepo) {
     // Create a feature branch from main
     repo.git_command()
         .args(["branch", "feature-squashed"])
-        .output()
+        .run()
         .unwrap();
 
     // On feature branch: add a file
     repo.git_command()
         .args(["checkout", "feature-squashed"])
-        .output()
+        .run()
         .unwrap();
     std::fs::write(repo.root_path().join("feature.txt"), "squash content").unwrap();
     repo.git_command()
         .args(["add", "feature.txt"])
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["commit", "-m", "Add feature (on feature branch)"])
-        .output()
+        .run()
         .unwrap();
 
     // On main: add the same file with same content (simulates squash merge result)
-    repo.git_command()
-        .args(["checkout", "main"])
-        .output()
-        .unwrap();
+    repo.git_command().args(["checkout", "main"]).run().unwrap();
     std::fs::write(repo.root_path().join("feature.txt"), "squash content").unwrap();
     repo.git_command()
         .args(["add", "feature.txt"])
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["commit", "-m", "Add feature (squash merged)"])
-        .output()
+        .run()
         .unwrap();
 
     // Verify the setup: feature-squashed is NOT an ancestor of main (different commits)
     let is_ancestor = repo
         .git_command()
         .args(["merge-base", "--is-ancestor", "feature-squashed", "main"])
-        .output()
+        .run()
         .unwrap();
     assert!(
         !is_ancestor.status.success(),
@@ -930,7 +915,7 @@ fn test_remove_branch_matching_tree_content(repo: TestRepo) {
     let feature_tree = String::from_utf8(
         repo.git_command()
             .args(["rev-parse", "feature-squashed^{tree}"])
-            .output()
+            .run()
             .unwrap()
             .stdout,
     )
@@ -938,7 +923,7 @@ fn test_remove_branch_matching_tree_content(repo: TestRepo) {
     let main_tree = String::from_utf8(
         repo.git_command()
             .args(["rev-parse", "main^{tree}"])
-            .output()
+            .run()
             .unwrap()
             .stdout,
     )
@@ -1098,54 +1083,51 @@ fn test_remove_squash_merged_then_main_advanced(repo: TestRepo) {
     // Create feature branch
     repo.git_command()
         .args(["checkout", "-b", "feature-squash"])
-        .output()
+        .run()
         .unwrap();
 
     // Make changes on feature branch (file A)
     std::fs::write(repo.root_path().join("feature-a.txt"), "feature content").unwrap();
     repo.git_command()
         .args(["add", "feature-a.txt"])
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["commit", "-m", "Add feature A"])
-        .output()
+        .run()
         .unwrap();
 
     // Go back to main
-    repo.git_command()
-        .args(["checkout", "main"])
-        .output()
-        .unwrap();
+    repo.git_command().args(["checkout", "main"]).run().unwrap();
 
     // Squash merge feature into main (simulating GitHub squash merge)
     // This creates a NEW commit on main with the same content changes
     std::fs::write(repo.root_path().join("feature-a.txt"), "feature content").unwrap();
     repo.git_command()
         .args(["add", "feature-a.txt"])
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["commit", "-m", "Add feature A (squash merged)"])
-        .output()
+        .run()
         .unwrap();
 
     // Main advances with another commit (file B)
     std::fs::write(repo.root_path().join("main-b.txt"), "main content").unwrap();
     repo.git_command()
         .args(["add", "main-b.txt"])
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["commit", "-m", "Main advances with B"])
-        .output()
+        .run()
         .unwrap();
 
     // Verify setup: feature-squash is NOT an ancestor of main (squash creates different SHAs)
     let is_ancestor = repo
         .git_command()
         .args(["merge-base", "--is-ancestor", "feature-squash", "main"])
-        .output()
+        .run()
         .unwrap();
     assert!(
         !is_ancestor.status.success(),
@@ -1156,7 +1138,7 @@ fn test_remove_squash_merged_then_main_advanced(repo: TestRepo) {
     let feature_tree = String::from_utf8(
         repo.git_command()
             .args(["rev-parse", "feature-squash^{tree}"])
-            .output()
+            .run()
             .unwrap()
             .stdout,
     )
@@ -1164,7 +1146,7 @@ fn test_remove_squash_merged_then_main_advanced(repo: TestRepo) {
     let main_tree = String::from_utf8(
         repo.git_command()
             .args(["rev-parse", "main^{tree}"])
-            .output()
+            .run()
             .unwrap()
             .stdout,
     )
@@ -1523,7 +1505,7 @@ approved-commands = ["echo 'hook ran' > {}"]
     // Create a branch without a worktree
     repo.git_command()
         .args(["branch", "branch-only"])
-        .output()
+        .run()
         .unwrap();
 
     // Remove the branch (no worktree)
@@ -1758,7 +1740,7 @@ fn test_remove_path_mismatch_warning(repo: TestRepo) {
             "-b",
             "feature",
         ])
-        .output()
+        .run()
         .unwrap();
 
     // Remove the worktree - should show path mismatch warning
@@ -1782,7 +1764,7 @@ fn test_remove_path_mismatch_warning_foreground(repo: TestRepo) {
             "-b",
             "feature-fg",
         ])
-        .output()
+        .run()
         .unwrap();
 
     // Remove in foreground mode - should show path mismatch warning
@@ -1936,7 +1918,7 @@ fn test_remove_pruned_worktree_directory_missing(mut repo: TestRepo) {
     let list_output = repo
         .git_command()
         .args(["worktree", "list", "--porcelain"])
-        .output()
+        .run()
         .unwrap();
     let list_str = String::from_utf8_lossy(&list_output.stdout);
     assert!(
@@ -1956,7 +1938,7 @@ fn test_remove_pruned_worktree_directory_missing(mut repo: TestRepo) {
     let list_after = repo
         .git_command()
         .args(["worktree", "list", "--porcelain"])
-        .output()
+        .run()
         .unwrap();
     let list_after_str = String::from_utf8_lossy(&list_after.stdout);
     assert!(
@@ -1968,7 +1950,7 @@ fn test_remove_pruned_worktree_directory_missing(mut repo: TestRepo) {
     let branch_exists = repo
         .git_command()
         .args(["branch", "--list", "feature-pruned"])
-        .output()
+        .run()
         .unwrap();
     assert!(
         String::from_utf8_lossy(&branch_exists.stdout)
@@ -1999,7 +1981,7 @@ fn test_remove_pruned_worktree_keep_branch(mut repo: TestRepo) {
     let branch_exists = repo
         .git_command()
         .args(["branch", "--list", "feature-pruned-keep"])
-        .output()
+        .run()
         .unwrap();
     assert!(
         !String::from_utf8_lossy(&branch_exists.stdout)
@@ -2019,12 +2001,12 @@ fn test_remove_pruned_worktree_unmerged_branch(mut repo: TestRepo) {
     repo.git_command()
         .args(["add", "unmerged.txt"])
         .current_dir(&worktree_path)
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["commit", "-m", "unmerged work"])
         .current_dir(&worktree_path)
-        .output()
+        .run()
         .unwrap();
 
     // Delete the worktree directory externally (simulating user running `rm -rf`)
@@ -2042,7 +2024,7 @@ fn test_remove_pruned_worktree_unmerged_branch(mut repo: TestRepo) {
     let branch_exists = repo
         .git_command()
         .args(["branch", "--list", "feature-pruned-unmerged"])
-        .output()
+        .run()
         .unwrap();
     assert!(
         !String::from_utf8_lossy(&branch_exists.stdout)
@@ -2107,7 +2089,7 @@ fn test_remove_background_git_metadata_pruned(mut repo: TestRepo) {
     let list_before = repo
         .git_command()
         .args(["worktree", "list", "--porcelain"])
-        .output()
+        .run()
         .unwrap();
     assert!(
         String::from_utf8_lossy(&list_before.stdout).contains("feature-prune-test"),
@@ -2131,7 +2113,7 @@ fn test_remove_background_git_metadata_pruned(mut repo: TestRepo) {
     let list_after = repo
         .git_command()
         .args(["worktree", "list", "--porcelain"])
-        .output()
+        .run()
         .unwrap();
     assert!(
         !String::from_utf8_lossy(&list_after.stdout).contains("feature-prune-test"),
@@ -2154,7 +2136,7 @@ fn test_remove_background_deletes_merged_branch(mut repo: TestRepo) {
     let branches_before = repo
         .git_command()
         .args(["branch", "--list", "feature-merged"])
-        .output()
+        .run()
         .unwrap();
     assert!(
         !String::from_utf8_lossy(&branches_before.stdout)
@@ -2180,7 +2162,7 @@ fn test_remove_background_deletes_merged_branch(mut repo: TestRepo) {
     let branches_after = repo
         .git_command()
         .args(["branch", "--list", "feature-merged"])
-        .output()
+        .run()
         .unwrap();
     assert!(
         String::from_utf8_lossy(&branches_after.stdout)
@@ -2204,7 +2186,7 @@ fn test_remove_worktree_with_special_path_chars(mut repo: TestRepo) {
     let list_before = repo
         .git_command()
         .args(["worktree", "list", "--porcelain"])
-        .output()
+        .run()
         .unwrap();
     assert!(
         String::from_utf8_lossy(&list_before.stdout).contains("feature--double-dash"),
@@ -2229,7 +2211,7 @@ fn test_remove_worktree_with_special_path_chars(mut repo: TestRepo) {
         let list = repo
             .git_command()
             .args(["worktree", "list", "--porcelain"])
-            .output()
+            .run()
             .unwrap();
         !String::from_utf8_lossy(&list.stdout).contains("feature--double-dash")
     });
@@ -2291,7 +2273,7 @@ fn test_remove_background_fallback_on_rename_failure(mut repo: TestRepo) {
         let branches = repo
             .git_command()
             .args(["branch", "--list", "feature-fallback"])
-            .output()
+            .run()
             .unwrap();
         String::from_utf8_lossy(&branches.stdout).trim().is_empty()
     });
@@ -2480,7 +2462,7 @@ fn test_remove_foreground_with_submodules(mut repo: TestRepo) {
             sub_source.to_str().unwrap(),
             "submod",
         ])
-        .output()
+        .run()
         .unwrap();
     assert!(
         output.status.success(),
@@ -2501,7 +2483,7 @@ fn test_remove_foreground_with_submodules(mut repo: TestRepo) {
             "update",
             "--init",
         ])
-        .output()
+        .run()
         .unwrap();
     assert!(
         output.status.success(),

--- a/tests/integration_tests/repository.rs
+++ b/tests/integration_tests/repository.rs
@@ -144,7 +144,7 @@ fn test_available_branches_some_without_worktrees() {
     // Create a branch without a worktree
     repo.git_command()
         .args(["branch", "orphan-branch"])
-        .output()
+        .run()
         .unwrap();
 
     let repository = Repository::at(repo.root_path().to_path_buf()).unwrap();
@@ -164,14 +164,8 @@ fn test_available_branches_some_without_worktrees() {
 fn test_all_branches() {
     let repo = TestRepo::new();
     // Create some branches
-    repo.git_command()
-        .args(["branch", "alpha"])
-        .output()
-        .unwrap();
-    repo.git_command()
-        .args(["branch", "beta"])
-        .output()
-        .unwrap();
+    repo.git_command().args(["branch", "alpha"]).run().unwrap();
+    repo.git_command().args(["branch", "beta"]).run().unwrap();
 
     let repository = Repository::at(repo.root_path().to_path_buf()).unwrap();
     let branches = repository.all_branches().unwrap();
@@ -197,7 +191,7 @@ fn test_project_identifier_https() {
             "origin",
             "https://github.com/user/repo.git",
         ])
-        .output()
+        .run()
         .unwrap();
 
     let repository = Repository::at(repo.root_path().to_path_buf()).unwrap();
@@ -217,7 +211,7 @@ fn test_project_identifier_http() {
             "origin",
             "http://gitlab.example.com/team/project.git",
         ])
-        .output()
+        .run()
         .unwrap();
 
     let repository = Repository::at(repo.root_path().to_path_buf()).unwrap();
@@ -237,7 +231,7 @@ fn test_project_identifier_ssh_colon() {
             "origin",
             "git@github.com:user/repo.git",
         ])
-        .output()
+        .run()
         .unwrap();
 
     let repository = Repository::at(repo.root_path().to_path_buf()).unwrap();
@@ -257,7 +251,7 @@ fn test_project_identifier_ssh_protocol() {
             "origin",
             "ssh://git@github.com/user/repo.git",
         ])
-        .output()
+        .run()
         .unwrap();
 
     let repository = Repository::at(repo.root_path().to_path_buf()).unwrap();
@@ -278,7 +272,7 @@ fn test_project_identifier_ssh_protocol_with_port() {
             "origin",
             "ssh://git@gitlab.example.com:2222/team/project.git",
         ])
-        .output()
+        .run()
         .unwrap();
 
     let repository = Repository::at(repo.root_path().to_path_buf()).unwrap();
@@ -309,7 +303,7 @@ fn test_get_config_exists() {
     let repo = TestRepo::new();
     repo.git_command()
         .args(["config", "test.key", "test-value"])
-        .output()
+        .run()
         .unwrap();
 
     let repository = Repository::at(repo.root_path().to_path_buf()).unwrap();

--- a/tests/integration_tests/security.rs
+++ b/tests/integration_tests/security.rs
@@ -160,11 +160,8 @@ fn test_rust_prevents_nul_bytes_in_args(repo: TestRepo) {
     // Rust's Command API should reject NUL bytes in arguments
     let malicious_branch = "feature\0__WORKTRUNK_EXEC__echo PWNED";
 
-    let mut cmd = repo.git_command();
-    cmd.args(["branch", malicious_branch]);
-
-    // Command::output() should fail with InvalidInput error
-    let result = cmd.output();
+    // Cmd::run() should fail with InvalidInput error (NUL bytes rejected by Command API)
+    let result = repo.git_command().args(["branch", malicious_branch]).run();
 
     match result {
         Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => {
@@ -195,7 +192,7 @@ fn test_branch_name_is_directive_not_executed(repo: TestRepo) {
     let result = repo
         .git_command()
         .args(["branch", malicious_branch])
-        .output()
+        .run()
         .unwrap();
 
     if !result.status.success() {
@@ -233,7 +230,7 @@ fn test_branch_name_with_newline_directive_not_executed(repo: TestRepo) {
     let result = repo
         .git_command()
         .args(["branch", malicious_branch])
-        .output()
+        .run()
         .unwrap();
 
     if !result.status.success() {
@@ -332,7 +329,7 @@ fn test_branch_name_with_cd_directive_not_executed(repo: TestRepo) {
     let result = repo
         .git_command()
         .args(["branch", malicious_branch])
-        .output()
+        .run()
         .unwrap();
 
     if !result.status.success() {
@@ -397,7 +394,7 @@ fn test_execute_flag_with_directive_like_branch_name(repo: TestRepo) {
     let result = repo
         .git_command()
         .args(["branch", malicious_branch])
-        .output()
+        .run()
         .unwrap();
 
     if !result.status.success() {
@@ -521,7 +518,7 @@ fn test_git_ignores_malformed_refs_with_ansi(repo: TestRepo) {
 fn test_literal_escape_like_branch_names_displayed_safely(repo: TestRepo) {
     let branch_name = "fix-backslash-x1b-test";
 
-    let result = repo.git_command().args(["branch", branch_name]).output();
+    let result = repo.git_command().args(["branch", branch_name]).run();
 
     if let Ok(output) = result
         && output.status.success()

--- a/tests/integration_tests/statusline.rs
+++ b/tests/integration_tests/statusline.rs
@@ -77,24 +77,24 @@ fn add_commits_ahead(repo: &mut TestRepo) {
     repo.git_command()
         .args(["add", "."])
         .current_dir(&feature_path)
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["commit", "-m", "Feature commit 1"])
         .current_dir(&feature_path)
-        .output()
+        .run()
         .unwrap();
 
     std::fs::write(feature_path.join("feature2.txt"), "more content").unwrap();
     repo.git_command()
         .args(["add", "."])
         .current_dir(&feature_path)
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["commit", "-m", "Feature commit 2"])
         .current_dir(&feature_path)
-        .output()
+        .run()
         .unwrap();
 }
 
@@ -306,15 +306,12 @@ fn test_statusline_reflects_checked_out_branch(mut repo: TestRepo) {
     );
 
     // Create and checkout a different branch "other" in the feature worktree
-    repo.git_command()
-        .args(["branch", "other"])
-        .output()
-        .unwrap();
+    repo.git_command().args(["branch", "other"]).run().unwrap();
     let checkout_output = repo
         .git_command()
         .args(["checkout", "other"])
         .current_dir(&feature_path)
-        .output()
+        .run()
         .unwrap();
     assert!(
         checkout_output.status.success(),
@@ -343,7 +340,7 @@ fn test_statusline_detached_head(mut repo: TestRepo) {
     repo.git_command()
         .args(["checkout", "--detach"])
         .current_dir(&feature_path)
-        .output()
+        .run()
         .unwrap();
 
     // Verify statusline shows HEAD (not "feature")
@@ -448,12 +445,12 @@ fn test_statusline_json_feature_branch(mut repo: TestRepo) {
     repo.git_command()
         .args(["add", "."])
         .current_dir(&feature_path)
-        .output()
+        .run()
         .unwrap();
     repo.git_command()
         .args(["commit", "-m", "Feature commit"])
         .current_dir(&feature_path)
-        .output()
+        .run()
         .unwrap();
 
     let output = run_statusline_from_dir(&repo, &["--format=json"], None, &feature_path);

--- a/tests/integration_tests/step_copy_ignored.rs
+++ b/tests/integration_tests/step_copy_ignored.rs
@@ -492,7 +492,7 @@ fn test_copy_ignored_from_nonexistent_worktree(repo: TestRepo) {
     // Create a branch without a worktree
     repo.git_command()
         .args(["branch", "orphan-branch"])
-        .output()
+        .run()
         .unwrap();
 
     // Try to copy from a branch with no worktree
@@ -510,7 +510,7 @@ fn test_copy_ignored_to_nonexistent_worktree(repo: TestRepo) {
     // Create a branch without a worktree
     repo.git_command()
         .args(["branch", "orphan-branch"])
-        .output()
+        .run()
         .unwrap();
 
     // Setup a file to copy
@@ -1233,7 +1233,7 @@ fn test_copy_ignored_skips_nested_worktrees(mut repo: TestRepo) {
             "feature-nested",
             nested_worktree_path.to_str().unwrap(),
         ])
-        .output()
+        .run()
         .unwrap();
 
     // Add .worktrees to .gitignore (typical for this setup)

--- a/tests/integration_tests/step_diff.rs
+++ b/tests/integration_tests/step_diff.rs
@@ -147,7 +147,7 @@ fn git_status(repo: &TestRepo, dir: &Path) -> String {
         .git_command()
         .args(["status", "--porcelain"])
         .current_dir(dir)
-        .output()
+        .run()
         .unwrap();
     String::from_utf8_lossy(&output.stdout).to_string()
 }

--- a/tests/integration_tests/step_promote.rs
+++ b/tests/integration_tests/step_promote.rs
@@ -13,7 +13,7 @@ fn branch_name(repo: &TestRepo, dir: &std::path::Path) -> String {
         .git_command()
         .args(["rev-parse", "--abbrev-ref", "HEAD"])
         .current_dir(dir)
-        .output()
+        .run()
         .unwrap();
     assert!(
         output.status.success(),
@@ -364,14 +364,14 @@ fn test_promote_detached_head_main(mut repo: TestRepo) {
         .git_command()
         .args(["rev-parse", "HEAD"])
         .current_dir(repo.root_path())
-        .output()
+        .run()
         .unwrap();
     let sha = String::from_utf8_lossy(&sha.stdout).trim().to_string();
 
     repo.git_command()
         .args(["checkout", "--detach", &sha])
         .current_dir(repo.root_path())
-        .output()
+        .run()
         .unwrap();
 
     // Promote should fail due to detached HEAD
@@ -905,14 +905,14 @@ fn test_promote_detached_head_linked(mut repo: TestRepo) {
         .git_command()
         .args(["rev-parse", "HEAD"])
         .current_dir(&feature_path)
-        .output()
+        .run()
         .unwrap();
     let sha = String::from_utf8_lossy(&sha.stdout).trim().to_string();
 
     repo.git_command()
         .args(["checkout", "--detach", &sha])
         .current_dir(&feature_path)
-        .output()
+        .run()
         .unwrap();
 
     // No-arg promote from linked worktree should fail due to detached HEAD

--- a/tests/integration_tests/step_prune.rs
+++ b/tests/integration_tests/step_prune.rs
@@ -455,7 +455,7 @@ fn test_prune_during_rebase(mut repo: TestRepo) {
         .args(["rebase", "-i", "--exec", "false", "main"])
         .current_dir(&feature_path)
         .env("GIT_SEQUENCE_EDITOR", "true")
-        .output()
+        .run()
         .unwrap();
     // The rebase should pause (exec false fails), leaving us in rebase state
     assert!(!git_status.status.success(), "rebase should be paused");
@@ -511,7 +511,7 @@ fn test_prune_skips_default_branch_orphan() {
     std::fs::remove_dir_all(&main_wt).unwrap();
     test.git_command(test.bare_repo_path())
         .args(["worktree", "prune"])
-        .output()
+        .run()
         .unwrap();
 
     // Create a feature branch (integrated, at same commit as main)
@@ -532,7 +532,7 @@ fn test_prune_skips_default_branch_orphan() {
     let output = test
         .git_command(test.bare_repo_path())
         .args(["branch", "--list", "main"])
-        .output()
+        .run()
         .unwrap();
     let branches = String::from_utf8_lossy(&output.stdout);
     assert!(

--- a/tests/integration_tests/step_relocate.rs
+++ b/tests/integration_tests/step_relocate.rs
@@ -422,7 +422,7 @@ fn test_relocate_main_worktree(repo: TestRepo) {
     let output = repo
         .git_command()
         .args(["branch", "--show-current"])
-        .output()
+        .run()
         .unwrap();
     let current_branch = String::from_utf8_lossy(&output.stdout);
     assert_eq!(

--- a/tests/integration_tests/switch.rs
+++ b/tests/integration_tests/switch.rs
@@ -229,7 +229,7 @@ fn test_switch_create_from_remote_base_no_upstream(#[from(repo_with_remote)] rep
     let upstream_check = repo
         .git_command()
         .args(["rev-parse", "--abbrev-ref", "my-feature@{upstream}"])
-        .output()
+        .run()
         .unwrap();
 
     assert!(
@@ -984,7 +984,7 @@ fn test_switch_error_path_occupied_detached(repo: TestRepo) {
         .git_command()
         .args(["rev-parse", "HEAD"])
         .current_dir(&feature_path)
-        .output()
+        .run()
         .unwrap();
     let commit = String::from_utf8_lossy(&output.stdout).trim().to_string();
 
@@ -1620,7 +1620,7 @@ fn test_switch_pr_same_repo(#[from(repo_with_remote)] mut repo: TestRepo) {
         &repo
             .git_command()
             .args(["config", "remote.origin.url"])
-            .output()
+            .run()
             .unwrap()
             .stdout,
     )
@@ -1687,7 +1687,7 @@ fn test_switch_pr_same_repo_limited_refspec(#[from(repo_with_remote)] mut repo: 
         &repo
             .git_command()
             .args(["config", "remote.origin.url"])
-            .output()
+            .run()
             .unwrap()
             .stdout,
     )
@@ -1801,7 +1801,7 @@ fn test_switch_pr_fork(#[from(repo_with_remote)] repo: TestRepo) {
     let commit_sha = repo
         .git_command()
         .args(["rev-parse", "HEAD"])
-        .output()
+        .run()
         .unwrap();
     let sha = String::from_utf8_lossy(&commit_sha.stdout)
         .trim()
@@ -1818,7 +1818,7 @@ fn test_switch_pr_fork(#[from(repo_with_remote)] repo: TestRepo) {
         &repo
             .git_command()
             .args(["config", "remote.origin.url"])
-            .output()
+            .run()
             .unwrap()
             .stdout,
     )
@@ -2045,7 +2045,7 @@ fn test_switch_pr_fork_existing_different_pr(#[from(repo_with_remote)] repo: Tes
     let commit_sha = repo
         .git_command()
         .args(["rev-parse", "HEAD"])
-        .output()
+        .run()
         .unwrap();
     let sha = String::from_utf8_lossy(&commit_sha.stdout)
         .trim()
@@ -2072,7 +2072,7 @@ fn test_switch_pr_fork_existing_different_pr(#[from(repo_with_remote)] repo: Tes
         &repo
             .git_command()
             .args(["config", "remote.origin.url"])
-            .output()
+            .run()
             .unwrap()
             .stdout,
     )
@@ -2129,7 +2129,7 @@ fn test_switch_pr_fork_existing_no_tracking(#[from(repo_with_remote)] repo: Test
     let commit_sha = repo
         .git_command()
         .args(["rev-parse", "HEAD"])
-        .output()
+        .run()
         .unwrap();
     let sha = String::from_utf8_lossy(&commit_sha.stdout)
         .trim()
@@ -2147,7 +2147,7 @@ fn test_switch_pr_fork_existing_no_tracking(#[from(repo_with_remote)] repo: Test
         &repo
             .git_command()
             .args(["config", "remote.origin.url"])
-            .output()
+            .run()
             .unwrap()
             .stdout,
     )
@@ -2232,7 +2232,7 @@ fn test_switch_pr_fork_prefixed_exists_same_pr(#[from(repo_with_remote)] repo: T
         &repo
             .git_command()
             .args(["config", "remote.origin.url"])
-            .output()
+            .run()
             .unwrap()
             .stdout,
     )
@@ -2301,7 +2301,7 @@ fn test_switch_pr_fork_prefixed_exists_different_pr(#[from(repo_with_remote)] re
         &repo
             .git_command()
             .args(["config", "remote.origin.url"])
-            .output()
+            .run()
             .unwrap()
             .stdout,
     )
@@ -2618,7 +2618,7 @@ fn test_switch_mr_same_repo(#[from(repo_with_remote)] mut repo: TestRepo) {
         &repo
             .git_command()
             .args(["config", "remote.origin.url"])
-            .output()
+            .run()
             .unwrap()
             .stdout,
     )
@@ -2677,7 +2677,7 @@ fn test_switch_mr_same_repo_limited_refspec(#[from(repo_with_remote)] mut repo: 
         &repo
             .git_command()
             .args(["config", "remote.origin.url"])
-            .output()
+            .run()
             .unwrap()
             .stdout,
     )
@@ -2936,7 +2936,7 @@ fn test_switch_mr_fork(#[from(repo_with_remote)] repo: TestRepo) {
     let commit_sha = repo
         .git_command()
         .args(["rev-parse", "HEAD"])
-        .output()
+        .run()
         .unwrap();
     let sha = String::from_utf8_lossy(&commit_sha.stdout)
         .trim()
@@ -2957,7 +2957,7 @@ fn test_switch_mr_fork(#[from(repo_with_remote)] repo: TestRepo) {
         &repo
             .git_command()
             .args(["config", "remote.origin.url"])
-            .output()
+            .run()
             .unwrap()
             .stdout,
     )
@@ -3055,7 +3055,7 @@ fn test_switch_mr_fork_existing_branch_tracks_mr(#[from(repo_with_remote)] repo:
     let commit_sha = repo
         .git_command()
         .args(["rev-parse", "HEAD"])
-        .output()
+        .run()
         .unwrap();
     let sha = String::from_utf8_lossy(&commit_sha.stdout)
         .trim()
@@ -3083,7 +3083,7 @@ fn test_switch_mr_fork_existing_branch_tracks_mr(#[from(repo_with_remote)] repo:
         &repo
             .git_command()
             .args(["config", "remote.origin.url"])
-            .output()
+            .run()
             .unwrap()
             .stdout,
     )

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -599,7 +599,7 @@ fn test_switch_picker_with_branches(mut repo: TestRepo) {
     let output = repo
         .git_command()
         .args(["branch", "orphan-branch"])
-        .output()
+        .run()
         .unwrap();
     assert!(output.status.success(), "Failed to create branch");
 
@@ -639,7 +639,7 @@ fn test_switch_picker_preview_panel_uncommitted(mut repo: TestRepo) {
     let output = repo
         .git_command()
         .args(["-C", feature_path.to_str().unwrap(), "add", "tracked.txt"])
-        .output()
+        .run()
         .unwrap();
     assert!(output.status.success(), "Failed to add file");
     let output = repo
@@ -651,7 +651,7 @@ fn test_switch_picker_preview_panel_uncommitted(mut repo: TestRepo) {
             "-m",
             "Add tracked file",
         ])
-        .output()
+        .run()
         .unwrap();
     assert!(output.status.success(), "Failed to commit");
 
@@ -705,7 +705,7 @@ fn test_switch_picker_preview_panel_log(mut repo: TestRepo) {
         let output = repo
             .git_command()
             .args(["-C", feature_path.to_str().unwrap(), "add", "."])
-            .output()
+            .run()
             .unwrap();
         assert!(output.status.success(), "Failed to add files");
         let output = repo
@@ -717,7 +717,7 @@ fn test_switch_picker_preview_panel_log(mut repo: TestRepo) {
                 "-m",
                 &format!("Add file {i} with content"),
             ])
-            .output()
+            .run()
             .unwrap();
         assert!(output.status.success(), "Failed to commit");
     }
@@ -770,7 +770,7 @@ fn test_switch_picker_preview_panel_main_diff(mut repo: TestRepo) {
     let output = repo
         .git_command()
         .args(["-C", feature_path.to_str().unwrap(), "add", "."])
-        .output()
+        .run()
         .unwrap();
     assert!(output.status.success(), "Failed to add files");
     let output = repo
@@ -782,7 +782,7 @@ fn test_switch_picker_preview_panel_main_diff(mut repo: TestRepo) {
             "-m",
             "Add new feature implementation",
         ])
-        .output()
+        .run()
         .unwrap();
     assert!(output.status.success(), "Failed to commit");
 
@@ -799,7 +799,7 @@ fn test_new_feature() {
     let output = repo
         .git_command()
         .args(["-C", feature_path.to_str().unwrap(), "add", "."])
-        .output()
+        .run()
         .unwrap();
     assert!(output.status.success(), "Failed to add files");
     let output = repo
@@ -811,7 +811,7 @@ fn test_new_feature() {
             "-m",
             "Add tests for new feature",
         ])
-        .output()
+        .run()
         .unwrap();
     assert!(output.status.success(), "Failed to commit");
 
@@ -853,7 +853,7 @@ fn test_switch_picker_preview_panel_summary(mut repo: TestRepo) {
     let output = repo
         .git_command()
         .args(["-C", feature_path.to_str().unwrap(), "add", "."])
-        .output()
+        .run()
         .unwrap();
     assert!(output.status.success(), "Failed to add file");
     let output = repo
@@ -865,7 +865,7 @@ fn test_switch_picker_preview_panel_summary(mut repo: TestRepo) {
             "-m",
             "Add new file",
         ])
-        .output()
+        .run()
         .unwrap();
     assert!(output.status.success(), "Failed to commit");
 
@@ -906,7 +906,7 @@ fn test_switch_picker_respects_list_config(mut repo: TestRepo) {
     let output = repo
         .git_command()
         .args(["branch", "orphan-branch"])
-        .output()
+        .run()
         .unwrap();
     assert!(output.status.success(), "Failed to create branch");
 
@@ -982,7 +982,7 @@ fn test_switch_picker_create_worktree_with_alt_c(mut repo: TestRepo) {
     let branch_output = repo
         .git_command()
         .args(["branch", "--list", "new-feature"])
-        .output()
+        .run()
         .unwrap();
     assert!(
         String::from_utf8_lossy(&branch_output.stdout).contains("new-feature"),

--- a/tests/integration_tests/user_hooks.rs
+++ b/tests/integration_tests/user_hooks.rs
@@ -651,7 +651,7 @@ fn test_user_post_remove_template_vars_reference_removed_worktree(mut repo: Test
         .git_command()
         .args(["rev-parse", "HEAD"])
         .current_dir(&feature_wt_path)
-        .output()
+        .run()
         .unwrap();
     let feature_commit = String::from_utf8_lossy(&feature_commit.stdout);
     let feature_commit = feature_commit.trim();
@@ -1019,7 +1019,7 @@ failing = "exit 1"
         .git_command()
         .current_dir(&feature_wt)
         .args(["log", "--oneline", "-1"])
-        .output()
+        .run()
         .unwrap();
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(


### PR DESCRIPTION
The test infrastructure's `git_command()` returned `std::process::Command`, so test git commands bypassed `Cmd`'s debug logging (`$ git status [ctx]`) and timing traces (`[wt-trace]`). This changes it to return `worktrunk::shell_exec::Cmd`.

## Approach

Added `configure_git_env(Cmd, &Path) -> Cmd` alongside the existing `configure_git_cmd(&mut Command)`. The `Command` version is kept because `configure_wt_cmd` (which configures wt binary commands) still needs it — wt commands go through `Command`, not `Cmd`.

Key changes in `tests/common/mod.rs`:
- `TestRepoBase::git_command()` and `TestRepo::git_command()` now return `Cmd`
- All wrapper methods (`run_git`, `git_output`, `head_sha`, etc.) use `.run()` instead of `.output()`
- `BareRepoTest::new()` and `NestedBareRepoTest::new()` use `Cmd::new("git")` for init

247 call sites across 25 files converted: `.output()` → `.run()` and `.status()` → `.run()` on git command chains. Zero `Command::new("git")` remaining in the test directory.

Follows #1714 and #1716 which converted raw `Cmd::new("git")` and `Command::new("git")` in test bodies to `repo.run_command()`.

> _This was written by Claude Code on behalf of maximilian_