### PR TITLE
refactor: accept AsRef<OsStr> in Cmd::env for path compatibility

### DIFF
--- a/src/shell_exec.rs
+++ b/src/shell_exec.rs
@@ -8,6 +8,7 @@
 //! On Windows, Git for Windows must be installed — this is nearly universal among
 //! Windows developers since git itself is required.
 
+use std::ffi::{OsStr, OsString};
 use std::io::{ErrorKind, Read, Write};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
@@ -380,8 +381,8 @@ pub struct Cmd {
     context: Option<String>,
     stdin_data: Option<Vec<u8>>,
     timeout: Option<std::time::Duration>,
-    envs: Vec<(String, String)>,
-    env_removes: Vec<String>,
+    envs: Vec<(OsString, OsString)>,
+    env_removes: Vec<OsString>,
     /// If true, wrap command through ShellConfig (for stream())
     shell_wrap: bool,
     /// Stdout configuration for stream() (defaults to inherit)
@@ -489,14 +490,18 @@ impl Cmd {
     }
 
     /// Set an environment variable.
-    pub fn env(mut self, key: impl Into<String>, val: impl Into<String>) -> Self {
-        self.envs.push((key.into(), val.into()));
+    ///
+    /// Accepts the same types as [`Command::env`]: string literals, `String`,
+    /// `&Path`, `PathBuf`, `OsString`, etc.
+    pub fn env(mut self, key: impl AsRef<OsStr>, val: impl AsRef<OsStr>) -> Self {
+        self.envs
+            .push((key.as_ref().to_os_string(), val.as_ref().to_os_string()));
         self
     }
 
     /// Remove an environment variable.
-    pub fn env_remove(mut self, key: impl Into<String>) -> Self {
-        self.env_removes.push(key.into());
+    pub fn env_remove(mut self, key: impl AsRef<OsStr>) -> Self {
+        self.env_removes.push(key.as_ref().to_os_string());
         self
     }
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -380,7 +380,7 @@ Tests use `TEST_EPOCH` (2025-01-01) for reproducible timestamps. The constant is
 ```rust
 use crate::common::TEST_EPOCH;
 
-repo.git_command(&[
+repo.run_git(&[
     "config", "worktrunk.state.feature.ci-status",
     &format!(r#"{{"checked_at":{TEST_EPOCH},"head":"abc123"}}"#),
 ]);

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -770,7 +770,7 @@ pub fn configure_git_cmd(cmd: &mut Command, git_config_path: &Path) {
 /// This is the `Cmd` equivalent of [`configure_git_cmd`]. Use this when building
 /// git commands via the builder pattern (`Cmd::new("git")`).
 pub fn configure_git_env(cmd: Cmd, git_config_path: &Path) -> Cmd {
-    cmd.env("GIT_CONFIG_GLOBAL", git_config_path.to_str().unwrap())
+    cmd.env("GIT_CONFIG_GLOBAL", git_config_path)
         .env("GIT_CONFIG_SYSTEM", NULL_DEVICE)
         .env("GIT_AUTHOR_DATE", "2025-01-01T00:00:00Z")
         .env("GIT_COMMITTER_DATE", "2025-01-01T00:00:00Z")

--- a/tests/integration_tests/bare_repository.rs
+++ b/tests/integration_tests/bare_repository.rs
@@ -1391,10 +1391,7 @@ mod bare_repo_prompt_pty {
         let git_config_output = Cmd::new("git")
             .args(["config", "worktrunk.skip-bare-repo-prompt"])
             .current_dir(&main_worktree)
-            .env(
-                "GIT_CONFIG_GLOBAL",
-                test.git_config_path().to_str().unwrap(),
-            )
+            .env("GIT_CONFIG_GLOBAL", test.git_config_path())
             .run()
             .unwrap();
         let value = String::from_utf8_lossy(&git_config_output.stdout);


### PR DESCRIPTION
`Cmd::env()` took `impl Into<String>`, forcing callers to convert paths with `.to_str().unwrap()`. Changed to `impl AsRef<OsStr>` to match `Command::env`'s interface — `&Path`, `PathBuf`, and `OsString` now work directly alongside string literals.

Internal storage changed from `Vec<(String, String)>` to `Vec<(OsString, OsString)>`. All existing callers (`"literal"`, `String`, `&str`) continue to work since `str: AsRef<OsStr>`.

Also fixes a stale example in `tests/CLAUDE.md` that referenced `repo.git_command(&[...])` instead of `repo.run_git(&[...])`.

> _This was written by Claude Code on behalf of maximilian_