### PR TITLE
feat: use append semantics for alias merging

### DIFF
--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -6,9 +6,9 @@
 //!
 //! Project-config aliases require command approval (same as project hooks).
 //! User-config aliases are trusted and skip approval. When an alias exists
-//! in both configs, the user version wins and is trusted.
+//! in both configs, both run — user first, then project (with approval).
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::HashMap;
 
 use anyhow::{Context, bail};
 use color_print::cformat;
@@ -103,30 +103,18 @@ fn parse_var(s: &str) -> anyhow::Result<(String, String)> {
 
 /// Determine whether an alias requires project-config approval.
 ///
-/// An alias needs approval when:
-/// - It exists in project config AND
-/// - It does NOT exist in user config (user overrides are trusted)
+/// Returns the project-config commands for this alias, if any exist.
+/// Project-config commands always need approval, regardless of whether
+/// user config also defines the same alias — matching hook behavior.
 fn alias_needs_approval(
     alias_name: &str,
     project_config: &Option<ProjectConfig>,
-    user_config: &UserConfig,
-    project_id: Option<&str>,
 ) -> Option<CommandConfig> {
-    // Check if alias exists in project config
-    let project_commands = project_config
+    project_config
         .as_ref()
         .and_then(|pc| pc.aliases.as_ref())
-        .and_then(|a| a.get(alias_name));
-
-    let project_commands = project_commands?;
-
-    // Check if user config overrides this alias (user overrides are trusted)
-    let user_aliases = user_config.aliases(project_id);
-    if user_aliases.contains_key(alias_name) {
-        return None;
-    }
-
-    Some(project_commands.clone())
+        .and_then(|a| a.get(alias_name))
+        .cloned()
 }
 
 /// Find the closest match for `input` among `candidates` using Jaro similarity.
@@ -154,13 +142,18 @@ pub fn step_alias(opts: AliasOptions) -> anyhow::Result<()> {
     let project_id = repo.project_identifier().ok();
     let project_config = ProjectConfig::load(&repo, true)?;
 
-    // Merge aliases: start with project config, user config replaces on collision
-    // (user aliases are trusted; project aliases need approval)
-    let mut aliases: BTreeMap<String, CommandConfig> = project_config
-        .as_ref()
-        .and_then(|pc| pc.aliases.clone())
-        .unwrap_or_default();
-    aliases.extend(user_config.aliases(project_id.as_deref()));
+    // Merge aliases: user config first, then project config appends.
+    // Matches hook merge semantics — both sources run, project commands
+    // need approval regardless of whether user also defines the alias.
+    let mut aliases = user_config.aliases(project_id.as_deref());
+    if let Some(project_aliases) = project_config.as_ref().and_then(|pc| pc.aliases.as_ref()) {
+        for (k, v) in project_aliases {
+            aliases
+                .entry(k.clone())
+                .and_modify(|existing| *existing = existing.merge_append(v))
+                .or_insert_with(|| v.clone());
+        }
+    }
 
     // Warn about aliases that shadow built-in step commands
     let shadowed: Vec<_> = aliases
@@ -227,12 +220,7 @@ pub fn step_alias(opts: AliasOptions) -> anyhow::Result<()> {
     // project_id is required for approval — re-derive with error propagation
     // rather than using the .ok() from above.
     if !opts.dry_run
-        && let Some(project_commands) = alias_needs_approval(
-            &opts.name,
-            &project_config,
-            &user_config,
-            project_id.as_deref(),
-        )
+        && let Some(project_commands) = alias_needs_approval(&opts.name, &project_config)
     {
         let project_id = repo
             .project_identifier()

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -426,20 +426,27 @@ fn inject_alias_subcommands(cmd: Command) -> Command {
 }
 
 /// Load aliases from user and project config for completion.
+///
+/// Merges user and project aliases with append semantics (matching hooks).
 fn load_aliases_for_completion() -> BTreeMap<String, CommandConfig> {
     let mut aliases = BTreeMap::new();
 
     if let Ok(repo) = Repository::current() {
-        // Project config aliases first
-        if let Ok(Some(project_config)) = ProjectConfig::load(&repo, false)
-            && let Some(project_aliases) = project_config.aliases
-        {
-            aliases.extend(project_aliases);
-        }
-        // User config aliases replace on collision (trusted)
+        // User config first
         if let Ok(user_config) = UserConfig::load() {
             let project_id = repo.project_identifier().ok();
             aliases.extend(user_config.aliases(project_id.as_deref()));
+        }
+        // Project config appends
+        if let Ok(Some(project_config)) = ProjectConfig::load(&repo, false)
+            && let Some(project_aliases) = project_config.aliases
+        {
+            for (k, v) in &project_aliases {
+                aliases
+                    .entry(k.clone())
+                    .and_modify(|existing| *existing = existing.merge_append(v))
+                    .or_insert_with(|| v.clone());
+            }
         }
     } else if let Ok(user_config) = UserConfig::load() {
         aliases.extend(user_config.aliases(None));

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -117,6 +117,10 @@ pub struct ProjectConfig {
     /// Each alias maps a name to one or more command templates. All hook
     /// template variables are available (e.g., `{{ branch }}`, `{{ worktree_path }}`).
     ///
+    /// Uses `CommandConfig` for consistency with hooks. This means the
+    /// named-table format (`[aliases.deploy] build = "..." run = "..."`)
+    /// technically works, but the single-string format is the expected usage.
+    ///
     /// ```toml
     /// [aliases]
     /// deploy = "cd {{ worktree_path }} && make deploy"

--- a/src/config/user/sections.rs
+++ b/src/config/user/sections.rs
@@ -476,6 +476,10 @@ pub struct OverridableConfig {
     /// Per-project aliases append to global aliases on name collision (global
     /// first, then per-project), matching hook merge semantics.
     ///
+    /// Uses `CommandConfig` for consistency with hooks. This means the
+    /// named-table format (`[aliases.deploy] build = "..." run = "..."`)
+    /// technically works, but the single-string format is the expected usage.
+    ///
     /// ```toml
     /// [aliases]
     /// deploy = "cd {{ worktree_path }} && make deploy"

--- a/tests/integration_tests/step_alias.rs
+++ b/tests/integration_tests/step_alias.rs
@@ -280,9 +280,9 @@ shared = "echo user-version"
         )
     );
 
-    // User overrides project on collision (user config = trusted, no approval needed)
+    // Both run on collision: user first, then project (append semantics)
     assert_cmd_snapshot!(
-        "user_overrides_project",
+        "user_and_project_append",
         make_snapshot_cmd(&repo, "step", &["shared", "--dry-run"], Some(&feature_path),)
     );
 }
@@ -410,11 +410,11 @@ deploy = "echo deploying from user config"
 
 /// User override of project alias skips approval (user is trusted)
 #[rstest]
-fn test_alias_approval_user_override_skips(mut repo: TestRepo) {
+fn test_alias_approval_user_and_project_both_need_approval(mut repo: TestRepo) {
     repo.write_project_config(
         r#"
 [aliases]
-deploy = "echo UNTRUSTED project deploy"
+deploy = "echo project deploy"
 "#,
     );
     repo.commit("Add alias config");
@@ -422,18 +422,18 @@ deploy = "echo UNTRUSTED project deploy"
     repo.write_test_config(
         r#"
 [aliases]
-deploy = "echo trusted user deploy"
+deploy = "echo user deploy"
 "#,
     );
 
     let settings = setup_snapshot_settings(&repo);
     let _guard = settings.bind_to_scope();
 
-    // User override runs without approval — the user version is trusted
+    // Both run with --yes: user first, then project (project needs approval)
     assert_cmd_snapshot!(make_snapshot_cmd(
         &repo,
         "step",
-        &["deploy"],
+        &["deploy", "--yes"],
         Some(&feature_path),
     ));
 }

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_approval_user_and_project_both_need_approval.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_approval_user_and_project_both_need_approval.snap
@@ -4,8 +4,8 @@ info:
   program: wt
   args:
     - step
-    - shared
-    - "--dry-run"
+    - deploy
+    - "--yes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -43,5 +43,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m Alias [1mshared[22m would run:
-[107m [0m [2m[0m[2m[34mecho[0m[2m user-version
+[36m◎[39m [36mRunning alias [1mdeploy[22m[39m
+user deploy
+project deploy

--- a/tests/snapshots/integration__integration_tests__step_alias__user_and_project_append.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__user_and_project_append.snap
@@ -4,7 +4,8 @@ info:
   program: wt
   args:
     - step
-    - deploy
+    - shared
+    - "--dry-run"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -42,5 +43,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRunning alias [1mdeploy[22m[39m
-trusted user deploy
+[2m○[22m Alias [1mshared[22m would run:
+[107m [0m [2m[0m[2m[34mecho[0m[2m user-version
+[107m [0m [2m[0m[2m[34mecho[0m[2m project-version


### PR DESCRIPTION
Alias merging now uses append semantics across all layers, matching how hooks merge:

**Within user config** (global + per-project): both run on name collision (global first). Uses `CommandConfig::merge_append()`.

**Across configs** (user + project): both run (user first, then project). Project commands always need approval — the old bypass that skipped approval when user had the same alias name is removed.

The alias value type changes from `String` to `CommandConfig` — the same type hooks use. This stores each command separately and enables the named-table TOML format for multi-command aliases.

Key changes:
- `merge_alias_maps()` and `UserConfig::aliases()` use `CommandConfig::merge_append()` on collision
- `step_alias()` iterates over `CommandConfig.commands()`, running each command separately (fail-fast)
- `approve_alias_commands()` approves each project-config command individually
- `alias_needs_approval()` simplified — always returns project commands if they exist

> _This was written by Claude Code on behalf of @max-sixty_