### PR TITLE
fix: render [experimental] badge in Aliases section of step docs

### DIFF
--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -844,7 +844,7 @@ Usage: <b><span class=c>wt step relocate</span></b> <span class=c>[OPTIONS]</spa
 
 ## Aliases
 
-[experimental] Custom command templates configured in user config (`~/.config/worktrunk/config.toml`) or project config (`.config/wt.toml`). Aliases support the same [template variables](@/hook.md#template-variables) as hooks.
+<span class="badge-experimental"></span> Custom command templates configured in user config (`~/.config/worktrunk/config.toml`) or project config (`.config/wt.toml`). Aliases support the same [template variables](@/hook.md#template-variables) as hooks.
 
 ```toml
 # .config/wt.toml

--- a/src/help.rs
+++ b/src/help.rs
@@ -403,10 +403,13 @@ Commands with pages: merge, switch, remove, list"
     std::println!("```");
 
     // Subdocs follow, each with their own command reference at the end.
-    // post_process_for_html is already applied inside format_subcommand_section,
-    // so we don't apply it again here (it would corrupt HTML inside reference blocks).
     if let Some(subdocs) = subdoc_content {
-        let subdocs_expanded = expand_subdoc_placeholders(subdocs, sub, &parent_name);
+        // Apply post-processing to non-marker text (e.g., the Aliases section after
+        // the last subdoc marker). Must happen before expansion — after expansion,
+        // post_process_for_html has already run on each subcommand section internally
+        // (in format_subcommand_section), so re-running it would double-convert.
+        let subdocs = post_process_for_html(subdocs);
+        let subdocs_expanded = expand_subdoc_placeholders(&subdocs, sub, &parent_name);
         std::println!();
         std::println!("# Subcommands");
         std::println!();


### PR DESCRIPTION
\`post_process_for_html()\` only ran on content before the first \`<!-- subdoc: -->\` marker. The Aliases section lives after the last marker, so its \`[experimental]\` was never converted to a badge \`<span>\`. Apply the transform to the subdoc region before expanding markers.

> _This was written by Claude Code on behalf of maximilian_