### PR TITLE
fix: apply post_process_for_html to nested subdoc trailing text

### DIFF
--- a/src/help.rs
+++ b/src/help.rs
@@ -627,10 +627,9 @@ fn format_subcommand_section(
     section.push_str("\n```\n");
 
     // Expand nested subdocs after the command reference.
-    // post_process_for_html is already applied inside format_subcommand_section,
-    // so we don't apply it again here (it would corrupt HTML inside reference blocks).
     if let Some(subdocs) = subdoc_content {
-        let subdocs_expanded = expand_subdoc_placeholders(subdocs, sub, &full_command);
+        let subdocs = post_process_for_html(subdocs);
+        let subdocs_expanded = expand_subdoc_placeholders(&subdocs, sub, &full_command);
         section.push('\n');
         section.push_str(subdocs_expanded.trim());
         section.push('\n');


### PR DESCRIPTION
Same fix as #1729 but for the symmetric case in `format_subcommand_section`. No current content triggers this path, but it prevents the same bug if a nested subcommand ever adds trailing content after its last `<!-- subdoc: -->` marker.

> _This was written by Claude Code on behalf of maximilian_