### PR TITLE
fix(ci): set uv cache-dependency-glob to silence CI warning

### DIFF
--- a/.github/actions/claude-setup/action.yaml
+++ b/.github/actions/claude-setup/action.yaml
@@ -34,6 +34,8 @@ runs:
 
     - name: Install uv
       uses: astral-sh/setup-uv@v7.6.0
+      with:
+        cache-dependency-glob: .pre-commit-config.yaml
 
     - name: Install pre-commit
       shell: bash


### PR DESCRIPTION
The `setup-uv` action enables caching by default with a `cache-dependency-glob` that looks for Python dependency files (`requirements.txt`, `pyproject.toml`, `uv.lock`, etc.). Since this is a Rust project, none match, producing this warning on every CI run:

> No file matched to [...]. The cache will never get invalidated.

The uv cache does help — with a cache hit, `uv tool install pre-commit` resolves and prepares 10 packages in ~170ms from cached wheels instead of downloading from PyPI. Set the glob to `.pre-commit-config.yaml` so the cache invalidates when pre-commit hook configuration changes.

> _This was written by Claude Code on behalf of @max-sixty_