### PR TITLE
fix: use correct tend plugin skill names in workflows

### DIFF
--- a/.github/workflows/tend-ci-fix.yaml
+++ b/.github/workflows/tend-ci-fix.yaml
@@ -33,7 +33,7 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           bot_name: worktrunk-bot
           prompt: |
-            /tend:tend-ci-fix ${{ github.event.workflow_run.id }}
+            /tend-ci-runner:ci-fix ${{ github.event.workflow_run.id }}
             - Run URL: ${{ github.event.workflow_run.html_url }}
             - Commit: ${{ github.event.workflow_run.head_sha }}
             - Commit message: ${{ github.event.workflow_run.head_commit.message }}

--- a/.github/workflows/tend-nightly.yaml
+++ b/.github/workflows/tend-nightly.yaml
@@ -32,4 +32,4 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           bot_name: worktrunk-bot
           prompt: |
-            /tend:tend-nightly
+            /tend-ci-runner:nightly

--- a/.github/workflows/tend-renovate.yaml
+++ b/.github/workflows/tend-renovate.yaml
@@ -32,4 +32,4 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           bot_name: worktrunk-bot
           prompt: |
-            /tend:tend-renovate
+            /tend-ci-runner:renovate

--- a/.github/workflows/tend-review.yaml
+++ b/.github/workflows/tend-review.yaml
@@ -62,7 +62,7 @@ jobs:
           use_sticky_comment: ${{ github.event_name == 'pull_request_target' }}
           prompt: >-
             ${{ github.event_name == 'pull_request_target'
-              && format('/tend:tend-review {0}', github.event.pull_request.number)
+              && format('/tend-ci-runner:review {0}', github.event.pull_request.number)
               || format(
                 'A review was submitted on your PR #{0} ({1}). Read the review and full PR context (description, diff, comments, CI status), then respond appropriately. If changes were requested, make them, commit, and push. If questions were asked, answer them.',
                 github.event.pull_request.number,

--- a/.github/workflows/tend-triage.yaml
+++ b/.github/workflows/tend-triage.yaml
@@ -38,4 +38,4 @@ jobs:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           bot_name: worktrunk-bot
           prompt: |
-            /tend:tend-triage ${{ github.event.issue.number }}
+            /tend-ci-runner:triage ${{ github.event.issue.number }}


### PR DESCRIPTION
The generated workflows referenced skills as `/tend:tend-*` (e.g., `/tend:tend-review`), but the plugin is named `tend-ci-runner` and the skills are `review`, `triage`, etc. The correct format is `/tend-ci-runner:review`.

This caused the silent review failure on #1736 — Claude resolved the skill client-side, found nothing, and returned "Unknown skill" with zero tokens. The CI check showed green because the process exited cleanly.

The root cause is the published `uvx tend` generator (v0.0.2) still uses the old naming convention. A new release of the generator will fix it for future `uvx tend init` runs; this PR fixes the existing generated files.

> _This was written by Claude Code on behalf of @max-sixty_