### PR TITLE
refactor: remove experimental() shortcode, use badge span directly

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -98,7 +98,7 @@ Created by `wt config shell install`:
 - **Bash**: adds line to `~/.bashrc`
 - **Zsh**: adds line to `~/.zshrc` (or `$ZDOTDIR/.zshrc`)
 - **Fish**: creates `~/.config/fish/functions/wt.fish` and `~/.config/fish/completions/wt.fish`
-- **Nushell** {{ experimental() }}: creates `$nu.default-config-dir/vendor/autoload/wt.nu` (typically `~/.config/nushell` on Linux, `~/Library/Application Support/nushell` on macOS)
+- **Nushell** <span class="badge-experimental"></span>: creates `$nu.default-config-dir/vendor/autoload/wt.nu` (typically `~/.config/nushell` on Linux, `~/Library/Application Support/nushell` on macOS)
 - **PowerShell** (Windows): creates both profile files if they don't exist:
   - `Documents/PowerShell/Microsoft.PowerShell_profile.ps1` (PowerShell 7+)
   - `Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1` (Windows PowerShell 5.1)

--- a/docs/templates/shortcodes/experimental.html
+++ b/docs/templates/shortcodes/experimental.html
@@ -1,1 +1,0 @@
-<span class="badge-experimental"></span>

--- a/src/help.rs
+++ b/src/help.rs
@@ -35,10 +35,10 @@
 //! ```
 //!
 //! **Manually-written pages** (faq.md, llm-commits.md) bypass this pipeline.
-//! They use `{{ experimental() }}` (Zola shortcode) for badges.
+//! They use `<span class="badge-experimental"></span>` directly for badges.
 //!
 //! **Skill reference files** mirror docs/ content via `transform_docs_for_skill()`,
-//! which strips Zola syntax (terminal shortcodes, `{{ experimental() }}` → `[experimental]`)
+//! which strips Zola syntax (terminal shortcodes, badge `<span>` → `[experimental]`)
 //! for plain-markdown consumption.
 
 use std::process;


### PR DESCRIPTION
The shortcode had one remaining usage in faq.md. Replace with the raw `<span class="badge-experimental"></span>` used everywhere else, then delete the unused shortcode template. Updated module doc comments in help.rs that referenced it.

> _This was written by Claude Code on behalf of maximilian_