### PR TITLE
docs: replace stale module doc with pointers to canonical sources

### DIFF
--- a/src/config/commands.rs
+++ b/src/config/commands.rs
@@ -1,30 +1,7 @@
 //! Command configuration types for hook pipelines.
 //!
-//! The data structure determines execution order:
-//! - **String** → single command
-//! - **Map** (TOML table) → concurrent commands
-//! - **List** (TOML array) → serial pipeline (steps execute in order)
-//!
-//! List elements can be strings (anonymous serial steps) or maps (named commands).
-//! A single-entry map is a named serial step; a multi-entry map is a concurrent group.
-//!
-//! Examples:
-//! ```toml
-//! # Single command
-//! post-start = "npm install"
-//!
-//! # Concurrent (map)
-//! [hooks.post-start]
-//! build = "npm run build"
-//! lint = "npm run lint"
-//!
-//! # Serial pipeline with concurrent stage
-//! [hooks]
-//! post-start = [
-//!     { install = "npm install" },
-//!     { build = "npm run build", lint = "npm run lint" }
-//! ]
-//! ```
+//! See `wt hook --help` → "Pipeline Ordering" for user-facing docs.
+//! See [`HookStep`] and [`CommandConfig`] for the internal model.
 
 use std::collections::BTreeMap;
 


### PR DESCRIPTION
Follow-up to #1756. The module doc in `commands.rs` duplicated the pipeline ordering docs with stale `[hooks.post-start]` syntax. Replaced with pointers to `wt hook --help` and the type-level docs on `HookStep`/`CommandConfig`, which are the canonical sources.

> _This was written by Claude Code on behalf of max-sixty_