### PR TITLE
Enrich quick start wt list output

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,14 +151,14 @@ This creates a new branch and worktree, then switches to it. Do your work, then 
 ```console
 $ wt list
   Branch        Status        HEAD±    main↕  Remote⇅  Commit    Age   Message
-@ feature-auth  +   –      +53                         0e631add  1d    Initial commit
+@ feature-auth  +   ↑      +27   -8   ↑1               4bc72dc9  2h    Add authentication module
 ^ main              ^⇡                         ⇡1      0e631add  1d    Initial commit
 
-○ Showing 2 worktrees, 1 with changes, 1 column hidden
+○ Showing 2 worktrees, 1 with changes, 1 ahead, 1 column hidden
 
 ```
 
-The `@` marks the current worktree. `+` means staged changes, `⇡` means unpushed commits.
+The `@` marks the current worktree. `+` means staged changes, `↑1` means 1 commit ahead of main, `⇡` means unpushed commits.
 
 When done, either:
 

--- a/docs/content/worktrunk.md
+++ b/docs/content/worktrunk.md
@@ -159,15 +159,15 @@ This creates a new branch and worktree, then switches to it. Do your work, then 
 {% terminal(cmd="wt list") %}
 <span class="cmd">wt list</span>
   <b>Branch</b>        <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>  <b>Remote⇅</b>  <b>Commit</b>    <b>Age</b>   <b>Message</b>
-@ feature-auth  <span class=c>+</span>   <span class=d>–</span>      <span class=g>+53</span>                         <span class=d>0e631add</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
+@ feature-auth  <span class=c>+</span>   <span class=d>↑</span>      <span class=g>+27</span>   <span class=r>-8</span>   <span class=g>↑1</span>               <span class=d>4bc72dc9</span>  <span class=d>2h</span>    <span class=d>Add authentication module</span>
 ^ main              <span class=d>^</span><span class=d>⇡</span>                         <span class=g>⇡1</span>      <span class=d>0e631add</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
 
-<span class=d>○</span> <span class=d>Showing 2 worktrees, 1 with changes, 1 column hidden</span>
+<span class=d>○</span> <span class=d>Showing 2 worktrees, 1 with changes, 1 ahead, 1 column hidden</span>
 {% end %}
 
 <!-- END AUTO-GENERATED -->
 
-The `@` marks the current worktree. `+` means staged changes, `⇡` means unpushed commits.
+The `@` marks the current worktree. `+` means staged changes, `↑1` means 1 commit ahead of main, `⇡` means unpushed commits.
 
 When done, either:
 

--- a/skills/worktrunk/reference/worktrunk.md
+++ b/skills/worktrunk/reference/worktrunk.md
@@ -130,13 +130,13 @@ This creates a new branch and worktree, then switches to it. Do your work, then 
 {% terminal(cmd="wt list") %}
 <span class="cmd">wt list</span>
   <b>Branch</b>        <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>  <b>Remote⇅</b>  <b>Commit</b>    <b>Age</b>   <b>Message</b>
-@ feature-auth  <span class=c>+</span>   <span class=d>–</span>      <span class=g>+53</span>                         <span class=d>0e631add</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
+@ feature-auth  <span class=c>+</span>   <span class=d>↑</span>      <span class=g>+27</span>   <span class=r>-8</span>   <span class=g>↑1</span>               <span class=d>4bc72dc9</span>  <span class=d>2h</span>    <span class=d>Add authentication module</span>
 ^ main              <span class=d>^</span><span class=d>⇡</span>                         <span class=g>⇡1</span>      <span class=d>0e631add</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
 
-<span class=d>○</span> <span class=d>Showing 2 worktrees, 1 with changes, 1 column hidden</span>
+<span class=d>○</span> <span class=d>Showing 2 worktrees, 1 with changes, 1 ahead, 1 column hidden</span>
 {% end %}
 
-The `@` marks the current worktree. `+` means staged changes, `⇡` means unpushed commits.
+The `@` marks the current worktree. `+` means staged changes, `↑1` means 1 commit ahead of main, `⇡` means unpushed commits.
 
 When done, either:
 

--- a/tests/integration_tests/list.rs
+++ b/tests/integration_tests/list.rs
@@ -840,9 +840,12 @@ mod tests {
 
 /// Set up a Quick Start example repo with main + feature-auth.
 ///
-/// Creates a simple scenario:
-/// - main: Initial codebase
-/// - feature-auth: Uncommitted changes adding authentication (WIP state)
+/// Creates a scenario with a committed feature branch plus staged WIP:
+/// - main: Initial codebase (1 commit behind remote)
+/// - feature-auth: 1 commit ahead of main + staged WIP changes (adds + removes)
+///
+/// The staged WIP extends auth.rs and restructures lib.rs, producing both
+/// additions and deletions in HEAD± to showcase more of `wt list`.
 ///
 /// Returns the feature-auth worktree path.
 fn setup_quickstart_repo(repo: &mut TestRepo) -> std::path::PathBuf {
@@ -851,7 +854,55 @@ fn setup_quickstart_repo(repo: &mut TestRepo) -> std::path::PathBuf {
     // Create feature-auth worktree
     let feature_auth = repo.add_worktree("feature-auth");
 
-    // Add authentication module (not committed - realistic WIP state)
+    // === Commit: Add authentication module (1 commit ahead of main) ===
+    std::fs::write(
+        feature_auth.join("auth.rs"),
+        r#"//! Authentication module for user session management.
+
+use std::time::{Duration, SystemTime};
+
+/// A user session with token and expiry.
+pub struct Session {
+    token: String,
+    expires_at: SystemTime,
+}
+
+impl Session {
+    /// Creates a new session with the given token and TTL.
+    pub fn new(token: String, ttl: Duration) -> Self {
+        Self {
+            token,
+            expires_at: SystemTime::now() + ttl,
+        }
+    }
+
+    /// Returns true if the session has not expired.
+    pub fn is_valid(&self) -> bool {
+        SystemTime::now() < self.expires_at
+    }
+
+    /// Validates the token format.
+    pub fn validate_token(token: &str) -> bool {
+        token.len() >= 32 && token.chars().all(|c| c.is_ascii_alphanumeric())
+    }
+}
+"#,
+    )
+    .unwrap();
+
+    let lib_content = std::fs::read_to_string(feature_auth.join("lib.rs")).unwrap();
+    std::fs::write(
+        feature_auth.join("lib.rs"),
+        format!("mod auth;\n\n{}", lib_content),
+    )
+    .unwrap();
+
+    repo.run_git_in(&feature_auth, &["add", "auth.rs", "lib.rs"]);
+    repo.commit_staged_with_age("Add authentication module", 2 * HOUR, &feature_auth);
+
+    // === Staged WIP: extend auth + restructure lib (produces both +N and -N in HEAD±) ===
+
+    // Extend auth.rs with is_authenticated and tests
     std::fs::write(
         feature_auth.join("auth.rs"),
         r#"//! Authentication module for user session management.
@@ -909,15 +960,26 @@ mod tests {
     )
     .unwrap();
 
-    // Update lib.rs to include the new module
-    let lib_content = std::fs::read_to_string(feature_auth.join("lib.rs")).unwrap();
+    // Restructure lib.rs: remove test module, add pub use + init
     std::fs::write(
         feature_auth.join("lib.rs"),
-        format!("mod auth;\n\n{}", lib_content),
+        r#"mod auth;
+
+pub use auth::Session;
+
+/// Adds two numbers.
+pub fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+/// Initializes the application with default settings.
+pub fn init() -> bool {
+    true
+}
+"#,
     )
     .unwrap();
 
-    // Stage all changes (but don't commit - WIP state for wt list demo)
     repo.run_git_in(&feature_auth, &["add", "auth.rs", "lib.rs"]);
 
     feature_auth
@@ -1831,7 +1893,7 @@ fn test_quickstart_merge(mut repo: TestRepo) {
     // Create feature-auth worktree with one commit
     let feature_auth = repo.add_worktree("feature-auth");
 
-    // Add authentication module (same as setup_quickstart_repo)
+    // Add authentication module (full WIP version — all staged, no commit, for wt merge)
     std::fs::write(
         feature_auth.join("auth.rs"),
         r#"//! Authentication module for user session management.

--- a/tests/snapshots/integration__integration_tests__list__quickstart_list.snap
+++ b/tests/snapshots/integration__integration_tests__list__quickstart_list.snap
@@ -18,16 +18,20 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -36,9 +40,9 @@ success: true
 exit_code: 0
 ----- stdout -----
   [1mBranch[0m        [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
-@ feature-auth  [36m+[39m   [2m–[22m      [32m+53[0m                         [2m0e631add[0m  [2m1d[0m    [2mInitial commit
+@ feature-auth  [36m+[39m   [2m↑[22m      [32m+27[0m   [31m-8[0m   [32m↑1[0m               [2m4bc72dc9[0m  [2m2h[0m    [2mAdd authentication module
 ^ main              [2m^[22m[2m⇡[22m                         [32m⇡1[0m      [2m0e631add[0m  [2m1d[0m    [2mInitial commit
 
-[2m○[22m [2mShowing 2 worktrees, 1 with changes, 1 column hidden
+[2m○[22m [2mShowing 2 worktrees, 1 with changes, 1 ahead, 1 column hidden
 
 ----- stderr -----


### PR DESCRIPTION
The quick start `wt list` example was sparse — only staged additions (+53), no removed lines, no commits ahead of main, and both branches showing the same "Initial commit" hash. Now feature-auth has a committed change plus staged WIP, so the output showcases more columns at a glance:

```
  Branch        Status        HEAD±    main↕  Remote⇅  Commit    Age   Message
@ feature-auth  +   ↑      +27  -8   ↑1               4bc72dc9  2h    Add authentication module
^ main              ^⇡                         ⇡1      0e631add  1d    Initial commit
```

The test creates a two-phase setup: commit auth.rs (1 commit ahead of main), then stage WIP changes that extend auth.rs and restructure lib.rs (producing both additions and deletions in HEAD±). The explanatory text was updated to mention `↑1`.

> _This was written by Claude Code on behalf of @max-sixty_