### PR TITLE
Add fish syntax highlighting, delta diffs, and website-matched demo theme

### DIFF
--- a/docs/demos/build
+++ b/docs/demos/build
@@ -438,6 +438,7 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
+  ./build docs social             Build all demos for both targets
   ./build docs                    Build all doc site demos (light + dark)
   ./build social                  Build all social media demos (light only)
   ./build docs --only wt-merge    Build specific demo for docs
@@ -446,7 +447,10 @@ Examples:
 """,
     )
     parser.add_argument(
-        "target", choices=["docs", "social"], help="Target to build demos for"
+        "target",
+        nargs="+",
+        choices=["docs", "social"],
+        help="Target(s) to build demos for",
     )
     parser.add_argument("--only", help="Only record specific demo (e.g., wt-switch)")
     parser.add_argument(
@@ -485,24 +489,47 @@ Examples:
         print("--text and --snapshot are mutually exclusive")
         return
 
+    if args.only and len(args.target) > 1:
+        print("--only cannot be used with multiple targets")
+        return
+
     # Check dependencies (VHS is built from source, not required in PATH)
     deps = ["wt", "starship", "zellij"]
     check_dependencies(deps)
     if not args.text and not args.snapshot:
+        check_dependencies(["delta"])
         check_ffmpeg_libass()
+
+    # Kill stale Zellij processes from previous demo runs (they interfere
+    # with new recordings by holding locks or sockets)
+    subprocess.run(["pkill", "-f", "zellij.*wt-demos"], capture_output=True)
 
     # Ensure VHS is built (requires Go)
     vhs_binary = str(ensure_vhs_binary())
 
-    # Output goes to mode/theme subdirectories
-    mode_out_dir = OUT_DIR / args.target
+    # Build each target sequentially (parallel targets cause Zellij conflicts)
+    all_failed = []
+    for target in dict.fromkeys(args.target):  # deduplicate, preserve order
+        failed = build_target(
+            target, args, vhs_binary,
+        )
+        all_failed.extend(f"{target}/{name}" for name in failed)
+
+    if all_failed:
+        print(f"\n{'=' * 60}")
+        print(f"Failed: {', '.join(all_failed)}")
+        sys.exit(1)
+
+
+def build_target(target: str, args, vhs_binary: str) -> list[str]:
+    """Build all demos for a single target. Returns list of failed demo names."""
+    mode_out_dir = OUT_DIR / target
     mode_out_dir.mkdir(parents=True, exist_ok=True)
 
-    # Copy starship config to docs/ only
-    if args.target == "docs":
+    if target == "docs":
         shutil.copy(FIXTURES_DIR / "starship.toml", mode_out_dir / "starship.toml")
 
-    target_config = TARGETS[args.target]
+    target_config = TARGETS[target]
     demos = target_config["demos"]
     demo_size = target_config["size"]
     themes = target_config["themes"]
@@ -513,8 +540,8 @@ Examples:
         if not demos:
             all_names = [n for _, n, _ in target_config["demos"]]
             print(f"Unknown demo: {args.only}")
-            print(f"Available for {args.target}: {', '.join(all_names)}")
-            return
+            print(f"Available for {target}: {', '.join(all_names)}")
+            return []
 
     # In snapshot mode, skip TUI demos (they validate via checkpoints during GIF recording)
     if args.snapshot:
@@ -525,7 +552,7 @@ Examples:
             print(f"Skipping {skipped} TUI demo(s) (validate during GIF recording instead)")
         if not demos:
             print("No snapshotable demos found")
-            return
+            return []
 
     # Handle --shell mode (interactive, must be sequential)
     if args.shell:
@@ -536,12 +563,12 @@ Examples:
         setup_func(env)
         print(f"Demo repo: {env.repo}")
         spawn_debug_shell(env, FIXTURES_DIR / "starship.toml")
-        return
+        return []
 
     # Record demos
+    failed = []
     if args.sequential or len(demos) == 1:
-        print(f"\nRecording {len(demos)} demo(s) sequentially...")
-        failed = []
+        print(f"\n[{target}] Recording {len(demos)} demo(s) sequentially...")
         for tape_file, output_name, setup_func in demos:
             try:
                 record_demo(
@@ -559,7 +586,7 @@ Examples:
                 print(f"✗ {output_name}: {e}")
                 failed.append(output_name)
     else:
-        print(f"\nRecording {len(demos)} demo(s) in parallel...")
+        print(f"\n[{target}] Recording {len(demos)} demo(s) in parallel...")
         max_workers = min(len(demos), os.cpu_count() or 4)
 
         with ProcessPoolExecutor(max_workers=max_workers) as executor:
@@ -579,7 +606,6 @@ Examples:
                 for tape_file, output_name, setup_func in demos
             }
 
-            failed = []
             for future in as_completed(futures):
                 output_name = futures[future]
                 try:
@@ -588,10 +614,7 @@ Examples:
                     print(f"✗ {output_name}: {e}")
                     failed.append(output_name)
 
-    if failed:
-        print(f"\n{'=' * 60}")
-        print(f"Failed: {', '.join(failed)}")
-        sys.exit(1)
+    return failed
 
 
 if __name__ == "__main__":

--- a/docs/demos/shared/fixtures/starship.toml
+++ b/docs/demos/shared/fixtures/starship.toml
@@ -9,10 +9,11 @@ yellow = "#d29922"
 green = "#2ea043"
 red = "#d73a49"
 muted = "#57606a"
+soft = "#8b7355"
 gold = "#d97706"
 
 [directory]
-style = "bold fg:gold"
+style = "bold fg:soft"
 truncation_length = 3
 truncate_to_repo = true
 home_symbol = "~"
@@ -39,9 +40,9 @@ format = " [$duration]($style)"
 style = "fg:muted"
 
 [character]
-success_symbol = "[❯](fg:gold)"
+success_symbol = "[❯](fg:soft)"
 error_symbol = "[❯](fg:red)"
-vicmd_symbol = "[❮](fg:gold)"
+vicmd_symbol = "[❮](fg:soft)"
 
 [time]
 disabled = true

--- a/docs/demos/shared/lib.py
+++ b/docs/demos/shared/lib.py
@@ -397,6 +397,47 @@ fi
     install_env["HOME"] = str(env.home)
     run([str(wt_bin), "config", "shell", "install", "fish", "--yes"], env=install_env)
 
+    # Fish syntax highlighting colors — use ANSI names so the VHS terminal
+    # theme controls the actual rendered RGB values (light vs dark).
+    # Two mechanisms: fish_variables for --shell/--snapshot mode (fish reads at
+    # startup), colors.fish for VHS recordings (VHS applies Env HOME after fish
+    # starts, so fish_variables from the demo home isn't read).
+    fish_config_dir = env.home / ".config" / "fish"
+    fish_config_dir.mkdir(parents=True, exist_ok=True)
+    color_vars = {
+        "fish_color_autosuggestion": "brblack",
+        "fish_color_command": "yellow",  # amber — matches website .cmd color
+        "fish_color_comment": "brblack",
+        "fish_color_end": "normal",
+        "fish_color_error": "red",
+        "fish_color_escape": "cyan",
+        "fish_color_keyword": "yellow",
+        "fish_color_normal": "normal",
+        "fish_color_operator": "normal",
+        "fish_color_param": "normal",
+        "fish_color_quote": "green",
+        "fish_color_redirection": "normal",
+    }
+
+    # fish_variables file (for --shell and --snapshot modes)
+    lines = [
+        "# This file contains fish universal variable definitions.",
+        "# VERSION: 3.0",
+    ]
+    lines.extend(f"SETUVAR {k}:{v}" for k, v in color_vars.items())
+    lines.extend([
+        "SETUVAR fish_color_cancel:\\x2d\\x2dreverse",
+        "SETUVAR fish_color_search_match:\\x2d\\x2dbackground\\x3d111",
+        "SETUVAR fish_color_selection:\\x2d\\x2dbackground\\x3dbrblack",
+        "SETUVAR fish_color_valid_path:\\x2d\\x2dunderline",
+        "SETUVAR fish_greeting:",
+    ])
+    (fish_config_dir / "fish_variables").write_text("\n".join(lines) + "\n")
+
+    # colors.fish script (sourced in VHS tape hidden section)
+    color_lines = [f"set -g {k} {v}" for k, v in color_vars.items()]
+    (fish_config_dir / "colors.fish").write_text("\n".join(color_lines) + "\n")
+
     # User config directory (demos add their own config.toml)
     config_dir = env.home / ".config" / "worktrunk"
     config_dir.mkdir(parents=True)
@@ -636,7 +677,6 @@ def setup_fish_config(env: DemoEnv, wsl_create: bool = False) -> None:
 
     fish_config = fish_config_dir / "config.fish"
     fish_config.write_text(f"""# Demo fish config
-set -U fish_greeting ""
 # wsl abbreviation: switch to worktree and launch Claude
 abbr --add wsl '{wsl_cmd}'
 starship init fish | source
@@ -1134,6 +1174,7 @@ def record_snapshot(
             "TERM": "xterm-256color",
             "LANG": "en_US.UTF-8",
             "LC_ALL": "en_US.UTF-8",
+            "GIT_PAGER": "",  # Plain text output, no delta formatting
         }
     )
 
@@ -1215,6 +1256,7 @@ def build_tape_replacements(demo_env: DemoEnv, repo_root: Path) -> dict:
         "STARSHIP_CONFIG": starship_config,
         "TARGET_DEBUG": (repo_root / "target" / "debug").resolve(),
         "ANTHROPIC_API_KEY": os.environ.get("ANTHROPIC_API_KEY", ""),
+        "GIT_PAGER": "",  # Overridden per-theme in record_all_themes
     }
 
 
@@ -1244,6 +1286,9 @@ def record_all_themes(
 
     for theme_name, output_gif in output_gifs.items():
         theme = THEMES[theme_name]
+        delta_flags = "delta --paging=never"
+        if theme_name == "light":
+            delta_flags += " --light"
         replacements = {
             **base_replacements,
             "OUTPUT_GIF": output_gif,
@@ -1251,6 +1296,7 @@ def record_all_themes(
             "WIDTH": size.width,
             "HEIGHT": size.height,
             "FONTSIZE": size.fontsize,
+            "GIT_PAGER": delta_flags,
         }
 
         rendered = render_tape(tape_template, replacements, repo_root)

--- a/docs/demos/shared/themes.py
+++ b/docs/demos/shared/themes.py
@@ -7,24 +7,24 @@ so demos integrate seamlessly with light/dark mode switching.
 import json
 
 # Light theme - matches the "Warm Workbench" light mode
-# Based on the original "Warm Gold Light" theme with doc site alignment
+# Terminal colors from docs/templates/_variables.html (light mode)
 LIGHT_THEME = {
     "name": "Warm Gold Light",
-    "black": "#8c959f",
-    "red": "#d73a49",
-    "green": "#22863a",
-    "yellow": "#d29922",
-    "blue": "#0969da",
-    "magenta": "#8250df",
-    "cyan": "#1b7c83",
+    "black": "#6b7280",  # --bright-black
+    "red": "#dc2626",  # --red
+    "green": "#357a59",  # --green (desaturated from website's #1b7f4b)
+    "yellow": "#ca8a04",  # --yellow
+    "blue": "#2563eb",  # --blue
+    "magenta": "#9333ea",  # --magenta
+    "cyan": "#3d7f7f",  # --cyan (muted from website's #0a8080)
     "white": "#8c959f",
-    "brightBlack": "#8c959f",
-    "brightRed": "#cb2431",
-    "brightGreen": "#2ea043",
-    "brightYellow": "#f2cc60",
-    "brightBlue": "#218bff",
-    "brightMagenta": "#a475f9",
-    "brightCyan": "#39c5cf",
+    "brightBlack": "#6b7280",  # --bright-black
+    "brightRed": "#ef4444",
+    "brightGreen": "#4a9b76",
+    "brightYellow": "#eab308",
+    "brightBlue": "#3b82f6",
+    "brightMagenta": "#a855f7",
+    "brightCyan": "#5a9e9e",
     "brightWhite": "#8c959f",
     "background": "#FFFBF0",
     "foreground": "#1f2328",

--- a/docs/demos/tapes/shared-commands.tape
+++ b/docs/demos/tapes/shared-commands.tape
@@ -5,6 +5,7 @@ Require git
 Env CLAUDECODE ""
 Env IS_DEMO "1"
 Env GIT_TERMINAL_PROMPT "0"
+Env GIT_PAGER "{{GIT_PAGER}}"
 Env DEMO_REPO "{{DEMO_REPO}}"
 Env RUSTUP_HOME "{{REAL_HOME}}/.rustup"
 Env CARGO_HOME "{{REAL_HOME}}/.cargo"
@@ -14,6 +15,8 @@ Env STARSHIP_CONFIG "{{STARSHIP_CONFIG}}"
 
 Hide
 Type "set -g fish_autosuggestion_enabled 0"
+Enter
+Type "source $HOME/.config/fish/colors.fish"
 Enter
 Type "set -gx LANG en_US.UTF-8; set -gx LC_ALL en_US.UTF-8"
 Enter


### PR DESCRIPTION
Three improvements to demo GIF recordings:

- **Fish syntax highlighting** — commands render in amber matching the website's `.cmd` accent. Params/args use the default foreground. Starship prompt uses craft-brown (`#8b7355`) to differentiate from commands. Two delivery mechanisms: `fish_variables` for `--shell`/`--snapshot` mode, `colors.fish` sourced in VHS hidden section (VHS applies `Env HOME` after fish starts).
- **Delta diff viewer** — `GIT_PAGER` set per-theme (`delta --paging=never --light` for light, `delta --paging=never` for dark). Empty for text/snapshot recordings.
- **Light theme aligned to website** — terminal colors updated to match `_variables.html`. Cyan and green desaturated to avoid garish bold rendering.

Also: build script accepts multiple targets (`./build docs social`), kills stale Zellij processes before recording, and requires delta only for GIF mode.

> _This was written by Claude Code on behalf of maximilian_