### PR TITLE
docs: tighten summary caching line and fix broken hook anchor

### DIFF
--- a/docs/content/llm-commits.md
+++ b/docs/content/llm-commits.md
@@ -107,7 +107,7 @@ Enable in user config:
 summary = true
 ```
 
-Disabled by default — when enabled, each branch's diff is sent to the configured LLM for summarization. Results are cached until the diff changes.
+Summaries are cached and regenerated only when the diff changes.
 
 ## Prompt templates
 

--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -871,7 +871,7 @@ wt step deploy --var env=staging          # pass extra template variables
 wt step deploy --yes                      # skip approval prompt
 ```
 
-When defined in both user and project config, both run — user first, then project. Project-config aliases require [command approval](@/hook.md#security) on first run, same as project hooks. User-config aliases are trusted.
+When defined in both user and project config, both run — user first, then project. Project-config aliases require [command approval](@/hook.md#wt-hook-approvals) on first run, same as project hooks. User-config aliases are trusted.
 
 Alias names that match a built-in step command (`commit`, `squash`, etc.) are shadowed by the built-in and will never run.
 

--- a/docs/content/tips-patterns.md
+++ b/docs/content/tips-patterns.md
@@ -176,7 +176,7 @@ With `summary = true` and [`commit.generation`](@/config.md#commit) configured, 
 summary = true
 ```
 
-Disabled by default — when enabled, each branch's diff is sent to the configured LLM for summarization. See [LLM Commits](@/llm-commits.md#branch-summaries) for details.
+Summaries are cached and regenerated only when the diff changes. See [LLM Commits](@/llm-commits.md#branch-summaries) for details.
 
 ## JSON API
 

--- a/skills/worktrunk/reference/llm-commits.md
+++ b/skills/worktrunk/reference/llm-commits.md
@@ -93,7 +93,7 @@ Enable in user config:
 summary = true
 ```
 
-Disabled by default — when enabled, each branch's diff is sent to the configured LLM for summarization. Results are cached until the diff changes.
+Summaries are cached and regenerated only when the diff changes.
 
 ## Prompt templates
 

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -837,6 +837,6 @@ wt step deploy --var env=staging          # pass extra template variables
 wt step deploy --yes                      # skip approval prompt
 ```
 
-When defined in both user and project config, both run — user first, then project. Project-config aliases require [command approval](https://worktrunk.dev/hook/#security) on first run, same as project hooks. User-config aliases are trusted.
+When defined in both user and project config, both run — user first, then project. Project-config aliases require [command approval](https://worktrunk.dev/hook/#wt-hook-approvals) on first run, same as project hooks. User-config aliases are trusted.
 
 Alias names that match a built-in step command (`commit`, `squash`, etc.) are shadowed by the built-in and will never run.

--- a/skills/worktrunk/reference/tips-patterns.md
+++ b/skills/worktrunk/reference/tips-patterns.md
@@ -165,7 +165,7 @@ With `summary = true` and [`commit.generation`](https://worktrunk.dev/config/#co
 summary = true
 ```
 
-Disabled by default — when enabled, each branch's diff is sent to the configured LLM for summarization. See [LLM Commits](https://worktrunk.dev/llm-commits/#branch-summaries) for details.
+Summaries are cached and regenerated only when the diff changes. See [LLM Commits](https://worktrunk.dev/llm-commits/#branch-summaries) for details.
 
 ## JSON API
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1089,7 +1089,7 @@ wt step deploy --var env=staging          # pass extra template variables
 wt step deploy --yes                      # skip approval prompt
 ```
 
-When defined in both user and project config, both run — user first, then project. Project-config aliases require [command approval](@/hook.md#security) on first run, same as project hooks. User-config aliases are trusted.
+When defined in both user and project config, both run — user first, then project. Project-config aliases require [command approval](@/hook.md#wt-hook-approvals) on first run, same as project hooks. User-config aliases are trusted.
 
 Alias names that match a built-in step command (`commit`, `squash`, etc.) are shadowed by the built-in and will never run."#
     )]


### PR DESCRIPTION
Rewrite the redundant summary caching sentence in llm-commits and tips-patterns docs — the preceding paragraph already explains what summaries are and how to enable them, so "Disabled by default — when enabled, each branch's diff is sent to the configured LLM for summarization" was restating known information. Replaced with "Summaries are cached and regenerated only when the diff changes."

Also fix a broken `#security` anchor in step aliases docs — the hook page has no such heading; the correct target is `#wt-hook-approvals`.

> _This was written by Claude Code on behalf of @max-sixty_