### PR TITLE
Unify approval example to pre-start and add drift test

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -176,11 +176,11 @@ User hooks don't require approval (you defined them). Commands from project hook
 {% terminal() %}
 <span class="y">▲ <b>repo</b> needs approval to execute <b>3</b> commands:</span>
 
-<span class="d">○</span> post-create <b>install</b>:
+<span class="d">○</span> pre-start <b>install</b>:
 <span style='background:var(--bright-white,#fff)'> </span> <span class="d"><span class="b">npm</span> ci</span>
-<span class="d">○</span> post-create <b>build</b>:
+<span class="d">○</span> pre-start <b>build</b>:
 <span style='background:var(--bright-white,#fff)'> </span> <span class="d"><span class="b">cargo</span> build <span class="c">--release</span></span>
-<span class="d">○</span> post-create <b>env</b>:
+<span class="d">○</span> pre-start <b>env</b>:
 <span style='background:var(--bright-white,#fff)'> </span> <span class="d"><span class="b">echo</span> <span class="g">'PORT={{ branch | hash_port }}'</span> <span class="c">></span> .env.local</span>
 
 <span class="c">❯</span> Allow and remember? <b>[y/N]</b>

--- a/skills/worktrunk/reference/faq.md
+++ b/skills/worktrunk/reference/faq.md
@@ -168,11 +168,11 @@ User hooks don't require approval (you defined them). Commands from project hook
 
 <span class="y">▲ <b>repo</b> needs approval to execute <b>3</b> commands:</span>
 
-<span class="d">○</span> post-create <b>install</b>:
+<span class="d">○</span> pre-start <b>install</b>:
 <span style='background:var(--bright-white,#fff)'> </span> <span class="d"><span class="b">npm</span> ci</span>
-<span class="d">○</span> post-create <b>build</b>:
+<span class="d">○</span> pre-start <b>build</b>:
 <span style='background:var(--bright-white,#fff)'> </span> <span class="d"><span class="b">cargo</span> build <span class="c">--release</span></span>
-<span class="d">○</span> post-create <b>env</b>:
+<span class="d">○</span> pre-start <b>env</b>:
 <span style='background:var(--bright-white,#fff)'> </span> <span class="d"><span class="b">echo</span> <span class="g">'PORT={{ branch | hash_port }}'</span> <span class="c">></span> .env.local</span>
 
 <span class="c">❯</span> Allow and remember? <b>[y/N]</b>

--- a/tests/integration_tests/readme_sync.rs
+++ b/tests/integration_tests/readme_sync.rs
@@ -1947,3 +1947,24 @@ fn test_command_pages_and_skill_files_are_in_sync() {
         );
     }
 }
+
+/// Verify that post_process_for_html() transforms the approval prompt code block
+/// into a styled terminal shortcode. If the source text in cli/mod.rs changes
+/// without updating the replacement in help.rs, the .replace() silently stops
+/// matching and the web docs fall back to a plain code block.
+#[test]
+fn test_approval_prompt_styled_in_hook_page() {
+    let project_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let output = wt_command()
+        .args(["hook", "--help-page"])
+        .current_dir(project_root)
+        .output()
+        .expect("Failed to run wt hook --help-page");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(r#"class="y""#),
+        "hook --help-page should contain styled approval prompt (class=\"y\" for yellow ▲). \
+         If cli/mod.rs approval example changed, update the replacement in help.rs post_process_for_html()."
+    );
+}


### PR DESCRIPTION
Follows up on #1766. Two changes:

1. **Unify hook type**: faq.md approval prompt used `post-create` while hook.md used `pre-start`. Both now use `pre-start` for consistency.

2. **Drift detection**: Added `test_approval_prompt_styled_in_hook_page` — runs `wt hook --help-page` and asserts the output contains the styled terminal shortcode. If the cli/mod.rs approval example changes without updating the `post_process_for_html()` replacement in help.rs, this test fails with an actionable error message.

> _This was written by Claude Code on behalf of @max-sixty_