### PR TITLE
fix(fish): prevent getcwd error after worktree removal in Zellij

### DIFF
--- a/src/commands/process.rs
+++ b/src/commands/process.rs
@@ -442,14 +442,12 @@ pub fn build_remove_command(
     let worktree_path_str = worktree_path.to_string_lossy();
     let worktree_escaped = escape(worktree_path_str.as_ref().into());
 
-    // TODO: This delay is a timing-based workaround, not a principled fix.
-    // The race: after wt exits, the shell wrapper reads the directive file and
-    // runs `cd`. But fish (and other shells) may call getcwd() before the cd
-    // completes (e.g., for prompt updates), and if the background removal has
-    // already deleted the directory, we get "shell-init: error retrieving current
-    // directory". A 1s delay is very conservative (shell cd takes ~1-5ms), but
-    // deterministic solutions (shell-spawned background, marker file sync) add
-    // significant complexity for marginal benefit.
+    // Delay before deleting the worktree directory. After wt exits, the shell
+    // wrapper reads the directive file and runs `cd`. The 1s delay ensures the
+    // shell has finished cd'ing before the directory is removed. The primary fix
+    // for the "shell-init: error retrieving current directory" race is in the
+    // fish wrapper (using builtins instead of subprocesses to read the directive),
+    // but this delay provides defense in depth for other shells and edge cases.
     let delay = "sleep 1";
 
     // Stop fsmonitor daemon first (best effort - ignore errors)

--- a/src/shell/snapshots/worktrunk__shell__tests__init_fish.snap
+++ b/src/shell/snapshots/worktrunk__shell__tests__init_fish.snap
@@ -11,10 +11,11 @@ expression: output
 # Creates a temp file, passes path via WORKTRUNK_DIRECTIVE_FILE, evals it after.
 # WORKTRUNK_BIN can override the binary path (for testing dev builds).
 #
-# Note: We use `eval (cat ... | string collect)` instead of `source` because:
-# 1. fish's `source` doesn't propagate exit codes to the parent function
-# 2. `eval (cat ...)` without `string collect` splits on newlines, breaking multiline directives
-# With `string collect`, we get proper exit code propagation for cd and other directives.
+# Note: We use `eval (string collect < file)` instead of `source` because
+# fish's `source` doesn't propagate exit codes to the parent function.
+# We read the directive with `string collect` (builtin) instead of `cat`
+# (external) to avoid spawning a subprocess whose CWD may have been renamed
+# by worktree removal.
 function wt
     set -l use_source false
     set -l args
@@ -39,13 +40,16 @@ function wt
     set -l exit_code $status
 
     if test -s "$directive_file"
-        eval (cat "$directive_file" | string collect)
+        # Use fish builtin instead of cat to avoid spawning a subprocess
+        # whose CWD may have been renamed by worktree removal.
+        set -l directive (string collect < "$directive_file")
+        eval $directive
         if test $exit_code -eq 0
             set exit_code $status
         end
     end
 
-    rm -f "$directive_file"
+    command rm -f "$directive_file"
     return $exit_code
 end
 

--- a/templates/fish.fish
+++ b/templates/fish.fish
@@ -7,10 +7,11 @@
 # Creates a temp file, passes path via WORKTRUNK_DIRECTIVE_FILE, evals it after.
 # WORKTRUNK_BIN can override the binary path (for testing dev builds).
 #
-# Note: We use `eval (cat ... | string collect)` instead of `source` because:
-# 1. fish's `source` doesn't propagate exit codes to the parent function
-# 2. `eval (cat ...)` without `string collect` splits on newlines, breaking multiline directives
-# With `string collect`, we get proper exit code propagation for cd and other directives.
+# Note: We use `eval (string collect < file)` instead of `source` because
+# fish's `source` doesn't propagate exit codes to the parent function.
+# We read the directive with `string collect` (builtin) instead of `cat`
+# (external) to avoid spawning a subprocess whose CWD may have been renamed
+# by worktree removal.
 function {{ cmd }}
     set -l use_source false
     set -l args
@@ -35,13 +36,16 @@ function {{ cmd }}
     set -l exit_code $status
 
     if test -s "$directive_file"
-        eval (cat "$directive_file" | string collect)
+        # Use fish builtin instead of cat to avoid spawning a subprocess
+        # whose CWD may have been renamed by worktree removal.
+        set -l directive (string collect < "$directive_file")
+        eval $directive
         if test $exit_code -eq 0
             set exit_code $status
         end
     end
 
-    rm -f "$directive_file"
+    command rm -f "$directive_file"
     return $exit_code
 end
 

--- a/tests/snapshots/integration__integration_tests__init__init_fish.snap
+++ b/tests/snapshots/integration__integration_tests__init__init_fish.snap
@@ -21,16 +21,20 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -47,10 +51,11 @@ exit_code: 0
 # Creates a temp file, passes path via WORKTRUNK_DIRECTIVE_FILE, evals it after.
 # WORKTRUNK_BIN can override the binary path (for testing dev builds).
 #
-# Note: We use `eval (cat ... | string collect)` instead of `source` because:
-# 1. fish's `source` doesn't propagate exit codes to the parent function
-# 2. `eval (cat ...)` without `string collect` splits on newlines, breaking multiline directives
-# With `string collect`, we get proper exit code propagation for cd and other directives.
+# Note: We use `eval (string collect < file)` instead of `source` because
+# fish's `source` doesn't propagate exit codes to the parent function.
+# We read the directive with `string collect` (builtin) instead of `cat`
+# (external) to avoid spawning a subprocess whose CWD may have been renamed
+# by worktree removal.
 function wt
     set -l use_source false
     set -l args
@@ -75,13 +80,16 @@ function wt
     set -l exit_code $status
 
     if test -s "$directive_file"
-        eval (cat "$directive_file" | string collect)
+        # Use fish builtin instead of cat to avoid spawning a subprocess
+        # whose CWD may have been renamed by worktree removal.
+        set -l directive (string collect < "$directive_file")
+        eval $directive
         if test $exit_code -eq 0
             set exit_code $status
         end
     end
 
-    rm -f "$directive_file"
+    command rm -f "$directive_file"
     return $exit_code
 end
 


### PR DESCRIPTION
Replace `cat` (external subprocess) with `string collect` (fish builtin) when reading the directive file in the fish shell wrapper.

After worktree removal via the fast path, the shell's CWD inode follows the `rename()` into `.git/wt/trash/`. Spawning any subprocess from this CWD can trigger `shell-init: error retrieving current directory` — on macOS, `/bin/sh` calls `getcwd()` during initialization, and in terminal multiplexers like Zellij the error is visible to the user. Using a fish builtin avoids subprocess spawning entirely.

The `sleep 1` delay in the background removal command remains as defense in depth, but the primary fix is eliminating the subprocess. bash/zsh wrappers already use `source` (a builtin) and are unaffected.

> _This was written by Claude Code on behalf of @max-sixty_