### PR TITLE
Convert stray bash block to console convention in config docs

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -576,9 +576,7 @@ Default branch detection and override.
 
 Useful in scripts to avoid hardcoding `main` or `master`:
 
-```bash
-git rebase $(wt config state default-branch)
-```
+{{ terminal(cmd="git rebase $(wt config state default-branch)") }}
 
 Without a subcommand, runs `get`. Use `set` to override, or `clear` then `get` to re-detect.
 

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -588,7 +588,7 @@ Default branch detection and override.
 Useful in scripts to avoid hardcoding `main` or `master`:
 
 ```bash
-git rebase $(wt config state default-branch)
+$ git rebase $(wt config state default-branch)
 ```
 
 Without a subcommand, runs `get`. Use `set` to override, or `clear` then `get` to re-detect.

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -322,8 +322,8 @@ pub enum StateCommand {
         name = "default-branch",
         after_long_help = r#"Useful in scripts to avoid hardcoding `main` or `master`:
 
-```bash
-git rebase $(wt config state default-branch)
+```console
+$ git rebase $(wt config state default-branch)
 ```
 
 Without a subcommand, runs `get`. Use `set` to override, or `clear` then `get` to re-detect.

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
@@ -58,7 +58,7 @@ Usage: [1m[36mwt config state default-branch[0m [36m[OPTIONS][0m [36m[COMM
 
 Useful in scripts to avoid hardcoding [2mmain[0m or [2mmaster[0m:
 
-[107m [0m [2m[0m[2m[34mgit[0m[2m rebase $([0m[2m[34mwt[0m[2m config state default-branch)[0m
+[107m [0m [2m[0m[2m[36m$[0m[2m git[0m[2m rebase $([0m[2m[34mwt[0m[2m config state default-branch)[0m
 
 Without a subcommand, runs [2mget[0m. Use [2mset[0m to override, or [2mclear[0m then [2mget[0m to re-detect.
 


### PR DESCRIPTION
Follow-up to #1777. The `wt config state default-branch` example in `src/cli/config.rs` was introduced on main after the code block convention conversion and used the old ```bash format. Converts to ```console with `$ ` prefix so the sync test generates a terminal shortcode.

Also verified: zero ```bash and zero ```console blocks remain in docs/content/ — all are terminal shortcodes now.

> _This was written by Claude Code on behalf of @max-sixty_