### PR TITLE
Wrap prompt openers in <task> tags and reword squash template

### DIFF
--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -174,7 +174,7 @@
 # <!-- DEFAULT_TEMPLATE_START -->
 # [commit.generation]
 # template = """
-# Write a commit message for the staged changes below.
+# <task>Write a commit message for the staged changes below.</task>
 #
 # <format>
 # - Subject line under 50 chars
@@ -218,7 +218,7 @@
 # <!-- DEFAULT_SQUASH_TEMPLATE_START -->
 # [commit.generation]
 # squash-template = """
-# Combine these commits into a single commit message.
+# <task>Write a commit message for the combined effect of these commits.</task>
 #
 # <format>
 # - Subject line under 50 chars

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -265,7 +265,7 @@ Default template:
 ```toml
 [commit.generation]
 template = """
-Write a commit message for the staged changes below.
+<task>Write a commit message for the staged changes below.</task>
 
 <format>
 - Subject line under 50 chars
@@ -311,7 +311,7 @@ Default template:
 ```toml
 [commit.generation]
 squash-template = """
-Combine these commits into a single commit message.
+<task>Write a commit message for the combined effect of these commits.</task>
 
 <format>
 - Subject line under 50 chars

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -264,7 +264,7 @@ Default template:
 ```toml
 [commit.generation]
 template = """
-Write a commit message for the staged changes below.
+<task>Write a commit message for the staged changes below.</task>
 
 <format>
 - Subject line under 50 chars
@@ -310,7 +310,7 @@ Default template:
 ```toml
 [commit.generation]
 squash-template = """
-Combine these commits into a single commit message.
+<task>Write a commit message for the combined effect of these commits.</task>
 
 <format>
 - Subject line under 50 chars

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1815,7 +1815,7 @@ Default template:
 ```toml
 [commit.generation]
 template = """
-Write a commit message for the staged changes below.
+<task>Write a commit message for the staged changes below.</task>
 
 <format>
 - Subject line under 50 chars
@@ -1861,7 +1861,7 @@ Default template:
 ```toml
 [commit.generation]
 squash-template = """
-Combine these commits into a single commit message.
+<task>Write a commit message for the combined effect of these commits.</task>
 
 <format>
 - Subject line under 50 chars

--- a/src/commands/picker/summary.rs
+++ b/src/commands/picker/summary.rs
@@ -258,7 +258,7 @@ mod tests {
         // With diff content and stat
         let prompt = render_prompt("diff content", "1 file changed").unwrap();
         assert_snapshot!(prompt, @r#"
-        Write a summary of this branch's changes as a commit message.
+        <task>Write a summary of this branch's changes as a commit message.</task>
 
         <format>
         - Subject line under 50 chars, imperative mood ("Add feature" not "Adds feature")
@@ -278,7 +278,7 @@ mod tests {
         // Empty inputs still include format instructions
         let empty_prompt = render_prompt("", "").unwrap();
         assert_snapshot!(empty_prompt, @r#"
-        Write a summary of this branch's changes as a commit message.
+        <task>Write a summary of this branch's changes as a commit message.</task>
 
         <format>
         - Subject line under 50 chars, imperative mood ("Add feature" not "Adds feature")

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -222,7 +222,7 @@ struct TemplateContext<'a> {
 /// Default template for commit message prompts
 ///
 /// Synced to dev/config.example.toml by `cargo test readme_sync`
-const DEFAULT_TEMPLATE: &str = r#"Write a commit message for the staged changes below.
+const DEFAULT_TEMPLATE: &str = r#"<task>Write a commit message for the staged changes below.</task>
 
 <format>
 - Subject line under 50 chars
@@ -255,7 +255,7 @@ Branch: {{ branch }}
 /// Default template for squash commit message prompts
 ///
 /// Synced to dev/config.example.toml by `cargo test readme_sync`
-const DEFAULT_SQUASH_TEMPLATE: &str = r#"Combine these commits into a single commit message.
+const DEFAULT_SQUASH_TEMPLATE: &str = r#"<task>Write a commit message for the combined effect of these commits.</task>
 
 <format>
 - Subject line under 50 chars
@@ -766,7 +766,7 @@ mod tests {
         let context = commit_context("diff content", "main", None, "myrepo");
         let prompt = build_prompt(&config, TemplateType::Commit, &context).unwrap();
         assert_snapshot!(prompt, @r#"
-        Write a commit message for the staged changes below.
+        <task>Write a commit message for the staged changes below.</task>
 
         <format>
         - Subject line under 50 chars
@@ -799,7 +799,7 @@ mod tests {
         let context = commit_context("diff", "main", Some(&commits), "repo");
         let prompt = build_prompt(&config, TemplateType::Commit, &context).unwrap();
         assert_snapshot!(prompt, @r#"
-        Write a commit message for the staged changes below.
+        <task>Write a commit message for the staged changes below.</task>
 
         <format>
         - Subject line under 50 chars
@@ -835,7 +835,7 @@ mod tests {
         let context = commit_context("diff", "main", Some(&commits), "repo");
         let prompt = build_prompt(&config, TemplateType::Commit, &context).unwrap();
         assert_snapshot!(prompt, @r#"
-        Write a commit message for the staged changes below.
+        <task>Write a commit message for the staged changes below.</task>
 
         <format>
         - Subject line under 50 chars
@@ -937,7 +937,7 @@ mod tests {
         let context = squash_context("diff content", "feature", None, "repo", &commits, "main");
         let prompt = build_prompt(&config, TemplateType::Squash, &context).unwrap();
         assert_snapshot!(prompt, @r#"
-        Combine these commits into a single commit message.
+        <task>Write a commit message for the combined effect of these commits.</task>
 
         <format>
         - Subject line under 50 chars

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -46,7 +46,7 @@ pub(crate) struct CombinedDiff {
 ///
 /// Uses commit-message format (subject + body) which naturally produces
 /// imperative-mood summaries without "This branch..." preamble.
-const SUMMARY_TEMPLATE: &str = r#"Write a summary of this branch's changes as a commit message.
+const SUMMARY_TEMPLATE: &str = r#"<task>Write a summary of this branch's changes as a commit message.</task>
 
 <format>
 - Subject line under 50 chars, imperative mood ("Add feature" not "Adds feature")
@@ -259,7 +259,7 @@ mod tests {
     fn test_render_prompt_includes_diff_and_stat() {
         let result = render_prompt("diff content here", "stat content here").unwrap();
         insta::assert_snapshot!(result, @r#"
-        Write a summary of this branch's changes as a commit message.
+        <task>Write a summary of this branch's changes as a commit message.</task>
 
         <format>
         - Subject line under 50 chars, imperative mood ("Add feature" not "Adds feature")

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -233,7 +233,7 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# <!-- DEFAULT_TEMPLATE_START -->[0m
 [107m [0m [2m# [commit.generation][0m
 [107m [0m [2m# template = """[0m
-[107m [0m [2m# Write a commit message for the staged changes below.[0m
+[107m [0m [2m# <task>Write a commit message for the staged changes below.</task>[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# <format>[0m
 [107m [0m [2m# - Subject line under 50 chars[0m
@@ -277,7 +277,7 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# <!-- DEFAULT_SQUASH_TEMPLATE_START -->[0m
 [107m [0m [2m# [commit.generation][0m
 [107m [0m [2m# squash-template = """[0m
-[107m [0m [2m# Combine these commits into a single commit message.[0m
+[107m [0m [2m# <task>Write a commit message for the combined effect of these commits.</task>[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# <format>[0m
 [107m [0m [2m# - Subject line under 50 chars[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -277,7 +277,7 @@ Default template:
 
 [107m [0m [2m[36m[commit.generation][0m
 [107m [0m [2mtemplate = [0m[2m[32m""[0m[2m[32m"[0m
-[107m [0m [2m[32mWrite a commit message for the staged changes below.[0m
+[107m [0m [2m[32m<task>Write a commit message for the staged changes below.</task>[0m
 [107m [0m 
 [107m [0m [2m[32m<format>[0m
 [107m [0m [2m[32m- Subject line under 50 chars[0m
@@ -319,7 +319,7 @@ Default template:
 
 [107m [0m [2m[36m[commit.generation][0m
 [107m [0m [2msquash-template = [0m[2m[32m""[0m[2m[32m"[0m
-[107m [0m [2m[32mCombine these commits into a single commit message.[0m
+[107m [0m [2m[32m<task>Write a commit message for the combined effect of these commits.</task>[0m
 [107m [0m 
 [107m [0m [2m[32m<format>[0m
 [107m [0m [2m[32m- Subject line under 50 chars[0m

--- a/tests/snapshots/integration__integration_tests__merge__step_commit_show_prompt.snap
+++ b/tests/snapshots/integration__integration_tests__merge__step_commit_show_prompt.snap
@@ -20,16 +20,20 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -37,7 +41,7 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-Write a commit message for the staged changes below.
+<task>Write a commit message for the staged changes below.</task>
 
 <format>
 - Subject line under 50 chars

--- a/tests/snapshots/integration__integration_tests__merge__step_commit_show_prompt_no_staged_changes.snap
+++ b/tests/snapshots/integration__integration_tests__merge__step_commit_show_prompt_no_staged_changes.snap
@@ -20,16 +20,20 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -37,7 +41,7 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-Write a commit message for the staged changes below.
+<task>Write a commit message for the staged changes below.</task>
 
 <format>
 - Subject line under 50 chars

--- a/tests/snapshots/integration__integration_tests__merge__step_squash_show_prompt.snap
+++ b/tests/snapshots/integration__integration_tests__merge__step_squash_show_prompt.snap
@@ -20,16 +20,20 @@ info:
     LANG: C
     LC_ALL: C
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
     PATH: "[PATH]"
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -37,7 +41,7 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-Combine these commits into a single commit message.
+<task>Write a commit message for the combined effect of these commits.</task>
 
 <format>
 - Subject line under 50 chars


### PR DESCRIPTION
Wraps the opening instruction line in all three LLM prompt templates (commit, squash, summary) in `<task>` XML tags — the only content that wasn't already in XML tags. Also rewords the squash template opener from "Combine these commits into a single commit message" to "Write a commit message for the combined effect of these commits", shifting the framing from mechanical concatenation to synthesis.

> _This was written by Claude Code on behalf of @max-sixty_