### PR TITLE
Post-merge: run clippy and build tests for warm cache

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -5,7 +5,8 @@ assets = "task fetch-assets"
 docs = "cd docs && zola serve -p {{ branch | hash_port }}"
 
 [post-merge]
-build = "cargo build --all-targets"
+clippy = "pre-commit run clippy --all-files || true"
+build = "cargo test --no-run --all-targets"
 install = "cargo install --path ."
 sync = 'if [ "{{ target }}" = "main" ]; then git pull && git push; fi'
 


### PR DESCRIPTION
Replace `cargo build --all-targets` with `pre-commit run clippy` (read-only — won't modify files in the primary worktree) and `cargo test --no-run --all-targets` (compiles test binaries without running them). New worktrees that `wt step copy-ignored` get both the clippy analysis cache and pre-compiled test binaries.

> _This was written by Claude Code on behalf of @max-sixty_