### PR TITLE
Regenerate tend workflows

### DIFF
--- a/.config/tend.toml
+++ b/.config/tend.toml
@@ -1,11 +1,13 @@
 bot_name = "worktrunk-bot"
 
+setup = [
+  {uses = "./.github/actions/claude-setup"},
+]
+
 [secrets]
 bot_token = "WORKTRUNK_BOT_TOKEN"
 claude_token = "CLAUDE_CODE_OAUTH_TOKEN"
-
-[setup]
-uses = ["./.github/actions/claude-setup"]
+allowed = ["CODECOV_TOKEN"]
 
 [workflows.ci-fix]
 watched_workflows = ["ci", "publish-docs"]

--- a/.github/workflows/tend-ci-fix.yaml
+++ b/.github/workflows/tend-ci-fix.yaml
@@ -5,7 +5,7 @@ on:
   workflow_run:
     workflows: ["ci", "publish-docs"]
     types: [completed]
-    branches: [main]
+    branches: ["main"]
 
 jobs:
   fix-ci:
@@ -20,7 +20,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}

--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -6,6 +6,7 @@ on:
     types: [edited]
   issue_comment:
     types: [created, edited]
+  # Works for same-repo PRs only; secrets unavailable on fork PRs (no _target variant exists)
   pull_request_review_comment:
     types: [created, edited]
 
@@ -108,6 +109,9 @@ jobs:
   handle:
     needs: verify
     if: needs.verify.outputs.should_run == 'true'
+    concurrency:
+      group: ${{ github.workflow }}-handle-${{ github.event.issue.number || github.event.pull_request.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/tend-nightly.yaml
+++ b/.github/workflows/tend-nightly.yaml
@@ -3,7 +3,7 @@
 name: tend-nightly
 on:
   schedule:
-    - cron: '17 6 * * *'
+    - cron: "17 6 * * *"
   workflow_dispatch:
 
 jobs:
@@ -19,7 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}

--- a/.github/workflows/tend-renovate.yaml
+++ b/.github/workflows/tend-renovate.yaml
@@ -3,7 +3,7 @@
 name: tend-renovate
 on:
   schedule:
-    - cron: '17 9 * * 0'
+    - cron: "17 9 * * 0"
   workflow_dispatch:
 
 jobs:
@@ -19,7 +19,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}

--- a/.github/workflows/tend-triage.yaml
+++ b/.github/workflows/tend-triage.yaml
@@ -25,7 +25,6 @@ jobs:
     steps:
       - uses: actions/checkout@v6
         with:
-          ref: main
           fetch-depth: 0
           fetch-tags: true
           token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}


### PR DESCRIPTION
Runs `uvx tend init` to pick up upstream tend changes. Also migrates config to current format and adds CODECOV_TOKEN to the secrets allowlist.

Config: migrates `[setup]` section to top-level `setup = [{uses = "..."}]` array (new format), adds `allowed = ["CODECOV_TOKEN"]` to `[secrets]`.

Workflows: removes explicit `ref: main` from checkout (uses default branch automatically), adds concurrency group on `tend-mention` handle job, adds comment about fork PR limitation, minor quoting fixes.

> _This was written by Claude Code on behalf of max-sixty_