### PR TITLE
chore: clippy sort_by_key and stabilize thread ID in snapshot

### DIFF
--- a/src/git/repository/branches.rs
+++ b/src/git/repository/branches.rs
@@ -230,7 +230,7 @@ impl Repository {
                 (name, remotes, timestamp)
             })
             .collect();
-        remote_branches.sort_by(|a, b| b.2.cmp(&a.2));
+        remote_branches.sort_by_key(|b| std::cmp::Reverse(b.2));
 
         // Build result: worktrees first, then local, then remote
         let mut result = Vec::new();

--- a/tests/integration_tests/hook_show.rs
+++ b/tests/integration_tests/hook_show.rs
@@ -299,6 +299,8 @@ lint = "pre-commit run"
     let canonical_home = crate::common::canonicalize(temp_home.path())
         .unwrap_or_else(|_| temp_home.path().to_path_buf());
     settings.add_filter(&regex::escape(&canonical_home.to_string_lossy()), "~");
+    // Normalize thread IDs in panic messages (e.g., "thread 'main' (1234567)")
+    settings.add_filter(r"thread '([^']+)' \(\d+\)", "thread '$1' ([THREAD_ID])");
     settings.bind(|| {
         let mut cmd = wt_command();
         cmd.arg("hook").arg("show").current_dir(temp_dir.path());


### PR DESCRIPTION
## Summary

- Replace `sort_by` closure with `sort_by_key` + `Reverse` in `branches.rs` (clippy lint)
- Add thread ID regex filter to `test_hook_show_outside_git_repo` snapshot settings to prevent flakiness from varying thread IDs in panic messages

Both changes are minor cleanup extracted from #1807 per review feedback requesting unrelated changes be split out.