### PR TITLE
fix: check GitLab MR remote in branch_tracks_ref

### DIFF
--- a/src/commands/worktree/switch.rs
+++ b/src/commands/worktree/switch.rs
@@ -116,7 +116,13 @@ fn resolve_fork_ref(
                 None
             }
         },
-        RefType::Mr => None,
+        RefType::Mr => match find_gitlab_remote(repo, info) {
+            Ok(remote) => Some(remote),
+            Err(e) => {
+                log::debug!("Could not resolve GitLab remote for MR: {e:#}");
+                None
+            }
+        },
     };
 
     // Check if branch already exists and is tracking this ref
@@ -279,6 +285,31 @@ fn find_github_remote(repo: &Repository, info: &RemoteRefInfo) -> anyhow::Result
                 owner: base_owner.clone(),
                 repo: base_repo.clone(),
                 suggested_url,
+            }
+            .into()
+        })
+}
+
+/// Find the remote for a GitLab MR (where MR refs live).
+fn find_gitlab_remote(repo: &Repository, info: &RemoteRefInfo) -> anyhow::Result<String> {
+    use worktrunk::git::remote_ref::PlatformData;
+
+    let PlatformData::GitLab {
+        host,
+        base_owner,
+        base_repo,
+        ..
+    } = &info.platform_data
+    else {
+        anyhow::bail!("find_gitlab_remote called on non-GitLab ref");
+    };
+
+    repo.find_remote_for_repo(Some(host), base_owner, base_repo)
+        .ok_or_else(|| {
+            GitError::NoRemoteForRepo {
+                owner: base_owner.clone(),
+                repo: base_repo.clone(),
+                suggested_url: format!("https://{host}/{base_owner}/{base_repo}.git"),
             }
             .into()
         })


### PR DESCRIPTION
The GitLab MR path in `resolve_fork_ref` was passing `expected_remote: None` to `branch_tracks_ref`, skipping the remote check entirely. This meant a branch tracking `refs/merge-requests/N/head` on the wrong remote (e.g., `origin` instead of `upstream`) would be incorrectly reused by `wt switch mr:N`.

The GitHub PR path already had this fix via `find_github_remote`. This adds the symmetric `find_gitlab_remote`, which resolves the target project's remote from the `PlatformData::GitLab` fields (`host`/`base_owner`/`base_repo`) already populated by `fetch_mr_info` — a local-only `find_remote_for_repo` call that doesn't compromise the deferred URL fetching optimization.

> _This was written by Claude Code on behalf of @max-sixty_