### PR TITLE
feat: hide CLAUDE CODE section when claude CLI unavailable

### DIFF
--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -52,9 +52,11 @@ pub fn handle_config_show(full: bool) -> anyhow::Result<()> {
     // Render shell integration status
     render_shell_status(&mut show_output)?;
 
-    // Render Claude Code status
-    show_output.push('\n');
-    render_claude_code_status(&mut show_output)?;
+    // Render Claude Code status (only when claude CLI is available)
+    if is_claude_available() {
+        show_output.push('\n');
+        render_claude_code_status(&mut show_output)?;
+    }
 
     // Run full diagnostic checks if requested (includes slow network calls)
     if full {
@@ -181,20 +183,10 @@ fn check_zsh_compinit_missing() -> bool {
 
 // ==================== Render Functions ====================
 
-/// Render CLAUDE CODE section (plugin and statusline status)
+/// Render CLAUDE CODE section (plugin and statusline status).
+/// Caller must check `is_claude_available()` first.
 fn render_claude_code_status(out: &mut String) -> anyhow::Result<()> {
-    let claude_available = is_claude_available();
-
     writeln!(out, "{}", format_heading("CLAUDE CODE", None))?;
-
-    if !claude_available {
-        writeln!(
-            out,
-            "{}",
-            info_message(cformat!("<bold>claude</> CLI not installed"))
-        )?;
-        return Ok(());
-    }
 
     // Plugin status
     let plugin_installed = is_plugin_installed();

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
@@ -69,9 +69,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
@@ -73,9 +73,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
@@ -75,9 +75,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_empty_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_empty_project_config.snap
@@ -58,9 +58,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_empty_system_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_empty_system_config.snap
@@ -60,9 +60,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_fish_outdated_wrapper.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_fish_outdated_wrapper.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration_tests/config_show.rs
-assertion_line: 768
 info:
   program: wt
   args:
@@ -59,9 +58,6 @@ exit_code: 0
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_fish_with_completions.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_fish_with_completions.snap
@@ -60,9 +60,6 @@ exit_code: 0
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_fish_without_completions.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_fish_without_completions.snap
@@ -61,9 +61,6 @@ exit_code: 0
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
@@ -62,9 +62,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_command_not_found.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_command_not_found.snap
@@ -33,7 +33,7 @@ info:
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
-    WORKTRUNK_TEST_LATEST_VERSION: 0.28.2
+    WORKTRUNK_TEST_LATEST_VERSION: 0.33.0
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -62,9 +62,6 @@ exit_code: 0
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
 
 [36mDIAGNOSTICS[39m
 [2m↳[22m [2mCI status requires GitHub or GitLab remote[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_not_configured.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_not_configured.snap
@@ -33,7 +33,7 @@ info:
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
-    WORKTRUNK_TEST_LATEST_VERSION: 0.28.2
+    WORKTRUNK_TEST_LATEST_VERSION: 0.33.0
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -59,9 +59,6 @@ exit_code: 0
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
 
 [36mDIAGNOSTICS[39m
 [2m↳[22m [2mCI status requires GitHub or GitLab remote[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_update_available.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_update_available.snap
@@ -60,9 +60,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mDIAGNOSTICS[39m
 [2m↳[22m [2mCI status requires GitHub or GitLab remote[22m
 [2m○[22m Update available: [1m99.0.0[22m (current: [VERSION])

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_version_check_unavailable.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_version_check_unavailable.snap
@@ -60,9 +60,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mDIAGNOSTICS[39m
 [2m↳[22m [2mCI status requires GitHub or GitLab remote[22m
 [2m↳[22m [2mVersion check unavailable[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_github_remote.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_github_remote.snap
@@ -58,9 +58,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_gitlab_remote.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_gitlab_remote.snap
@@ -58,9 +58,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_project_toml.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_project_toml.snap
@@ -64,9 +64,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_system_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_system_config.snap
@@ -66,9 +66,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_user_toml.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_user_toml.snap
@@ -64,9 +64,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_no_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_no_project_config.snap
@@ -58,9 +58,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_no_user_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_no_user_config.snap
@@ -57,9 +57,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_nushell_outdated_wrapper.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_nushell_outdated_wrapper.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration_tests/config_show.rs
-assertion_line: 799
 info:
   program: wt
   args:
@@ -59,9 +58,6 @@ exit_code: 0
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_outside_git_repo.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_outside_git_repo.snap
@@ -52,9 +52,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_partial_shell_config_shows_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_partial_shell_config_shows_hint.snap
@@ -61,9 +61,6 @@ exit_code: 0
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_powershell_detected_via_psmodulepath.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_powershell_detected_via_psmodulepath.snap
@@ -60,9 +60,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_shell_integration_active.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_shell_integration_active.snap
@@ -58,9 +58,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_project_config_for_ci.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_project_config_for_ci.snap
@@ -62,9 +62,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
@@ -74,9 +74,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_not_suppressed_by_wrapper.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_not_suppressed_by_wrapper.snap
@@ -63,9 +63,6 @@ exit_code: 0
 [107m [0m [2m[0m[2m[34malias[0m[2m wt=[0m[2m[32m"git worktree"[0m[2m
 [2m↳[22m [2mIf `alias wt="git worktree"` is shell integration, report a false negative: https://github.com/max-sixty/worktrunk/issues/new?title=Shell%20integration%20detection%20false%20negative&body=Shell%20integration%20not%20detected%20despite%20config%20containing%20%60wt%60.%0A%0A%2A%2AUnmatched%20lines%3A%2A%2A%0A%60%60%60%0Aalias%20wt%3D%22git%20worktree%22%0A%60%60%60%0A%0A%2A%2AExpected%20behavior%3A%2A%2A%20These%20lines%20should%20be%20detected%20as%20shell%20integration.[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_warning.snap
@@ -62,9 +62,6 @@ exit_code: 0
 [107m [0m [2m[0m[2m[34malias[0m[2m wt=[0m[2m[32m"git worktree"[0m[2m
 [2m↳[22m [2mIf `alias wt="git worktree"` is shell integration, report a false negative: https://github.com/max-sixty/worktrunk/issues/new?title=Shell%20integration%20detection%20false%20negative&body=Shell%20integration%20not%20detected%20despite%20config%20containing%20%60wt%60.%0A%0A%2A%2AUnmatched%20lines%3A%2A%2A%0A%60%60%60%0Aalias%20wt%3D%22git%20worktree%22%0A%60%60%60%0A%0A%2A%2AExpected%20behavior%3A%2A%2A%20These%20lines%20should%20be%20detected%20as%20shell%20integration.[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_project_keys.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_project_keys.snap
@@ -60,9 +60,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_user_keys.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_user_keys.snap
@@ -62,9 +62,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_whitespace_only_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_whitespace_only_project_config.snap
@@ -58,9 +58,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_with_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_with_project_config.snap
@@ -75,9 +75,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_with_system_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_with_system_config.snap
@@ -65,9 +65,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_correct_order.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_correct_order.snap
@@ -60,9 +60,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_warning.snap
@@ -62,9 +62,6 @@ exit_code: 0
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__configure_shell__config_show_detects_fish_legacy_conf_d.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__config_show_detects_fish_legacy_conf_d.snap
@@ -59,9 +59,6 @@ exit_code: 0
 [2m↳[22m [2mTo migrate to [4m~/.config/fish/functions/wt.fish[24m, run [4mwt config shell install fish[24m[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__configure_shell__config_show_fish_legacy_with_functions_dir.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__config_show_fish_legacy_with_functions_dir.snap
@@ -59,9 +59,6 @@ exit_code: 0
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
 
-[36mCLAUDE CODE[39m
-[2m○[22m [1mclaude[22m CLI not installed
-
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m


### PR DESCRIPTION
The CLAUDE CODE section in `wt config show` previously always rendered — showing an "not installed" hint when `claude` wasn't on PATH. Users who don't use Claude Code shouldn't see the section at all.

The `is_claude_available()` guard is now at the call site in `handle_config_show()`, matching the existing conditional pattern used by `render_diagnostics`. When claude is unavailable, the heading, content, and separator are all skipped.

> _This was written by Claude Code on behalf of @max-sixty_