### PR TITLE
fix: use terminal shortcode for installation commands

### DIFF
--- a/docs/content/claude-code.md
+++ b/docs/content/claude-code.md
@@ -14,10 +14,7 @@ The worktrunk Claude Code plugin provides two features:
 
 ## Installation
 
-{% terminal() %}
-<span class="cmd">claude plugin marketplace add max-sixty/worktrunk</span>
-<span class="cmd">claude plugin install worktrunk@worktrunk</span>
-{% end %}
+{{ terminal(cmd="claude plugin marketplace add max-sixty/worktrunk|||claude plugin install worktrunk@worktrunk") }}
 
 ## Configuration skill
 


### PR DESCRIPTION
The installation block on the Claude Code docs page used raw `{% terminal() %}` with manual `<span>` tags, bypassing the `cmd` parameter path — no Syntect syntax highlighting and no `$ ` prompts, unlike every other command block on the site.

Switched to the `{{ terminal(cmd="...") }}` shortcode format via the standard `$ ` console block convention.

> _This was written by Claude Code on behalf of @max-sixty_