### PR TITLE
docs: add config example file guidance to Documentation section

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -114,6 +114,7 @@ When changing:
 - Detection logic
 - CLI flags or their defaults
 - Error conditions or messages
+- Config fields or sections — also update `dev/*.example.toml` (these are embedded in CLI help via `include_str!`, so stale examples propagate to docs and snapshots)
 
 Ask: "Does `--help` still describe what the code does?" If not, update `src/cli/mod.rs` first.
 
@@ -123,6 +124,8 @@ Documentation has three categories:
 
 1. **Command pages** (config, hook, list, merge, remove, step, switch):
    ```
+   dev/*.example.toml (included via include_str!)
+       ↓
    src/cli/mod.rs (PRIMARY SOURCE)
        ↓ test_command_pages_and_skill_files_are_in_sync
    docs/content/{command}.md → skills/worktrunk/reference/{command}.md


### PR DESCRIPTION
Stale example configs in `dev/*.example.toml` propagate to CLI help (via `include_str!`), then to auto-generated docs and help snapshots. This happened when renaming the `[ci]` config section to `[forge]` — the example file wasn't updated, so docs and snapshots showed the old section name.

Adds two things to the Documentation section of CLAUDE.md:
- Config fields/sections added to the "When changing" checklist, noting the `include_str!` propagation path
- `dev/*.example.toml` shown as an upstream source in the auto-generated docs pipeline diagram

> _This was written by Claude Code on behalf of @max-sixty_