### PR TITLE
Show defaults uncommented in config example

### DIFF
--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -1,6 +1,6 @@
 # # User Configuration
 #
-# Create with `wt config create`.
+# Create with `wt config create`. Values shown are defaults unless noted otherwise.
 #
 # Location:
 #
@@ -21,20 +21,20 @@
 #
 # **Examples** for repo at `~/code/myproject`, branch `feature/auth`:
 #
-# # Default — sibling directory
-# # Creates: ~/code/myproject.feature-auth
-# # worktree-path = "{{ repo_path }}/../{{ repo }}.{{ branch | sanitize }}"
+# Default — sibling directory (`~/code/myproject.feature-auth`):
 #
-# # Inside the repository
-# # Creates: ~/code/myproject/.worktrees/feature-auth
+# worktree-path = "{{ repo_path }}/../{{ repo }}.{{ branch | sanitize }}"
+#
+# Inside the repository (`~/code/myproject/.worktrees/feature-auth`):
+#
 # worktree-path = "{{ repo_path }}/.worktrees/{{ branch | sanitize }}"
 #
-# # Centralized worktrees directory
-# # Creates: ~/worktrees/myproject/feature-auth
+# Centralized worktrees directory (`~/worktrees/myproject/feature-auth`):
+#
 # worktree-path = "~/worktrees/{{ repo }}/{{ branch | sanitize }}"
 #
-# # Bare repository (git clone --bare <url> myproject/.git)
-# # Creates: ~/code/myproject/feature-auth
+# Bare repository (`~/code/myproject/feature-auth`):
+#
 # worktree-path = "{{ repo_path }}/../{{ branch | sanitize }}"
 #
 # `~` expands to the home directory. Relative paths resolve from `repo_path`.
@@ -45,28 +45,28 @@
 #
 # ### Claude Code
 #
-# # [commit.generation]
-# # command = "CLAUDECODE= MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"
+# [commit.generation]
+# command = "CLAUDECODE= MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"
 #
 # ### Codex
 #
-# # [commit.generation]
-# # command = "codex exec -m gpt-5.1-codex-mini -c model_reasoning_effort='low' -c system_prompt='' --sandbox=read-only --json - | jq -sr '[.[] | select(.item.type? == \"agent_message\")] | last.item.text'"
+# [commit.generation]
+# command = "codex exec -m gpt-5.1-codex-mini -c model_reasoning_effort='low' -c system_prompt='' --sandbox=read-only --json - | jq -sr '[.[] | select(.item.type? == \"agent_message\")] | last.item.text'"
 #
 # ### opencode
 #
-# # [commit.generation]
-# # command = "opencode run -m anthropic/claude-haiku-4.5 --variant fast"
+# [commit.generation]
+# command = "opencode run -m anthropic/claude-haiku-4.5 --variant fast"
 #
 # ### llm
 #
-# # [commit.generation]
-# # command = "llm -m claude-haiku-4.5"
+# [commit.generation]
+# command = "llm -m claude-haiku-4.5"
 #
 # ### aichat
 #
-# # [commit.generation]
-# # command = "aichat -m claude:claude-haiku-4.5"
+# [commit.generation]
+# command = "aichat -m claude:claude-haiku-4.5"
 #
 # See LLM commits docs (https://worktrunk.dev/llm-commits/) for setup and Custom prompt templates (#custom-prompt-templates) for template customization.
 #
@@ -108,20 +108,16 @@
 # ### Switch
 #
 # [switch]
-# no-cd = true       # Skip directory change after switching (--cd to override)
+# no-cd = false      # Skip directory change after switching (--no-cd; --cd to override)
 #
 # [switch.picker]
-# # Pager command for diff preview (overrides git's core.pager)
-# # pager = "delta --paging=never"
-#
-# # Wall-clock budget (ms) for picker data collection (default: 500)
-# # Tasks still running when the budget expires are abandoned; 0 disables
-# # timeout-ms = 500
+# pager = "delta --paging=never"   # Example: override git's core.pager for diff preview
+# timeout-ms = 500   # Wall-clock budget (ms) for picker data collection; 0 disables
 #
 # ### Step
 #
 # [step.copy-ignored]
-# exclude = [".cache/", ".turbo/"]  # Add more excludes after built-in defaults and .worktreeinclude
+# exclude = []   # Additional excludes (e.g., [".cache/", ".turbo/"])
 #
 # Built-in excludes always apply: VCS metadata directories (`.bzr/`, `.hg/`, `.jj/`, `.pijul/`, `.sl/`, `.svn/`) and tool-state directories (`.conductor/`, `.entire/`, `.pi/`, `.worktrees/`). User config and project config exclusions are combined.
 #

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -62,7 +62,7 @@ test = "npm test"
 <!-- USER_CONFIG_START -->
 # User Configuration
 
-Create with `wt config create`.
+Create with `wt config create`. Values shown are defaults unless noted otherwise.
 
 Location:
 
@@ -83,21 +83,27 @@ Controls where new worktrees are created.
 
 **Examples** for repo at `~/code/myproject`, branch `feature/auth`:
 
+Default — sibling directory (`~/code/myproject.feature-auth`):
+
 ```toml
-# Default — sibling directory
-# Creates: ~/code/myproject.feature-auth
-# worktree-path = "{{ repo_path }}/../{{ repo }}.{{ branch | sanitize }}"
+worktree-path = "{{ repo_path }}/../{{ repo }}.{{ branch | sanitize }}"
+```
 
-# Inside the repository
-# Creates: ~/code/myproject/.worktrees/feature-auth
+Inside the repository (`~/code/myproject/.worktrees/feature-auth`):
+
+```toml
 worktree-path = "{{ repo_path }}/.worktrees/{{ branch | sanitize }}"
+```
 
-# Centralized worktrees directory
-# Creates: ~/worktrees/myproject/feature-auth
+Centralized worktrees directory (`~/worktrees/myproject/feature-auth`):
+
+```toml
 worktree-path = "~/worktrees/{{ repo }}/{{ branch | sanitize }}"
+```
 
-# Bare repository (git clone --bare <url> myproject/.git)
-# Creates: ~/code/myproject/feature-auth
+Bare repository (`~/code/myproject/feature-auth`):
+
+```toml
 worktree-path = "{{ repo_path }}/../{{ branch | sanitize }}"
 ```
 
@@ -110,36 +116,36 @@ Generate commit messages automatically during merge. Requires an external CLI to
 ### Claude Code
 
 ```toml
-# [commit.generation]
-# command = "CLAUDECODE= MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"
+[commit.generation]
+command = "CLAUDECODE= MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"
 ```
 
 ### Codex
 
 ```toml
-# [commit.generation]
-# command = "codex exec -m gpt-5.1-codex-mini -c model_reasoning_effort='low' -c system_prompt='' --sandbox=read-only --json - | jq -sr '[.[] | select(.item.type? == \"agent_message\")] | last.item.text'"
+[commit.generation]
+command = "codex exec -m gpt-5.1-codex-mini -c model_reasoning_effort='low' -c system_prompt='' --sandbox=read-only --json - | jq -sr '[.[] | select(.item.type? == \"agent_message\")] | last.item.text'"
 ```
 
 ### opencode
 
 ```toml
-# [commit.generation]
-# command = "opencode run -m anthropic/claude-haiku-4.5 --variant fast"
+[commit.generation]
+command = "opencode run -m anthropic/claude-haiku-4.5 --variant fast"
 ```
 
 ### llm
 
 ```toml
-# [commit.generation]
-# command = "llm -m claude-haiku-4.5"
+[commit.generation]
+command = "llm -m claude-haiku-4.5"
 ```
 
 ### aichat
 
 ```toml
-# [commit.generation]
-# command = "aichat -m claude:claude-haiku-4.5"
+[commit.generation]
+command = "aichat -m claude:claude-haiku-4.5"
 ```
 
 See [LLM commits docs](@/llm-commits.md) for setup and [Custom prompt templates](#custom-prompt-templates) for template customization.
@@ -189,22 +195,18 @@ no-ff = false      # Create a merge commit even when fast-forward is possible (-
 
 ```toml
 [switch]
-no-cd = true       # Skip directory change after switching (--cd to override)
+no-cd = false      # Skip directory change after switching (--no-cd; --cd to override)
 
 [switch.picker]
-# Pager command for diff preview (overrides git's core.pager)
-# pager = "delta --paging=never"
-
-# Wall-clock budget (ms) for picker data collection (default: 500)
-# Tasks still running when the budget expires are abandoned; 0 disables
-# timeout-ms = 500
+pager = "delta --paging=never"   # Example: override git's core.pager for diff preview
+timeout-ms = 500   # Wall-clock budget (ms) for picker data collection; 0 disables
 ```
 
 ### Step
 
 ```toml
 [step.copy-ignored]
-exclude = [".cache/", ".turbo/"]  # Add more excludes after built-in defaults and .worktreeinclude
+exclude = []   # Additional excludes (e.g., [".cache/", ".turbo/"])
 ```
 
 Built-in excludes always apply: VCS metadata directories (`.bzr/`, `.hg/`, `.jj/`, `.pijul/`, `.sl/`, `.svn/`) and tool-state directories (`.conductor/`, `.entire/`, `.pi/`, `.worktrees/`). User config and project config exclusions are combined.

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -61,7 +61,7 @@ test = "npm test"
 <!-- USER_CONFIG_START -->
 # User Configuration
 
-Create with `wt config create`.
+Create with `wt config create`. Values shown are defaults unless noted otherwise.
 
 Location:
 
@@ -82,21 +82,27 @@ Controls where new worktrees are created.
 
 **Examples** for repo at `~/code/myproject`, branch `feature/auth`:
 
+Default — sibling directory (`~/code/myproject.feature-auth`):
+
 ```toml
-# Default — sibling directory
-# Creates: ~/code/myproject.feature-auth
-# worktree-path = "{{ repo_path }}/../{{ repo }}.{{ branch | sanitize }}"
+worktree-path = "{{ repo_path }}/../{{ repo }}.{{ branch | sanitize }}"
+```
 
-# Inside the repository
-# Creates: ~/code/myproject/.worktrees/feature-auth
+Inside the repository (`~/code/myproject/.worktrees/feature-auth`):
+
+```toml
 worktree-path = "{{ repo_path }}/.worktrees/{{ branch | sanitize }}"
+```
 
-# Centralized worktrees directory
-# Creates: ~/worktrees/myproject/feature-auth
+Centralized worktrees directory (`~/worktrees/myproject/feature-auth`):
+
+```toml
 worktree-path = "~/worktrees/{{ repo }}/{{ branch | sanitize }}"
+```
 
-# Bare repository (git clone --bare <url> myproject/.git)
-# Creates: ~/code/myproject/feature-auth
+Bare repository (`~/code/myproject/feature-auth`):
+
+```toml
 worktree-path = "{{ repo_path }}/../{{ branch | sanitize }}"
 ```
 
@@ -109,36 +115,36 @@ Generate commit messages automatically during merge. Requires an external CLI to
 ### Claude Code
 
 ```toml
-# [commit.generation]
-# command = "CLAUDECODE= MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"
+[commit.generation]
+command = "CLAUDECODE= MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"
 ```
 
 ### Codex
 
 ```toml
-# [commit.generation]
-# command = "codex exec -m gpt-5.1-codex-mini -c model_reasoning_effort='low' -c system_prompt='' --sandbox=read-only --json - | jq -sr '[.[] | select(.item.type? == \"agent_message\")] | last.item.text'"
+[commit.generation]
+command = "codex exec -m gpt-5.1-codex-mini -c model_reasoning_effort='low' -c system_prompt='' --sandbox=read-only --json - | jq -sr '[.[] | select(.item.type? == \"agent_message\")] | last.item.text'"
 ```
 
 ### opencode
 
 ```toml
-# [commit.generation]
-# command = "opencode run -m anthropic/claude-haiku-4.5 --variant fast"
+[commit.generation]
+command = "opencode run -m anthropic/claude-haiku-4.5 --variant fast"
 ```
 
 ### llm
 
 ```toml
-# [commit.generation]
-# command = "llm -m claude-haiku-4.5"
+[commit.generation]
+command = "llm -m claude-haiku-4.5"
 ```
 
 ### aichat
 
 ```toml
-# [commit.generation]
-# command = "aichat -m claude:claude-haiku-4.5"
+[commit.generation]
+command = "aichat -m claude:claude-haiku-4.5"
 ```
 
 See [LLM commits docs](https://worktrunk.dev/llm-commits/) for setup and [Custom prompt templates](#custom-prompt-templates) for template customization.
@@ -188,22 +194,18 @@ no-ff = false      # Create a merge commit even when fast-forward is possible (-
 
 ```toml
 [switch]
-no-cd = true       # Skip directory change after switching (--cd to override)
+no-cd = false      # Skip directory change after switching (--no-cd; --cd to override)
 
 [switch.picker]
-# Pager command for diff preview (overrides git's core.pager)
-# pager = "delta --paging=never"
-
-# Wall-clock budget (ms) for picker data collection (default: 500)
-# Tasks still running when the budget expires are abandoned; 0 disables
-# timeout-ms = 500
+pager = "delta --paging=never"   # Example: override git's core.pager for diff preview
+timeout-ms = 500   # Wall-clock budget (ms) for picker data collection; 0 disables
 ```
 
 ### Step
 
 ```toml
 [step.copy-ignored]
-exclude = [".cache/", ".turbo/"]  # Add more excludes after built-in defaults and .worktreeinclude
+exclude = []   # Additional excludes (e.g., [".cache/", ".turbo/"])
 ```
 
 Built-in excludes always apply: VCS metadata directories (`.bzr/`, `.hg/`, `.jj/`, `.pijul/`, `.sl/`, `.svn/`) and tool-state directories (`.conductor/`, `.entire/`, `.pi/`, `.worktrees/`). User config and project config exclusions are combined.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1631,7 +1631,7 @@ test = "npm test"
 <!-- USER_CONFIG_START -->
 # User Configuration
 
-Create with `wt config create`.
+Create with `wt config create`. Values shown are defaults unless noted otherwise.
 
 Location:
 
@@ -1652,21 +1652,27 @@ Controls where new worktrees are created.
 
 **Examples** for repo at `~/code/myproject`, branch `feature/auth`:
 
+Default — sibling directory (`~/code/myproject.feature-auth`):
+
 ```toml
-# Default — sibling directory
-# Creates: ~/code/myproject.feature-auth
-# worktree-path = "{{ repo_path }}/../{{ repo }}.{{ branch | sanitize }}"
+worktree-path = "{{ repo_path }}/../{{ repo }}.{{ branch | sanitize }}"
+```
 
-# Inside the repository
-# Creates: ~/code/myproject/.worktrees/feature-auth
+Inside the repository (`~/code/myproject/.worktrees/feature-auth`):
+
+```toml
 worktree-path = "{{ repo_path }}/.worktrees/{{ branch | sanitize }}"
+```
 
-# Centralized worktrees directory
-# Creates: ~/worktrees/myproject/feature-auth
+Centralized worktrees directory (`~/worktrees/myproject/feature-auth`):
+
+```toml
 worktree-path = "~/worktrees/{{ repo }}/{{ branch | sanitize }}"
+```
 
-# Bare repository (git clone --bare <url> myproject/.git)
-# Creates: ~/code/myproject/feature-auth
+Bare repository (`~/code/myproject/feature-auth`):
+
+```toml
 worktree-path = "{{ repo_path }}/../{{ branch | sanitize }}"
 ```
 
@@ -1679,36 +1685,36 @@ Generate commit messages automatically during merge. Requires an external CLI to
 ### Claude Code
 
 ```toml
-# [commit.generation]
-# command = "CLAUDECODE= MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"
+[commit.generation]
+command = "CLAUDECODE= MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"
 ```
 
 ### Codex
 
 ```toml
-# [commit.generation]
-# command = "codex exec -m gpt-5.1-codex-mini -c model_reasoning_effort='low' -c system_prompt='' --sandbox=read-only --json - | jq -sr '[.[] | select(.item.type? == \"agent_message\")] | last.item.text'"
+[commit.generation]
+command = "codex exec -m gpt-5.1-codex-mini -c model_reasoning_effort='low' -c system_prompt='' --sandbox=read-only --json - | jq -sr '[.[] | select(.item.type? == \"agent_message\")] | last.item.text'"
 ```
 
 ### opencode
 
 ```toml
-# [commit.generation]
-# command = "opencode run -m anthropic/claude-haiku-4.5 --variant fast"
+[commit.generation]
+command = "opencode run -m anthropic/claude-haiku-4.5 --variant fast"
 ```
 
 ### llm
 
 ```toml
-# [commit.generation]
-# command = "llm -m claude-haiku-4.5"
+[commit.generation]
+command = "llm -m claude-haiku-4.5"
 ```
 
 ### aichat
 
 ```toml
-# [commit.generation]
-# command = "aichat -m claude:claude-haiku-4.5"
+[commit.generation]
+command = "aichat -m claude:claude-haiku-4.5"
 ```
 
 See [LLM commits docs](@/llm-commits.md) for setup and [Custom prompt templates](#custom-prompt-templates) for template customization.
@@ -1758,22 +1764,18 @@ no-ff = false      # Create a merge commit even when fast-forward is possible (-
 
 ```toml
 [switch]
-no-cd = true       # Skip directory change after switching (--cd to override)
+no-cd = false      # Skip directory change after switching (--no-cd; --cd to override)
 
 [switch.picker]
-# Pager command for diff preview (overrides git's core.pager)
-# pager = "delta --paging=never"
-
-# Wall-clock budget (ms) for picker data collection (default: 500)
-# Tasks still running when the budget expires are abandoned; 0 disables
-# timeout-ms = 500
+pager = "delta --paging=never"   # Example: override git's core.pager for diff preview
+timeout-ms = 500   # Wall-clock budget (ms) for picker data collection; 0 disables
 ```
 
 ### Step
 
 ```toml
 [step.copy-ignored]
-exclude = [".cache/", ".turbo/"]  # Add more excludes after built-in defaults and .worktreeinclude
+exclude = []   # Additional excludes (e.g., [".cache/", ".turbo/"])
 ```
 
 Built-in excludes always apply: VCS metadata directories (`.bzr/`, `.hg/`, `.jj/`, `.pijul/`, `.sl/`, `.svn/`) and tool-state directories (`.conductor/`, `.entire/`, `.pi/`, `.worktrees/`). User config and project config exclusions are combined.

--- a/src/output/commit_generation.rs
+++ b/src/output/commit_generation.rs
@@ -49,7 +49,7 @@ impl LlmTool {
 
     /// Returns the recommended configuration command for this tool.
     ///
-    /// Parsed from the double-commented examples in dev/config.example.toml,
+    /// Parsed from the examples in dev/config.example.toml,
     /// which is the single source of truth for these commands.
     pub fn recommended_config(&self) -> &str {
         // Indexing is safe: all LlmTool variants have entries in the config example.
@@ -63,11 +63,11 @@ impl std::fmt::Display for LlmTool {
     }
 }
 
-/// Parse tool commands from the double-commented config example.
+/// Parse tool commands from the config example.
 ///
-/// Scans the entire file for `# ### ToolName` headings followed by `# # command = "..."`
+/// Scans the entire file for `# ### ToolName` headings followed by `# command = "..."`
 /// lines. Currently only the LLM section uses this pattern; if other sections gain
-/// `# # command = ` lines, scope the scan to the `## LLM commit messages` section.
+/// `# command = ` lines, scope the scan to the `## LLM commit messages` section.
 /// The command value is TOML-unescaped via the `toml` crate.
 fn parse_recommended_commands(config: &str) -> HashMap<String, String> {
     let mut commands = HashMap::new();
@@ -80,8 +80,8 @@ fn parse_recommended_commands(config: &str) -> HashMap<String, String> {
             continue;
         }
 
-        // Double-commented command: "# # command = "...""
-        if let Some(toml_part) = line.strip_prefix("# # ")
+        // Command line: "# command = "...""
+        if let Some(toml_part) = line.strip_prefix("# ")
             && toml_part.starts_with("command = ")
             && let Some(heading) = current_heading.take()
         {
@@ -253,13 +253,13 @@ mod tests {
         let config = "\
 # ### MyTool
 #
-# # [commit.generation]
-# # command = \"echo hello\"
+# [commit.generation]
+# command = \"echo hello\"
 #
 # ### OtherTool
 #
-# # [commit.generation]
-# # command = \"jq -sr '[.[] | select(.type? == \\\"msg\\\")]'\"
+# [commit.generation]
+# command = \"jq -sr '[.[] | select(.type? == \\\"msg\\\")]'\"
 ";
         let commands = parse_recommended_commands(config);
         assert_eq!(commands.len(), 2);
@@ -275,10 +275,10 @@ mod tests {
         let config = "\
 # ### ToolA
 #
-# # [commit.generation]
-# # template = \"not a command\"
+# [commit.generation]
+# template = \"not a command\"
 # ### ToolB
-# # command = \"real command\"
+# command = \"real command\"
 ";
         let commands = parse_recommended_commands(config);
         // ToolA has no command line, ToolB does

--- a/tests/integration_tests/readme_sync.rs
+++ b/tests/integration_tests/readme_sync.rs
@@ -975,8 +975,8 @@ fn sync_readme_markers(
 ///
 /// The generated file (`dev/config.example.toml`) is the entire source with every line
 /// `# ` prefixed and code fence markers stripped. This creates a fully-commented config
-/// file that serves as inline documentation — users read through, find what they want,
-/// and uncomment the relevant `key = value` line.
+/// file that serves as inline documentation. Code blocks show default values (single `#`
+/// prefix in the output); users uncomment the relevant `key = value` line to customize.
 ///
 /// # Transform Rules
 ///
@@ -1142,17 +1142,17 @@ fn test_config_docs_include_all_sections() {
 }
 
 /// Verify that LLM tool commands in docs/content/llm-commits.md match
-/// the double-commented examples in config.example.toml (the single source of truth).
+/// the examples in config.example.toml (the single source of truth).
 #[test]
 fn test_llm_docs_commands_match_config_example() {
     let project_root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let config_example = fs::read_to_string(project_root.join("dev/config.example.toml")).unwrap();
     let llm_docs = fs::read_to_string(project_root.join("docs/content/llm-commits.md")).unwrap();
 
-    // Extract commands from config example: "# # command = ..." lines
+    // Extract commands from config example: "# command = ..." lines
     let config_commands: Vec<String> = config_example
         .lines()
-        .filter_map(|line| line.strip_prefix("# # "))
+        .filter_map(|line| line.strip_prefix("# "))
         .filter(|line| line.starts_with("command = "))
         .filter_map(|line| {
             let table: toml::Table = toml::from_str(line).ok()?;
@@ -1187,7 +1187,7 @@ fn test_llm_docs_commands_match_config_example() {
 }
 
 /// Verify that LLM tool commands in Taskfile.yaml bench-llm-commits match
-/// the double-commented examples in config.example.toml (the single source of truth).
+/// the examples in config.example.toml (the single source of truth).
 /// Only compares tools present in both files — either side may have tools the other lacks.
 #[test]
 fn test_taskfile_llm_commands_match_config_example() {
@@ -1196,13 +1196,13 @@ fn test_taskfile_llm_commands_match_config_example() {
     let taskfile = fs::read_to_string(project_root.join("Taskfile.yaml")).unwrap();
 
     // Extract tool -> command from config example using h3 headings for tool names
-    // e.g. "# ### Claude Code" heading followed by '# # command = "..."' line
+    // e.g. "# ### Claude Code" heading followed by '# command = "..."' line
     let mut config_commands = std::collections::HashMap::new();
     let mut current_tool: Option<String> = None;
     for line in config_example.lines() {
         if let Some(heading) = line.strip_prefix("# ### ") {
             current_tool = heading.split_whitespace().next().map(|s| s.to_lowercase());
-        } else if let Some(cmd_line) = line.strip_prefix("# # ")
+        } else if let Some(cmd_line) = line.strip_prefix("# ")
             && cmd_line.starts_with("command = ")
             && let Some(ref tool) = current_tool
             && let Ok(table) = toml::from_str::<toml::Table>(cmd_line)

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -59,7 +59,7 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 
 [107m [0m [2m# # User Configuration[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# Create with `wt config create`.[0m
+[107m [0m [2m# Create with `wt config create`. Values shown are defaults unless noted otherwise.[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# Location:[0m
 [107m [0m [2m#[0m
@@ -80,20 +80,20 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m#[0m
 [107m [0m [2m# **Examples** for repo at `~/code/myproject`, branch `feature/auth`:[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# # Default — sibling directory[0m
-[107m [0m [2m# # Creates: ~/code/myproject.feature-auth[0m
-[107m [0m [2m# # worktree-path = "{{ repo_path }}/../{{ repo }}.{{ branch | sanitize }}"[0m
+[107m [0m [2m# Default — sibling directory (`~/code/myproject.feature-auth`):[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# # Inside the repository[0m
-[107m [0m [2m# # Creates: ~/code/myproject/.worktrees/feature-auth[0m
+[107m [0m [2m# worktree-path = "{{ repo_path }}/../{{ repo }}.{{ branch | sanitize }}"[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Inside the repository (`~/code/myproject/.worktrees/feature-auth`):[0m
+[107m [0m [2m#[0m
 [107m [0m [2m# worktree-path = "{{ repo_path }}/.worktrees/{{ branch | sanitize }}"[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# # Centralized worktrees directory[0m
-[107m [0m [2m# # Creates: ~/worktrees/myproject/feature-auth[0m
+[107m [0m [2m# Centralized worktrees directory (`~/worktrees/myproject/feature-auth`):[0m
+[107m [0m [2m#[0m
 [107m [0m [2m# worktree-path = "~/worktrees/{{ repo }}/{{ branch | sanitize }}"[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# # Bare repository (git clone --bare <url> myproject/.git)[0m
-[107m [0m [2m# # Creates: ~/code/myproject/feature-auth[0m
+[107m [0m [2m# Bare repository (`~/code/myproject/feature-auth`):[0m
+[107m [0m [2m#[0m
 [107m [0m [2m# worktree-path = "{{ repo_path }}/../{{ branch | sanitize }}"[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# `~` expands to the home directory. Relative paths resolve from `repo_path`.[0m
@@ -104,28 +104,28 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m#[0m
 [107m [0m [2m# ### Claude Code[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# # [commit.generation][0m
-[107m [0m [2m# # command = "CLAUDECODE= MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"[0m
+[107m [0m [2m# [commit.generation][0m
+[107m [0m [2m# command = "CLAUDECODE= MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# ### Codex[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# # [commit.generation][0m
-[107m [0m [2m# # command = "codex exec -m gpt-5.1-codex-mini -c model_reasoning_effort='low' -c system_prompt='' --sandbox=read-only --json - | jq -sr '[.[] | select(.item.type? == \"agent_message\")] | last.item.text'"[0m
+[107m [0m [2m# [commit.generation][0m
+[107m [0m [2m# command = "codex exec -m gpt-5.1-codex-mini -c model_reasoning_effort='low' -c system_prompt='' --sandbox=read-only --json - | jq -sr '[.[] | select(.item.type? == \"agent_message\")] | last.item.text'"[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# ### opencode[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# # [commit.generation][0m
-[107m [0m [2m# # command = "opencode run -m anthropic/claude-haiku-4.5 --variant fast"[0m
+[107m [0m [2m# [commit.generation][0m
+[107m [0m [2m# command = "opencode run -m anthropic/claude-haiku-4.5 --variant fast"[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# ### llm[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# # [commit.generation][0m
-[107m [0m [2m# # command = "llm -m claude-haiku-4.5"[0m
+[107m [0m [2m# [commit.generation][0m
+[107m [0m [2m# command = "llm -m claude-haiku-4.5"[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# ### aichat[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# # [commit.generation][0m
-[107m [0m [2m# # command = "aichat -m claude:claude-haiku-4.5"[0m
+[107m [0m [2m# [commit.generation][0m
+[107m [0m [2m# command = "aichat -m claude:claude-haiku-4.5"[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# See LLM commits docs (https://worktrunk.dev/llm-commits/) for setup and Custom prompt templates (#custom-prompt-templates) for template customization.[0m
 [107m [0m [2m#[0m
@@ -167,20 +167,16 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# ### Switch[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# [switch][0m
-[107m [0m [2m# no-cd = true       # Skip directory change after switching (--cd to override)[0m
+[107m [0m [2m# no-cd = false      # Skip directory change after switching (--no-cd; --cd to override)[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# [switch.picker][0m
-[107m [0m [2m# # Pager command for diff preview (overrides git's core.pager)[0m
-[107m [0m [2m# # pager = "delta --paging=never"[0m
-[107m [0m [2m#[0m
-[107m [0m [2m# # Wall-clock budget (ms) for picker data collection (default: 500)[0m
-[107m [0m [2m# # Tasks still running when the budget expires are abandoned; 0 disables[0m
-[107m [0m [2m# # timeout-ms = 500[0m
+[107m [0m [2m# pager = "delta --paging=never"   # Example: override git's core.pager for diff preview[0m
+[107m [0m [2m# timeout-ms = 500   # Wall-clock budget (ms) for picker data collection; 0 disables[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# ### Step[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# [step.copy-ignored][0m
-[107m [0m [2m# exclude = [".cache/", ".turbo/"]  # Add more excludes after built-in defaults and .worktreeinclude[0m
+[107m [0m [2m# exclude = []   # Additional excludes (e.g., [".cache/", ".turbo/"])[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# Built-in excludes always apply: VCS metadata directories (`.bzr/`, `.hg/`, `.jj/`, `.pijul/`, `.sl/`, `.svn/`) and tool-state directories (`.conductor/`, `.entire/`, `.pi/`, `.worktrees/`). User config and project config exclusions are combined.[0m
 [107m [0m [2m#[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -104,7 +104,7 @@ Organizations can also deploy a system-wide config file for shared defaults — 
 
 [32mUSER CONFIGURATION[0m
 
-Create with [2mwt config create[0m.
+Create with [2mwt config create[0m. Values shown are defaults unless noted otherwise.
 
 Location:
 
@@ -125,20 +125,20 @@ Controls where new worktrees are created.
 
 [1mExamples[0m for repo at [2m~/code/myproject[0m, branch [2mfeature/auth[0m:
 
-[107m [0m [2m# Default — sibling directory[0m
-[107m [0m [2m# Creates: ~/code/myproject.feature-auth[0m
-[107m [0m [2m# worktree-path = "{{ repo_path }}/../{{ repo }}.{{ branch | sanitize }}"[0m
-[107m [0m 
-[107m [0m [2m# Inside the repository[0m
-[107m [0m [2m# Creates: ~/code/myproject/.worktrees/feature-auth[0m
+Default — sibling directory ([2m~/code/myproject.feature-auth[0m):
+
+[107m [0m [2mworktree-path = [0m[2m[32m"{{ repo_path }}/../{{ repo }}.{{ branch | sanitize }}"[0m
+
+Inside the repository ([2m~/code/myproject/.worktrees/feature-auth[0m):
+
 [107m [0m [2mworktree-path = [0m[2m[32m"{{ repo_path }}/.worktrees/{{ branch | sanitize }}"[0m
-[107m [0m 
-[107m [0m [2m# Centralized worktrees directory[0m
-[107m [0m [2m# Creates: ~/worktrees/myproject/feature-auth[0m
+
+Centralized worktrees directory ([2m~/worktrees/myproject/feature-auth[0m):
+
 [107m [0m [2mworktree-path = [0m[2m[32m"~/worktrees/{{ repo }}/{{ branch | sanitize }}"[0m
-[107m [0m 
-[107m [0m [2m# Bare repository (git clone --bare <url> myproject/.git)[0m
-[107m [0m [2m# Creates: ~/code/myproject/feature-auth[0m
+
+Bare repository ([2m~/code/myproject/feature-auth[0m):
+
 [107m [0m [2mworktree-path = [0m[2m[32m"{{ repo_path }}/../{{ branch | sanitize }}"[0m
 
 [2m~[0m expands to the home directory. Relative paths resolve from [2mrepo_path[0m.
@@ -149,28 +149,28 @@ Generate commit messages automatically during merge. Requires an external CLI to
 
 [32mClaude Code[0m
 
-[107m [0m [2m# [commit.generation][0m
-[107m [0m [2m# command = "CLAUDECODE= MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"[0m
+[107m [0m [2m[36m[commit.generation][0m
+[107m [0m [2mcommand = [0m[2m[32m"CLAUDECODE= MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --disable-slash-commands --setting-sources='' --system-prompt=''"[0m
 
 [32mCodex[0m
 
-[107m [0m [2m# [commit.generation][0m
-[107m [0m [2m# command = "codex exec -m gpt-5.1-codex-mini -c model_reasoning_effort='low' -c system_prompt='' --sandbox=read-only --json - | jq -sr '[.[] | select(.item.type? == \"agent_message\")] | last.item.text'"[0m
+[107m [0m [2m[36m[commit.generation][0m
+[107m [0m [2mcommand = [0m[2m[32m"codex exec -m gpt-5.1-codex-mini -c model_reasoning_effort='low' -c system_prompt='' --sandbox=read-only --json - | jq -sr '[.[] | select(.item.type? == \"agent_message\")] | last.item.text'"[0m
 
 [32mopencode[0m
 
-[107m [0m [2m# [commit.generation][0m
-[107m [0m [2m# command = "opencode run -m anthropic/claude-haiku-4.5 --variant fast"[0m
+[107m [0m [2m[36m[commit.generation][0m
+[107m [0m [2mcommand = [0m[2m[32m"opencode run -m anthropic/claude-haiku-4.5 --variant fast"[0m
 
 [32mllm[0m
 
-[107m [0m [2m# [commit.generation][0m
-[107m [0m [2m# command = "llm -m claude-haiku-4.5"[0m
+[107m [0m [2m[36m[commit.generation][0m
+[107m [0m [2mcommand = [0m[2m[32m"llm -m claude-haiku-4.5"[0m
 
 [32maichat[0m
 
-[107m [0m [2m# [commit.generation][0m
-[107m [0m [2m# command = "aichat -m claude:claude-haiku-4.5"[0m
+[107m [0m [2m[36m[commit.generation][0m
+[107m [0m [2mcommand = [0m[2m[32m"aichat -m claude:claude-haiku-4.5"[0m
 
 See LLM commits docs for setup and Custom prompt templates for template customization.
 
@@ -212,20 +212,16 @@ Most flags are on by default. Set to false to change default behavior.
 [32mSwitch[0m
 
 [107m [0m [2m[36m[switch][0m
-[107m [0m [2mno-cd = [0m[2m[33mtrue[0m[2m       [0m[2m# Skip directory change after switching (--cd to override)[0m
+[107m [0m [2mno-cd = [0m[2m[33mfalse[0m[2m      [0m[2m# Skip directory change after switching (--no-cd; --cd to override)[0m
 [107m [0m 
 [107m [0m [2m[36m[switch.picker][0m
-[107m [0m [2m# Pager command for diff preview (overrides git's core.pager)[0m
-[107m [0m [2m# pager = "delta --paging=never"[0m
-[107m [0m 
-[107m [0m [2m# Wall-clock budget (ms) for picker data collection (default: 500)[0m
-[107m [0m [2m# Tasks still running when the budget expires are abandoned; 0 disables[0m
-[107m [0m [2m# timeout-ms = 500[0m
+[107m [0m [2mpager = [0m[2m[32m"delta --paging=never"[0m[2m   [0m[2m# Example: override git's core.pager for diff preview[0m
+[107m [0m [2mtimeout-ms = [0m[2m[33m500[0m[2m   [0m[2m# Wall-clock budget (ms) for picker data collection; 0 disables[0m
 
 [32mStep[0m
 
 [107m [0m [2m[36m[step.copy-ignored][0m
-[107m [0m [2mexclude = [[0m[2m[32m".cache/"[0m[2m, [0m[2m[32m".turbo/"[0m[2m]  [0m[2m# Add more excludes after built-in defaults and .worktreeinclude[0m
+[107m [0m [2mexclude = []   [0m[2m# Additional excludes (e.g., [".cache/", ".turbo/"])[0m
 
 Built-in excludes always apply: VCS metadata directories ([2m.bzr/[0m, [2m.hg/[0m, [2m.jj/[0m, [2m.pijul/[0m, [2m.sl/[0m, [2m.svn/[0m) and tool-state directories ([2m.conductor/[0m, [2m.entire/[0m, [2m.pi/[0m, [2m.worktrees/[0m). User config and project config exclusions are combined.
 


### PR DESCRIPTION
The example config had all TOML values double-commented (`# #`), making them look disabled-within-disabled. Config code blocks in the source markdown now show actual default values uncommented, producing clean single-commented lines in the generated `config.example.toml`.

Other fixes: `switch.no-cd` default was shown as `true` but code defaults to `false`; `step.copy-ignored.exclude` was shown as `[".cache/", ".turbo/"]` but defaults to `[]`.

> _This was written by Claude Code on behalf of @max-sixty_