### PR TITLE
Remove redundant `as_value().and_then()` in deprecation check

### DIFF
--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -687,11 +687,7 @@ pub fn find_ci_section_deprecation(content: &str) -> bool {
     doc.get("ci")
         .and_then(|ci| ci.as_table())
         .and_then(|t| t.get("platform"))
-        .is_some_and(|p| {
-            p.as_str()
-                .or_else(|| p.as_value().and_then(|v| v.as_str()))
-                .is_some_and(|s| !s.is_empty())
-        })
+        .is_some_and(|p| p.as_str().is_some_and(|s| !s.is_empty()))
 }
 
 /// Migrate `[ci]` section to `[forge]`.


### PR DESCRIPTION
\`Item::as_str()\` in toml_edit already delegates through the value — the \`.or_else(|| p.as_value().and_then(|v| v.as_str()))\` fallback never matches a case \`.as_str()\` alone wouldn't.

> _This was written by Claude Code on behalf of max-sixty_