### PR TITLE
Remove resolved TODO about project config hooks approach

### DIFF
--- a/tests/integration_tests/readme_sync.rs
+++ b/tests/integration_tests/readme_sync.rs
@@ -1112,9 +1112,6 @@ fn test_config_source_generates_example_toml() {
     );
 }
 
-// TODO: Evaluate whether pointing to `wt hook --help` is sufficient for the project
-// config example, or whether it should include a slim hooks quick-start (formats +
-// common examples) so the created file is more self-contained.
 #[test]
 fn test_project_config_source_generates_example_toml() {
     let project_root = Path::new(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
The pointer to `wt hook --help` plus quick-reference of all three formats is sufficient for the created `.config/wt.toml`. Users get uncommentable examples for common hooks and a pointer to the full reference. Removes the evaluation TODO added in #1835.

> _This was written by Claude Code on behalf of @max-sixty_