### PR TITLE
fix: parse JSON in is_statusline_configured()

### DIFF
--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -125,11 +125,14 @@ pub(super) fn is_statusline_configured() -> bool {
         return false;
     };
 
-    // Check if statusLine is configured with a wt command
-    // Match "wt " at a word boundary in command context to avoid false positives
-    // from unrelated JSON keys containing "wt" (e.g., "fontWeight", "tabWidth")
-    content.contains("\"statusLine\"")
-        && (content.contains("\"wt ") || content.contains(": \"wt ") || content.contains(":\"wt "))
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return false;
+    };
+
+    json.get("statusLine")
+        .and_then(|s| s.get("command"))
+        .and_then(|c| c.as_str())
+        .is_some_and(|cmd| cmd.contains("wt "))
 }
 
 /// Get the git version string (e.g., "2.47.1")


### PR DESCRIPTION
The old implementation used fragile substring matching on raw JSON text (`content.contains("\"statusLine\"") && content.contains("\"wt ")`), which could false-positive on unrelated keys or miss valid configurations with different formatting. Parse the JSON structure with `serde_json` and check `statusLine.command` directly.

> _This was written by Claude Code on behalf of max-sixty_