### PR TITLE
fix: use underscores in db_url var key examples

### DIFF
--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -341,7 +341,7 @@ post-start = [
   wt config state vars set \
     container='{{ repo }}-{{ branch | sanitize }}-postgres' \
     port='{{ ('db-' ~ branch) | hash_port }}' \
-    db-url='postgres://postgres:dev@localhost:{{ ('db-' ~ branch) | hash_port }}/{{ branch | sanitize_db }}'
+    db_url='postgres://postgres:dev@localhost:{{ ('db-' ~ branch) | hash_port }}/{{ branch | sanitize_db }}'
   """,
   { db = """
   docker run -d --rm \
@@ -361,7 +361,7 @@ The first pipeline step derives names and ports from the branch name and stores 
 
 The connection string is accessible anywhere — not just in hooks:
 
-{{ terminal(cmd="DATABASE_URL=$(wt config state vars get db-url) npm start") }}
+{{ terminal(cmd="DATABASE_URL=$(wt config state vars get db_url) npm start") }}
 
 ## Progressive validation
 

--- a/docs/content/tips-patterns.md
+++ b/docs/content/tips-patterns.md
@@ -73,7 +73,7 @@ post-start = [
   wt config state vars set \
     container='{{ repo }}-{{ branch | sanitize }}-postgres' \
     port='{{ ('db-' ~ branch) | hash_port }}' \
-    db-url='postgres://postgres:dev@localhost:{{ ('db-' ~ branch) | hash_port }}/{{ branch | sanitize_db }}'
+    db_url='postgres://postgres:dev@localhost:{{ ('db-' ~ branch) | hash_port }}/{{ branch | sanitize_db }}'
   """,
   { db = """
   docker run -d --rm \
@@ -95,7 +95,7 @@ The `('db-' ~ branch)` concatenation hashes differently than plain `branch`, so 
 
 The connection string is accessible anywhere — not just in hooks:
 
-{{ terminal(cmd="DATABASE_URL=$(wt config state vars get db-url) npm start") }}
+{{ terminal(cmd="DATABASE_URL=$(wt config state vars get db_url) npm start") }}
 
 ## Local CI gate
 

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -339,7 +339,7 @@ post-start = [
   wt config state vars set \
     container='{{ repo }}-{{ branch | sanitize }}-postgres' \
     port='{{ ('db-' ~ branch) | hash_port }}' \
-    db-url='postgres://postgres:dev@localhost:{{ ('db-' ~ branch) | hash_port }}/{{ branch | sanitize_db }}'
+    db_url='postgres://postgres:dev@localhost:{{ ('db-' ~ branch) | hash_port }}/{{ branch | sanitize_db }}'
   """,
   { db = """
   docker run -d --rm \
@@ -360,7 +360,7 @@ The first pipeline step derives names and ports from the branch name and stores 
 The connection string is accessible anywhere — not just in hooks:
 
 ```bash
-$ DATABASE_URL=$(wt config state vars get db-url) npm start
+$ DATABASE_URL=$(wt config state vars get db_url) npm start
 ```
 
 ## Progressive validation

--- a/skills/worktrunk/reference/tips-patterns.md
+++ b/skills/worktrunk/reference/tips-patterns.md
@@ -66,7 +66,7 @@ post-start = [
   wt config state vars set \
     container='{{ repo }}-{{ branch | sanitize }}-postgres' \
     port='{{ ('db-' ~ branch) | hash_port }}' \
-    db-url='postgres://postgres:dev@localhost:{{ ('db-' ~ branch) | hash_port }}/{{ branch | sanitize_db }}'
+    db_url='postgres://postgres:dev@localhost:{{ ('db-' ~ branch) | hash_port }}/{{ branch | sanitize_db }}'
   """,
   { db = """
   docker run -d --rm \
@@ -89,7 +89,7 @@ The `('db-' ~ branch)` concatenation hashes differently than plain `branch`, so 
 The connection string is accessible anywhere — not just in hooks:
 
 ```bash
-$ DATABASE_URL=$(wt config state vars get db-url) npm start
+$ DATABASE_URL=$(wt config state vars get db_url) npm start
 ```
 
 ## Local CI gate

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1452,7 +1452,7 @@ post-start = [
   wt config state vars set \
     container='{{ repo }}-{{ branch | sanitize }}-postgres' \
     port='{{ ('db-' ~ branch) | hash_port }}' \
-    db-url='postgres://postgres:dev@localhost:{{ ('db-' ~ branch) | hash_port }}/{{ branch | sanitize_db }}'
+    db_url='postgres://postgres:dev@localhost:{{ ('db-' ~ branch) | hash_port }}/{{ branch | sanitize_db }}'
   """,
   { db = """
   docker run -d --rm \
@@ -1473,7 +1473,7 @@ The first pipeline step derives names and ports from the branch name and stores 
 The connection string is accessible anywhere — not just in hooks:
 
 ```console
-$ DATABASE_URL=$(wt config state vars get db-url) npm start
+$ DATABASE_URL=$(wt config state vars get db_url) npm start
 ```
 
 ## Progressive validation


### PR DESCRIPTION
Hyphens in var keys conflict with Jinja2 expression parsing — `vars.db-url` is interpreted as `vars.db` minus `url`. Renamed `db-url` to `db_url` in the database examples in hook docs and tips-patterns.

> _This was written by Claude Code on behalf of maximilian_