### PR TITLE
refactor: rename merge config `no-ff` to `ff` with reversed polarity

### DIFF
--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -103,7 +103,7 @@
 # rebase = true      # Rebase onto target before merge (--no-rebase to skip)
 # remove = true      # Remove worktree after merge (--no-remove to keep)
 # verify = true      # Run project hooks (--no-verify to skip)
-# no-ff = false      # Create a merge commit even when fast-forward is possible (--no-ff)
+# ff = true          # Fast-forward merge (--no-ff to create a merge commit instead)
 #
 # ### Switch
 #

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -188,7 +188,7 @@ commit = true      # Commit uncommitted changes first (--no-commit to skip)
 rebase = true      # Rebase onto target before merge (--no-rebase to skip)
 remove = true      # Remove worktree after merge (--no-remove to keep)
 verify = true      # Run project hooks (--no-verify to skip)
-no-ff = false      # Create a merge commit even when fast-forward is possible (--no-ff)
+ff = true          # Fast-forward merge (--no-ff to create a merge commit instead)
 ```
 
 ### Switch

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -187,7 +187,7 @@ commit = true      # Commit uncommitted changes first (--no-commit to skip)
 rebase = true      # Rebase onto target before merge (--no-rebase to skip)
 remove = true      # Remove worktree after merge (--no-remove to keep)
 verify = true      # Run project hooks (--no-verify to skip)
-no-ff = false      # Create a merge commit even when fast-forward is possible (--no-ff)
+ff = true          # Fast-forward merge (--no-ff to create a merge commit instead)
 ```
 
 ### Switch

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1764,7 +1764,7 @@ commit = true      # Commit uncommitted changes first (--no-commit to skip)
 rebase = true      # Rebase onto target before merge (--no-rebase to skip)
 remove = true      # Remove worktree after merge (--no-remove to keep)
 verify = true      # Run project hooks (--no-verify to skip)
-no-ff = false      # Create a merge commit even when fast-forward is possible (--no-ff)
+ff = true          # Fast-forward merge (--no-ff to create a merge commit instead)
 ```
 
 ### Switch

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -35,8 +35,8 @@ pub struct MergeOptions<'a> {
     pub rebase: Option<bool>,
     /// CLI override for remove. None = use effective config default.
     pub remove: Option<bool>,
-    /// CLI override for no-ff. None = use effective config default.
-    pub no_ff: Option<bool>,
+    /// CLI override for ff. None = use effective config default.
+    pub ff: Option<bool>,
     /// CLI override for verify. None = use effective config default.
     pub verify: Option<bool>,
     pub yes: bool,
@@ -92,7 +92,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
         commit: commit_opt,
         rebase: rebase_opt,
         remove: remove_opt,
-        no_ff: no_ff_opt,
+        ff: ff_opt,
         verify: verify_opt,
         yes,
         stage,
@@ -119,7 +119,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
     let commit = commit_opt.unwrap_or(resolved.merge.commit());
     let rebase = rebase_opt.unwrap_or(resolved.merge.rebase());
     let remove = remove_opt.unwrap_or(resolved.merge.remove());
-    let no_ff = no_ff_opt.unwrap_or(resolved.merge.no_ff());
+    let ff = ff_opt.unwrap_or(resolved.merge.ff());
     let verify = verify_opt.unwrap_or(resolved.merge.verify());
     let stage_mode = stage.unwrap_or(resolved.commit.stage());
 
@@ -248,7 +248,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
         squashed,
         rebased,
     });
-    if no_ff {
+    if !ff {
         // Create a merge commit on the target branch via commit-tree + update-ref
         handle_no_ff_merge(Some(&target_branch), operations, &current_branch)?;
     } else {

--- a/src/config/user/mod.rs
+++ b/src/config/user/mod.rs
@@ -116,6 +116,9 @@ impl UserConfig {
             &mut self.configs.commit,
         );
         Self::normalize_select_section(&mut self.configs.select, &mut self.configs.switch);
+        if let Some(merge) = &mut self.configs.merge {
+            merge.normalize_deprecated_fields();
+        }
 
         for project in self.projects.values_mut() {
             Self::normalize_commit_generation_section(
@@ -126,6 +129,9 @@ impl UserConfig {
                 &mut project.overrides.select,
                 &mut project.overrides.switch,
             );
+            if let Some(merge) = &mut project.overrides.merge {
+                merge.normalize_deprecated_fields();
+            }
         }
     }
 

--- a/src/config/user/sections.rs
+++ b/src/config/user/sections.rs
@@ -267,12 +267,33 @@ pub struct MergeConfig {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub verify: Option<bool>,
 
-    /// Create a merge commit instead of fast-forwarding (default: false)
-    #[serde(rename = "no-ff", skip_serializing_if = "Option::is_none")]
-    pub no_ff: Option<bool>,
+    /// Fast-forward merge instead of creating a merge commit (default: true)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ff: Option<bool>,
+
+    /// Deprecated: use `ff` instead. Kept for backward-compatible deserialization.
+    #[serde(rename = "no-ff", skip_serializing, default)]
+    #[schemars(skip)]
+    pub(crate) no_ff_deprecated: Option<bool>,
 }
 
 impl MergeConfig {
+    /// Migrate deprecated `no-ff` field to `ff` (inverted). Warns on use.
+    pub fn normalize_deprecated_fields(&mut self) {
+        if let Some(no_ff) = self.no_ff_deprecated.take()
+            && self.ff.is_none()
+        {
+            self.ff = Some(!no_ff);
+            eprintln!(
+                "{}",
+                crate::styling::warning_message(format!(
+                    "`no-ff` in [merge] is deprecated; use `ff = {}` instead",
+                    !no_ff
+                ))
+            );
+        }
+    }
+
     /// Squash commits when merging (default: true)
     pub fn squash(&self) -> bool {
         self.squash.unwrap_or(true)
@@ -298,9 +319,9 @@ impl MergeConfig {
         self.verify.unwrap_or(true)
     }
 
-    /// Create a merge commit instead of fast-forwarding (default: false)
-    pub fn no_ff(&self) -> bool {
-        self.no_ff.unwrap_or(false)
+    /// Fast-forward merge instead of creating a merge commit (default: true)
+    pub fn ff(&self) -> bool {
+        self.ff.unwrap_or(true)
     }
 }
 
@@ -312,7 +333,8 @@ impl Merge for MergeConfig {
             rebase: other.rebase.or(self.rebase),
             remove: other.remove.or(self.remove),
             verify: other.verify.or(self.verify),
-            no_ff: other.no_ff.or(self.no_ff),
+            ff: other.ff.or(self.ff),
+            no_ff_deprecated: None,
         }
     }
 }

--- a/src/config/user/tests.rs
+++ b/src/config/user/tests.rs
@@ -462,7 +462,8 @@ fn test_merge_config_serde() {
         rebase: Some(false),
         remove: Some(true),
         verify: Some(true),
-        no_ff: None,
+        ff: None,
+        ..Default::default()
     };
     let json = serde_json::to_string(&config).unwrap();
     let parsed: MergeConfig = serde_json::from_str(&json).unwrap();
@@ -670,7 +671,8 @@ fn test_merge_merge_config() {
         rebase: Some(true),
         remove: Some(true),
         verify: Some(true),
-        no_ff: Some(false),
+        ff: Some(true),
+        ..Default::default()
     };
     let override_config = MergeConfig {
         squash: Some(false), // Override
@@ -678,7 +680,8 @@ fn test_merge_merge_config() {
         rebase: None,        // Fall back to base
         remove: Some(false), // Override
         verify: None,        // Fall back to base
-        no_ff: Some(true),   // Override
+        ff: Some(false),     // Override
+        ..Default::default()
     };
 
     let merged = base.merge_with(&override_config);
@@ -687,7 +690,7 @@ fn test_merge_merge_config() {
     assert_eq!(merged.rebase, Some(true));
     assert_eq!(merged.remove, Some(false));
     assert_eq!(merged.verify, Some(true));
-    assert_eq!(merged.no_ff, Some(true));
+    assert_eq!(merged.ff, Some(false));
 }
 
 #[test]
@@ -871,7 +874,8 @@ fn test_effective_merge_with_partial_override() {
                 rebase: Some(true),
                 remove: Some(true),
                 verify: Some(true),
-                no_ff: Some(false),
+                ff: Some(true),
+                ..Default::default()
             }),
             ..Default::default()
         },
@@ -888,7 +892,8 @@ fn test_effective_merge_with_partial_override() {
                     rebase: None,
                     remove: None,
                     verify: None,
-                    no_ff: None,
+                    ff: None,
+                    ..Default::default()
                 }),
                 ..Default::default()
             },
@@ -1028,13 +1033,13 @@ fn test_list_config_accessor_methods_with_values() {
 #[test]
 fn test_merge_config_accessor_methods_defaults() {
     let config = MergeConfig::default();
-    // MergeConfig defaults are all true except no_ff (false)
+    // MergeConfig defaults are all true (including ff)
     assert!(config.squash());
     assert!(config.commit());
     assert!(config.rebase());
     assert!(config.remove());
     assert!(config.verify());
-    assert!(!config.no_ff());
+    assert!(config.ff());
 }
 
 #[test]
@@ -1045,14 +1050,28 @@ fn test_merge_config_accessor_methods_with_values() {
         rebase: Some(false),
         remove: Some(false),
         verify: Some(false),
-        no_ff: Some(true),
+        ff: Some(false),
+        ..Default::default()
     };
     assert!(!config.squash());
     assert!(!config.commit());
     assert!(!config.rebase());
     assert!(!config.remove());
     assert!(!config.verify());
-    assert!(config.no_ff());
+    assert!(!config.ff());
+}
+
+#[test]
+fn test_deprecated_no_ff_migrated_to_ff() {
+    let config = UserConfig::load_from_str("[merge]\nno-ff = true\n").unwrap();
+    assert!(!config.configs.merge.unwrap().ff());
+}
+
+#[test]
+fn test_deprecated_no_ff_does_not_override_explicit_ff() {
+    // If both `ff` and `no-ff` are set, `ff` wins (no-ff is ignored)
+    let config = UserConfig::load_from_str("[merge]\nff = true\nno-ff = true\n").unwrap();
+    assert!(config.configs.merge.unwrap().ff());
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1049,7 +1049,7 @@ fn dispatch_command(command: Commands) -> anyhow::Result<()> {
             commit: flag_pair(commit, no_commit),
             rebase: flag_pair(rebase, no_rebase),
             remove: flag_pair(remove, no_remove),
-            no_ff: flag_pair(no_ff, ff),
+            ff: flag_pair(ff, no_ff),
             verify: flag_pair(verify, no_verify),
             yes,
             stage,

--- a/tests/integration_tests/merge.rs
+++ b/tests/integration_tests/merge.rs
@@ -2273,8 +2273,8 @@ fn test_merge_no_ff_with_squash(repo_with_multi_commit_feature: TestRepo) {
 fn test_merge_no_ff_from_config(merge_scenario: (TestRepo, PathBuf)) {
     let (repo, feature_wt) = merge_scenario;
 
-    // Write user config with no-ff = true
-    fs::write(repo.test_config_path(), "[merge]\nno-ff = true\n").unwrap();
+    // Write user config with ff = false
+    fs::write(repo.test_config_path(), "[merge]\nff = false\n").unwrap();
 
     assert_cmd_snapshot!(make_snapshot_cmd(
         &repo,
@@ -2296,13 +2296,13 @@ fn test_merge_no_ff_from_config(merge_scenario: (TestRepo, PathBuf)) {
     );
 }
 
-/// --ff CLI flag overrides config no-ff = true.
+/// --ff CLI flag overrides config ff = false.
 #[rstest]
 fn test_merge_ff_flag_overrides_config(merge_scenario: (TestRepo, PathBuf)) {
     let (repo, feature_wt) = merge_scenario;
 
-    // Write user config with no-ff = true
-    fs::write(repo.test_config_path(), "[merge]\nno-ff = true\n").unwrap();
+    // Write user config with ff = false
+    fs::write(repo.test_config_path(), "[merge]\nff = false\n").unwrap();
 
     // --ff should override config and do a fast-forward
     assert_cmd_snapshot!(make_snapshot_cmd(

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -162,7 +162,7 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# rebase = true      # Rebase onto target before merge (--no-rebase to skip)[0m
 [107m [0m [2m# remove = true      # Remove worktree after merge (--no-remove to keep)[0m
 [107m [0m [2m# verify = true      # Run project hooks (--no-verify to skip)[0m
-[107m [0m [2m# no-ff = false      # Create a merge commit even when fast-forward is possible (--no-ff)[0m
+[107m [0m [2m# ff = true          # Fast-forward merge (--no-ff to create a merge commit instead)[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# ### Switch[0m
 [107m [0m [2m#[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -208,7 +208,7 @@ Most flags are on by default. Set to false to change default behavior.
 [107m [0m [2mrebase = [0m[2m[33mtrue[0m[2m      [0m[2m# Rebase onto target before merge (--no-rebase to skip)[0m
 [107m [0m [2mremove = [0m[2m[33mtrue[0m[2m      [0m[2m# Remove worktree after merge (--no-remove to keep)[0m
 [107m [0m [2mverify = [0m[2m[33mtrue[0m[2m      [0m[2m# Run project hooks (--no-verify to skip)[0m
-[107m [0m [2mno-ff = [0m[2m[33mfalse[0m[2m      [0m[2m# Create a merge commit even when fast-forward is possible (--no-ff)[0m
+[107m [0m [2mff = [0m[2m[33mtrue[0m[2m          [0m[2m# Fast-forward merge (--no-ff to create a merge commit instead)[0m
 
 [32mSwitch[0m
 


### PR DESCRIPTION
`ff = true` (default) is more natural than `no-ff = false` — now consistent with all other merge config fields which are positive-sense defaulting to true.

CLI flags `--no-ff` and `--ff` are unchanged. The old `no-ff` config key still works via serde deserialization + polarity inversion in `normalize_deprecated_fields()`, with a deprecation warning.

> _This was written by Claude Code on behalf of Maximilian Roos_