### PR TITLE
Document config deprecation recipe in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -374,7 +374,7 @@ Config deprecation has two layers, both required for a complete migration.
 To register a new deprecation at this layer:
 
 1. Add detection logic to `detect_deprecations()` and extend the `Deprecations` struct
-2. Add the migration instructions to `format_migration_file()`
+2. Add the migration instructions to `write_migration_file()`
 3. If it's a top-level section, add the key to `DEPRECATED_SECTION_KEYS` (this prevents `warn_unknown_fields` from also flagging it)
 
 ### Layer 2: Post-deserialization normalization (`src/config/user/mod.rs`)


### PR DESCRIPTION
Adds a "Config Deprecation" section after "Error Handling" documenting the two-layer deprecation system and the recipe for renaming fields within config sections. The field-rename pattern (serde `rename`/`skip_serializing` + normalization method) is the most common case developers need, and the inner-section `warn_unknown_fields` limitation is easy to miss without explicit documentation.

> _This was written by Claude Code on behalf of @max-sixty_