### PR TITLE
refactor: rename switch config `no-cd` to `cd` with reversed polarity

### DIFF
--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -108,7 +108,7 @@
 # ### Switch
 #
 # [switch]
-# no-cd = false      # Skip directory change after switching (--no-cd; --cd to override)
+# cd = true          # Change directory after switching (--no-cd to skip)
 #
 # [switch.picker]
 # pager = "delta --paging=never"   # Example: override git's core.pager for diff preview

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -195,7 +195,7 @@ ff = true          # Fast-forward merge (--no-ff to create a merge commit instea
 
 ```toml
 [switch]
-no-cd = false      # Skip directory change after switching (--no-cd; --cd to override)
+cd = true          # Change directory after switching (--no-cd to skip)
 
 [switch.picker]
 pager = "delta --paging=never"   # Example: override git's core.pager for diff preview

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -194,7 +194,7 @@ ff = true          # Fast-forward merge (--no-ff to create a merge commit instea
 
 ```toml
 [switch]
-no-cd = false      # Skip directory change after switching (--no-cd; --cd to override)
+cd = true          # Change directory after switching (--no-cd to skip)
 
 [switch.picker]
 pager = "delta --paging=never"   # Example: override git's core.pager for diff preview

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1771,7 +1771,7 @@ ff = true          # Fast-forward merge (--no-ff to create a merge commit instea
 
 ```toml
 [switch]
-no-cd = false      # Skip directory change after switching (--no-cd; --cd to override)
+cd = true          # Change directory after switching (--no-cd to skip)
 
 [switch.picker]
 pager = "delta --paging=never"   # Example: override git's core.pager for diff preview

--- a/src/commands/handle_switch.rs
+++ b/src/commands/handle_switch.rs
@@ -239,7 +239,7 @@ pub fn handle_switch(
     // Now that we have the repo, we can resolve project-specific config.
     let change_dir = change_dir_flag.unwrap_or_else(|| {
         let project_id = repo.project_identifier().ok();
-        !config.resolved(project_id.as_deref()).switch.no_cd()
+        config.resolved(project_id.as_deref()).switch.cd()
     });
 
     // Build switch suggestion context for enriching error hints with --execute/trailing args.

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -281,7 +281,7 @@ pub fn handle_picker(
 
     // Merge CLI flags with resolved config (project-specific config is now available)
     let config = repo.config();
-    let change_dir = change_dir_flag.unwrap_or_else(|| !config.switch.no_cd());
+    let change_dir = change_dir_flag.unwrap_or_else(|| config.switch.cd());
     let show_branches = cli_branches || config.list.branches();
     let show_remotes = cli_remotes || config.list.remotes();
 

--- a/src/config/user/mod.rs
+++ b/src/config/user/mod.rs
@@ -119,6 +119,9 @@ impl UserConfig {
         if let Some(merge) = &mut self.configs.merge {
             merge.normalize_deprecated_fields();
         }
+        if let Some(switch) = &mut self.configs.switch {
+            switch.normalize_deprecated_fields();
+        }
 
         for project in self.projects.values_mut() {
             Self::normalize_commit_generation_section(
@@ -131,6 +134,9 @@ impl UserConfig {
             );
             if let Some(merge) = &mut project.overrides.merge {
                 merge.normalize_deprecated_fields();
+            }
+            if let Some(switch) = &mut project.overrides.switch {
+                switch.normalize_deprecated_fields();
             }
         }
     }

--- a/src/config/user/resolved.rs
+++ b/src/config/user/resolved.rs
@@ -23,7 +23,7 @@ use super::sections::{
 /// let stage = resolved.commit.stage();                      // StageMode, default applied
 /// let pager = resolved.switch_picker.pager();               // Option<&str>
 /// let timeout = resolved.switch_picker.timeout();               // Option<Duration>
-/// let no_cd = resolved.switch.no_cd();                       // bool, default applied
+/// let cd = resolved.switch.cd();                              // bool, default applied
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct ResolvedConfig {

--- a/src/config/user/sections.rs
+++ b/src/config/user/sections.rs
@@ -418,9 +418,14 @@ impl Merge for SwitchPickerConfig {
 /// Configuration for the `wt switch` command
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Default, JsonSchema)]
 pub struct SwitchConfig {
-    /// Skip directory change after switch (equivalent to --no-cd)
-    #[serde(rename = "no-cd", default, skip_serializing_if = "Option::is_none")]
-    pub no_cd: Option<bool>,
+    /// Change directory after switch (default: true)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cd: Option<bool>,
+
+    /// Deprecated: use `cd` instead. Kept for backward-compatible deserialization.
+    #[serde(rename = "no-cd", skip_serializing, default)]
+    #[schemars(skip)]
+    pub(crate) no_cd_deprecated: Option<bool>,
 
     /// Picker settings for the interactive selector
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -428,16 +433,33 @@ pub struct SwitchConfig {
 }
 
 impl SwitchConfig {
-    /// Skip directory change (default: false)
-    pub fn no_cd(&self) -> bool {
-        self.no_cd.unwrap_or(false)
+    /// Migrate deprecated `no-cd` field to `cd` (inverted). Warns on use.
+    pub fn normalize_deprecated_fields(&mut self) {
+        if let Some(no_cd) = self.no_cd_deprecated.take()
+            && self.cd.is_none()
+        {
+            self.cd = Some(!no_cd);
+            eprintln!(
+                "{}",
+                crate::styling::warning_message(format!(
+                    "`no-cd` in [switch] is deprecated; use `cd = {}` instead",
+                    !no_cd
+                ))
+            );
+        }
+    }
+
+    /// Change directory after switch (default: true)
+    pub fn cd(&self) -> bool {
+        self.cd.unwrap_or(true)
     }
 }
 
 impl Merge for SwitchConfig {
     fn merge_with(&self, other: &Self) -> Self {
         Self {
-            no_cd: other.no_cd.or(self.no_cd),
+            cd: other.cd.or(self.cd),
+            no_cd_deprecated: None,
             picker: match (&self.picker, &other.picker) {
                 (None, None) => None,
                 (Some(s), None) => Some(s.clone()),

--- a/src/config/user/tests.rs
+++ b/src/config/user/tests.rs
@@ -1224,77 +1224,89 @@ fn test_switch_config_merge() {
 }
 
 #[test]
-fn test_switch_config_no_cd_accessor() {
+fn test_switch_config_cd_accessor() {
     use crate::config::user::SwitchConfig;
 
-    // Default is false
+    // Default is true
     let config = SwitchConfig::default();
-    assert!(!config.no_cd());
-
-    // Explicit false
-    let config = SwitchConfig {
-        no_cd: Some(false),
-        ..Default::default()
-    };
-    assert!(!config.no_cd());
+    assert!(config.cd());
 
     // Explicit true
     let config = SwitchConfig {
-        no_cd: Some(true),
+        cd: Some(true),
         ..Default::default()
     };
-    assert!(config.no_cd());
+    assert!(config.cd());
+
+    // Explicit false
+    let config = SwitchConfig {
+        cd: Some(false),
+        ..Default::default()
+    };
+    assert!(!config.cd());
 }
 
 #[test]
-fn test_switch_config_no_cd_merge() {
+fn test_switch_config_cd_merge() {
     use crate::config::user::{Merge, SwitchConfig};
 
     // Other overrides base
     let base = SwitchConfig {
-        no_cd: Some(false),
+        cd: Some(true),
         ..Default::default()
     };
     let other = SwitchConfig {
-        no_cd: Some(true),
+        cd: Some(false),
         ..Default::default()
     };
     let merged = base.merge_with(&other);
-    assert!(merged.no_cd());
+    assert!(!merged.cd());
 
     // Base preserved when other is None
     let base = SwitchConfig {
-        no_cd: Some(true),
+        cd: Some(false),
         ..Default::default()
     };
     let merged = base.merge_with(&SwitchConfig::default());
-    assert!(merged.no_cd());
+    assert!(!merged.cd());
 
     // Neither set
     let merged = SwitchConfig::default().merge_with(&SwitchConfig::default());
-    assert!(!merged.no_cd()); // default false
+    assert!(merged.cd()); // default true
 }
 
 #[test]
-fn test_switch_config_no_cd_from_toml() {
+fn test_switch_config_cd_from_toml() {
     let toml = r#"
 [switch]
-no-cd = true
+cd = false
 "#;
     let config = UserConfig::load_from_str(toml).unwrap();
     let switch = config.switch(None).unwrap();
-    assert!(switch.no_cd());
+    assert!(!switch.cd());
 }
 
 #[test]
-fn test_switch_config_no_cd_resolved() {
+fn test_switch_config_cd_resolved() {
     let toml = r#"
 [switch]
-no-cd = true
+cd = false
 "#;
     let config = UserConfig::load_from_str(toml).unwrap();
     let resolved = config.resolved(None);
-    assert!(resolved.switch.no_cd());
+    assert!(!resolved.switch.cd());
+}
+
+#[test]
+fn test_deprecated_no_cd_migrated_to_cd() {
+    let config = UserConfig::load_from_str("[switch]\nno-cd = true\n").unwrap();
+    assert!(!config.configs.switch.unwrap().cd());
+}
+
+#[test]
+fn test_deprecated_no_cd_does_not_override_explicit_cd() {
+    let config = UserConfig::load_from_str("[switch]\ncd = true\nno-cd = true\n").unwrap();
+    assert!(config.configs.switch.unwrap().cd());
 }
 
 #[test]
@@ -1456,7 +1468,7 @@ fn test_resolved_config_for_project() {
     assert_eq!(resolved.commit.stage(), StageMode::None);
     assert_eq!(resolved.switch_picker.pager(), Some("less"));
     assert_eq!(resolved.switch_picker.timeout_ms, Some(300));
-    assert!(!resolved.switch.no_cd()); // Default false
+    assert!(resolved.switch.cd()); // Default true
 }
 
 // =========================================================================

--- a/tests/integration_tests/directives.rs
+++ b/tests/integration_tests/directives.rs
@@ -342,12 +342,12 @@ fn test_switch_no_cd_config_suppresses_directive(#[from(repo_with_remote)] mut r
     let _feature_wt = repo.add_worktree("feature");
     let (directive_path, _guard) = directive_file();
 
-    // Set up config with no-cd = true
+    // Set up config with cd = false
     repo.write_test_config(
         r#"worktree-path = "../{{ repo }}.{{ branch }}"
 
 [switch]
-no-cd = true
+cd = false
 "#,
     );
 

--- a/tests/integration_tests/switch.rs
+++ b/tests/integration_tests/switch.rs
@@ -3531,15 +3531,15 @@ fn test_switch_base_without_create_warns_not_errors(repo: TestRepo) {
     );
 }
 
-/// Test that `--cd` flag overrides `[switch] no-cd = true` config
+/// Test that `--cd` flag overrides `[switch] cd = false` config
 #[rstest]
 fn test_switch_cd_flag_overrides_no_cd_config(repo: TestRepo) {
-    // Set up config with no-cd = true
+    // Set up config with cd = false
     repo.write_test_config(
         r#"worktree-path = "../{{ repo }}.{{ branch }}"
 
 [switch]
-no-cd = true
+cd = false
 "#,
     );
 
@@ -3613,15 +3613,15 @@ fn test_switch_with_relative_worktree_paths(repo: TestRepo) {
     snapshot_switch("switch_to_relative_paths", &repo, &["relative-test"]);
 }
 
-/// Test that `[switch] no-cd = true` config is respected when no flags provided
+/// Test that `[switch] cd = false` config is respected when no flags provided
 #[rstest]
 fn test_switch_no_cd_config_default(repo: TestRepo) {
-    // Set up config with no-cd = true
+    // Set up config with cd = false
     repo.write_test_config(
         r#"worktree-path = "../{{ repo }}.{{ branch }}"
 
 [switch]
-no-cd = true
+cd = false
 "#,
     );
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -167,7 +167,7 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# ### Switch[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# [switch][0m
-[107m [0m [2m# no-cd = false      # Skip directory change after switching (--no-cd; --cd to override)[0m
+[107m [0m [2m# cd = true          # Change directory after switching (--no-cd to skip)[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# [switch.picker][0m
 [107m [0m [2m# pager = "delta --paging=never"   # Example: override git's core.pager for diff preview[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -213,7 +213,7 @@ Most flags are on by default. Set to false to change default behavior.
 [32mSwitch[0m
 
 [107m [0m [2m[36m[switch][0m
-[107m [0m [2mno-cd = [0m[2m[33mfalse[0m[2m      [0m[2m# Skip directory change after switching (--no-cd; --cd to override)[0m
+[107m [0m [2mcd = [0m[2m[33mtrue[0m[2m          [0m[2m# Change directory after switching (--no-cd to skip)[0m
 [107m [0m 
 [107m [0m [2m[36m[switch.picker][0m
 [107m [0m [2mpager = [0m[2m[32m"delta --paging=never"[0m[2m   [0m[2m# Example: override git's core.pager for diff preview[0m


### PR DESCRIPTION
Follow-up to #1856 (`no-ff` → `ff`). Renames the last negative-sense config field so all boolean config fields use positive names defaulting to true: `squash`, `commit`, `rebase`, `remove`, `verify`, `ff`, and now `cd`.

The old `no-cd` field is kept for backward-compatible deserialization with a deprecation warning guiding users to `cd = false`.

> _This was written by Claude Code on behalf of @max-sixty_