### PR TITLE
Add system docstring guideline and CLAUDE.md compliance review

### DIFF
--- a/.claude/skills/running-tend/references/review-pr.md
+++ b/.claude/skills/running-tend/references/review-pr.md
@@ -6,8 +6,6 @@
 
 - Does the code follow Rust idioms? (Iterator chains over manual loops, `?` over
   match-on-error, proper use of Option/Result, etc.)
-- Does it follow the project's conventions documented in CLAUDE.md? (Cmd for
-  shell commands, error handling with anyhow, accessor naming conventions, etc.)
 - Are there unnecessary allocations, clones, or owned types where borrows would
   suffice?
 - Does new code use `.expect()` or `.unwrap()` in functions returning `Result`?
@@ -16,6 +14,12 @@
 **Testing:**
 
 - Do the tests follow the project's testing conventions (see tests/CLAUDE.md)?
+
+**CLAUDE.md compliance:**
+
+- Review the CLAUDE.md sections relevant to the changed code and flag
+  deviations — code quality, error handling, command execution, data safety,
+  system docstrings, etc.
 
 **Documentation accuracy:**
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -334,6 +334,10 @@ Don't suppress warnings with `#[allow(dead_code)]` — either delete the code or
 fn validate_config() { ... }
 ```
 
+### System Docstrings
+
+Complex systems (multi-step workflows, state machines, coordination logic) should have a module-level docstring that serves as a spec — purpose, key decisions, behavioral contracts, and invariants. Keep the docstring current as the module evolves.
+
 ### No Test Code in Library Code
 
 Never use `#[cfg(test)]` to add test-only convenience methods to library code. Tests should call the real API directly. If tests need helpers, define them in the test module.


### PR DESCRIPTION
Complex systems (multi-step workflows, state machines, coordination logic) should have module-level docstrings that serve as specs. Added this as a code quality guideline in CLAUDE.md.

Also promoted CLAUDE.md compliance checking to its own review criterion in the tend PR review reference, rather than a sub-bullet under "Idiomatic Rust". This makes it a systematic check against all relevant CLAUDE.md sections during reviews.

> _This was written by Claude Code on behalf of @max-sixty_