### PR TITLE
chore: remove run_git_ok helper from remove benchmark

### DIFF
--- a/benches/remove.rs
+++ b/benches/remove.rs
@@ -88,12 +88,16 @@ fn recreate_worktree(repo_path: &Path) {
     let _ = Cmd::new("git")
         .args(["worktree", "prune"])
         .current_dir(repo_path)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
         .run();
 
     // Delete branch if it exists (may already be deleted by removal)
     let _ = Cmd::new("git")
         .args(["branch", "-D", "feature-wt-1"])
         .current_dir(repo_path)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
         .run();
 
     // Recreate branch + worktree


### PR DESCRIPTION
Inline the two cleanup calls using `Cmd::new("git")...run()` directly instead of a dedicated `run_git_ok` wrapper — the same pattern used throughout the codebase for fallible git commands.

Follow-up to #1858.

> _This was written by Claude Code on behalf of maximilian_