### PR TITLE
docs: complete trace event SQL categories in benchmarks

### DIFF
--- a/benches/CLAUDE.md
+++ b/benches/CLAUDE.md
@@ -152,7 +152,7 @@ WITH status_times AS (
 ),
 trees_times AS (
   SELECT MIN(ts) as start_us, MAX(ts + dur) as end_us
-  FROM slice WHERE name LIKE '%rev-parse%tree%'
+  FROM slice WHERE name LIKE '%rev-parse%{tree}%'
 )
 SELECT
   s.start_us/1e6 as status_start_ms, s.end_us/1e6 as status_end_ms,


### PR DESCRIPTION
The task type breakdown query in `benches/CLAUDE.md` only had 5 categories, leaving most commands as "other". Surveyed all git commands from `wt list`, `wt list --branches`, and `wt list --full --branches` traces against a `typical-4` benchmark repo to build a complete taxonomy of 22 categories.

Key fixes: tightened `%rev-parse%tree%` to `%rev-parse%{tree}%` (was misclassifying `--is-inside-work-tree` as `trees_match`), added `rev_list` for commit counting, `diff_3dot`/`diff_wt` for full-mode diffs, `sparse_checkout`, `llm_summary` for Claude commit summaries, and all remaining standard categories. Verified zero commands fall to "other" across all three trace modes.

> _This was written by Claude Code on behalf of @max-sixty_