### PR TITLE
refactor: share TOML parse between detection and migration

### DIFF
--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -114,14 +114,6 @@ fn find_deprecated_vars_from_strings(
         .collect()
 }
 
-/// Extract all string values from TOML content that might contain templates
-fn extract_template_strings(content: &str) -> Vec<String> {
-    let Ok(doc) = content.parse::<toml_edit::DocumentMut>() else {
-        return vec![];
-    };
-    extract_template_strings_from_doc(&doc)
-}
-
 /// Extract all string values from an already-parsed TOML document
 fn extract_template_strings_from_doc(doc: &toml_edit::DocumentMut) -> Vec<String> {
     let mut strings = Vec::new();
@@ -168,18 +160,17 @@ fn collect_strings_from_edit_value(value: &toml_edit::Value, strings: &mut Vec<S
     }
 }
 
-/// Replace all deprecated variables with their new names
-fn replace_deprecated_vars(content: &str) -> String {
-    let strings = extract_template_strings(content);
+/// Core logic for variable replacement, operating on pre-extracted template strings
+fn replace_deprecated_vars_from_strings(content: &str, template_strings: &[String]) -> String {
     let mut result = content.to_string();
 
-    for original in strings {
+    for original in template_strings {
         let mut modified = original.clone();
         for (re, new) in DEPRECATED_VAR_REGEXES.iter() {
             modified = re.replace_all(&modified, *new).into_owned();
         }
-        if modified != original {
-            result = result.replace(&original, &modified);
+        if modified != *original {
+            result = result.replace(original, &modified);
         }
     }
 
@@ -244,16 +235,22 @@ pub fn detect_deprecations(content: &str) -> Deprecations {
     let Ok(doc) = content.parse::<toml_edit::DocumentMut>() else {
         return Deprecations::default();
     };
-
     let template_strings = extract_template_strings_from_doc(&doc);
+    detect_deprecations_from_doc(&doc, &template_strings)
+}
 
+/// Detect deprecations from an already-parsed document and pre-extracted template strings.
+fn detect_deprecations_from_doc(
+    doc: &toml_edit::DocumentMut,
+    template_strings: &[String],
+) -> Deprecations {
     Deprecations {
-        vars: find_deprecated_vars_from_strings(&template_strings),
-        commit_gen: find_commit_generation_from_doc(&doc),
-        approved_commands: find_approved_commands_from_doc(&doc),
-        select: find_select_from_doc(&doc),
-        post_create: find_post_create_from_doc(&doc),
-        ci_section: find_ci_section_from_doc(&doc),
+        vars: find_deprecated_vars_from_strings(template_strings),
+        commit_gen: find_commit_generation_from_doc(doc),
+        approved_commands: find_approved_commands_from_doc(doc),
+        select: find_select_from_doc(doc),
+        post_create: find_post_create_from_doc(doc),
+        ci_section: find_ci_section_from_doc(doc),
     }
 }
 
@@ -822,8 +819,12 @@ pub fn check_and_migrate(
     repo: Option<&crate::git::Repository>,
     show_brief_warning: bool,
 ) -> anyhow::Result<Option<DeprecationInfo>> {
-    // Detect all deprecation types
-    let deprecations = detect_deprecations(content);
+    // Parse once — shared by detection and migration
+    let Ok(doc) = content.parse::<toml_edit::DocumentMut>() else {
+        return Ok(None);
+    };
+    let template_strings = extract_template_strings_from_doc(&doc);
+    let deprecations = detect_deprecations_from_doc(&doc, &template_strings);
 
     if deprecations.is_empty() {
         // Config is clean - clear hint so future deprecations get full treatment.
@@ -906,7 +907,8 @@ pub fn check_and_migrate(
         // Still write migration file if needed (first time only)
         // The file is needed for `wt config update` / `wt config show` to work
         if !should_skip_write {
-            info.migration_path = write_migration_file(path, content, &info.deprecations, repo);
+            info.migration_path =
+                write_migration_file(path, content, &info.deprecations, repo, &template_strings);
         }
 
         std::io::stderr().flush().ok();
@@ -916,7 +918,8 @@ pub fn check_and_migrate(
     // Silent mode for `wt config show` - just write migration file and return info
     // The caller will use format_deprecation_details() to add output to its buffer
     if !should_skip_write {
-        info.migration_path = write_migration_file(path, content, &info.deprecations, repo);
+        info.migration_path =
+            write_migration_file(path, content, &info.deprecations, repo, &template_strings);
     }
 
     Ok(Some(info))
@@ -946,17 +949,19 @@ pub fn format_brief_warning(label: &str) -> String {
 /// * `content` - Content of the config file
 /// * `deprecations` - Detected deprecations to fix
 /// * `repo` - Optional repository for hint tracking (project config only)
+/// * `template_strings` - Pre-extracted template strings from detection (avoids re-parsing)
 pub fn write_migration_file(
     path: &Path,
     content: &str,
     deprecations: &Deprecations,
     repo: Option<&crate::git::Repository>,
+    template_strings: &[String],
 ) -> Option<PathBuf> {
     let new_path = migration_path(path);
 
     // Apply string-level var replacement first (operates on raw content)
     let new_content = if !deprecations.vars.is_empty() {
-        replace_deprecated_vars(content)
+        replace_deprecated_vars_from_strings(content, template_strings)
     } else {
         content.to_string()
     };
@@ -1234,6 +1239,18 @@ mod tests {
     // Test helpers that parse from string and delegate to the internal functions.
     // These mirror the former pub wrappers that were inlined into
     // `detect_deprecations` and `write_migration_file`.
+
+    fn extract_template_strings(content: &str) -> Vec<String> {
+        let Ok(doc) = content.parse::<toml_edit::DocumentMut>() else {
+            return vec![];
+        };
+        extract_template_strings_from_doc(&doc)
+    }
+
+    fn replace_deprecated_vars(content: &str) -> String {
+        let strings = extract_template_strings(content);
+        replace_deprecated_vars_from_strings(content, &strings)
+    }
 
     fn find_deprecated_vars(content: &str) -> Vec<(&'static str, &'static str)> {
         let strings = extract_template_strings(content);
@@ -2323,7 +2340,7 @@ approved-commands = ["npm install"]
             post_create: false,
             ci_section: false,
         };
-        let result = write_migration_file(&config_path, content, &deprecations, None);
+        let result = write_migration_file(&config_path, content, &deprecations, None, &[]);
         assert!(
             result.is_some(),
             "Should write migration file for approved-commands"
@@ -2617,7 +2634,7 @@ pager = "delta --paging=never"
             post_create: false,
             ci_section: false,
         };
-        let result = write_migration_file(&config_path, content, &deprecations, None);
+        let result = write_migration_file(&config_path, content, &deprecations, None, &[]);
         assert!(result.is_some(), "Should write migration file for select");
         let migration_path = result.unwrap();
         let migrated = std::fs::read_to_string(&migration_path).unwrap();
@@ -2899,7 +2916,7 @@ server = "npm run dev"
             post_create: true,
             ci_section: false,
         };
-        let result = write_migration_file(&config_path, content, &deprecations, None);
+        let result = write_migration_file(&config_path, content, &deprecations, None, &[]);
         assert!(
             result.is_some(),
             "Should write migration file for post_create"


### PR DESCRIPTION
Follow-up to #1876. `check_and_migrate()` now parses the TOML content once and threads the parsed document and template strings through to both `detect_deprecations_from_doc()` and `write_migration_file()`, eliminating the last redundant parse in the deprecation pipeline.

The `extract_template_strings` and `replace_deprecated_vars` convenience wrappers (which parsed internally) are now test-only helpers. Production code uses the `_from_strings`/`_from_doc` variants exclusively.

> _This was written by Claude Code on behalf of @max-sixty_