### PR TITLE
docs: restructure trace queries around performance questions

### DIFF
--- a/benches/CLAUDE.md
+++ b/benches/CLAUDE.md
@@ -110,7 +110,7 @@ Three questions drive `wt list` performance work:
 
 2. **How parallel are we?** Total subprocess time divided by wall time gives a parallelism factor. A factor of 4.0 means 4 commands running concurrently on average. Close to 1.0 means mostly serial execution with headroom to parallelize.
 
-3. **What's on the critical path?** The critical path passes through serial phases (setup, finalization) plus the slowest work item in the parallel phase. Phase durations show where serial overhead is; the per-worktree breakdown identifies the parallel bottleneck.
+3. **What's on the critical path?** The critical path passes through serial phases (setup, finalization) plus the slowest work item in the parallel phase. We don't have good queries for this yet — the trace format doesn't capture task dependencies, and rayon's work-stealing means thread IDs don't map to worktrees. The queries below are a starting point (phase boundaries from milestones, per-worktree time from args) but don't give a real critical path answer. Visualizing the trace in Perfetto is more useful here.
 
 ### Queries
 


### PR DESCRIPTION
Replaces the ad-hoc trace query collection (including the narrow status-vs-trees overlap query) with queries organized around three performance questions:

1. **Where does time go?** — slowest commands + task type breakdown (kept from previous PR, reorganized)
2. **How parallel are we?** — new query comparing total subprocess time to subprocess span
3. **What's on the critical path?** — phase durations from milestones + per-worktree breakdown via `EXTRACT_ARG`. Honestly noted as incomplete — the trace format doesn't capture task dependencies, so Perfetto visualization is better for real critical path analysis.

All queries validated against a real trace from a `typical-4` benchmark repo.

> _This was written by Claude Code on behalf of @max-sixty_