### PR TITLE
refactor: filter deprecated keys inside warn_unknown_fields

### DIFF
--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -155,15 +155,15 @@ mod tests {
         );
         assert_snapshot!(warn_unknown_keys::<ProjectConfig>(&unknown), @"[33m▲[39m [33mKey [1mskip-shell-integration-prompt[22m belongs in user config (will be ignored)[39m");
 
-        // ci in user config should suggest project config
+        // forge in user config should suggest project config
         let mut unknown = HashMap::new();
         let mut inner = toml::map::Map::new();
         inner.insert(
             "platform".to_string(),
             toml::Value::String("github".to_string()),
         );
-        unknown.insert("ci".to_string(), toml::Value::Table(inner));
-        assert_snapshot!(warn_unknown_keys::<UserConfig>(&unknown), @"[33m▲[39m [33mKey [1mci[22m belongs in project config (will be ignored)[39m");
+        unknown.insert("forge".to_string(), toml::Value::Table(inner));
+        assert_snapshot!(warn_unknown_keys::<UserConfig>(&unknown), @"[33m▲[39m [33mKey [1mforge[22m belongs in project config (will be ignored)[39m");
     }
 
     // ==================== render_ci_tool_status tests ====================

--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -374,11 +374,9 @@ fn render_system_config(out: &mut String) -> anyhow::Result<bool> {
         writeln!(out, "{}", error_message("Invalid config"))?;
         writeln!(out, "{}", format_with_gutter(&e.to_string(), None))?;
     } else {
-        let unknown_keys: std::collections::HashMap<_, _> = find_unknown_user_keys(&contents)
-            .into_iter()
-            .filter(|(k, _)| !worktrunk::config::DEPRECATED_SECTION_KEYS.contains(&k.as_str()))
-            .collect();
-        out.push_str(&warn_unknown_keys::<UserConfig>(&unknown_keys));
+        out.push_str(&warn_unknown_keys::<UserConfig>(&find_unknown_user_keys(
+            &contents,
+        )));
     }
 
     // Display TOML with syntax highlighting
@@ -449,11 +447,9 @@ fn render_user_config(out: &mut String, has_system_config: bool) -> anyhow::Resu
         // Only check for unknown keys if config is valid.
         // Filter deprecated section keys to avoid duplicate warnings
         // (deprecation system already warns about these).
-        let unknown_keys: std::collections::HashMap<_, _> = find_unknown_user_keys(&contents)
-            .into_iter()
-            .filter(|(k, _)| !worktrunk::config::DEPRECATED_SECTION_KEYS.contains(&k.as_str()))
-            .collect();
-        out.push_str(&warn_unknown_keys::<UserConfig>(&unknown_keys));
+        out.push_str(&warn_unknown_keys::<UserConfig>(&find_unknown_user_keys(
+            &contents,
+        )));
     }
 
     // Add "Current config" label when deprecations shown (to separate from diff)
@@ -494,8 +490,12 @@ pub(super) fn warn_unknown_keys<C: worktrunk::config::WorktrunkConfig>(
 ) -> String {
     let mut out = String::new();
 
-    // Sort keys for deterministic output order
-    let mut keys: Vec<_> = unknown_keys.keys().collect();
+    // Sort keys for deterministic output order, skipping deprecated keys
+    // (the deprecation system handles those with better messaging)
+    let mut keys: Vec<_> = unknown_keys
+        .keys()
+        .filter(|k| !worktrunk::config::DEPRECATED_SECTION_KEYS.contains(&k.as_str()))
+        .collect();
     keys.sort();
 
     for key in keys {

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -67,8 +67,13 @@ const DEPRECATED_VARS: &[(&str, &str)] = &[
     ("main_worktree_path", "primary_worktree_path"),
 ];
 
-/// Top-level section keys that are deprecated and handled separately.
-/// Callers should filter these out before calling `warn_unknown_fields` to avoid duplicate warnings.
+/// Top-level section keys that are deprecated and handled by the deprecation system.
+/// `warn_unknown_fields` skips these automatically.
+///
+/// TODO: When a deprecated key appears in the wrong config file (e.g., `[commit-generation]`
+/// in project config), the deprecation system suggests renaming it — but the renamed key
+/// isn't valid in that config either. Ideally we'd detect "deprecated + wrong file" and
+/// suggest moving to the correct config instead of just renaming.
 pub const DEPRECATED_SECTION_KEYS: &[&str] = &["commit-generation", "select", "ci"];
 
 /// Normalize a template string by replacing deprecated variables with their canonical names.
@@ -1418,8 +1423,12 @@ pub fn warn_unknown_fields<C: WorktrunkConfig>(
         guard.insert(canonical_path);
     }
 
-    // Sort keys for deterministic output order
-    let mut keys: Vec<_> = unknown_keys.keys().collect();
+    // Sort keys for deterministic output order, skipping deprecated keys
+    // (the deprecation system handles those with better messaging)
+    let mut keys: Vec<_> = unknown_keys
+        .keys()
+        .filter(|k| !DEPRECATED_SECTION_KEYS.contains(&k.as_str()))
+        .collect();
     keys.sort();
 
     for key in keys {

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -226,13 +226,9 @@ impl ProjectConfig {
 
         // Warn about unknown fields (only in main worktree where it's actionable)
         if is_main_worktree {
-            let unknown_keys: std::collections::HashMap<_, _> = find_unknown_keys(&contents)
-                .into_iter()
-                .filter(|(k, _)| !super::deprecation::DEPRECATED_SECTION_KEYS.contains(&k.as_str()))
-                .collect();
             super::deprecation::warn_unknown_fields::<ProjectConfig>(
                 &config_path,
-                &unknown_keys,
+                &find_unknown_keys(&contents),
                 "Project config",
             );
         }

--- a/src/config/user/mod.rs
+++ b/src/config/user/mod.rs
@@ -117,13 +117,9 @@ impl UserConfig {
             && let Ok(content) = std::fs::read_to_string(&system_path)
         {
             // Warn about unknown fields in system config
-            let unknown_keys: std::collections::HashMap<_, _> = find_unknown_keys(&content)
-                .into_iter()
-                .filter(|(k, _)| !super::deprecation::DEPRECATED_SECTION_KEYS.contains(&k.as_str()))
-                .collect();
             super::deprecation::warn_unknown_fields::<UserConfig>(
                 &system_path,
-                &unknown_keys,
+                &find_unknown_keys(&content),
                 "System config",
             );
 
@@ -156,15 +152,9 @@ impl UserConfig {
                 // Warn about unknown fields in the config file
                 // (must check file content directly, not config.unknown, because
                 // config.unknown includes env vars which shouldn't trigger warnings)
-                let unknown_keys: std::collections::HashMap<_, _> = find_unknown_keys(&content)
-                    .into_iter()
-                    .filter(|(k, _)| {
-                        !super::deprecation::DEPRECATED_SECTION_KEYS.contains(&k.as_str())
-                    })
-                    .collect();
                 super::deprecation::warn_unknown_fields::<UserConfig>(
                     config_path,
-                    &unknown_keys,
+                    &find_unknown_keys(&content),
                     "User config",
                 );
 

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
@@ -60,7 +60,6 @@ exit_code: 0
 [107m [0m / No newline at end of file[m
 [107m [0m [32m+[m[32m[commit.generation][m
 [107m [0m [32m+[m[32mcommand = "claude"[m
-[33m▲[39m [33mUnknown key [1mcommit-generation[22m will be ignored[39m
 [2m○[22m Current config:
 [107m [0m [2m[36m[commit-generation]
 [107m [0m [2mcommand = [0m[2m[32m"claude"


### PR DESCRIPTION
Moves the `DEPRECATED_SECTION_KEYS` filter from 5 separate call sites into `warn_unknown_fields` and `warn_unknown_keys` themselves. Previously every caller had to remember `.filter(|k| !DEPRECATED_SECTION_KEYS.contains(...))` before calling — and the project config path in `config show` was missing it, causing a spurious "Unknown key `commit-generation` will be ignored" alongside the deprecation warning that already covers it.

Now adding a key to `DEPRECATED_SECTION_KEYS` automatically suppresses it from "unknown key" warnings everywhere.

> _This was written by Claude Code on behalf of Maximilian Roos_