### PR TITLE
refactor: remove dedicated copy thread pool

### DIFF
--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -24,7 +24,7 @@ use ignore::gitignore::GitignoreBuilder;
 use rayon::prelude::*;
 use worktrunk::HookType;
 use worktrunk::config::{CopyIgnoredConfig, UserConfig};
-use worktrunk::copy::{copy_dir_recursive, create_symlink, in_copy_pool, remove_if_exists};
+use worktrunk::copy::{copy_dir_recursive, create_symlink, remove_if_exists};
 use worktrunk::git::Repository;
 use worktrunk::path::format_path_for_display;
 use worktrunk::shell_exec::Cmd;
@@ -801,71 +801,67 @@ pub fn step_copy_ignored(
         }
     }
 
-    // Run all copies in the shared copy pool so that the outer par_iter and
-    // inner copy_dir_recursive calls share the same bounded thread pool.
-    in_copy_pool(|| {
-        entries_to_copy
-            .par_iter()
-            .try_for_each(|(src_entry, is_dir)| -> anyhow::Result<()> {
-                // Paths from git ls-files are always under source_path
-                let relative = src_entry
-                    .strip_prefix(&source_path)
-                    .expect("git ls-files path under worktree");
-                let dest_entry = dest_path.join(relative);
+    entries_to_copy
+        .par_iter()
+        .try_for_each(|(src_entry, is_dir)| -> anyhow::Result<()> {
+            // Paths from git ls-files are always under source_path
+            let relative = src_entry
+                .strip_prefix(&source_path)
+                .expect("git ls-files path under worktree");
+            let dest_entry = dest_path.join(relative);
 
-                if *is_dir {
-                    copy_dir_recursive(src_entry, &dest_entry, force).with_context(|| {
-                        format!("copying directory {}", format_path_for_display(relative))
+            if *is_dir {
+                copy_dir_recursive(src_entry, &dest_entry, force).with_context(|| {
+                    format!("copying directory {}", format_path_for_display(relative))
+                })?;
+                copied_count.fetch_add(1, Ordering::Relaxed);
+            } else {
+                if let Some(parent) = dest_entry.parent() {
+                    fs::create_dir_all(parent).with_context(|| {
+                        format!(
+                            "creating directory for {}",
+                            format_path_for_display(relative)
+                        )
                     })?;
-                    copied_count.fetch_add(1, Ordering::Relaxed);
+                }
+                if force {
+                    remove_if_exists(&dest_entry)?;
+                }
+                // Check if source is a symlink — preserve it instead of following it
+                let display_path = format_path_for_display(relative);
+                let source_is_symlink = fs::symlink_metadata(src_entry)
+                    .context(format!("reading metadata for {display_path}"))?
+                    .file_type()
+                    .is_symlink();
+                if source_is_symlink {
+                    // Skip existing symlinks for idempotent hook usage
+                    if dest_entry.symlink_metadata().is_err() {
+                        let target = fs::read_link(src_entry)
+                            .context(format!("reading symlink {display_path}"))?;
+                        create_symlink(&target, src_entry, &dest_entry)?;
+                        copied_count.fetch_add(1, Ordering::Relaxed);
+                    }
                 } else {
-                    if let Some(parent) = dest_entry.parent() {
-                        fs::create_dir_all(parent).with_context(|| {
-                            format!(
-                                "creating directory for {}",
-                                format_path_for_display(relative)
-                            )
-                        })?;
-                    }
-                    if force {
-                        remove_if_exists(&dest_entry)?;
-                    }
-                    // Check if source is a symlink — preserve it instead of following it
-                    let display_path = format_path_for_display(relative);
-                    let source_is_symlink = fs::symlink_metadata(src_entry)
-                        .context(format!("reading metadata for {display_path}"))?
-                        .file_type()
-                        .is_symlink();
-                    if source_is_symlink {
-                        // Skip existing symlinks for idempotent hook usage
-                        if dest_entry.symlink_metadata().is_err() {
-                            let target = fs::read_link(src_entry)
-                                .context(format!("reading symlink {display_path}"))?;
-                            create_symlink(&target, src_entry, &dest_entry)?;
-                            copied_count.fetch_add(1, Ordering::Relaxed);
-                        }
-                    } else {
-                        // Skip existing entries (files or symlinks) for idempotent hook usage.
-                        // Check symlink_metadata (not exists()) because exists() follows symlinks
-                        // and returns false for broken ones, which would cause reflink_or_copy to
-                        // fail with ENOENT on some platforms when copying through the broken symlink.
-                        if dest_entry.symlink_metadata().is_err() {
-                            match reflink_copy::reflink_or_copy(src_entry, &dest_entry) {
-                                Ok(_) => {
-                                    copied_count.fetch_add(1, Ordering::Relaxed);
-                                }
-                                Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
-                                Err(e) => {
-                                    return Err(anyhow::Error::from(e)
-                                        .context(format!("copying {display_path}")));
-                                }
+                    // Skip existing entries (files or symlinks) for idempotent hook usage.
+                    // Check symlink_metadata (not exists()) because exists() follows symlinks
+                    // and returns false for broken ones, which would cause reflink_or_copy to
+                    // fail with ENOENT on some platforms when copying through the broken symlink.
+                    if dest_entry.symlink_metadata().is_err() {
+                        match reflink_copy::reflink_or_copy(src_entry, &dest_entry) {
+                            Ok(_) => {
+                                copied_count.fetch_add(1, Ordering::Relaxed);
+                            }
+                            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {}
+                            Err(e) => {
+                                return Err(anyhow::Error::from(e)
+                                    .context(format!("copying {display_path}")));
                             }
                         }
                     }
                 }
-                Ok(())
-            })
-    })?;
+            }
+            Ok(())
+        })?;
 
     // Show summary
     let copied_count = copied_count.load(Ordering::Relaxed);

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -4,43 +4,15 @@
 //! copy-on-write clones where the filesystem supports them (APFS, btrfs, XFS),
 //! falling back to regular copies otherwise.
 //!
-//! Parallelism is achieved with rayon's `par_iter` at each directory level,
-//! so sibling entries are copied concurrently while the tree is walked
-//! depth-first.
+//! Parallelism uses rayon's global thread pool. `par_iter` at each directory
+//! level copies siblings concurrently while the tree is walked depth-first.
 
 use std::fs;
 use std::io::ErrorKind;
 use std::path::Path;
-use std::sync::LazyLock;
 
 use anyhow::Context;
 use rayon::prelude::*;
-
-// TODO: benchmark thread count for the shared pool — the old per-call pool
-// was tuned to 4 threads for single-directory copies (#1721), but the shared
-// pool workload is different. Using rayon default (num cores) for now.
-/// Shared thread pool for all filesystem copy operations, created once on first
-/// use. Callers that batch many copies (e.g. `step_copy_ignored`) should wrap
-/// the entire batch in `in_copy_pool()` so all work — including nested
-/// `copy_dir_recursive` calls — shares this pool rather than each spawning its
-/// own (which would exhaust file-descriptor limits on large trees).
-static COPY_POOL: LazyLock<rayon::ThreadPool> = LazyLock::new(|| {
-    rayon::ThreadPoolBuilder::new()
-        .build()
-        .expect("failed to build copy thread pool")
-});
-
-/// Run a closure in the shared copy thread pool.
-///
-/// When already inside the copy pool (e.g. from a nested `copy_dir_recursive`
-/// call), this is a no-op — the closure runs inline on the current thread.
-pub fn in_copy_pool<F, T>(f: F) -> T
-where
-    F: FnOnce() -> T + Send,
-    T: Send,
-{
-    COPY_POOL.install(f)
-}
 
 /// Copy a directory tree recursively using reflink (COW) per file.
 ///
@@ -50,14 +22,7 @@ where
 ///
 /// When `force` is true, existing files and symlinks at the destination are
 /// removed before copying.
-///
-/// Uses the shared copy pool (capped at 4 threads) to avoid SSD I/O contention
-/// from the larger global rayon pool.
 pub fn copy_dir_recursive(src: &Path, dest: &Path, force: bool) -> anyhow::Result<()> {
-    in_copy_pool(|| copy_dir_recursive_inner(src, dest, force))
-}
-
-fn copy_dir_recursive_inner(src: &Path, dest: &Path, force: bool) -> anyhow::Result<()> {
     fs::create_dir_all(dest).with_context(|| format!("creating directory {}", dest.display()))?;
 
     let entries: Vec<_> = fs::read_dir(src)?.collect::<Result<Vec<_>, _>>()?;
@@ -79,7 +44,7 @@ fn copy_dir_recursive_inner(src: &Path, dest: &Path, force: bool) -> anyhow::Res
                 create_symlink(&target, &src_path, &dest_path)?;
             }
         } else if file_type.is_dir() {
-            copy_dir_recursive_inner(&src_path, &dest_path, force)?;
+            copy_dir_recursive(&src_path, &dest_path, force)?;
         } else if !file_type.is_file() {
             log::debug!("skipping non-regular file: {}", src_path.display());
         } else {


### PR DESCRIPTION
The separate `COPY_POOL` (`LazyLock<rayon::ThreadPool>`) isolated copy I/O from the global rayon pool. In practice there's no concurrent rayon work during copies, so the isolation added complexity without benefit. This removes the pool, `in_copy_pool()`, and the `copy_dir_recursive_inner` indirection — copy operations now use the global rayon pool directly.

Follows #1894 which introduced the static pool.

> _This was written by Claude Code on behalf of @max-sixty_