### PR TITLE
refactor: extract classify_unknown_key to deduplicate warn logic

### DIFF
--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -10,8 +10,8 @@ use std::path::{Path, PathBuf};
 use anyhow::Context;
 use color_print::cformat;
 use worktrunk::config::{
-    ProjectConfig, UserConfig, WorktrunkConfig as _, default_system_config_path,
-    find_unknown_project_keys, find_unknown_user_keys, system_config_path,
+    ProjectConfig, UserConfig, default_system_config_path, find_unknown_project_keys,
+    find_unknown_user_keys, system_config_path,
 };
 use worktrunk::git::Repository;
 use worktrunk::path::format_path_for_display;
@@ -494,30 +494,20 @@ pub(super) fn warn_unknown_keys<C: worktrunk::config::WorktrunkConfig>(
     keys.sort();
 
     for key in keys {
-        // Check if this is a deprecated section key
-        if let Some(dep) = worktrunk::config::DEPRECATED_SECTION_KEYS
-            .iter()
-            .find(|d| d.key == key.as_str())
-        {
-            if C::is_valid_key(dep.canonical_top_key) {
-                // Canonical form belongs to this config type — deprecation system handles it
-                continue;
+        let msg = match worktrunk::config::classify_unknown_key::<C>(key) {
+            worktrunk::config::UnknownKeyKind::DeprecatedHandled => continue,
+            worktrunk::config::UnknownKeyKind::DeprecatedWrongConfig {
+                other_description,
+                canonical_display,
+            } => {
+                cformat!("Key <bold>{key}</> belongs in {other_description} as {canonical_display}")
             }
-            // Deprecated key in wrong config file — point to the correct config
-            let msg = cformat!(
-                "Key <bold>{key}</> belongs in {} as {}",
-                C::Other::description(),
-                dep.canonical_display,
-            );
-            let _ = writeln!(out, "{}", warning_message(msg));
-            continue;
-        }
-
-        let msg = match worktrunk::config::key_belongs_in::<C>(key) {
-            Some(location) => {
-                cformat!("Key <bold>{key}</> belongs in {location} (will be ignored)")
+            worktrunk::config::UnknownKeyKind::WrongConfig { other_description } => {
+                cformat!("Key <bold>{key}</> belongs in {other_description} (will be ignored)")
             }
-            None => cformat!("Unknown key <bold>{key}</> will be ignored"),
+            worktrunk::config::UnknownKeyKind::Unknown => {
+                cformat!("Unknown key <bold>{key}</> will be ignored")
+            }
         };
         let _ = writeln!(out, "{}", warning_message(msg));
     }

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -1424,6 +1424,41 @@ pub fn key_belongs_in<C: WorktrunkConfig>(key: &str) -> Option<&'static str> {
     C::Other::is_valid_key(key).then(C::Other::description)
 }
 
+/// Classification of an unknown config key for warning purposes.
+pub enum UnknownKeyKind {
+    /// Deprecated key in its correct config type — deprecation system handles it
+    DeprecatedHandled,
+    /// Deprecated key in the wrong config type
+    DeprecatedWrongConfig {
+        other_description: &'static str,
+        canonical_display: &'static str,
+    },
+    /// Non-deprecated key that belongs in the other config type
+    WrongConfig { other_description: &'static str },
+    /// Truly unknown key (not valid in either config type)
+    Unknown,
+}
+
+/// Classify an unknown config key: deprecated (right/wrong file), misplaced, or unknown.
+pub fn classify_unknown_key<C: WorktrunkConfig>(key: &str) -> UnknownKeyKind {
+    if let Some(dep) = DEPRECATED_SECTION_KEYS.iter().find(|d| d.key == key) {
+        return if C::is_valid_key(dep.canonical_top_key) {
+            UnknownKeyKind::DeprecatedHandled
+        } else {
+            UnknownKeyKind::DeprecatedWrongConfig {
+                other_description: C::Other::description(),
+                canonical_display: dep.canonical_display,
+            }
+        };
+    }
+    match key_belongs_in::<C>(key) {
+        Some(other) => UnknownKeyKind::WrongConfig {
+            other_description: other,
+        },
+        None => UnknownKeyKind::Unknown,
+    }
+}
+
 /// Warn about unknown fields in config file
 ///
 /// Generic over `C`, the config type being loaded. Emits a warning for each
@@ -1456,42 +1491,22 @@ pub fn warn_unknown_fields<C: WorktrunkConfig>(
     keys.sort();
 
     for key in keys {
-        // Check if this is a deprecated section key
-        if let Some(dep) = DEPRECATED_SECTION_KEYS
-            .iter()
-            .find(|d| d.key == key.as_str())
-        {
-            if C::is_valid_key(dep.canonical_top_key) {
-                // Canonical form belongs to this config type — deprecation system handles it
-                continue;
+        let msg = match classify_unknown_key::<C>(key) {
+            UnknownKeyKind::DeprecatedHandled => continue,
+            UnknownKeyKind::DeprecatedWrongConfig {
+                other_description,
+                canonical_display,
+            } => cformat!(
+                "{label} has key <bold>{key}</> which belongs in {other_description} as {canonical_display}"
+            ),
+            UnknownKeyKind::WrongConfig { other_description } => cformat!(
+                "{label} has key <bold>{key}</> which belongs in {other_description} (will be ignored)"
+            ),
+            UnknownKeyKind::Unknown => {
+                cformat!("{label} has unknown field <bold>{key}</> (will be ignored)")
             }
-            // Deprecated key in wrong config file — point to the correct config
-            eprintln!(
-                "{}",
-                warning_message(cformat!(
-                    "{label} has key <bold>{key}</> which belongs in {} as {}",
-                    C::Other::description(),
-                    dep.canonical_display,
-                ))
-            );
-            continue;
-        }
-
-        if let Some(other_location) = key_belongs_in::<C>(key) {
-            eprintln!(
-                "{}",
-                warning_message(cformat!(
-                    "{label} has key <bold>{key}</> which belongs in {other_location} (will be ignored)"
-                ))
-            );
-        } else {
-            eprintln!(
-                "{}",
-                warning_message(cformat!(
-                    "{label} has unknown field <bold>{key}</> (will be ignored)"
-                ))
-            );
-        }
+        };
+        eprintln!("{}", warning_message(msg));
     }
 
     // Flush stderr to ensure output appears before any subsequent messages

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -86,7 +86,8 @@ pub use deprecation::migrate_content;
 pub use deprecation::normalize_template_vars;
 pub use deprecation::write_migration_file;
 pub use deprecation::{
-    DEPRECATED_SECTION_KEYS, DeprecatedSection, key_belongs_in, warn_unknown_fields,
+    DEPRECATED_SECTION_KEYS, DeprecatedSection, UnknownKeyKind, classify_unknown_key,
+    key_belongs_in, warn_unknown_fields,
 };
 pub use expansion::{
     DEPRECATED_TEMPLATE_VARS, TEMPLATE_VARS, TemplateExpandError, expand_template,


### PR DESCRIPTION
Both `warn_unknown_fields` (deprecation.rs, called at config load) and `warn_unknown_keys` (show.rs, called in `wt config show`) had identical key classification logic — checking deprecated keys, wrong config file, and truly unknown keys. Extracted into a shared `classify_unknown_key<C>()` function with an `UnknownKeyKind` enum, reducing both callers to simple match expressions.

Follow-up to #1899.

> _This was written by Claude Code on behalf of @max-sixty_