### PR TITLE
docs: clarify plugin install command

### DIFF
--- a/docs/content/claude-code.md
+++ b/docs/content/claude-code.md
@@ -18,8 +18,6 @@ Recommended:
 
 {{ terminal(cmd="wt config plugins claude install") }}
 
-This wraps the marketplace flow for you and installs the same plugin automatically.
-
 Manual equivalent:
 
 {{ terminal(cmd="claude plugin marketplace add max-sixty/worktrunk|||claude plugin install worktrunk@worktrunk") }}

--- a/skills/worktrunk/reference/claude-code.md
+++ b/skills/worktrunk/reference/claude-code.md
@@ -13,8 +13,6 @@ Recommended:
 $ wt config plugins claude install
 ```
 
-This wraps the marketplace flow for you and installs the same plugin automatically.
-
 Manual equivalent:
 
 ```bash


### PR DESCRIPTION
## Summary
- document `wt config plugins claude install` as the recommended plugin install path
- keep the existing Claude marketplace commands as the manual equivalent
- align the docs page with the shipped CLI help and plugin installer behavior

## Testing
- compared the docs change against `src/cli/config.rs`, which already advertises `wt config plugins claude install`
- verified the diff stays limited to `docs/content/claude-code.md`

## Notes
- docs-only change
