### PR TITLE
Fix `primary_remote()` failing when non-remote config keys match the regex.

### DIFF
--- a/src/git/repository/remotes.rs
+++ b/src/git/repository/remotes.rs
@@ -125,9 +125,13 @@ impl Repository {
                 let output = self
                     .run_command(&["config", "--get-regexp", r"remote\..+\.url"])
                     .unwrap_or_default();
-                let first_remote = output.lines().next().and_then(|line| {
+                let first_remote = output.lines().find_map(|line| {
                     // Parse "remote.<name>.url <value>" format
                     // Use ".url " as delimiter to handle remote names with dots (e.g., "my.remote")
+                    // Use find_map (not next + parse) because the unanchored regex matches
+                    // any config key containing "remote.<something>.url" — not just actual
+                    // remote entries. For example, includeIf.hasconfig:remote.*.url:... keys
+                    // match and can appear before the first real remote URL.
                     line.strip_prefix("remote.")
                         .and_then(|s| s.split_once(".url "))
                         .map(|(name, _)| name)

--- a/tests/integration_tests/default_branch.rs
+++ b/tests/integration_tests/default_branch.rs
@@ -1,5 +1,6 @@
 use crate::common::{TestRepo, repo, repo_with_remote};
 use rstest::rstest;
+use std::fs;
 use worktrunk::git::{GitRemoteUrl, Repository};
 
 #[rstest]
@@ -111,6 +112,30 @@ fn test_primary_remote_detects_custom_remote(mut repo: TestRepo) {
     let git_repo = Repository::at(repo.root_path()).unwrap();
     let remote = git_repo.primary_remote().unwrap();
     assert_eq!(remote, "upstream");
+}
+
+#[rstest]
+fn test_primary_remote_skips_includeif_lines(repo: TestRepo) {
+    // `git config --get-regexp remote\..+\.url` uses an unanchored regex, so it matches
+    // any config key containing "remote.<something>.url" — not just actual remote entries.
+    // For example, `includeIf.hasconfig:remote.*.url:...` keys match and can appear before
+    // the first real remote URL. primary_remote() must skip these non-remote lines.
+    //
+    // We prepend an includeIf section to the local .git/config so it appears before the
+    // [remote "origin"] section in git's output (git emits config entries in file order
+    // within each scope, and global config entries appear before local ones).
+    let git_config = repo.root_path().join(".git/config");
+    let original = fs::read_to_string(&git_config).unwrap();
+    let patched = format!(
+        "[includeIf \"hasconfig:remote.*.url:https://github.com/example/other.git\"]\n\
+         \tpath = /dev/null\n{}",
+        original
+    );
+    fs::write(&git_config, patched).unwrap();
+
+    let git_repo = Repository::at(repo.root_path()).unwrap();
+    let remote = git_repo.primary_remote().unwrap();
+    assert_eq!(remote, "origin");
 }
 
 #[rstest]


### PR DESCRIPTION
I've been running into an issue where on one particular machine I could not get project-specific config to load from my _~/.config/worktrunk/config.toml_ file using a simple match pattern such as `[projects."github.com/ruby/ruby"]`. Instead, I had to use a fully-qualified path to the project. While I was happy I had a workaround, it bugged me that I couldn't unify my config across machines. I debugged the issue and tracked it down to a difference in `git config --get-regexp remote\..+\.url` output. (By the way, the diagnostic log is fantastic -- thank you for implementing that).

On this machine, I need to source a common git config file and it has conditional git config that also uses patterns, such as `includeif.hasconfig:remote.*.url:<url> <path>`. Worktrunk 0.34.1 uses `git config --get-regexp remote\..+\.url` to find remotes, but that is an unanchored regex so it matches any config key containing `remote.<something>.url`, not just actual remote entries. For example, `includeIf.hasconfig:remote.*.url:...` keys match and can appear before the first real remote URL in the output.

`primary_remote()` used `.lines().next().and_then(...)` which only examined the first line. If that line was a non-remote entry (not starting with `remote.`), parsing failed and the function returned "No remotes configured" even though valid remote lines followed.

This PR changes it to use `.lines().find_map(...)` to skip non-remote lines, consistent with how `all_remote_urls()` already handles the same output. I've added a test to demonstrate the problem and help verify the fix works.