### PR TITLE
fix: bump AUR deploy action to v4.1.2

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -377,7 +377,7 @@ jobs:
           sed -i "s/^pkgver=.*/pkgver=${VERSION}/" .github/aur/PKGBUILD
           cat .github/aur/PKGBUILD
       - name: Publish AUR package
-        uses: KSXGitHub/github-actions-deploy-aur@v4.1.1
+        uses: KSXGitHub/github-actions-deploy-aur@v4.1.2
         with:
           pkgname: worktrunk-bin
           pkgbuild: .github/aur/PKGBUILD


### PR DESCRIPTION
Arch Linux updated util-linux with stricter `runuser` argument parsing in su-compatible mode. The v4.1.1 entrypoint ran `runuser builder --command 'bash -l -c /build.sh'`, but with the username before `--command`, the new `runuser` passes `--command` as a shell argument to bash — producing `bash: --command: invalid option`. This broke the v0.34.1 AUR publish.

v4.1.2 ([KSXGitHub/github-actions-deploy-aur#49](https://github.com/KSXGitHub/github-actions-deploy-aur/pull/49), released 2026-04-03) switches to `runuser -u builder -- bash -l -c /build.sh`.

> _This was written by Claude Code on behalf of @max-sixty_