### PR TITLE
feat: renice copy-ignored to lowest OS priority

### DIFF
--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -358,7 +358,7 @@ Reflink copies share disk blocks until modified — no data is actually copied. 
 | `cp -R` (full copy) | 2m |
 | `cp -Rc` / `wt step copy-ignored` | 20s |
 
-Uses per-file reflink (like `cp -Rc`) — copy time scales with file count.
+Uses per-file reflink (like `cp -Rc`) — copy time scales with file count. On Unix, the process is automatically reniced to lowest priority (nice 19) so it yields to interactive work.
 
 Use the `post-start` hook so the copy runs in the background. Use `pre-start` instead if subsequent hooks or `--execute` command need the copied files immediately.
 

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -373,7 +373,7 @@ Reflink copies share disk blocks until modified — no data is actually copied. 
 | `cp -R` (full copy) | 2m |
 | `cp -Rc` / `wt step copy-ignored` | 20s |
 
-Uses per-file reflink (like `cp -Rc`) — copy time scales with file count.
+Uses per-file reflink (like `cp -Rc`) — copy time scales with file count. On Unix, the process is automatically reniced to lowest priority (nice 19) so it yields to interactive work.
 
 Use the `post-start` hook so the copy runs in the background. Use `pre-start` instead if subsequent hooks or `--execute` command need the copied files immediately.
 

--- a/src/cli/step.rs
+++ b/src/cli/step.rs
@@ -288,7 +288,7 @@ Reflink copies share disk blocks until modified — no data is actually copied. 
 | `cp -R` (full copy) | 2m |
 | `cp -Rc` / `wt step copy-ignored` | 20s |
 
-Uses per-file reflink (like `cp -Rc`) — copy time scales with file count.
+Uses per-file reflink (like `cp -Rc`) — copy time scales with file count. On Unix, the process is automatically reniced to lowest priority (nice 19) so it yields to interactive work.
 
 Use the `post-start` hook so the copy runs in the background. Use `pre-start` instead if subsequent hooks or `--execute` command need the copied files immediately.
 

--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -707,6 +707,7 @@ pub fn step_copy_ignored(
     dry_run: bool,
     force: bool,
 ) -> anyhow::Result<()> {
+    worktrunk::copy::lower_process_priority();
     let repo = Repository::current()?;
     let copy_ignored_config = resolve_copy_ignored_config(&repo)?;
 

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -7,6 +7,9 @@
 //! All copy I/O runs in a dedicated 4-thread pool rather than the global rayon
 //! pool (which is sized at 2× CPU cores for network I/O) to avoid saturating
 //! the CPU on a background operation.
+//!
+//! Callers that want low-priority I/O (e.g. `step_copy_ignored`) should call
+//! [`lower_process_priority`] before starting work.
 
 use std::fs;
 use std::io::ErrorKind;
@@ -38,6 +41,25 @@ static COPY_POOL: LazyLock<rayon::ThreadPool> = LazyLock::new(|| {
 /// global-pool threads while waiting for copy workers.
 pub fn copy_pool_install<R: Send>(f: impl FnOnce() -> R + Send) -> R {
     COPY_POOL.install(f)
+}
+
+/// Lower the current process's scheduling priority so copy I/O doesn't
+/// compete with interactive foreground work.
+///
+/// Uses `renice` rather than a direct `nice(2)` syscall to stay within the
+/// `forbid(unsafe_code)` lint. Non-fatal: if `renice` is missing or fails,
+/// copies proceed at normal priority.
+pub fn lower_process_priority() {
+    #[cfg(unix)]
+    {
+        use std::process::{Command, Stdio};
+        let _ = Command::new("renice")
+            .args(["-n", "19", "-p", &std::process::id().to_string()])
+            .stdin(Stdio::null())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
 }
 
 /// Copy a directory tree recursively using reflink (COW) per file.


### PR DESCRIPTION
`wt step copy-ignored` now calls `renice -n 19` on its own process before starting work, so large reflink copies yield to interactive foreground tasks. The call is in `step_copy_ignored()` rather than the shared `COPY_POOL` init, so other callers (like `handle_promote`'s cross-device fallback) keep normal priority. Non-fatal if `renice` is missing or fails.

Avoids `libc::nice()` directly because of `forbid(unsafe_code)` — `renice` is a one-time subprocess spawn during pool init.

> _This was written by Claude Code on behalf of @max-sixty_