### PR TITLE
ci: replace deprecated test-results-action with codecov-action

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -136,10 +136,11 @@ jobs:
 
     - name: 📊 Upload test results to Codecov
       if: ${{ !cancelled() && github.repository_owner == 'max-sixty' }}
-      uses: codecov/test-results-action@v1.2.1
+      uses: codecov/codecov-action@v6.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: target/nextest/default/junit.xml
+        report_type: test_results
 
   # Check if Cargo/CI files changed (for conditional jobs below)
   changes:


### PR DESCRIPTION
\`codecov/test-results-action\` is deprecated — CI warns to switch to \`codecov/codecov-action@v5\` with \`report_type: test_results\`. Replaced with \`codecov-action@v6\` (matching the version already used for coverage upload) and added the \`report_type\` parameter.

> _This was written by Claude Code on behalf of @max-sixty_