### PR TITLE
chore: remove lychee exclusion for opencode plugin path

### DIFF
--- a/.config/lychee.toml
+++ b/.config/lychee.toml
@@ -74,7 +74,4 @@ exclude = [
     # Local dev server URLs (not running during CI)
     "127\\.0\\.0\\.1",
     "localhost",
-
-    # Not yet on main (remove after first release with dev/opencode-plugin.ts)
-    "github\\.com/max-sixty/worktrunk/tree/main/dev/opencode-plugin\\.ts",
 ]


### PR DESCRIPTION
dev/opencode-plugin.ts is on main now (#1807), so the link check exclusion is no longer needed.

> _This was written by Claude Code on behalf of @max-sixty_