### PR TITLE
fix: resolve analyze_trace test timeouts under nextest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [workspace]
 members = ["tests/helpers/wt-perf", "tests/helpers/mock-stub"]
-# Include mock-stub so `cargo test` builds its binary (via its integration test)
-default-members = [".", "tests/helpers/mock-stub"]
+# Include mock-stub and wt-perf so `cargo test` builds their binaries
+default-members = [".", "tests/helpers/mock-stub", "tests/helpers/wt-perf"]
 
 [package]
 name = "worktrunk"

--- a/tests/common/mock_commands.rs
+++ b/tests/common/mock_commands.rs
@@ -20,17 +20,7 @@ use std::path::Path;
 
 /// Path to the mock-stub binary, built by `cargo test`.
 fn mock_stub_binary() -> std::path::PathBuf {
-    let mut path = std::env::current_exe().expect("failed to get test executable path");
-    path.pop(); // Remove test binary name
-    path.pop(); // Remove deps/
-
-    #[cfg(windows)]
-    path.push("mock-stub.exe");
-
-    #[cfg(not(windows))]
-    path.push("mock-stub");
-
-    path
+    super::workspace_bin("mock-stub")
 }
 
 /// Builder for mock command configuration.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -406,6 +406,25 @@ use std::process::Command;
 pub fn wt_bin() -> PathBuf {
     PathBuf::from(env!("CARGO_BIN_EXE_wt"))
 }
+
+/// Path to a workspace member binary (e.g., `wt-perf`, `mock-stub`).
+///
+/// These are binaries from other workspace packages (not the main `wt` crate),
+/// so `CARGO_BIN_EXE_<name>` isn't available. Derives the path from the test
+/// executable's location in `target/debug/deps/`.
+pub fn workspace_bin(name: &str) -> PathBuf {
+    let mut path = std::env::current_exe().expect("failed to get test executable path");
+    path.pop(); // Remove test binary name
+    path.pop(); // Remove deps/
+
+    #[cfg(windows)]
+    path.push(format!("{name}.exe"));
+
+    #[cfg(not(windows))]
+    path.push(name);
+
+    path
+}
 use tempfile::TempDir;
 use worktrunk::config::sanitize_branch_name;
 use worktrunk::path::to_posix_path;

--- a/tests/helpers/wt-perf/Cargo.toml
+++ b/tests/helpers/wt-perf/Cargo.toml
@@ -1,3 +1,7 @@
+# HOW THE BINARY GETS BUILT:
+# Has a dummy integration test (tests/builds.rs) that triggers binary compilation
+# when running `cargo test`. Combined with `workspace.default-members` including
+# this package, `cargo test` automatically builds the binary.
 [package]
 name = "wt-perf"
 version = "0.1.0"

--- a/tests/helpers/wt-perf/tests/builds.rs
+++ b/tests/helpers/wt-perf/tests/builds.rs
@@ -1,0 +1,5 @@
+//! Dummy test that triggers binary compilation.
+//! See wt-perf/Cargo.toml and mock-stub/Cargo.toml for why this is needed.
+
+#[test]
+fn builds() {}

--- a/tests/integration_tests/analyze_trace.rs
+++ b/tests/integration_tests/analyze_trace.rs
@@ -3,17 +3,10 @@
 use std::io::Write;
 use std::process::{Command, Stdio};
 
-fn wt_perf_bin() -> std::path::PathBuf {
-    // Build and get path to wt-perf binary
-    let output = Command::new("cargo")
-        .args(["build", "-p", "wt-perf"])
-        .output()
-        .expect("Failed to build wt-perf");
-    assert!(output.status.success(), "Failed to build wt-perf");
+use crate::common::workspace_bin;
 
-    std::env::current_dir()
-        .unwrap()
-        .join("target/debug/wt-perf")
+fn wt_perf_bin() -> std::path::PathBuf {
+    workspace_bin("wt-perf")
 }
 
 /// Test that the binary produces Chrome Trace Format JSON for sample trace input.


### PR DESCRIPTION
The 4 `analyze_trace` tests called `cargo build -p wt-perf` at runtime, which blocks on the Cargo lock when nextest runs tests in parallel — causing 60-second timeouts locally.

Replace with compile-time binary path resolution via a shared `workspace_bin()` helper (in `tests/common/mod.rs`) that derives the path from `current_exe()`. Consolidate `mock_stub_binary()` to use the same helper. Add `wt-perf` to `default-members` with a dummy integration test (matching the existing `mock-stub` pattern) so `cargo test` places the binary in `target/debug/`.

> _This was written by Claude Code on behalf of @max-sixty_