### PR TITLE
fix(opencode): fix broken unicode escaping depending on Bun version

### DIFF
--- a/dev/opencode-plugin.ts
+++ b/dev/opencode-plugin.ts
@@ -14,10 +14,10 @@ export default (async ({ $ }) => {
     event: async ({ event }) => {
       switch (event.type) {
         case "session.status":
-          await $`wt config state marker set 🤖 || true`.quiet();
+          await $`wt config state marker set ${'🤖'} || true`.quiet();
           break;
         case "session.idle":
-          await $`wt config state marker set 💬 || true`.quiet();
+          await $`wt config state marker set ${'💬'} || true`.quiet();
           break;
         case "session.deleted":
           await $`wt config state marker clear || true`.quiet();


### PR DESCRIPTION
A small fix on the OpenCode plugin: depending on the Bun version, unicode can be broken ([escaped while it shouldn't](https://github.com/bikeshaving/crank/issues/342)).

This fix ensures it works whatever the Bun version used in OpenCode (I already use this fix locally).