### PR TITLE
refactor: consolidate duplicated TestRepo across unit tests

### DIFF
--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -537,26 +537,7 @@ mod tests {
     use insta::assert_snapshot;
 
     use super::*;
-    use crate::shell_exec::Cmd;
-
-    /// Test fixture that creates a real temporary git repository.
-    struct TestRepo {
-        _dir: tempfile::TempDir,
-        repo: Repository,
-    }
-
-    impl TestRepo {
-        fn new() -> Self {
-            let dir = tempfile::tempdir().unwrap();
-            Cmd::new("git")
-                .args(["init"])
-                .current_dir(dir.path())
-                .run()
-                .unwrap();
-            let repo = Repository::at(dir.path()).unwrap();
-            Self { _dir: dir, repo }
-        }
-    }
+    use crate::testutil::TestRepo;
 
     fn test_repo() -> TestRepo {
         TestRepo::new()
@@ -1162,12 +1143,12 @@ mod tests {
         // Set vars data via git config
         std::process::Command::new("git")
             .args(["config", "worktrunk.state.main.vars.env", "staging"])
-            .current_dir(test._dir.path())
+            .current_dir(test.path())
             .status()
             .unwrap();
         std::process::Command::new("git")
             .args(["config", "worktrunk.state.main.vars.port", "3000"])
-            .current_dir(test._dir.path())
+            .current_dir(test.path())
             .status()
             .unwrap();
 
@@ -1222,7 +1203,7 @@ mod tests {
                 "worktrunk.state.main.vars.config",
                 r#"{"port": 3000, "debug": true}"#,
             ])
-            .current_dir(test._dir.path())
+            .current_dir(test.path())
             .status()
             .unwrap();
 
@@ -1233,14 +1214,14 @@ mod tests {
                 "worktrunk.state.main.vars.tags",
                 r#"["alpha", "beta"]"#,
             ])
-            .current_dir(test._dir.path())
+            .current_dir(test.path())
             .status()
             .unwrap();
 
         // Store a plain string (not JSON)
         std::process::Command::new("git")
             .args(["config", "worktrunk.state.main.vars.env", "staging"])
-            .current_dir(test._dir.path())
+            .current_dir(test.path())
             .status()
             .unwrap();
 
@@ -1293,7 +1274,7 @@ mod tests {
                 "worktrunk.state.main.vars.config",
                 r#"{"name": "my project", "cmd": "echo hello"}"#,
             ])
-            .current_dir(test._dir.path())
+            .current_dir(test.path())
             .status()
             .unwrap();
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -112,27 +112,7 @@ mod tests {
     use insta::assert_snapshot;
 
     use super::*;
-    use crate::git::Repository;
-    use crate::shell_exec::Cmd;
-
-    /// Test fixture that creates a real temporary git repository.
-    struct TestRepo {
-        _dir: tempfile::TempDir,
-        repo: Repository,
-    }
-
-    impl TestRepo {
-        fn new() -> Self {
-            let dir = tempfile::tempdir().unwrap();
-            Cmd::new("git")
-                .args(["init"])
-                .current_dir(dir.path())
-                .run()
-                .unwrap();
-            let repo = Repository::at(dir.path()).unwrap();
-            Self { _dir: dir, repo }
-        }
-    }
+    use crate::testutil::TestRepo;
 
     fn test_repo() -> TestRepo {
         TestRepo::new()

--- a/src/config/test.rs
+++ b/src/config/test.rs
@@ -4,28 +4,8 @@
 //! edge cases in template variable substitution.
 
 use super::expand_template;
-use crate::git::Repository;
-use crate::shell_exec::Cmd;
+use crate::testutil::TestRepo;
 use std::collections::HashMap;
-
-/// Test fixture that creates a real temporary git repository.
-struct TestRepo {
-    _dir: tempfile::TempDir,
-    repo: Repository,
-}
-
-impl TestRepo {
-    fn new() -> Self {
-        let dir = tempfile::tempdir().unwrap();
-        Cmd::new("git")
-            .args(["init"])
-            .current_dir(dir.path())
-            .run()
-            .unwrap();
-        let repo = Repository::at(dir.path()).unwrap();
-        Self { _dir: dir, repo }
-    }
-}
 
 fn test_repo() -> TestRepo {
     TestRepo::new()

--- a/src/config/user/tests.rs
+++ b/src/config/user/tests.rs
@@ -1,26 +1,7 @@
 use super::*;
 use crate::config::HooksConfig;
-use crate::git::{HookType, Repository};
-use crate::shell_exec::Cmd;
-
-/// Test fixture that creates a real temporary git repository.
-struct TestRepo {
-    _dir: tempfile::TempDir,
-    repo: Repository,
-}
-
-impl TestRepo {
-    fn new() -> Self {
-        let dir = tempfile::tempdir().unwrap();
-        Cmd::new("git")
-            .args(["init"])
-            .current_dir(dir.path())
-            .run()
-            .unwrap();
-        let repo = Repository::at(dir.path()).unwrap();
-        Self { _dir: dir, repo }
-    }
-}
+use crate::git::HookType;
+use crate::testutil::TestRepo;
 
 fn test_repo() -> TestRepo {
     TestRepo::new()

--- a/src/git/recover.rs
+++ b/src/git/recover.rs
@@ -208,19 +208,14 @@ fn paths_match(worktree_path: &Path, deleted_path: &Path) -> bool {
 mod tests {
     use super::*;
     use crate::shell_exec::Cmd;
+    use crate::testutil::set_test_identity;
     use ansi_str::AnsiStr;
 
     fn git_init(path: &Path) {
         Cmd::new("git")
-            .args(["init", "--quiet"])
+            .args(["init", "--quiet", "-b", "main"])
             .current_dir(path)
             .run()
-            .unwrap();
-    }
-
-    fn configure_test_identity(repo: &Repository) {
-        repo.run_command(&["config", "user.name", "Test"]).unwrap();
-        repo.run_command(&["config", "user.email", "test@test.com"])
             .unwrap();
     }
 
@@ -288,7 +283,7 @@ mod tests {
         std::fs::create_dir(&repo_dir).unwrap();
         git_init(&repo_dir);
         let repo = Repository::at(&repo_dir).unwrap();
-        configure_test_identity(&repo);
+        set_test_identity(&repo);
         // Create an initial commit so worktree add works
         repo.run_command(&["commit", "--allow-empty", "-m", "init"])
             .unwrap();
@@ -307,7 +302,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         git_init(tmp.path());
         let repo = Repository::at(tmp.path()).unwrap();
-        configure_test_identity(&repo);
+        set_test_identity(&repo);
         repo.run_command(&["commit", "--allow-empty", "-m", "init"])
             .unwrap();
 
@@ -333,7 +328,7 @@ mod tests {
         std::fs::create_dir(&repo_dir).unwrap();
         git_init(&repo_dir);
         let repo = Repository::at(&repo_dir).unwrap();
-        configure_test_identity(&repo);
+        set_test_identity(&repo);
         repo.run_command(&["commit", "--allow-empty", "-m", "init"])
             .unwrap();
 
@@ -358,7 +353,7 @@ mod tests {
         std::fs::create_dir(&repo_dir).unwrap();
         git_init(&repo_dir);
         let repo = Repository::at(&repo_dir).unwrap();
-        configure_test_identity(&repo);
+        set_test_identity(&repo);
         repo.run_command(&["commit", "--allow-empty", "-m", "init"])
             .unwrap();
 
@@ -382,7 +377,7 @@ mod tests {
         let repo_a_handle = Repository::at(&repo_a).unwrap();
         let repo_b_handle = Repository::at(&repo_b).unwrap();
         for repo in [&repo_a_handle, &repo_b_handle] {
-            configure_test_identity(repo);
+            set_test_identity(repo);
             repo.run_command(&["commit", "--allow-empty", "-m", "init"])
                 .unwrap();
         }
@@ -419,7 +414,7 @@ mod tests {
         std::fs::create_dir(&repo_dir).unwrap();
         git_init(&repo_dir);
         let repo = Repository::at(&repo_dir).unwrap();
-        configure_test_identity(&repo);
+        set_test_identity(&repo);
         repo.run_command(&["commit", "--allow-empty", "-m", "init"])
             .unwrap();
 
@@ -445,7 +440,7 @@ mod tests {
         std::fs::create_dir(&repo_dir).unwrap();
         git_init(&repo_dir);
         let repo = Repository::at(&repo_dir).unwrap();
-        configure_test_identity(&repo);
+        set_test_identity(&repo);
         repo.run_command(&["commit", "--allow-empty", "-m", "init"])
             .unwrap();
 
@@ -469,7 +464,7 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         git_init(tmp.path());
         let repo = Repository::at(tmp.path()).unwrap();
-        configure_test_identity(&repo);
+        set_test_identity(&repo);
         repo.run_command(&["commit", "--allow-empty", "-m", "init"])
             .unwrap();
         let hint = hint_for_repo(&repo);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,5 +20,8 @@ pub mod sync;
 pub mod trace;
 pub mod utils;
 
+#[cfg(test)]
+pub(crate) mod testutil;
+
 // Re-export HookType for convenience
 pub use git::HookType;

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -1,0 +1,52 @@
+//! Shared test utilities for unit tests within the worktrunk crate.
+//!
+//! Provides lightweight git repository fixtures for tests that need a real
+//! `.git` directory (template expansion, config resolution, work item generation).
+//!
+//! For integration tests, use `tests/common/mod.rs` (`TestRepo`) instead — it
+//! provides full CLI isolation, snapshot filters, and mock commands.
+
+use std::path::Path;
+
+use crate::git::Repository;
+use crate::shell_exec::Cmd;
+
+/// Minimal test git repository backed by a temp directory.
+///
+/// The temp directory is cleaned up when this struct is dropped.
+pub struct TestRepo {
+    _dir: tempfile::TempDir,
+    pub repo: Repository,
+}
+
+impl TestRepo {
+    /// Create a new repo with `git init -b main`.
+    ///
+    /// Uses explicit `-b main` for determinism regardless of system git config.
+    pub fn new() -> Self {
+        let dir = tempfile::tempdir().unwrap();
+        Cmd::new("git")
+            .args(["init", "-b", "main"])
+            .current_dir(dir.path())
+            .run()
+            .unwrap();
+        let repo = Repository::at(dir.path()).unwrap();
+        Self { _dir: dir, repo }
+    }
+
+    /// Path to the repository working directory.
+    pub fn path(&self) -> &Path {
+        self._dir.path()
+    }
+}
+
+/// Set git user identity on a repository.
+///
+/// Use this for tests that manage their own repo creation and need
+/// identity configured for commits. For self-contained repos,
+/// prefer `TestRepo::new()` + `set_test_identity(&test.repo)`.
+pub fn set_test_identity(repo: &Repository) {
+    repo.run_command(&["config", "user.name", "Test"]).unwrap();
+    repo.run_command(&["config", "user.email", "test@test.com"])
+        .unwrap();
+}

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -669,6 +669,10 @@ pub fn configure_completion_invocation_for_shell(cmd: &mut Command, words: &[&st
 /// and is intended for cases where tests need to construct the command manually
 /// (e.g., to execute shell pipelines).
 ///
+/// This is intentionally more thorough than `wt_perf::isolate_cmd()`:
+/// integration tests need full determinism (timestamps, locale, mock commands,
+/// wide COLUMNS for path display) while benchmarks only need host config stripped.
+///
 /// ## Related: `TestRepo::test_env_vars()`
 ///
 /// PTY tests use `test_env_vars()` which returns env vars as a Vec. Both functions

--- a/tests/helpers/wt-perf/src/lib.rs
+++ b/tests/helpers/wt-perf/src/lib.rs
@@ -150,6 +150,11 @@ pub fn run_git_ok(path: &Path, args: &[&str]) -> bool {
 /// Removes `GIT_*`, `WORKTRUNK_*`, `SHELL`, and `NO_COLOR` env vars, then sets
 /// config/system/approvals paths. Pass a `user_config_path` to use a real config
 /// file (e.g., with hooks); `None` points at a nonexistent path (defaults only).
+///
+/// This is intentionally minimal compared to `tests/common::configure_cli_command()`:
+/// benchmarks need realistic timing without host config interference, while
+/// integration tests need full determinism (timestamps, locale, mock commands,
+/// snapshot filters). Coupling them would make benchmarks slower or tests flaky.
 pub fn isolate_cmd(cmd: &mut std::process::Command, user_config_path: Option<&Path>) {
     for (key, _) in std::env::vars() {
         if key.starts_with("GIT_") || key.starts_with("WORKTRUNK_") {


### PR DESCRIPTION
Four identical `TestRepo` structs existed across `src/config/` (in `test.rs`, `user/tests.rs`, `expansion.rs`, and `mod.rs`), and `configure_test_identity()` was duplicated between `src/git/recover.rs` and `src/commands/picker/summary.rs`. This extracts a shared `src/testutil.rs` module (gated with `#[cfg(test)]`) that the library-side tests import.

The new `TestRepo::new()` uses `git init -b main` for determinism (the old copies used bare `git init` which depends on system config). A standalone `set_test_identity()` function handles the cases where tests manage their own temp directories and repo paths.

Binary-side tests (`src/commands/`) can't access `#[cfg(test)]` library modules, so they keep their local helpers — this is a Rust crate boundary limitation, not oversight.

Also adds cross-referencing doc comments to `wt_perf::isolate_cmd()` and `tests/common::configure_cli_command()` explaining why they're intentionally separate (benchmarks need minimal isolation for realistic timing; tests need full determinism for snapshots).

> _This was written by Claude Code on behalf of @max-sixty_