### PR TITLE
docs: add MSRV bump to weekly tend maintenance

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -95,7 +95,9 @@ Files to update:
 | File | Field | Example (if stable is 1.94) |
 |------|-------|----|
 | `Cargo.toml` | `rust-version` | `"1.93"` |
+| `tests/helpers/wt-perf/Cargo.toml` | `rust-version` | `"1.93"` |
 | `rust-toolchain.toml` | `channel` | `"1.93.0"` |
+| `flake.nix` | MSRV comment | `1.93` |
 
 After bumping, run the full test suite (`cargo run -- hook pre-merge --yes`)
 and verify `cargo msrv verify` passes.


### PR DESCRIPTION
The `floor_char_boundary` incident (1.91.0 method used with 1.89.0 MSRV) showed we lack a systematic MSRV bump process. This adds guidance to the `running-tend` skill: bump MSRV and toolchain to **latest stable − 1** during weekly maintenance, covering which files to update and how to verify.

> _This was written by Claude Code on behalf of Maximilian Roos_