### PR TITLE
refactor: simplify dispatch_command with clap Args structs

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -13,7 +13,7 @@ pub(crate) use list::ListSubcommand;
 pub(crate) use step::StepCommand;
 
 use clap::builder::styling::{AnsiColor, Color, Styles};
-use clap::{Command, CommandFactory, Parser, Subcommand, ValueEnum};
+use clap::{Args, Command, CommandFactory, Parser, Subcommand, ValueEnum};
 use std::sync::OnceLock;
 use worktrunk::config::{DEPRECATED_TEMPLATE_VARS, TEMPLATE_VARS};
 
@@ -260,6 +260,244 @@ pub(crate) struct Cli {
     pub command: Option<Commands>,
 }
 
+#[derive(Args)]
+pub(crate) struct SwitchArgs {
+    /// Branch name or shortcut
+    ///
+    /// Opens interactive picker if omitted.
+    /// Shortcuts: '^' (default branch), '-' (previous), '@' (current), 'pr:{N}' (GitHub PR), 'mr:{N}' (GitLab MR)
+    #[arg(add = crate::completion::worktree_branch_completer())]
+    pub(crate) branch: Option<String>,
+
+    /// Include branches without worktrees
+    #[arg(long, help_heading = "Picker Options", conflicts_with_all = ["create", "base", "execute", "execute_args", "clobber"])]
+    pub(crate) branches: bool,
+
+    /// Include remote branches
+    #[arg(long, help_heading = "Picker Options", conflicts_with_all = ["create", "base", "execute", "execute_args", "clobber"])]
+    pub(crate) remotes: bool,
+
+    /// Create a new branch
+    #[arg(short = 'c', long, requires = "branch")]
+    pub(crate) create: bool,
+
+    /// Base branch
+    ///
+    /// Defaults to default branch.
+    #[arg(short = 'b', long, requires = "branch", add = crate::completion::branch_value_completer())]
+    pub(crate) base: Option<String>,
+
+    /// Command to run after switch
+    ///
+    /// Replaces the wt process with the command after switching, giving
+    /// it full terminal control. Useful for launching editors, AI agents,
+    /// or other interactive tools.
+    ///
+    /// Supports [hook template variables](@/hook.md#template-variables)
+    /// (`{{ branch }}`, `{{ worktree_path }}`, etc.) and filters.
+    /// `{{ base }}` and `{{ base_worktree_path }}` require `--create`.
+    ///
+    /// Especially useful with shell aliases:
+    ///
+    /// ```sh
+    /// alias wsc='wt switch --create -x claude'
+    /// wsc feature-branch -- 'Fix GH #322'
+    /// ```
+    ///
+    /// Then `wsc feature-branch` creates the worktree and launches Claude
+    /// Code. Arguments after `--` are passed to the command, so
+    /// `wsc feature -- 'Fix GH #322'` runs `claude 'Fix GH #322'`,
+    /// starting Claude with a prompt.
+    ///
+    /// Template example: `-x 'code {{ worktree_path }}'` opens VS Code
+    /// at the worktree, `-x 'tmux new -s {{ branch | sanitize }}'` starts
+    /// a tmux session named after the branch.
+    #[arg(short = 'x', long, requires = "branch")]
+    pub(crate) execute: Option<String>,
+
+    /// Additional arguments for --execute command (after --)
+    ///
+    /// Arguments after `--` are appended to the execute command.
+    /// Each argument is expanded for templates, then POSIX shell-escaped.
+    #[arg(last = true, requires = "execute")]
+    pub(crate) execute_args: Vec<String>,
+
+    /// Remove stale paths at target
+    #[arg(long, requires = "branch")]
+    pub(crate) clobber: bool,
+
+    /// Skip directory change after switching
+    ///
+    /// Hooks still run normally. Useful when hooks handle navigation
+    /// (e.g., tmux workflows) or for CI/automation. Use --cd to override.
+    ///
+    /// In picker mode (no branch argument), prints the selected branch
+    /// name and exits without switching. Useful for scripting.
+    #[arg(long, overrides_with = "cd")]
+    pub(crate) no_cd: bool,
+
+    /// Change directory after switching
+    #[arg(long, overrides_with = "no_cd", hide = true)]
+    pub(crate) cd: bool,
+
+    /// Skip approval prompts
+    #[arg(short, long, help_heading = "Automation")]
+    pub(crate) yes: bool,
+
+    /// Skip hooks
+    #[arg(long = "no-hooks", action = clap::ArgAction::SetFalse, default_value_t = true, help_heading = "Automation")]
+    pub(crate) verify: bool,
+
+    /// Skip hooks (deprecated alias for --no-hooks)
+    #[arg(long = "no-verify", hide = true)]
+    pub(crate) no_verify_deprecated: bool,
+}
+
+#[derive(Args)]
+pub(crate) struct ListArgs {
+    #[command(subcommand)]
+    pub(crate) subcommand: Option<ListSubcommand>,
+
+    /// Output format (table, json)
+    #[arg(long, value_enum, default_value = "table", hide_possible_values = true)]
+    pub(crate) format: OutputFormat,
+
+    /// Include branches without worktrees
+    #[arg(long)]
+    pub(crate) branches: bool,
+
+    /// Include remote branches
+    #[arg(long)]
+    pub(crate) remotes: bool,
+
+    /// Show CI, diff analysis, and LLM summaries
+    #[arg(long)]
+    pub(crate) full: bool,
+
+    /// Show fast info immediately, update with slow info
+    ///
+    /// Displays local data (branches, paths, status) first, then updates
+    /// with remote data (CI, upstream) as it arrives. Use --no-progressive
+    /// to force buffered rendering. Auto-enabled for TTY.
+    #[arg(long, overrides_with = "no_progressive")]
+    pub(crate) progressive: bool,
+
+    /// Force buffered rendering
+    #[arg(long = "no-progressive", overrides_with = "progressive", hide = true)]
+    pub(crate) no_progressive: bool,
+}
+
+#[derive(Args)]
+pub(crate) struct RemoveArgs {
+    /// Branch name [default: current]
+    #[arg(add = crate::completion::local_branches_completer())]
+    pub(crate) branches: Vec<String>,
+
+    /// Keep branch after removal
+    #[arg(long = "no-delete-branch", action = clap::ArgAction::SetFalse, default_value_t = true)]
+    pub(crate) delete_branch: bool,
+
+    /// Delete unmerged branches
+    #[arg(short = 'D', long = "force-delete")]
+    pub(crate) force_delete: bool,
+
+    /// Run removal in foreground (block until complete)
+    #[arg(long)]
+    pub(crate) foreground: bool,
+
+    /// Skip approval prompts
+    #[arg(short, long, help_heading = "Automation")]
+    pub(crate) yes: bool,
+
+    /// Skip hooks
+    #[arg(long = "no-hooks", action = clap::ArgAction::SetFalse, default_value_t = true, help_heading = "Automation")]
+    pub(crate) verify: bool,
+
+    /// Skip hooks (deprecated alias for --no-hooks)
+    #[arg(long = "no-verify", hide = true)]
+    pub(crate) no_verify_deprecated: bool,
+
+    /// Force worktree removal
+    ///
+    /// Remove worktrees even if they contain untracked files (like build
+    /// artifacts). Without this flag, removal fails if untracked files exist.
+    #[arg(short, long)]
+    pub(crate) force: bool,
+}
+
+#[derive(Args)]
+pub(crate) struct MergeArgs {
+    /// Target branch
+    ///
+    /// Defaults to default branch.
+    #[arg(add = crate::completion::branch_value_completer())]
+    pub(crate) target: Option<String>,
+
+    /// Force commit squashing
+    #[arg(long, overrides_with = "no_squash", hide = true)]
+    pub(crate) squash: bool,
+
+    /// Skip commit squashing
+    #[arg(long = "no-squash", overrides_with = "squash")]
+    pub(crate) no_squash: bool,
+
+    /// Force commit and squash
+    #[arg(long, overrides_with = "no_commit", hide = true)]
+    pub(crate) commit: bool,
+
+    /// Skip commit and squash
+    #[arg(long = "no-commit", overrides_with = "commit")]
+    pub(crate) no_commit: bool,
+
+    /// Force rebasing onto target
+    #[arg(long, overrides_with = "no_rebase", hide = true)]
+    pub(crate) rebase: bool,
+
+    /// Skip rebase (fail if not already rebased)
+    #[arg(long = "no-rebase", overrides_with = "rebase")]
+    pub(crate) no_rebase: bool,
+
+    /// Force worktree removal after merge
+    #[arg(long, overrides_with = "no_remove", hide = true)]
+    pub(crate) remove: bool,
+
+    /// Keep worktree after merge
+    #[arg(long = "no-remove", overrides_with = "remove")]
+    pub(crate) no_remove: bool,
+
+    /// Create a merge commit (no fast-forward)
+    #[arg(long = "no-ff", overrides_with = "ff")]
+    pub(crate) no_ff: bool,
+
+    /// Allow fast-forward (default)
+    #[arg(long, overrides_with = "no_ff", hide = true)]
+    pub(crate) ff: bool,
+
+    /// Skip approval prompts
+    #[arg(short, long, help_heading = "Automation")]
+    pub(crate) yes: bool,
+
+    /// Force running hooks
+    #[arg(long, overrides_with_all = ["no_hooks", "no_verify"], hide = true)]
+    pub(crate) verify: bool,
+
+    /// Skip hooks
+    #[arg(
+        long = "no-hooks",
+        overrides_with_all = ["verify", "no_verify"],
+        help_heading = "Automation"
+    )]
+    pub(crate) no_hooks: bool,
+
+    /// Skip hooks (deprecated alias for --no-hooks)
+    #[arg(long = "no-verify", overrides_with_all = ["verify", "no_hooks"], hide = true)]
+    pub(crate) no_verify: bool,
+
+    /// What to stage before committing [default: all]
+    #[arg(long)]
+    pub(crate) stage: Option<crate::commands::commit::StageMode>,
+}
+
 #[derive(Subcommand)]
 pub(crate) enum Commands {
     /// Switch to a worktree; create if needed
@@ -379,97 +617,7 @@ To change which branch a worktree is on, use `git switch` inside that worktree.
 - [`wt merge`](@/merge.md) — Integrate changes back to the default branch
 "#
     )]
-    Switch {
-        /// Branch name or shortcut
-        ///
-        /// Opens interactive picker if omitted.
-        /// Shortcuts: '^' (default branch), '-' (previous), '@' (current), 'pr:{N}' (GitHub PR), 'mr:{N}' (GitLab MR)
-        #[arg(add = crate::completion::worktree_branch_completer())]
-        branch: Option<String>,
-
-        /// Include branches without worktrees
-        #[arg(long, help_heading = "Picker Options", conflicts_with_all = ["create", "base", "execute", "execute_args", "clobber"])]
-        branches: bool,
-
-        /// Include remote branches
-        #[arg(long, help_heading = "Picker Options", conflicts_with_all = ["create", "base", "execute", "execute_args", "clobber"])]
-        remotes: bool,
-
-        /// Create a new branch
-        #[arg(short = 'c', long, requires = "branch")]
-        create: bool,
-
-        /// Base branch
-        ///
-        /// Defaults to default branch.
-        #[arg(short = 'b', long, requires = "branch", add = crate::completion::branch_value_completer())]
-        base: Option<String>,
-
-        /// Command to run after switch
-        ///
-        /// Replaces the wt process with the command after switching, giving
-        /// it full terminal control. Useful for launching editors, AI agents,
-        /// or other interactive tools.
-        ///
-        /// Supports [hook template variables](@/hook.md#template-variables)
-        /// (`{{ branch }}`, `{{ worktree_path }}`, etc.) and filters.
-        /// `{{ base }}` and `{{ base_worktree_path }}` require `--create`.
-        ///
-        /// Especially useful with shell aliases:
-        ///
-        /// ```sh
-        /// alias wsc='wt switch --create -x claude'
-        /// wsc feature-branch -- 'Fix GH #322'
-        /// ```
-        ///
-        /// Then `wsc feature-branch` creates the worktree and launches Claude
-        /// Code. Arguments after `--` are passed to the command, so
-        /// `wsc feature -- 'Fix GH #322'` runs `claude 'Fix GH #322'`,
-        /// starting Claude with a prompt.
-        ///
-        /// Template example: `-x 'code {{ worktree_path }}'` opens VS Code
-        /// at the worktree, `-x 'tmux new -s {{ branch | sanitize }}'` starts
-        /// a tmux session named after the branch.
-        #[arg(short = 'x', long, requires = "branch")]
-        execute: Option<String>,
-
-        /// Additional arguments for --execute command (after --)
-        ///
-        /// Arguments after `--` are appended to the execute command.
-        /// Each argument is expanded for templates, then POSIX shell-escaped.
-        #[arg(last = true, requires = "execute")]
-        execute_args: Vec<String>,
-
-        /// Remove stale paths at target
-        #[arg(long, requires = "branch")]
-        clobber: bool,
-
-        /// Skip directory change after switching
-        ///
-        /// Hooks still run normally. Useful when hooks handle navigation
-        /// (e.g., tmux workflows) or for CI/automation. Use --cd to override.
-        ///
-        /// In picker mode (no branch argument), prints the selected branch
-        /// name and exits without switching. Useful for scripting.
-        #[arg(long, overrides_with = "cd")]
-        no_cd: bool,
-
-        /// Change directory after switching
-        #[arg(long, overrides_with = "no_cd", hide = true)]
-        cd: bool,
-
-        /// Skip approval prompts
-        #[arg(short, long, help_heading = "Automation")]
-        yes: bool,
-
-        /// Skip hooks
-        #[arg(long = "no-hooks", action = clap::ArgAction::SetFalse, default_value_t = true, help_heading = "Automation")]
-        verify: bool,
-
-        /// Skip hooks (deprecated alias for --no-hooks)
-        #[arg(long = "no-verify", hide = true)]
-        no_verify_deprecated: bool,
-    },
+    Switch(SwitchArgs),
 
     /// List worktrees and their status
     #[command(
@@ -730,38 +878,7 @@ Missing a field that would be generally useful? Open an issue at https://github.
     // Could fix with external_subcommand + post-parse validation, but not worth the
     // code. The `statusline` subcommand may move elsewhere anyway.
     #[command(args_conflicts_with_subcommands = true)]
-    List {
-        #[command(subcommand)]
-        subcommand: Option<ListSubcommand>,
-
-        /// Output format (table, json)
-        #[arg(long, value_enum, default_value = "table", hide_possible_values = true)]
-        format: OutputFormat,
-
-        /// Include branches without worktrees
-        #[arg(long)]
-        branches: bool,
-
-        /// Include remote branches
-        #[arg(long)]
-        remotes: bool,
-
-        /// Show CI, diff analysis, and LLM summaries
-        #[arg(long)]
-        full: bool,
-
-        /// Show fast info immediately, update with slow info
-        ///
-        /// Displays local data (branches, paths, status) first, then updates
-        /// with remote data (CI, upstream) as it arrives. Use --no-progressive
-        /// to force buffered rendering. Auto-enabled for TTY.
-        #[arg(long, overrides_with = "no_progressive")]
-        progressive: bool,
-
-        /// Force buffered rendering
-        #[arg(long = "no-progressive", overrides_with = "progressive", hide = true)]
-        no_progressive: bool,
-    },
+    List(ListArgs),
 
     /// Remove worktree; delete branch if merged
     ///
@@ -844,42 +961,7 @@ Detached worktrees have no branch name. Pass the worktree path instead: `wt remo
 - [`wt merge`](@/merge.md) — Remove worktree after merging
 - [`wt list`](@/list.md) — View all worktrees
 "#)]
-    Remove {
-        /// Branch name [default: current]
-        #[arg(add = crate::completion::local_branches_completer())]
-        branches: Vec<String>,
-
-        /// Keep branch after removal
-        #[arg(long = "no-delete-branch", action = clap::ArgAction::SetFalse, default_value_t = true)]
-        delete_branch: bool,
-
-        /// Delete unmerged branches
-        #[arg(short = 'D', long = "force-delete")]
-        force_delete: bool,
-
-        /// Run removal in foreground (block until complete)
-        #[arg(long)]
-        foreground: bool,
-
-        /// Skip approval prompts
-        #[arg(short, long, help_heading = "Automation")]
-        yes: bool,
-
-        /// Skip hooks
-        #[arg(long = "no-hooks", action = clap::ArgAction::SetFalse, default_value_t = true, help_heading = "Automation")]
-        verify: bool,
-
-        /// Skip hooks (deprecated alias for --no-hooks)
-        #[arg(long = "no-verify", hide = true)]
-        no_verify_deprecated: bool,
-
-        /// Force worktree removal
-        ///
-        /// Remove worktrees even if they contain untracked files (like build
-        /// artifacts). Without this flag, removal fails if untracked files exist.
-        #[arg(short, long)]
-        force: bool,
-    },
+    Remove(RemoveArgs),
 
     /// Merge current branch into the target branch
     ///
@@ -962,77 +1044,7 @@ lint = "cargo clippy"
 - [`wt switch`](@/switch.md) — Navigate to other worktrees
 "#
     )]
-    Merge {
-        /// Target branch
-        ///
-        /// Defaults to default branch.
-        #[arg(add = crate::completion::branch_value_completer())]
-        target: Option<String>,
-
-        /// Force commit squashing
-        #[arg(long, overrides_with = "no_squash", hide = true)]
-        squash: bool,
-
-        /// Skip commit squashing
-        #[arg(long = "no-squash", overrides_with = "squash")]
-        no_squash: bool,
-
-        /// Force commit and squash
-        #[arg(long, overrides_with = "no_commit", hide = true)]
-        commit: bool,
-
-        /// Skip commit and squash
-        #[arg(long = "no-commit", overrides_with = "commit")]
-        no_commit: bool,
-
-        /// Force rebasing onto target
-        #[arg(long, overrides_with = "no_rebase", hide = true)]
-        rebase: bool,
-
-        /// Skip rebase (fail if not already rebased)
-        #[arg(long = "no-rebase", overrides_with = "rebase")]
-        no_rebase: bool,
-
-        /// Force worktree removal after merge
-        #[arg(long, overrides_with = "no_remove", hide = true)]
-        remove: bool,
-
-        /// Keep worktree after merge
-        #[arg(long = "no-remove", overrides_with = "remove")]
-        no_remove: bool,
-
-        /// Create a merge commit (no fast-forward)
-        #[arg(long = "no-ff", overrides_with = "ff")]
-        no_ff: bool,
-
-        /// Allow fast-forward (default)
-        #[arg(long, overrides_with = "no_ff", hide = true)]
-        ff: bool,
-
-        /// Skip approval prompts
-        #[arg(short, long, help_heading = "Automation")]
-        yes: bool,
-
-        /// Force running hooks
-        #[arg(long, overrides_with_all = ["no_hooks", "no_verify"], hide = true)]
-        verify: bool,
-
-        /// Skip hooks
-        #[arg(
-            long = "no-hooks",
-            overrides_with_all = ["verify", "no_verify"],
-            help_heading = "Automation"
-        )]
-        no_hooks: bool,
-
-        /// Skip hooks (deprecated alias for --no-hooks)
-        #[arg(long = "no-verify", overrides_with_all = ["verify", "no_hooks"], hide = true)]
-        no_verify: bool,
-
-        /// What to stage before committing [default: all]
-        #[arg(long)]
-        stage: Option<crate::commands::commit::StageMode>,
-    },
+    Merge(MergeArgs),
     /// Deprecated: use `wt switch` instead
     ///
     /// Interactive worktree picker (now integrated into `wt switch`).

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,8 +63,8 @@ use output::handle_remove_output;
 use cli::{
     ApprovalsCommand, CiStatusAction, Cli, Commands, ConfigCommand, ConfigPluginsClaudeCommand,
     ConfigPluginsCommand, ConfigPluginsOpencodeCommand, ConfigShellCommand, DefaultBranchAction,
-    HintsAction, HookCommand, ListSubcommand, LogsAction, MarkerAction, PreviousBranchAction,
-    StateCommand, StepCommand, VarsAction,
+    HintsAction, HookCommand, ListArgs, ListSubcommand, LogsAction, MarkerAction, MergeArgs,
+    PreviousBranchAction, RemoveArgs, StateCommand, StepCommand, SwitchArgs, VarsAction,
 };
 use worktrunk::HookType;
 
@@ -513,16 +513,8 @@ fn handle_plugins_command(action: ConfigPluginsCommand) -> anyhow::Result<()> {
     }
 }
 
-fn handle_list_command(
-    subcommand: Option<ListSubcommand>,
-    format: OutputFormat,
-    branches: bool,
-    remotes: bool,
-    full: bool,
-    progressive: bool,
-    no_progressive: bool,
-) -> anyhow::Result<()> {
-    match subcommand {
+fn handle_list_command(args: ListArgs) -> anyhow::Result<()> {
+    match args.subcommand {
         Some(ListSubcommand::Statusline {
             format,
             claude_code,
@@ -538,8 +530,15 @@ fn handle_list_command(
         }
         None => {
             let (repo, _recovered) = current_or_recover()?;
-            let render_mode = RenderMode::detect(flag_pair(progressive, no_progressive));
-            handle_list(repo, format, branches, remotes, full, render_mode)
+            let render_mode = RenderMode::detect(flag_pair(args.progressive, args.no_progressive));
+            handle_list(
+                repo,
+                args.format,
+                args.branches,
+                args.remotes,
+                args.full,
+                render_mode,
+            )
         }
     }
 }
@@ -559,39 +558,25 @@ fn handle_select_command(_branches: bool, _remotes: bool) -> anyhow::Result<()> 
     Err(WorktrunkError::AlreadyDisplayed { exit_code: 1 }.into())
 }
 
-struct SwitchCommandArgs {
-    branch: Option<String>,
-    branches: bool,
-    remotes: bool,
-    create: bool,
-    base: Option<String>,
-    execute: Option<String>,
-    execute_args: Vec<String>,
-    yes: bool,
-    clobber: bool,
-    cd: bool,
-    no_cd: bool,
-    verify: bool,
-}
-
-fn handle_switch_command(spec: SwitchCommandArgs) -> anyhow::Result<()> {
+fn handle_switch_command(args: SwitchArgs) -> anyhow::Result<()> {
+    let verify = resolve_verify(args.verify, args.no_verify_deprecated);
     UserConfig::load()
         .context("Failed to load config")
         .and_then(|mut config| {
             // No branch argument: open interactive picker
-            let change_dir_flag = flag_pair(spec.cd, spec.no_cd);
+            let change_dir_flag = flag_pair(args.cd, args.no_cd);
 
-            let Some(branch) = spec.branch else {
+            let Some(branch) = args.branch else {
                 #[cfg(unix)]
                 {
-                    return handle_picker(spec.branches, spec.remotes, change_dir_flag);
+                    return handle_picker(args.branches, args.remotes, change_dir_flag);
                 }
 
                 #[cfg(not(unix))]
                 {
                     use worktrunk::git::WorktrunkError;
                     // Suppress unused variable warnings on Windows
-                    let _ = (spec.branches, spec.remotes, change_dir_flag);
+                    let _ = (args.branches, args.remotes, change_dir_flag);
 
                     print_windows_picker_unavailable();
                     return Err(WorktrunkError::AlreadyDisplayed { exit_code: 2 }.into());
@@ -601,29 +586,19 @@ fn handle_switch_command(spec: SwitchCommandArgs) -> anyhow::Result<()> {
             handle_switch(
                 SwitchOptions {
                     branch: &branch,
-                    create: spec.create,
-                    base: spec.base.as_deref(),
-                    execute: spec.execute.as_deref(),
-                    execute_args: &spec.execute_args,
-                    yes: spec.yes,
-                    clobber: spec.clobber,
+                    create: args.create,
+                    base: args.base.as_deref(),
+                    execute: args.execute.as_deref(),
+                    execute_args: &args.execute_args,
+                    yes: args.yes,
+                    clobber: args.clobber,
                     change_dir: change_dir_flag,
-                    verify: spec.verify,
+                    verify,
                 },
                 &mut config,
                 &binary_name(),
             )
         })
-}
-
-struct RemoveCommandArgs {
-    branches: Vec<String>,
-    delete_branch: bool,
-    force_delete: bool,
-    foreground: bool,
-    verify: bool,
-    yes: bool,
-    force: bool,
 }
 
 /// Validated removal plans, categorized for ordered execution.
@@ -745,12 +720,13 @@ fn validate_remove_targets(
     plans
 }
 
-fn handle_remove_command(spec: RemoveCommandArgs) -> anyhow::Result<()> {
+fn handle_remove_command(args: RemoveArgs) -> anyhow::Result<()> {
+    let verify = resolve_verify(args.verify, args.no_verify_deprecated);
     UserConfig::load()
         .context("Failed to load config")
         .and_then(|config| {
             // Validate conflicting flags
-            if !spec.delete_branch && spec.force_delete {
+            if !args.delete_branch && args.force_delete {
                 return Err(worktrunk::git::GitError::Other {
                     message: "Cannot use --force-delete with --no-delete-branch".into(),
                 }
@@ -790,15 +766,15 @@ fn handle_remove_command(spec: RemoveCommandArgs) -> anyhow::Result<()> {
                 Ok(approved)
             };
 
-            let branches = spec.branches;
+            let branches = args.branches;
 
             if branches.is_empty() {
                 // Single worktree removal: validate FIRST, then approve, then execute
                 let result = repo
                     .prepare_worktree_removal(
                         RemoveTarget::Current,
-                        BranchDeletionMode::from_flags(!spec.delete_branch, spec.force_delete),
-                        spec.force,
+                        BranchDeletionMode::from_flags(!args.delete_branch, args.force_delete),
+                        args.force,
                         &config,
                         None,
                     )
@@ -810,18 +786,18 @@ fn handle_remove_command(spec: RemoveCommandArgs) -> anyhow::Result<()> {
                 }
 
                 // "Approve at the Gate": approval happens AFTER validation passes
-                let run_hooks = spec.verify && approve_remove(spec.yes)?;
+                let run_hooks = verify && approve_remove(args.yes)?;
 
-                handle_remove_output(&result, spec.foreground, run_hooks, false)
+                handle_remove_output(&result, args.foreground, run_hooks, false)
             } else {
                 // Multi-worktree removal: validate ALL first, then approve, then execute
                 let plans = validate_remove_targets(
                     &repo,
                     branches,
                     &config,
-                    !spec.delete_branch,
-                    spec.force_delete,
-                    spec.force,
+                    !args.delete_branch,
+                    args.force_delete,
+                    args.force,
                 );
 
                 if !plans.has_valid_plans() {
@@ -836,17 +812,17 @@ fn handle_remove_command(spec: RemoveCommandArgs) -> anyhow::Result<()> {
                 // Approve hooks (only if we have valid plans)
                 // TODO(pre-remove-context): Approval context uses current worktree,
                 // but hooks execute in each target worktree.
-                let run_hooks = spec.verify && approve_remove(spec.yes)?;
+                let run_hooks = verify && approve_remove(args.yes)?;
 
                 // Execute all validated plans: others first, branch-only next, current last
                 for result in plans.others {
-                    handle_remove_output(&result, spec.foreground, run_hooks, false)?;
+                    handle_remove_output(&result, args.foreground, run_hooks, false)?;
                 }
                 for result in plans.branch_only {
-                    handle_remove_output(&result, spec.foreground, run_hooks, false)?;
+                    handle_remove_output(&result, args.foreground, run_hooks, false)?;
                 }
                 if let Some(result) = plans.current {
-                    handle_remove_output(&result, spec.foreground, run_hooks, false)?;
+                    handle_remove_output(&result, args.foreground, run_hooks, false)?;
                 }
 
                 if !plans.errors.is_empty() {
@@ -994,112 +970,36 @@ fn init_logging(verbose_level: u8) {
         .init();
 }
 
+fn handle_merge_command(args: MergeArgs) -> anyhow::Result<()> {
+    if args.no_verify {
+        eprintln!(
+            "{}",
+            warning_message("--no-verify is deprecated; use --no-hooks instead")
+        );
+    }
+    handle_merge(MergeOptions {
+        target: args.target.as_deref(),
+        squash: flag_pair(args.squash, args.no_squash),
+        commit: flag_pair(args.commit, args.no_commit),
+        rebase: flag_pair(args.rebase, args.no_rebase),
+        remove: flag_pair(args.remove, args.no_remove),
+        ff: flag_pair(args.ff, args.no_ff),
+        verify: flag_pair(args.verify, args.no_hooks || args.no_verify),
+        yes: args.yes,
+        stage: args.stage,
+    })
+}
+
 fn dispatch_command(command: Commands) -> anyhow::Result<()> {
     match command {
         Commands::Config { action } => handle_config_command(action),
         Commands::Step { action } => handle_step_command(action),
         Commands::Hook { action } => handle_hook_command(action),
         Commands::Select { branches, remotes } => handle_select_command(branches, remotes),
-        Commands::List {
-            subcommand,
-            format,
-            branches,
-            remotes,
-            full,
-            progressive,
-            no_progressive,
-        } => handle_list_command(
-            subcommand,
-            format,
-            branches,
-            remotes,
-            full,
-            progressive,
-            no_progressive,
-        ),
-        Commands::Switch {
-            branch,
-            branches,
-            remotes,
-            create,
-            base,
-            execute,
-            execute_args,
-            yes,
-            clobber,
-            cd,
-            no_cd,
-            verify,
-            no_verify_deprecated,
-        } => handle_switch_command(SwitchCommandArgs {
-            branch,
-            branches,
-            remotes,
-            create,
-            base,
-            execute,
-            execute_args,
-            yes,
-            clobber,
-            cd,
-            no_cd,
-            verify: resolve_verify(verify, no_verify_deprecated),
-        }),
-        Commands::Remove {
-            branches,
-            delete_branch,
-            force_delete,
-            foreground,
-            verify,
-            no_verify_deprecated,
-            yes,
-            force,
-        } => handle_remove_command(RemoveCommandArgs {
-            branches,
-            delete_branch,
-            force_delete,
-            foreground,
-            verify: resolve_verify(verify, no_verify_deprecated),
-            yes,
-            force,
-        }),
-        Commands::Merge {
-            target,
-            squash,
-            no_squash,
-            commit,
-            no_commit,
-            rebase,
-            no_rebase,
-            remove,
-            no_remove,
-            no_ff,
-            ff,
-            verify,
-            no_hooks,
-            no_verify,
-            yes,
-            stage,
-        } => {
-            // Merge uses flag_pair, so resolve_verify doesn't apply directly
-            if no_verify {
-                eprintln!(
-                    "{}",
-                    warning_message("--no-verify is deprecated; use --no-hooks instead")
-                );
-            }
-            handle_merge(MergeOptions {
-                target: target.as_deref(),
-                squash: flag_pair(squash, no_squash),
-                commit: flag_pair(commit, no_commit),
-                rebase: flag_pair(rebase, no_rebase),
-                remove: flag_pair(remove, no_remove),
-                ff: flag_pair(ff, no_ff),
-                verify: flag_pair(verify, no_hooks || no_verify),
-                yes,
-                stage,
-            })
-        }
+        Commands::List(args) => handle_list_command(args),
+        Commands::Switch(args) => handle_switch_command(args),
+        Commands::Remove(args) => handle_remove_command(args),
+        Commands::Merge(args) => handle_merge_command(args),
     }
 }
 


### PR DESCRIPTION
Move field definitions from inline `Commands` enum variants to `#[derive(clap::Args)]` structs (`SwitchArgs`, `ListArgs`, `RemoveArgs`, `MergeArgs`). Enum variants become tuple variants, turning `dispatch_command` from 107 lines of destructure-and-reconstruct boilerplate into 11 lines of direct forwarding.

Handlers now accept the clap Args structs directly — `SwitchCommandArgs` and `RemoveCommandArgs` intermediate structs are eliminated. `resolve_verify` and `flag_pair` transformations move into their respective handlers.

Help text is unchanged (all 38 snapshot tests pass).

> _This was written by Claude Code on behalf of @max-sixty_