### PR TITLE
refactor: simplify copy_leaf and add file count test

### DIFF
--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -819,13 +819,7 @@ pub fn step_copy_ignored(
                     )
                 })?;
             }
-            let is_symlink = fs::symlink_metadata(src_entry)
-                .with_context(|| {
-                    format!("reading metadata for {}", format_path_for_display(relative))
-                })?
-                .file_type()
-                .is_symlink();
-            if copy_leaf(src_entry, &dest_entry, is_symlink, force)? {
+            if copy_leaf(src_entry, &dest_entry, force)? {
                 copied_count += 1;
             }
         }

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -51,10 +51,10 @@ pub fn lower_process_priority() {
 
 /// Copy a single file or symlink, using reflink (COW) when possible.
 ///
-/// Returns `true` if the entry was copied, `false` if skipped (destination
-/// already exists). When `force` is true, existing entries are removed before
-/// copying.
-pub fn copy_leaf(src: &Path, dest: &Path, is_symlink: bool, force: bool) -> anyhow::Result<bool> {
+/// Detects symlinks via `symlink_metadata` on the source. Returns `true` if
+/// the entry was copied, `false` if skipped (destination already exists).
+/// When `force` is true, existing entries are removed before copying.
+pub fn copy_leaf(src: &Path, dest: &Path, force: bool) -> anyhow::Result<bool> {
     if force {
         remove_if_exists(dest)?;
     }
@@ -63,6 +63,12 @@ pub fn copy_leaf(src: &Path, dest: &Path, is_symlink: bool, force: bool) -> anyh
     if dest.symlink_metadata().is_ok() {
         return Ok(false);
     }
+
+    let is_symlink = src
+        .symlink_metadata()
+        .with_context(|| format!("reading metadata for {}", src.display()))?
+        .file_type()
+        .is_symlink();
 
     if is_symlink {
         let target =
@@ -84,7 +90,6 @@ pub fn copy_leaf(src: &Path, dest: &Path, is_symlink: bool, force: bool) -> anyh
 struct CopyLeaf {
     src: PathBuf,
     dest: PathBuf,
-    is_symlink: bool,
 }
 
 /// Copy a directory tree using reflink (COW) per file.
@@ -123,7 +128,6 @@ pub fn copy_dir_recursive(src: &Path, dest: &Path, force: bool) -> anyhow::Resul
                 leaves.push(CopyLeaf {
                     src: src_path,
                     dest: dest_path,
-                    is_symlink: file_type.is_symlink(),
                 });
             } else {
                 log::debug!("skipping non-regular file: {}", src_path.display());
@@ -137,7 +141,7 @@ pub fn copy_dir_recursive(src: &Path, dest: &Path, force: bool) -> anyhow::Resul
         leaves
             .par_iter()
             .try_for_each(|leaf| -> anyhow::Result<()> {
-                if copy_leaf(&leaf.src, &leaf.dest, leaf.is_symlink, force)? {
+                if copy_leaf(&leaf.src, &leaf.dest, force)? {
                     copied.fetch_add(1, Ordering::Relaxed);
                 }
                 Ok(())

--- a/tests/integration_tests/step_copy_ignored.rs
+++ b/tests/integration_tests/step_copy_ignored.rs
@@ -828,6 +828,27 @@ fn test_copy_ignored_verbose_directory(mut repo: TestRepo) {
     );
 }
 
+#[rstest]
+fn test_copy_ignored_counts_files_not_entries(mut repo: TestRepo) {
+    let feature_path = repo.add_worktree("feature");
+
+    // Create a directory with multiple files — the summary should count
+    // individual files, not top-level entries.
+    let target_dir = repo.root_path().join("target");
+    fs::create_dir_all(target_dir.join("debug/deps")).unwrap();
+    fs::write(target_dir.join("debug/output"), "bin1").unwrap();
+    fs::write(target_dir.join("debug/deps/libfoo.rlib"), "lib").unwrap();
+    fs::write(target_dir.join("debug/deps/libbar.rlib"), "lib").unwrap();
+    fs::write(repo.root_path().join(".gitignore"), "target/\n").unwrap();
+
+    assert_cmd_snapshot!(make_snapshot_cmd(
+        &repo,
+        "step",
+        &["copy-ignored"],
+        Some(&feature_path),
+    ));
+}
+
 /// Test idempotent behavior with broken symlinks after interrupted copy (GitHub issue #1084)
 ///
 /// When ctrl+c interrupts a copy, broken symlinks may remain at the destination.

--- a/tests/snapshots/integration__integration_tests__step_copy_ignored__copy_ignored_counts_files_not_entries.snap
+++ b/tests/snapshots/integration__integration_tests__step_copy_ignored__copy_ignored_counts_files_not_entries.snap
@@ -1,0 +1,47 @@
+---
+source: tests/integration_tests/step_copy_ignored.rs
+info:
+  program: wt
+  args:
+    - step
+    - copy-ignored
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[32m✓[39m [32mCopied 3 files[39m


### PR DESCRIPTION
Follow-up to #1931. Two small improvements:

- **Move symlink detection into `copy_leaf`** — `copy_leaf` now calls `symlink_metadata` on the source internally instead of requiring callers to pass `is_symlink`. This removes duplicated metadata inspection from `step_copy_ignored` and drops the `is_symlink` field from the internal `CopyLeaf` struct.
- **Add `test_copy_ignored_counts_files_not_entries`** — Creates a directory with 3 files and verifies the summary says "Copied 3 files", not "Copied 1 entry". All existing tests happened to have 1 file per entry, so old and new counts were indistinguishable.

> _This was written by Claude Code on behalf of Maximilian Roos_