### PR TITLE
Simplify wt-perf truncate to plain ASCII slicing

### DIFF
--- a/tests/helpers/wt-perf/src/main.rs
+++ b/tests/helpers/wt-perf/src/main.rs
@@ -252,16 +252,12 @@ To capture traces, run with RUST_LOG=debug:
     entries
 }
 
-/// Truncate a string for display, respecting UTF-8 char boundaries.
+/// Truncate an ASCII string for display, appending "..." if it exceeds `max` chars.
 fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
         s.to_string()
     } else {
-        let mut boundary = max - 3;
-        while !s.is_char_boundary(boundary) {
-            boundary -= 1;
-        }
-        format!("{}...", &s[..boundary])
+        format!("{}...", &s[..max - 3])
     }
 }
 


### PR DESCRIPTION
The `truncate` function in wt-perf processes git command strings, which are always ASCII. The UTF-8 char boundary walk (originally `floor_char_boundary`, then a manual loop) was unnecessary — plain byte slicing is safe and direct.

> _This was written by Claude Code on behalf of @max-sixty_