### PR TITLE
refactor: extract StepCommand::Commit and Squash into Args structs

### DIFF
--- a/src/cli/step.rs
+++ b/src/cli/step.rs
@@ -1,4 +1,64 @@
-use clap::Subcommand;
+use clap::{Args, Subcommand};
+
+#[derive(Args)]
+pub struct CommitArgs {
+    /// Branch to operate on (defaults to current worktree)
+    #[arg(short, long, add = crate::completion::worktree_only_completer())]
+    pub(crate) branch: Option<String>,
+
+    /// Skip approval prompts
+    #[arg(short, long, help_heading = "Automation")]
+    pub(crate) yes: bool,
+
+    /// Skip hooks
+    #[arg(long = "no-hooks", action = clap::ArgAction::SetFalse, default_value_t = true, help_heading = "Automation")]
+    pub(crate) verify: bool,
+
+    /// Skip hooks (deprecated alias for --no-hooks)
+    #[arg(long = "no-verify", hide = true)]
+    pub(crate) no_verify_deprecated: bool,
+
+    /// What to stage before committing [default: all]
+    #[arg(long)]
+    pub(crate) stage: Option<crate::commands::commit::StageMode>,
+
+    /// Show prompt without running LLM
+    ///
+    /// Outputs the rendered prompt to stdout for debugging or manual piping.
+    #[arg(long)]
+    pub(crate) show_prompt: bool,
+}
+
+#[derive(Args)]
+pub struct SquashArgs {
+    /// Target branch
+    ///
+    /// Defaults to default branch.
+    #[arg(add = crate::completion::branch_value_completer())]
+    pub(crate) target: Option<String>,
+
+    /// Skip approval prompts
+    #[arg(short, long, help_heading = "Automation")]
+    pub(crate) yes: bool,
+
+    /// Skip hooks
+    #[arg(long = "no-hooks", action = clap::ArgAction::SetFalse, default_value_t = true, help_heading = "Automation")]
+    pub(crate) verify: bool,
+
+    /// Skip hooks (deprecated alias for --no-hooks)
+    #[arg(long = "no-verify", hide = true)]
+    pub(crate) no_verify_deprecated: bool,
+
+    /// What to stage before committing [default: all]
+    #[arg(long)]
+    pub(crate) stage: Option<crate::commands::commit::StageMode>,
+
+    /// Show prompt without running LLM
+    ///
+    /// Outputs the rendered prompt to stdout for debugging or manual piping.
+    #[arg(long)]
+    pub(crate) show_prompt: bool,
+}
 
 /// Run individual operations
 #[derive(Subcommand)]
@@ -44,33 +104,7 @@ $ wt step commit --show-prompt | llm -m gpt-5-nano
 ```
 "#
     )]
-    Commit {
-        /// Branch to operate on (defaults to current worktree)
-        #[arg(short, long, add = crate::completion::worktree_only_completer())]
-        branch: Option<String>,
-
-        /// Skip approval prompts
-        #[arg(short, long, help_heading = "Automation")]
-        yes: bool,
-
-        /// Skip hooks
-        #[arg(long = "no-hooks", action = clap::ArgAction::SetFalse, default_value_t = true, help_heading = "Automation")]
-        verify: bool,
-
-        /// Skip hooks (deprecated alias for --no-hooks)
-        #[arg(long = "no-verify", hide = true)]
-        no_verify_deprecated: bool,
-
-        /// What to stage before committing [default: all]
-        #[arg(long)]
-        stage: Option<crate::commands::commit::StageMode>,
-
-        /// Show prompt without running LLM
-        ///
-        /// Outputs the rendered prompt to stdout for debugging or manual piping.
-        #[arg(long)]
-        show_prompt: bool,
-    },
+    Commit(CommitArgs),
 
     /// Squash commits since branching
     ///
@@ -110,35 +144,7 @@ $ wt step squash --show-prompt | less
 ```
 "#
     )]
-    Squash {
-        /// Target branch
-        ///
-        /// Defaults to default branch.
-        #[arg(add = crate::completion::branch_value_completer())]
-        target: Option<String>,
-
-        /// Skip approval prompts
-        #[arg(short, long, help_heading = "Automation")]
-        yes: bool,
-
-        /// Skip hooks
-        #[arg(long = "no-hooks", action = clap::ArgAction::SetFalse, default_value_t = true, help_heading = "Automation")]
-        verify: bool,
-
-        /// Skip hooks (deprecated alias for --no-hooks)
-        #[arg(long = "no-verify", hide = true)]
-        no_verify_deprecated: bool,
-
-        /// What to stage before committing [default: all]
-        #[arg(long)]
-        stage: Option<crate::commands::commit::StageMode>,
-
-        /// Show prompt without running LLM
-        ///
-        /// Outputs the rendered prompt to stdout for debugging or manual piping.
-        #[arg(long)]
-        show_prompt: bool,
-    },
+    Squash(SquashArgs),
 
     /// Fast-forward target to current branch
     #[command(

--- a/src/main.rs
+++ b/src/main.rs
@@ -272,46 +272,34 @@ fn handle_hook_command(action: HookCommand) -> anyhow::Result<()> {
 
 fn handle_step_command(action: StepCommand) -> anyhow::Result<()> {
     match action {
-        StepCommand::Commit {
-            branch,
-            yes,
-            verify,
-            no_verify_deprecated,
-            stage,
-            show_prompt,
-        } => {
-            let verify = resolve_verify(verify, no_verify_deprecated);
-            step_commit(branch, yes, verify, stage, show_prompt)
+        StepCommand::Commit(args) => {
+            let verify = resolve_verify(args.verify, args.no_verify_deprecated);
+            step_commit(args.branch, args.yes, verify, args.stage, args.show_prompt)
         }
-        StepCommand::Squash {
-            target,
-            yes,
-            verify,
-            no_verify_deprecated,
-            stage,
-            show_prompt,
-        } => {
-            let verify = resolve_verify(verify, no_verify_deprecated);
+        StepCommand::Squash(args) => {
+            let verify = resolve_verify(args.verify, args.no_verify_deprecated);
             // Handle --show-prompt early: just build and output the prompt
-            if show_prompt {
-                commands::step_show_squash_prompt(target.as_deref())
+            if args.show_prompt {
+                commands::step_show_squash_prompt(args.target.as_deref())
             } else {
                 // Approval is handled inside handle_squash (like step_commit)
-                handle_squash(target.as_deref(), yes, verify, stage).map(|result| match result {
-                    SquashResult::Squashed | SquashResult::NoNetChanges => {}
-                    SquashResult::NoCommitsAhead(branch) => {
-                        eprintln!(
-                            "{}",
-                            info_message(format!(
-                                "Nothing to squash; no commits ahead of {branch}"
-                            ))
-                        );
-                    }
-                    SquashResult::AlreadySingleCommit => {
-                        eprintln!(
-                            "{}",
-                            info_message("Nothing to squash; already a single commit")
-                        );
+                handle_squash(args.target.as_deref(), args.yes, verify, args.stage).map(|result| {
+                    match result {
+                        SquashResult::Squashed | SquashResult::NoNetChanges => {}
+                        SquashResult::NoCommitsAhead(branch) => {
+                            eprintln!(
+                                "{}",
+                                info_message(format!(
+                                    "Nothing to squash; no commits ahead of {branch}"
+                                ))
+                            );
+                        }
+                        SquashResult::AlreadySingleCommit => {
+                            eprintln!(
+                                "{}",
+                                info_message("Nothing to squash; already a single commit")
+                            );
+                        }
                     }
                 })
             }


### PR DESCRIPTION
Same pattern as #1949 — move field definitions from inline enum variants to `#[derive(clap::Args)]` structs (`CommitArgs`, `SquashArgs`) and use tuple variants. Eliminates the 6-field destructure-and-reconstruct in `handle_step_command` for these two variants.

> _This was written by Claude Code on behalf of @max-sixty_