### PR TITLE
feat: structured JSON output for wt-perf cache-check

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3268,6 +3268,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "dunce",
+ "serde_json",
  "tempfile",
  "worktrunk",
 ]

--- a/tests/helpers/wt-perf/Cargo.toml
+++ b/tests/helpers/wt-perf/Cargo.toml
@@ -18,6 +18,9 @@ dunce = "1"
 # For CLI
 clap = { version = "4", features = ["derive"] }
 
+# For JSON output
+serde_json = "1"
+
 # For trace parsing (reuse worktrunk's trace module)
 worktrunk = { path = "../../.." }
 

--- a/tests/helpers/wt-perf/src/main.rs
+++ b/tests/helpers/wt-perf/src/main.rs
@@ -265,12 +265,10 @@ fn truncate(s: &str, max: usize) -> String {
     }
 }
 
-/// Analyze trace entries for cache effectiveness and report findings.
+/// Analyze trace entries for cache effectiveness.
 ///
-/// Two analyses:
-/// 1. Same-context duplicates — commands that ran multiple times for the
-///    same worktree, indicating missing or bypassed caches
-/// 2. Summary — total commands, unique commands, duplicate counts
+/// Outputs structured JSON to stdout (composable with jq) and a human-readable
+/// report to stderr.
 fn cache_check(entries: &[worktrunk::trace::TraceEntry]) {
     use std::collections::{BTreeMap, HashMap, HashSet};
     use worktrunk::trace::TraceEntryKind;
@@ -290,7 +288,7 @@ fn cache_check(entries: &[worktrunk::trace::TraceEntry]) {
         }
     }
 
-    // === Same-context duplicates ===
+    // Build structured duplicates list
     let mut cmd_ctx_info: BTreeMap<&str, Vec<(&str, usize)>> = BTreeMap::new();
     for ((cmd, ctx), count) in &pair_counts {
         if *count > 1 {
@@ -298,56 +296,69 @@ fn cache_check(entries: &[worktrunk::trace::TraceEntry]) {
         }
     }
 
+    // Build JSON output
+    let mut duplicates = Vec::new();
+    let mut total_extra = 0usize;
+    for (cmd, ctx_list) in &cmd_ctx_info {
+        let max_count = *ctx_list.iter().map(|(_, c)| c).max().unwrap();
+        let extra: usize = ctx_list.iter().map(|(_, c)| c - 1).sum();
+        total_extra += extra;
+        let contexts: Vec<_> = ctx_list
+            .iter()
+            .map(|(ctx, count)| serde_json::json!({"context": ctx, "count": count}))
+            .collect();
+        duplicates.push(serde_json::json!({
+            "command": cmd,
+            "max_per_context": max_count,
+            "extra_calls": extra,
+            "contexts": contexts,
+        }));
+    }
+    duplicates.sort_by(|a, b| {
+        b["max_per_context"]
+            .as_u64()
+            .cmp(&a["max_per_context"].as_u64())
+    });
+
+    let dup_count = cmd_counts.values().filter(|c| **c > 1).count();
+    let dup_total: usize = cmd_counts.values().filter(|c| **c > 1).map(|c| c - 1).sum();
+
+    let output = serde_json::json!({
+        "total_commands": total_commands,
+        "unique_commands": cmd_counts.len(),
+        "contexts": contexts.len(),
+        "duplicated_commands": dup_count,
+        "total_extra_calls": dup_total,
+        "same_context_duplicates": duplicates,
+        "same_context_extra_calls": total_extra,
+    });
+    println!("{}", serde_json::to_string_pretty(&output).unwrap());
+
+    // Human-readable report to stderr
     if !cmd_ctx_info.is_empty() {
-        println!(
+        eprintln!(
             "\
 === Same-context duplicates (potential cache misses) ===
-
-Commands that ran multiple times for the SAME worktree.
-These are the strongest signal of missing/bypassed caches.
 "
         );
-
-        let mut sorted: Vec<_> = cmd_ctx_info.iter().collect();
-        sorted.sort_by(|a, b| {
-            let max_a = a.1.iter().map(|(_, c)| c).max().unwrap();
-            let max_b = b.1.iter().map(|(_, c)| c).max().unwrap();
-            max_b.cmp(max_a)
-        });
-
-        let mut total_wasted = 0usize;
-        for (cmd, ctx_list) in &sorted {
-            let max_count = ctx_list.iter().map(|(_, c)| c).max().unwrap();
-            let extra: usize = ctx_list.iter().map(|(_, c)| c - 1).sum();
-            total_wasted += extra;
-            println!(
-                "  {} (max {}x/context, {} extra calls)",
-                truncate(cmd, 70),
-                max_count,
-                extra
+        for dup in &duplicates {
+            eprintln!(
+                "  {} (max {}x/context, {} extra)",
+                truncate(dup["command"].as_str().unwrap(), 70),
+                dup["max_per_context"],
+                dup["extra_calls"]
             );
-            let mut sorted_ctx: Vec<_> = ctx_list.to_vec();
-            sorted_ctx.sort_by(|a, b| b.1.cmp(&a.1));
-            for (ctx, count) in sorted_ctx.iter().take(3) {
-                println!("      {}x in [{}]", count, ctx);
-            }
-            if sorted_ctx.len() > 3 {
-                println!("      ... and {} more contexts", sorted_ctx.len() - 3);
-            }
         }
-        println!();
-        println!("  Total extra calls from same-context duplicates: {total_wasted}");
+        eprintln!();
+        eprintln!("  Total extra calls: {total_extra}");
     }
 
-    // === Summary ===
-    let dup_count: usize = cmd_counts.values().filter(|c| **c > 1).count();
-    let dup_total: usize = cmd_counts.values().filter(|c| **c > 1).map(|c| c - 1).sum();
-    println!(
+    eprintln!(
         "\
 \n=== Summary ===
 
-  {total_commands} commands total, {} unique, {} contexts
-  {dup_count} commands ran more than once ({dup_total} extra calls)",
+  {total_commands} commands, {} unique, {} contexts
+  {dup_count} duplicated ({dup_total} extra calls)",
         cmd_counts.len(),
         contexts.len()
     );


### PR DESCRIPTION
`wt-perf cache-check` now outputs structured JSON to stdout (composable with `jq`) and keeps the human-readable summary on stderr.

```bash
# Pipe to jq for specific queries
RUST_LOG=debug wt list 2>&1 | grep wt-trace | wt-perf cache-check 2>/dev/null | jq '.same_context_duplicates[:3]'

# Human report still visible by default (stderr)
RUST_LOG=debug wt list 2>&1 | grep wt-trace | wt-perf cache-check > /dev/null
```

> _This was written by Claude Code on behalf of Maximilian Roos_