### PR TITLE
refactor: use copy_leaf in cross-device move fallback

### DIFF
--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -900,11 +900,7 @@ fn copy_and_remove(src: &Path, dest: &Path, is_dir: bool) -> anyhow::Result<()> 
         copy_dir_recursive(src, dest, true)?;
         fs::remove_dir_all(src).context(format!("removing source directory {}", src.display()))?;
     } else {
-        reflink_copy::reflink_or_copy(src, dest).context(format!(
-            "copying {} to {}",
-            src.display(),
-            dest.display()
-        ))?;
+        copy_leaf(src, dest, true)?;
         fs::remove_file(src).context(format!("removing source file {}", src.display()))?;
     }
     Ok(())


### PR DESCRIPTION
The `copy_and_remove` fallback (used by `step_promote` when moving gitignored files across devices) was calling `reflink_or_copy` directly, bypassing the canonical `copy_leaf` function. This meant symlinks weren't handled and idempotency checks were skipped. Now uses `copy_leaf`, consistent with the directory branch which already goes through `copy_dir_recursive` → `copy_leaf`.

> _This was written by Claude Code on behalf of Maximilian Roos_