### PR TITLE
fix: use correct CC WorktreeCreate input field

### DIFF
--- a/.claude-plugin/hooks/hooks.json
+++ b/.claude-plugin/hooks/hooks.json
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.worktree_name // .branch // empty' | xargs -I{} wt switch --create {} --no-cd --format=json | jq -r '.path'"
+            "command": "jq -r '.name' | xargs -I{} wt switch --create {} --no-cd --format=json | jq -r '.path'"
           }
         ]
       }


### PR DESCRIPTION
CC sends `{"name": "..."}` on stdin to WorktreeCreate hooks. The jq filter was using `.worktree_name // .branch // empty`, which would always produce empty output since neither field exists.

Fixed to `.name` per the [CC hooks docs](https://code.claude.com/docs/en/hooks) and [community](https://github.com/tfriedel/claude-worktree-hooks) [implementations](https://mattbrailsford.dev/replacing-my-custom-git-worktree-skill-with-claude-code-hooks). The WorktreeRemove hook's `.worktree_path` was already correct.

> _This was written by Claude Code on behalf of @max-sixty_