### PR TITLE
fix: add missing newline between log sections in state logs

### DIFF
--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -155,7 +155,7 @@ fn render_log_table(out: &mut String, entries: &mut [std::fs::DirEntry]) -> std:
         .collect();
 
     let rendered = crate::md_help::render_data_table(&["File", "Size", "Age"], &rows);
-    write!(out, "{}", rendered.trim_end())?;
+    writeln!(out, "{}", rendered.trim_end())?;
 
     Ok(())
 }

--- a/tests/integration_tests/config_state.rs
+++ b/tests/integration_tests/config_state.rs
@@ -468,21 +468,15 @@ fn test_state_clear_marker_all_empty(repo: TestRepo) {
 fn test_state_get_logs_empty(repo: TestRepo) {
     let output = wt_state_cmd(&repo, "logs", "get", &[]).output().unwrap();
     assert!(output.status.success());
-    // Path is dynamic (temp dir), so check pattern instead of exact snapshot
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("COMMAND LOG"),
-        "Expected COMMAND LOG heading: {stderr}"
-    );
-    assert!(
-        stderr.contains("HOOK OUTPUT"),
-        "Expected HOOK OUTPUT heading: {stderr}"
-    );
-    // Path separator varies by platform, so check for either / or \
-    assert!(
-        stderr.contains(".git/wt/logs") || stderr.contains(".git\\wt\\logs"),
-        "Expected .git/wt/logs or .git\\wt\\logs in output: {stderr}"
-    );
+    state_get_settings().bind(|| {
+        assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"
+        [36mCOMMAND LOG[39m @ <PATH>
+        [107m [0m (none)
+
+        [36mHOOK OUTPUT[39m @ <PATH>
+        [107m [0m (none)
+        ");
+    });
 }
 
 #[rstest]
@@ -501,21 +495,20 @@ fn test_state_get_logs_with_files(repo: TestRepo) {
 
     let output = wt_state_cmd(&repo, "logs", "get", &[]).output().unwrap();
     assert!(output.status.success());
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    // Verify both sections are present
-    assert!(
-        stderr.contains("COMMAND LOG"),
-        "Expected COMMAND LOG heading: {stderr}"
-    );
-    assert!(
-        stderr.contains("HOOK OUTPUT"),
-        "Expected HOOK OUTPUT heading: {stderr}"
-    );
-    // Command log section shows jsonl file
-    assert!(stderr.contains("commands.jsonl"));
-    // Hook output section shows .log files
-    assert!(stderr.contains("feature-post-start-npm.log"));
-    assert!(stderr.contains("bugfix-remove.log"));
+    state_get_settings().bind(|| {
+        assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"
+        [36mCOMMAND LOG[39m @ <PATH>
+              File      Size  Age   
+         ────────────── ──── ────── 
+         commands.jsonl 19B  future
+
+        [36mHOOK OUTPUT[39m @ <PATH>
+                    File            Size  Age   
+         ────────────────────────── ──── ────── 
+         bugfix-remove.log          13B  future 
+         feature-post-start-npm.log 15B  future
+        ");
+    });
 }
 
 #[rstest]
@@ -529,19 +522,15 @@ fn test_state_get_logs_dir_exists_no_log_files(repo: TestRepo) {
 
     let output = wt_state_cmd(&repo, "logs", "get", &[]).output().unwrap();
     assert!(output.status.success());
-    // Both sections should show "(none)" since no log files exist
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains("COMMAND LOG"),
-        "Expected COMMAND LOG heading: {stderr}"
-    );
-    assert!(
-        stderr.contains("HOOK OUTPUT"),
-        "Expected HOOK OUTPUT heading: {stderr}"
-    );
-    // Count "(none)" occurrences — should appear twice (once per section)
-    let none_count = stderr.matches("(none)").count();
-    assert_eq!(none_count, 2, "Expected two (none) entries: {stderr}");
+    state_get_settings().bind(|| {
+        assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"
+        [36mCOMMAND LOG[39m @ <PATH>
+        [107m [0m (none)
+
+        [36mHOOK OUTPUT[39m @ <PATH>
+        [107m [0m (none)
+        ");
+    });
 }
 
 #[rstest]


### PR DESCRIPTION
`render_log_table` used `write!` instead of `writeln!`, so the table output had no trailing newline. The `writeln!` separator between COMMAND LOG and HOOK OUTPUT sections only terminated the last table row instead of creating a visible blank line between sections.

Also converts the three `test_state_get_logs_*` tests from `assert!(stderr.contains(...))` spot-checks to inline `assert_snapshot!` tests, matching the project's testing guidelines.

> _This was written by Claude Code on behalf of Maximilian Roos_