### PR TITLE
docs: fix marker position and use snapshot-backed example

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -744,14 +744,21 @@ Custom status text or emoji shown in the `wt list` Status column.
 
 ### Display
 
-Markers appear at the start of the Status column:
+Markers appear at the end of the Status column, after git symbols:
 
-```
-Branch    Status   Path
-main      ^        ~/code/myproject
-feature   🚧↑      ~/code/myproject.feature
-bugfix    🤖!↑⇡    ~/code/myproject.bugfix
-```
+<!-- ⚠️ AUTO-GENERATED from tests/snapshots/integration__integration_tests__list__readme_example_list_marker.snap — edit source to update -->
+
+{% terminal(cmd="wt list (markers)") %}
+&#32;&#32;<b>Branch</b>       <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>  <b>Remote⇅</b>  <b>Commit</b>    <b>Age</b>   <b>Message</b>
+@ main             <span class=d>^</span><span class=d>⇡</span>                         <span class=g>⇡1</span>      <span class=d>33323bc1</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
++ feature-api      <span class=d>↑</span> 🤖              <span class=g>↑1</span>               <span class=d>70343f03</span>  <span class=d>1d</span>    <span class=d>Add REST API endpoints</span>
++ review-ui      <span class=c>?</span> <span class=d>↑</span> 💬              <span class=g>↑1</span>               <span class=d>a585d6ed</span>  <span class=d>1d</span>    <span class=d>Add dashboard component</span>
++ wip-docs       <span class=c>?</span> <span class=d>–</span>                                  <span class=d>33323bc1</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
+
+<span class=d>○</span> <span class=d>Showing 4 worktrees, 2 with changes, 2 ahead, 1 column hidden</span>
+{% end %}
+
+<!-- END AUTO-GENERATED -->
 
 ### Use cases
 

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -765,13 +765,11 @@ Custom status text or emoji shown in the `wt list` Status column.
 
 ### Display
 
-Markers appear at the start of the Status column:
+Markers appear at the end of the Status column, after git symbols:
 
-```
-Branch    Status   Path
-main      ^        ~/code/myproject
-feature   🚧↑      ~/code/myproject.feature
-bugfix    🤖!↑⇡    ~/code/myproject.bugfix
+<!-- wt list (markers) -->
+```bash
+wt list
 ```
 
 ### Use cases

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -572,13 +572,11 @@ Without a subcommand, runs `get` for the current branch. Use `clear` to reset ca
 
 ## Display
 
-Markers appear at the start of the Status column:
+Markers appear at the end of the Status column, after git symbols:
 
-```
-Branch    Status   Path
-main      ^        ~/code/myproject
-feature   🚧↑      ~/code/myproject.feature
-bugfix    🤖!↑⇡    ~/code/myproject.bugfix
+<!-- wt list (markers) -->
+```console
+wt list
 ```
 
 ## Use cases

--- a/tests/integration_tests/list.rs
+++ b/tests/integration_tests/list.rs
@@ -2145,6 +2145,46 @@ fn test_readme_example_list_branches(mut repo: TestRepo) {
     });
 }
 
+/// Generate config state marker example: `wt list` with user markers
+///
+/// Shows how user markers appear in the Status column alongside git symbols.
+/// Used by `wt config state marker --help` and docs via placeholder expansion.
+/// Output: tests/snapshots/integration__integration_tests__list__readme_example_list_marker.snap
+#[rstest]
+fn test_readme_example_list_marker(mut repo: TestRepo) {
+    remove_fixture_worktrees(&mut repo);
+
+    repo.commit_with_age("Initial commit", DAY);
+
+    // Branch ahead of main with commits and user marker 🤖
+    let _feature_wt = repo.add_worktree_with_commit(
+        "feature-api",
+        "api.rs",
+        "// API implementation",
+        "Add REST API endpoints",
+    );
+    repo.set_marker("feature-api", "🤖");
+
+    // Branch with uncommitted changes and user marker 💬
+    let review_wt = repo.add_worktree_with_commit(
+        "review-ui",
+        "component.tsx",
+        "// UI component",
+        "Add dashboard component",
+    );
+    std::fs::write(review_wt.join("styles.css"), "/* pending styles */").unwrap();
+    repo.set_marker("review-ui", "💬");
+
+    // Branch with uncommitted changes only (no user marker)
+    let wip_wt = repo.add_worktree("wip-docs");
+    std::fs::write(wip_wt.join("README.md"), "# Documentation").unwrap();
+
+    assert_cmd_snapshot!(
+        "readme_example_list_marker",
+        list_snapshots::command_readme(&repo, repo.root_path())
+    );
+}
+
 /// Generate tips-patterns.md example: dev server per worktree workflow
 ///
 /// Uses the realistic README example repo and adds URL config.

--- a/tests/integration_tests/readme_sync.rs
+++ b/tests/integration_tests/readme_sync.rs
@@ -388,6 +388,9 @@ fn command_to_snapshot(command: &str) -> Option<&'static str> {
         "wt list --branches --full" => {
             Some("integration__integration_tests__list__readme_example_list_branches.snap")
         }
+        "wt list (markers)" => {
+            Some("integration__integration_tests__list__readme_example_list_marker.snap")
+        }
         _ => None,
     }
 }

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
@@ -61,12 +61,9 @@ Custom status text or emoji shown in the [2mwt list[0m Status column.
 
 [1m[32mDisplay[0m
 
-Markers appear at the start of the Status column:
+Markers appear at the end of the Status column, after git symbols:
 
-[107m [0m [2mBranch    Status   Path[0m
-[107m [0m [2mmain      ^        ~/code/myproject[0m
-[107m [0m [2mfeature   🚧↑      ~/code/myproject.feature[0m
-[107m [0m [2mbugfix    🤖!↑⇡    ~/code/myproject.bugfix[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list[0m
 
 [1m[32mUse cases[0m
 

--- a/tests/snapshots/integration__integration_tests__list__readme_example_list_marker.snap
+++ b/tests/snapshots/integration__integration_tests__list__readme_example_list_marker.snap
@@ -1,0 +1,52 @@
+---
+source: tests/integration_tests/list.rs
+info:
+  program: wt
+  args:
+    - list
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "98"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m       [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main             [2m^[22m[2m⇡[22m                         [32m⇡1[0m      [2m33323bc1[0m  [2m1d[0m    [2mInitial commit
++ feature-api      [2m↑[22m 🤖              [32m↑1[0m               [2m70343f03[0m  [2m1d[0m    [2mAdd REST API endpoints
++ review-ui      [36m?[39m [2m↑[22m 💬              [32m↑1[0m               [2ma585d6ed[0m  [2m1d[0m    [2mAdd dashboard component
++ wip-docs       [36m?[39m [2m–[22m                                  [2m33323bc1[0m  [2m1d[0m    [2mInitial commit
+
+[2m○[22m [2mShowing 4 worktrees, 2 with changes, 2 ahead, 1 column hidden
+
+----- stderr -----


### PR DESCRIPTION
The marker help text incorrectly stated markers appear at the "start" of the Status column with examples like `🚧↑`. The rendering code (`status_symbols.rs:300`) places markers at the end, after all git symbols (`↑🚧`).

Replaced the hand-written example with the `<!-- wt list (markers) -->` placeholder pattern, backed by a new `test_readme_example_list_marker` snapshot test. In terminal `--help`, this shows `wt list` as a command hint; in web docs, it expands to the actual colored table output.

> _This was written by Claude Code on behalf of Maximilian Roos_