### PR TITLE
refactor: consolidate test repo creation into testing::TestRepo

### DIFF
--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -716,39 +716,6 @@ pub mod tests {
     use super::{PickerAction, PickerCollector, resolve_identifier};
     use crate::commands::worktree::{BranchDeletionMode, RemoveResult};
     use std::fs;
-    use std::path::PathBuf;
-    use worktrunk::shell_exec::Cmd;
-
-    /// Create a git repo with one commit at `tmp/repo` and return the path.
-    fn init_test_repo(tmp: &tempfile::TempDir) -> PathBuf {
-        let repo_path = tmp.path().join("repo");
-        Cmd::new("git")
-            .args(["init", "--initial-branch=main", repo_path.to_str().unwrap()])
-            .run()
-            .unwrap();
-        Cmd::new("git")
-            .args(["config", "user.email", "test@test.com"])
-            .current_dir(&repo_path)
-            .run()
-            .unwrap();
-        Cmd::new("git")
-            .args(["config", "user.name", "Test"])
-            .current_dir(&repo_path)
-            .run()
-            .unwrap();
-        fs::write(repo_path.join("file.txt"), "hello").unwrap();
-        Cmd::new("git")
-            .args(["add", "."])
-            .current_dir(&repo_path)
-            .run()
-            .unwrap();
-        Cmd::new("git")
-            .args(["commit", "-m", "init"])
-            .current_dir(&repo_path)
-            .run()
-            .unwrap();
-        repo_path
-    }
 
     #[test]
     fn test_preview_state_data_roundtrip() {
@@ -821,10 +788,10 @@ pub mod tests {
 
     #[test]
     fn test_execute_removal_removes_worktree_and_branch() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let repo_path = init_test_repo(&tmp);
-        let repo = worktrunk::git::Repository::at(&repo_path).unwrap();
-        let wt_path = tmp.path().join("repo.feature");
+        let test = worktrunk::testing::TestRepo::with_initial_commit();
+        let repo = worktrunk::git::Repository::at(test.path()).unwrap();
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("feature");
 
         repo.run_command(&[
             "worktree",
@@ -837,7 +804,7 @@ pub mod tests {
         assert!(wt_path.exists());
 
         let result = RemoveResult::RemovedWorktree {
-            main_path: repo_path,
+            main_path: test.path().to_path_buf(),
             worktree_path: wt_path.clone(),
             changed_directory: false,
             branch_name: Some("feature".to_string()),
@@ -858,9 +825,8 @@ pub mod tests {
 
     #[test]
     fn test_do_removal_branch_only_deletes_integrated_branch() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let repo_path = init_test_repo(&tmp);
-        let repo = worktrunk::git::Repository::at(&repo_path).unwrap();
+        let test = worktrunk::testing::TestRepo::with_initial_commit();
+        let repo = worktrunk::git::Repository::at(test.path()).unwrap();
 
         // Create a branch at the same commit (fully integrated into main)
         repo.run_command(&["branch", "feature"]).unwrap();
@@ -878,13 +844,12 @@ pub mod tests {
 
     #[test]
     fn test_do_removal_branch_only_retains_unmerged_branch() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let repo_path = init_test_repo(&tmp);
-        let repo = worktrunk::git::Repository::at(&repo_path).unwrap();
+        let test = worktrunk::testing::TestRepo::with_initial_commit();
+        let repo = worktrunk::git::Repository::at(test.path()).unwrap();
 
         // Create a branch with an unmerged commit
         repo.run_command(&["checkout", "-b", "unmerged"]).unwrap();
-        fs::write(repo_path.join("new.txt"), "unmerged work").unwrap();
+        fs::write(test.path().join("new.txt"), "unmerged work").unwrap();
         repo.run_command(&["add", "."]).unwrap();
         repo.run_command(&["commit", "-m", "unmerged work"])
             .unwrap();
@@ -907,10 +872,10 @@ pub mod tests {
 
     #[test]
     fn test_do_removal_removes_detached_worktree() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let repo_path = init_test_repo(&tmp);
-        let repo = worktrunk::git::Repository::at(&repo_path).unwrap();
-        let wt_path = tmp.path().join("repo.detached");
+        let test = worktrunk::testing::TestRepo::with_initial_commit();
+        let repo = worktrunk::git::Repository::at(test.path()).unwrap();
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("detached");
 
         repo.run_command(&[
             "worktree",
@@ -922,7 +887,7 @@ pub mod tests {
         .unwrap();
 
         // Detach HEAD in the new worktree
-        Cmd::new("git")
+        worktrunk::shell_exec::Cmd::new("git")
             .args(["checkout", "--detach", "HEAD"])
             .current_dir(&wt_path)
             .run()
@@ -931,7 +896,7 @@ pub mod tests {
         assert!(wt_path.exists());
 
         let result = RemoveResult::RemovedWorktree {
-            main_path: repo_path,
+            main_path: test.path().to_path_buf(),
             worktree_path: wt_path.clone(),
             changed_directory: false,
             branch_name: None,

--- a/src/commands/picker/summary.rs
+++ b/src/commands/picker/summary.rs
@@ -63,7 +63,6 @@ mod tests {
     /// Create a minimal temp git repo (for cache-only tests that don't need branches).
     fn temp_repo() -> (TestRepo, Repository) {
         let t = TestRepo::new();
-        set_test_identity(&t.repo);
         t.repo
             .run_command(&["commit", "--allow-empty", "-m", "init"])
             .unwrap();
@@ -74,7 +73,6 @@ mod tests {
     /// Create a temp repo with main branch, default-branch config, and a real commit.
     fn temp_repo_configured() -> (TestRepo, Repository, String) {
         let t = TestRepo::new();
-        set_test_identity(&t.repo);
         t.repo
             .run_command(&["config", "worktrunk.default-branch", "main"])
             .unwrap();

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -794,144 +794,115 @@ mod tests {
         assert!(branch_ref.is_remote);
     }
 
-    /// Create a git repo with one commit and return the TempDir + repo path.
-    fn init_test_repo() -> (tempfile::TempDir, PathBuf) {
-        use crate::shell_exec::Cmd;
-
-        let tmp = tempfile::tempdir().unwrap();
-        let repo = tmp.path().join("repo");
-        Cmd::new("git")
-            .args(["init", "--initial-branch=main", repo.to_str().unwrap()])
-            .run()
-            .unwrap();
-        Cmd::new("git")
-            .args(["config", "user.email", "test@test.com"])
-            .current_dir(&repo)
-            .run()
-            .unwrap();
-        Cmd::new("git")
-            .args(["config", "user.name", "Test"])
-            .current_dir(&repo)
-            .run()
-            .unwrap();
-        std::fs::write(repo.join("file.txt"), "hello").unwrap();
-        Cmd::new("git")
-            .args(["add", "."])
-            .current_dir(&repo)
-            .run()
-            .unwrap();
-        Cmd::new("git")
-            .args(["commit", "-m", "init"])
-            .current_dir(&repo)
-            .run()
-            .unwrap();
-        (tmp, repo)
-    }
-
     #[test]
     fn test_branch_tracks_ref_matching() {
-        let (_tmp, repo) = init_test_repo();
+        let test = crate::testing::TestRepo::with_initial_commit();
+        let repo = test.path();
 
         // Create a branch and set its merge config to a PR ref
         crate::shell_exec::Cmd::new("git")
             .args(["branch", "pr-branch"])
-            .current_dir(&repo)
+            .current_dir(repo)
             .run()
             .unwrap();
         crate::shell_exec::Cmd::new("git")
             .args(["config", "branch.pr-branch.merge", "refs/pull/101/head"])
-            .current_dir(&repo)
+            .current_dir(repo)
             .run()
             .unwrap();
         crate::shell_exec::Cmd::new("git")
             .args(["config", "branch.pr-branch.remote", "origin"])
-            .current_dir(&repo)
+            .current_dir(repo)
             .run()
             .unwrap();
 
         assert_eq!(
-            branch_tracks_ref(&repo, "pr-branch", "refs/pull/101/head", None),
+            branch_tracks_ref(repo, "pr-branch", "refs/pull/101/head", None),
             Some(true),
         );
         assert_eq!(
-            branch_tracks_ref(&repo, "pr-branch", "refs/pull/101/head", Some("origin")),
+            branch_tracks_ref(repo, "pr-branch", "refs/pull/101/head", Some("origin")),
             Some(true),
         );
     }
 
     #[test]
     fn test_branch_tracks_ref_different_ref() {
-        let (_tmp, repo) = init_test_repo();
+        let test = crate::testing::TestRepo::with_initial_commit();
+        let repo = test.path();
 
         crate::shell_exec::Cmd::new("git")
             .args(["branch", "pr-branch"])
-            .current_dir(&repo)
+            .current_dir(repo)
             .run()
             .unwrap();
         crate::shell_exec::Cmd::new("git")
             .args(["config", "branch.pr-branch.merge", "refs/pull/101/head"])
-            .current_dir(&repo)
+            .current_dir(repo)
             .run()
             .unwrap();
 
         // Ask about a different ref — should return Some(false)
         assert_eq!(
-            branch_tracks_ref(&repo, "pr-branch", "refs/pull/999/head", None),
+            branch_tracks_ref(repo, "pr-branch", "refs/pull/999/head", None),
             Some(false),
         );
     }
 
     #[test]
     fn test_branch_tracks_ref_wrong_remote() {
-        let (_tmp, repo) = init_test_repo();
+        let test = crate::testing::TestRepo::with_initial_commit();
+        let repo = test.path();
 
         crate::shell_exec::Cmd::new("git")
             .args(["branch", "pr-branch"])
-            .current_dir(&repo)
+            .current_dir(repo)
             .run()
             .unwrap();
         crate::shell_exec::Cmd::new("git")
             .args(["config", "branch.pr-branch.merge", "refs/pull/101/head"])
-            .current_dir(&repo)
+            .current_dir(repo)
             .run()
             .unwrap();
         crate::shell_exec::Cmd::new("git")
             .args(["config", "branch.pr-branch.remote", "fork"])
-            .current_dir(&repo)
+            .current_dir(repo)
             .run()
             .unwrap();
 
         assert_eq!(
-            branch_tracks_ref(&repo, "pr-branch", "refs/pull/101/head", Some("origin")),
+            branch_tracks_ref(repo, "pr-branch", "refs/pull/101/head", Some("origin")),
             Some(false),
         );
     }
 
     #[test]
     fn test_branch_tracks_ref_no_tracking_config() {
-        let (_tmp, repo) = init_test_repo();
+        let test = crate::testing::TestRepo::with_initial_commit();
+        let repo = test.path();
 
         // Create a branch with no tracking config
         crate::shell_exec::Cmd::new("git")
             .args(["branch", "local-only"])
-            .current_dir(&repo)
+            .current_dir(repo)
             .run()
             .unwrap();
 
         // Branch exists but has no merge config — Some(false)
         assert_eq!(
-            branch_tracks_ref(&repo, "local-only", "refs/pull/1/head", None),
+            branch_tracks_ref(repo, "local-only", "refs/pull/1/head", None),
             Some(false),
         );
     }
 
     #[test]
     fn test_branch_tracks_ref_nonexistent_branch() {
-        let (_tmp, repo) = init_test_repo();
+        let test = crate::testing::TestRepo::with_initial_commit();
+        let repo = test.path();
 
         // Branch doesn't exist at all — None
         assert_eq!(
-            branch_tracks_ref(&repo, "no-such-branch", "refs/pull/1/head", None),
+            branch_tracks_ref(repo, "no-such-branch", "refs/pull/1/head", None),
             None,
         );
     }
@@ -948,12 +919,13 @@ mod tests {
 
     #[test]
     fn test_branch_tracks_ref_mr_ref() {
-        let (_tmp, repo) = init_test_repo();
+        let test = crate::testing::TestRepo::with_initial_commit();
+        let repo = test.path();
 
         // Test with GitLab-style MR ref
         crate::shell_exec::Cmd::new("git")
             .args(["branch", "mr-branch"])
-            .current_dir(&repo)
+            .current_dir(repo)
             .run()
             .unwrap();
         crate::shell_exec::Cmd::new("git")
@@ -962,18 +934,18 @@ mod tests {
                 "branch.mr-branch.merge",
                 "refs/merge-requests/42/head",
             ])
-            .current_dir(&repo)
+            .current_dir(repo)
             .run()
             .unwrap();
         crate::shell_exec::Cmd::new("git")
             .args(["config", "branch.mr-branch.remote", "origin"])
-            .current_dir(&repo)
+            .current_dir(repo)
             .run()
             .unwrap();
 
         assert_eq!(
             branch_tracks_ref(
-                &repo,
+                repo,
                 "mr-branch",
                 "refs/merge-requests/42/head",
                 Some("origin"),
@@ -981,7 +953,7 @@ mod tests {
             Some(true),
         );
         assert_eq!(
-            branch_tracks_ref(&repo, "mr-branch", "refs/pull/42/head", Some("origin")),
+            branch_tracks_ref(repo, "mr-branch", "refs/pull/42/head", Some("origin")),
             Some(false),
         );
     }

--- a/src/testing.rs
+++ b/src/testing.rs
@@ -24,9 +24,10 @@ pub struct TestRepo {
 }
 
 impl TestRepo {
-    /// Create a new repo with `git init -b main`.
+    /// Create a new empty repo with `git init -b main` and test identity.
     ///
     /// Uses explicit `-b main` for determinism regardless of system git config.
+    /// Identity is always configured so callers can commit without extra setup.
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
         let dir = tempfile::tempdir().unwrap();
@@ -36,7 +37,23 @@ impl TestRepo {
             .run()
             .unwrap();
         let repo = Repository::at(dir.path()).unwrap();
+        repo.run_command(&["config", "user.name", "Test"]).unwrap();
+        repo.run_command(&["config", "user.email", "test@test.com"])
+            .unwrap();
         Self { _dir: dir, repo }
+    }
+
+    /// Create a repo with one initial commit on `main`.
+    ///
+    /// Equivalent to `new()` followed by creating a file and committing it.
+    /// Use this when tests need a non-empty repo (e.g. for branching or
+    /// worktree operations that require at least one commit).
+    pub fn with_initial_commit() -> Self {
+        let test = Self::new();
+        std::fs::write(test.path().join("file.txt"), "hello").unwrap();
+        test.repo.run_command(&["add", "."]).unwrap();
+        test.repo.run_command(&["commit", "-m", "init"]).unwrap();
+        test
     }
 
     /// Path to the repository working directory.
@@ -47,9 +64,8 @@ impl TestRepo {
 
 /// Set git user identity on a repository.
 ///
-/// Use this for tests that manage their own repo creation and need
-/// identity configured for commits. For self-contained repos,
-/// prefer `TestRepo::new()` + `set_test_identity(&test.repo)`.
+/// Use this for tests that manage their own repo creation (not via
+/// [`TestRepo`]) and need identity configured for commits.
 pub fn set_test_identity(repo: &Repository) {
     repo.run_command(&["config", "user.name", "Test"]).unwrap();
     repo.run_command(&["config", "user.email", "test@test.com"])


### PR DESCRIPTION
`TestRepo::new()` now sets git identity (previously callers had to call `set_test_identity` separately), and `with_initial_commit()` provides a repo with one commit on `main`. This replaces two identical `init_test_repo()` functions in `git/mod.rs` and `picker/mod.rs` (-49 lines of duplicated setup code).

`set_test_identity()` is kept for tests that manage their own repo creation (recover.rs, one summary.rs test with a non-standard initial branch).

> _This was written by Claude Code on behalf of Maximilian Roos_