### PR TITLE
fix: combine multiple hook-type announcements into a single status line

### DIFF
--- a/src/commands/handle_switch.rs
+++ b/src/commands/handle_switch.rs
@@ -237,13 +237,14 @@ pub(crate) fn spawn_switch_background_hooks(
 ) -> anyhow::Result<()> {
     let ctx = CommandContext::new(repo, config, branch, result.path(), yes);
 
+    let mut pipelines = Vec::new();
     for steps in super::hooks::prepare_background_hooks(
         &ctx,
         HookType::PostSwitch,
         extra_vars,
         hooks_display_path,
     )? {
-        super::hooks::spawn_hook_pipeline(&ctx, steps)?;
+        pipelines.push((ctx, steps));
     }
 
     if matches!(result, SwitchResult::Created { .. }) {
@@ -253,11 +254,11 @@ pub(crate) fn spawn_switch_background_hooks(
             extra_vars,
             hooks_display_path,
         )? {
-            super::hooks::spawn_hook_pipeline(&ctx, steps)?;
+            pipelines.push((ctx, steps));
         }
     }
 
-    Ok(())
+    super::hooks::spawn_hook_pipelines_combined(pipelines)
 }
 
 /// Handle the switch command.

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -178,8 +178,6 @@ pub struct SourcedStep {
 /// - Multiple unnamed steps from the same source repeat the label (`user → user`)
 /// - Source prefix was dropped for named steps (`user:bg` → `bg`) — less
 ///   informative when both user and project hooks are present
-/// - Combined hook-type messages were split (`post-switch: X; post-start: Y`
-///   → two separate lines) — more verbose for the common create case
 fn format_pipeline_summary(steps: &[SourcedStep]) -> String {
     let mut parts = Vec::new();
     for step in steps {
@@ -204,35 +202,50 @@ fn format_pipeline_summary(steps: &[SourcedStep]) -> String {
     parts.join(" → ")
 }
 
-/// Spawn a hook pipeline as a background `wt hook run-pipeline` process.
+/// Announce one or more pipelines as a single combined status line.
 ///
-/// Serializes the pipeline steps to JSON and spawns `wt hook run-pipeline`
-/// as a detached process, piping the spec to stdin. The background
-/// process expands templates just-in-time and executes each step via
-/// the detected shell.
-///
-/// Used for all post-* background hooks regardless of config format.
-pub fn spawn_hook_pipeline(ctx: &CommandContext, steps: Vec<SourcedStep>) -> anyhow::Result<()> {
-    use super::pipeline_spec::{PipelineCommandSpec, PipelineSpec, PipelineStepSpec};
-
-    if steps.is_empty() {
-        return Ok(());
+/// Pipelines with the same hook type are grouped: "Running post-start: user, project"
+/// Different hook types are separated with ";": "Running post-remove: docs; post-switch: zellij-tab"
+fn announce_pipelines(pipelines: &[&[SourcedStep]]) {
+    if pipelines.is_empty() {
+        return;
     }
 
-    let hook_type = steps[0].hook_type;
-    let source = steps[0].source;
-    let display_path = steps[0].display_path.as_ref();
+    // Group adjacent pipelines by hook type to avoid repeating it.
+    let mut parts = Vec::new();
+    let mut i = 0;
+    while i < pipelines.len() {
+        let hook_type = pipelines[i][0].hook_type;
+        let mut summaries = vec![format_pipeline_summary(pipelines[i])];
+        while i + 1 < pipelines.len() && pipelines[i + 1][0].hook_type == hook_type {
+            i += 1;
+            summaries.push(format_pipeline_summary(pipelines[i]));
+        }
+        parts.push(format!("{hook_type}: {}", summaries.join(", ")));
+        i += 1;
+    }
+    let combined = parts.join("; ");
 
-    // Show summary: "Running post-start: install → build, lint"
-    let summary = format_pipeline_summary(&steps);
+    let display_path = pipelines
+        .iter()
+        .find_map(|steps| steps[0].display_path.as_ref());
+
     let message = match display_path {
         Some(path) => {
             let path_display = format_path_for_display(path);
-            cformat!("Running {hook_type}: {summary} @ <bold>{path_display}</>")
+            cformat!("Running {combined} @ <bold>{path_display}</>")
         }
-        None => format!("Running {hook_type}: {summary}"),
+        None => format!("Running {combined}"),
     };
     eprintln!("{}", progress_message(message));
+}
+
+/// Spawn a single pipeline as a background process (no announcement).
+fn spawn_pipeline_process(ctx: CommandContext, steps: Vec<SourcedStep>) -> anyhow::Result<()> {
+    use super::pipeline_spec::{PipelineCommandSpec, PipelineSpec, PipelineStepSpec};
+
+    let hook_type = steps[0].hook_type;
+    let source = steps[0].source;
 
     // Extract base context from the first command. All steps share the same base context,
     // but per-step metadata (hook_name) is stripped — it gets injected per-step by the
@@ -303,6 +316,45 @@ pub fn spawn_hook_pipeline(ctx: &CommandContext, steps: Vec<SourcedStep>) -> any
         worktrunk::command_log::log_command(&log_label, &cmd_display, None, None);
     }
 
+    Ok(())
+}
+
+/// Spawn a hook pipeline as a background `wt hook run-pipeline` process.
+///
+/// Announces the pipeline and spawns it as a detached process.
+/// For spawning multiple pipelines with a single combined announcement,
+/// use [`spawn_hook_pipelines_combined`] instead.
+pub fn spawn_hook_pipeline(ctx: &CommandContext, steps: Vec<SourcedStep>) -> anyhow::Result<()> {
+    if steps.is_empty() {
+        return Ok(());
+    }
+    announce_pipelines(&[&steps]);
+    spawn_pipeline_process(*ctx, steps)
+}
+
+/// Spawn multiple hook pipelines with a single combined status line.
+///
+/// Produces one announcement for all pipelines:
+/// "Running post-remove: docs; post-switch: zellij-tab @ path"
+///
+/// Each pipeline is still spawned as an independent background process.
+pub fn spawn_hook_pipelines_combined(
+    pipelines: Vec<(CommandContext<'_>, Vec<SourcedStep>)>,
+) -> anyhow::Result<()> {
+    let non_empty: Vec<_> = pipelines
+        .into_iter()
+        .filter(|(_, steps)| !steps.is_empty())
+        .collect();
+    if non_empty.is_empty() {
+        return Ok(());
+    }
+
+    let step_refs: Vec<&[SourcedStep]> = non_empty.iter().map(|(_, s)| s.as_slice()).collect();
+    announce_pipelines(&step_refs);
+
+    for (ctx, steps) in non_empty {
+        spawn_pipeline_process(ctx, steps)?;
+    }
     Ok(())
 }
 

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -14,7 +14,7 @@ use crate::commands::branch_deletion::{
 };
 use crate::commands::command_executor::CommandContext;
 use crate::commands::hooks::{
-    HookFailureStrategy, execute_hook, prepare_background_hooks, spawn_hook_pipeline,
+    HookFailureStrategy, execute_hook, prepare_background_hooks, spawn_hook_pipelines_combined,
 };
 use crate::commands::process::{
     HookLog, InternalOp, build_remove_command, build_remove_command_staged, spawn_detached,
@@ -848,21 +848,26 @@ fn spawn_hooks_after_remove(
     // branch since both post-remove and post-switch are consequences of that removal.
     let remove_ctx = CommandContext::new(repo, &config, Some(removed_branch), main_path, false);
 
-    // Post-remove hooks.
+    // Collect post-remove and post-switch hooks for a single combined announcement.
+    let mut pipelines: Vec<(CommandContext, Vec<_>)> = Vec::new();
     for steps in prepare_background_hooks(
         &remove_ctx,
         worktrunk::HookType::PostRemove,
         &extra_vars,
         display_path,
     )? {
-        spawn_hook_pipeline(&remove_ctx, steps)?;
+        pipelines.push((remove_ctx, steps));
     }
 
     // Post-switch: only when the user actually changed directory.
-    // Uses its own context for template variable preparation (dest branch),
-    // but spawned under remove_ctx (removed branch) for log naming.
-    if changed_directory {
-        let dest_branch = repo.worktree_at(main_path).branch()?;
+    // Uses its own context with the destination branch for template variables.
+    // dest_branch hoisted so it outlives the pipelines vec.
+    let dest_branch = if changed_directory {
+        Some(repo.worktree_at(main_path).branch()?)
+    } else {
+        None
+    };
+    if let Some(ref dest_branch) = dest_branch {
         let switch_ctx =
             CommandContext::new(repo, &config, dest_branch.as_deref(), main_path, false);
         for steps in prepare_background_hooks(
@@ -871,9 +876,11 @@ fn spawn_hooks_after_remove(
             &[],
             display_path,
         )? {
-            spawn_hook_pipeline(&switch_ctx, steps)?;
+            pipelines.push((switch_ctx, steps));
         }
     }
+
+    spawn_hook_pipelines_combined(pipelines)?;
 
     Ok(())
 }

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_mixed_user_pipeline_project_flat.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_mixed_user_pipeline_project_flat.snap
@@ -49,5 +49,4 @@ exit_code: 0
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
-[36m◎[39m [36mRunning post-start: [1muser[22m → [1muser_bg[22m @ [1m_REPO_.feature[22m[39m
-[36m◎[39m [36mRunning post-start: [1mproj[22m @ [1m_REPO_.feature[22m[39m
+[36m◎[39m [36mRunning post-start: [1muser[22m → [1muser_bg[22m, [1mproj[22m @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_combined_hooks.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_combined_hooks.snap
@@ -50,5 +50,4 @@ exit_code: 0
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
-[36m◎[39m [36mRunning post-switch: [1mproject[22m @ [1m_REPO_.combined-hooks-test[22m[39m
-[36m◎[39m [36mRunning post-start: [1mproject[22m @ [1m_REPO_.combined-hooks-test[22m[39m
+[36m◎[39m [36mRunning post-switch: [1mproject[22m; post-start: [1mproject[22m @ [1m_REPO_.combined-hooks-test[22m[39m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_and_project_post_start.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_and_project_post_start.snap
@@ -49,5 +49,4 @@ exit_code: 0
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
-[36m◎[39m [36mRunning post-start: [1mbg[22m @ [1m_REPO_.feature[22m[39m
-[36m◎[39m [36mRunning post-start: [1mproject[22m @ [1m_REPO_.feature[22m[39m
+[36m◎[39m [36mRunning post-start: [1mbg[22m, [1mproject[22m @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_and_project_unnamed_post_start.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_and_project_unnamed_post_start.snap
@@ -49,5 +49,4 @@ exit_code: 0
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
-[36m◎[39m [36mRunning post-start: [1muser[22m @ [1m_REPO_.feature[22m[39m
-[36m◎[39m [36mRunning post-start: [1mproject[22m @ [1m_REPO_.feature[22m[39m
+[36m◎[39m [36mRunning post-start: [1muser[22m, [1mproject[22m @ [1m_REPO_.feature[22m[39m


### PR DESCRIPTION
When multiple hook types fire together (e.g., post-switch + post-start on create, or post-remove + post-switch on remove), they were producing separate status lines per type. This restores them to a single combined line.

Splits `spawn_hook_pipeline` into `announce_pipelines` + `spawn_pipeline_process`, and adds `spawn_hook_pipelines_combined` for call sites that fire multiple hook types together. Same-type pipelines from different sources (user + project) are grouped with commas; different hook types with semicolons.

Before: two lines
```
◎ Running post-remove: docs
◎ Running post-switch: zellij-tab
```

After: one line
```
◎ Running post-remove: docs; post-switch: zellij-tab
```

> _This was written by Claude Code on behalf of @max-sixty_