### PR TITLE
fix: support per-group contexts in combined hook announcements

### DIFF
--- a/src/commands/handle_switch.rs
+++ b/src/commands/handle_switch.rs
@@ -237,25 +237,32 @@ pub(crate) fn spawn_switch_background_hooks(
 ) -> anyhow::Result<()> {
     let ctx = CommandContext::new(repo, config, branch, result.path(), yes);
 
-    let mut all_groups: Vec<Vec<super::hooks::SourcedStep>> = Vec::new();
-
-    all_groups.extend(super::hooks::prepare_background_hooks(
-        &ctx,
-        HookType::PostSwitch,
-        extra_vars,
-        hooks_display_path,
-    )?);
-
-    if matches!(result, SwitchResult::Created { .. }) {
-        all_groups.extend(super::hooks::prepare_background_hooks(
+    let mut pipelines = Vec::new();
+    pipelines.extend(
+        super::hooks::prepare_background_hooks(
             &ctx,
-            HookType::PostStart,
+            HookType::PostSwitch,
             extra_vars,
             hooks_display_path,
-        )?);
+        )?
+        .into_iter()
+        .map(|g| (ctx, g)),
+    );
+
+    if matches!(result, SwitchResult::Created { .. }) {
+        pipelines.extend(
+            super::hooks::prepare_background_hooks(
+                &ctx,
+                HookType::PostStart,
+                extra_vars,
+                hooks_display_path,
+            )?
+            .into_iter()
+            .map(|g| (ctx, g)),
+        );
     }
 
-    super::hooks::announce_and_spawn_background_hooks(&ctx, all_groups)
+    super::hooks::announce_and_spawn_background_hooks(pipelines)
 }
 
 /// Handle the switch command.

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -209,26 +209,33 @@ fn format_pipeline_summary(steps: &[SourcedStep]) -> String {
 /// of calling `spawn_hook_pipeline` directly when multiple hook types
 /// fire together (e.g., post-switch + post-start on create).
 ///
+/// Each pipeline carries its own `CommandContext` so that different hook types
+/// can use different contexts (e.g., post-remove uses the removed branch while
+/// post-switch uses the destination branch).
+///
 /// Example output: `Running post-switch: zellij-tab; post-start: deps, assets, docs`
 pub fn announce_and_spawn_background_hooks(
-    ctx: &CommandContext,
-    groups: Vec<Vec<SourcedStep>>,
+    pipelines: Vec<(CommandContext<'_>, Vec<SourcedStep>)>,
 ) -> anyhow::Result<()> {
-    if groups.iter().all(|g| g.is_empty()) {
+    let non_empty: Vec<_> = pipelines
+        .into_iter()
+        .filter(|(_, steps)| !steps.is_empty())
+        .collect();
+    if non_empty.is_empty() {
         return Ok(());
     }
 
     // Build combined summary, merging groups with the same hook type:
     // "post-switch: zellij-tab; post-start: deps, assets, docs"
-    let display_path = groups
+    let display_path = non_empty
         .iter()
-        .flat_map(|g| g.iter())
+        .flat_map(|(_, g)| g.iter())
         .find_map(|s| s.display_path.as_ref());
 
     // Merge summaries by hook type so user+project for the same type
     // shows "post-start: user_bg, project" not "post-start: user_bg; post-start: project".
     let mut type_summaries: Vec<(HookType, Vec<String>)> = Vec::new();
-    for group in &groups {
+    for (_, group) in &non_empty {
         let hook_type = group[0].hook_type;
         let summary = format_pipeline_summary(group);
         if let Some(entry) = type_summaries.iter_mut().find(|(ht, _)| *ht == hook_type) {
@@ -252,8 +259,8 @@ pub fn announce_and_spawn_background_hooks(
     };
     eprintln!("{}", progress_message(message));
 
-    for group in groups {
-        spawn_hook_pipeline_quiet(ctx, group)?;
+    for (ctx, group) in non_empty {
+        spawn_hook_pipeline_quiet(&ctx, group)?;
     }
 
     Ok(())

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -14,7 +14,8 @@ use crate::commands::branch_deletion::{
 };
 use crate::commands::command_executor::CommandContext;
 use crate::commands::hooks::{
-    HookFailureStrategy, execute_hook, prepare_background_hooks, spawn_hook_pipeline,
+    HookFailureStrategy, announce_and_spawn_background_hooks, execute_hook,
+    prepare_background_hooks,
 };
 use crate::commands::process::{
     HookLog, InternalOp, build_remove_command, build_remove_command_staged, spawn_detached,
@@ -848,32 +849,43 @@ fn spawn_hooks_after_remove(
     // branch since both post-remove and post-switch are consequences of that removal.
     let remove_ctx = CommandContext::new(repo, &config, Some(removed_branch), main_path, false);
 
-    // Post-remove hooks.
-    for steps in prepare_background_hooks(
-        &remove_ctx,
-        worktrunk::HookType::PostRemove,
-        &extra_vars,
-        display_path,
-    )? {
-        spawn_hook_pipeline(&remove_ctx, steps)?;
-    }
+    // Collect post-remove and post-switch hooks for a single combined announcement.
+    let mut pipelines = Vec::new();
+    pipelines.extend(
+        prepare_background_hooks(
+            &remove_ctx,
+            worktrunk::HookType::PostRemove,
+            &extra_vars,
+            display_path,
+        )?
+        .into_iter()
+        .map(|g| (remove_ctx, g)),
+    );
 
     // Post-switch: only when the user actually changed directory.
-    // Uses its own context for template variable preparation (dest branch),
-    // but spawned under remove_ctx (removed branch) for log naming.
-    if changed_directory {
-        let dest_branch = repo.worktree_at(main_path).branch()?;
+    // Uses its own context with the destination branch for template variables.
+    // dest_branch hoisted so it outlives the pipelines vec.
+    let dest_branch = if changed_directory {
+        Some(repo.worktree_at(main_path).branch()?)
+    } else {
+        None
+    };
+    if let Some(ref dest_branch) = dest_branch {
         let switch_ctx =
             CommandContext::new(repo, &config, dest_branch.as_deref(), main_path, false);
-        for steps in prepare_background_hooks(
-            &switch_ctx,
-            worktrunk::HookType::PostSwitch,
-            &[],
-            display_path,
-        )? {
-            spawn_hook_pipeline(&switch_ctx, steps)?;
-        }
+        pipelines.extend(
+            prepare_background_hooks(
+                &switch_ctx,
+                worktrunk::HookType::PostSwitch,
+                &[],
+                display_path,
+            )?
+            .into_iter()
+            .map(|g| (switch_ctx, g)),
+        );
     }
+
+    announce_and_spawn_background_hooks(pipelines)?;
 
     Ok(())
 }


### PR DESCRIPTION
The remove flow in `handlers.rs` fires both post-remove and post-switch hooks, but they need different `CommandContext` values (removed branch vs destination branch). The current `announce_and_spawn_background_hooks` takes a single shared context, so `handlers.rs` couldn't use it and still printed two separate status lines.

Changes the signature from `(&CommandContext, Vec<Vec<SourcedStep>>)` to `Vec<(CommandContext, Vec<SourcedStep>)>` so each pipeline group carries its own context. Converts the remove flow to use it.

Before (`wt remove` when cd'ing back to main):
```
◎ Running post-remove: docs
◎ Running post-switch: zellij-tab
```

After:
```
◎ Running post-remove: docs; post-switch: zellij-tab
```

> _This was written by Claude Code on behalf of @max-sixty_