### PR TITLE
fix: use horizontal whitespace in switch_picker test filters

### DIFF
--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -516,8 +516,8 @@ fn switch_picker_settings(repo: &TestRepo) -> insta::Settings {
     // The tab header line may have the count jammed against "summary" (no space)
     // or even truncate "summary" when skim's width_cjk() treats ambiguous-width
     // unicode symbols (±, …, ⇅) as double-width, consuming extra columns.
-    settings.add_filter(r"(?m)summary?\w*\s*\d+/\d+\s*$", "summary [N/M]");
-    settings.add_filter(r"(?m)\s+\d+/\d+\s*$", " [N/M]");
+    settings.add_filter(r"(?m)summary?\w*\s*\d+/\d+[ \t]*$", "summary [N/M]");
+    settings.add_filter(r"(?m)\s+\d+/\d+[ \t]*$", " [N/M]");
 
     // Commit hashes (7-8 hex chars)
     settings.add_filter(r"\b[0-9a-f]{7,8}\b", "[HASH]");


### PR DESCRIPTION
Same fix as #1981 — `\s*$` in Rust regex matches newlines, so `add_filter` patterns ending with `\s*$` can consume trailing `\n` and collapse blank line separators in insta inline snapshots. Changed to `[ \t]*$` in the two remaining instances in `switch_picker.rs`.

> _This was written by Claude Code on behalf of @max-sixty_