### PR TITLE
test: combined post-remove + post-switch hook announcement

### DIFF
--- a/tests/integration_tests/user_hooks.rs
+++ b/tests/integration_tests/user_hooks.rs
@@ -804,6 +804,32 @@ cleanup = "echo 'POST_REMOVE_DURING_MERGE' > ../merge_postremove_marker.txt"
     );
 }
 
+/// When removing the current worktree (cd back to main), both post-remove and
+/// post-switch hooks fire. They should appear on a single combined announcement line.
+#[rstest]
+fn test_combined_post_remove_and_post_switch_hooks(mut repo: TestRepo) {
+    let feature_wt = repo.add_worktree("feature");
+
+    // Configure both post-remove and post-switch user hooks
+    repo.write_test_config(
+        r#"[post-remove]
+cleanup = "echo removed"
+
+[post-switch]
+notify = "echo switched"
+"#,
+    );
+
+    // Remove from inside the feature worktree — triggers cd back to main,
+    // which means changed_directory=true and both hook types fire.
+    snapshot_remove(
+        "combined_post_remove_and_post_switch",
+        &repo,
+        &["feature", "--force-delete"],
+        Some(&feature_wt),
+    );
+}
+
 // Note: The `return Ok(())` path in spawn_hooks_after_remove when UserConfig::load()
 // fails is defensive code for an extremely rare race condition where config becomes
 // invalid between command startup and hook execution. This is not easily testable

--- a/tests/snapshots/integration__integration_tests__user_hooks__combined_post_remove_and_post_switch.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__combined_post_remove_and_post_switch.snap
@@ -1,0 +1,51 @@
+---
+source: tests/integration_tests/user_hooks.rs
+info:
+  program: wt
+  args:
+    - remove
+    - feature
+    - "--force-delete"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mRemoving [1mfeature[22m worktree & branch in background (--force-delete)[39m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
+[2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
+[36m◎[39m [36mRunning post-remove: [1mcleanup[22m; post-switch: [1mnotify[22m @ [1m_REPO_[22m[39m


### PR DESCRIPTION
Adds an integration test exercising the combined announcement path in `spawn_hooks_after_remove` when both post-remove and post-switch hooks fire together (removing the current worktree triggers cd-back to main). Covers lines 860/882 in `handlers.rs` flagged by codecov/patch.

> _This was written by Claude Code on behalf of @max-sixty_