### PR TITLE
fix: strip `$ ` prompt from terminal help for copy-paste

### DIFF
--- a/src/md_help.rs
+++ b/src/md_help.rs
@@ -75,7 +75,17 @@ pub(crate) fn render_markdown_in_help_with_width(help: &str, width: Option<usize
                 let content = code_block_lines.join("\n");
                 let formatted = match code_block_lang.as_str() {
                     "toml" => format_toml(&content),
-                    "console" | "bash" | "sh" => format_bash_with_gutter(&content),
+                    "console" => {
+                        // Strip `$ ` prompt from console blocks for copy-paste.
+                        // The prefix is preserved in source for web docs.
+                        let stripped = content
+                            .lines()
+                            .map(|l| l.strip_prefix("$ ").unwrap_or(l))
+                            .collect::<Vec<_>>()
+                            .join("\n");
+                        format_bash_with_gutter(&stripped)
+                    }
+                    "bash" | "sh" => format_bash_with_gutter(&content),
                     _ => {
                         // Dim the content before adding gutter (format_with_gutter
                         // doesn't style text; bash/toml formatters handle their own)
@@ -574,6 +584,19 @@ mod tests {
 
         [1m[32mSection[0m
         ");
+    }
+
+    #[test]
+    fn test_render_markdown_in_help_console_strips_dollar() {
+        // Console blocks strip `$ ` for copy-paste; web docs keep it
+        let result = render_markdown_in_help("```console\n$ wt step deploy\n$ wt list\n```");
+        let stripped = ansi_str::AnsiStr::ansi_strip(&result);
+        assert!(
+            !stripped.contains("$ "),
+            "terminal output should not contain '$ ' prompt: {stripped}"
+        );
+        assert!(stripped.contains("wt step deploy"));
+        assert!(stripped.contains("wt list"));
     }
 
     #[test]

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -64,19 +64,19 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 
 Install shell integration (required for directory switching):
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m config shell install[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config shell install[0m
 
 Create user config file with documented examples:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m config create[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config create[0m
 
 Create project config file ([2m.config/wt.toml[0m) for hooks:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m config create [0m[2m[36m--project[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config create [0m[2m[36m--project[0m[2m[0m
 
 Show current configuration and file locations:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m config show[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config show[0m
 
 [1m[32mConfiguration files[0m
 
@@ -413,7 +413,7 @@ Aliases defined here are shared with teammates. For personal aliases, use the us
 
 Worktrunk needs shell integration to change directories when switching worktrees. Install with:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m config shell install[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config shell install[0m
 
 For manual setup, see [2mwt config shell init --help[0m.
 
@@ -447,7 +447,7 @@ Note the single underscore after [2mWORKTRUNK[0m and double underscores betwee
 
 Override the LLM command in CI to use a mock:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m WORKTRUNK_COMMIT__GENERATION__COMMAND=[0m[2m[32m"echo 'test: automated commit'"[0m[2m[0m[2m wt merge[0m
+[107m [0m [2mWORKTRUNK_COMMIT__GENERATION__COMMAND=[0m[2m[32m"echo 'test: automated commit'"[0m[2m [0m[2m[34mwt[0m[2m merge[0m
 
 [32mOther environment variables[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_show.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_show.snap
@@ -63,7 +63,7 @@ If a config file doesn't exist, shows defaults that would be used.
 
 Use [2m--full[0m to run diagnostic checks:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m config show [0m[2m[36m--full[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config show [0m[2m[36m--full[0m[2m[0m
 
 This tests:
 - [1mCI tool status[0m — Whether [2mgh[0m (GitHub) or [2mglab[0m (GitLab) is installed and authenticated

--- a/tests/snapshots/integration__integration_tests__help__help_config_state.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state.snap
@@ -76,22 +76,22 @@ State is stored in [2m.git/[0m (config entries and log files), separate from c
 [1m[32mExamples[0m
 
 Get the default branch:
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m config state default-branch[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config state default-branch[0m
 
 Set the default branch manually:
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m config state default-branch set main[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config state default-branch set main[0m
 
 Set a marker for current branch:
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m config state marker set 🚧[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config state marker set 🚧[0m
 
 Store arbitrary data:
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m config state vars set env=staging[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config state vars set env=staging[0m
 
 Clear all CI status cache:
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m config state ci-status clear [0m[2m[36m--all[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config state ci-status clear [0m[2m[36m--all[0m[2m[0m
 
 Show all stored state:
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m config state get[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config state get[0m
 
 Clear all stored state:
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m config state clear[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config state clear[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
@@ -59,7 +59,7 @@ Usage: [1m[36mwt config state default-branch[0m [36m[OPTIONS][0m [36m[COMM
 
 Useful in scripts to avoid hardcoding [2mmain[0m or [2mmaster[0m:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m git[0m[2m rebase $([0m[2m[34mwt[0m[2m config state default-branch)[0m
+[107m [0m [2m[0m[2m[34mgit[0m[2m rebase $([0m[2m[34mwt[0m[2m config state default-branch)[0m
 
 Without a subcommand, runs [2mget[0m. Use [2mset[0m to override, or [2mclear[0m then [2mget[0m to re-detect.
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
@@ -97,13 +97,13 @@ All logs are stored in [2m.git/wt/logs/[0m (in the main worktree's git directo
 [1m[32mExamples[0m
 
 List all log files:
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m config state logs get[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config state logs get[0m
 
 Query the command log:
-[107m [0m [2m[0m[2m[36m$[0m[2m tail[0m[2m [0m[2m[36m-5[0m[2m .git/wt/logs/commands.jsonl [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m .[0m
+[107m [0m [2m[0m[2m[34mtail[0m[2m [0m[2m[36m-5[0m[2m .git/wt/logs/commands.jsonl [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m .[0m
 
 View a specific hook log:
-[107m [0m [2m[0m[2m[36m$[0m[2m cat[0m[2m [0m[2m[32m"$([0m[2m[34mgit[0m[2m rev-parse [0m[2m[36m--git-dir[0m[2m)/wt/logs/feature-project-post-start-build.log"[0m[2m[0m
+[107m [0m [2m[0m[2m[34mcat[0m[2m [0m[2m[32m"$([0m[2m[34mgit[0m[2m rev-parse [0m[2m[36m--git-dir[0m[2m)/wt/logs/feature-project-post-start-build.log"[0m[2m[0m
 
 Clear all logs:
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m config state logs clear[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config state logs clear[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
@@ -75,6 +75,6 @@ Markers appear at the end of the Status column, after git symbols:
 
 Stored in git config as [2mworktrunk.state.<branch>.marker[0m. Set directly with:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m git[0m[2m config worktrunk.state.feature.marker [0m[2m[32m'{"marker":"🚧","set_at":0}'[0m[2m[0m
+[107m [0m [2m[0m[2m[34mgit[0m[2m config worktrunk.state.feature.marker [0m[2m[32m'{"marker":"🚧","set_at":0}'[0m[2m[0m
 
 Without a subcommand, runs [2mget[0m for the current branch. For [2m--branch[0m, use [2mget --branch=NAME[0m.

--- a/tests/snapshots/integration__integration_tests__help__help_hook_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_approvals.snap
@@ -60,13 +60,13 @@ Project hooks require approval on first run to prevent untrusted projects from r
 [1m[32mExamples[0m
 
 Pre-approve all commands for current project:
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m hook approvals add[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m hook approvals add[0m
 
 Clear approvals for current project:
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m hook approvals clear[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m hook approvals clear[0m
 
 Clear global approvals:
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m hook approvals clear [0m[2m[36m--global[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m hook approvals clear [0m[2m[36m--global[0m[2m[0m
 
 [1m[32mHow approvals work[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -85,19 +85,19 @@ The table renders progressively: branch names, paths, and commit hashes appear i
 
 List all worktrees:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list[0m
 
 Include CI status, line diffs, and LLM summaries:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--full[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--full[0m[2m[0m
 
 Include branches that don't have worktrees:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--branches[0m[2m [0m[2m[36m--full[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--branches[0m[2m [0m[2m[36m--full[0m[2m[0m
 
 Output as JSON for scripting:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m[0m
 
 [1m[32mColumns[0m
 
@@ -187,28 +187,28 @@ These appear across all columns while the table is loading:
 Query structured data with [2m--format=json[0m:
 
 [107m [0m [2m# Current worktree path (for scripts)[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[36m-r[0m[2m [0m[2m[32m'.[] | select(.is_current) | .path'[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[36m-r[0m[2m [0m[2m[32m'.[] | select(.is_current) | .path'[0m[2m[0m
 [107m [0m [2m[0m
 [107m [0m [2m# Branches with uncommitted changes[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.working_tree.modified)'[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.working_tree.modified)'[0m[2m[0m
 [107m [0m [2m[0m
 [107m [0m [2m# Worktrees with merge conflicts[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.operation_state == "conflicts")'[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.operation_state == "conflicts")'[0m[2m[0m
 [107m [0m [2m[0m
 [107m [0m [2m# Branches ahead of main (needs merging)[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.main.ahead > 0) | .branch'[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.main.ahead > 0) | .branch'[0m[2m[0m
 [107m [0m [2m[0m
 [107m [0m [2m# Integrated branches (safe to remove)[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.main_state == "integrated" or .main_state == "empty") | .branch'[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.main_state == "integrated" or .main_state == "empty") | .branch'[0m[2m[0m
 [107m [0m [2m[0m
 [107m [0m [2m# Branches without worktrees[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m--branches[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.kind == "branch") | .branch'[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m--branches[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.kind == "branch") | .branch'[0m[2m[0m
 [107m [0m [2m[0m
 [107m [0m [2m# Worktrees ahead of remote (needs pushing)[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.remote.ahead > 0) | {branch, ahead: .remote.ahead}'[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.remote.ahead > 0) | {branch, ahead: .remote.ahead}'[0m[2m[0m
 [107m [0m [2m[0m
 [107m [0m [2m# Stale CI (local changes not reflected in CI)[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m--full[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.ci.stale) | .branch'[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m--full[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.ci.stale) | .branch'[0m[2m[0m
 
 [1mFields:[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -93,19 +93,19 @@ and columns fill in as results arrive.
 
 List all worktrees:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list[0m
 
 Include CI status, line diffs, and LLM summaries:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--full[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--full[0m[2m[0m
 
 Include branches that don't have worktrees:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--branches[0m[2m [0m[2m[36m--full[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--branches[0m[2m [0m[2m[36m--full[0m[2m[0m
 
 Output as JSON for scripting:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m[0m
 
 [1m[32mColumns[0m
 
@@ -209,31 +209,31 @@ These appear across all columns while the table is loading:
 Query structured data with [2m--format=json[0m:
 
 [107m [0m [2m# Current worktree path (for scripts)[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[36m-r[0m[2m [0m[2m[32m'.[] | select(.is_current) | .path'[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[36m-r[0m[2m [0m[2m[32m'.[] | select(.is_current) | .path'[0m[2m[0m
 [107m [0m [2m[0m
 [107m [0m [2m# Branches with uncommitted changes[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.working_tree.modified)'[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.working_tree.modified)'[0m[2m[0m
 [107m [0m [2m[0m
 [107m [0m [2m# Worktrees with merge conflicts[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.operation_state == "conflicts")'[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.operation_state == "conflicts")'[0m[2m[0m
 [107m [0m [2m[0m
 [107m [0m [2m# Branches ahead of main (needs merging)[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.main.ahead > 0) | .branch'[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.main.ahead > 0) | .branch'[0m[2m[0m
 [107m [0m [2m[0m
 [107m [0m [2m# Integrated branches (safe to remove)[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.main_state == "integrated" or [0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.main_state == "integrated" or [0m
 [107m [0m [2m[32m.main_state == "empty") | .branch'[0m[2m[0m
 [107m [0m [2m[0m
 [107m [0m [2m# Branches without worktrees[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m--branches[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.kind == "branch") | [0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m--branches[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.kind == "branch") | [0m
 [107m [0m [2m[32m.branch'[0m[2m[0m
 [107m [0m [2m[0m
 [107m [0m [2m# Worktrees ahead of remote (needs pushing)[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.remote.ahead > 0) | {branch, [0m
-[107m [0m [2m[32mahead: .remote.ahead}'[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.remote.ahead > 0) | {branch, ahead: [0m
+[107m [0m [2m[32m.remote.ahead}'[0m[2m[0m
 [107m [0m [2m[0m
 [107m [0m [2m# Stale CI (local changes not reflected in CI)[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m--full[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.ci.stale) | .branch'[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--format=json[0m[2m [0m[2m[36m--full[0m[2m [0m[2m[36m|[0m[2m [0m[2m[34mjq[0m[2m [0m[2m[32m'.[] | select(.ci.stale) | .branch'[0m[2m[0m
 
 [1mFields:[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
@@ -94,27 +94,27 @@ Unlike [2mgit merge[0m, this merges the current branch into the target branch 
 
 Merge to the default branch:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m merge[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m merge[0m
 
 Merge to a different branch:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m merge develop[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m merge develop[0m
 
 Keep the worktree after merging:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m merge [0m[2m[36m--no-remove[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m merge [0m[2m[36m--no-remove[0m[2m[0m
 
 Preserve commit history (no squash):
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m merge [0m[2m[36m--no-squash[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m merge [0m[2m[36m--no-squash[0m[2m[0m
 
 Create a merge commit — semi-linear history:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m merge [0m[2m[36m--no-ff[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m merge [0m[2m[36m--no-ff[0m[2m[0m
 
 Skip committing/squashing (rebase still runs unless --no-rebase):
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m merge [0m[2m[36m--no-commit[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m merge [0m[2m[36m--no-commit[0m[2m[0m
 
 [1m[32mPipeline[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
@@ -81,20 +81,20 @@ Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...[0m
 
 Remove current worktree:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m remove[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m remove[0m
 
 Remove specific worktrees / branches:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m remove feature-branch[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m remove old-feature another-branch[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m remove feature-branch[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m remove old-feature another-branch[0m
 
 Keep the branch:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m remove [0m[2m[36m--no-delete-branch[0m[2m feature-branch[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m remove [0m[2m[36m--no-delete-branch[0m[2m feature-branch[0m
 
 Force-delete an unmerged branch:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m remove [0m[2m[36m-D[0m[2m experimental[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m remove [0m[2m[36m-D[0m[2m experimental[0m
 
 [1m[32mBranch cleanup[0m
 
@@ -122,9 +122,9 @@ Worktrunk has two force flags for different situations:
  [2m--force[0m ([2m-f[0m)        Worktree Worktree has untracked files 
  [2m--force-delete[0m ([2m-D[0m) Branch   Branch has unmerged commits  
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m remove feature [0m[2m[36m--force[0m[2m       # Remove worktree with untracked files[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m remove feature [0m[2m[36m-D[0m[2m            # Delete unmerged branch[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m remove feature [0m[2m[36m--force[0m[2m [0m[2m[36m-D[0m[2m    # Both[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m remove feature [0m[2m[36m--force[0m[2m       # Remove worktree with untracked files[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m remove feature [0m[2m[36m-D[0m[2m            # Delete unmerged branch[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m remove feature [0m[2m[36m--force[0m[2m [0m[2m[36m-D[0m[2m    # Both[0m[2m[0m
 
 Without [2m--force[0m, removal fails if the worktree contains untracked files. Without [2m--force-delete[0m, removal keeps branches with unmerged changes. Use [2m--no-delete-branch[0m to keep the branch regardless of merge status.
 

--- a/tests/snapshots/integration__integration_tests__help__help_step_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_long.snap
@@ -69,14 +69,14 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 
 Commit with LLM-generated message:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m step commit[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step commit[0m
 
 Manual merge workflow with review between steps:
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m step commit[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m step squash[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m step rebase[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m step push[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step commit[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step squash[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step rebase[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step push[0m
 
 [1m[32mOperations[0m
 
@@ -107,10 +107,10 @@ Custom command templates configured in user config ([2m~/.config/worktrunk/conf
 [107m [0m [2mdeploy = [0m[2m[32m"make deploy BRANCH={{ branch }}"[0m
 [107m [0m [2mport = [0m[2m[32m"echo http://localhost:{{ branch | hash_port }}"[0m
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m step deploy                            # run the alias[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m step deploy [0m[2m[36m--dry-run[0m[2m                  # show expanded command[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m step deploy [0m[2m[36m--var[0m[2m env=staging          # pass extra template variables[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m step deploy [0m[2m[36m--yes[0m[2m                      # skip approval prompt[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step deploy                            # run the alias[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step deploy [0m[2m[36m--dry-run[0m[2m                  # show expanded command[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step deploy [0m[2m[36m--var[0m[2m env=staging          # pass extra template variables[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step deploy [0m[2m[36m--yes[0m[2m                      # skip approval prompt[0m[2m[0m
 
 When defined in both user and project config, both run — user first, then project. Project-config aliases require command approval on first run, same as project hooks. User-config aliases are trusted.
 

--- a/tests/snapshots/integration__integration_tests__help__help_step_promote.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_promote.snap
@@ -64,7 +64,7 @@ Usage: [1m[36mwt step promote[0m [36m[OPTIONS][0m [36m[BRANCH][0m
 [1m[32mExample[0m
 
 [107m [0m [2m# from ~/project (main worktree)[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m step promote feature[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step promote feature[0m
 
 Before:
 

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -124,11 +124,11 @@ Worktrees are addressed by branch name; paths are computed from a configurable t
 
 [1m[32mExamples[0m
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m switch feature-auth           # Switch to worktree[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m switch [0m[2m[36m-[0m[2m                      # Previous worktree (like cd -)[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m switch [0m[2m[36m--create[0m[2m new-feature   # Create new branch and worktree[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m switch [0m[2m[36m--create[0m[2m hotfix [0m[2m[36m--base[0m[2m production[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m switch pr:123                 # Switch to PR #123's branch[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch feature-auth           # Switch to worktree[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch [0m[2m[36m-[0m[2m                      # Previous worktree (like cd -)[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch [0m[2m[36m--create[0m[2m new-feature   # Create new branch and worktree[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch [0m[2m[36m--create[0m[2m hotfix [0m[2m[36m--base[0m[2m production[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch pr:123                 # Switch to PR #123's branch[0m[2m[0m
 
 [1m[32mCreating a branch[0m
 
@@ -144,10 +144,10 @@ If the branch already has a worktree, [2mwt switch[0m changes directories to i
 4. Runs pre-start hooks, blocking until complete
 5. Spawns post-start and post-switch hooks in the background
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m switch feature                        # Existing branch → creates worktree[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m switch [0m[2m[36m--create[0m[2m feature               # New branch and worktree[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m switch [0m[2m[36m--create[0m[2m fix [0m[2m[36m--base[0m[2m release    # New branch from release[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m switch [0m[2m[36m--create[0m[2m temp [0m[2m[36m--no-hooks[0m[2m       # Skip hooks[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch feature                        # Existing branch → creates worktree[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch [0m[2m[36m--create[0m[2m feature               # New branch and worktree[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch [0m[2m[36m--create[0m[2m fix [0m[2m[36m--base[0m[2m release    # New branch from release[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch [0m[2m[36m--create[0m[2m temp [0m[2m[36m--no-hooks[0m[2m       # Skip hooks[0m[2m[0m
 
 [1m[32mShortcuts[0m
 
@@ -159,11 +159,11 @@ If the branch already has a worktree, [2mwt switch[0m changes directories to i
  [2mpr:{N}[0m   GitHub PR #N's branch         
  [2mmr:{N}[0m   GitLab MR !N's branch         
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m switch [0m[2m[36m-[0m[2m                      # Back to previous[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m switch ^                      # Default branch worktree[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m switch [0m[2m[36m--create[0m[2m fix [0m[2m[36m--base=@[0m[2m  # Branch from current HEAD[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m switch pr:123                 # PR #123's branch[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m switch mr:101                 # MR !101's branch[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch [0m[2m[36m-[0m[2m                      # Back to previous[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch ^                      # Default branch worktree[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch [0m[2m[36m--create[0m[2m fix [0m[2m[36m--base=@[0m[2m  # Branch from current HEAD[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch pr:123                 # PR #123's branch[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch mr:101                 # MR !101's branch[0m[2m[0m
 
 [1m[32mInteractive picker[0m
 
@@ -201,8 +201,8 @@ Available on Unix only (macOS, Linux). On Windows, use [2mwt list[0m or [2mwt
 
 The [2mpr:<number>[0m and [2mmr:<number>[0m shortcuts resolve a GitHub PR or GitLab MR to its branch. For same-repo PRs/MRs, worktrunk switches to the branch directly. For fork PRs/MRs, it fetches the ref ([2mrefs/pull/N/head[0m or [2mrefs/merge-requests/N/head[0m) and configures [2mpushRemote[0m to the fork URL.
 
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m switch pr:101                 # GitHub PR #101[0m[2m[0m
-[107m [0m [2m[0m[2m[36m$[0m[2m wt[0m[2m switch mr:101                 # GitLab MR !101[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch pr:101                 # GitHub PR #101[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch mr:101                 # GitLab MR !101[0m[2m[0m
 
 Requires [2mgh[0m (GitHub) or [2mglab[0m (GitLab) CLI to be installed and authenticated. The [2m--create[0m flag cannot be used with [2mpr:[0m/[2mmr:[0m syntax since the branch already exists.
 


### PR DESCRIPTION
Console code blocks in `--help` output included `$ ` prompt prefixes, which meant selecting and copying a command from the terminal would include the prompt. The web docs don't have this problem — their copy buttons strip the `$ `.

The fix strips `$ ` during terminal rendering in `md_help.rs`, giving `console` its own match arm. The source markdown keeps `$ ` intact for the web docs pipeline (`docs.rs` uses it to distinguish commands from output). Side benefit: `wt` is now correctly highlighted as the command name instead of `$` being highlighted as an operator.

> _This was written by Claude Code on behalf of @max-sixty_