### PR TITLE
fix: use effective integration target in RemovedWorktree display

### DIFF
--- a/src/commands/repository_ext.rs
+++ b/src/commands/repository_ext.rs
@@ -259,13 +259,15 @@ impl RepositoryCliExt for Repository {
         };
 
         // Pre-compute integration reason to avoid race conditions when removing
-        // multiple worktrees in background mode.
-        let (integration_reason, _) = compute_integration_reason(
+        // multiple worktrees in background mode. Use the effective target for
+        // display (e.g., origin/main when upstream is ahead).
+        let (integration_reason, effective_target) = compute_integration_reason(
             self,
             branch_name.as_deref(),
             target_branch.as_deref(),
             deletion_mode,
         );
+        let target_branch = effective_target.or(target_branch);
 
         // Compute expected_path for path mismatch detection
         // Only set if actual path differs from expected (path mismatch)

--- a/tests/integration_tests/remove.rs
+++ b/tests/integration_tests/remove.rs
@@ -1484,6 +1484,46 @@ fn test_remove_squash_merged_on_remote_then_advanced(#[from(repo_with_remote)] r
     ));
 }
 
+/// Like `test_remove_squash_merged_on_remote`, but with a **worktree** (not just
+/// a branch). Tests that the `RemovedWorktree` path displays the effective target
+/// (`origin/main`) rather than the local default branch when upstream is ahead.
+#[rstest]
+fn test_remove_worktree_squash_merged_on_remote(#[from(repo_with_remote)] mut repo: TestRepo) {
+    let remote_path = repo.remote_path().unwrap().to_path_buf();
+
+    // Create a worktree for the feature branch
+    let _wt_path = repo.add_worktree("feature-wt-squash");
+    let wt_path = repo.worktrees["feature-wt-squash"].clone();
+    std::fs::write(wt_path.join("feature-wt.txt"), "feature content").unwrap();
+    repo.run_git_in(&wt_path, &["add", "feature-wt.txt"]);
+    repo.run_git_in(&wt_path, &["commit", "-m", "Add feature"]);
+    repo.run_git_in(&wt_path, &["push", "-u", "origin", "feature-wt-squash"]);
+
+    // Simulate GitHub squash merge on the remote
+    let github_sim = repo.home_path().join("github-sim-wt");
+    repo.run_git_in(
+        repo.home_path(),
+        &["clone", remote_path.to_str().unwrap(), "github-sim-wt"],
+    );
+    repo.run_git_in(
+        &github_sim,
+        &["merge", "--squash", "origin/feature-wt-squash"],
+    );
+    repo.run_git_in(&github_sim, &["commit", "-m", "Add feature (#1)"]);
+    repo.run_git_in(&github_sim, &["push", "origin", "main"]);
+
+    // Fetch locally — origin/main now has the squash merge, local main does not
+    repo.run_git(&["fetch", "origin"]);
+
+    // Remove the worktree — should show origin/main as the integration target
+    assert_cmd_snapshot!(make_snapshot_cmd(
+        &repo,
+        "remove",
+        &["feature-wt-squash"],
+        None
+    ));
+}
+
 // ============================================================================
 // Pre-Remove Hook Tests
 // ============================================================================

--- a/tests/snapshots/integration__integration_tests__remove__remove_worktree_squash_merged_on_remote.snap
+++ b/tests/snapshots/integration__integration_tests__remove__remove_worktree_squash_merged_on_remote.snap
@@ -1,0 +1,47 @@
+---
+source: tests/integration_tests/remove.rs
+info:
+  program: wt
+  args:
+    - remove
+    - feature-wt-squash
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mRemoving [1mfeature-wt-squash[22m worktree & branch in background (tree matches [1morigin/main[22m,[39m [2m⊂[22m[36m)[39m


### PR DESCRIPTION
The background removal path was showing the local default branch (e.g., `main`) instead of the effective target (e.g., `origin/main`) when the upstream was ahead. This was a pre-existing inconsistency between foreground and background removal — foreground gets the effective target from `delete_branch_if_safe`, but background used `target_branch` directly.

Now `prepare_worktree_removal` Phase 5 uses the effective target returned by `compute_integration_reason` (which was added in #1989 but discarded with `_`). One-line fix: `let target_branch = effective_target.or(target_branch);`

Added `test_remove_worktree_squash_merged_on_remote` which creates a worktree where `origin/main` is ahead of local `main` after a squash merge, and verifies the background removal output shows `origin/main`.

> _This was written by Claude Code on behalf of @max-sixty_