### PR TITLE
refactor: extract shared TestRepo::init_repo() and use TestRepo in recover tests

### DIFF
--- a/src/git/recover.rs
+++ b/src/git/recover.rs
@@ -208,7 +208,7 @@ fn paths_match(worktree_path: &Path, deleted_path: &Path) -> bool {
 mod tests {
     use super::*;
     use crate::shell_exec::Cmd;
-    use crate::testing::set_test_identity;
+    use crate::testing::{TestRepo, set_test_identity};
     use ansi_str::AnsiStr;
 
     fn git_init(path: &Path) {
@@ -299,15 +299,9 @@ mod tests {
 
     #[test]
     fn test_was_worktree_of_rejects_unknown_path() {
-        let tmp = tempfile::tempdir().unwrap();
-        git_init(tmp.path());
-        let repo = Repository::at(tmp.path()).unwrap();
-        set_test_identity(&repo);
-        repo.run_command(&["commit", "--allow-empty", "-m", "init"])
-            .unwrap();
-
+        let test = TestRepo::with_initial_commit();
         let unknown = PathBuf::from("/nonexistent/unknown");
-        assert!(!was_worktree_of(&repo, &unknown));
+        assert!(!was_worktree_of(&test.repo, &unknown));
     }
 
     #[test]
@@ -461,13 +455,8 @@ mod tests {
     #[test]
     fn test_hint_for_repo_suggests_switch() {
         // A normal repo with a main worktree should suggest `wt switch ^`.
-        let tmp = tempfile::tempdir().unwrap();
-        git_init(tmp.path());
-        let repo = Repository::at(tmp.path()).unwrap();
-        set_test_identity(&repo);
-        repo.run_command(&["commit", "--allow-empty", "-m", "init"])
-            .unwrap();
-        let hint = hint_for_repo(&repo);
+        let test = TestRepo::with_initial_commit();
+        let hint = hint_for_repo(&test.repo);
         insta::assert_snapshot!(hint.ansi_strip(), @"Current directory was removed. Try: wt switch ^");
     }
 

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -632,45 +632,16 @@ impl TestRepo {
     /// commands), use [`standard()`](Self::standard) instead.
     #[allow(clippy::new_without_default)]
     pub fn new() -> Self {
-        let temp_dir = TempDir::new().unwrap();
-        let root = temp_dir.path().join("repo");
-        std::fs::create_dir(&root).unwrap();
-
-        let test_config_path = temp_dir.path().join("test-config.toml");
-        let test_approvals_path = temp_dir.path().join("test-approvals.toml");
-        let git_config_path = temp_dir.path().join("test-gitconfig");
-        write_test_gitconfig(&git_config_path);
-
-        configure_git_env(Cmd::new("git"), &git_config_path)
-            .args(["init", "-b", "main"])
-            .current_dir(&root)
-            .run()
-            .unwrap();
-
-        let root = canonicalize(&root).unwrap();
-        let repo = Repository::at(&root).unwrap();
-
+        let repo = Self::init_repo(&["init", "-b", "main"]);
         // Also set identity in local config so unit tests that commit via
         // repo.run_command() work without GIT_CONFIG_GLOBAL.
-        repo.run_command(&["config", "user.name", "Test User"])
+        repo.repo
+            .run_command(&["config", "user.name", "Test User"])
             .unwrap();
-        repo.run_command(&["config", "user.email", "test@example.com"])
+        repo.repo
+            .run_command(&["config", "user.email", "test@example.com"])
             .unwrap();
-
-        Self {
-            temp_dir,
-            root,
-            repo,
-            worktrees: HashMap::new(),
-            remote: None,
-            test_config_path,
-            test_approvals_path,
-            git_config_path,
-            mock_bin_path: None,
-            claude_installed: false,
-            opencode_installed: false,
-            _lifetime_guard: None,
-        }
+        repo
     }
 
     /// Create a repo with one initial commit on `main`.
@@ -756,23 +727,31 @@ impl TestRepo {
     /// Use this for tests that specifically need to test behavior in an
     /// uninitialized repo. Most tests should use `new()` instead.
     pub fn empty() -> Self {
+        Self::init_repo(&["init", "-q"])
+    }
+
+    /// Shared initializer for `new()` and `empty()`.
+    ///
+    /// Creates a tempdir, writes gitconfig, runs `git init` with the given
+    /// arguments, and returns a `TestRepo` with no commits and no identity
+    /// in local config. Callers add identity or other setup as needed.
+    fn init_repo(git_args: &[&str]) -> Self {
         let temp_dir = TempDir::new().unwrap();
         let root = temp_dir.path().join("repo");
         std::fs::create_dir(&root).unwrap();
-        let root = canonicalize(&root).unwrap();
 
         let test_config_path = temp_dir.path().join("test-config.toml");
         let test_approvals_path = temp_dir.path().join("test-approvals.toml");
         let git_config_path = temp_dir.path().join("test-gitconfig");
-
         write_test_gitconfig(&git_config_path);
 
-        // Run git init first so Repository::at() can find the .git directory
         configure_git_env(Cmd::new("git"), &git_config_path)
-            .args(["init", "-q"])
+            .args(git_args.iter().copied())
             .current_dir(&root)
             .run()
             .unwrap();
+
+        let root = canonicalize(&root).unwrap();
 
         Self {
             temp_dir,


### PR DESCRIPTION
Deduplicate the ~20 lines of identical setup between `TestRepo::new()` and `TestRepo::empty()` into a private `init_repo()` method. Migrate two recover.rs tests that only need "a repo with a commit" from manual `git_init() + set_test_identity()` to `TestRepo::with_initial_commit()`.

The remaining 8 recover tests keep their local pattern — they intentionally create sibling/nested repo layouts within a shared tempdir that TestRepo doesn't support.

Follow-up to #1991.

> _This was written by Claude Code on behalf of @max-sixty_