### PR TITLE
refactor: remove lifetime guard field from TestRepo

### DIFF
--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -29,7 +29,6 @@
 
 pub mod mock_commands;
 
-use std::any::Any;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -615,11 +614,6 @@ pub struct TestRepo {
     claude_installed: bool,
     /// Whether OpenCode CLI should be treated as installed
     opencode_installed: bool,
-    /// Opaque data kept alive for this repo's lifetime.
-    /// Integration tests use this to hold insta snapshot filter guards.
-    // TODO: Consider moving snapshot guard setup entirely out of TestRepo
-    // into rstest fixtures, eliminating this field.
-    _lifetime_guard: Option<Box<dyn Any>>,
 }
 
 impl TestRepo {
@@ -665,13 +659,6 @@ impl TestRepo {
         self.root_path()
     }
 
-    /// Store an opaque guard that will be kept alive for this repo's lifetime.
-    ///
-    /// Integration tests use this to hold insta snapshot filter guards.
-    pub fn set_lifetime_guard(&mut self, guard: Box<dyn Any>) {
-        self._lifetime_guard = Some(guard);
-    }
-
     /// Create a test repository from the standard fixture.
     ///
     /// The repo includes:
@@ -713,7 +700,6 @@ impl TestRepo {
             mock_bin_path: None,
             claude_installed: false,
             opencode_installed: false,
-            _lifetime_guard: None,
         };
 
         // Mock gh/glab as authenticated to prevent CI hints in test output
@@ -765,7 +751,6 @@ impl TestRepo {
             mock_bin_path: None,
             claude_installed: false,
             opencode_installed: false,
-            _lifetime_guard: None,
         }
     }
 

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -116,10 +116,13 @@ pub fn pty_safe() {
 /// ```
 #[rstest::fixture]
 pub fn repo() -> TestRepo {
-    let mut repo = TestRepo::standard();
+    let repo = TestRepo::standard();
+    // Bind insta snapshot filters for this test thread. `mem::forget` intentionally
+    // leaks the scope guard so settings persist without storing the guard in TestRepo.
+    // Safe: each test sets its own settings, and thread-locals are cleaned up on exit.
     let guard =
         setup_snapshot_settings_for_paths(repo.root_path(), &repo.worktrees).bind_to_scope();
-    repo.set_lifetime_guard(Box::new(guard));
+    std::mem::forget(guard);
     repo
 }
 

--- a/tests/integration_tests/list.rs
+++ b/tests/integration_tests/list.rs
@@ -3136,10 +3136,10 @@ fn test_list_nested_worktree_json_is_current(mut repo: TestRepo) {
 /// and spurious "default branch does not exist locally" warnings.
 #[test]
 fn test_list_empty_repo() {
-    let mut repo = TestRepo::empty();
+    let repo = TestRepo::empty();
     let guard =
         setup_snapshot_settings_for_paths(repo.root_path(), &repo.worktrees).bind_to_scope();
-    repo.set_lifetime_guard(Box::new(guard));
+    std::mem::forget(guard);
     // Pre-set default branch cache so the `is_unborn_head_branch` validation path is exercised
     repo.run_git(&["config", "worktrunk.default-branch", "main"]);
     // Should show the branch with empty commit columns and no errors


### PR DESCRIPTION
The `_lifetime_guard: Option<Box<dyn Any>>` field and `set_lifetime_guard()` method existed to hold insta snapshot filter guards alive via type erasure — insta is a dev-dependency and can't appear in `src/` code. Replace with `std::mem::forget(guard)` at the two call sites (the `repo()` rstest fixture and `test_list_empty_repo`). The insta settings are thread-local, so leaking the scope guard keeps them active without needing to store anything in TestRepo.

> _This was written by Claude Code on behalf of @max-sixty_