### PR TITLE
refactor: add `TestRepo::bare()` and consolidate bare repo test creation

### DIFF
--- a/src/git/recover.rs
+++ b/src/git/recover.rs
@@ -207,7 +207,6 @@ fn paths_match(worktree_path: &Path, deleted_path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::shell_exec::Cmd;
     use crate::testing::TestRepo;
     use ansi_str::AnsiStr;
 
@@ -424,14 +423,8 @@ mod tests {
     fn test_hint_for_repo_fallback_to_list() {
         // A bare repo with no worktrees has no default branch worktree,
         // so it should suggest `wt list` instead of `wt switch ^`.
-        let tmp = tempfile::tempdir().unwrap();
-        Cmd::new("git")
-            .args(["init", "--bare", "--quiet"])
-            .current_dir(tmp.path())
-            .run()
-            .unwrap();
-        let repo = Repository::at(tmp.path()).unwrap();
-        let hint = hint_for_repo(&repo);
+        let test = TestRepo::bare();
+        let hint = hint_for_repo(&test.repo);
         insta::assert_snapshot!(hint.ansi_strip(), @"Current directory was removed. Run wt list to see worktrees");
     }
 }

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -14,6 +14,7 @@
 //!
 //! - [`TestRepo::new()`] — lightweight: `git init` + identity. For unit tests.
 //! - [`TestRepo::with_initial_commit()`] — lightweight + one commit.
+//! - [`TestRepo::bare()`] — bare repository (`git init --bare`). No working tree.
 //! - [`TestRepo::at(path)`](TestRepo::at) — repo at a caller-specified path.
 //!   For tests needing multiple repos in a shared directory.
 //! - [`TestRepo::standard()`] — copies pre-built fixture with remote + worktrees.
@@ -641,6 +642,14 @@ impl TestRepo {
         test.run_git(&["add", "."]);
         test.run_git(&["commit", "-m", "init"]);
         test
+    }
+
+    /// Create a bare repository (`git init --bare`).
+    ///
+    /// Bare repos have no working tree — useful for testing error paths
+    /// and bare-repo-specific behavior (e.g., hint fallback to `wt list`).
+    pub fn bare() -> Self {
+        Self::init_repo(&["init", "--bare"])
     }
 
     /// Path to the repository working directory.

--- a/tests/integration_tests/step_promote.rs
+++ b/tests/integration_tests/step_promote.rs
@@ -267,19 +267,12 @@ fn test_promote_shows_mismatch_in_list(mut repo: TestRepo) {
 /// Test error when run in a bare repository (no worktrees)
 #[test]
 fn test_promote_bare_repo_no_worktrees() {
-    let temp_dir = tempfile::tempdir().unwrap();
-    let bare_repo = temp_dir.path().join("bare.git");
-
-    // Create a bare repository
-    Cmd::new("git")
-        .args(["init", "--bare", bare_repo.to_str().unwrap()])
-        .run()
-        .unwrap();
+    let test = TestRepo::bare();
 
     // Try to run promote in the bare repo - fails with "No worktrees found"
-    let output = wt_command()
+    let output = test
+        .wt_command()
         .args(["step", "promote", "feature"])
-        .current_dir(&bare_repo)
         .output()
         .unwrap();
 


### PR DESCRIPTION
Adds a `bare()` constructor to `TestRepo` that delegates to `init_repo(["init", "--bare"])`, following the established pattern of the other constructors. Migrates two bare repo test sites from manual `git init --bare` to use it, improving env isolation in the step_promote test (now uses `test.wt_command()` instead of the free `wt_command()`).

Continues #2005.

> _This was written by Claude Code on behalf of maximilian_