### PR TITLE
cli: order VarsAction reads before writes

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -951,8 +951,8 @@ Usage: <b><span class=c>wt config state vars</span></b> <span class=c>[OPTIONS]<
 
 <b><span class=g>Commands:</span></b>
   <b><span class=c>get</span></b>    Get a value
-  <b><span class=c>set</span></b>    Set a value
   <b><span class=c>list</span></b>   List all keys
+  <b><span class=c>set</span></b>    Set a value
   <b><span class=c>clear</span></b>  Clear a key or all keys
 
 <b><span class=g>Options:</span></b>

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -984,8 +984,8 @@ Usage: wt config state vars [OPTIONS] <COMMAND>
 
 Commands:
   get    Get a value
-  set    Set a value
   list   List all keys
+  set    Set a value
   clear  Clear a key or all keys
 
 Options:

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1112,7 +1112,7 @@ $ wt config state hints clear worktree-path
     },
 }
 
-// Ordering: CRUD — get, set, list, clear.
+// Ordering: reads before writes — get, list, set, clear.
 #[derive(Subcommand)]
 pub enum VarsAction {
     /// Get a value
@@ -1134,6 +1134,28 @@ $ wt config state vars get env --branch=feature
         /// Target branch (defaults to current)
         #[arg(long, add = crate::completion::branch_value_completer())]
         branch: Option<String>,
+    },
+
+    /// List all keys
+    #[command(after_long_help = r#"## Examples
+
+List keys for current branch:
+```console
+$ wt config state vars list
+```
+
+List keys for a specific branch:
+```console
+$ wt config state vars list --branch=feature
+```"#)]
+    List {
+        /// Target branch (defaults to current)
+        #[arg(long, add = crate::completion::branch_value_completer())]
+        branch: Option<String>,
+
+        /// Output format (text, json)
+        #[arg(long, default_value = "text", help_heading = "Output")]
+        format: SwitchFormat,
     },
 
     /// Set a value
@@ -1161,28 +1183,6 @@ $ wt config state vars set env=production --branch=main
         /// Target branch (defaults to current)
         #[arg(long, add = crate::completion::branch_value_completer())]
         branch: Option<String>,
-    },
-
-    /// List all keys
-    #[command(after_long_help = r#"## Examples
-
-List keys for current branch:
-```console
-$ wt config state vars list
-```
-
-List keys for a specific branch:
-```console
-$ wt config state vars list --branch=feature
-```"#)]
-    List {
-        /// Target branch (defaults to current)
-        #[arg(long, add = crate::completion::branch_value_completer())]
-        branch: Option<String>,
-
-        /// Output format (text, json)
-        #[arg(long, default_value = "text", help_heading = "Output")]
-        format: SwitchFormat,
     },
 
     /// Clear a key or all keys


### PR DESCRIPTION
`wt config state vars` now lists subcommands as `get → list → set → clear` instead of `get → set → list → clear`, grouping all reads ahead of all writes. The policy comment on `VarsAction` is updated to match.

Follow-up to #2043 — was noted there as a deferred tightening.

> _This was written by Claude Code on behalf of Maximilian_