### PR TITLE
chore: reset tend model to generator default (opus)

### DIFF
--- a/.config/tend.toml
+++ b/.config/tend.toml
@@ -1,6 +1,4 @@
 bot_name = "worktrunk-bot"
-# TODO: reset model back to default (2026-04-09 Thu 8:00 PM PT)
-model = "sonnet"
 
 setup = [
   {uses = "./.github/actions/claude-setup"},

--- a/.github/workflows/tend-ci-fix.yaml
+++ b/.github/workflows/tend-ci-fix.yaml
@@ -38,7 +38,7 @@ jobs:
           github_token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           bot_name: worktrunk-bot
-          model: sonnet
+          model: opus
           prompt: |
             /tend-ci-runner:ci-fix ${{ github.event.workflow_run.id }}
             - Run URL: ${{ github.event.workflow_run.html_url }}

--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -20,13 +20,17 @@ on:
 
 jobs:
   verify:
+    # Filter out fork PRs for review events — secrets are unavailable there
+    # (no _target variant exists). The notifications workflow polls for these.
     if: |
       (github.event_name == 'issues' &&
         contains(github.event.issue.body, '@worktrunk-bot')) ||
       (github.event_name == 'issue_comment' &&
         github.event.comment.user.login != 'worktrunk-bot') ||
-      github.event_name == 'pull_request_review_comment' ||
-      github.event_name == 'pull_request_review'
+      (github.event_name == 'pull_request_review_comment' &&
+        github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_review' &&
+        github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-24.04
     outputs:
       should_run: ${{ steps.check.outputs.should_run }}
@@ -166,7 +170,7 @@ jobs:
           github_token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           bot_name: worktrunk-bot
-          model: sonnet
+          model: opus
           prompt: >-
             ${{ steps.delay.outputs.seconds
             && format('This job started {0}s after the triggering event (over ~40s means it was queued). ',

--- a/.github/workflows/tend-nightly.yaml
+++ b/.github/workflows/tend-nightly.yaml
@@ -37,6 +37,6 @@ jobs:
           github_token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           bot_name: worktrunk-bot
-          model: sonnet
+          model: opus
           prompt: |
             /tend-ci-runner:nightly

--- a/.github/workflows/tend-notifications.yaml
+++ b/.github/workflows/tend-notifications.yaml
@@ -52,6 +52,6 @@ jobs:
           github_token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           bot_name: worktrunk-bot
-          model: sonnet
+          model: opus
           prompt: |
             /tend-ci-runner:notifications

--- a/.github/workflows/tend-review-runs.yaml
+++ b/.github/workflows/tend-review-runs.yaml
@@ -37,6 +37,6 @@ jobs:
           github_token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           bot_name: worktrunk-bot
-          model: sonnet
+          model: opus
           prompt: |
             /tend-ci-runner:review-runs

--- a/.github/workflows/tend-review.yaml
+++ b/.github/workflows/tend-review.yaml
@@ -41,7 +41,7 @@ jobs:
           github_token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           bot_name: worktrunk-bot
-          model: sonnet
+          model: opus
           use_sticky_comment: true
           prompt: >-
             ${{ format('/tend-ci-runner:review {0}', github.event.pull_request.number) }}

--- a/.github/workflows/tend-triage.yaml
+++ b/.github/workflows/tend-triage.yaml
@@ -40,6 +40,6 @@ jobs:
           github_token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           bot_name: worktrunk-bot
-          model: sonnet
+          model: opus
           prompt: |
             /tend-ci-runner:triage ${{ github.event.issue.number }}

--- a/.github/workflows/tend-weekly.yaml
+++ b/.github/workflows/tend-weekly.yaml
@@ -37,6 +37,6 @@ jobs:
           github_token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           bot_name: worktrunk-bot
-          model: sonnet
+          model: opus
           prompt: |
             /tend-ci-runner:weekly


### PR DESCRIPTION
Removes the `sonnet` override in `.config/tend.toml` (added in #2019) and the accompanying dated TODO. The tend generator defaults to `opus`, so relying on the default keeps the config minimal.

Regenerated workflows via `uvx tend@latest init`, which flipped `model: sonnet` → `model: opus` across all seven `tend-*.yaml` files and also picked up an upstream improvement to `tend-mention.yaml` that filters out fork PR review events (secrets are unavailable there, so the notifications workflow handles them via polling).