### PR TITLE
Add {{ owner }} template variable for worktree paths

### DIFF
--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -15,6 +15,7 @@
 #
 # - `{{ repo_path }}` — absolute path to the repository root (e.g., `/Users/me/code/myproject`. Or for bare repos, the bare directory itself)
 # - `{{ repo }}` — repository directory name (e.g., `myproject`)
+# - `{{ owner }}` — primary remote owner path (may include subgroups like `group/subgroup`)
 # - `{{ branch }}` — raw branch name (e.g., `feature/auth`)
 # - `{{ branch | sanitize }}` — filesystem-safe: `/` and `\` become `-` (e.g., `feature-auth`)
 # - `{{ branch | sanitize_db }}` — database-safe: lowercase, underscores, hash suffix (e.g., `feature_auth_x7k`)
@@ -32,6 +33,10 @@
 # Centralized worktrees directory (`~/worktrees/myproject/feature-auth`):
 #
 # worktree-path = "~/worktrees/{{ repo }}/{{ branch | sanitize }}"
+#
+# By remote owner path (`~/development/max-sixty/myproject/feature/auth`):
+#
+# worktree-path = "~/development/{{ owner }}/{{ repo }}/{{ branch }}"
 #
 # Bare repository (`~/code/myproject/feature-auth`):
 #

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -77,6 +77,7 @@ Controls where new worktrees are created.
 
 - `{{ repo_path }}` — absolute path to the repository root (e.g., `/Users/me/code/myproject`. Or for bare repos, the bare directory itself)
 - `{{ repo }}` — repository directory name (e.g., `myproject`)
+- `{{ owner }}` — primary remote owner path (may include subgroups like `group/subgroup`)
 - `{{ branch }}` — raw branch name (e.g., `feature/auth`)
 - `{{ branch | sanitize }}` — filesystem-safe: `/` and `\` become `-` (e.g., `feature-auth`)
 - `{{ branch | sanitize_db }}` — database-safe: lowercase, underscores, hash suffix (e.g., `feature_auth_x7k`)
@@ -99,6 +100,12 @@ Centralized worktrees directory (`~/worktrees/myproject/feature-auth`):
 
 ```toml
 worktree-path = "~/worktrees/{{ repo }}/{{ branch | sanitize }}"
+```
+
+By remote owner path (`~/development/max-sixty/myproject/feature/auth`):
+
+```toml
+worktree-path = "~/development/{{ owner }}/{{ repo }}/{{ branch }}"
 ```
 
 Bare repository (`~/code/myproject/feature-auth`):

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -112,6 +112,7 @@ Hooks can use template variables that expand at runtime:
 | `{{ cwd }}` | Directory where the hook command runs |
 | `{{ repo }}` | Repository directory name |
 | `{{ repo_path }}` | Absolute path to repository root |
+| `{{ owner }}` | Primary remote owner path (may include subgroups) |
 | `{{ primary_worktree_path }}` | Primary worktree path |
 | `{{ default_branch }}` | Default branch name |
 | `{{ remote }}` | Primary remote name |

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -76,6 +76,7 @@ Controls where new worktrees are created.
 
 - `{{ repo_path }}` — absolute path to the repository root (e.g., `/Users/me/code/myproject`. Or for bare repos, the bare directory itself)
 - `{{ repo }}` — repository directory name (e.g., `myproject`)
+- `{{ owner }}` — primary remote owner path (may include subgroups like `group/subgroup`)
 - `{{ branch }}` — raw branch name (e.g., `feature/auth`)
 - `{{ branch | sanitize }}` — filesystem-safe: `/` and `\` become `-` (e.g., `feature-auth`)
 - `{{ branch | sanitize_db }}` — database-safe: lowercase, underscores, hash suffix (e.g., `feature_auth_x7k`)
@@ -98,6 +99,12 @@ Centralized worktrees directory (`~/worktrees/myproject/feature-auth`):
 
 ```toml
 worktree-path = "~/worktrees/{{ repo }}/{{ branch | sanitize }}"
+```
+
+By remote owner path (`~/development/max-sixty/myproject/feature/auth`):
+
+```toml
+worktree-path = "~/development/{{ owner }}/{{ repo }}/{{ branch }}"
 ```
 
 Bare repository (`~/code/myproject/feature-auth`):

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -103,6 +103,7 @@ Hooks can use template variables that expand at runtime:
 | `{{ cwd }}` | Directory where the hook command runs |
 | `{{ repo }}` | Repository directory name |
 | `{{ repo_path }}` | Absolute path to repository root |
+| `{{ owner }}` | Primary remote owner path (may include subgroups) |
 | `{{ primary_worktree_path }}` | Primary worktree path |
 | `{{ default_branch }}` | Default branch name |
 | `{{ remote }}` | Primary remote name |

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1270,6 +1270,7 @@ Hooks can use template variables that expand at runtime:
 | `{{ cwd }}` | Directory where the hook command runs |
 | `{{ repo }}` | Repository directory name |
 | `{{ repo_path }}` | Absolute path to repository root |
+| `{{ owner }}` | Primary remote owner path (may include subgroups) |
 | `{{ primary_worktree_path }}` | Primary worktree path |
 | `{{ default_branch }}` | Default branch name |
 | `{{ remote }}` | Primary remote name |
@@ -1702,6 +1703,7 @@ Controls where new worktrees are created.
 
 - `{{ repo_path }}` — absolute path to the repository root (e.g., `/Users/me/code/myproject`. Or for bare repos, the bare directory itself)
 - `{{ repo }}` — repository directory name (e.g., `myproject`)
+- `{{ owner }}` — primary remote owner path (may include subgroups like `group/subgroup`)
 - `{{ branch }}` — raw branch name (e.g., `feature/auth`)
 - `{{ branch | sanitize }}` — filesystem-safe: `/` and `\` become `-` (e.g., `feature-auth`)
 - `{{ branch | sanitize_db }}` — database-safe: lowercase, underscores, hash suffix (e.g., `feature_auth_x7k`)
@@ -1724,6 +1726,12 @@ Centralized worktrees directory (`~/worktrees/myproject/feature-auth`):
 
 ```toml
 worktree-path = "~/worktrees/{{ repo }}/{{ branch | sanitize }}"
+```
+
+By remote owner path (`~/development/max-sixty/myproject/feature/auth`):
+
+```toml
+worktree-path = "~/development/{{ owner }}/{{ repo }}/{{ branch }}"
 ```
 
 Bare repository (`~/code/myproject/feature-auth`):

--- a/src/commands/command_executor.rs
+++ b/src/commands/command_executor.rs
@@ -112,6 +112,10 @@ pub fn build_hook_context(
     map.insert("repo_root".into(), repo_path);
     map.insert("worktree".into(), worktree);
 
+    if let Some(parsed_remote) = ctx.repo.primary_remote_parsed_url() {
+        map.insert("owner".into(), parsed_remote.owner().to_string());
+    }
+
     // Default branch
     if let Some(default_branch) = ctx.repo.default_branch() {
         map.insert("default_branch".into(), default_branch);

--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -30,6 +30,7 @@ use crate::styling::{
 /// This list is the single source of truth for `--var` validation in CLI.
 pub const TEMPLATE_VARS: &[&str] = &[
     "repo",
+    "owner",
     "branch",
     "worktree_name",
     "repo_path",

--- a/src/config/user/accessors.rs
+++ b/src/config/user/accessors.rs
@@ -224,6 +224,7 @@ impl UserConfig {
     /// * `main_worktree` - Main worktree directory name (replaces {{ main_worktree }} in template)
     /// * `branch` - Branch name (replaces {{ branch }} in template; use `{{ branch | sanitize }}` for paths)
     /// * `repo` - Repository for template function access
+    /// * remote owner/namespace is available as {{ owner }}
     /// * `project` - Optional project identifier (e.g., "github.com/user/repo") to look up
     ///   project-specific worktree-path template
     pub fn format_path(
@@ -244,6 +245,12 @@ impl UserConfig {
         vars.insert("repo", main_worktree);
         vars.insert("branch", branch);
         vars.insert("repo_path", repo_path.as_str());
+        let owner = repo
+            .primary_remote_parsed_url()
+            .map(|parsed_remote| parsed_remote.owner().to_string());
+        if let Some(ref owner) = owner {
+            vars.insert("owner", owner.as_str());
+        }
         Ok(
             expand_template(&template, &vars, false, repo, "worktree-path")
                 .map(|p| shellexpand::tilde(&p).into_owned())?,

--- a/src/config/user/tests.rs
+++ b/src/config/user/tests.rs
@@ -431,6 +431,58 @@ fn test_worktrunk_config_format_path_tilde_expansion() {
 }
 
 #[test]
+fn test_worktrunk_config_format_path_owner_variable() {
+    let mut test = TestRepo::with_initial_commit();
+    test.setup_remote("main");
+    test.run_git(&[
+        "remote",
+        "set-url",
+        "origin",
+        "git@github.com:max-sixty/worktrunk.git",
+    ]);
+
+    let config = UserConfig {
+        configs: OverridableConfig {
+            worktree_path: Some("{{ owner }}/{{ repo }}/{{ branch }}".to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let path = config
+        .format_path("myrepo", "feature/branch", &test.repo, None)
+        .unwrap();
+
+    assert_eq!(path, "max-sixty/myrepo/feature/branch");
+}
+
+#[test]
+fn test_worktrunk_config_format_path_owner_uses_full_namespace() {
+    let mut test = TestRepo::with_initial_commit();
+    test.setup_remote("main");
+    test.run_git(&[
+        "remote",
+        "set-url",
+        "origin",
+        "git@gitlab.com:group/subgroup/project.git",
+    ]);
+
+    let config = UserConfig {
+        configs: OverridableConfig {
+            worktree_path: Some("{{ owner }}/{{ repo }}/{{ branch }}".to_string()),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let path = config
+        .format_path("myrepo", "feature/branch", &test.repo, None)
+        .unwrap();
+
+    assert_eq!(path, "group/subgroup/myrepo/feature/branch");
+}
+
+#[test]
 fn test_merge_config_serde() {
     let config = MergeConfig {
         squash: Some(true),

--- a/src/git/repository/remotes.rs
+++ b/src/git/repository/remotes.rs
@@ -276,6 +276,16 @@ impl Repository {
             .clone()
     }
 
+    /// Parse the primary remote URL into structured host/owner/repo components.
+    ///
+    /// Uses the raw configured URL rather than `effective_remote_url()` so owner/namespace
+    /// extraction follows the same "path is the source of truth" rule used elsewhere.
+    pub fn primary_remote_parsed_url(&self) -> Option<GitRemoteUrl> {
+        self.primary_remote_url()
+            .as_deref()
+            .and_then(GitRemoteUrl::parse)
+    }
+
     /// Get a project identifier for approval tracking.
     ///
     /// Uses the git remote URL if available (e.g., "github.com/user/repo"),

--- a/tests/integration_tests/eval.rs
+++ b/tests/integration_tests/eval.rs
@@ -68,6 +68,32 @@ fn test_eval_dry_run(repo: TestRepo) {
 }
 
 #[rstest]
+fn test_eval_owner(repo: TestRepo) {
+    repo.run_git(&[
+        "remote",
+        "set-url",
+        "origin",
+        "git@github.com:max-sixty/worktrunk.git",
+    ]);
+
+    let output = repo
+        .wt_command()
+        .args(["step", "eval", "{{ owner }}/{{ repo }}"])
+        .output()
+        .expect("Failed to run wt step eval");
+
+    assert!(
+        output.status.success(),
+        "wt step eval should succeed, stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        String::from_utf8_lossy(&output.stdout).trim(),
+        "max-sixty/repo"
+    );
+}
+
+#[rstest]
 fn test_eval_conditional(repo: TestRepo) {
     assert_cmd_snapshot!(make_snapshot_cmd(
         &repo,

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -75,6 +75,7 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m#[0m
 [107m [0m [2m# - `{{ repo_path }}` — absolute path to the repository root (e.g., `/Users/me/code/myproject`. Or for bare repos, the bare directory itself)[0m
 [107m [0m [2m# - `{{ repo }}` — repository directory name (e.g., `myproject`)[0m
+[107m [0m [2m# - `{{ owner }}` — primary remote owner path (may include subgroups like `group/subgroup`)[0m
 [107m [0m [2m# - `{{ branch }}` — raw branch name (e.g., `feature/auth`)[0m
 [107m [0m [2m# - `{{ branch | sanitize }}` — filesystem-safe: `/` and `\` become `-` (e.g., `feature-auth`)[0m
 [107m [0m [2m# - `{{ branch | sanitize_db }}` — database-safe: lowercase, underscores, hash suffix (e.g., `feature_auth_x7k`)[0m
@@ -92,6 +93,10 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# Centralized worktrees directory (`~/worktrees/myproject/feature-auth`):[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# worktree-path = "~/worktrees/{{ repo }}/{{ branch | sanitize }}"[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# By remote owner path (`~/development/max-sixty/myproject/feature/auth`):[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# worktree-path = "~/development/{{ owner }}/{{ repo }}/{{ branch }}"[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# Bare repository (`~/code/myproject/feature-auth`):[0m
 [107m [0m [2m#[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -8,7 +8,7 @@ info:
   env:
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
-    GIT_EDITOR: ""
+    GIT_PAGER: ""
     LANG: C
     LC_ALL: C
     NO_COLOR: ""
@@ -121,6 +121,7 @@ Controls where new worktrees are created.
 
 - [2m{{ repo_path }}[0m — absolute path to the repository root (e.g., [2m/Users/me/code/myproject[0m. Or for bare repos, the bare directory itself)
 - [2m{{ repo }}[0m — repository directory name (e.g., [2mmyproject[0m)
+- [2m{{ owner }}[0m — primary remote owner path (may include subgroups like [2mgroup/subgroup[0m)
 - [2m{{ branch }}[0m — raw branch name (e.g., [2mfeature/auth[0m)
 - [2m{{ branch | sanitize }}[0m — filesystem-safe: [2m/[0m and [2m\[0m become [2m-[0m (e.g., [2mfeature-auth[0m)
 - [2m{{ branch | sanitize_db }}[0m — database-safe: lowercase, underscores, hash suffix (e.g., [2mfeature_auth_x7k[0m)
@@ -138,6 +139,10 @@ Inside the repository ([2m~/code/myproject/.worktrees/feature-auth[0m):
 Centralized worktrees directory ([2m~/worktrees/myproject/feature-auth[0m):
 
 [107m [0m [2mworktree-path = [0m[2m[32m"~/worktrees/{{ repo }}/{{ branch | sanitize }}"[0m
+
+By remote owner path ([2m~/development/max-sixty/myproject/feature/auth[0m):
+
+[107m [0m [2mworktree-path = [0m[2m[32m"~/development/{{ owner }}/{{ repo }}/{{ branch }}"[0m
 
 Bare repository ([2m~/code/myproject/feature-auth[0m):
 


### PR DESCRIPTION
## Summary

Adds a new `{{ owner }}` template variable for worktree path and hook templates, derived from the primary remote URL.

This makes owner-qualified layouts easy to express, for example:

- `~/development/{{ owner }}/{{ repo }}`
- `~/worktrees/{{ owner }}/{{ repo }}/{{ branch }}`

That avoids path collisions when the same repository name exists under different owners or orgs.

For GitHub, `owner` is the account or organization name. For GitLab-style remotes, it preserves the full owner path such as `group/subgroup`.

## Changes

- expose `{{ owner }}` in worktree-path template expansion
- expose `{{ owner }}` in hook and `wt step eval` template contexts
- document the new variable in help/docs
- add unit and integration coverage for both single-owner and nested-owner-path remotes

## Validation

- `cargo test --lib test_worktrunk_config_format_path_owner`
- `cargo test --test integration test_eval_`
- `cargo test --test integration test_command_pages_and_skill_files_are_in_sync`
- `INSTA_UPDATE=always cargo test --test integration test_help`
