### PR TITLE
fix(readme-sync): don't leak placeholder disambiguation suffix into web docs prompt

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -846,7 +846,7 @@ Markers appear at the end of the Status column, after git symbols:
 
 <!-- ⚠️ AUTO-GENERATED from tests/snapshots/integration__integration_tests__list__readme_example_list_marker.snap — edit source to update -->
 
-{% terminal(cmd="wt list (markers)") %}
+{% terminal(cmd="wt list") %}
 &#32;&#32;<b>Branch</b>       <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>  <b>Remote⇅</b>  <b>Commit</b>    <b>Age</b>   <b>Message</b>
 @ main             <span class=d>^</span><span class=d>⇡</span>                         <span class=g>⇡1</span>      <span class=d>33323bc1</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
 + feature-api      <span class=d>↑</span> 🤖              <span class=g>↑1</span>               <span class=d>70343f03</span>  <span class=d>1d</span>    <span class=d>Add REST API endpoints</span>

--- a/tests/integration_tests/readme_sync.rs
+++ b/tests/integration_tests/readme_sync.rs
@@ -373,19 +373,20 @@ fn update_section(
 // =============================================================================
 
 /// Regex to find command placeholder comments in help pages
-/// Matches: <!-- wt <args> -->\n```bash\nwt <args>\n```
-/// The HTML comment triggers expansion, the code block shows in terminal help
-/// Note: Pattern expects ```bash``` because --help-page converts ```console``` first
-static COMMAND_PLACEHOLDER_PATTERN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"<!-- (wt [^>]+) -->\n```bash\nwt [^\n]+\n```").unwrap());
-
-/// Regex for command placeholders in --help-page --plain output
 /// Matches: <!-- wt <id> -->\n```bash\n[$ ]wt <cmd>\n```
-/// Plain mode preserves the source block verbatim (skips convert_dollar_console_to_terminal),
-/// so blocks with and without the `$ ` prompt both appear — the prompt is optional.
-/// Group 1 captures the placeholder id (used for snapshot lookup, e.g. `wt list (markers)`);
-/// group 2 captures the actual command to display (e.g. `wt list`).
-static COMMAND_PLACEHOLDER_PATTERN_PLAIN: LazyLock<Regex> = LazyLock::new(|| {
+///
+/// The HTML comment triggers expansion, the code block shows in terminal help.
+/// Pattern expects ```bash``` because --help-page converts ```console``` first.
+/// The `$ ` prompt is optional: in the HTML pipeline, `$ `-prefixed blocks are
+/// consumed entirely by `convert_dollar_console_to_terminal` before this regex
+/// runs, so only bare `wt …` blocks reach here. The `$ ` branch matters only
+/// in the plain pipeline, which skips that conversion and sees the source
+/// block verbatim.
+///
+/// Group 1 captures the placeholder id (used for snapshot lookup, e.g.
+/// `wt list (markers)`); group 2 captures the actual command to display (e.g.
+/// `wt list`), so disambiguation suffixes don't leak into the rendered prompt.
+static COMMAND_PLACEHOLDER_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"<!-- (wt [^>]+) -->\n```bash\n(?:\$ )?(wt [^\n]+)\n```").unwrap()
 });
 
@@ -412,6 +413,10 @@ fn command_to_snapshot(command: &str) -> Option<&'static str> {
 /// to ```bash``` by --help-page) and replaces them with {% terminal() %}
 /// shortcodes containing snapshot output.
 ///
+/// The placeholder id (e.g. `wt list (markers)`) drives snapshot lookup; the
+/// displayed command comes from the block body so disambiguation suffixes
+/// don't leak into the rendered `cmd=` prompt.
+///
 /// Commands without a snapshot mapping are left as plain code blocks.
 fn expand_command_placeholders(content: &str, snapshots_dir: &Path) -> Result<String, String> {
     let mut result = content.to_string();
@@ -420,10 +425,11 @@ fn expand_command_placeholders(content: &str, snapshots_dir: &Path) -> Result<St
     // Find all placeholder blocks
     for cap in COMMAND_PLACEHOLDER_PATTERN.captures_iter(content) {
         let full_match = cap.get(0).unwrap().as_str();
-        let command = cap.get(1).unwrap().as_str();
+        let placeholder_id = cap.get(1).unwrap().as_str();
+        let display_cmd = cap.get(2).unwrap().as_str();
 
         // Skip commands without snapshot mappings - leave as plain code blocks
-        let Some(snapshot_name) = command_to_snapshot(command) else {
+        let Some(snapshot_name) = command_to_snapshot(placeholder_id) else {
             continue;
         };
 
@@ -432,7 +438,7 @@ fn expand_command_placeholders(content: &str, snapshots_dir: &Path) -> Result<St
             errors.push(format!(
                 "Snapshot file not found: {} (for command '{}')",
                 snapshot_path.display(),
-                command
+                placeholder_id
             ));
             continue;
         }
@@ -452,7 +458,7 @@ fn expand_command_placeholders(content: &str, snapshots_dir: &Path) -> Result<St
              {}\n\
              {{% end %}}\n\n\
              <!-- END AUTO-GENERATED -->",
-            snapshot_name, command, normalized
+            snapshot_name, display_cmd, normalized
         );
 
         result = result.replace(full_match, &replacement);
@@ -482,7 +488,7 @@ fn expand_command_placeholders_plain(
     let mut result = content.to_string();
     let mut errors = Vec::new();
 
-    for cap in COMMAND_PLACEHOLDER_PATTERN_PLAIN.captures_iter(content) {
+    for cap in COMMAND_PLACEHOLDER_PATTERN.captures_iter(content) {
         let full_match = cap.get(0).unwrap().as_str();
         let placeholder_id = cap.get(1).unwrap().as_str();
         let display_cmd = cap.get(2).unwrap().as_str();


### PR DESCRIPTION
## Summary

`docs/content/config.md` was rendering `$ wt list (markers)` as its prompt line. The HTML branch of `expand_command_placeholders` used the placeholder id (the snapshot-lookup key, e.g. `wt list (markers)`) for the `cmd=` parameter of the generated terminal shortcode, so disambiguation suffixes leaked into the rendered prompt. This swaps it for `display_cmd` (the inner command from the source code block), mirroring what `ExpandMode::Plain` already does and the fix that landed for the plain pipeline in #2049.

After rebasing on top of #2057 (which unified the HTML/plain functions behind `ExpandMode`), the fix is a one-line change: `cmd=\"{placeholder_id}\"` → `cmd=\"{display_cmd}\"`, plus a comment update explaining why. The `docs/content/config.md` line is the auto-regenerated artifact.

## Test plan

- [x] `cargo test --test integration test_command_pages_and_skill_files_are_in_sync` — passes; `docs/content/config.md:856` reads `cmd="wt list"` with no `(markers)` suffix
- [x] `cargo run -- hook pre-merge --yes` — all tests, lints, doctests pass
- [x] `docs/content/list.md` unchanged
- [x] `skills/worktrunk/reference/config.md` unchanged (plain pipeline was already correct via #2049)

> _This was written by Claude Code on behalf of Maximilian Roos_