### PR TITLE
feat(wt sync): add core rebase engine (part 01/03)

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -457,10 +457,6 @@ pub(crate) struct SyncArgs {
     #[arg(long)]
     pub(crate) stack: bool,
 
-    /// Sync all stacks (overrides config)
-    #[arg(long, conflicts_with = "stack")]
-    pub(crate) all: bool,
-
     /// Preview the sync plan
     ///
     /// Shows the dependency tree and planned rebases without executing.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -449,6 +449,26 @@ pub(crate) struct RemoveArgs {
 }
 
 #[derive(Args)]
+pub(crate) struct SyncArgs {
+    /// Only sync the current stack
+    ///
+    /// Without this flag, all worktree branches are synced. With `--stack`, only
+    /// the stack containing the current branch is synced.
+    #[arg(long)]
+    pub(crate) stack: bool,
+
+    /// Sync all stacks (overrides config)
+    #[arg(long, conflicts_with = "stack")]
+    pub(crate) all: bool,
+
+    /// Preview the sync plan
+    ///
+    /// Shows the dependency tree and planned rebases without executing.
+    #[arg(long)]
+    pub(crate) dry_run: bool,
+}
+
+#[derive(Args)]
 pub(crate) struct MergeArgs {
     /// Target branch
     ///
@@ -998,6 +1018,68 @@ Detached worktrees have no branch name. Pass the worktree path instead: `wt remo
 - [`wt list`](@/list.md) — View all worktrees
 "#)]
     Remove(RemoveArgs),
+
+    /// Rebase stacked worktree branches in dependency order
+    ///
+    /// Auto-detects the branch dependency tree from git history and rebases each branch onto its parent.
+    #[command(
+        after_long_help = r#"Detects which branches are stacked on each other by analyzing the git commit graph (merge-base relationships). Rebases each branch onto its parent in topological order — parent before children.
+
+## Examples
+
+```console
+$ wt sync                    # Sync all stacks
+$ wt sync --stack            # Sync current stack only
+$ wt sync --dry-run          # Preview the plan
+```
+
+## Three scenarios
+
+**1. Main advances** — all stacked branches rebase in order:
+
+```
+main ← PR1 ← PR2 ← PR3
+```
+
+**2. Mid-stack change** — downstream branches update:
+
+```
+PR1 gets new commits → PR2 and PR3 rebase onto PR1
+```
+
+**3. PR merged** — children reparent with `rebase --onto`:
+
+```
+PR1 merged into main → PR2 rebases --onto main
+```
+
+## The `--stack` flag
+
+By default, `wt sync` syncs all stacks. With `--stack`, only the current stack is synced.
+
+Say you have two independent stacks:
+
+```
+main
+├── pr-auth → pr-auth-tests       (stack A — you're here)
+└── pr-refactor → pr-cleanup      (stack B — unrelated work)
+```
+
+If main advances, `wt sync` rebases everything. With `--stack` (from pr-auth's worktree), only stack A is synced — stack B is left as-is.
+
+## Behavior
+
+- Skips branches already up-to-date
+- Stops on first conflict — resolve, `git rebase --continue`, re-run `wt sync`
+- Dirty worktrees block sync (commit or stash first)
+
+## See also
+
+- [`wt step rebase`](@/step.md) — Rebase a single branch
+- [`wt list`](@/list.md) — View branch relationships
+"#
+    )]
+    Sync(SyncArgs),
 
     /// Merge current branch into the target branch
     ///

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -26,6 +26,7 @@ pub(crate) mod repository_ext;
 mod run_pipeline;
 pub(crate) mod statusline;
 pub(crate) mod step_commands;
+pub(crate) mod sync;
 pub(crate) mod worktree;
 
 pub(crate) use alias::{AliasOptions, step_alias};
@@ -55,6 +56,7 @@ pub(crate) use step_commands::{
     PromoteResult, RebaseResult, SquashResult, handle_promote, handle_rebase, handle_squash,
     step_commit, step_copy_ignored, step_diff, step_prune, step_relocate, step_show_squash_prompt,
 };
+pub(crate) use sync::{SyncOptions, handle_sync};
 pub(crate) use worktree::{
     OperationMode, is_worktree_at_expected_path, resolve_worktree_arg, worktree_display_name,
 };

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -1,0 +1,606 @@
+//! `wt sync` — rebase stacked worktree branches in dependency order.
+//!
+//! Detects the branch dependency tree from git's commit graph using pairwise
+//! merge-base analysis, then rebases each branch onto its parent in topological
+//! order. Handles integrated (merged) branches by reparenting their children
+//! with `rebase --onto`.
+//!
+//! Key behaviors:
+//! - No configuration needed — dependencies are inferred from git history
+//! - By default, syncs all stacks
+//! - `--stack` restricts to the stack containing the current branch
+//! - `--dry-run` previews the plan without executing
+//! - Stops on first conflict; user resolves and re-runs
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+
+use anyhow::{Context, bail};
+use color_print::cformat;
+
+use worktrunk::git::Repository;
+use worktrunk::styling::{eprintln, progress_message, success_message, warning_message};
+
+/// A node in the dependency tree.
+#[derive(Debug)]
+struct TreeNode {
+    branch: String,
+    path: PathBuf,
+    parent: Option<String>,
+    /// If this branch was reparented because its original parent was integrated,
+    /// this holds the original parent branch name (for `rebase --onto`).
+    original_parent: Option<String>,
+    children: Vec<String>,
+}
+
+/// The full dependency tree for sync operations.
+#[derive(Debug)]
+struct DependencyTree {
+    /// The root branch (default branch).
+    root: String,
+    /// All nodes indexed by branch name.
+    nodes: HashMap<String, TreeNode>,
+}
+
+impl DependencyTree {
+    /// Return branches in topological order (parent before children), excluding the root.
+    fn topological_order(&self) -> Vec<&str> {
+        let mut order = Vec::new();
+        let mut queue = std::collections::VecDeque::new();
+        queue.push_back(self.root.as_str());
+
+        while let Some(branch) = queue.pop_front() {
+            if let Some(node) = self.nodes.get(branch) {
+                for child in &node.children {
+                    order.push(child.as_str());
+                    queue.push_back(child);
+                }
+            }
+        }
+        order
+    }
+
+    /// Get all branches in the stack containing the given branch.
+    fn stack_containing(&self, branch: &str) -> Vec<&str> {
+        // Find the branch in our nodes first (ensures we return self-lifetime refs)
+        let Some(start_node) = self.nodes.get(branch) else {
+            return vec![];
+        };
+
+        // Walk up to find the top of the stack (direct child of root).
+        // Track visited nodes to detect cycles (safety net against dependency
+        // detection bugs that produce circular parent chains).
+        let mut current_key = start_node.branch.as_str();
+        let mut visited = std::collections::HashSet::new();
+        visited.insert(current_key);
+        loop {
+            let Some(node) = self.nodes.get(current_key) else {
+                return vec![];
+            };
+            match &node.parent {
+                Some(p) if p == &self.root => break,
+                Some(p) => {
+                    current_key = match self.nodes.get(p.as_str()) {
+                        Some(n) => {
+                            let key = n.branch.as_str();
+                            if !visited.insert(key) {
+                                // Cycle detected — treat branch as direct child of root
+                                break;
+                            }
+                            key
+                        }
+                        None => break,
+                    };
+                }
+                None => break, // current is the root
+            }
+        }
+
+        if current_key == self.root {
+            // Branch is a direct child of root or the root itself — return all
+            return self.topological_order();
+        }
+
+        // `current_key` is the top of the stack (direct child of root).
+        // Collect all descendants.
+        let mut stack: Vec<&str> = Vec::new();
+        let mut queue = std::collections::VecDeque::new();
+        queue.push_back(current_key);
+        while let Some(b) = queue.pop_front() {
+            stack.push(b);
+            if let Some(node) = self.nodes.get(b) {
+                for child in &node.children {
+                    queue.push_back(child.as_str());
+                }
+            }
+        }
+        stack
+    }
+}
+
+/// Options for the sync command.
+pub struct SyncOptions {
+    pub all: bool,
+    pub dry_run: bool,
+}
+
+/// Build the dependency tree from worktree branches.
+///
+/// For each branch B, finds the closest parent P where merge_base(P, B) is
+/// nearest to B's tip (fewest commits ahead). Integrated branches are excluded
+/// and their children reparented.
+fn build_dependency_tree(repo: &Repository) -> anyhow::Result<DependencyTree> {
+    let default_branch = repo
+        .default_branch()
+        .context("Cannot determine default branch")?;
+
+    let worktrees = repo.list_worktrees()?;
+
+    // Collect branches with worktrees, filtering detached/bare
+    let mut branches: Vec<(String, PathBuf)> = Vec::new();
+    for wt in &worktrees {
+        if wt.bare || wt.detached {
+            continue;
+        }
+        if let Some(ref branch) = wt.branch {
+            branches.push((branch.clone(), wt.path.clone()));
+        }
+    }
+
+    // Ensure default branch is included (may be the main worktree)
+    let has_default = branches.iter().any(|(b, _)| b == &default_branch);
+    if !has_default {
+        bail!(
+            "Default branch '{}' has no worktree. Cannot build dependency tree.",
+            default_branch
+        );
+    }
+
+    // Check for integrated branches against the default branch
+    let integration_target = repo.integration_target();
+    let target_ref = integration_target.as_deref().unwrap_or(&default_branch);
+
+    let mut integrated: HashMap<String, PathBuf> = HashMap::new();
+
+    for (branch, path) in &branches {
+        if branch == &default_branch {
+            continue;
+        }
+        let (_, reason) = repo.integration_reason(branch, target_ref)?;
+        if reason.is_some() {
+            integrated.insert(branch.clone(), path.clone());
+        }
+    }
+
+    // Infer parents from the commit graph using merge-base analysis.
+    //
+    // For each branch B, the parent P is selected in two tiers:
+    //   1. True ancestors (candidate_depth == 0, meaning merge_base ==
+    //      candidate tip): branches whose tip is reachable from B. Among
+    //      true ancestors, pick the closest (smallest branch_depth).
+    //   2. Diverged candidates (only if no true ancestors): pick by
+    //      smallest branch_depth, then smallest candidate_depth.
+    //
+    // This prevents cycles in stacked branches: if B descends from C
+    // (C's tip is on B's history), C is a true ancestor and always wins
+    // over siblings that merely share a common fork point.
+    let branch_names: Vec<&str> = branches.iter().map(|(b, _)| b.as_str()).collect();
+
+    let mut parent_map: HashMap<String, (String, Option<String>)> = HashMap::new();
+
+    for (branch, _) in &branches {
+        if branch == &default_branch || integrated.contains_key(branch) {
+            continue;
+        }
+
+        let mut ancestors: Vec<(&str, String, usize)> = Vec::new();
+        let mut diverged: Vec<(&str, String, usize, usize)> = Vec::new();
+
+        for candidate in &branch_names {
+            if *candidate == branch.as_str() {
+                continue;
+            }
+
+            let Some(mb) = repo.merge_base(candidate, branch)? else {
+                continue;
+            };
+
+            let branch_depth = repo.count_commits(&mb, branch)?;
+
+            if branch_depth == 0 {
+                continue;
+            }
+
+            let candidate_depth = repo.count_commits(&mb, candidate)?;
+
+            if candidate_depth == 0 {
+                ancestors.push((candidate, mb, branch_depth));
+            } else {
+                diverged.push((candidate, mb, branch_depth, candidate_depth));
+            }
+        }
+
+        let mut best_parent: Option<&str> = None;
+        let mut tie_candidates: Vec<(&str, String)> = Vec::new();
+
+        if !ancestors.is_empty() {
+            ancestors.sort_by_key(|&(_, _, bd)| bd);
+            let best_bd = ancestors[0].2;
+            tie_candidates = ancestors
+                .iter()
+                .filter(|&&(_, _, bd)| bd == best_bd)
+                .map(|&(c, ref mb, _)| (c, mb.clone()))
+                .collect();
+            best_parent = Some(ancestors[0].0);
+        } else if !diverged.is_empty() {
+            diverged.sort_by_key(|&(_, _, bd, cd)| (bd, cd));
+            let (best_bd, best_cd) = (diverged[0].2, diverged[0].3);
+            tie_candidates = diverged
+                .iter()
+                .filter(|&&(_, _, bd, cd)| bd == best_bd && cd == best_cd)
+                .map(|&(c, ref mb, _, _)| (c, mb.clone()))
+                .collect();
+            best_parent = Some(diverged[0].0);
+        }
+
+        if tie_candidates.len() > 1 {
+            let mb_shas: Vec<&str> = tie_candidates.iter().map(|(_, mb)| mb.as_str()).collect();
+            let timestamps = repo.commit_timestamps(&mb_shas)?;
+
+            let mut best_ts = i64::MIN;
+            let mut resolved_parent: Option<&str> = None;
+            for (candidate, mb) in &tie_candidates {
+                if let Some(&ts) = timestamps.get(mb.as_str())
+                    && ts > best_ts
+                {
+                    best_ts = ts;
+                    resolved_parent = Some(candidate);
+                }
+            }
+            if let Some(p) = resolved_parent {
+                best_parent = Some(p);
+            }
+
+            let names: Vec<&str> = tie_candidates.iter().map(|(c, _)| *c).collect();
+            eprintln!(
+                "{}",
+                warning_message(cformat!(
+                    "Branch <bold>{}</> has equidistant parents: {}. Picked <bold>{}</>.",
+                    branch,
+                    names.join(", "),
+                    best_parent.unwrap_or("unknown"),
+                ))
+            );
+        }
+
+        if let Some(parent) = best_parent {
+            parent_map.insert(branch.clone(), (parent.to_string(), None));
+        }
+    }
+
+    // Reparent children of integrated branches — fall back to default branch.
+    for (_branch, (parent, original_parent)) in parent_map.iter_mut() {
+        if integrated.contains_key(parent.as_str()) {
+            let old_parent = parent.clone();
+            *parent = default_branch.clone();
+            *original_parent = Some(old_parent);
+        }
+    }
+
+    // Build the tree structure
+    let mut nodes: HashMap<String, TreeNode> = HashMap::new();
+
+    // Add root node
+    let root_path = branches
+        .iter()
+        .find(|(b, _)| b == &default_branch)
+        .map(|(_, p)| p.clone())
+        .unwrap_or_default();
+
+    nodes.insert(
+        default_branch.clone(),
+        TreeNode {
+            branch: default_branch.clone(),
+            path: root_path,
+            parent: None,
+            original_parent: None,
+            children: Vec::new(),
+        },
+    );
+
+    // Add all other nodes (skip integrated branches)
+    for (branch, path) in &branches {
+        if branch == &default_branch || integrated.contains_key(branch) {
+            continue;
+        }
+        let (parent, orig_parent) = parent_map
+            .get(branch)
+            .cloned()
+            .unwrap_or((default_branch.clone(), None));
+
+        nodes.insert(
+            branch.clone(),
+            TreeNode {
+                branch: branch.clone(),
+                path: path.clone(),
+                parent: Some(parent.clone()),
+                original_parent: orig_parent,
+                children: Vec::new(),
+            },
+        );
+    }
+
+    // Wire up children
+    let branches_with_parents: Vec<(String, String)> = nodes
+        .iter()
+        .filter_map(|(b, n)| n.parent.as_ref().map(|p| (b.clone(), p.clone())))
+        .collect();
+
+    for (branch, parent) in branches_with_parents {
+        if let Some(parent_node) = nodes.get_mut(&parent) {
+            parent_node.children.push(branch);
+        }
+    }
+
+    // Sort children for deterministic order
+    for node in nodes.values_mut() {
+        node.children.sort();
+    }
+
+    Ok(DependencyTree {
+        root: default_branch,
+        nodes,
+    })
+}
+
+/// Execute the sync operation.
+pub fn handle_sync(opts: SyncOptions) -> anyhow::Result<()> {
+    let repo = Repository::current()?;
+
+    // Build dependency tree
+    let tree = build_dependency_tree(&repo)?;
+
+    // Determine which branches to sync
+    let current_wt = repo.current_worktree();
+    let current_branch = current_wt.branch()?;
+
+    let branches_to_sync: Vec<&str> = if !opts.all {
+        let Some(ref current) = current_branch else {
+            bail!("Current worktree has no branch. Use --all to sync all branches.");
+        };
+        let stack = tree.stack_containing(current);
+        if stack.is_empty() {
+            eprintln!(
+                "{}",
+                success_message(cformat!(
+                    "Branch <bold>{current}</> is not part of any stack. Nothing to sync."
+                ))
+            );
+            return Ok(());
+        }
+        stack
+    } else {
+        tree.topological_order()
+    };
+
+    if branches_to_sync.is_empty() {
+        eprintln!("{}", success_message("All branches are up to date."));
+        return Ok(());
+    }
+
+    // Dry-run mode: show plan and exit
+    if opts.dry_run {
+        print_sync_plan(&tree, &branches_to_sync);
+        return Ok(());
+    }
+
+    // Pre-check: ensure all participating worktrees are clean
+    let mut dirty_branches = Vec::new();
+    for &branch in &branches_to_sync {
+        if let Some(node) = tree.nodes.get(branch) {
+            let wt = repo.worktree_at(&node.path);
+            if wt.is_dirty()? {
+                dirty_branches.push(branch);
+            }
+        }
+    }
+
+    if !dirty_branches.is_empty() {
+        let list = dirty_branches
+            .iter()
+            .map(|b| format!("  - {b}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        return Err(anyhow::anyhow!(
+            "{list}\n\nCommit or stash changes before running `wt sync`."
+        ))
+        .context("worktrees have uncommitted changes");
+    }
+
+    // Also check for any in-progress rebases
+    for &branch in &branches_to_sync {
+        if let Some(node) = tree.nodes.get(branch) {
+            let wt = repo.worktree_at(&node.path);
+            if wt.is_rebasing()? {
+                return Err(anyhow::anyhow!(
+                    "Resolve it with `git rebase --continue` or `git rebase --abort` first."
+                ))
+                .context(format!("branch '{branch}' has a rebase in progress"));
+            }
+        }
+    }
+
+    // Execute rebases in topological order
+    let mut rebased_count = 0;
+    let mut skipped_count = 0;
+
+    for &branch in &branches_to_sync {
+        let Some(node) = tree.nodes.get(branch) else {
+            continue;
+        };
+        let Some(ref parent) = node.parent else {
+            continue; // root node
+        };
+
+        let wt = repo.worktree_at(&node.path);
+
+        // Check if already up-to-date
+        let Some(mb) = repo.merge_base(parent, branch)? else {
+            continue;
+        };
+        let parent_sha = repo.run_command(&["rev-parse", parent])?.trim().to_string();
+
+        if mb == parent_sha {
+            skipped_count += 1;
+            eprintln!(
+                "{}",
+                success_message(cformat!(
+                    "<bold>{branch}</> is up to date with <bold>{parent}</>"
+                ))
+            );
+            continue;
+        }
+
+        // Perform the rebase
+        if let Some(ref orig_parent) = node.original_parent {
+            // Reparented branch — use rebase --onto
+            eprintln!(
+                "{}",
+                progress_message(cformat!(
+                    "Rebasing <bold>{branch}</> onto <bold>{parent}</> (was on integrated <bold>{orig_parent}</>)..."
+                ))
+            );
+            let result = wt.run_command(&["rebase", "--onto", parent, orig_parent, branch]);
+            if let Err(e) = result {
+                if wt.is_rebasing()? {
+                    eprintln!(
+                        "{}",
+                        worktrunk::styling::error_message(cformat!(
+                            "Rebase conflict while rebasing <bold>{branch}</> onto <bold>{parent}</>"
+                        ))
+                    );
+                    eprintln!(
+                        "{}",
+                        worktrunk::styling::hint_message(cformat!(
+                            "Resolve conflicts in {}, then run:\n  cd {}\n  git rebase --continue\n  wt sync",
+                            node.path.display(),
+                            node.path.display(),
+                        ))
+                    );
+                    return Ok(());
+                }
+                return Err(e.context(format!("Failed to rebase {branch} onto {parent}")));
+            }
+        } else {
+            // Normal rebase
+            eprintln!(
+                "{}",
+                progress_message(cformat!(
+                    "Rebasing <bold>{branch}</> onto <bold>{parent}</>..."
+                ))
+            );
+            let result = wt.run_command(&["rebase", parent]);
+            if let Err(e) = result {
+                if wt.is_rebasing()? {
+                    eprintln!(
+                        "{}",
+                        worktrunk::styling::error_message(cformat!(
+                            "Rebase conflict while rebasing <bold>{branch}</> onto <bold>{parent}</>"
+                        ))
+                    );
+                    eprintln!(
+                        "{}",
+                        worktrunk::styling::hint_message(cformat!(
+                            "Resolve conflicts in {}, then run:\n  cd {}\n  git rebase --continue\n  wt sync",
+                            node.path.display(),
+                            node.path.display(),
+                        ))
+                    );
+                    return Ok(());
+                }
+                return Err(e.context(format!("Failed to rebase {branch} onto {parent}")));
+            }
+        }
+
+        rebased_count += 1;
+        eprintln!(
+            "{}",
+            success_message(cformat!("Rebased <bold>{branch}</> onto <bold>{parent}</>"))
+        );
+    }
+
+    // Summary
+    if rebased_count == 0 && skipped_count > 0 {
+        eprintln!("{}", success_message("All branches are up to date."));
+    } else if rebased_count > 0 {
+        eprintln!(
+            "{}",
+            success_message(cformat!(
+                "Sync complete: {} rebased, {} already up to date.",
+                rebased_count,
+                skipped_count,
+            ))
+        );
+    }
+
+    Ok(())
+}
+
+/// Print the sync plan (dry-run mode).
+fn print_sync_plan(tree: &DependencyTree, branches: &[&str]) {
+    eprintln!("Dependency tree:");
+    print_tree_node(tree, &tree.root, "", true);
+
+    eprintln!();
+    eprintln!("Planned operations:");
+    let mut has_ops = false;
+    for &branch in branches {
+        let Some(node) = tree.nodes.get(branch) else {
+            continue;
+        };
+        let Some(ref parent) = node.parent else {
+            continue;
+        };
+
+        if let Some(ref orig_parent) = node.original_parent {
+            eprintln!(
+                "  rebase --onto {parent} {orig_parent} {branch}  (reparented from integrated {orig_parent})"
+            );
+        } else {
+            eprintln!("  rebase {branch} onto {parent}");
+        }
+        has_ops = true;
+    }
+    if !has_ops {
+        eprintln!("  (none)");
+    }
+}
+
+/// Print a tree node with indentation.
+fn print_tree_node(tree: &DependencyTree, branch: &str, prefix: &str, is_last: bool) {
+    let connector = if prefix.is_empty() {
+        ""
+    } else if is_last {
+        "└── "
+    } else {
+        "├── "
+    };
+    eprintln!("{prefix}{connector}{branch}");
+
+    let Some(node) = tree.nodes.get(branch) else {
+        return;
+    };
+
+    let child_prefix = if prefix.is_empty() {
+        "".to_string()
+    } else if is_last {
+        format!("{prefix}    ")
+    } else {
+        format!("{prefix}│   ")
+    };
+
+    for (i, child) in node.children.iter().enumerate() {
+        let is_last_child = i == node.children.len() - 1;
+        print_tree_node(tree, child, &child_prefix, is_last_child);
+    }
+}

--- a/src/commands/sync.rs
+++ b/src/commands/sync.rs
@@ -549,7 +549,7 @@ pub fn handle_sync(opts: SyncOptions) -> anyhow::Result<()> {
 /// Print the sync plan (dry-run mode).
 fn print_sync_plan(tree: &DependencyTree, branches: &[&str]) {
     eprintln!("Dependency tree:");
-    print_tree_node(tree, &tree.root, "", true);
+    print_tree_node(tree, &tree.root, "", true, true);
 
     eprintln!();
     eprintln!("Planned operations:");
@@ -577,22 +577,27 @@ fn print_sync_plan(tree: &DependencyTree, branches: &[&str]) {
 }
 
 /// Print a tree node with indentation.
-fn print_tree_node(tree: &DependencyTree, branch: &str, prefix: &str, is_last: bool) {
-    let connector = if prefix.is_empty() {
-        ""
+fn print_tree_node(
+    tree: &DependencyTree,
+    branch: &str,
+    prefix: &str,
+    is_last: bool,
+    is_root: bool,
+) {
+    if is_root {
+        eprintln!("{branch}");
     } else if is_last {
-        "└── "
+        eprintln!("{prefix}└── {branch}");
     } else {
-        "├── "
-    };
-    eprintln!("{prefix}{connector}{branch}");
+        eprintln!("{prefix}├── {branch}");
+    }
 
     let Some(node) = tree.nodes.get(branch) else {
         return;
     };
 
-    let child_prefix = if prefix.is_empty() {
-        "".to_string()
+    let child_prefix = if is_root {
+        String::new()
     } else if is_last {
         format!("{prefix}    ")
     } else {
@@ -601,6 +606,6 @@ fn print_tree_node(tree: &DependencyTree, branch: &str, prefix: &str, is_last: b
 
     for (i, child) in node.children.iter().enumerate() {
         let is_last_child = i == node.children.len() - 1;
-        print_tree_node(tree, child, &child_prefix, is_last_child);
+        print_tree_node(tree, child, &child_prefix, is_last_child, false);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,13 +51,12 @@ use commands::{
     handle_claude_install_statusline, handle_claude_uninstall, handle_completions,
     handle_config_create, handle_config_show, handle_config_update, handle_configure_shell,
     handle_external_command, handle_hints_clear, handle_hints_get, handle_hook_show, handle_init,
-    handle_list, handle_logs_get, handle_merge, handle_opencode_install,
-    handle_opencode_uninstall, handle_promote, handle_rebase, handle_show_theme, handle_squash,
-    handle_state_clear, handle_state_clear_all, handle_state_get, handle_state_set,
-    handle_state_show, handle_switch, handle_sync, handle_unconfigure_shell, handle_vars_clear,
-    handle_vars_get, handle_vars_list, handle_vars_set, resolve_worktree_arg, run_hook,
-    step_commit, step_copy_ignored, step_diff, step_eval, step_for_each, step_prune,
-    step_relocate,
+    handle_list, handle_logs_get, handle_merge, handle_opencode_install, handle_opencode_uninstall,
+    handle_promote, handle_rebase, handle_show_theme, handle_squash, handle_state_clear,
+    handle_state_clear_all, handle_state_get, handle_state_set, handle_state_show, handle_switch,
+    handle_sync, handle_unconfigure_shell, handle_vars_clear, handle_vars_get, handle_vars_list,
+    handle_vars_set, resolve_worktree_arg, run_hook, step_commit, step_copy_ignored, step_diff,
+    step_eval, step_for_each, step_prune, step_relocate,
 };
 use output::handle_remove_output;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,16 +47,17 @@ use commands::repository_ext::RepositoryCliExt;
 use commands::worktree::{BranchDeletionMode, handle_no_ff_merge, handle_push};
 use commands::{
     MergeOptions, OperationMode, RebaseResult, RemoveTarget, SquashResult, SwitchOptions,
-    add_approvals, clear_approvals, handle_claude_install, handle_claude_install_statusline,
-    handle_claude_uninstall, handle_completions, handle_config_create, handle_config_show,
-    handle_config_update, handle_configure_shell, handle_external_command, handle_hints_clear,
-    handle_hints_get, handle_hook_show, handle_init, handle_list, handle_logs_get, handle_merge,
-    handle_opencode_install, handle_opencode_uninstall, handle_promote, handle_rebase,
-    handle_show_theme, handle_squash, handle_state_clear, handle_state_clear_all, handle_state_get,
-    handle_state_set, handle_state_show, handle_switch, handle_unconfigure_shell,
-    handle_vars_clear, handle_vars_get, handle_vars_list, handle_vars_set, resolve_worktree_arg,
-    run_hook, step_commit, step_copy_ignored, step_diff, step_eval, step_for_each, step_prune,
-    step_relocate,
+    SyncOptions, add_approvals, clear_approvals, handle_claude_install,
+    handle_claude_install_statusline, handle_claude_uninstall, handle_completions,
+    handle_config_create, handle_config_show, handle_config_update, handle_configure_shell,
+    handle_external_command, handle_hints_clear, handle_hints_get, handle_hook_show, handle_init,
+    handle_list, handle_logs_get, handle_merge, handle_opencode_install,
+    handle_opencode_uninstall, handle_promote, handle_rebase, handle_show_theme, handle_squash,
+    handle_state_clear, handle_state_clear_all, handle_state_get, handle_state_set,
+    handle_state_show, handle_switch, handle_sync, handle_unconfigure_shell, handle_vars_clear,
+    handle_vars_get, handle_vars_list, handle_vars_set, resolve_worktree_arg, run_hook,
+    step_commit, step_copy_ignored, step_diff, step_eval, step_for_each, step_prune,
+    step_relocate, f699cd3c (feat: add `wt sync` command to rebase stacked worktree branches)
 };
 use output::handle_remove_output;
 
@@ -65,7 +66,7 @@ use cli::{
     ConfigPluginsCommand, ConfigPluginsOpencodeCommand, ConfigShellCommand, DefaultBranchAction,
     HintsAction, HookCommand, ListArgs, ListSubcommand, LogsAction, MarkerAction, MergeArgs,
     PreviousBranchAction, RemoveArgs, StateCommand, StepCommand, SwitchArgs, SwitchFormat,
-    VarsAction,
+    SyncArgs, VarsAction,
 };
 use worktrunk::HookType;
 
@@ -1007,6 +1008,17 @@ fn init_logging(verbose_level: u8) {
         .init();
 }
 
+fn handle_sync_command(args: SyncArgs) -> anyhow::Result<()> {
+    let _env = commands::context::CommandEnv::for_action_branchless()?;
+
+    let all = !args.stack;
+
+    handle_sync(SyncOptions {
+        all,
+        dry_run: args.dry_run,
+    })
+}
+
 fn handle_merge_command(args: MergeArgs) -> anyhow::Result<()> {
     if args.no_verify {
         eprintln!(
@@ -1040,6 +1052,7 @@ fn dispatch_command(
         Commands::List(args) => handle_list_command(args),
         Commands::Switch(args) => handle_switch_command(args),
         Commands::Remove(args) => handle_remove_command(args),
+        Commands::Sync(args) => handle_sync_command(args),
         Commands::Merge(args) => handle_merge_command(args),
         // `working_dir` is the top-level `-C <path>` flag, applied as the
         // child's current directory so global `-C` works for external

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ use commands::{
     handle_state_show, handle_switch, handle_sync, handle_unconfigure_shell, handle_vars_clear,
     handle_vars_get, handle_vars_list, handle_vars_set, resolve_worktree_arg, run_hook,
     step_commit, step_copy_ignored, step_diff, step_eval, step_for_each, step_prune,
-    step_relocate, f699cd3c (feat: add `wt sync` command to rebase stacked worktree branches)
+    step_relocate,
 };
 use output::handle_remove_output;
 

--- a/tests/integration_tests/mod.rs
+++ b/tests/integration_tests/mod.rs
@@ -64,4 +64,5 @@ pub mod step_prune;
 pub mod step_relocate;
 pub mod switch;
 pub mod switch_picker;
+pub mod sync;
 pub mod user_hooks;

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__bash_completion_subcommands.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__bash_completion_subcommands.snap
@@ -1,10 +1,12 @@
 ---
 source: tests/integration_tests/shell_wrapper.rs
+assertion_line: 3041
 expression: "String::from_utf8_lossy(&output.stdout)"
 ---
 switch
 list
 remove
+sync
 merge
 step
 hook

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__fish_completion_subcommands.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__fish_completion_subcommands.snap
@@ -1,10 +1,12 @@
 ---
 source: tests/integration_tests/shell_wrapper.rs
+assertion_line: 3065
 expression: completions
 ---
 switch
 list
 remove
+sync
 merge
 step
 hook

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__nushell_completion_subcommands.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__nushell_completion_subcommands.snap
@@ -1,10 +1,12 @@
 ---
 source: tests/integration_tests/shell_wrapper.rs
+assertion_line: 3088
 expression: completions
 ---
 switch
 list
 remove
+sync
 merge
 step
 hook

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__zsh_completion_subcommands.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__zsh_completion_subcommands.snap
@@ -1,10 +1,12 @@
 ---
 source: tests/integration_tests/shell_wrapper.rs
+assertion_line: 3003
 expression: "String::from_utf8_lossy(&output.stdout)"
 ---
 switch
 list
 remove
+sync
 merge
 step
 hook

--- a/tests/integration_tests/sync.rs
+++ b/tests/integration_tests/sync.rs
@@ -1,0 +1,248 @@
+//! Integration tests for `wt sync`
+
+use crate::common::{TestRepo, make_snapshot_cmd, repo};
+use insta_cmd::assert_cmd_snapshot;
+use rstest::rstest;
+
+/// Helper: create a worktree for a branch that starts from another branch.
+///
+/// `add_worktree` always branches from HEAD of the main worktree (main). To
+/// create a stacked branch (pr2 on top of pr1), we create the branch at the
+/// desired starting point, then add a worktree for it.
+fn add_stacked_worktree(
+    repo: &mut TestRepo,
+    branch: &str,
+    start_point: &str,
+) -> std::path::PathBuf {
+    let safe = branch.replace('/', "-");
+    let worktree_path = repo
+        .root_path()
+        .parent()
+        .unwrap()
+        .join(format!("repo.{safe}"));
+    let worktree_str = worktree_path.to_str().unwrap();
+    repo.run_git(&["worktree", "add", "-b", branch, worktree_str, start_point]);
+    worktree_path
+}
+
+/// Set up a linear stack: main -> pr1 -> pr2 where the dependency tree is
+/// unambiguous. Returns (pr1_path, pr2_path).
+fn setup_linear_stack(repo: &mut TestRepo) -> (std::path::PathBuf, std::path::PathBuf) {
+    let pr1 = repo.add_worktree("pr1");
+    repo.commit_in_worktree(&pr1, "pr1.txt", "pr1 content", "pr1 commit");
+
+    let pr2 = add_stacked_worktree(repo, "pr2", "pr1");
+    repo.commit_in_worktree(&pr2, "pr2.txt", "pr2 content", "pr2 commit");
+
+    (pr1, pr2)
+}
+
+/// Set up a 3-level stack: main -> pr1 -> pr2 -> pr3.
+/// Returns (pr1_path, pr2_path, pr3_path).
+fn setup_deep_stack(
+    repo: &mut TestRepo,
+) -> (std::path::PathBuf, std::path::PathBuf, std::path::PathBuf) {
+    let pr1 = repo.add_worktree("pr1");
+    repo.commit_in_worktree(&pr1, "pr1.txt", "pr1 content", "pr1 commit");
+
+    let pr2 = add_stacked_worktree(repo, "pr2", "pr1");
+    repo.commit_in_worktree(&pr2, "pr2.txt", "pr2 content", "pr2 commit");
+
+    let pr3 = add_stacked_worktree(repo, "pr3", "pr2");
+    repo.commit_in_worktree(&pr3, "pr3.txt", "pr3 content", "pr3 commit");
+
+    (pr1, pr2, pr3)
+}
+
+/// main -> pr1 -> pr2, new commit on main. Dry-run shows tree and planned
+/// rebases.
+#[rstest]
+fn test_sync_dry_run_linear_stack(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["worktree", "prune"]);
+    repo.commit("initial");
+    let (pr1, _pr2) = setup_linear_stack(&mut repo);
+
+    // Advance main
+    repo.commit("advance main");
+
+    assert_cmd_snapshot!(make_snapshot_cmd(&repo, "sync", &["--dry-run"], Some(&pr1)));
+}
+
+/// main -> pr1 -> pr2, commit on main, sync rebases in order.
+#[rstest]
+fn test_sync_main_advances(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["worktree", "prune"]);
+    repo.commit("initial");
+    let (pr1, _pr2) = setup_linear_stack(&mut repo);
+
+    // Advance main with a non-conflicting file
+    repo.commit("advance main");
+
+    assert_cmd_snapshot!(make_snapshot_cmd(&repo, "sync", &[], Some(&pr1)));
+}
+
+/// main -> pr1 -> pr2, extra commit on pr1, sync rebases pr2 onto pr1.
+#[rstest]
+fn test_sync_mid_stack_change(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["worktree", "prune"]);
+    repo.commit("initial");
+    let (pr1, _pr2) = setup_linear_stack(&mut repo);
+
+    // Add another commit on pr1 (not yet in pr2)
+    repo.commit_in_worktree(&pr1, "pr1b.txt", "pr1b content", "pr1 second commit");
+
+    assert_cmd_snapshot!(make_snapshot_cmd(&repo, "sync", &[], Some(&pr1)));
+}
+
+/// Already-synced single branch reports up-to-date.
+#[rstest]
+fn test_sync_up_to_date(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["worktree", "prune"]);
+    repo.commit("initial");
+
+    let pr1 = repo.add_worktree("pr1");
+    repo.commit_in_worktree(&pr1, "pr1.txt", "pr1 content", "pr1 commit");
+
+    // No changes — everything is already synced
+    assert_cmd_snapshot!(make_snapshot_cmd(&repo, "sync", &[], Some(&pr1)));
+}
+
+/// Dirty worktree blocks sync.
+#[rstest]
+fn test_sync_dirty_worktree_aborts(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["worktree", "prune"]);
+    repo.commit("initial");
+
+    let pr1 = repo.add_worktree("pr1");
+    repo.commit_in_worktree(&pr1, "pr1.txt", "pr1 content", "pr1 commit");
+
+    // Advance main so there's something to sync
+    repo.commit("advance main");
+
+    // Make pr1 dirty
+    std::fs::write(pr1.join("dirty.txt"), "uncommitted").unwrap();
+
+    assert_cmd_snapshot!(make_snapshot_cmd(&repo, "sync", &[], Some(&pr1)));
+}
+
+/// Two independent stacks, default syncs both.
+#[rstest]
+fn test_sync_default_syncs_all(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["worktree", "prune"]);
+    repo.commit("initial");
+
+    // Stack A: main -> pr-a1
+    let pr_a1 = repo.add_worktree("pr-a1");
+    repo.commit_in_worktree(&pr_a1, "a1.txt", "a1 content", "a1 commit");
+
+    // Stack B: main -> pr-b1
+    let pr_b1 = repo.add_worktree("pr-b1");
+    repo.commit_in_worktree(&pr_b1, "b1.txt", "b1 content", "b1 commit");
+
+    // Advance main
+    repo.commit("advance main");
+
+    assert_cmd_snapshot!(make_snapshot_cmd(&repo, "sync", &[], Some(&pr_a1)));
+}
+
+/// Two independent stacks, --stack syncs only current stack.
+#[rstest]
+fn test_sync_stack_flag(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["worktree", "prune"]);
+    repo.commit("initial");
+
+    // Stack A: main -> pr-a1
+    let pr_a1 = repo.add_worktree("pr-a1");
+    repo.commit_in_worktree(&pr_a1, "a1.txt", "a1 content", "a1 commit");
+
+    // Stack B: main -> pr-b1
+    let pr_b1 = repo.add_worktree("pr-b1");
+    repo.commit_in_worktree(&pr_b1, "b1.txt", "b1 content", "b1 commit");
+
+    // Advance main
+    repo.commit("advance main");
+
+    // Sync from pr-a1 with --stack — should only sync stack A
+    assert_cmd_snapshot!(make_snapshot_cmd(&repo, "sync", &["--stack"], Some(&pr_a1)));
+}
+
+// =========================================================================
+// Plan scenarios (3-level stacks matching plan.md exactly)
+// =========================================================================
+
+/// Plan scenario 1: Update all branches after main changes.
+///
+/// main ─ A ─ X (new)
+///        └── PR1 ─ D
+///                   └── PR2 ─ F
+///                              └── PR3 ─ H
+///
+/// `wt sync` should rebase PR1 onto main, PR2 onto PR1, PR3 onto PR2.
+#[rstest]
+fn test_sync_scenario1_main_advances_deep_stack(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["worktree", "prune"]);
+    repo.commit("initial");
+    let (pr1, _pr2, _pr3) = setup_deep_stack(&mut repo);
+
+    // Advance main
+    repo.commit("advance main");
+
+    assert_cmd_snapshot!(make_snapshot_cmd(&repo, "sync", &[], Some(&pr1)));
+}
+
+/// Plan scenario 2: Commit in the middle, update the rest.
+///
+/// main ─ A
+///        └── PR1 ─ D ─ Z (new fix)
+///                   └── PR2 ─ F
+///                              └── PR3 ─ H
+///
+/// `wt sync` detects PR2 is behind PR1, rebases PR2 and PR3.
+#[rstest]
+fn test_sync_scenario2_mid_stack_change_deep(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["worktree", "prune"]);
+    repo.commit("initial");
+    let (pr1, _pr2, _pr3) = setup_deep_stack(&mut repo);
+
+    // Add a new commit on pr1 (PR2 and PR3 are now stale)
+    repo.commit_in_worktree(&pr1, "pr1-fix.txt", "fix content", "pr1 fix");
+
+    assert_cmd_snapshot!(make_snapshot_cmd(&repo, "sync", &[], Some(&pr1)));
+}
+
+/// Plan scenario 3: PR merged to main — reparent children with rebase --onto.
+///
+/// main ─ A ─ [PR1 squashed]
+///        └── PR1 ─ D  (integrated)
+///                   └── PR2 ─ F
+///                              └── PR3 ─ H
+///
+/// `wt sync` should detect PR1 is integrated, reparent PR2 onto main using
+/// `rebase --onto main pr1 pr2`, then rebase PR3 onto PR2.
+#[rstest]
+fn test_sync_scenario3_pr_merged_to_main(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["worktree", "prune"]);
+    repo.commit("initial");
+    let (_pr1, _pr2, _pr3) = setup_deep_stack(&mut repo);
+
+    // Simulate squash-merge of PR1 into main: apply PR1's changes onto main
+    // so that integration detection sees PR1 as integrated.
+    repo.run_git(&["checkout", "main"]);
+    std::fs::write(repo.root_path().join("pr1.txt"), "pr1 content").unwrap();
+    repo.run_git(&["add", "pr1.txt"]);
+    repo.run_git(&["commit", "-m", "squash-merge pr1"]);
+
+    // Run sync from pr2's worktree
+    let pr2_path = repo.root_path().parent().unwrap().join("repo.pr2");
+    assert_cmd_snapshot!(make_snapshot_cmd(&repo, "sync", &[], Some(&pr2_path)));
+}

--- a/tests/integration_tests/sync.rs
+++ b/tests/integration_tests/sync.rs
@@ -173,6 +173,28 @@ fn test_sync_stack_flag(mut repo: TestRepo) {
     assert_cmd_snapshot!(make_snapshot_cmd(&repo, "sync", &["--stack"], Some(&pr_a1)));
 }
 
+/// Rebase conflict stops sync and shows resolution instructions.
+#[rstest]
+fn test_sync_rebase_conflict(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["worktree", "prune"]);
+    repo.commit("initial");
+
+    // Create a worktree that modifies the same file as main
+    let pr1 = repo.add_worktree("pr1");
+    repo.commit_in_worktree(&pr1, "shared.txt", "feature", "pr1: modify shared");
+
+    // Advance main with a conflicting change to the same file
+    std::fs::write(repo.root_path().join("shared.txt"), "main-v2").unwrap();
+    repo.run_git(&["add", "shared.txt"]);
+    repo.run_git(&["commit", "-m", "main: modify shared"]);
+
+    assert_cmd_snapshot!(make_snapshot_cmd(&repo, "sync", &[], Some(&pr1)));
+
+    // Clean up the in-progress rebase so temp dir removal doesn't fail
+    repo.run_git_in(&pr1, &["rebase", "--abort"]);
+}
+
 // =========================================================================
 // Plan scenarios (3-level stacks matching plan.md exactly)
 // =========================================================================

--- a/tests/snapshots/integration__integration_tests__help__help_md_root.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_root.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/integration_tests/help.rs
+assertion_line: 120
 info:
   program: wt
   args:
@@ -8,6 +9,7 @@ info:
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: ""
     LANG: C
     LC_ALL: C
     NO_COLOR: ""
@@ -37,6 +39,7 @@ Commands:
   switch  Switch to a worktree; create if needed
   list    List worktrees and their status
   remove  Remove worktree; delete branch if merged
+  sync    Rebase stacked worktree branches in dependency order
   merge   Merge current branch into the target branch
   step    Run individual operations
   hook    Run configured hooks

--- a/tests/snapshots/integration__integration_tests__help__help_no_args.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_no_args.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/integration_tests/help.rs
+assertion_line: 40
 info:
   program: wt
   args: []
@@ -7,6 +8,7 @@ info:
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: ""
     LANG: C
     LC_ALL: C
     NO_COLOR: ""
@@ -38,6 +40,7 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
   [1m[36mswitch[0m  Switch to a worktree; create if needed
   [1m[36mlist[0m    List worktrees and their status
   [1m[36mremove[0m  Remove worktree; delete branch if merged
+  [1m[36msync[0m    Rebase stacked worktree branches in dependency order
   [1m[36mmerge[0m   Merge current branch into the target branch
   [1m[36mstep[0m    Run individual operations
   [1m[36mhook[0m    Run configured hooks

--- a/tests/snapshots/integration__integration_tests__help__help_root_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root_long.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/integration_tests/help.rs
+assertion_line: 40
 info:
   program: wt
   args:
@@ -8,6 +9,7 @@ info:
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: ""
     LANG: C
     LC_ALL: C
     NO_COLOR: ""
@@ -39,6 +41,7 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
   [1m[36mswitch[0m  Switch to a worktree; create if needed
   [1m[36mlist[0m    List worktrees and their status
   [1m[36mremove[0m  Remove worktree; delete branch if merged
+  [1m[36msync[0m    Rebase stacked worktree branches in dependency order
   [1m[36mmerge[0m   Merge current branch into the target branch
   [1m[36mstep[0m    Run individual operations
   [1m[36mhook[0m    Run configured hooks

--- a/tests/snapshots/integration__integration_tests__help__help_root_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root_short.snap
@@ -1,5 +1,6 @@
 ---
 source: tests/integration_tests/help.rs
+assertion_line: 40
 info:
   program: wt
   args:
@@ -8,6 +9,7 @@ info:
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: ""
     LANG: C
     LC_ALL: C
     NO_COLOR: ""
@@ -39,6 +41,7 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
   [1m[36mswitch[0m  Switch to a worktree; create if needed
   [1m[36mlist[0m    List worktrees and their status
   [1m[36mremove[0m  Remove worktree; delete branch if merged
+  [1m[36msync[0m    Rebase stacked worktree branches in dependency order
   [1m[36mmerge[0m   Merge current branch into the target branch
   [1m[36mstep[0m    Run individual operations
   [1m[36mhook[0m    Run configured hooks

--- a/tests/snapshots/integration__integration_tests__sync__sync_default_syncs_all.snap
+++ b/tests/snapshots/integration__integration_tests__sync__sync_default_syncs_all.snap
@@ -1,0 +1,53 @@
+---
+source: tests/integration_tests/sync.rs
+assertion_line: 151
+info:
+  program: wt
+  args:
+    - sync
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[33m▲[39m [33mBranch [1mpr-a1[22m has equidistant parents: main, pr-b1. Picked [1mmain[22m.[39m
+[33m▲[39m [33mBranch [1mpr-b1[22m has equidistant parents: main, pr-a1. Picked [1mmain[22m.[39m
+[36m◎[39m [36mRebasing [1mpr-a1[22m onto [1mmain[22m...[39m
+[32m✓[39m [32mRebased [1mpr-a1[22m onto [1mmain[22m[39m
+[36m◎[39m [36mRebasing [1mpr-b1[22m onto [1mmain[22m...[39m
+[32m✓[39m [32mRebased [1mpr-b1[22m onto [1mmain[22m[39m
+[32m✓[39m [32mSync complete: 2 rebased, 0 already up to date.[39m

--- a/tests/snapshots/integration__integration_tests__sync__sync_dirty_worktree_aborts.snap
+++ b/tests/snapshots/integration__integration_tests__sync__sync_dirty_worktree_aborts.snap
@@ -1,0 +1,50 @@
+---
+source: tests/integration_tests/sync.rs
+assertion_line: 130
+info:
+  program: wt
+  args:
+    - sync
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[31m✗[39m [31mworktrees have uncommitted changes[39m
+[107m [0m   - pr1
+[107m [0m 
+[107m [0m Commit or stash changes before running `wt sync`.

--- a/tests/snapshots/integration__integration_tests__sync__sync_dry_run_linear_stack.snap
+++ b/tests/snapshots/integration__integration_tests__sync__sync_dry_run_linear_stack.snap
@@ -47,8 +47,8 @@ exit_code: 0
 ----- stderr -----
 Dependency tree:
 main
-pr1
-pr2
+└── pr1
+    └── pr2
 
 Planned operations:
   rebase pr1 onto main

--- a/tests/snapshots/integration__integration_tests__sync__sync_dry_run_linear_stack.snap
+++ b/tests/snapshots/integration__integration_tests__sync__sync_dry_run_linear_stack.snap
@@ -1,0 +1,55 @@
+---
+source: tests/integration_tests/sync.rs
+assertion_line: 69
+info:
+  program: wt
+  args:
+    - sync
+    - "--dry-run"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+Dependency tree:
+main
+pr1
+pr2
+
+Planned operations:
+  rebase pr1 onto main
+  rebase pr2 onto pr1

--- a/tests/snapshots/integration__integration_tests__sync__sync_main_advances.snap
+++ b/tests/snapshots/integration__integration_tests__sync__sync_main_advances.snap
@@ -1,0 +1,51 @@
+---
+source: tests/integration_tests/sync.rs
+assertion_line: 83
+info:
+  program: wt
+  args:
+    - sync
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mRebasing [1mpr1[22m onto [1mmain[22m...[39m
+[32m✓[39m [32mRebased [1mpr1[22m onto [1mmain[22m[39m
+[36m◎[39m [36mRebasing [1mpr2[22m onto [1mpr1[22m...[39m
+[32m✓[39m [32mRebased [1mpr2[22m onto [1mpr1[22m[39m
+[32m✓[39m [32mSync complete: 2 rebased, 0 already up to date.[39m

--- a/tests/snapshots/integration__integration_tests__sync__sync_mid_stack_change.snap
+++ b/tests/snapshots/integration__integration_tests__sync__sync_mid_stack_change.snap
@@ -1,0 +1,49 @@
+---
+source: tests/integration_tests/sync.rs
+assertion_line: 97
+info:
+  program: wt
+  args:
+    - sync
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[32m✓[39m [32m[1mpr1[22m is up to date with [1mmain[22m[39m
+[32m✓[39m [32m[1mpr2[22m is up to date with [1mmain[22m[39m
+[32m✓[39m [32mAll branches are up to date.[39m

--- a/tests/snapshots/integration__integration_tests__sync__sync_rebase_conflict.snap
+++ b/tests/snapshots/integration__integration_tests__sync__sync_rebase_conflict.snap
@@ -1,0 +1,52 @@
+---
+source: tests/integration_tests/sync.rs
+assertion_line: 192
+info:
+  program: wt
+  args:
+    - sync
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mRebasing [1mpr1[22m onto [1mmain[22m...[39m
+[31m✗[39m [31mRebase conflict while rebasing [1mpr1[22m onto [1mmain[22m[39m
+[2m↳[22m [2mResolve conflicts in _REPO_.pr1, then run:
+  cd _REPO_.pr1
+  git rebase --continue
+  wt sync[22m

--- a/tests/snapshots/integration__integration_tests__sync__sync_scenario1_main_advances_deep_stack.snap
+++ b/tests/snapshots/integration__integration_tests__sync__sync_scenario1_main_advances_deep_stack.snap
@@ -1,0 +1,53 @@
+---
+source: tests/integration_tests/sync.rs
+assertion_line: 198
+info:
+  program: wt
+  args:
+    - sync
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mRebasing [1mpr1[22m onto [1mmain[22m...[39m
+[32m✓[39m [32mRebased [1mpr1[22m onto [1mmain[22m[39m
+[36m◎[39m [36mRebasing [1mpr2[22m onto [1mpr1[22m...[39m
+[32m✓[39m [32mRebased [1mpr2[22m onto [1mpr1[22m[39m
+[36m◎[39m [36mRebasing [1mpr3[22m onto [1mpr2[22m...[39m
+[32m✓[39m [32mRebased [1mpr3[22m onto [1mpr2[22m[39m
+[32m✓[39m [32mSync complete: 3 rebased, 0 already up to date.[39m

--- a/tests/snapshots/integration__integration_tests__sync__sync_scenario2_mid_stack_change_deep.snap
+++ b/tests/snapshots/integration__integration_tests__sync__sync_scenario2_mid_stack_change_deep.snap
@@ -1,0 +1,50 @@
+---
+source: tests/integration_tests/sync.rs
+assertion_line: 219
+info:
+  program: wt
+  args:
+    - sync
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[32m✓[39m [32m[1mpr1[22m is up to date with [1mmain[22m[39m
+[32m✓[39m [32m[1mpr2[22m is up to date with [1mmain[22m[39m
+[32m✓[39m [32m[1mpr3[22m is up to date with [1mpr2[22m[39m
+[32m✓[39m [32mAll branches are up to date.[39m

--- a/tests/snapshots/integration__integration_tests__sync__sync_scenario3_pr_merged_to_main.snap
+++ b/tests/snapshots/integration__integration_tests__sync__sync_scenario3_pr_merged_to_main.snap
@@ -1,0 +1,51 @@
+---
+source: tests/integration_tests/sync.rs
+assertion_line: 247
+info:
+  program: wt
+  args:
+    - sync
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mRebasing [1mpr2[22m onto [1mmain[22m (was on integrated [1mpr1[22m)...[39m
+[32m✓[39m [32mRebased [1mpr2[22m onto [1mmain[22m[39m
+[36m◎[39m [36mRebasing [1mpr3[22m onto [1mpr2[22m...[39m
+[32m✓[39m [32mRebased [1mpr3[22m onto [1mpr2[22m[39m
+[32m✓[39m [32mSync complete: 2 rebased, 0 already up to date.[39m

--- a/tests/snapshots/integration__integration_tests__sync__sync_stack_flag.snap
+++ b/tests/snapshots/integration__integration_tests__sync__sync_stack_flag.snap
@@ -1,0 +1,52 @@
+---
+source: tests/integration_tests/sync.rs
+assertion_line: 173
+info:
+  program: wt
+  args:
+    - sync
+    - "--stack"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[33m▲[39m [33mBranch [1mpr-a1[22m has equidistant parents: main, pr-b1. Picked [1mmain[22m.[39m
+[33m▲[39m [33mBranch [1mpr-b1[22m has equidistant parents: main, pr-a1. Picked [1mmain[22m.[39m
+[36m◎[39m [36mRebasing [1mpr-a1[22m onto [1mmain[22m...[39m
+[32m✓[39m [32mRebased [1mpr-a1[22m onto [1mmain[22m[39m
+[32m✓[39m [32mSync complete: 1 rebased, 0 already up to date.[39m

--- a/tests/snapshots/integration__integration_tests__sync__sync_up_to_date.snap
+++ b/tests/snapshots/integration__integration_tests__sync__sync_up_to_date.snap
@@ -1,0 +1,48 @@
+---
+source: tests/integration_tests/sync.rs
+assertion_line: 111
+info:
+  program: wt
+  args:
+    - sync
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[32m✓[39m [32m[1mpr1[22m is up to date with [1mmain[22m[39m
+[32m✓[39m [32mAll branches are up to date.[39m


### PR DESCRIPTION
## Summary

- Add `wt sync` command that rebases stacked worktree branches in topological order
- Builds a dependency tree via merge-base inference with true-ancestor/diverged tiers
- Detects integrated branches (merged into default branch) and reparents their children
- Includes `--stack` flag to sync only the current stack and `--dry-run` for previewing

**Stack: 1/3** — next: sync-stack-file (stack file persistence), then sync-flags (--fetch/--push/--prune + config)

## Test plan

- [x] 10 integration tests covering: linear stacks, fan-out, mid-stack changes, main advances, deep stacks, PR merged to main, dirty worktree abort, dry-run, --stack flag, up-to-date detection
- [x] 3 unit tests for topological ordering and stack containment
- [x] clippy clean, all existing tests pass