### PR TITLE
Unify conflict-detection skip sets between wt list and wt switch

### DIFF
--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -217,7 +217,6 @@ pub struct CollectOptions {
     ///   since they depend on skipped tasks
     ///
     /// Note: `wt switch` interactive picker doesn't show the BranchDiff column, so `…` isn't visible there.
-    /// This is similar to how `✗` conflict only shows with `--full` even in `wt list`.
     ///
     /// TODO: Consider adding a visible indicator in Status column when integration
     /// checks are skipped, so users know the `⊂` symbol may be incomplete.

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -391,7 +391,6 @@ pub fn collect(
                     [
                         TaskKind::BranchDiff,
                         TaskKind::CiStatus,
-                        TaskKind::WorkingTreeConflicts,
                         TaskKind::SummaryGenerate,
                     ]
                     .into_iter()

--- a/src/commands/list/collect/tasks.rs
+++ b/src/commands/list/collect/tasks.rs
@@ -430,7 +430,7 @@ impl Task for MergeTreeConflictsTask {
     }
 }
 
-/// Task 6b (worktree only, --full only): Working tree conflict check
+/// Task 6b (worktree only): Working tree conflict check
 ///
 /// For dirty worktrees, uses `git stash create` to get a tree object that
 /// includes uncommitted changes, then runs merge-tree against that.

--- a/src/commands/list/collect/types.rs
+++ b/src/commands/list/collect/types.rs
@@ -18,7 +18,7 @@ use super::super::model::{
 #[derive(Clone, Default)]
 pub(super) struct StatusContext {
     pub has_merge_tree_conflicts: bool,
-    /// Working tree conflict check result (--full only, worktrees only).
+    /// Working tree conflict check result (worktrees only).
     /// None = use commit check (task didn't run or working tree clean)
     /// Some(b) = dirty working tree, b is conflict result
     // TODO: If we need to distinguish "task didn't run" from "clean working tree",
@@ -33,7 +33,7 @@ impl StatusContext {
     pub fn apply_to(&self, item: &mut ListItem, target: Option<&str>) {
         // Main worktree case is handled inside check_integration_state()
         //
-        // Prefer working tree conflicts (--full) when available.
+        // Prefer working tree conflicts when available.
         // None means task didn't run or working tree was clean - use commit check.
         let has_conflicts = self
             .has_working_tree_conflicts
@@ -115,7 +115,7 @@ pub(crate) enum TaskResult {
         item_idx: usize,
         has_merge_tree_conflicts: bool,
     },
-    /// Potential merge conflicts including working tree changes (--full only)
+    /// Potential merge conflicts including working tree changes
     ///
     /// For dirty worktrees, uses `git stash create` to get a tree object that
     /// includes uncommitted changes, then runs merge-tree against that.

--- a/src/commands/list/layout.rs
+++ b/src/commands/list/layout.rs
@@ -1568,12 +1568,11 @@ mod tests {
         calculate_layout_with_width(&items, skip_tasks, width, Path::new("/test"), None)
     }
 
-    /// Default skip_tasks for non-full mode (Summary, BranchDiff, CI, WorkingTreeConflicts skipped).
+    /// Default skip_tasks for non-full mode (Summary, BranchDiff, CI skipped).
     fn non_full_skip_tasks() -> HashSet<TaskKind> {
         [
             TaskKind::BranchDiff,
             TaskKind::CiStatus,
-            TaskKind::WorkingTreeConflicts,
             TaskKind::SummaryGenerate,
         ]
         .into_iter()

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -300,13 +300,10 @@ pub fn handle_picker(
 
     // Gather list data using simplified collection (buffered mode)
     // Skip expensive operations not needed for picker UI
-    let skip_tasks: std::collections::HashSet<collect::TaskKind> = [
-        collect::TaskKind::BranchDiff,
-        collect::TaskKind::CiStatus,
-        collect::TaskKind::MergeTreeConflicts,
-    ]
-    .into_iter()
-    .collect();
+    let skip_tasks: std::collections::HashSet<collect::TaskKind> =
+        [collect::TaskKind::BranchDiff, collect::TaskKind::CiStatus]
+            .into_iter()
+            .collect();
 
     // Per-task command timeout from shared [list] config.
     let command_timeout = config.list.task_timeout();

--- a/tests/integration_tests/list.rs
+++ b/tests/integration_tests/list.rs
@@ -3063,7 +3063,7 @@ fn test_list_with_nonexistent_default_branch(repo: TestRepo) {
 
 /// Tests that wt list --full works correctly when the configured default branch doesn't exist.
 ///
-/// The --full flag enables expensive tasks like BranchDiff and WorkingTreeConflicts.
+/// The --full flag enables expensive tasks like BranchDiff.
 /// These should also degrade gracefully when default_branch is None.
 #[rstest]
 fn test_list_full_with_nonexistent_default_branch(repo: TestRepo) {

--- a/tests/integration_tests/list.rs
+++ b/tests/integration_tests/list.rs
@@ -2823,11 +2823,11 @@ fn test_list_maximum_status_symbols(mut repo: TestRepo) {
 /// 1. Uses `git stash create` to get a tree object from uncommitted changes
 /// 2. Runs merge-tree against the default branch to detect conflicts
 ///
-/// The key distinction from commit-level conflicts:
-/// - Commit-level: HEAD conflicts with main (always checked)
-/// - Working tree: Uncommitted changes conflict with main (only with --full)
+/// Both kinds of conflicts are checked in both `wt list` and `wt list --full`:
+/// - Commit-level: HEAD conflicts with main
+/// - Working tree: uncommitted changes conflict with main
 #[rstest]
-fn test_list_full_working_tree_conflicts(mut repo: TestRepo) {
+fn test_list_working_tree_conflicts(mut repo: TestRepo) {
     // Create initial commit with a shared file
     std::fs::write(repo.root_path().join("shared.txt"), "original content").unwrap();
     repo.commit("Initial commit");
@@ -2845,13 +2845,14 @@ fn test_list_full_working_tree_conflicts(mut repo: TestRepo) {
     // Now add uncommitted changes to feature that would conflict with main
     std::fs::write(feature.join("shared.txt"), "feature's uncommitted version").unwrap();
 
-    // Without --full: no conflict symbol (only checks commit-level)
+    // Without --full: WorkingTreeConflicts runs and detects the uncommitted conflict.
     assert_cmd_snapshot!(
         "working_tree_conflicts_without_full",
         list_snapshots::command(&repo, repo.root_path())
     );
 
-    // With --full: should show conflict symbol because uncommitted changes conflict
+    // With --full: same conflict detection, plus the wide status column and extra
+    // post-skeleton tasks that non-full mode skips.
     assert_cmd_snapshot!("working_tree_conflicts_with_full", {
         let mut cmd = list_snapshots::command(&repo, repo.root_path());
         cmd.arg("--full");

--- a/tests/snapshots/integration__integration_tests__list__list_shows_warning_on_git_error.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_shows_warning_on_git_error.snap
@@ -48,9 +48,10 @@ exit_code: 0
 + feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
 + feature                               [2m⋯[0m        [2m⋯[0m  ../repo.feature              [2m⋯[0m     [2m⋯
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead. 1 task failed
+[2m○[22m [2mShowing 5 worktrees, 3 ahead. 2 tasks failed
 
 ----- stderr -----
 [33m▲[39m [33mSome git operations failed:
-[107m [0m [1mfeature[22m: working-tree-diff (fatal: bad object HEAD)[39m
+[107m [0m [1mfeature[22m: working-tree-diff (fatal: bad object HEAD)
+[107m [0m [1mfeature[22m: working-tree-conflicts (fatal: bad object HEAD)[39m
 [2m↳[22m [2mTo create a diagnostic file, run with [4m-vv[24m[22m

--- a/tests/snapshots/integration__integration_tests__list__working_tree_conflicts_without_full.snap
+++ b/tests/snapshots/integration__integration_tests__list__working_tree_conflicts_without_full.snap
@@ -46,7 +46,7 @@ exit_code: 0
 + feature-a      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m           ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
 + feature-b      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m           ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file
 + feature-c      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m           ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
-+ feature     [36m![39m  [2m↓[22m       [32m+1[0m   [31m-1[0m       [2m[31m↓1[0m           ../repo.feature    [2ma756a743[0m  [2m1d[0m    [2mInitial commit
++ feature     [36m![39m  [33m✗[39m       [32m+1[0m   [31m-1[0m       [2m[31m↓1[0m           ../repo.feature    [2ma756a743[0m  [2m1d[0m    [2mInitial commit
 
 [2m○[22m [2mShowing 5 worktrees, 1 with changes, 3 ahead
 


### PR DESCRIPTION
Both `wt list` (non-full) and the `wt switch` picker now run both `WorkingTreeConflicts` and `MergeTreeConflicts`. The only remaining asymmetry is `SummaryGenerate`: `wt list` still skips it (doesn't render summaries inline), the picker still runs it (tab 5 preview).

## Why

The picker's old skip set was inconsistent in two ways:

1. **Cost inverted.** It skipped the cheaper probe (`MergeTreeConflicts` = one `merge-tree HEAD base` call) and ran the more expensive one (`WorkingTreeConflicts` = `git status` + `git stash create` + `git merge-tree` for dirty worktrees).

2. **Fallback unreachable.** `WorkingTreeConflicts` short-circuits to `None` on clean worktrees with an explicit contract that the caller falls back to `MergeTreeConflicts` (see `src/commands/list/collect/tasks.rs:437`). The picker blocked that fallback, so clean worktrees in the picker produced no real conflict answer — they fell through to the struct default.

`wt list` non-full's old choice was internally consistent (skip the working-tree probe, always use commit-level), but asymmetric with the picker. Adding `WorkingTreeConflicts` to `wt list` is strictly a correctness improvement: rows with a conflicted rebase-in-progress now render `✗` instead of a counts-based fallback.

## Safety

Adding `MergeTreeConflicts` to the picker is safe because the per-symbol atomic rendering refactor on this branch makes gate 3 position 4 render as `⋯` when its inputs haven't resolved within the collect deadline. Tail cost is capped, not unbounded.

## Reviewer tour

**Commit 1** (skip-set unification):
- `src/commands/list/collect/mod.rs` — one line removed from non-full skip set.
- `src/commands/picker/mod.rs` — one line removed from picker skip set; cargo fmt collapsed the now-2-element array.
- `src/commands/list/layout.rs` — test helper `non_full_skip_tasks()` updated to match the new production skip set (its doc comment claimed to mirror non-full mode).
- `tests/integration_tests/list.rs` — renamed `test_list_full_working_tree_conflicts` → `test_list_working_tree_conflicts` and updated its module doc + inline comments; the test now documents that both modes detect working-tree conflicts.
- Two snapshot updates are the point of the change — one gains `✗` for a real conflict, the other gains a second "task failed" warning line (both conflict tasks now fail symmetrically on a broken HEAD).

**Commit 2** (doc-comment cleanup, from auto-review feedback):
- Dropped stale "--full only" qualifiers from 5 doc-comment locations in `tasks.rs`, `types.rs`, and `mod.rs`, plus one in the test file. No behavior change.

## Follow-up worth considering separately

For dirty worktrees the picker now runs both `WorkingTreeConflicts` and `MergeTreeConflicts`, duplicating a `merge-tree` call. If that shows up in profiles, the right fix is conditional dispatch — skip `MergeTreeConflicts` when `WorkingTreeConflicts` produced a non-`None` answer — rather than reinstating the asymmetric skip sets.

> _This was written by Claude Code on behalf of Maximilian_