### PR TITLE
Add TODO for duplicate merge-tree call on dirty worktrees

### DIFF
--- a/src/commands/list/collect/execution.rs
+++ b/src/commands/list/collect/execution.rs
@@ -231,6 +231,11 @@ pub fn work_items_for_worktree(
         TaskKind::UserMarker,
         TaskKind::WorkingTreeConflicts,
         TaskKind::BranchDiff,
+        // TODO: For dirty worktrees, WorkingTreeConflicts already runs merge-tree
+        // (via stash-create + merge-tree). MergeTreeConflicts duplicates that call
+        // against HEAD. Could skip MergeTreeConflicts when WorkingTreeConflicts
+        // produces a non-None answer, but needs result-ordering changes since both
+        // tasks run in parallel today.
         TaskKind::MergeTreeConflicts,
         TaskKind::CiStatus,
         TaskKind::WouldMergeAdd,


### PR DESCRIPTION
Follow-up to #2064. Notes the optimization opportunity: for dirty worktrees, `WorkingTreeConflicts` already runs `merge-tree` (via stash-create), making the parallel `MergeTreeConflicts` call redundant. Could skip `MergeTreeConflicts` when `WorkingTreeConflicts` produces a non-`None` answer, but needs result-ordering changes since both tasks run in parallel today.

Comment-only change, no behavior change.

> _This was written by Claude Code on behalf of Maximilian_