### PR TITLE
fix(config show): don't show false 'Not configured' when shell integration is active

### DIFF
--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -927,6 +927,17 @@ fn render_shell_status(out: &mut String) -> anyhow::Result<()> {
                         "To update, run <underline>{cmd} config shell install {shell}</>"
                     ));
                     writeln!(out, "{warning}\n{hint}")?;
+                } else if shell_active && Some(shell) == worktrunk::shell::current_shell() {
+                    // Shell integration is active at runtime even though we can't
+                    // find the init line in config files — likely sourced from
+                    // another file (common with dotfile managers like stow/chezmoi).
+                    writeln!(
+                        out,
+                        "{}",
+                        info_message(cformat!(
+                            "<bold>{shell}</>: Configured {what} (not found in {path})"
+                        ))
+                    )?;
                 } else {
                     any_not_configured = true;
                     writeln!(

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -2053,6 +2053,44 @@ fn test_config_show_shell_integration_active(mut repo: TestRepo, temp_home: Temp
     });
 }
 
+/// When shell integration is active at runtime (WORKTRUNK_DIRECTIVE_FILE set) but the
+/// init line is NOT in the scanned config file (e.g., sourced from another file), config
+/// show should report "Configured ... (not found in ...)" instead of "Not configured".
+/// Regression test for https://github.com/max-sixty/worktrunk/issues/1306
+#[rstest]
+fn test_config_show_shell_active_but_not_in_config_file(mut repo: TestRepo, temp_home: TempDir) {
+    repo.setup_mock_ci_tools_unauthenticated();
+
+    let global_config_dir = temp_home.path().join(".config").join("worktrunk");
+    fs::create_dir_all(&global_config_dir).unwrap();
+    fs::write(
+        global_config_dir.join("config.toml"),
+        "worktree-path = \"../{{ repo }}.{{ branch }}\"\n",
+    )
+    .unwrap();
+
+    // Create ~/.zshrc WITHOUT the init line (simulates it being in a sourced file)
+    fs::write(temp_home.path().join(".zshrc"), "# my zsh config\n").unwrap();
+
+    let directive_file = temp_home.path().join("directive");
+    fs::write(&directive_file, "").unwrap();
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        repo.configure_mock_commands(&mut cmd);
+        cmd.arg("config").arg("show").current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+        set_xdg_config_path(&mut cmd, temp_home.path());
+        cmd.env("WORKTRUNK_DIRECTIVE_FILE", &directive_file);
+        // Set SHELL to zsh so current_shell() returns Some(Zsh)
+        cmd.env("SHELL", "/bin/zsh");
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
 #[rstest]
 fn test_config_show_plugin_installed(mut repo: TestRepo, temp_home: TempDir) {
     // Setup mock gh/glab for deterministic output

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_shell_active_but_not_in_config_file.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_shell_active_but_not_in_config_file.snap
@@ -1,0 +1,66 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - show
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: /bin/zsh
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_DIRECTIVE_FILE: "[DIRECTIVE_FILE]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
+[2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
+
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
+[2m↳[22m [2mNot found[22m
+
+[36mSHELL INTEGRATION[39m
+[2m○[22m Shell integration active
+
+[2m○[22m [1mzsh[22m: Configured shell extension & completions (not found in ~/.zshrc)
+[2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
+[2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
+[2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
+
+[36mOTHER[39m
+[2m○[22m wt: [1m[VERSION][22m
+[2m○[22m git: [1m[VERSION][22m
+[2m○[22m Hyperlinks: [1minactive[22m


### PR DESCRIPTION
When the init line lives in a sourced file (common with dotfile managers like stow/chezmoi), `wt config show` couldn't find it in the scanned config files and reported "Not configured" despite integration working fine at runtime.

Now checks `is_shell_integration_active()` for the current shell before showing "Not configured" — if integration is provably active, shows "Configured (not found in ~/.zshrc)" instead.

Thanks to @wouter-intveld for reporting in #1306

Closes #1306

> _This was written by Claude Code on behalf of @max-sixty_