### PR TITLE
config: attribute load errors to file vs env-var source

### DIFF
--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -99,6 +99,7 @@ pub use project::{
     ProjectCiConfig, ProjectConfig, ProjectListConfig,
     find_unknown_keys as find_unknown_project_keys, valid_project_config_keys,
 };
+pub(crate) use user::LoadError;
 pub use user::{
     CommitConfig, CommitGenerationConfig, CopyIgnoredConfig, ListConfig, MergeConfig,
     OverridableConfig, ResolvedConfig, StageMode, StepConfig, SwitchConfig, SwitchPickerConfig,

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -233,8 +233,12 @@ impl ProjectConfig {
             );
         }
 
-        let config: ProjectConfig = toml::from_str(&contents)
-            .map_err(|e| ConfigError::Message(format!("Failed to parse TOML: {}", e)))?;
+        let config: ProjectConfig = toml::from_str(&contents).map_err(|e| {
+            ConfigError::Message(format!(
+                "Project config at {} failed to parse:\n{e}",
+                crate::path::format_path_for_display(&config_path),
+            ))
+        })?;
 
         Ok(Some(config))
     }

--- a/src/config/user/mod.rs
+++ b/src/config/user/mod.rs
@@ -203,13 +203,19 @@ impl UserConfig {
             let migrated = super::deprecation::migrate_content(&content);
 
             // Pre-validate with the toml crate for rich line/col errors.
-            // Validate as OverridableConfig (not UserConfig) because
-            // UserConfig's `#[serde(flatten)]` on OverridableConfig causes
-            // toml to lose field paths — errors point at the section header
-            // instead of the bad value. OverridableConfig has the section
-            // fields (list, commit, merge, ...) as direct fields, so the
-            // toml crate tracks their location correctly.
+            // Try OverridableConfig first — it has section fields (list,
+            // commit, merge, ...) as direct fields, so toml tracks their
+            // location correctly. UserConfig's flatten loses field paths.
+            // Then try UserConfig to catch non-section fields (projects,
+            // skip-*-prompt) that OverridableConfig silently ignores.
             if let Err(err) = toml::from_str::<OverridableConfig>(&migrated) {
+                return Err(LoadError::File {
+                    path: system_path,
+                    label: "System config",
+                    err: Box::new(err),
+                });
+            }
+            if let Err(err) = toml::from_str::<Self>(&migrated) {
                 return Err(LoadError::File {
                     path: system_path,
                     label: "System config",
@@ -251,8 +257,15 @@ impl UserConfig {
                 );
 
                 // Pre-validate with the toml crate for rich line/col errors
-                // (OverridableConfig — see system config comment above for why).
+                // (see system config comment above for the two-pass rationale).
                 if let Err(err) = toml::from_str::<OverridableConfig>(&migrated) {
+                    return Err(LoadError::File {
+                        path: config_path.clone(),
+                        label: "User config",
+                        err: Box::new(err),
+                    });
+                }
+                if let Err(err) = toml::from_str::<Self>(&migrated) {
                     return Err(LoadError::File {
                         path: config_path.clone(),
                         label: "User config",

--- a/src/config/user/mod.rs
+++ b/src/config/user/mod.rs
@@ -180,7 +180,7 @@ impl UserConfig {
 
     /// Like [`load()`](Self::load), but returns a [`LoadError`] that
     /// distinguishes file-level parse failures (with line/col) from
-    /// env-var override failures. Used by [`Repository::user_config()`]
+    /// env-var override failures. Used by `Repository::user_config()`
     /// to emit targeted diagnostics.
     pub(crate) fn load_with_cause() -> Result<Self, LoadError> {
         // Note: worktree-path has no default set here - it's handled by the getter

--- a/src/config/user/mod.rs
+++ b/src/config/user/mod.rs
@@ -13,6 +13,8 @@ mod sections;
 #[cfg(test)]
 mod tests;
 
+use std::path::PathBuf;
+
 use config::{Case, Config, ConfigError, File};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -30,6 +32,72 @@ pub use sections::{
     OverridableConfig, StageMode, StepConfig, SwitchConfig, SwitchPickerConfig,
     UserProjectOverrides,
 };
+
+/// Distinguishes *why* `UserConfig::load()` failed so callers can emit
+/// targeted diagnostics (file errors with line/col vs env-var attribution).
+#[derive(Debug)]
+pub enum LoadError {
+    /// A config file failed to parse. The `toml::de::Error` includes
+    /// line/column info and a source-snippet pointer.
+    File {
+        path: PathBuf,
+        label: &'static str,
+        err: Box<toml::de::Error>,
+    },
+    /// Config files parsed cleanly; applying env-var overrides failed.
+    /// `override_vars` lists `WORKTRUNK_*` env vars that could be the cause.
+    Env {
+        err: ConfigError,
+        override_vars: Vec<String>,
+    },
+    /// Other errors (validation, config-crate internals).
+    Other(ConfigError),
+}
+
+impl std::fmt::Display for LoadError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            LoadError::File { path, label, err } => {
+                write!(
+                    f,
+                    "{label} at {} failed to parse:\n{err}",
+                    crate::path::format_path_for_display(path)
+                )
+            }
+            LoadError::Env { err, .. } => write!(f, "{err}"),
+            LoadError::Other(err) => write!(f, "{err}"),
+        }
+    }
+}
+
+impl std::error::Error for LoadError {}
+
+/// Returns names of `WORKTRUNK_*` env vars that could be value overrides,
+/// excluding infrastructure paths and the `WORKTRUNK_TEST_` namespace.
+// TODO: This hardcoded exclusion list is a smell — ideally the config loading
+// layer would track which source each value came from, making attribution
+// automatic rather than heuristic. Consider integrating this into the config
+// crate's source-tracking or building our own env-var overlay.
+fn collect_worktrunk_override_vars() -> Vec<String> {
+    const INFRA_VARS: &[&str] = &[
+        "WORKTRUNK_CONFIG_PATH",
+        "WORKTRUNK_SYSTEM_CONFIG_PATH",
+        "WORKTRUNK_APPROVALS_PATH",
+    ];
+    let mut vars: Vec<String> = std::env::vars()
+        .filter_map(|(k, _)| {
+            if !k.starts_with("WORKTRUNK_") {
+                return None;
+            }
+            if INFRA_VARS.contains(&k.as_str()) || k.starts_with("WORKTRUNK_TEST_") {
+                return None;
+            }
+            Some(k)
+        })
+        .collect();
+    vars.sort();
+    vars
+}
 
 /// User-level configuration for worktree path formatting and LLM integration.
 ///
@@ -107,6 +175,14 @@ impl UserConfig {
     /// 3. User config file (personal preferences)
     /// 4. Environment variables (WORKTRUNK_*)
     pub fn load() -> Result<Self, ConfigError> {
+        Self::load_with_cause().map_err(|e| ConfigError::Message(e.to_string()))
+    }
+
+    /// Like [`load()`](Self::load), but returns a [`LoadError`] that
+    /// distinguishes file-level parse failures (with line/col) from
+    /// env-var override failures. Used by [`Repository::user_config()`]
+    /// to emit targeted diagnostics.
+    pub(crate) fn load_with_cause() -> Result<Self, LoadError> {
         // Note: worktree-path has no default set here - it's handled by the getter
         // which returns the default when None. This allows us to distinguish
         // "user explicitly set this" from "using default".
@@ -125,6 +201,22 @@ impl UserConfig {
 
             // Feed migrated content to serde so deprecated patterns parse correctly
             let migrated = super::deprecation::migrate_content(&content);
+
+            // Pre-validate with the toml crate for rich line/col errors.
+            // Validate as OverridableConfig (not UserConfig) because
+            // UserConfig's `#[serde(flatten)]` on OverridableConfig causes
+            // toml to lose field paths — errors point at the section header
+            // instead of the bad value. OverridableConfig has the section
+            // fields (list, commit, merge, ...) as direct fields, so the
+            // toml crate tracks their location correctly.
+            if let Err(err) = toml::from_str::<OverridableConfig>(&migrated) {
+                return Err(LoadError::File {
+                    path: system_path,
+                    label: "System config",
+                    err: Box::new(err),
+                });
+            }
+
             builder = builder.add_source(File::from_str(&migrated, config::FileFormat::Toml));
         }
 
@@ -157,6 +249,16 @@ impl UserConfig {
                     &find_unknown_keys(&content),
                     "User config",
                 );
+
+                // Pre-validate with the toml crate for rich line/col errors
+                // (OverridableConfig — see system config comment above for why).
+                if let Err(err) = toml::from_str::<OverridableConfig>(&migrated) {
+                    return Err(LoadError::File {
+                        path: config_path.clone(),
+                        label: "User config",
+                        err: Box::new(err),
+                    });
+                }
 
                 // Feed migrated content from check_and_migrate to serde so deprecated
                 // patterns parse correctly without reparsing the TOML here.
@@ -198,8 +300,20 @@ impl UserConfig {
         // The config crate's `preserve_order` feature ensures TOML insertion order
         // is preserved (uses IndexMap instead of HashMap internally).
         // See: https://github.com/max-sixty/worktrunk/issues/737
-        let config: Self = builder.build()?.try_deserialize()?;
-        config.validate()?;
+        let config: Self = builder
+            .build()
+            .map_err(LoadError::Other)?
+            .try_deserialize()
+            .map_err(|err| {
+                // Files were pre-validated above, so a deserialize failure here
+                // is caused by env-var overrides.
+                LoadError::Env {
+                    err,
+                    override_vars: collect_worktrunk_override_vars(),
+                }
+            })?;
+
+        config.validate().map_err(LoadError::Other)?;
 
         Ok(config)
     }

--- a/src/config/user/tests.rs
+++ b/src/config/user/tests.rs
@@ -2501,8 +2501,7 @@ fn test_reload_projects_from_permission_error() {
 
 #[test]
 fn test_load_error_display_file() {
-    let toml_err = toml::from_str::<OverridableConfig>("[list]\nbranches = \"bad\"\n")
-        .unwrap_err();
+    let toml_err = toml::from_str::<OverridableConfig>("[list]\nbranches = \"bad\"\n").unwrap_err();
     let err = LoadError::File {
         path: std::path::PathBuf::from("/tmp/config.toml"),
         label: "User config",

--- a/src/config/user/tests.rs
+++ b/src/config/user/tests.rs
@@ -2514,6 +2514,15 @@ fn test_load_error_display_file() {
 }
 
 #[test]
+fn test_load_error_display_env() {
+    let err = LoadError::Env {
+        err: config::ConfigError::Message("invalid type".into()),
+        override_vars: vec!["WORKTRUNK__LIST__BRANCHES".into()],
+    };
+    assert_eq!(err.to_string(), "invalid type");
+}
+
+#[test]
 fn test_load_error_display_other() {
     let err = LoadError::Other(config::ConfigError::Message("bad".into()));
     assert_eq!(err.to_string(), "bad");

--- a/src/config/user/tests.rs
+++ b/src/config/user/tests.rs
@@ -2498,3 +2498,24 @@ fn test_reload_projects_from_permission_error() {
         "Expected path in error, got: {err}"
     );
 }
+
+#[test]
+fn test_load_error_display_file() {
+    let toml_err = toml::from_str::<OverridableConfig>("[list]\nbranches = \"bad\"\n")
+        .unwrap_err();
+    let err = LoadError::File {
+        path: std::path::PathBuf::from("/tmp/config.toml"),
+        label: "User config",
+        err: Box::new(toml_err),
+    };
+    let msg = err.to_string();
+    assert!(msg.contains("User config at"), "{msg}");
+    assert!(msg.contains("failed to parse"), "{msg}");
+    assert!(msg.contains("line 2"), "{msg}");
+}
+
+#[test]
+fn test_load_error_display_other() {
+    let err = LoadError::Other(config::ConfigError::Message("bad".into()));
+    assert_eq!(err.to_string(), "bad");
+}

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -78,7 +78,7 @@ use anyhow::{Context, bail};
 
 use dunce::canonicalize;
 
-use crate::config::{ProjectConfig, ResolvedConfig, UserConfig};
+use crate::config::{LoadError, ProjectConfig, ResolvedConfig, UserConfig};
 
 // Import types from parent module
 use super::{DefaultBranchName, GitError, IntegrationReason, LineDiff, WorktreeInfo};
@@ -389,27 +389,53 @@ impl Repository {
     /// would hide it from anyone not running with `RUST_LOG=warn`.
     pub fn user_config(&self) -> &UserConfig {
         self.cache.user_config.get_or_init(|| {
-            UserConfig::load()
-                .inspect_err(|err| {
-                    // Include the config file path so users know where to look.
-                    // Serde's flatten/Option wrapping loses the offending field
-                    // name inside the config crate's error, so the file path is
-                    // the most reliable pointer we can give.
-                    let path_hint = crate::config::config_path()
-                        .map(|p| format!(" at {}", crate::path::format_path_for_display(&p)))
-                        .unwrap_or_default();
-                    crate::styling::eprintln!(
-                        "{}",
-                        crate::styling::warning_message(format!(
-                            "Failed to load user config{path_hint}, using defaults: {err}"
-                        ))
-                    );
-                    crate::styling::eprintln!(
-                        "{}",
-                        crate::styling::hint_message(
-                            "If the value came from a WORKTRUNK_* env var, check those too.",
-                        )
-                    );
+            UserConfig::load_with_cause()
+                .inspect_err(|err| match err {
+                    LoadError::File { path, label, err } => {
+                        crate::styling::eprintln!(
+                            "{}",
+                            crate::styling::warning_message(format!(
+                                "{label} at {} failed to parse, using defaults",
+                                crate::path::format_path_for_display(path),
+                            ))
+                        );
+                        crate::styling::eprintln!(
+                            "{}",
+                            crate::styling::format_with_gutter(&err.to_string(), None)
+                        );
+                    }
+                    LoadError::Env {
+                        err,
+                        override_vars,
+                    } => {
+                        crate::styling::eprintln!(
+                            "{}",
+                            crate::styling::warning_message(format!(
+                                "Failed to apply WORKTRUNK_* env var override, using defaults: {err}"
+                            ))
+                        );
+                        // TODO: With source-tracking in the config layer
+                        // (see collect_worktrunk_override_vars TODO) we could
+                        // pinpoint the exact var and show its value, rather
+                        // than dumping all override vars.
+                        if !override_vars.is_empty() {
+                            crate::styling::eprintln!(
+                                "{}",
+                                crate::styling::hint_message(format!(
+                                    "Currently set: {}",
+                                    override_vars.join(", ")
+                                ))
+                            );
+                        }
+                    }
+                    LoadError::Other(err) => {
+                        crate::styling::eprintln!(
+                            "{}",
+                            crate::styling::warning_message(format!(
+                                "Failed to load user config, using defaults: {err}"
+                            ))
+                        );
+                    }
                 })
                 .unwrap_or_default()
         })

--- a/tests/integration_tests/list_config.rs
+++ b/tests/integration_tests/list_config.rs
@@ -519,6 +519,23 @@ branches = "not-a-bool"
     });
 }
 
+/// When a WORKTRUNK_* env var override fails (e.g. a string value for a typed
+/// field), the warning must blame env vars — not the config file — and list
+/// the override vars currently set.
+#[rstest]
+fn test_list_config_env_override_bad_value_warns_on_stderr(repo: TestRepo) {
+    let settings = setup_snapshot_settings(&repo);
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        // `list.branches` is Option<bool>; "not-a-bool" can't coerce.
+        cmd.env("WORKTRUNK__LIST__BRANCHES", "not-a-bool");
+        cmd.arg("list").current_dir(repo.root_path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
 /// Test that --full disables the task timeout.
 #[rstest]
 fn test_list_config_timeout_disabled_with_full(repo: TestRepo, temp_home: TempDir) {

--- a/tests/integration_tests/list_config.rs
+++ b/tests/integration_tests/list_config.rs
@@ -559,6 +559,22 @@ fn test_list_config_malformed_non_section_field_warns_on_stderr(repo: TestRepo) 
     });
 }
 
+/// Validation errors (e.g. empty worktree-path) are neither file parse
+/// errors nor env-var errors — they fire after successful deserialization.
+#[rstest]
+fn test_list_config_validation_error_warns_on_stderr(repo: TestRepo) {
+    fs::write(repo.test_config_path(), "worktree-path = \"\"\n").unwrap();
+
+    let settings = setup_snapshot_settings(&repo);
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        cmd.arg("list").current_dir(repo.root_path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
 /// System config parse errors are attributed to the system config file,
 /// not the user config or env vars.
 #[rstest]

--- a/tests/integration_tests/list_config.rs
+++ b/tests/integration_tests/list_config.rs
@@ -575,12 +575,34 @@ fn test_list_config_validation_error_warns_on_stderr(repo: TestRepo) {
     });
 }
 
-/// System config parse errors are attributed to the system config file,
-/// not the user config or env vars.
+/// System config with a section-field error (caught by OverridableConfig).
 #[rstest]
 fn test_list_config_malformed_system_config_warns_on_stderr(repo: TestRepo) {
     let system_config = repo.root_path().join("system-config.toml");
     fs::write(&system_config, "[list]\nbranches = \"not-a-bool\"\n").unwrap();
+
+    let mut settings = setup_snapshot_settings(&repo);
+    settings.add_filter(r"_REPO_/system-config\.toml", "[TEST_SYSTEM_CONFIG_FILE]");
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        cmd.env("WORKTRUNK_SYSTEM_CONFIG_PATH", &system_config);
+        cmd.arg("list").current_dir(repo.root_path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
+/// System config with a non-section field error (skips OverridableConfig,
+/// caught by the UserConfig fallback validation).
+#[rstest]
+fn test_list_config_malformed_system_config_non_section_field(repo: TestRepo) {
+    let system_config = repo.root_path().join("system-config.toml");
+    fs::write(
+        &system_config,
+        "skip-shell-integration-prompt = \"not-a-bool\"\n",
+    )
+    .unwrap();
 
     let mut settings = setup_snapshot_settings(&repo);
     settings.add_filter(r"_REPO_/system-config\.toml", "[TEST_SYSTEM_CONFIG_FILE]");

--- a/tests/integration_tests/list_config.rs
+++ b/tests/integration_tests/list_config.rs
@@ -536,6 +536,48 @@ fn test_list_config_env_override_bad_value_warns_on_stderr(repo: TestRepo) {
     });
 }
 
+/// Bad values in non-section fields (projects, skip-*-prompt) must still be
+/// attributed to the file, not to env vars. These fields are NOT caught by
+/// the OverridableConfig pre-validation (which only covers section fields) —
+/// the UserConfig fallback validation catches them.
+#[rstest]
+fn test_list_config_malformed_non_section_field_warns_on_stderr(repo: TestRepo) {
+    fs::write(
+        repo.test_config_path(),
+        "skip-shell-integration-prompt = \"not-a-bool\"\n",
+    )
+    .unwrap();
+
+    let mut settings = setup_snapshot_settings(&repo);
+    settings.add_filter(r"_PARENT_/[^\s,]*test-config\.toml", "[TEST_CONFIG]");
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        cmd.arg("list").current_dir(repo.root_path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
+/// System config parse errors are attributed to the system config file,
+/// not the user config or env vars.
+#[rstest]
+fn test_list_config_malformed_system_config_warns_on_stderr(repo: TestRepo) {
+    let system_config = repo.root_path().join("system-config.toml");
+    fs::write(&system_config, "[list]\nbranches = \"not-a-bool\"\n").unwrap();
+
+    let mut settings = setup_snapshot_settings(&repo);
+    settings.add_filter(r"_REPO_/system-config\.toml", "[TEST_SYSTEM_CONFIG_FILE]");
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        cmd.env("WORKTRUNK_SYSTEM_CONFIG_PATH", &system_config);
+        cmd.arg("list").current_dir(repo.root_path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
 /// Test that --full disables the task timeout.
 #[rstest]
 fn test_list_config_timeout_disabled_with_full(repo: TestRepo, temp_home: TempDir) {

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_bad_value_warns_on_stderr.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_bad_value_warns_on_stderr.snap
@@ -36,6 +36,7 @@ info:
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK__LIST__BRANCHES: not-a-bool
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
@@ -50,9 +51,5 @@ exit_code: 0
 [2m○[22m [2mShowing 4 worktrees, 3 ahead
 
 ----- stderr -----
-[33m▲[39m [33mUser config at [TEST_CONFIG] failed to parse, using defaults[39m
-[107m [0m TOML parse error at line 2, column 12
-[107m [0m   |
-[107m [0m 2 | branches = "not-a-bool"
-[107m [0m   |            ^^^^^^^^^^^^
-[107m [0m invalid type: string "not-a-bool", expected a boolean
+[33m▲[39m [33mFailed to apply WORKTRUNK_* env var override, using defaults: invalid type: string "not-a-bool", expected a boolean[39m
+[2m↳[22m [2mCurrently set: WORKTRUNK__LIST__BRANCHES[22m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_non_section_field_warns_on_stderr.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_non_section_field_warns_on_stderr.snap
@@ -1,0 +1,58 @@
+---
+source: tests/integration_tests/list_config.rs
+info:
+  program: wt
+  args:
+    - list
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
++ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
++ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file
++ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead
+
+----- stderr -----
+[33m▲[39m [33mUser config at [TEST_CONFIG] failed to parse, using defaults[39m
+[107m [0m TOML parse error at line 1, column 33
+[107m [0m   |
+[107m [0m 1 | skip-shell-integration-prompt = "not-a-bool"
+[107m [0m   |                                 ^^^^^^^^^^^^
+[107m [0m invalid type: string "not-a-bool", expected a boolean

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_system_config_non_section_field.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_system_config_non_section_field.snap
@@ -1,0 +1,58 @@
+---
+source: tests/integration_tests/list_config.rs
+info:
+  program: wt
+  args:
+    - list
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main         [36m?[39m [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
++ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
++ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file
++ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
+
+[2m○[22m [2mShowing 4 worktrees, 1 with changes, 3 ahead
+
+----- stderr -----
+[33m▲[39m [33mSystem config at [TEST_SYSTEM_CONFIG_FILE] failed to parse, using defaults[39m
+[107m [0m TOML parse error at line 1, column 33
+[107m [0m   |
+[107m [0m 1 | skip-shell-integration-prompt = "not-a-bool"
+[107m [0m   |                                 ^^^^^^^^^^^^
+[107m [0m invalid type: string "not-a-bool", expected a boolean

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_system_config_warns_on_stderr.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_system_config_warns_on_stderr.snap
@@ -1,0 +1,58 @@
+---
+source: tests/integration_tests/list_config.rs
+info:
+  program: wt
+  args:
+    - list
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main         [36m?[39m [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
++ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
++ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file
++ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
+
+[2m○[22m [2mShowing 4 worktrees, 1 with changes, 3 ahead
+
+----- stderr -----
+[33m▲[39m [33mSystem config at [TEST_SYSTEM_CONFIG_FILE] failed to parse, using defaults[39m
+[107m [0m TOML parse error at line 2, column 12
+[107m [0m   |
+[107m [0m 2 | branches = "not-a-bool"
+[107m [0m   |            ^^^^^^^^^^^^
+[107m [0m invalid type: string "not-a-bool", expected a boolean

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_validation_error_warns_on_stderr.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_validation_error_warns_on_stderr.snap
@@ -1,0 +1,53 @@
+---
+source: tests/integration_tests/list_config.rs
+info:
+  program: wt
+  args:
+    - list
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
++ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
++ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file
++ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead
+
+----- stderr -----
+[33m▲[39m [33mFailed to load user config, using defaults: worktree-path cannot be empty[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__invalid_toml.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__invalid_toml.snap
@@ -46,7 +46,8 @@ exit_code: 1
 
 ----- stderr -----
 [31m✗[39m [31mFailed to load project config[39m
-[107m [0m Failed to parse TOML: TOML parse error at line 1, column 30
+[107m [0m Project config at _REPO_/.config/wt.toml failed to parse:
+[107m [0m TOML parse error at line 1, column 30
 [107m [0m   |
 [107m [0m 1 | post-create = [invalid syntax
 [107m [0m   |                              ^


### PR DESCRIPTION
When config loading fails, the error now tells users exactly where the problem is rather than always printing a misleading hint about env vars.

**File errors** get the toml crate's line/col pointer in a gutter block:
```
▲ User config at ~/.config/worktrunk/config.toml failed to parse, using defaults
 ┃ TOML parse error at line 2, column 12
 ┃   |
 ┃ 2 | branches = "not-a-bool"
 ┃   |            ^^^^^^^^^^^^
 ┃ invalid type: string "not-a-bool", expected a boolean
```

**Env-var errors** blame the right source and list override vars:
```
▲ Failed to apply WORKTRUNK_* env var override, using defaults: invalid type: ...
↳ Currently set: WORKTRUNK__LIST__BRANCHES
```

Pre-validates config files with two passes: first as `OverridableConfig` for precise line/col on section fields (the `#[serde(flatten)]` on `UserConfig.configs` causes toml to lose source locations), then as `UserConfig` to catch non-section fields (`projects`, `skip-*-prompt`) that `OverridableConfig` ignores. Project config errors now include the file path.

Follows up on #2062 which introduced the (always-firing) env-var hint.

> _This was written by Claude Code on behalf of Maximilian Roos_