### PR TITLE
docs: add `wt step up` as example multi-line alias

### DIFF
--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -831,7 +831,7 @@ Multi-line aliases work too. This `up` alias fetches all remotes and rebases eac
 [aliases]
 up = '''
 git fetch --all --prune && wt step for-each -- '
-  git rev-parse --verify @{u} &>/dev/null || exit 0
+  git rev-parse --verify @{u} >/dev/null 2>&1 || exit 0
   g=$(git rev-parse --git-dir)
   test -d "$g/rebase-merge" -o -d "$g/rebase-apply" && exit 0
   git rebase @{u} --no-autostash || git rebase --abort

--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -824,6 +824,22 @@ port = "echo http://localhost:{{ branch | hash_port }}"
 
 {{ terminal(cmd="wt step deploy                            # run the alias|||wt step deploy --dry-run                  # show expanded command|||wt step deploy --var env=staging          # pass extra template variables|||wt step deploy --yes                      # skip approval prompt") }}
 
+Multi-line aliases work too. This `up` alias fetches all remotes and rebases each worktree onto its upstream, skipping worktrees without a tracking branch or with a rebase already in progress:
+
+```toml
+# ~/.config/worktrunk/config.toml
+[aliases]
+up = '''
+git fetch --all --prune && wt step for-each -- '
+  git rev-parse --verify @{u} &>/dev/null || exit 0
+  g=$(git rev-parse --git-dir)
+  test -d "$g/rebase-merge" -o -d "$g/rebase-apply" && exit 0
+  git rebase @{u} --no-autostash || git rebase --abort
+''''
+```
+
+{{ terminal(cmd="wt step up") }}
+
 When defined in both user and project config, both run — user first, then project. Project-config aliases require [command approval](@/hook.md#wt-hook-approvals) on first run, same as project hooks. User-config aliases are trusted.
 
 Inside an alias body, an inner `wt switch` (or `wt switch --create`) passes its `cd` through to the parent shell, so an alias wrapping `wt switch --create` lands the shell in the new worktree just like running it directly.

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -874,6 +874,24 @@ $ wt step deploy --var env=staging          # pass extra template variables
 $ wt step deploy --yes                      # skip approval prompt
 ```
 
+Multi-line aliases work too. This `up` alias fetches all remotes and rebases each worktree onto its upstream, skipping worktrees without a tracking branch or with a rebase already in progress:
+
+```toml
+# ~/.config/worktrunk/config.toml
+[aliases]
+up = '''
+git fetch --all --prune && wt step for-each -- '
+  git rev-parse --verify @{u} &>/dev/null || exit 0
+  g=$(git rev-parse --git-dir)
+  test -d "$g/rebase-merge" -o -d "$g/rebase-apply" && exit 0
+  git rebase @{u} --no-autostash || git rebase --abort
+''''
+```
+
+```bash
+$ wt step up
+```
+
 When defined in both user and project config, both run — user first, then project. Project-config aliases require [command approval](https://worktrunk.dev/hook/#wt-hook-approvals) on first run, same as project hooks. User-config aliases are trusted.
 
 Inside an alias body, an inner `wt switch` (or `wt switch --create`) passes its `cd` through to the parent shell, so an alias wrapping `wt switch --create` lands the shell in the new worktree just like running it directly.

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -881,7 +881,7 @@ Multi-line aliases work too. This `up` alias fetches all remotes and rebases eac
 [aliases]
 up = '''
 git fetch --all --prune && wt step for-each -- '
-  git rev-parse --verify @{u} &>/dev/null || exit 0
+  git rev-parse --verify @{u} >/dev/null 2>&1 || exit 0
   g=$(git rev-parse --git-dir)
   test -d "$g/rebase-merge" -o -d "$g/rebase-apply" && exit 0
   git rebase @{u} --no-autostash || git rebase --abort

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1164,6 +1164,24 @@ $ wt step deploy --var env=staging          # pass extra template variables
 $ wt step deploy --yes                      # skip approval prompt
 ```
 
+Multi-line aliases work too. This `up` alias fetches all remotes and rebases each worktree onto its upstream, skipping worktrees without a tracking branch or with a rebase already in progress:
+
+```toml
+# ~/.config/worktrunk/config.toml
+[aliases]
+up = '''
+git fetch --all --prune && wt step for-each -- '
+  git rev-parse --verify @{u} &>/dev/null || exit 0
+  g=$(git rev-parse --git-dir)
+  test -d "$g/rebase-merge" -o -d "$g/rebase-apply" && exit 0
+  git rebase @{u} --no-autostash || git rebase --abort
+''''
+```
+
+```console
+$ wt step up
+```
+
 When defined in both user and project config, both run — user first, then project. Project-config aliases require [command approval](@/hook.md#wt-hook-approvals) on first run, same as project hooks. User-config aliases are trusted.
 
 Inside an alias body, an inner `wt switch` (or `wt switch --create`) passes its `cd` through to the parent shell, so an alias wrapping `wt switch --create` lands the shell in the new worktree just like running it directly.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1171,7 +1171,7 @@ Multi-line aliases work too. This `up` alias fetches all remotes and rebases eac
 [aliases]
 up = '''
 git fetch --all --prune && wt step for-each -- '
-  git rev-parse --verify @{u} &>/dev/null || exit 0
+  git rev-parse --verify @{u} >/dev/null 2>&1 || exit 0
   g=$(git rev-parse --git-dir)
   test -d "$g/rebase-merge" -o -d "$g/rebase-apply" && exit 0
   git rebase @{u} --no-autostash || git rebase --abort

--- a/tests/snapshots/integration__integration_tests__help__help_step_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_long.snap
@@ -112,6 +112,20 @@ Custom command templates configured in user config ([2m~/.config/worktrunk/conf
 [107m [0m [2m[0m[2m[34mwt[0m[2m step deploy [0m[2m[36m--var[0m[2m env=staging          # pass extra template variables[0m[2m[0m
 [107m [0m [2m[0m[2m[34mwt[0m[2m step deploy [0m[2m[36m--yes[0m[2m                      # skip approval prompt[0m[2m[0m
 
+Multi-line aliases work too. This [2mup[0m alias fetches all remotes and rebases each worktree onto its upstream, skipping worktrees without a tracking branch or with a rebase already in progress:
+
+[107m [0m [2m# ~/.config/worktrunk/config.toml[0m
+[107m [0m [2m[36m[aliases][0m
+[107m [0m [2mup = [0m[2m[32m''[0m[2m[32m'[0m
+[107m [0m [2m[32mgit fetch --all --prune && wt step for-each -- '[0m
+[107m [0m [2m  git rev-parse --verify @{u} &>/dev/null || exit 0[0m
+[107m [0m [2m  g=$(git rev-parse --git-dir)[0m
+[107m [0m [2m  test -d [0m[2m[32m"$g/rebase-merge"[0m[2m -o -d [0m[2m[32m"$g/rebase-apply"[0m[2m && exit 0[0m
+[107m [0m [2m  git rebase @{u} --no-autostash || git rebase --abort[0m
+[107m [0m [2m[32m''[0m[2m[32m''[0m
+
+[107m [0m [2m[0m[2m[34mwt[0m[2m step up[0m
+
 When defined in both user and project config, both run — user first, then project. Project-config aliases require command approval on first run, same as project hooks. User-config aliases are trusted.
 
 Inside an alias body, an inner [2mwt switch[0m (or [2mwt switch --create[0m) passes its [2mcd[0m through to the parent shell, so an alias wrapping [2mwt switch --create[0m lands the shell in the new worktree just like running it directly.

--- a/tests/snapshots/integration__integration_tests__help__help_step_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_long.snap
@@ -118,7 +118,7 @@ Multi-line aliases work too. This [2mup[0m alias fetches all remotes and rebas
 [107m [0m [2m[36m[aliases][0m
 [107m [0m [2mup = [0m[2m[32m''[0m[2m[32m'[0m
 [107m [0m [2m[32mgit fetch --all --prune && wt step for-each -- '[0m
-[107m [0m [2m  git rev-parse --verify @{u} &>/dev/null || exit 0[0m
+[107m [0m [2m  git rev-parse --verify @{u} >/dev/null 2>&1 || exit 0[0m
 [107m [0m [2m  g=$(git rev-parse --git-dir)[0m
 [107m [0m [2m  test -d [0m[2m[32m"$g/rebase-merge"[0m[2m -o -d [0m[2m[32m"$g/rebase-apply"[0m[2m && exit 0[0m
 [107m [0m [2m  git rebase @{u} --no-autostash || git rebase --abort[0m


### PR DESCRIPTION
Adds a real-world alias example to the step aliases documentation, showing multi-line syntax and composition with `wt step for-each`. The `up` alias fetches all remotes and rebases each worktree onto its upstream.

> _This was written by Claude Code on behalf of @max-sixty_