### PR TITLE
docs(faq): qualify "no background processes" claim

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -130,7 +130,7 @@ None of this is tracked by git or pushed to remotes.
 - No files outside `.git/`, config directories, or worktree directories
 - No global git hooks
 - No modifications to `~/.gitconfig`
-- No background processes or daemons
+- No long-running background processes or daemons
 
 ## What can Worktrunk delete?
 

--- a/skills/worktrunk/reference/faq.md
+++ b/skills/worktrunk/reference/faq.md
@@ -123,7 +123,7 @@ None of this is tracked by git or pushed to remotes.
 - No files outside `.git/`, config directories, or worktree directories
 - No global git hooks
 - No modifications to `~/.gitconfig`
-- No background processes or daemons
+- No long-running background processes or daemons
 
 ## What can Worktrunk delete?
 


### PR DESCRIPTION
Hooks and worktree removal spawn short-lived detached processes, so the blanket "no background processes" was inaccurate. Adds "long-running" qualifier.

> _This was written by Claude Code on behalf of @max-sixty_