### PR TITLE
fix(docs): use quote placeholders in terminal shortcode

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -142,7 +142,7 @@ Worktrunk can delete **worktrees** and **branches**. Both have safeguards.
 
 For worktrees containing precious ignored data (databases, caches, large assets), use `git worktree lock`:
 
-{{ terminal(cmd="git worktree lock ../myproject.feature --reason \"Contains local database\"") }}
+{{ terminal(cmd="git worktree lock ../myproject.feature --reason __WT_QUOT__Contains local database__WT_QUOT__") }}
 
 Locked worktrees show `⊞` in `wt list`. Neither `git worktree remove` nor `wt remove` (even with `--force`) will delete them. Unlock with `git worktree unlock`.
 

--- a/skills/worktrunk/reference/faq.md
+++ b/skills/worktrunk/reference/faq.md
@@ -135,7 +135,9 @@ Worktrunk can delete **worktrees** and **branches**. Both have safeguards.
 
 For worktrees containing precious ignored data (databases, caches, large assets), use `git worktree lock`:
 
-{{ terminal(cmd="git worktree lock ../myproject.feature --reason \"Contains local database\"") }}
+```bash
+$ git worktree lock ../myproject.feature --reason "Contains local database"
+```
 
 Locked worktrees show `⊞` in `wt list`. Neither `git worktree remove` nor `wt remove` (even with `--force`) will delete them. Unlock with `git worktree unlock`.
 


### PR DESCRIPTION
Tera has no backslash-escape for string literals, so `\"` inside a `cmd` parameter closes the string prematurely. The `git worktree lock` example in the FAQ was rendering as literal `{{ terminal(...) }}` text instead of a styled terminal block.

Switched to the `__WT_QUOT__` placeholder that the shortcode template already handles (replacing back to `"` before Syntect highlighting).

> _This was written by Claude Code on behalf of @max-sixty_