### PR TITLE
docs: use `git rev-parse --verify -q` in `up` alias example

### DIFF
--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -831,7 +831,7 @@ Multi-line aliases work too. This `up` alias fetches all remotes and rebases eac
 [aliases]
 up = '''
 git fetch --all --prune && wt step for-each -- '
-  git rev-parse --verify -q @{u} || exit 0
+  git rev-parse --verify -q @{u} >/dev/null || exit 0
   g=$(git rev-parse --git-dir)
   test -d "$g/rebase-merge" -o -d "$g/rebase-apply" && exit 0
   git rebase @{u} --no-autostash || git rebase --abort

--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -831,7 +831,7 @@ Multi-line aliases work too. This `up` alias fetches all remotes and rebases eac
 [aliases]
 up = '''
 git fetch --all --prune && wt step for-each -- '
-  git rev-parse --verify @{u} >/dev/null 2>&1 || exit 0
+  git rev-parse --verify -q @{u} || exit 0
   g=$(git rev-parse --git-dir)
   test -d "$g/rebase-merge" -o -d "$g/rebase-apply" && exit 0
   git rebase @{u} --no-autostash || git rebase --abort

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -881,7 +881,7 @@ Multi-line aliases work too. This `up` alias fetches all remotes and rebases eac
 [aliases]
 up = '''
 git fetch --all --prune && wt step for-each -- '
-  git rev-parse --verify -q @{u} || exit 0
+  git rev-parse --verify -q @{u} >/dev/null || exit 0
   g=$(git rev-parse --git-dir)
   test -d "$g/rebase-merge" -o -d "$g/rebase-apply" && exit 0
   git rebase @{u} --no-autostash || git rebase --abort

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -881,7 +881,7 @@ Multi-line aliases work too. This `up` alias fetches all remotes and rebases eac
 [aliases]
 up = '''
 git fetch --all --prune && wt step for-each -- '
-  git rev-parse --verify @{u} >/dev/null 2>&1 || exit 0
+  git rev-parse --verify -q @{u} || exit 0
   g=$(git rev-parse --git-dir)
   test -d "$g/rebase-merge" -o -d "$g/rebase-apply" && exit 0
   git rebase @{u} --no-autostash || git rebase --abort

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1171,7 +1171,7 @@ Multi-line aliases work too. This `up` alias fetches all remotes and rebases eac
 [aliases]
 up = '''
 git fetch --all --prune && wt step for-each -- '
-  git rev-parse --verify -q @{u} || exit 0
+  git rev-parse --verify -q @{u} >/dev/null || exit 0
   g=$(git rev-parse --git-dir)
   test -d "$g/rebase-merge" -o -d "$g/rebase-apply" && exit 0
   git rebase @{u} --no-autostash || git rebase --abort

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1171,7 +1171,7 @@ Multi-line aliases work too. This `up` alias fetches all remotes and rebases eac
 [aliases]
 up = '''
 git fetch --all --prune && wt step for-each -- '
-  git rev-parse --verify @{u} >/dev/null 2>&1 || exit 0
+  git rev-parse --verify -q @{u} || exit 0
   g=$(git rev-parse --git-dir)
   test -d "$g/rebase-merge" -o -d "$g/rebase-apply" && exit 0
   git rebase @{u} --no-autostash || git rebase --abort

--- a/tests/snapshots/integration__integration_tests__help__help_step_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_long.snap
@@ -118,7 +118,7 @@ Multi-line aliases work too. This [2mup[0m alias fetches all remotes and rebas
 [107m [0m [2m[36m[aliases][0m
 [107m [0m [2mup = [0m[2m[32m''[0m[2m[32m'[0m
 [107m [0m [2m[32mgit fetch --all --prune && wt step for-each -- '[0m
-[107m [0m [2m  git rev-parse --verify -q @{u} || exit 0[0m
+[107m [0m [2m  git rev-parse --verify -q @{u} >/dev/null || exit 0[0m
 [107m [0m [2m  g=$(git rev-parse --git-dir)[0m
 [107m [0m [2m  test -d [0m[2m[32m"$g/rebase-merge"[0m[2m -o -d [0m[2m[32m"$g/rebase-apply"[0m[2m && exit 0[0m
 [107m [0m [2m  git rebase @{u} --no-autostash || git rebase --abort[0m

--- a/tests/snapshots/integration__integration_tests__help__help_step_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_long.snap
@@ -118,7 +118,7 @@ Multi-line aliases work too. This [2mup[0m alias fetches all remotes and rebas
 [107m [0m [2m[36m[aliases][0m
 [107m [0m [2mup = [0m[2m[32m''[0m[2m[32m'[0m
 [107m [0m [2m[32mgit fetch --all --prune && wt step for-each -- '[0m
-[107m [0m [2m  git rev-parse --verify @{u} >/dev/null 2>&1 || exit 0[0m
+[107m [0m [2m  git rev-parse --verify -q @{u} || exit 0[0m
 [107m [0m [2m  g=$(git rev-parse --git-dir)[0m
 [107m [0m [2m  test -d [0m[2m[32m"$g/rebase-merge"[0m[2m -o -d [0m[2m[32m"$g/rebase-apply"[0m[2m && exit 0[0m
 [107m [0m [2m  git rebase @{u} --no-autostash || git rebase --abort[0m


### PR DESCRIPTION
Use `git rev-parse --verify -q` to suppress the error message natively, plus `>/dev/null` to hide the SHA printed on success. Replaces the `>/dev/null 2>&1` redirect.

> _This was written by Claude Code on behalf of @max-sixty_