### PR TITLE
docs(faq): use `git config worktrunk.*` for config key location

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -113,7 +113,7 @@ Worktrunk stores small amounts of cache and log data in the repository's `.git/`
 
 | Location | Purpose | Created by |
 |----------|---------|------------|
-| `.git/config` keys under `worktrunk.*` | Cached default branch, switch history, branch markers, custom variables | Various commands |
+| `git config worktrunk.*` | Cached default branch, switch history, branch markers, custom variables | Various commands |
 | `.git/wt/cache/ci-status/*.json` | CI status cache (~1KB each) | `wt list` when `gh` or `glab` CLI is installed |
 | `.git/wt/logs/{branch}/**/*.log` | Background hook output (nested per branch) | Hooks, background `wt remove` |
 | `.git/wt/logs/commands.jsonl` | Command audit log (~2MB max) | Hooks, LLM commands |

--- a/skills/worktrunk/reference/faq.md
+++ b/skills/worktrunk/reference/faq.md
@@ -106,7 +106,7 @@ Worktrunk stores small amounts of cache and log data in the repository's `.git/`
 
 | Location | Purpose | Created by |
 |----------|---------|------------|
-| `.git/config` keys under `worktrunk.*` | Cached default branch, switch history, branch markers, custom variables | Various commands |
+| `git config worktrunk.*` | Cached default branch, switch history, branch markers, custom variables | Various commands |
 | `.git/wt/cache/ci-status/*.json` | CI status cache (~1KB each) | `wt list` when `gh` or `glab` CLI is installed |
 | `.git/wt/logs/{branch}/**/*.log` | Background hook output (nested per branch) | Hooks, background `wt remove` |
 | `.git/wt/logs/commands.jsonl` | Command audit log (~2MB max) | Hooks, LLM commands |


### PR DESCRIPTION
The previous wording (`.git/config` keys under `worktrunk.*`) mixed plain text between two code spans in the Location column. The `td:first-child` CSS rule sets `font-weight: 550`, so "keys under" rendered semi-bold while the flanking `<code>` elements stayed at 400 — visually inconsistent with every other row.

`git config worktrunk.*` is a single code span that also avoids tying the location to a specific config file (`.git/config` vs `~/.gitconfig`).

> _This was written by Claude Code on behalf of @max-sixty_