### PR TITLE
docs: cross-link Extending Worktrunk page

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ The `-x` flag runs a command after switching; arguments after `--` are passed to
   picker](https://worktrunk.dev/switch/#interactive-picker), [Claude Code integration](https://worktrunk.dev/claude-code/), [CI
   status & PR links](https://worktrunk.dev/list/#ci-status)
 - Browse [tips & patterns](https://worktrunk.dev/tips-patterns/) for recipes: aliases, dev servers, databases, agent handoffs, and more
+- [Extending Worktrunk](https://worktrunk.dev/extending/) — customize workflows with hooks & aliases
 - Run `wt --help` or `wt <command> --help` for quick CLI reference
 
 ## Further reading

--- a/docs/content/extending.md
+++ b/docs/content/extending.md
@@ -106,13 +106,25 @@ See [Tips & Patterns](@/tips-patterns.md) for more recipes: dev server per workt
 Aliases are custom commands invoked via `wt step <name>`. They share the same template variables and approval model as hooks.
 
 ```toml
-# .config/wt.toml
 [aliases]
 deploy = "make deploy BRANCH={{ branch }}"
 open = "open http://localhost:{{ branch | hash_port }}"
 ```
 
 {{ terminal(cmd="wt step deploy|||wt step deploy --dry-run|||wt step deploy --var env=staging") }}
+
+An `up` alias that fetches all remotes and rebases each worktree onto its upstream:
+
+```toml
+[aliases]
+up = '''
+git fetch --all --prune && wt step for-each -- '
+  git rev-parse --verify @{u} >/dev/null 2>&1 || exit 0
+  g=$(git rev-parse --git-dir)
+  test -d "$g/rebase-merge" -o -d "$g/rebase-apply" && exit 0
+  git rebase @{u} --no-autostash || git rebase --abort
+''''
+```
 
 When both user and project config define the same alias name, both run — user first, then project. Project-config aliases require approval, same as project hooks.
 

--- a/docs/content/worktrunk.md
+++ b/docs/content/worktrunk.md
@@ -202,6 +202,7 @@ The `-x` flag runs a command after switching; arguments after `--` are passed to
   picker](@/switch.md#interactive-picker), [Claude Code integration](@/claude-code.md), [CI
   status & PR links](@/list.md#ci-status)
 - Browse [tips & patterns](@/tips-patterns.md) for recipes: aliases, dev servers, databases, agent handoffs, and more
+- [Extending Worktrunk](@/extending.md) — customize workflows with hooks & aliases
 - Run `wt --help` or `wt <command> --help` for quick CLI reference
 
 ## Further reading

--- a/skills/worktrunk/reference/extending.md
+++ b/skills/worktrunk/reference/extending.md
@@ -99,7 +99,6 @@ See [Tips & Patterns](https://worktrunk.dev/tips-patterns/) for more recipes: de
 Aliases are custom commands invoked via `wt step <name>`. They share the same template variables and approval model as hooks.
 
 ```toml
-# .config/wt.toml
 [aliases]
 deploy = "make deploy BRANCH={{ branch }}"
 open = "open http://localhost:{{ branch | hash_port }}"
@@ -109,6 +108,19 @@ open = "open http://localhost:{{ branch | hash_port }}"
 $ wt step deploy
 $ wt step deploy --dry-run
 $ wt step deploy --var env=staging
+```
+
+An `up` alias that fetches all remotes and rebases each worktree onto its upstream:
+
+```toml
+[aliases]
+up = '''
+git fetch --all --prune && wt step for-each -- '
+  git rev-parse --verify @{u} >/dev/null 2>&1 || exit 0
+  g=$(git rev-parse --git-dir)
+  test -d "$g/rebase-merge" -o -d "$g/rebase-apply" && exit 0
+  git rebase @{u} --no-autostash || git rebase --abort
+''''
 ```
 
 When both user and project config define the same alias name, both run — user first, then project. Project-config aliases require approval, same as project hooks.

--- a/skills/worktrunk/reference/worktrunk.md
+++ b/skills/worktrunk/reference/worktrunk.md
@@ -184,6 +184,7 @@ The `-x` flag runs a command after switching; arguments after `--` are passed to
   picker](https://worktrunk.dev/switch/#interactive-picker), [Claude Code integration](https://worktrunk.dev/claude-code/), [CI
   status & PR links](https://worktrunk.dev/list/#ci-status)
 - Browse [tips & patterns](https://worktrunk.dev/tips-patterns/) for recipes: aliases, dev servers, databases, agent handoffs, and more
+- [Extending Worktrunk](https://worktrunk.dev/extending/) — customize workflows with hooks & aliases
 - Run `wt --help` or `wt <command> --help` for quick CLI reference
 
 ## Further reading


### PR DESCRIPTION
Follow-up to #2079. Adds cross-links from the landing page and adds the `up` alias example to the extending page.

- worktrunk.md "Next steps": link to extending.md
- extending.md: add `wt step up` multi-line alias example, remove redundant TOML file-path comments

> _This was written by Claude Code on behalf of @max-sixty_