### PR TITLE
Run merge-tree tasks for stale branches in picker

### DIFF
--- a/src/commands/list/collect/execution.rs
+++ b/src/commands/list/collect/execution.rs
@@ -39,12 +39,12 @@ use super::types::{TaskError, TaskKind, TaskResult};
 // These are skipped for branches that are far behind the default branch (in `wt switch` interactive picker).
 // AheadBehind is NOT here - we use batch data for it instead of skipping.
 // CommittedTreesMatch is NOT here - it's a cheap tree comparison that aids integration detection.
+// WouldMergeAdd and MergeTreeConflicts are NOT here - they use the persistent SHA-keyed
+// probe cache, so they're instant on cache hits (only slow on the first invocation).
 const EXPENSIVE_TASKS: &[TaskKind] = &[
-    TaskKind::HasFileChanges,     // git diff with three-dot range
-    TaskKind::IsAncestor,         // git merge-base --is-ancestor
-    TaskKind::WouldMergeAdd,      // git merge-tree simulation
-    TaskKind::BranchDiff,         // git diff with three-dot range
-    TaskKind::MergeTreeConflicts, // git merge-tree simulation
+    TaskKind::HasFileChanges, // git diff with three-dot range
+    TaskKind::IsAncestor,     // git merge-base --is-ancestor
+    TaskKind::BranchDiff,     // git diff with three-dot range
 ];
 
 /// Tasks that require a valid commit SHA. Skipped for unborn branches (no commits yet).

--- a/tests/snapshots/integration__integration_tests__list__list_skips_expensive_for_stale_branches_only.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_skips_expensive_for_stale_branches_only.snap
@@ -49,7 +49,7 @@ exit_code: 0
 + feature-a         [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m          [2m⋯[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
 + feature-b         [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m          [2m⋯[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file
 + feature-c         [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m          [2m⋯[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
-  stale-branch     [2m/[22m[2m↓[22m                     [2m[31m↓2[0m          [2m⋯[0m                                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
+  [2mstale-branch[0m     [2m/[22m[2m⊂[22m                     [2m[31m↓2[0m          [2m⋯[0m                                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead
 


### PR DESCRIPTION
Now that merge-tree and integration probe results are cached on disk (SHA-keyed, instant on cache hit from #2085), `WouldMergeAdd` and `MergeTreeConflicts` no longer need to be in the `EXPENSIVE_TASKS` skip list. Stale branches now get full integration detection in both `wt list` and the picker.

The first invocation may be slightly slower for repos with many stale branches (cache cold), but the picker's 500ms collect deadline provides a safety net, and all subsequent invocations are instant from cache.

> _This was written by Claude Code on behalf of @max-sixty_