### PR TITLE
refactor: unify lazy template expansion and concurrent-group waits

### DIFF
--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -38,7 +38,9 @@ use worktrunk::styling::{
 };
 
 use crate::commands::command_approval::approve_alias_commands;
-use crate::commands::command_executor::{CommandContext, build_hook_context};
+use crate::commands::command_executor::{
+    CommandContext, build_hook_context, expand_shell_template, wait_first_error,
+};
 use crate::output::execute_shell_command;
 
 /// Built-in `wt step` subcommand names. Aliases with these names are
@@ -336,10 +338,11 @@ pub fn step_alias(opts: AliasOptions) -> anyhow::Result<()> {
                 std::thread::scope(|s| {
                     let handles: Vec<_> =
                         cmds.iter().map(|cmd| s.spawn(|| exec.run(cmd))).collect();
-                    for handle in handles {
-                        handle.join().expect("alias command thread panicked")?;
-                    }
-                    Ok::<(), anyhow::Error>(())
+                    wait_first_error(
+                        handles
+                            .into_iter()
+                            .map(|h| h.join().expect("alias command thread panicked")),
+                    )
                 })?;
             }
         }
@@ -368,11 +371,7 @@ impl AliasExecCtx<'_> {
         let command = if self.is_pipeline && template_references_var(&cmd.template, "vars") {
             let fresh_context: HashMap<String, String> = serde_json::from_str(self.context_json)
                 .context("failed to deserialize context_json")?;
-            let fresh_vars: HashMap<&str, &str> = fresh_context
-                .iter()
-                .map(|(k, v)| (k.as_str(), v.as_str()))
-                .collect();
-            expand_template(&cmd.template, &fresh_vars, true, self.repo, self.alias_name)?
+            expand_shell_template(&cmd.template, &fresh_context, self.repo, self.alias_name)?
         } else {
             expand_template(&cmd.template, self.vars, true, self.repo, self.alias_name)?
         };

--- a/src/commands/command_executor.rs
+++ b/src/commands/command_executor.rs
@@ -169,6 +169,47 @@ pub fn build_hook_context(
     Ok(map)
 }
 
+/// Drain a sequence of command results, returning the first error.
+///
+/// All items are consumed before returning, so callers can be sure every
+/// spawned child or joined thread has completed even when one item already
+/// errored. Used by alias and pipeline concurrent groups, which both want
+/// "wait all, return first error" semantics around different concurrency
+/// primitives (in-process threads vs OS subprocesses).
+pub fn wait_first_error<E>(
+    results: impl IntoIterator<Item = std::result::Result<(), E>>,
+) -> std::result::Result<(), E> {
+    let mut first = None;
+    for r in results {
+        if let Err(e) = r
+            && first.is_none()
+        {
+            first = Some(e);
+        }
+    }
+    first.map_or(Ok(()), Err)
+}
+
+/// Expand a shell-command template against a context map.
+///
+/// Builds the `&str` vars map required by `expand_template` and fixes
+/// `shell_escape=true` since every caller interpolates the result into a
+/// shell string. Used by the three execution paths — foreground hooks,
+/// background pipelines, and aliases — that defer `vars.*` expansion until
+/// just before the command runs so prior steps can set vars via git config.
+pub fn expand_shell_template(
+    template: &str,
+    context: &HashMap<String, String>,
+    repo: &Repository,
+    label: &str,
+) -> Result<String> {
+    let vars: HashMap<&str, &str> = context
+        .iter()
+        .map(|(k, v)| (k.as_str(), v.as_str()))
+        .collect();
+    Ok(expand_template(template, &vars, true, repo, label)?)
+}
+
 /// Expand commands from a CommandConfig without approval.
 ///
 /// When `lazy_enabled` is true, commands referencing `vars.` are validated but not
@@ -217,12 +258,8 @@ fn expand_commands(
             let tpl = cmd.template.clone();
             (tpl.clone(), Some(tpl))
         } else {
-            let vars: HashMap<&str, &str> = cmd_context
-                .iter()
-                .map(|(k, v)| (k.as_str(), v.as_str()))
-                .collect();
             (
-                expand_template(&cmd.template, &vars, true, ctx.repo, &template_name)?,
+                expand_shell_template(&cmd.template, &cmd_context, ctx.repo, &template_name)?,
                 None,
             )
         };

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -11,7 +11,8 @@ use worktrunk::styling::{
 };
 
 use super::command_executor::{
-    CommandContext, PreparedCommand, PreparedStep, prepare_commands, prepare_steps,
+    CommandContext, PreparedCommand, PreparedStep, expand_shell_template, prepare_commands,
+    prepare_steps,
 };
 use crate::commands::process::{HookLog, spawn_detached_exec};
 use crate::output::execute_shell_command;
@@ -521,7 +522,10 @@ pub fn run_hook_with_filter(
         // so that vars set by earlier commands in the pipeline are available.
         let expanded = if let Some(ref template) = cmd.prepared.lazy_template {
             let name = cmd.summary_name();
-            expand_lazy_template(template, &cmd.prepared.context_json, ctx.repo, &name)?
+            let context: std::collections::HashMap<String, String> =
+                serde_json::from_str(&cmd.prepared.context_json)
+                    .context("failed to deserialize context_json")?;
+            expand_shell_template(template, &context, ctx.repo, &name)?
         } else {
             cmd.prepared.expanded.clone()
         };
@@ -664,28 +668,6 @@ pub(crate) fn prepare_background_hooks(
     }
 
     Ok(groups)
-}
-
-/// Expand a lazy template using its command's context JSON.
-///
-/// Used by `run_hook_with_filter` (foreground) to expand templates that
-/// reference `vars.*` at execution time. Background hooks handle lazy
-/// expansion inside the pipeline runner process instead.
-fn expand_lazy_template(
-    template: &str,
-    context_json: &str,
-    repo: &worktrunk::git::Repository,
-    label: &str,
-) -> anyhow::Result<String> {
-    let context_map: std::collections::HashMap<String, String> =
-        serde_json::from_str(context_json).context("failed to deserialize context_json")?;
-    let vars: std::collections::HashMap<&str, &str> = context_map
-        .iter()
-        .map(|(k, v)| (k.as_str(), v.as_str()))
-        .collect();
-    Ok(worktrunk::config::expand_template(
-        template, &vars, true, repo, label,
-    )?)
 }
 
 #[cfg(test)]

--- a/src/commands/run_pipeline.rs
+++ b/src/commands/run_pipeline.rs
@@ -52,6 +52,7 @@
 //! Template values are shell-escaped at expansion time (`shell_escape=true`)
 //! since the expanded string is passed to a shell for interpretation.
 
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fs;
 use std::io::Read as _;
@@ -60,10 +61,10 @@ use std::process::{Child, Stdio};
 
 use anyhow::{Context, bail};
 
-use worktrunk::config::expand_template;
 use worktrunk::git::Repository;
 use worktrunk::shell_exec::ShellConfig;
 
+use super::command_executor::{expand_shell_template, wait_first_error};
 use super::pipeline_spec::{PipelineSpec, PipelineStepSpec};
 use super::process::HookLog;
 
@@ -98,8 +99,11 @@ pub fn run_pipeline() -> anyhow::Result<()> {
             PipelineStepSpec::Single { template, name } => {
                 let log_name = command_log_name(name.as_deref(), cmd_index);
                 let log_file = create_command_log(&spec, &log_name)?;
-                let expanded = expand_now(template, &spec, &repo, name.as_deref())?;
-                let step_json = build_step_context_json(&spec.context, name.as_deref())?;
+                let step_ctx = step_context(&spec.context, name.as_deref());
+                let label = name.as_deref().unwrap_or("pipeline step");
+                let expanded = expand_shell_template(template, &step_ctx, &repo, label)?;
+                let step_json = serde_json::to_string(&*step_ctx)
+                    .context("failed to serialize step context")?;
                 let mut child =
                     spawn_shell_command(&expanded, &spec.worktree_path, &step_json, log_file)?;
                 let status = child.wait().context("failed to wait for child process")?;
@@ -121,28 +125,22 @@ pub fn run_pipeline() -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Expand a template using the spec's context and fresh vars from git config.
+/// Build a per-step context, injecting `hook_name` when the step has a name.
 ///
-/// Injects per-step `hook_name` into the vars so each step sees its own name,
-/// not the first step's name (the shared context has `hook_name` stripped).
-fn expand_now(
-    template: &str,
-    spec: &PipelineSpec,
-    repo: &Repository,
+/// The shared pipeline context has `hook_name` stripped (it varies per step).
+/// Returns a `Cow` so unnamed steps borrow the base context without cloning.
+fn step_context<'a>(
+    base: &'a HashMap<String, String>,
     name: Option<&str>,
-) -> anyhow::Result<String> {
-    let mut vars: HashMap<&str, &str> = spec
-        .context
-        .iter()
-        .map(|(k, v)| (k.as_str(), v.as_str()))
-        .collect();
-    if let Some(n) = name {
-        vars.insert("hook_name", n);
+) -> Cow<'a, HashMap<String, String>> {
+    match name {
+        Some(n) => {
+            let mut ctx = base.clone();
+            ctx.insert("hook_name".into(), n.into());
+            Cow::Owned(ctx)
+        }
+        None => Cow::Borrowed(base),
     }
-    let label = name.unwrap_or("pipeline step");
-    // shell_escape=true — values are interpolated into a string passed to a shell,
-    // so they must be escaped to prevent word splitting and metachar injection.
-    Ok(expand_template(template, &vars, true, repo, label)?)
 }
 
 /// Spawn a shell command with context JSON piped to stdin.
@@ -181,6 +179,10 @@ fn spawn_shell_command(
 }
 
 /// Spawn all commands in a concurrent group, then wait for all.
+///
+/// Waits every spawned child before returning. If any failed, the first
+/// failure (in spawn order) is returned, matching the serial-step bail
+/// format. Per-command output already lives in each command's log file.
 fn run_concurrent_group(
     commands: &[super::pipeline_spec::PipelineCommandSpec],
     spec: &PipelineSpec,
@@ -192,46 +194,31 @@ fn run_concurrent_group(
     for cmd in commands {
         let log_name = command_log_name(cmd.name.as_deref(), *cmd_index);
         let log_file = create_command_log(spec, &log_name)?;
-        let expanded = expand_now(&cmd.template, spec, repo, cmd.name.as_deref())?;
-        let cmd_json = build_step_context_json(&spec.context, cmd.name.as_deref())?;
+        let cmd_ctx = step_context(&spec.context, cmd.name.as_deref());
+        let label = cmd.name.as_deref().unwrap_or("pipeline step");
+        let expanded = expand_shell_template(&cmd.template, &cmd_ctx, repo, label)?;
+        let cmd_json =
+            serde_json::to_string(&*cmd_ctx).context("failed to serialize step context")?;
         let child = spawn_shell_command(&expanded, &spec.worktree_path, &cmd_json, log_file)?;
         children.push((cmd.name.clone(), expanded, child));
         *cmd_index += 1;
     }
 
-    let mut failures = Vec::new();
-    for (name, expanded, mut child) in children {
-        let status = child
-            .wait()
-            .with_context(|| format!("failed to wait for: {expanded}"))?;
-        if !status.success() {
-            let label = name.as_deref().unwrap_or(&expanded);
-            failures.push(label.to_string());
-        }
-    }
-
-    if !failures.is_empty() {
-        bail!("concurrent group had failures: {}", failures.join(", "));
-    }
-    Ok(())
-}
-
-/// Build per-step context JSON, injecting `hook_name` when the step has a name.
-///
-/// The shared pipeline context has `hook_name` stripped (it varies per step).
-/// This function adds it back for the specific step so commands receive the
-/// correct `hook_name` on stdin.
-fn build_step_context_json(
-    base_context: &HashMap<String, String>,
-    name: Option<&str>,
-) -> anyhow::Result<String> {
-    if let Some(n) = name {
-        let mut ctx = base_context.clone();
-        ctx.insert("hook_name".into(), n.into());
-        serde_json::to_string(&ctx).context("failed to serialize step context")
-    } else {
-        serde_json::to_string(base_context).context("failed to serialize step context")
-    }
+    wait_first_error(children.into_iter().map(
+        |(name, expanded, mut child)| -> anyhow::Result<()> {
+            let status = child
+                .wait()
+                .with_context(|| format!("failed to wait for: {expanded}"))?;
+            if !status.success() {
+                bail!(
+                    "command failed with {}: {}",
+                    format_exit(status.code()),
+                    name.as_deref().unwrap_or(&expanded),
+                );
+            }
+            Ok(())
+        },
+    ))
 }
 
 /// Derive the log file name for a command.


### PR DESCRIPTION
Two small follow-ups to #2089, which unified shell command execution for hooks and aliases but left some duplication on the template-expansion and concurrent-wait paths.

## What changed

**`expand_shell_template`** (in `src/commands/command_executor.rs`) — one helper that builds the `&str` vars map and calls `expand_template` with `shell_escape=true`. Replaces three lazy-expansion sites (foreground hooks, background pipeline runner, alias runner) and the eager sibling inside `expand_commands`, so every shell template expansion now flows through one helper.

**`wait_first_error`** (same file) — drains a sequence of `Result<(), E>` items and returns the first error. Alias's `thread::scope` block and the pipeline runner's concurrent group now share "wait all, return first error" semantics over different concurrency primitives (in-process threads vs OS subprocesses). The concurrent-group bail format now matches the serial-step format (`command failed with {exit}: {label}`), removing a minor inconsistency — per-command output already lives in each command's log file.

**`step_context` in `run_pipeline.rs`** — folds `expand_now` and `build_step_context_json` into one helper returning `Cow<HashMap<String, String>>`. Unnamed steps borrow the base context; named steps clone once and insert `hook_name`. Previously, named steps cloned twice (once for expansion, once for JSON).

## Where to look

- `src/commands/command_executor.rs` — two new helpers
- `src/commands/hooks.rs` — deleted local `expand_lazy_template`
- `src/commands/alias.rs` — concurrent block and `AliasExecCtx::run`
- `src/commands/run_pipeline.rs` — `step_context`, `run_concurrent_group`, `expand_commands` in main loop

## Testing

`cargo run -- hook pre-merge --yes` is green: 3025/3025 insta-nextest tests, pre-commit lints, doctests, `cargo doc`. No snapshots changed.