### PR TITLE
feat(alias): canonicalize hyphens to underscores in variable names

### DIFF
--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -822,7 +822,9 @@ deploy = "make deploy BRANCH={{ branch }}"
 port = "echo http://localhost:{{ branch | hash_port }}"
 ```
 
-{{ terminal(cmd="wt step deploy                            # run the alias|||wt step deploy --dry-run                  # show expanded command|||wt step deploy --env=staging              # pass template variable|||wt step deploy --var env=staging          # equivalent long form|||wt step deploy --yes                      # skip approval prompt") }}
+{{ terminal(cmd="wt step deploy                            # run the alias|||wt step deploy --dry-run                  # show expanded command|||wt step deploy --env=staging              # pass template variable|||wt step deploy --var env=staging          # equivalent long form|||wt step deploy --my-var=value             # hyphens become underscores (__WT_OPEN2__ my_var __WT_CLOSE2__)|||wt step deploy --yes                      # skip approval prompt") }}
+
+Hyphens in variable names are canonicalized to underscores at parse time, so `--my-var=value` is referenced as `{{ my_var }}` in templates. This lets flags use natural kebab-case while avoiding the minijinja parser's interpretation of `{{ my-var }}` as subtraction.
 
 Multi-line aliases work too. This `up` alias fetches all remotes and rebases each worktree onto its upstream, skipping worktrees without a tracking branch or with a rebase already in progress:
 

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -872,8 +872,11 @@ $ wt step deploy                            # run the alias
 $ wt step deploy --dry-run                  # show expanded command
 $ wt step deploy --env=staging              # pass template variable
 $ wt step deploy --var env=staging          # equivalent long form
+$ wt step deploy --my-var=value             # hyphens become underscores ({{ my_var }})
 $ wt step deploy --yes                      # skip approval prompt
 ```
+
+Hyphens in variable names are canonicalized to underscores at parse time, so `--my-var=value` is referenced as `{{ my_var }}` in templates. This lets flags use natural kebab-case while avoiding the minijinja parser's interpretation of `{{ my-var }}` as subtraction.
 
 Multi-line aliases work too. This `up` alias fetches all remotes and rebases each worktree onto its upstream, skipping worktrees without a tracking branch or with a rebase already in progress:
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1162,8 +1162,11 @@ $ wt step deploy                            # run the alias
 $ wt step deploy --dry-run                  # show expanded command
 $ wt step deploy --env=staging              # pass template variable
 $ wt step deploy --var env=staging          # equivalent long form
+$ wt step deploy --my-var=value             # hyphens become underscores ({{ my_var }})
 $ wt step deploy --yes                      # skip approval prompt
 ```
+
+Hyphens in variable names are canonicalized to underscores at parse time, so `--my-var=value` is referenced as `{{ my_var }}` in templates. This lets flags use natural kebab-case while avoiding the minijinja parser's interpretation of `{{ my-var }}` as subtraction.
 
 Multi-line aliases work too. This `up` alias fetches all remotes and rebases each worktree onto its upstream, skipping worktrees without a tracking branch or with a rebase already in progress:
 

--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -76,6 +76,10 @@ impl AliasOptions {
     /// so `--env=staging` is equivalent to `--var env=staging`. The `=` is
     /// required — bare `--key` flags (without a value) are rejected. Use
     /// `--var KEY=VALUE` if a variable name collides with a built-in flag.
+    ///
+    /// Hyphens in variable names are canonicalized to underscores so users can
+    /// write `--my-var=value` and reference `{{ my_var }}` in templates
+    /// (minijinja parses `{{ my-var }}` as subtraction).
     pub fn parse(args: Vec<String>) -> anyhow::Result<Self> {
         let Some(name) = args.first().cloned() else {
             bail!("Missing alias name");
@@ -107,7 +111,7 @@ impl AliasOptions {
                         if key.is_empty() {
                             bail!("Variable name must not be empty (got '--={value}')");
                         }
-                        vars.push((key.to_string(), value.to_string()));
+                        vars.push((key.replace('-', "_"), value.to_string()));
                     } else {
                         bail!(
                             "Unknown flag '{arg}' for alias '{name}' (use --{rest}=VALUE to pass a variable)"
@@ -135,7 +139,7 @@ fn parse_var(s: &str) -> anyhow::Result<(String, String)> {
     if key.is_empty() {
         bail!("--var key must not be empty (got '={value}')");
     }
-    Ok((key.to_string(), value.to_string()))
+    Ok((key.replace('-', "_"), value.to_string()))
 }
 
 /// Determine whether an alias requires project-config approval.
@@ -566,6 +570,90 @@ mod tests {
                 (
                     "env",
                     "",
+                ),
+            ],
+        }
+        "#);
+        // Hyphens in shorthand key are canonicalized to underscores
+        assert_debug_snapshot!(parse(&["deploy", "--my-var=value"]).unwrap(), @r#"
+        AliasOptions {
+            name: "deploy",
+            dry_run: false,
+            yes: false,
+            vars: [
+                (
+                    "my_var",
+                    "value",
+                ),
+            ],
+        }
+        "#);
+        // Hyphens in --var KEY=VALUE are canonicalized too
+        assert_debug_snapshot!(parse(&["deploy", "--var", "my-var=value"]).unwrap(), @r#"
+        AliasOptions {
+            name: "deploy",
+            dry_run: false,
+            yes: false,
+            vars: [
+                (
+                    "my_var",
+                    "value",
+                ),
+            ],
+        }
+        "#);
+        // Hyphens in --var=KEY=VALUE form
+        assert_debug_snapshot!(parse(&["deploy", "--var=my-var=value"]).unwrap(), @r#"
+        AliasOptions {
+            name: "deploy",
+            dry_run: false,
+            yes: false,
+            vars: [
+                (
+                    "my_var",
+                    "value",
+                ),
+            ],
+        }
+        "#);
+        // Already-underscored keys pass through unchanged
+        assert_debug_snapshot!(parse(&["deploy", "--my_var=value"]).unwrap(), @r#"
+        AliasOptions {
+            name: "deploy",
+            dry_run: false,
+            yes: false,
+            vars: [
+                (
+                    "my_var",
+                    "value",
+                ),
+            ],
+        }
+        "#);
+        // Multiple hyphens in a single key
+        assert_debug_snapshot!(parse(&["deploy", "--long-var-name=x"]).unwrap(), @r#"
+        AliasOptions {
+            name: "deploy",
+            dry_run: false,
+            yes: false,
+            vars: [
+                (
+                    "long_var_name",
+                    "x",
+                ),
+            ],
+        }
+        "#);
+        // Hyphens in value are preserved (only key is canonicalized)
+        assert_debug_snapshot!(parse(&["deploy", "--region=us-east-1"]).unwrap(), @r#"
+        AliasOptions {
+            name: "deploy",
+            dry_run: false,
+            yes: false,
+            vars: [
+                (
+                    "region",
+                    "us-east-1",
                 ),
             ],
         }

--- a/tests/snapshots/integration__integration_tests__help__help_step_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_long.snap
@@ -111,7 +111,10 @@ Custom command templates configured in user config ([2m~/.config/worktrunk/conf
 [107m [0m [2m[0m[2m[34mwt[0m[2m step deploy [0m[2m[36m--dry-run[0m[2m                  # show expanded command[0m[2m[0m
 [107m [0m [2m[0m[2m[34mwt[0m[2m step deploy [0m[2m[36m--env=staging[0m[2m              # pass template variable[0m[2m[0m
 [107m [0m [2m[0m[2m[34mwt[0m[2m step deploy [0m[2m[36m--var[0m[2m env=staging          # equivalent long form[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m step deploy [0m[2m[36m--my-var=value[0m[2m             # hyphens become underscores ([0m[2m[32m{{[0m[2m my_var [0m[2m[32m}}[0m[2m)[0m[2m[0m
 [107m [0m [2m[0m[2m[34mwt[0m[2m step deploy [0m[2m[36m--yes[0m[2m                      # skip approval prompt[0m[2m[0m
+
+Hyphens in variable names are canonicalized to underscores at parse time, so [2m--my-var=value[0m is referenced as [2m{{ my_var }}[0m in templates. This lets flags use natural kebab-case while avoiding the minijinja parser's interpretation of [2m{{ my-var }}[0m as subtraction.
 
 Multi-line aliases work too. This [2mup[0m alias fetches all remotes and rebases each worktree onto its upstream, skipping worktrees without a tracking branch or with a rebase already in progress:
 


### PR DESCRIPTION
Follow-up to #2091. Users naturally reach for kebab-case flag names like `--my-var=value`, but minijinja parses `{{ my-var }}` as subtraction — so the value would silently never appear when the template expands.

Both parser paths (`--var KEY=VALUE` and the `--KEY=VALUE` shorthand) now call `key.replace('-', "_")` before storing the variable. `--my-var=value`, `--var my-var=value`, and `--my_var=value` all resolve to `{{ my_var }}`. No validation, no warning — friendlier than rejection, and values are left untouched so things like `--region=us-east-1` still work.

Doc updates in `src/cli/mod.rs` surface the behavior in `wt step --help` and the generated web/skill docs.