### PR TITLE
Warm picker's probe cache via detached child on exit

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2149,6 +2149,16 @@ $ WORKTRUNK_COMMIT__GENERATION__COMMAND="echo 'test: automated commit'" wt merge
         action: ConfigCommand,
     },
 
+    /// Internal subcommands invoked by other `wt` commands.
+    ///
+    /// Hidden from help. Used by the picker to spawn a detached cache-warming
+    /// process — never invoked directly by users.
+    #[command(hide = true)]
+    Internal {
+        #[command(subcommand)]
+        action: InternalCommand,
+    },
+
     /// Run an external `wt-<name>` command found on PATH.
     ///
     /// Captured by clap when the first positional argument doesn't match any
@@ -2156,4 +2166,17 @@ $ WORKTRUNK_COMMIT__GENERATION__COMMAND="echo 'test: automated commit'" wt merge
     /// the rest are the arguments to pass through. See `commands::external`.
     #[command(external_subcommand)]
     External(Vec<OsString>),
+}
+
+/// Internal subcommands. Hidden from `wt --help`.
+#[derive(Subcommand)]
+pub(crate) enum InternalCommand {
+    /// Run all expensive collect tasks against the current repo, populating
+    /// the persistent probe cache as a side effect. Produces no output.
+    ///
+    /// Spawned detached from the picker so subsequent `wt switch` invocations
+    /// see warm caches even when the picker's own task workers were killed
+    /// at process exit.
+    #[command(hide = true, name = "warm-cache")]
+    WarmCache,
 }

--- a/src/commands/internal_warm_cache.rs
+++ b/src/commands/internal_warm_cache.rs
@@ -1,0 +1,61 @@
+//! Detached cache-warming subcommand for the picker.
+//!
+//! Spawned by `wt switch` (interactive picker) at startup as a fully detached
+//! child process. Runs every expensive task in `wt list` against the current
+//! repository with no timeout, then exits. The cache writes happen as side
+//! effects of the task computations themselves — `MergeTreeConflictsTask` and
+//! `WouldMergeAddTask` write to `probe_cache` inside `compute()`, before
+//! sending their results.
+//!
+//! ## Why this exists
+//!
+//! The picker uses a 500ms wall-clock budget for its own data collection. Any
+//! tasks that don't finish in that window keep running on the picker's worker
+//! thread, but the process eventually exits after the user makes a selection
+//! and the switch completes. Tasks mid-execution at exit are killed and never
+//! write their cache entries.
+//!
+//! Spawning this command detached at picker *startup* gives a separate process
+//! the full skim-interaction window plus arbitrary post-exit time to finish
+//! every task and populate the cache for the next invocation. Both processes
+//! contend for the same `probe_cache` files; concurrent writes of the same
+//! key produce the same value (commit SHAs are content-addressed) so the race
+//! is benign.
+//!
+//! ## Output
+//!
+//! None. stdout, stderr, and stdin are redirected to `/dev/null` by the
+//! parent before spawn so the child can't pollute the user's terminal even
+//! if a downstream library writes to a stream directly.
+
+use anyhow::Result;
+use worktrunk::git::Repository;
+
+use super::list::collect::{self, ShowConfig};
+
+/// Run every expensive task in `wt list` against the current repository,
+/// populating the persistent probe cache. Returns when all work is done.
+///
+/// Spawned detached from the picker; never invoked directly by users.
+pub(crate) fn handle_warm_cache() -> Result<()> {
+    let repo = Repository::current()?;
+
+    // Run with no timeout, no rendering, every task enabled (skip_tasks empty),
+    // and don't skip stale branches — the whole point is to warm the cache for
+    // every (branch, target) pair.
+    let _ = collect::collect(
+        &repo,
+        ShowConfig::Resolved {
+            show_branches: true,
+            show_remotes: false,
+            skip_tasks: std::collections::HashSet::new(),
+            command_timeout: None,
+            collect_deadline: None,
+        },
+        false, // show_progress
+        false, // render_table
+        false, // skip_expensive_for_stale
+    )?;
+
+    Ok(())
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -14,6 +14,7 @@ mod hook_commands;
 mod hook_filter;
 pub(crate) mod hooks;
 pub(crate) mod init;
+mod internal_warm_cache;
 pub(crate) mod list;
 pub(crate) mod merge;
 #[cfg(unix)]
@@ -45,6 +46,7 @@ pub(crate) use for_each::step_for_each;
 pub(crate) use handle_switch::{SwitchOptions, handle_switch};
 pub(crate) use hook_commands::{add_approvals, clear_approvals, handle_hook_show, run_hook};
 pub(crate) use init::{handle_completions, handle_init};
+pub(crate) use internal_warm_cache::handle_warm_cache;
 pub(crate) use list::handle_list;
 pub(crate) use merge::{MergeOptions, handle_merge};
 #[cfg(unix)]

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -289,6 +289,20 @@ pub fn handle_picker(
 
     let (repo, is_recovered) = current_or_recover()?;
 
+    // Drop guard: spawn a detached `wt internal warm-cache` child on every
+    // function return path — normal exit, --no-cd early return, skim abort,
+    // or error from switch logic. Firing at drop (rather than at startup)
+    // means the parent's collect worker thread has had the full picker
+    // interaction window — drain timeout + skim browse time + switch —
+    // to finish expensive tasks and write them to `probe_cache` first.
+    // The child then hits cache for every (branch_sha, target_sha) pair
+    // the parent completed and only computes the stragglers. No duplicate
+    // work between parent and child.
+    //
+    // Installed *after* `current_or_recover()` so the spawn only fires when
+    // we actually resolved a repo to warm.
+    let _warm_guard = WarmCacheGuard;
+
     // Merge CLI flags with resolved config (project-specific config is now available)
     let config = repo.config();
     let change_dir = change_dir_flag.unwrap_or_else(|| config.switch.cd());
@@ -680,6 +694,78 @@ pub fn handle_picker(
     }
 
     Ok(())
+}
+
+/// Drop guard that fires [`spawn_detached_warm_cache`] when it goes out of
+/// scope. Installed at the top of [`handle_picker`] so the spawn happens on
+/// every return path without duplicating the call site.
+///
+/// See the comment at the guard's installation site for rationale on *why*
+/// the spawn is at exit rather than at startup — it's the key to avoiding
+/// duplicate work between parent and child.
+struct WarmCacheGuard;
+
+impl Drop for WarmCacheGuard {
+    fn drop(&mut self) {
+        spawn_detached_warm_cache();
+    }
+}
+
+/// Spawn a fully detached `wt internal warm-cache` child process.
+///
+/// The child:
+/// - Re-execs the same binary as the parent (`current_exe()`), so dev builds
+///   under `cargo run` use the dev binary.
+/// - Runs in its own process group (`process_group(0)`), matching the same
+///   detachment pattern used by `commands::process::spawn_detached_unix` for
+///   background hooks. This insulates the child from terminal SIGHUP when
+///   the user closes the terminal while the picker is running.
+/// - Has stdin/stdout/stderr redirected to `/dev/null`, so it can't pollute
+///   the user's terminal even if a downstream library writes directly to a
+///   stream.
+/// - Inherits the parent's current directory, which is sufficient for
+///   `Repository::current()` to discover the same repo.
+///
+/// Failures (binary missing, fork failure) are silently logged at debug
+/// level. Cache warming is best-effort — the picker must continue working
+/// even if the spawn fails.
+///
+/// **Coordination with the picker's own worker thread:** This function is
+/// called via [`WarmCacheGuard::drop`] *after* the picker returns, which is
+/// after the collect worker thread has had the entire picker-interaction
+/// window (500ms drain + skim browse + switch) to write its results to
+/// `probe_cache`. The child starts from a warm cache and only recomputes
+/// entries the parent never wrote — whether because they were still running
+/// when the process exited, or because the rayon pool never got to them.
+/// There is no overlap between parent and child computations.
+fn spawn_detached_warm_cache() {
+    use std::os::unix::process::CommandExt;
+    use std::process::{Command, Stdio};
+
+    let Ok(exe) = std::env::current_exe() else {
+        log::debug!("warm-cache: current_exe() failed; skipping detached spawn");
+        return;
+    };
+
+    let result = Command::new(&exe)
+        .args(["internal", "warm-cache"])
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .process_group(0)
+        .spawn();
+
+    match result {
+        Ok(child) => {
+            log::debug!("warm-cache: spawned detached child pid={}", child.id());
+            // Drop the Child without waiting. The new process group means
+            // the OS re-parents it to init when we exit; init reaps it.
+            // Not calling .wait() is intentional — fire-and-forget.
+        }
+        Err(e) => {
+            log::debug!("warm-cache: failed to spawn detached child: {e}");
+        }
+    }
 }
 
 /// Resolve the branch identifier from picker output.

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,9 +63,9 @@ use output::handle_remove_output;
 use cli::{
     ApprovalsCommand, CiStatusAction, Cli, Commands, ConfigCommand, ConfigPluginsClaudeCommand,
     ConfigPluginsCommand, ConfigPluginsOpencodeCommand, ConfigShellCommand, DefaultBranchAction,
-    HintsAction, HookCommand, ListArgs, ListSubcommand, LogsAction, MarkerAction, MergeArgs,
-    PreviousBranchAction, RemoveArgs, StateCommand, StepCommand, SwitchArgs, SwitchFormat,
-    VarsAction,
+    HintsAction, HookCommand, InternalCommand, ListArgs, ListSubcommand, LogsAction, MarkerAction,
+    MergeArgs, PreviousBranchAction, RemoveArgs, StateCommand, StepCommand, SwitchArgs,
+    SwitchFormat, VarsAction,
 };
 use worktrunk::HookType;
 
@@ -1041,6 +1041,9 @@ fn dispatch_command(
         Commands::Switch(args) => handle_switch_command(args),
         Commands::Remove(args) => handle_remove_command(args),
         Commands::Merge(args) => handle_merge_command(args),
+        Commands::Internal { action } => match action {
+            InternalCommand::WarmCache => commands::handle_warm_cache(),
+        },
         // `working_dir` is the top-level `-C <path>` flag, applied as the
         // child's current directory so global `-C` works for external
         // subcommands the same way it does for built-ins.


### PR DESCRIPTION
Exploring whether we can populate the persistent SHA-keyed probe cache for branches whose tasks don't finish inside the picker's 500ms drain budget. Drafting this to think through — not sure the mechanism is worth the complication yet.

## Approach

At the top of `handle_picker()`, install a `WarmCacheGuard` drop guard. When the picker returns (normal exit, `--no-cd`, skim abort, or error propagation), the guard spawns a fully detached `wt internal warm-cache` child — new process group, stdio piped to `/dev/null`, fire-and-forget. The child runs `collect::collect()` against the current repo with no timeout, no rendering, and every task enabled; cache writes happen as side effects of `MergeTreeConflictsTask::compute` and `WouldMergeAddTask::compute`, which already hit `probe_cache` internally.

Firing the spawn at *drop* rather than at startup is the key mechanic: by the time the guard fires, the parent's collect worker thread has had the full picker-interaction window — 500ms drain + skim browse + switch — to write its own results to `probe_cache`. The child starts from a partially-warm cache and every (branch_sha, target_sha) pair the parent completed becomes an instant cache hit. Only the tasks the parent never finished actually run in the child. No overlap, no duplicated git merge-tree calls.

## Why I'm not sure about this

It's a lot of moving parts — new hidden subcommand, new binary entry point, drop guard, detached process machinery, cross-process cache coordination — for a benefit that's hard to measure without a pathologically large repo. Concerns:

- **Scope of win.** Only tasks with `probe_cache` entries benefit. Today that's `MergeTreeConflicts` and `WouldMergeAdd`. `IsAncestor`, `HasFileChanges`, and `BranchDiff` have no persistent cache, so the child redoes them every run — the same work the current stale-branch skip avoids. Getting real value here probably depends on extending `probe_cache` to cover those tasks too.
- **Runaway child.** The child has no time bound. A hung git subprocess (or a pathologically slow repo) leaves it running forever with no one watching.
- **Resource use on repeated invocations.** Two quick-successive `wt switch` calls spawn two overlapping children that both try to warm the same entries. Race-safe (writes are idempotent) but wasteful. A lock file would help.
- **No `show_remotes` handling.** The child currently passes `show_remotes: false` regardless of the user's config, so users who run the picker with `--remotes` don't get their remote-branch caches warmed.
- **Test coverage.** Smoke-tested manually via tmux against a `wt-perf` picker-test repo: spawn fires, child exits cleanly (no zombie), 25 cache files appear. No automated test — adding one means driving the detached-spawn path through an integration test harness, which is awkward.

## Measurement gap

I don't have a benchmark showing this meaningfully improves second-invocation picker latency. Running `wt switch`, exiting, re-running on the 6-worktree picker-test repo doesn't show a visible difference because everything finishes within the 500ms budget anyway. Need a larger or slower repo to see the payoff — or to skip it entirely if the payoff is small.

## Files

- `src/cli/mod.rs` — adds hidden `Internal { action: InternalCommand }` with a `WarmCache` variant
- `src/commands/internal_warm_cache.rs` (new, ~60 lines) — the subcommand handler, wraps `collect::collect()`
- `src/commands/picker/mod.rs` — `WarmCacheGuard` drop guard + `spawn_detached_warm_cache()` helper using `Command::process_group(0)` (matches the existing `spawn_detached_unix` pattern)
- `src/main.rs` — dispatch wiring
- `src/commands/mod.rs` — module registration

Full pre-merge hook (pre-commit, clippy, 3022 nextest tests, doctest, rustdoc) passes.

> _This was written by Claude Opus 4.6 (1M context) on behalf of max-sixty_