### PR TITLE
docs(config): drop stale approved-commands example

### DIFF
--- a/src/config/user/mod.rs
+++ b/src/config/user/mod.rs
@@ -239,7 +239,7 @@ fn load_config_file(
 ///
 /// # Per-project configuration
 /// [projects."github.com/user/repo"]
-/// approved-commands = ["npm install", "npm test"]
+/// worktree-path = ".worktrees/{{ branch | sanitize }}"
 /// ```
 ///
 /// Config file location:

--- a/src/config/user/sections.rs
+++ b/src/config/user/sections.rs
@@ -470,7 +470,6 @@ impl Merge for StepConfig {
 /// ```toml
 /// [projects."github.com/user/repo"]
 /// worktree-path = ".worktrees/{{ branch | sanitize }}"
-/// approved-commands = ["npm install", "npm test"]
 ///
 /// [projects."github.com/user/repo".commit.generation]
 /// command = "llm -m gpt-4"


### PR DESCRIPTION
The deprecation layer migrates `approved-commands` out of the user config file into `approvals.toml` on load, so showing it inside a `[projects.*]` block in the `UserProjectOverrides` doc comment is misleading. One-line removal.