### PR TITLE
refactor(config): make aliases fields non-optional

### DIFF
--- a/src/config/user/accessors.rs
+++ b/src/config/user/accessors.rs
@@ -186,12 +186,9 @@ impl UserConfig {
     /// Merges global user aliases with per-project user aliases using append
     /// semantics: both run on name collision (global first, then per-project).
     pub fn aliases(&self, project: Option<&str>) -> BTreeMap<String, CommandConfig> {
-        let mut result = self.aliases.clone().unwrap_or_default();
-        if let Some(proj_aliases) = project
-            .and_then(|p| self.projects.get(p))
-            .and_then(|proj| proj.aliases.as_ref())
-        {
-            crate::config::commands::append_aliases(&mut result, proj_aliases);
+        let mut result = self.aliases.clone();
+        if let Some(proj) = self.project_overrides(project) {
+            crate::config::commands::append_aliases(&mut result, &proj.aliases);
         }
         result
     }

--- a/src/config/user/mod.rs
+++ b/src/config/user/mod.rs
@@ -289,8 +289,8 @@ pub struct UserConfig {
     pub step: Option<sections::StepConfig>,
 
     /// Command aliases for `wt step <name>`
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub aliases: Option<std::collections::BTreeMap<String, crate::config::commands::CommandConfig>>,
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub aliases: std::collections::BTreeMap<String, crate::config::commands::CommandConfig>,
 
     /// Skip the first-run shell integration prompt
     #[serde(

--- a/src/config/user/sections.rs
+++ b/src/config/user/sections.rs
@@ -518,6 +518,6 @@ pub struct UserProjectOverrides {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub step: Option<StepConfig>,
 
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub aliases: Option<BTreeMap<String, CommandConfig>>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub aliases: BTreeMap<String, CommandConfig>,
 }


### PR DESCRIPTION
Both `UserConfig::aliases` and `UserProjectOverrides::aliases` were `Option<BTreeMap<String, CommandConfig>>` even though every consumer treats absent and empty identically — the accessor unwrapped with `unwrap_or_default()` and no callsite ever inspected the `Option`. This replaces them with plain `BTreeMap` using `#[serde(default, skip_serializing_if = "BTreeMap::is_empty")]`, which preserves TOML serialization behavior (empty map omitted).

The accessor simplifies from a 6-line chain through `and_then` to a 3-line body reusing the existing `project_overrides()` helper.

> _This was written by Claude Code on behalf of @max-sixty_