### PR TITLE
refactor(config): make ProjectConfig::aliases non-optional

### DIFF
--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -177,8 +177,7 @@ fn alias_needs_approval(
 ) -> Option<CommandConfig> {
     project_config
         .as_ref()
-        .and_then(|pc| pc.aliases.as_ref())
-        .and_then(|a| a.get(alias_name))
+        .and_then(|pc| pc.aliases.get(alias_name))
         .cloned()
 }
 
@@ -242,8 +241,8 @@ pub fn step_alias(opts: AliasOptions) -> anyhow::Result<()> {
     // Matches hook merge semantics — both sources run, project commands
     // need approval regardless of whether user also defines the alias.
     let mut aliases = user_config.aliases(project_id.as_deref());
-    if let Some(project_aliases) = project_config.as_ref().and_then(|pc| pc.aliases.as_ref()) {
-        append_aliases(&mut aliases, project_aliases);
+    if let Some(pc) = project_config.as_ref() {
+        append_aliases(&mut aliases, &pc.aliases);
     }
 
     // Warn about aliases that shadow built-in step commands

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -437,10 +437,8 @@ fn load_aliases_for_completion() -> BTreeMap<String, CommandConfig> {
             aliases.extend(user_config.aliases(project_id.as_deref()));
         }
         // Project config appends
-        if let Ok(Some(project_config)) = ProjectConfig::load(&repo, false)
-            && let Some(ref project_aliases) = project_config.aliases
-        {
-            append_aliases(&mut aliases, project_aliases);
+        if let Ok(Some(project_config)) = ProjectConfig::load(&repo, false) {
+            append_aliases(&mut aliases, &project_config.aliases);
         }
     } else if let Ok(user_config) = UserConfig::load() {
         aliases.extend(user_config.aliases(None));

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -185,8 +185,8 @@ pub struct ProjectConfig {
     /// deploy = "cd {{ worktree_path }} && make deploy"
     /// lint = "npm run lint"
     /// ```
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub aliases: Option<BTreeMap<String, CommandConfig>>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub aliases: BTreeMap<String, CommandConfig>,
 }
 
 impl ProjectConfig {


### PR DESCRIPTION
Same pattern as #2102 — `ProjectConfig::aliases` was `Option<BTreeMap>` but every consumer treats absent and empty identically. Simplifies `alias_needs_approval` (drops one `.and_then` layer) and two merge-path callsites in `step_alias` and `load_aliases_for_completion`.

All three config structs now use plain `BTreeMap` for aliases: `UserConfig`, `UserProjectOverrides`, and `ProjectConfig`.

> _This was written by Claude Code on behalf of @max-sixty_