### PR TITLE
refactor: rename probe_cache to sha_cache

### DIFF
--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -887,13 +887,13 @@ pub fn handle_state_clear_all() -> anyhow::Result<()> {
     }
 
     // Clear git commands cache (merge-tree, ancestry, diff results)
-    let probe_cleared = repo.clear_git_commands_cache();
-    if probe_cleared > 0 {
+    let sha_cleared = repo.clear_git_commands_cache();
+    if sha_cleared > 0 {
         eprintln!(
             "{}",
             success_message(cformat!(
-                "Cleared <bold>{probe_cleared}</> git commands cache entr{}",
-                if probe_cleared == 1 { "y" } else { "ies" }
+                "Cleared <bold>{sha_cleared}</> git commands cache entr{}",
+                if sha_cleared == 1 { "y" } else { "ies" }
             ))
         );
         cleared_any = true;

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -100,18 +100,18 @@
 //!
 //! | Directory | Module | Key | Staleness |
 //! |-----------|--------|-----|-----------|
-//! | `merge-tree-conflicts/` | `git::repository::probe_cache` | `{sha1}-{sha2}.json` (sorted) | Never — content-addressed |
-//! | `merge-add-probe/` | `git::repository::probe_cache` | `{branch_sha}-{target_sha}.json` | Never — content-addressed |
-//! | `is-ancestor/` | `git::repository::probe_cache` | `{base_sha}-{head_sha}.json` | Never — content-addressed |
-//! | `has-added-changes/` | `git::repository::probe_cache` | `{branch_sha}-{target_sha}.json` | Never — content-addressed |
-//! | `diff-stats/` | `git::repository::probe_cache` | `{base_sha}-{head_sha}.json` | Never — content-addressed |
+//! | `merge-tree-conflicts/` | `git::repository::sha_cache` | `{sha1}-{sha2}.json` (sorted) | Never — content-addressed |
+//! | `merge-add-probe/` | `git::repository::sha_cache` | `{branch_sha}-{target_sha}.json` | Never — content-addressed |
+//! | `is-ancestor/` | `git::repository::sha_cache` | `{base_sha}-{head_sha}.json` | Never — content-addressed |
+//! | `has-added-changes/` | `git::repository::sha_cache` | `{branch_sha}-{target_sha}.json` | Never — content-addressed |
+//! | `diff-stats/` | `git::repository::sha_cache` | `{base_sha}-{head_sha}.json` | Never — content-addressed |
 //! | `ci-status/` | `commands::list::ci_status::cache` | `{branch}.json` | TTL 30–60s + HEAD SHA check |
 //! | `summaries/` | `summary` | `{branch}.json` | `diff_hash` mismatch |
 //!
 //! ### Key schemes
 //!
 //! - **SHA-pair**: pure function of two commit SHAs. Never stale, no TTL, no invalidation.
-//!   Used by all `probe_cache` kinds (merge-tree conflicts, merge-add probes, ancestry
+//!   Used by all `sha_cache` kinds (merge-tree conflicts, merge-add probes, ancestry
 //!   checks, file-change probes, diff stats).
 //! - **Branch + TTL + HEAD**: external mutable state (CI API, remote refs). TTL bounds
 //!   staleness; the HEAD check invalidates early when the branch moves.
@@ -122,11 +122,11 @@
 //!
 //! | Task | Cache |
 //! |------|-------|
-//! | `MergeTreeConflicts` | `probe_cache` (merge-tree-conflicts) |
-//! | `WouldMergeAdd` | `probe_cache` (merge-add-probe) |
-//! | `IsAncestor` | `probe_cache` (is-ancestor) |
-//! | `HasFileChanges` | `probe_cache` (has-added-changes) |
-//! | `BranchDiff` | `probe_cache` (diff-stats, skipped when sparse checkout is active) |
+//! | `MergeTreeConflicts` | `sha_cache` (merge-tree-conflicts) |
+//! | `WouldMergeAdd` | `sha_cache` (merge-add-probe) |
+//! | `IsAncestor` | `sha_cache` (is-ancestor) |
+//! | `HasFileChanges` | `sha_cache` (has-added-changes) |
+//! | `BranchDiff` | `sha_cache` (diff-stats, skipped when sparse checkout is active) |
 //! | `CiStatus` | `ci_status::cache` |
 //! | `SummaryGenerate` | `summary` |
 //!
@@ -135,13 +135,13 @@
 //! ### Cacheable but uncached
 //!
 //! A few tasks take ref *names* and reduce to a SHA pair once the refs are resolved. Same
-//! SHA-pair pattern as `probe_cache`, just not wired up yet:
+//! SHA-pair pattern as `sha_cache`, just not wired up yet:
 //!
 //! - `AheadBehind` — counts against the default branch
 //! - `CommittedTreesMatch` — tree equality against the integration target
 //! - `Upstream` — ahead/behind counts against the tracking branch
 //!
-//! Reuse `probe_cache` for any of these rather than inventing a new scheme.
+//! Reuse `sha_cache` for any of these rather than inventing a new scheme.
 //!
 //! ### Fundamentally uncacheable
 //!

--- a/src/git/repository/diff.rs
+++ b/src/git/repository/diff.rs
@@ -296,7 +296,7 @@ impl Repository {
         let use_cache = sparse_paths.is_empty();
 
         if use_cache
-            && let Some(cached) = super::probe_cache::get_diff_stats(self, &base_sha, &head_sha)
+            && let Some(cached) = super::sha_cache::get_diff_stats(self, &base_sha, &head_sha)
         {
             return Ok(cached);
         }
@@ -308,7 +308,7 @@ impl Repository {
         // Get merge-base (cached in shared repo cache)
         let Some(merge_base) = self.merge_base(&base_sha, &head_sha)? else {
             if use_cache {
-                super::probe_cache::put_diff_stats(self, &base_sha, &head_sha, LineDiff::default());
+                super::sha_cache::put_diff_stats(self, &base_sha, &head_sha, LineDiff::default());
             }
             return Ok(LineDiff::default());
         };
@@ -324,7 +324,7 @@ impl Repository {
         let stdout = self.run_command(&args)?;
         let result = LineDiff::from_shortstat(&stdout);
         if use_cache {
-            super::probe_cache::put_diff_stats(self, &base_sha, &head_sha, result);
+            super::sha_cache::put_diff_stats(self, &base_sha, &head_sha, result);
         }
         Ok(result)
     }

--- a/src/git/repository/integration.rs
+++ b/src/git/repository/integration.rs
@@ -62,13 +62,13 @@ impl Repository {
         let base_sha = self.rev_parse_commit(&base)?;
         let head_sha = self.rev_parse_commit(&head)?;
 
-        if let Some(cached) = super::probe_cache::get_is_ancestor(self, &base_sha, &head_sha) {
+        if let Some(cached) = super::sha_cache::get_is_ancestor(self, &base_sha, &head_sha) {
             return Ok(cached);
         }
 
         let result =
             self.run_command_check(&["merge-base", "--is-ancestor", &base_sha, &head_sha])?;
-        super::probe_cache::put_is_ancestor(self, &base_sha, &head_sha, result);
+        super::sha_cache::put_is_ancestor(self, &base_sha, &head_sha, result);
         Ok(result)
     }
 
@@ -102,21 +102,21 @@ impl Repository {
         let target_sha = self.rev_parse_commit(&target)?;
 
         if let Some(cached) =
-            super::probe_cache::get_has_added_changes(self, &branch_sha, &target_sha)
+            super::sha_cache::get_has_added_changes(self, &branch_sha, &target_sha)
         {
             return Ok(cached);
         }
 
         // Orphan branches have no common ancestor, so all their changes are unique
         let Some(merge_base) = self.merge_base(&target_sha, &branch_sha)? else {
-            super::probe_cache::put_has_added_changes(self, &branch_sha, &target_sha, true);
+            super::sha_cache::put_has_added_changes(self, &branch_sha, &target_sha, true);
             return Ok(true);
         };
 
         let range = format!("{merge_base}..{branch_sha}");
         let output = self.run_command(&["diff", "--name-only", &range])?;
         let result = !output.trim().is_empty();
-        super::probe_cache::put_has_added_changes(self, &branch_sha, &target_sha, result);
+        super::sha_cache::put_has_added_changes(self, &branch_sha, &target_sha, result);
         Ok(result)
     }
 
@@ -172,13 +172,13 @@ impl Repository {
         let base_sha = self.rev_parse_commit(&base)?;
         let head_sha = self.rev_parse_commit(&head)?;
 
-        if let Some(cached) = super::probe_cache::get_merge_conflicts(self, &base_sha, &head_sha) {
+        if let Some(cached) = super::sha_cache::get_merge_conflicts(self, &base_sha, &head_sha) {
             return Ok(cached);
         }
 
         // Unrelated histories (no common ancestor) can't be merged — that's a conflict.
         if self.merge_base(&base_sha, &head_sha)?.is_none() {
-            super::probe_cache::put_merge_conflicts(self, &base_sha, &head_sha, true);
+            super::sha_cache::put_merge_conflicts(self, &base_sha, &head_sha, true);
             return Ok(true);
         }
 
@@ -187,7 +187,7 @@ impl Repository {
             self.run_command_output(&["merge-tree", "--write-tree", &base_sha, &head_sha])?;
 
         if output.status.code() == Some(1) {
-            super::probe_cache::put_merge_conflicts(self, &base_sha, &head_sha, true);
+            super::sha_cache::put_merge_conflicts(self, &base_sha, &head_sha, true);
             return Ok(true);
         }
         if !output.status.success() {
@@ -197,7 +197,7 @@ impl Repository {
                 stderr.trim()
             );
         }
-        super::probe_cache::put_merge_conflicts(self, &base_sha, &head_sha, false);
+        super::sha_cache::put_merge_conflicts(self, &base_sha, &head_sha, false);
         Ok(false)
     }
 
@@ -315,8 +315,7 @@ impl Repository {
         let branch_sha = self.rev_parse_commit(&branch)?;
         let target_sha = self.rev_parse_commit(&target)?;
 
-        if let Some(cached) =
-            super::probe_cache::get_merge_add_probe(self, &branch_sha, &target_sha)
+        if let Some(cached) = super::sha_cache::get_merge_add_probe(self, &branch_sha, &target_sha)
         {
             return Ok(cached);
         }
@@ -329,7 +328,7 @@ impl Repository {
                 would_merge_add: true,
                 is_patch_id_match: false,
             };
-            super::probe_cache::put_merge_add_probe(self, &branch_sha, &target_sha, result);
+            super::sha_cache::put_merge_add_probe(self, &branch_sha, &target_sha, result);
             return Ok(result);
         }
 
@@ -352,7 +351,7 @@ impl Repository {
                 }
             }
         };
-        super::probe_cache::put_merge_add_probe(self, &branch_sha, &target_sha, result);
+        super::sha_cache::put_merge_add_probe(self, &branch_sha, &target_sha, result);
         Ok(result)
     }
 
@@ -438,7 +437,7 @@ impl Repository {
     /// Resolve a ref to its commit SHA (cached).
     ///
     /// Unlike [`Self::rev_parse_tree`], this returns the commit SHA rather than the
-    /// tree SHA. Used by the persistent `probe_cache` to convert ref names into
+    /// tree SHA. Used by the persistent `sha_cache` to convert ref names into
     /// stable SHA-based cache keys before looking up cached merge-tree results.
     pub(super) fn rev_parse_commit(&self, r: &str) -> anyhow::Result<String> {
         match self.cache.commit_shas.entry(r.to_string()) {

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -92,8 +92,8 @@ mod branches;
 mod config;
 mod diff;
 mod integration;
-mod probe_cache;
 mod remotes;
+mod sha_cache;
 mod working_tree;
 mod worktrees;
 
@@ -248,7 +248,7 @@ pub(super) struct RepoCache {
 
     /// Commit SHA cache: ref (e.g., "main", "refs/heads/main") -> commit SHA.
     /// The commit SHA for a given ref doesn't change during a command.
-    /// Used by `rev_parse_commit()` to key the persistent `probe_cache` by SHA.
+    /// Used by `rev_parse_commit()` to key the persistent `sha_cache` by SHA.
     pub(super) commit_shas: DashMap<String, String>,
 
     // ========== Per-worktree values (keyed by path) ==========
@@ -568,7 +568,7 @@ impl Repository {
 
     /// Clear all cached git command results, returning the count removed.
     pub fn clear_git_commands_cache(&self) -> usize {
-        probe_cache::clear_all(self)
+        sha_cache::clear_all(self)
     }
 
     /// Get the directory where worktrunk background logs are stored.

--- a/src/git/repository/sha_cache.rs
+++ b/src/git/repository/sha_cache.rs
@@ -93,7 +93,7 @@ fn read<T: DeserializeOwned>(path: &Path) -> Option<T> {
     match serde_json::from_str::<T>(&json) {
         Ok(value) => Some(value),
         Err(e) => {
-            log::debug!("probe_cache: corrupt entry at {}: {}", path.display(), e);
+            log::debug!("sha_cache: corrupt entry at {}: {}", path.display(), e);
             None
         }
     }
@@ -106,7 +106,7 @@ fn write<T: Serialize>(path: &Path, value: &T) {
         && let Err(e) = fs::create_dir_all(parent)
     {
         log::debug!(
-            "probe_cache: failed to create dir {}: {}",
+            "sha_cache: failed to create dir {}: {}",
             parent.display(),
             e
         );
@@ -115,14 +115,14 @@ fn write<T: Serialize>(path: &Path, value: &T) {
 
     let Ok(json) = serde_json::to_string(value) else {
         log::debug!(
-            "probe_cache: failed to serialize entry for {}",
+            "sha_cache: failed to serialize entry for {}",
             path.display()
         );
         return;
     };
 
     if let Err(e) = fs::write(path, &json) {
-        log::debug!("probe_cache: failed to write {}: {}", path.display(), e);
+        log::debug!("sha_cache: failed to write {}: {}", path.display(), e);
     }
 }
 
@@ -167,11 +167,7 @@ fn sweep_lru(dir: &Path, max: usize) {
     for (path, _) in with_mtime.iter().take(excess) {
         let _ = fs::remove_file(path);
     }
-    log::debug!(
-        "probe_cache: swept {} entries from {}",
-        excess,
-        dir.display()
-    );
+    log::debug!("sha_cache: swept {} entries from {}", excess, dir.display());
 }
 
 // ============================================================================
@@ -303,7 +299,7 @@ pub(super) fn put_diff_stats(repo: &Repository, base_sha: &str, head_sha: &str, 
 // Maintenance
 // ============================================================================
 
-/// Clear all cached merge-probe entries, returning the count removed.
+/// Clear all cached SHA-keyed entries, returning the count removed.
 ///
 /// Called by `wt config state clear` to give users a clean slate.
 pub(crate) fn clear_all(repo: &Repository) -> usize {

--- a/tests/integration_tests/config_state.rs
+++ b/tests/integration_tests/config_state.rs
@@ -791,11 +791,11 @@ fn test_state_clear_all_comprehensive(repo: TestRepo) {
         .run()
         .unwrap();
 
-    // Git commands cache (probe cache)
+    // Git commands cache (SHA-keyed)
     let git_dir = repo.root_path().join(".git");
-    let probe_dir = git_dir.join("wt/cache/merge-tree-conflicts");
-    std::fs::create_dir_all(&probe_dir).unwrap();
-    std::fs::write(probe_dir.join("abc123-def456.json"), "true").unwrap();
+    let sha_cache_dir = git_dir.join("wt/cache/merge-tree-conflicts");
+    std::fs::create_dir_all(&sha_cache_dir).unwrap();
+    std::fs::write(sha_cache_dir.join("abc123-def456.json"), "true").unwrap();
 
     // Logs
     let log_dir = git_dir.join("wt/logs");


### PR DESCRIPTION
The module now caches five kinds of git operations — is-ancestor, has-added-changes, and diff-stats alongside the original merge-tree-conflicts and merge-add-probe. "Probe" described only the original two merge-simulation operations. "sha_cache" captures the actual unifying concept: persistent caching keyed on content-addressed SHA pairs.

Pure rename — no behavioral changes, no on-disk cache directory changes.

> _This was written by Claude Code on behalf of Maximilian Roos_