### PR TITLE
refactor(config): replace manual save_to allowlist with diff-based merge

### DIFF
--- a/src/config/user/mutation.rs
+++ b/src/config/user/mutation.rs
@@ -61,7 +61,7 @@ impl UserConfig {
             None => path::config_path().ok_or_else(|| ConfigError(NO_CONFIG_DIR_MSG.into()))?,
         };
         let _lock = acquire_config_lock(&path)?;
-        self.reload_projects_from(&path)?;
+        self.reload_from(&path)?;
 
         if mutate(self) {
             self.save_to(&path)?;
@@ -69,14 +69,16 @@ impl UserConfig {
         Ok(())
     }
 
-    /// Reload only the projects section from disk, preserving other in-memory state
+    /// Reload all fields from disk so the in-memory config matches the current
+    /// file state before applying mutations.
     ///
-    /// This replaces the in-memory projects with the authoritative disk state,
-    /// while keeping other config values (worktree-path, commit-generation, etc.).
-    /// Callers should reload before modifying and saving to avoid race conditions.
-    fn reload_projects_from(&mut self, path: &std::path::Path) -> Result<(), ConfigError> {
+    /// The diff-based `save_to` writes ALL serializable fields, so the reload
+    /// must refresh everything to avoid overwriting concurrent manual edits
+    /// with stale in-memory data. After reload, the mutator applies its
+    /// specific change, and `save_to` persists the full state.
+    fn reload_from(&mut self, path: &std::path::Path) -> Result<(), ConfigError> {
         if !path.exists() {
-            return Ok(()); // Nothing to reload
+            return Ok(());
         }
 
         let content = std::fs::read_to_string(path).map_err(|e| {
@@ -96,8 +98,7 @@ impl UserConfig {
             ))
         })?;
 
-        // Replace in-memory projects with disk state (disk is authoritative)
-        self.projects = disk_config.projects;
+        *self = disk_config;
 
         Ok(())
     }

--- a/src/config/user/persistence.rs
+++ b/src/config/user/persistence.rs
@@ -1,9 +1,12 @@
 //! Config persistence - loading and saving to disk.
 //!
 //! Handles TOML serialization with formatting (multiline arrays, implicit tables)
-//! and preserves comments when updating existing files.
-
-use serde::Serialize;
+//! and preserves comments when updating existing files via diff-based merge.
+//!
+//! The existing-file save path works by diffing the serialized in-memory state
+//! against the parsed file and merging only changed keys. This automatically
+//! handles any new fields without manual wiring — if a struct field is
+//! serializable, save_to persists it.
 
 use crate::config::ConfigError;
 
@@ -11,140 +14,6 @@ use super::UserConfig;
 use super::sections::CommitGenerationConfig;
 
 impl UserConfig {
-    fn update_bool_flag(doc: &mut toml_edit::DocumentMut, key: &str, enabled: bool) {
-        if enabled {
-            doc[key] = toml_edit::value(true);
-        } else {
-            doc.remove(key);
-        }
-    }
-
-    fn sync_string_field(table: &mut toml_edit::Table, key: &str, new_value: Option<&String>) {
-        match new_value {
-            Some(v) => {
-                let current = table.get(key).and_then(|i| i.as_str());
-                if current != Some(v.as_str()) {
-                    table[key] = toml_edit::value(v.as_str());
-                }
-            }
-            None => {
-                table.remove(key);
-            }
-        }
-    }
-
-    fn sync_serialized_section(
-        table: &mut toml_edit::Table,
-        section_name: &str,
-        config: Option<&impl Serialize>,
-    ) {
-        match Self::serialize_section_item(config) {
-            Some(item) => {
-                table[section_name] = item;
-            }
-            None => {
-                table.remove(section_name);
-            }
-        }
-    }
-
-    fn serialize_section_item(config: Option<&impl Serialize>) -> Option<toml_edit::Item> {
-        let cfg = config?;
-        let toml_value = toml::to_string(cfg).ok()?;
-        let parsed = toml_value.parse::<toml_edit::DocumentMut>().ok()?;
-        let mut table = toml_edit::Table::new();
-        for (k, v) in parsed.iter() {
-            table[k] = v.clone();
-        }
-        Some(toml_edit::Item::Table(table))
-    }
-
-    /// Update the [commit.generation] section in the document.
-    fn update_commit_generation_section(&self, doc: &mut toml_edit::DocumentMut) {
-        if let Some(ref commit_cfg) = self.commit
-            && let Some(ref gen_cfg) = commit_cfg.generation
-        {
-            // Ensure [commit] table exists
-            if !doc.contains_key("commit") {
-                doc["commit"] = toml_edit::Item::Table(toml_edit::Table::new());
-            }
-            if let Some(commit_table) = doc["commit"].as_table_mut() {
-                // Ensure [commit.generation] table exists
-                if !commit_table.contains_key("generation") {
-                    commit_table["generation"] = toml_edit::Item::Table(toml_edit::Table::new());
-                }
-                if let Some(gen_table) = commit_table["generation"].as_table_mut() {
-                    for (key, value) in [
-                        ("command", gen_cfg.command.as_ref()),
-                        ("template", gen_cfg.template.as_ref()),
-                        ("template-file", gen_cfg.template_file.as_ref()),
-                        ("squash-template", gen_cfg.squash_template.as_ref()),
-                        (
-                            "squash-template-file",
-                            gen_cfg.squash_template_file.as_ref(),
-                        ),
-                    ] {
-                        Self::sync_string_field(gen_table, key, value);
-                    }
-                }
-            }
-        }
-    }
-
-    /// Update the \[projects\] section in the document.
-    fn update_projects_section(&self, doc: &mut toml_edit::DocumentMut) {
-        // Ensure projects table exists
-        if !doc.contains_key("projects") {
-            doc["projects"] = toml_edit::Item::Table(toml_edit::Table::new());
-        }
-
-        if let Some(projects) = doc["projects"].as_table_mut() {
-            // Remove stale projects
-            let stale: Vec<_> = projects
-                .iter()
-                .filter(|(k, _)| !self.projects.contains_key(*k))
-                .map(|(k, _)| k.to_string())
-                .collect();
-            for key in stale {
-                projects.remove(&key);
-            }
-
-            // Add/update projects
-            for (project_id, project_config) in &self.projects {
-                if !projects.contains_key(project_id) {
-                    projects[project_id] = toml_edit::Item::Table(toml_edit::Table::new());
-                }
-
-                let Some(project_table) = projects[project_id].as_table_mut() else {
-                    continue;
-                };
-
-                Self::sync_string_field(
-                    project_table,
-                    "worktree-path",
-                    project_config.worktree_path.as_ref(),
-                );
-
-                Self::sync_serialized_section(project_table, "list", project_config.list.as_ref());
-                Self::sync_serialized_section(
-                    project_table,
-                    "commit",
-                    project_config.commit.as_ref(),
-                );
-                Self::sync_serialized_section(
-                    project_table,
-                    "merge",
-                    project_config.merge.as_ref(),
-                );
-                Self::sync_serialized_section(
-                    project_table,
-                    "switch",
-                    project_config.switch.as_ref(),
-                );
-            }
-        }
-    }
-
     /// Recursively convert inline tables to standard tables for readability.
     ///
     /// When using `toml_edit::ser::to_document()`, nested structs are serialized as inline tables
@@ -173,59 +42,115 @@ impl UserConfig {
         }
     }
 
-    /// Save the current configuration to a specific file path
+    /// Recursively merge desired state into existing document.
     ///
-    /// Use this in tests to save to a temporary location instead of the user's config.
-    /// Preserves comments and formatting in the existing file when possible.
+    /// - Keys in desired but not existing: inserted
+    /// - Keys in existing but not desired: removed
+    /// - Both tables: recurse (preserves existing table's formatting and comments)
+    /// - Both exist, values differ: update existing to desired
+    /// - Both exist, values equal: leave existing unchanged (preserves comments)
+    fn merge_tables(existing: &mut toml_edit::Table, desired: &toml_edit::Table) {
+        let stale_keys: Vec<_> = existing
+            .iter()
+            .map(|(k, _)| k.to_string())
+            .filter(|k| !desired.contains_key(k))
+            .collect();
+        for key in &stale_keys {
+            existing.remove(key);
+        }
+
+        for (key, desired_item) in desired.iter() {
+            match existing.get_mut(key) {
+                Some(existing_item) if existing_item.is_table() && desired_item.is_table() => {
+                    Self::merge_tables(
+                        existing_item.as_table_mut().unwrap(),
+                        desired_item.as_table().unwrap(),
+                    );
+                }
+                Some(existing_item) => {
+                    if !Self::items_equal(existing_item, desired_item) {
+                        *existing_item = desired_item.clone();
+                    }
+                }
+                None => {
+                    existing[key] = desired_item.clone();
+                }
+            }
+        }
+    }
+
+    /// Compare two Items for value equality, ignoring formatting and comments.
+    fn items_equal(a: &toml_edit::Item, b: &toml_edit::Item) -> bool {
+        match (a, b) {
+            (toml_edit::Item::Value(va), toml_edit::Item::Value(vb)) => Self::values_equal(va, vb),
+            (toml_edit::Item::Table(ta), toml_edit::Item::Table(tb)) => Self::tables_equal(ta, tb),
+            _ => false,
+        }
+    }
+
+    fn values_equal(a: &toml_edit::Value, b: &toml_edit::Value) -> bool {
+        use toml_edit::Value;
+        match (a, b) {
+            (Value::String(a), Value::String(b)) => a.value() == b.value(),
+            (Value::Integer(a), Value::Integer(b)) => a.value() == b.value(),
+            (Value::Float(a), Value::Float(b)) => a.value() == b.value(),
+            (Value::Boolean(a), Value::Boolean(b)) => a.value() == b.value(),
+            (Value::Datetime(a), Value::Datetime(b)) => a.value() == b.value(),
+            (Value::Array(a), Value::Array(b)) => {
+                a.len() == b.len()
+                    && a.iter()
+                        .zip(b.iter())
+                        .all(|(a, b)| Self::values_equal(a, b))
+            }
+            (Value::InlineTable(a), Value::InlineTable(b)) => {
+                a.len() == b.len()
+                    && a.iter()
+                        .all(|(k, v)| b.get(k).is_some_and(|bv| Self::values_equal(v, bv)))
+            }
+            _ => false,
+        }
+    }
+
+    fn tables_equal(a: &toml_edit::Table, b: &toml_edit::Table) -> bool {
+        a.len() == b.len()
+            && a.iter()
+                .all(|(k, v)| b.get(k).is_some_and(|bv| Self::items_equal(v, bv)))
+    }
+
+    /// Save the current configuration to a specific file path.
     ///
-    /// TODO: This design is fragile. When file exists, we surgically update specific
-    /// sections to preserve comments. If a new programmatically-modifiable field is added
-    /// but not handled here, changes won't persist. Consider using a diff-based approach:
-    /// compare self vs existing config and only update what changed.
+    /// Preserves comments and formatting in the existing file by diffing the
+    /// serialized in-memory state against the parsed file and merging only
+    /// changed keys.
     pub fn save_to(&self, config_path: &std::path::Path) -> Result<(), ConfigError> {
-        // Create parent directory if it doesn't exist
         if let Some(parent) = config_path.parent() {
             std::fs::create_dir_all(parent)
                 .map_err(|e| ConfigError(format!("Failed to create config directory: {}", e)))?;
         }
 
         let toml_string = if config_path.exists() {
-            // Surgically update sections to preserve comments
             let existing_content = std::fs::read_to_string(config_path)
                 .map_err(|e| ConfigError(format!("Failed to read config file: {}", e)))?;
 
-            let mut doc: toml_edit::DocumentMut = existing_content
+            let mut existing_doc: toml_edit::DocumentMut = existing_content
                 .parse()
                 .map_err(|e| ConfigError(format!("Failed to parse config file: {}", e)))?;
 
-            // Update all programmatically-modifiable sections
-            // NOTE: If you add a new setter that modifies config, add the update here too!
-            Self::update_bool_flag(
-                &mut doc,
-                "skip-shell-integration-prompt",
-                self.skip_shell_integration_prompt,
-            );
-            Self::update_bool_flag(
-                &mut doc,
-                "skip-commit-generation-prompt",
-                self.skip_commit_generation_prompt,
-            );
+            let mut desired_doc = toml_edit::ser::to_document(&self)
+                .map_err(|e| ConfigError(format!("Serialization error: {e}")))?;
+            Self::expand_inline_tables(desired_doc.as_table_mut());
 
-            self.update_commit_generation_section(&mut doc);
-            self.update_projects_section(&mut doc);
-            Self::make_commit_table_implicit_if_only_subtables(&mut doc);
+            Self::merge_tables(existing_doc.as_table_mut(), desired_doc.as_table());
+            Self::make_commit_table_implicit_if_only_subtables(&mut existing_doc);
 
-            doc.to_string()
+            existing_doc.to_string()
         } else {
-            // No existing file: serialize struct directly, then post-process formatting
             let mut doc = toml_edit::ser::to_document(&self)
                 .map_err(|e| ConfigError(format!("Serialization error: {e}")))?;
 
-            // Convert inline tables to standard tables for readability
             Self::expand_inline_tables(doc.as_table_mut());
             Self::make_commit_table_implicit_if_only_subtables(&mut doc);
 
-            // Make [projects] implicit to avoid emitting header for readability
             if let Some(projects) = doc.get_mut("projects").and_then(|p| p.as_table_mut()) {
                 projects.set_implicit(true);
             }

--- a/src/config/user/persistence.rs
+++ b/src/config/user/persistence.rs
@@ -45,27 +45,50 @@ impl UserConfig {
     /// Recursively merge desired state into existing document.
     ///
     /// - Keys in desired but not existing: inserted
-    /// - Keys in existing but not desired: removed
-    /// - Both tables: recurse (preserves existing table's formatting and comments)
+    /// - Keys in existing but not desired: removed (unless in `preserve`)
+    /// - Both standard tables: recurse (preserves existing formatting and comments)
+    /// - Existing inline table, desired standard table: compare contents, preserve
+    ///   inline format when semantically equal
     /// - Both exist, values differ: update existing to desired
     /// - Both exist, values equal: leave existing unchanged (preserves comments)
-    fn merge_tables(existing: &mut toml_edit::Table, desired: &toml_edit::Table) {
+    fn merge_tables(
+        existing: &mut toml_edit::Table,
+        desired: &toml_edit::Table,
+        preserve: &std::collections::HashSet<String>,
+    ) {
         let stale_keys: Vec<_> = existing
             .iter()
             .map(|(k, _)| k.to_string())
-            .filter(|k| !desired.contains_key(k))
+            .filter(|k| !desired.contains_key(k) && !preserve.contains(k))
             .collect();
         for key in &stale_keys {
             existing.remove(key);
         }
 
+        let empty = std::collections::HashSet::new();
         for (key, desired_item) in desired.iter() {
             match existing.get_mut(key) {
+                // Both standard tables: recurse
                 Some(existing_item) if existing_item.is_table() && desired_item.is_table() => {
                     Self::merge_tables(
                         existing_item.as_table_mut().unwrap(),
                         desired_item.as_table().unwrap(),
+                        &empty,
                     );
+                }
+                // Existing inline table, desired standard table: compare contents
+                // to preserve the user's inline formatting when nothing changed
+                Some(existing_item)
+                    if existing_item.is_inline_table() && desired_item.is_table() =>
+                {
+                    let as_table = existing_item
+                        .as_inline_table()
+                        .unwrap()
+                        .clone()
+                        .into_table();
+                    if !Self::tables_equal(&as_table, desired_item.as_table().unwrap()) {
+                        *existing_item = desired_item.clone();
+                    }
                 }
                 Some(existing_item) => {
                     if !Self::items_equal(existing_item, desired_item) {
@@ -140,7 +163,18 @@ impl UserConfig {
                 .map_err(|e| ConfigError(format!("Serialization error: {e}")))?;
             Self::expand_inline_tables(desired_doc.as_table_mut());
 
-            Self::merge_tables(existing_doc.as_table_mut(), desired_doc.as_table());
+            // Preserve unknown top-level keys (typos, future fields, deprecated
+            // keys not yet migrated) so they aren't silently deleted on save.
+            let unknown_keys: std::collections::HashSet<String> =
+                super::find_unknown_keys(&existing_content)
+                    .into_keys()
+                    .collect();
+
+            Self::merge_tables(
+                existing_doc.as_table_mut(),
+                desired_doc.as_table(),
+                &unknown_keys,
+            );
             Self::make_commit_table_implicit_if_only_subtables(&mut existing_doc);
 
             existing_doc.to_string()

--- a/src/config/user/persistence.rs
+++ b/src/config/user/persistence.rs
@@ -116,19 +116,12 @@ impl UserConfig {
         match (a, b) {
             (Value::String(a), Value::String(b)) => a.value() == b.value(),
             (Value::Integer(a), Value::Integer(b)) => a.value() == b.value(),
-            (Value::Float(a), Value::Float(b)) => a.value() == b.value(),
             (Value::Boolean(a), Value::Boolean(b)) => a.value() == b.value(),
-            (Value::Datetime(a), Value::Datetime(b)) => a.value() == b.value(),
             (Value::Array(a), Value::Array(b)) => {
                 a.len() == b.len()
                     && a.iter()
                         .zip(b.iter())
                         .all(|(a, b)| Self::values_equal(a, b))
-            }
-            (Value::InlineTable(a), Value::InlineTable(b)) => {
-                a.len() == b.len()
-                    && a.iter()
-                        .all(|(k, v)| b.get(k).is_some_and(|bv| Self::values_equal(v, bv)))
             }
             _ => false,
         }

--- a/src/config/user/tests.rs
+++ b/src/config/user/tests.rs
@@ -2977,6 +2977,69 @@ fn test_save_to_new_file_expands_nested_project_inline_tables() {
     );
 }
 
+#[test]
+fn test_save_to_existing_file_preserves_unknown_keys() {
+    // Unknown top-level keys (typos, future fields) must survive a save.
+    // The diff-based merge skips unknown keys in its stale-key sweep.
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    std::fs::write(
+        &config_path,
+        r#"# A user comment
+unknown-key = "keep me"
+skip-shell-integration-prompt = true
+"#,
+    )
+    .unwrap();
+
+    let config = UserConfig {
+        skip_shell_integration_prompt: true,
+        ..Default::default()
+    };
+
+    config.save_to(&config_path).unwrap();
+
+    let saved = std::fs::read_to_string(&config_path).unwrap();
+    assert!(
+        saved.contains("unknown-key = \"keep me\""),
+        "unknown key should be preserved: {saved}"
+    );
+    assert!(
+        saved.contains("# A user comment"),
+        "comment should be preserved: {saved}"
+    );
+    assert!(
+        saved.contains("skip-shell-integration-prompt = true"),
+        "known key should be preserved: {saved}"
+    );
+}
+
+#[test]
+fn test_save_to_existing_file_preserves_inline_table_formatting() {
+    // When a user writes a hook as an inline table (e.g., `post-start = { ... }`),
+    // the diff-based merge must not rewrite it to a standard table if the value
+    // is semantically unchanged.
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    let original = "post-start = { build = \"cargo build\" }\n";
+    std::fs::write(&config_path, original).unwrap();
+
+    // Load the config (which parses hooks via flatten), then save it back
+    let config = UserConfig::load_from_str(original).unwrap();
+    config.save_to(&config_path).unwrap();
+
+    let saved = std::fs::read_to_string(&config_path).unwrap();
+    // The inline table syntax should be preserved (not expanded to [post-start])
+    assert!(
+        saved.contains("post-start = { build = \"cargo build\" }"),
+        "inline table should be preserved: {saved}"
+    );
+    assert!(
+        !saved.contains("[post-start]"),
+        "should not be expanded to standard table: {saved}"
+    );
+}
+
 // =========================================================================
 // mutation.rs — additional coverage
 // =========================================================================

--- a/src/config/user/tests.rs
+++ b/src/config/user/tests.rs
@@ -2978,6 +2978,70 @@ fn test_save_to_new_file_expands_nested_project_inline_tables() {
 }
 
 #[test]
+fn test_save_to_existing_file_preserves_integer_and_array_values() {
+    // Exercises values_equal for Integer (timeout-ms) and Array
+    // (approved-commands) — types beyond String and Boolean.
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    std::fs::write(
+        &config_path,
+        r#"# keep comment
+[list]
+timeout-ms = 5000
+full = true
+
+[projects."repo"]
+approved-commands = ["cargo test", "cargo build"]
+"#,
+    )
+    .unwrap();
+
+    let config =
+        UserConfig::load_from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+    config.save_to(&config_path).unwrap();
+
+    let saved = std::fs::read_to_string(&config_path).unwrap();
+    assert!(saved.contains("# keep comment"), "comment lost: {saved}");
+    assert!(
+        saved.contains("timeout-ms = 5000"),
+        "integer value should be preserved: {saved}"
+    );
+    assert!(
+        saved.contains("full = true"),
+        "boolean value should be preserved: {saved}"
+    );
+    assert!(
+        saved.contains("cargo test") && saved.contains("cargo build"),
+        "array values should be preserved: {saved}"
+    );
+}
+
+#[test]
+fn test_save_to_existing_file_replaces_changed_inline_table() {
+    // When an inline table's contents actually changed, the diff-based merge
+    // replaces it (even though this changes formatting from inline to standard).
+    let dir = tempfile::tempdir().unwrap();
+    let config_path = dir.path().join("config.toml");
+    std::fs::write(&config_path, "post-start = { build = \"cargo build\" }\n").unwrap();
+
+    // Load, modify the hook, then save
+    let mut config =
+        UserConfig::load_from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+    config.hooks = toml::from_str("post-start = { build = \"cargo test\" }").unwrap();
+    config.save_to(&config_path).unwrap();
+
+    let saved = std::fs::read_to_string(&config_path).unwrap();
+    assert!(
+        saved.contains("cargo test"),
+        "changed value should be written: {saved}"
+    );
+    assert!(
+        !saved.contains("cargo build"),
+        "old value should be gone: {saved}"
+    );
+}
+
+#[test]
 fn test_save_to_existing_file_preserves_unknown_keys() {
     // Unknown top-level keys (typos, future fields) must survive a save.
     // The diff-based merge skips unknown keys in its stale-key sweep.

--- a/src/config/user/tests.rs
+++ b/src/config/user/tests.rs
@@ -2060,13 +2060,13 @@ test = "npm test"
 }
 
 // =========================================================================
-// reload_projects_from error path tests
+// reload_from error path tests
 // =========================================================================
 
-/// Test that reload_projects_from returns a parse error with formatted path
+/// Test that reload_from returns a parse error with formatted path
 /// when the config file contains invalid TOML.
 #[test]
-fn test_reload_projects_from_invalid_toml() {
+fn test_reload_from_invalid_toml() {
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
 
@@ -2299,11 +2299,11 @@ project-only = "only-project"
     );
 }
 
-/// Test that reload_projects_from handles permission errors
+/// Test that reload_from handles permission errors
 /// when the config file exists but cannot be read.
 #[cfg(unix)]
 #[test]
-fn test_reload_projects_from_permission_error() {
+fn test_reload_from_permission_error() {
     use std::os::unix::fs::PermissionsExt;
 
     let dir = tempfile::tempdir().unwrap();
@@ -2401,9 +2401,8 @@ fn test_try_parse_value() {
 
 #[test]
 fn test_save_to_existing_file_writes_project_sections() {
-    // Covers sync_serialized_section and serialize_section_item for the "Some"
-    // branch: an existing file is updated with a project that has list, commit,
-    // merge, and switch sections populated.
+    // An existing file is updated with a project that has list, commit,
+    // merge, and switch sections populated via diff-based merge.
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
 
@@ -2486,9 +2485,8 @@ fn test_save_to_existing_file_writes_project_sections() {
 
 #[test]
 fn test_save_to_existing_file_removes_stale_projects_and_sections() {
-    // Covers the "remove stale projects" branch in update_projects_section,
-    // plus the sync_serialized_section "None" branch (removing a section whose
-    // in-memory value is now None).
+    // The diff-based merge removes projects not in the in-memory config
+    // and removes sections whose in-memory value is now None.
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
 
@@ -2538,8 +2536,8 @@ worktree-path = "drop-path"
 
 #[test]
 fn test_save_to_existing_file_updates_commit_generation_command() {
-    // Covers update_commit_generation_section when the file already has a
-    // [commit.generation] table — we overwrite the command in place.
+    // The file already has a [commit.generation] table — the diff-based merge
+    // updates the changed command in place while preserving unchanged keys.
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
     std::fs::write(
@@ -2588,8 +2586,8 @@ template = "stays: {{ diff }}"
 #[test]
 fn test_save_to_existing_file_adds_commit_generation_to_plain_commit_table() {
     // Existing file has a [commit] table (e.g., with `stage`) but no
-    // [commit.generation] subtable yet. update_commit_generation_section
-    // must create the subtable and populate it.
+    // [commit.generation] subtable yet. The diff-based merge inserts the
+    // new subtable while preserving existing keys.
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
     std::fs::write(
@@ -2626,14 +2624,10 @@ stage = "all"
 }
 
 #[test]
-fn test_save_to_existing_file_skips_non_table_project_entry() {
-    // Covers the defensive `continue` branch in update_projects_section:
-    // if an existing file has a bogus non-table value at projects."<id>",
-    // the entry is skipped (not replaced) so the save doesn't clobber the
-    // user's hand-edited oddity. This state is only reachable via raw file
-    // edits — the serializer never produces it — but the code defends
-    // against it to avoid panicking on malformed input. We still expect
-    // the save to succeed and the other valid project to be updated.
+fn test_save_to_existing_file_replaces_non_table_project_entry() {
+    // When an existing file has a non-table value at projects."<id>",
+    // the diff-based merge replaces it with the correct table structure
+    // from the in-memory config. Only reachable via raw file edits.
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
     std::fs::write(
@@ -2648,7 +2642,6 @@ worktree-path = "old"
     .unwrap();
 
     let mut config = UserConfig::default();
-    // "bogus" is in self.projects but the file has it as a non-table value.
     config
         .projects
         .insert("bogus".to_string(), UserProjectOverrides::default());
@@ -2660,30 +2653,26 @@ worktree-path = "old"
         },
     );
 
-    // save_to should succeed even though one of the entries can't be updated
     config.save_to(&config_path).unwrap();
 
     let saved = std::fs::read_to_string(&config_path).unwrap();
-    // The "real" project should be updated normally
+    // The "real" project should be updated
     assert!(
         saved.contains("worktree-path = \"new\""),
         "real project not updated: {saved}"
     );
-    // The bogus non-table entry should have been left alone (not replaced
-    // with a table), demonstrating the defensive continue.
+    // The bogus string entry is replaced with a proper (empty) table
     assert!(
-        saved.contains("bogus = \"not-a-table\""),
-        "bogus entry should be preserved verbatim: {saved}"
+        !saved.contains("bogus = \"not-a-table\""),
+        "malformed entry should be replaced: {saved}"
     );
 }
 
 #[test]
 fn test_save_to_existing_file_where_commit_is_scalar() {
-    // Covers the else branch of `if let Some(commit_table) = doc["commit"].as_table_mut()`
-    // in update_commit_generation_section: the existing file has a top-level
-    // `commit` that's a scalar (user-edited mistake), not a table. The code
-    // must not panic — it silently skips the update. Only reachable via raw
-    // file edits.
+    // When the existing file has `commit` as a scalar (user-edited mistake),
+    // the diff-based merge replaces it with the correct table structure.
+    // Only reachable via raw file edits.
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
     std::fs::write(&config_path, "commit = \"hand-edited-mistake\"\n").unwrap();
@@ -2702,19 +2691,22 @@ fn test_save_to_existing_file_where_commit_is_scalar() {
     config.save_to(&config_path).unwrap();
 
     let saved = std::fs::read_to_string(&config_path).unwrap();
-    // The malformed entry is preserved verbatim (defensive skip)
+    // The scalar is replaced with a proper table
     assert!(
-        saved.contains("\"hand-edited-mistake\""),
-        "malformed entry should be preserved: {saved}"
+        !saved.contains("\"hand-edited-mistake\""),
+        "malformed entry should be replaced: {saved}"
+    );
+    assert!(
+        saved.contains("command = \"llm\""),
+        "commit generation should be written: {saved}"
     );
 }
 
 #[test]
 fn test_save_to_existing_file_where_commit_generation_is_scalar() {
-    // Covers the else branch of `if let Some(gen_table) = commit_table["generation"].as_table_mut()`:
-    // `[commit]` is a valid table but `generation` within it is a scalar
-    // (another raw-edit mistake). The outer if let enters, the inner doesn't,
-    // and the update silently skips. Only reachable via raw file edits.
+    // When `[commit]` is a valid table but `generation` is a scalar
+    // (raw-edit mistake), the diff-based merge replaces the scalar with
+    // the correct table. Only reachable via raw file edits.
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
     std::fs::write(
@@ -2737,20 +2729,23 @@ fn test_save_to_existing_file_where_commit_generation_is_scalar() {
     config.save_to(&config_path).unwrap();
 
     let saved = std::fs::read_to_string(&config_path).unwrap();
-    // The scalar generation is preserved verbatim
+    // The scalar generation is replaced with a proper table
     assert!(
-        saved.contains("generation = \"oops\""),
-        "malformed generation should be preserved: {saved}"
+        !saved.contains("generation = \"oops\""),
+        "malformed generation should be replaced: {saved}"
     );
-    // The unrelated stage value is untouched
-    assert!(saved.contains("stage = \"tracked\""), "{saved}");
+    assert!(
+        saved.contains("command = \"llm\""),
+        "generation command should be written: {saved}"
+    );
+    // The unrelated stage value is preserved
+    assert!(saved.contains("stage = \"tracked\""), "stage lost: {saved}");
 }
 
 #[test]
 fn test_save_to_existing_file_where_projects_is_scalar() {
-    // Covers the else branch of `if let Some(projects) = doc["projects"].as_table_mut()`
-    // in update_projects_section: the existing file has a top-level
-    // `projects` as a scalar. Reachable only via raw file edits.
+    // When the existing file has `projects` as a scalar (raw-edit mistake),
+    // the diff-based merge replaces it with the correct table structure.
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
     std::fs::write(&config_path, "projects = \"oops\"\n").unwrap();
@@ -2767,10 +2762,14 @@ fn test_save_to_existing_file_where_projects_is_scalar() {
     config.save_to(&config_path).unwrap();
 
     let saved = std::fs::read_to_string(&config_path).unwrap();
-    // Defensive: the malformed projects entry is preserved, the update is skipped
+    // The scalar is replaced with a proper table
     assert!(
-        saved.contains("projects = \"oops\""),
-        "malformed projects should be preserved: {saved}"
+        !saved.contains("projects = \"oops\""),
+        "malformed projects should be replaced: {saved}"
+    );
+    assert!(
+        saved.contains("worktree-path = \"../x\""),
+        "project worktree-path should be written: {saved}"
     );
 }
 
@@ -2797,7 +2796,7 @@ fn test_save_to_existing_file_with_invalid_toml_returns_parse_error() {
 fn test_save_to_existing_file_with_unreadable_file_returns_read_error() {
     // Covers the `read_to_string.map_err(...)` closure in save_to: the file
     // exists but we can't read it. Matches the pattern of the mutation-side
-    // test_reload_projects_from_permission_error.
+    // test_reload_from_permission_error.
     use std::os::unix::fs::PermissionsExt;
 
     let dir = tempfile::tempdir().unwrap();
@@ -2957,9 +2956,9 @@ fn test_set_project_worktree_path_noop_when_unchanged() {
     // Sanity: first call actually wrote the value
     assert!(after_first.contains("../custom"), "{after_first}");
 
-    // Second call with identical value should be a no-op — reload_projects_from
-    // refreshes self.projects from disk, the mutator compares equal and
-    // returns false, so save is skipped.
+    // Second call with identical value should be a no-op — reload_from
+    // refreshes self from disk, the mutator compares equal and returns
+    // false, so save is skipped.
     let mut config2 = UserConfig::default();
     config2
         .set_project_worktree_path("user/repo", "../custom".to_string(), Some(&config_path))
@@ -2975,9 +2974,9 @@ fn test_set_project_worktree_path_noop_when_unchanged() {
 #[test]
 fn test_set_skip_shell_integration_prompt_noop_on_second_call() {
     // Covers the `return false` early-exit in set_skip_shell_integration_prompt's
-    // mutator. reload_projects_from only refreshes `projects` — the in-memory
-    // flag is preserved across calls on the same config object — so a second
-    // call sees the flag already true and skips the save.
+    // mutator. reload_from refreshes all fields from disk — after the first
+    // save, the flag is true on disk, so a second call sees it already true
+    // and skips the save.
     let dir = tempfile::tempdir().unwrap();
     let config_path = dir.path().join("config.toml");
     std::fs::write(&config_path, "# empty\n").unwrap();
@@ -3078,7 +3077,7 @@ fn test_with_locked_mutation_propagates_save_error() {
     let err = config
         .with_locked_mutation(Some(&config_path), move |_config| {
             // Mid-mutation: strip read permissions from the config file.
-            // Reload already ran; save_to will try to read again and fail.
+            // reload_from already ran; save_to will try to read again and fail.
             let mut perms = std::fs::metadata(&cfg_path_for_closure)
                 .unwrap()
                 .permissions();


### PR DESCRIPTION
The existing-file branch of `save_to` surgically updated specific sections by name (`skip-shell-integration-prompt`, `skip-commit-generation-prompt`, `commit.generation`, `projects`), with a comment warning that any new programmatically-modifiable field would need to be wired in by hand. If it wasn't, changes silently failed to persist on save-load round-trip.

This replaces the manual section updates with a diff-based approach: serialize the full struct to a `DocumentMut`, parse the existing file, and recursively merge only changed keys — preserving comments and formatting on unchanged entries. The generic `merge_tables` function handles any serializable field automatically, eliminating the entire category of bugs the old TODO warned about.

Also changes `reload_projects_from` to `reload_from` (`*self = disk_config`): since `save_to` now writes all fields, the reload must refresh everything to avoid overwriting concurrent manual edits with stale in-memory data.

Four defensive-behavior tests updated — the old code preserved malformed scalars (e.g., `commit = "hand-edited-mistake"`) where tables were expected; the new code correctly replaces them with proper tables from the in-memory state.

Net: -130 lines of section-specific update logic, +65 lines of generic merge logic.