### PR TITLE
refactor(config): flatten ProjectConfig fields, remove dead persistence branch

### DIFF
--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -9,6 +9,7 @@ use serde::{Deserialize, Serialize};
 
 use super::ConfigError;
 use super::commands::CommandConfig;
+use super::user::merge::is_default;
 use super::{CopyIgnoredConfig, HooksConfig, StepConfig};
 
 /// Project-level configuration for `wt list` output.
@@ -97,27 +98,25 @@ impl ProjectConfig {
     ///
     /// Deprecated: use [`forge_platform()`](Self::forge_platform) instead.
     pub fn ci_platform(&self) -> Option<&str> {
-        self.ci.as_ref().and_then(|ci| ci.platform.as_deref())
+        self.ci.platform.as_deref()
     }
 
     /// Get the forge platform override, checking `[forge]` first then `[ci]`.
     pub fn forge_platform(&self) -> Option<&str> {
         self.forge
-            .as_ref()
-            .and_then(|f| f.platform.as_deref())
+            .platform
+            .as_deref()
             .or_else(|| self.ci_platform())
     }
 
     /// Get the forge API hostname if configured.
     pub fn forge_hostname(&self) -> Option<&str> {
-        self.forge.as_ref().and_then(|f| f.hostname.as_deref())
+        self.forge.hostname.as_deref()
     }
 
     /// Get `wt step copy-ignored` configuration if configured.
     pub fn copy_ignored(&self) -> Option<&CopyIgnoredConfig> {
-        self.step
-            .as_ref()
-            .and_then(|step| step.copy_ignored.as_ref())
+        self.step.copy_ignored.as_ref()
     }
 }
 
@@ -156,20 +155,20 @@ pub struct ProjectConfig {
     pub hooks: HooksConfig,
 
     /// Configuration for `wt list` output
-    #[serde(default)]
-    pub list: Option<ProjectListConfig>,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub list: ProjectListConfig,
 
     /// CI configuration (platform override). Deprecated: use `[forge]` instead.
-    #[serde(default)]
-    pub ci: Option<ProjectCiConfig>,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub ci: ProjectCiConfig,
 
     /// Forge configuration (platform detection override, API hostname)
-    #[serde(default)]
-    pub forge: Option<ProjectForgeConfig>,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub forge: ProjectForgeConfig,
 
     /// Configuration for `wt step` subcommands.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub step: Option<StepConfig>,
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub step: StepConfig,
 
     /// \[experimental\] Command aliases for `wt step <name>`.
     ///
@@ -315,13 +314,11 @@ pre-remove = "echo bye"
 url = "http://localhost:{{ branch | hash_port }}"
 "#;
         let config: ProjectConfig = toml::from_str(contents).unwrap();
-        assert!(config.list.is_some());
-        let list = config.list.unwrap();
         assert_eq!(
-            list.url.as_deref(),
+            config.list.url.as_deref(),
             Some("http://localhost:{{ branch | hash_port }}")
         );
-        assert!(list.is_configured());
+        assert!(config.list.is_configured());
     }
 
     #[test]
@@ -330,10 +327,8 @@ url = "http://localhost:{{ branch | hash_port }}"
 [list]
 "#;
         let config: ProjectConfig = toml::from_str(contents).unwrap();
-        assert!(config.list.is_some());
-        let list = config.list.unwrap();
-        assert!(list.url.is_none());
-        assert!(!list.is_configured());
+        assert!(config.list.url.is_none());
+        assert!(!config.list.is_configured());
     }
 
     #[test]
@@ -360,9 +355,7 @@ exclude = [".conductor/", ".entire/"]
 platform = "github"
 "#;
         let config: ProjectConfig = toml::from_str(contents).unwrap();
-        assert!(config.ci.is_some());
-        let ci = config.ci.unwrap();
-        assert_eq!(ci.platform.as_deref(), Some("github"));
+        assert_eq!(config.ci.platform.as_deref(), Some("github"));
     }
 
     #[test]
@@ -372,9 +365,7 @@ platform = "github"
 platform = "gitlab"
 "#;
         let config: ProjectConfig = toml::from_str(contents).unwrap();
-        assert!(config.ci.is_some());
-        let ci = config.ci.unwrap();
-        assert_eq!(ci.platform.as_deref(), Some("gitlab"));
+        assert_eq!(config.ci.platform.as_deref(), Some("gitlab"));
     }
 
     #[test]
@@ -383,9 +374,7 @@ platform = "gitlab"
 [ci]
 "#;
         let config: ProjectConfig = toml::from_str(contents).unwrap();
-        assert!(config.ci.is_some());
-        let ci = config.ci.unwrap();
-        assert!(ci.platform.is_none());
+        assert!(config.ci.platform.is_none());
     }
 
     #[test]

--- a/src/config/user/mod.rs
+++ b/src/config/user/mod.rs
@@ -3,7 +3,7 @@
 //! Personal preferences and per-project approved commands, not checked into git.
 
 mod accessors;
-mod merge;
+pub(crate) mod merge;
 pub(crate) mod mutation;
 mod path;
 mod persistence;

--- a/src/config/user/persistence.rs
+++ b/src/config/user/persistence.rs
@@ -40,26 +40,21 @@ impl UserConfig {
     ) {
         if *config == T::default() {
             table.remove(section_name);
-            return;
-        }
-        match Self::serialize_section_item(config) {
-            Some(item) => {
-                table[section_name] = item;
-            }
-            None => {
-                table.remove(section_name);
-            }
+        } else {
+            table[section_name] = Self::serialize_section_item(config);
         }
     }
 
-    fn serialize_section_item(config: &impl Serialize) -> Option<toml_edit::Item> {
-        let toml_value = toml::to_string(config).ok()?;
-        let parsed = toml_value.parse::<toml_edit::DocumentMut>().ok()?;
+    fn serialize_section_item(config: &impl Serialize) -> toml_edit::Item {
+        let toml_value = toml::to_string(config).expect("config type should be serializable");
+        let parsed = toml_value
+            .parse::<toml_edit::DocumentMut>()
+            .expect("serialized TOML should be parseable");
         let mut table = toml_edit::Table::new();
         for (k, v) in parsed.iter() {
             table[k] = v.clone();
         }
-        Some(toml_edit::Item::Table(table))
+        toml_edit::Item::Table(table)
     }
 
     /// Update the [commit.generation] section in the document.

--- a/src/git/repository/remotes.rs
+++ b/src/git/repository/remotes.rs
@@ -331,8 +331,7 @@ impl Repository {
         self.load_project_config()
             .ok()
             .flatten()
-            .and_then(|config| config.list)
-            .and_then(|list| list.url)
+            .and_then(|config| config.list.url)
     }
 
     /// Check if a ref is a remote tracking branch.


### PR DESCRIPTION
Follow-up to #2104 (which flattened `UserConfig` section fields). Applies the same treatment to `ProjectConfig` and cleans up an unreachable branch in the persistence layer.

**`ProjectConfig` fields flattened** — `list: Option<ProjectListConfig>` → `ProjectListConfig`, same for `ci`, `forge`, and `step`. All inner fields are already `Option<T>`, so the outer `Option` was redundant. Accessors like `ci_platform()`, `forge_platform()`, `forge_hostname()`, and `copy_ignored()` simplify from `.as_ref().and_then(|x| x.field.as_deref())` to `.field.as_deref()`.

**Dead `None` branch removed** — `serialize_section_item` now returns `toml_edit::Item` directly with `expect()` instead of `Option<toml_edit::Item>`. The `None` arm in `sync_serialized_section` was unreachable after the `is_default` early return, since serialization of these simple structs can't fail.

> _This was written by Claude Code on behalf of @max-sixty_