### PR TITLE
chore: add TODO for pre-canonicalized key in warning

### DIFF
--- a/src/commands/hook_commands.rs
+++ b/src/commands/hook_commands.rs
@@ -223,6 +223,9 @@ fn warn_unreferenced_custom_vars(
         }
     }
 
+    // TODO: show the original (pre-canonicalized) key in the warning so
+    // `--my-env=staging` produces "my-env" not "my_env". Requires threading
+    // the raw input through parse_key_val.
     for (key, _) in custom_vars {
         if !referenced.contains(key) {
             eprintln!(


### PR DESCRIPTION
Adds a TODO noting that the unreferenced-var warning shows the post-canonicalized key (`my_var`) instead of the original input form (`my-env`). Requires threading the raw input through `parse_key_val` to fix.

> _This was written by Claude Code on behalf of @max-sixty_