### PR TITLE
docs(hook): name the set-vars step in Databases example

### DIFF
--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -332,12 +332,12 @@ Each worktree can have its own database. A pipeline sets up the container name a
 
 ```toml
 post-start = [
-  """
+  { set-vars = """
   wt config state vars set \
     container='{{ repo }}-{{ branch | sanitize }}-postgres' \
     port='{{ ('db-' ~ branch) | hash_port }}' \
     db_url='postgres://postgres:dev@localhost:{{ ('db-' ~ branch) | hash_port }}/{{ branch | sanitize_db }}'
-  """,
+  """ },
   { db = """
   docker run -d --rm \
     --name {{ vars.container }} \

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -330,12 +330,12 @@ Each worktree can have its own database. A pipeline sets up the container name a
 
 ```toml
 post-start = [
-  """
+  { set-vars = """
   wt config state vars set \
     container='{{ repo }}-{{ branch | sanitize }}-postgres' \
     port='{{ ('db-' ~ branch) | hash_port }}' \
     db_url='postgres://postgres:dev@localhost:{{ ('db-' ~ branch) | hash_port }}/{{ branch | sanitize_db }}'
-  """,
+  """ },
   { db = """
   docker run -d --rm \
     --name {{ vars.container }} \

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1519,12 +1519,12 @@ Each worktree can have its own database. A pipeline sets up the container name a
 
 ```toml
 post-start = [
-  """
+  { set-vars = """
   wt config state vars set \
     container='{{ repo }}-{{ branch | sanitize }}-postgres' \
     port='{{ ('db-' ~ branch) | hash_port }}' \
     db_url='postgres://postgres:dev@localhost:{{ ('db-' ~ branch) | hash_port }}/{{ branch | sanitize_db }}'
-  """,
+  """ },
   { db = """
   docker run -d --rm \
     --name {{ vars.container }} \


### PR DESCRIPTION
Wraps the first `post-start` step in the Databases example in `{ set-vars = ... }` so both steps are structurally parallel. Named steps produce meaningful log file names (`set-vars.log`), are selectable via `wt hook post-start set-vars`, and pair visually with the second step — worth modeling in a teaching example.

> _This was written by Claude Code on behalf of Maximilian_