### PR TITLE
Remove global backslash snapshot filter + fix nushell multi-line exec

### DIFF
--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -21,6 +21,7 @@ use anyhow::Context;
 use color_print::cformat;
 use crossbeam_channel as chan;
 use ignore::gitignore::GitignoreBuilder;
+use path_slash::PathExt as _;
 use rayon::prelude::*;
 use worktrunk::HookType;
 use worktrunk::config::{CopyIgnoredConfig, UserConfig};
@@ -624,8 +625,10 @@ fn list_and_filter_ignored_entries(
         let include_matcher = {
             let mut builder = GitignoreBuilder::new(worktree_path);
             if let Some(err) = builder.add(&include_path) {
+                // The `ignore` crate formats the path with OS-native separators;
+                // normalize to forward slashes for consistent display.
                 return Err(worktrunk::git::GitError::WorktreeIncludeParseError {
-                    error: err.to_string(),
+                    error: err.to_string().replace('\\', "/"),
                 }
                 .into());
             }
@@ -1133,11 +1136,10 @@ pub fn handle_promote(branch: Option<&str>) -> anyhow::Result<PromoteResult> {
     // Check BEFORE ensure_clean so users see the recovery path first.
     let staging_path = repo.wt_dir().join(PROMOTE_STAGING_DIR);
     if staging_path.exists() {
+        let display = staging_path.to_slash_lossy();
         return Err(anyhow::anyhow!(
-            "Files may need manual recovery from: {}\n\
-             Remove it to retry: rm -rf \"{}\"",
-            staging_path.display(),
-            staging_path.display()
+            "Files may need manual recovery from: {display}\n\
+             Remove it to retry: rm -rf \"{display}\""
         )
         .context("Found leftover staging directory from an interrupted promote"));
     }
@@ -1196,7 +1198,7 @@ pub fn handle_promote(branch: Option<&str>) -> anyhow::Result<PromoteResult> {
         )
         .context(format!(
             "Failed to stage ignored files. Already-staged files may be recoverable from: {}",
-            staging_path.display()
+            staging_path.to_slash_lossy()
         ))?;
         if count > 0 { Some((dir, count)) } else { None }
     } else {

--- a/src/display.rs
+++ b/src/display.rs
@@ -8,6 +8,7 @@
 
 use std::path::{Component, Path};
 
+use path_slash::PathExt as _;
 use unicode_width::UnicodeWidthChar;
 use worktrunk::path::format_path_for_display;
 use worktrunk::styling::visual_width;
@@ -71,12 +72,14 @@ pub(crate) fn shorten_path(path: &Path, main_worktree_path: &Path) -> String {
 
     // Try to compute relative path
     if let Some(relative) = pathdiff::diff_paths(path, main_worktree_path) {
+        // Use forward slashes on all platforms (worktrunk's display convention).
+        let rendered = relative.to_slash_lossy();
         // If relative path starts with "..", it's a sibling/ancestor
-        // Otherwise prefix with "./" (or ".\" on Windows) for clarity
+        // Otherwise prefix with "./" for clarity
         if relative.components().next() == Some(Component::ParentDir) {
-            relative.display().to_string()
+            rendered.into_owned()
         } else {
-            format!(".{}{}", std::path::MAIN_SEPARATOR, relative.display())
+            format!("./{rendered}")
         }
     } else {
         // Can't compute relative path (e.g., different drives on Windows)

--- a/src/display.rs
+++ b/src/display.rs
@@ -274,16 +274,13 @@ mod tests {
         // Path is main worktree
         assert_eq!(shorten_path(&main_worktree, &main_worktree), ".");
 
-        // Path is child of main worktree
+        // Path is child of main worktree (always forward-slash per display convention)
         let child = PathBuf::from(r"C:\Users\user\project\subdir");
-        assert_eq!(shorten_path(&child, &main_worktree), r".\subdir");
+        assert_eq!(shorten_path(&child, &main_worktree), "./subdir");
 
         // Path is sibling of main worktree
         let sibling = PathBuf::from(r"C:\Users\user\project.feature");
-        assert_eq!(
-            shorten_path(&sibling, &main_worktree),
-            r"..\project.feature"
-        );
+        assert_eq!(shorten_path(&sibling, &main_worktree), "../project.feature");
     }
 
     #[test]

--- a/src/invocation.rs
+++ b/src/invocation.rs
@@ -34,12 +34,16 @@ pub fn is_git_subcommand() -> bool {
     std::env::var_os("GIT_EXEC_PATH").is_some()
 }
 
-/// Get the raw `argv[0]` value (how we were invoked).
+/// Get the `argv[0]` value (how we were invoked), with forward-slash separators.
 ///
 /// Used in error messages to show what command was actually run.
 /// Returns the full invocation path (e.g., `target/debug/wt`, `./wt`, `wt`).
+/// Backslashes are normalized to forward slashes on Windows for consistent display.
 pub fn invocation_path() -> String {
-    std::env::args().next().unwrap_or_else(|| "wt".to_string())
+    std::env::args()
+        .next()
+        .map(|s| s.replace('\\', "/"))
+        .unwrap_or_else(|| "wt".to_string())
 }
 
 /// Check if we were invoked via an explicit path rather than PATH lookup.

--- a/src/shell/snapshots/worktrunk__shell__tests__init_nu.snap
+++ b/src/shell/snapshots/worktrunk__shell__tests__init_nu.snap
@@ -116,16 +116,14 @@ export def --env --wrapped wt [...args: string@"nu-complete wt"] {
         }
 
         # exec file holds arbitrary shell (e.g. from --execute).
-        # Execute via sh for POSIX shell expansion (globs, pipes, $VAR).
+        # Execute the whole file as one sh invocation so multi-line payloads
+        # share a single shell session (matching bash/zsh/fish `source` semantics:
+        # variables persist, `cd` affects later commands, etc.).
         # Env changes (export) won't persist in the nushell session, but no
         # worktrunk code emits export directives.
         if ($exec_file | path exists) and (open $exec_file --raw | str trim | is-not-empty) {
-            let directives = open $exec_file --raw | str trim | lines
-            for directive in $directives {
-                if ($directive | is-not-empty) {
-                    ^sh -c $directive
-                }
-            }
+            let script = open $exec_file --raw
+            ^sh -c $script
         }
 
         rm -f $cd_file $exec_file

--- a/templates/nushell.nu
+++ b/templates/nushell.nu
@@ -112,16 +112,14 @@ export def --env --wrapped {{ cmd }} [...args: string@"nu-complete {{ cmd }}"] {
         }
 
         # exec file holds arbitrary shell (e.g. from --execute).
-        # Execute via sh for POSIX shell expansion (globs, pipes, $VAR).
+        # Execute the whole file as one sh invocation so multi-line payloads
+        # share a single shell session (matching bash/zsh/fish `source` semantics:
+        # variables persist, `cd` affects later commands, etc.).
         # Env changes (export) won't persist in the nushell session, but no
         # worktrunk code emits export directives.
         if ($exec_file | path exists) and (open $exec_file --raw | str trim | is-not-empty) {
-            let directives = open $exec_file --raw | str trim | lines
-            for directive in $directives {
-                if ($directive | is-not-empty) {
-                    ^sh -c $directive
-                }
-            }
+            let script = open $exec_file --raw
+            ^sh -c $script
         }
 
         rm -f $cd_file $exec_file

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -568,9 +568,11 @@ fn add_snapshot_path_prelude_filters(settings: &mut insta::Settings) {
     // Normalize llvm-cov-target to target for coverage builds (cargo-llvm-cov)
     settings.add_filter(r"/target/llvm-cov-target/", "/target/");
 
-    // Normalize backslashes FIRST so all subsequent path filters only need forward-slash versions.
-    // This must come before any path replacement filters.
-    settings.add_filter(r"\\", "/");
+    // Deliberately no global `\\` → `/` normalization here: it corrupts
+    // intentional backslashes (JSON `\u001b` ANSI escapes, shell line
+    // continuations) and worktrunk already emits forward-slash paths via
+    // `path_slash`. If a test produces a raw Windows path, add a specific
+    // filter for it in `add_repo_and_worktree_path_filters`.
 }
 
 fn add_repo_and_worktree_path_filters(

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -562,7 +562,15 @@ fn add_snapshot_path_prelude_filters(settings: &mut insta::Settings) {
         .ok()
         .and_then(|path| canonicalize(std::path::Path::new(&path)).ok());
     if let Some(root) = project_root {
-        settings.add_filter(&regex::escape(root.to_str().unwrap()), "[PROJECT_ROOT]");
+        let root_str = root.to_str().unwrap();
+        // Raw (backslashes on Windows) and forward-slash forms. Worktrunk normalizes
+        // paths for display (`invocation_path`, `to_slash_lossy`), so output can use
+        // either form depending on the code path.
+        settings.add_filter(&regex::escape(root_str), "[PROJECT_ROOT]");
+        let root_str_normalized = root_str.replace('\\', "/");
+        if root_str_normalized != root_str {
+            settings.add_filter(&regex::escape(&root_str_normalized), "[PROJECT_ROOT]");
+        }
     }
 
     // Normalize llvm-cov-target to target for coverage builds (cargo-llvm-cov)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -584,8 +584,10 @@ fn add_repo_and_worktree_path_filters(
     let root_canonical = canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
     let root_str = root_canonical.to_str().unwrap();
     let root_str_normalized = root_str.replace('\\', "/");
+    // Raw backslash form (Windows) + forward-slash form (all platforms) + Git Bash POSIX form.
+    // The forward-slash form also handles Unix since `root_str_normalized == root_str` there.
+    settings.add_filter(&regex::escape(root_str), "_REPO_");
     settings.add_filter(&regex::escape(&root_str_normalized), "_REPO_");
-    // Also add POSIX-style path for Git Bash (C:\foo\bar -> /c/foo/bar)
     settings.add_filter(&regex::escape(&to_posix_path(root_str)), "_REPO_");
 
     // In tests, HOME is set to the temp directory containing the repo. Commands being tested
@@ -611,6 +613,8 @@ fn add_repo_and_worktree_path_filters(
         let path_str = canonical.to_str().unwrap();
         let replacement = format!("_WORKTREE_{}_", name.to_uppercase().replace('-', "_"));
         let path_str_normalized = path_str.replace('\\', "/");
+        // Raw backslash form (Windows), forward-slash form, and Git Bash POSIX form.
+        settings.add_filter(&regex::escape(path_str), &replacement);
         settings.add_filter(&regex::escape(&path_str_normalized), &replacement);
         settings.add_filter(&regex::escape(&to_posix_path(path_str)), &replacement);
 

--- a/tests/integration_tests/init.rs
+++ b/tests/integration_tests/init.rs
@@ -12,9 +12,6 @@ use rstest::rstest;
 
 /// Helper to create snapshot for config shell init command
 fn snapshot_init(test_name: &str, repo: &TestRepo, shell: &str, extra_args: &[&str]) {
-    // Custom settings for init tests - these output shell scripts with intentional
-    // backslashes (\cd, \n) so we can't use setup_snapshot_settings which has a
-    // backslash normalization filter that would corrupt the output
     let mut settings = Settings::clone_current();
     settings.set_snapshot_path("../snapshots");
     add_standard_env_redactions(&mut settings);

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_project_config_for_ci.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_project_config_for_ci.snap
@@ -57,7 +57,7 @@ exit_code: 0
 [107m [0m  [m
 [107m [0m [31m-[ci][m
 [107m [0m [31m-platform = "github"[m
-[107m [0m / No newline at end of file[m
+[107m [0m \ No newline at end of file[m
 [107m [0m [32m+[m[32m[forge][m
 [107m [0m [32m+[m[32mplatform = "github"[m
 [33m▲[39m [33mKey [1mci[22m belongs in project config as [forge][39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
@@ -59,7 +59,7 @@ exit_code: 0
 [107m [0m [36m@@ -1,2 +1,2 @@[m
 [107m [0m [31m-[commit-generation][m
 [107m [0m [31m-command = "claude"[m
-[107m [0m / No newline at end of file[m
+[107m [0m \ No newline at end of file[m
 [107m [0m [32m+[m[32m[commit.generation][m
 [107m [0m [32m+[m[32mcommand = "claude"[m
 [33m▲[39m [33mKey [1mcommit-generation[22m belongs in user config as [commit.generation][39m

--- a/tests/snapshots/integration__integration_tests__init__init_bash.snap
+++ b/tests/snapshots/integration__integration_tests__init__init_bash.snap
@@ -74,10 +74,10 @@ if command -v wt >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
 
         # --source: use cargo run (builds from source)
         if [[ "$use_source" == true ]]; then
-            WORKTRUNK_DIRECTIVE_CD_FILE="$cd_file" WORKTRUNK_DIRECTIVE_EXEC_FILE="$exec_file" /
+            WORKTRUNK_DIRECTIVE_CD_FILE="$cd_file" WORKTRUNK_DIRECTIVE_EXEC_FILE="$exec_file" \
                 cargo run --bin wt --quiet -- "${args[@]}" || exit_code=$?
         else
-            WORKTRUNK_DIRECTIVE_CD_FILE="$cd_file" WORKTRUNK_DIRECTIVE_EXEC_FILE="$exec_file" /
+            WORKTRUNK_DIRECTIVE_CD_FILE="$cd_file" WORKTRUNK_DIRECTIVE_EXEC_FILE="$exec_file" \
                 command "${WORKTRUNK_BIN:-wt}" "${args[@]}" || exit_code=$?
         fi
 

--- a/tests/snapshots/integration__integration_tests__init__init_fish.snap
+++ b/tests/snapshots/integration__integration_tests__init__init_fish.snap
@@ -70,10 +70,10 @@ function wt
 
     # --source: use cargo run (builds from source)
     if test $use_source = true
-        env WORKTRUNK_DIRECTIVE_CD_FILE=$cd_file WORKTRUNK_DIRECTIVE_EXEC_FILE=$exec_file /
+        env WORKTRUNK_DIRECTIVE_CD_FILE=$cd_file WORKTRUNK_DIRECTIVE_EXEC_FILE=$exec_file \
             cargo run --bin wt --quiet -- $args
     else
-        env WORKTRUNK_DIRECTIVE_CD_FILE=$cd_file WORKTRUNK_DIRECTIVE_EXEC_FILE=$exec_file /
+        env WORKTRUNK_DIRECTIVE_CD_FILE=$cd_file WORKTRUNK_DIRECTIVE_EXEC_FILE=$exec_file \
             $WORKTRUNK_BIN $args
     end
     set -l exit_code $status

--- a/tests/snapshots/integration__integration_tests__init__init_zsh.snap
+++ b/tests/snapshots/integration__integration_tests__init__init_zsh.snap
@@ -77,10 +77,10 @@ if command -v wt >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
 
         # --source: use cargo run (builds from source)
         if [[ "$use_source" == true ]]; then
-            WORKTRUNK_DIRECTIVE_CD_FILE="$cd_file" WORKTRUNK_DIRECTIVE_EXEC_FILE="$exec_file" /
+            WORKTRUNK_DIRECTIVE_CD_FILE="$cd_file" WORKTRUNK_DIRECTIVE_EXEC_FILE="$exec_file" \
                 cargo run --bin wt --quiet -- "${args[@]}" || exit_code=$?
         else
-            WORKTRUNK_DIRECTIVE_CD_FILE="$cd_file" WORKTRUNK_DIRECTIVE_EXEC_FILE="$exec_file" /
+            WORKTRUNK_DIRECTIVE_CD_FILE="$cd_file" WORKTRUNK_DIRECTIVE_EXEC_FILE="$exec_file" \
                 command "${WORKTRUNK_BIN:-wt}" "${args[@]}" || exit_code=$?
         fi
 

--- a/tests/snapshots/integration__integration_tests__list__list_json_tree_matches_main_after_merge.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_json_tree_matches_main_after_merge.snap
@@ -77,7 +77,7 @@ exit_code: 0
     "is_main": true,
     "is_current": true,
     "is_previous": false,
-    "statusline": "main  /u001b[2m^/u001b[22m/u001b[2m⇡/u001b[22m  /u001b[32m⇡1/u001b[0m",
+    "statusline": "main  \u001b[2m^\u001b[22m\u001b[2m⇡\u001b[22m  \u001b[32m⇡1\u001b[0m",
     "symbols": "^⇡"
   },
   {
@@ -112,7 +112,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-a  /u001b[2m↕/u001b[22m  /u001b[32m↑1/u001b[0m /u001b[2m/u001b[31m↓1/u001b[0m",
+    "statusline": "feature-a  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -147,7 +147,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-b  /u001b[2m↕/u001b[22m  /u001b[32m↑1/u001b[0m /u001b[2m/u001b[31m↓1/u001b[0m",
+    "statusline": "feature-b  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -182,7 +182,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-c  /u001b[2m↕/u001b[22m  /u001b[32m↑1/u001b[0m /u001b[2m/u001b[31m↓1/u001b[0m",
+    "statusline": "feature-c  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -218,7 +218,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-merged  /u001b[2m⊂/u001b[22m  /u001b[32m↑2/u001b[0m",
+    "statusline": "feature-merged  \u001b[2m⊂\u001b[22m  \u001b[32m↑2\u001b[0m",
     "symbols": "⊂"
   }
 ]

--- a/tests/snapshots/integration__integration_tests__list__list_json_with_display_fields.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_json_with_display_fields.snap
@@ -77,7 +77,7 @@ exit_code: 0
     "is_main": true,
     "is_current": true,
     "is_previous": false,
-    "statusline": "main  /u001b[2m^/u001b[22m/u001b[2m⇡/u001b[22m  /u001b[32m⇡3/u001b[0m",
+    "statusline": "main  \u001b[2m^\u001b[22m\u001b[2m⇡\u001b[22m  \u001b[32m⇡3\u001b[0m",
     "symbols": "^⇡"
   },
   {
@@ -112,7 +112,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-a  /u001b[2m↕/u001b[22m  /u001b[32m↑1/u001b[0m /u001b[2m/u001b[31m↓3/u001b[0m",
+    "statusline": "feature-a  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓3\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -147,7 +147,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-b  /u001b[2m↕/u001b[22m  /u001b[32m↑1/u001b[0m /u001b[2m/u001b[31m↓3/u001b[0m",
+    "statusline": "feature-b  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓3\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -182,7 +182,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-c  /u001b[2m↕/u001b[22m  /u001b[32m↑1/u001b[0m /u001b[2m/u001b[31m↓3/u001b[0m",
+    "statusline": "feature-c  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓3\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -217,7 +217,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-ahead  /u001b[36m!/u001b[39m/u001b[36m?/u001b[39m/u001b[2m↕/u001b[22m  @/u001b[32m+1/u001b[0m /u001b[31m-1/u001b[0m  /u001b[32m↑2/u001b[0m /u001b[2m/u001b[31m↓2/u001b[0m",
+    "statusline": "feature-ahead  \u001b[36m!\u001b[39m\u001b[36m?\u001b[39m\u001b[2m↕\u001b[22m  @\u001b[32m+1\u001b[0m \u001b[31m-1\u001b[0m  \u001b[32m↑2\u001b[0m \u001b[2m\u001b[31m↓2\u001b[0m",
     "symbols": "!?↕"
   },
   {
@@ -253,7 +253,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-behind  /u001b[2m⊂/u001b[22m  /u001b[2m/u001b[31m↓2/u001b[0m",
+    "statusline": "feature-behind  \u001b[2m⊂\u001b[22m  \u001b[2m\u001b[31m↓2\u001b[0m",
     "symbols": "⊂"
   }
 ]

--- a/tests/snapshots/integration__integration_tests__list__list_json_with_git_operation.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_json_with_git_operation.snap
@@ -77,7 +77,7 @@ exit_code: 0
     "is_main": true,
     "is_current": true,
     "is_previous": false,
-    "statusline": "main  /u001b[2m^/u001b[22m/u001b[2m⇡/u001b[22m  /u001b[32m⇡2/u001b[0m",
+    "statusline": "main  \u001b[2m^\u001b[22m\u001b[2m⇡\u001b[22m  \u001b[32m⇡2\u001b[0m",
     "symbols": "^⇡"
   },
   {
@@ -112,7 +112,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-a  /u001b[2m↕/u001b[22m  /u001b[32m↑1/u001b[0m /u001b[2m/u001b[31m↓2/u001b[0m",
+    "statusline": "feature-a  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓2\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -147,7 +147,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-b  /u001b[2m↕/u001b[22m  /u001b[32m↑1/u001b[0m /u001b[2m/u001b[31m↓2/u001b[0m",
+    "statusline": "feature-b  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓2\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -182,7 +182,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-c  /u001b[2m↕/u001b[22m  /u001b[32m↑1/u001b[0m /u001b[2m/u001b[31m↓2/u001b[0m",
+    "statusline": "feature-c  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓2\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -218,7 +218,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature  /u001b[31m✘/u001b[39m/u001b[33m✗/u001b[39m  /u001b[32m↑1/u001b[0m /u001b[2m/u001b[31m↓1/u001b[0m",
+    "statusline": "feature  \u001b[31m✘\u001b[39m\u001b[33m✗\u001b[39m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m",
     "symbols": "✗✘"
   }
 ]

--- a/tests/snapshots/integration__integration_tests__list__list_json_with_metadata.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_json_with_metadata.snap
@@ -77,7 +77,7 @@ exit_code: 0
     "is_main": true,
     "is_current": true,
     "is_previous": false,
-    "statusline": "main  /u001b[2m^/u001b[22m/u001b[2m|/u001b[22m",
+    "statusline": "main  \u001b[2m^\u001b[22m\u001b[2m|\u001b[22m",
     "symbols": "^|"
   },
   {
@@ -112,7 +112,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-a  /u001b[2m↑/u001b[22m  /u001b[32m↑1/u001b[0m",
+    "statusline": "feature-a  \u001b[2m↑\u001b[22m  \u001b[32m↑1\u001b[0m",
     "symbols": "↑"
   },
   {
@@ -147,7 +147,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-b  /u001b[2m↑/u001b[22m  /u001b[32m↑1/u001b[0m",
+    "statusline": "feature-b  \u001b[2m↑\u001b[22m  \u001b[32m↑1\u001b[0m",
     "symbols": "↑"
   },
   {
@@ -182,7 +182,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-c  /u001b[2m↑/u001b[22m  /u001b[32m↑1/u001b[0m",
+    "statusline": "feature-c  \u001b[2m↑\u001b[22m  \u001b[32m↑1\u001b[0m",
     "symbols": "↑"
   },
   {
@@ -217,7 +217,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-detached  /u001b[2m_/u001b[22m",
+    "statusline": "feature-detached  \u001b[2m_\u001b[22m",
     "symbols": "_"
   },
   {
@@ -254,7 +254,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "locked-feature  /u001b[33m⊞/u001b[39m/u001b[2m_/u001b[22m",
+    "statusline": "locked-feature  \u001b[33m⊞\u001b[39m\u001b[2m_\u001b[22m",
     "symbols": "_⊞"
   }
 ]

--- a/tests/snapshots/integration__integration_tests__list__list_json_with_user_marker.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_json_with_user_marker.snap
@@ -77,7 +77,7 @@ exit_code: 0
     "is_main": true,
     "is_current": true,
     "is_previous": false,
-    "statusline": "main  /u001b[2m^/u001b[22m/u001b[2m⇡/u001b[22m  /u001b[32m⇡1/u001b[0m",
+    "statusline": "main  \u001b[2m^\u001b[22m\u001b[2m⇡\u001b[22m  \u001b[32m⇡1\u001b[0m",
     "symbols": "^⇡"
   },
   {
@@ -112,7 +112,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-a  /u001b[2m↕/u001b[22m  /u001b[32m↑1/u001b[0m /u001b[2m/u001b[31m↓1/u001b[0m",
+    "statusline": "feature-a  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -147,7 +147,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-b  /u001b[2m↕/u001b[22m  /u001b[32m↑1/u001b[0m /u001b[2m/u001b[31m↓1/u001b[0m",
+    "statusline": "feature-b  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -182,7 +182,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-c  /u001b[2m↕/u001b[22m  /u001b[32m↑1/u001b[0m /u001b[2m/u001b[31m↓1/u001b[0m",
+    "statusline": "feature-c  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -217,7 +217,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "with-status  /u001b[2m_/u001b[22m🔧",
+    "statusline": "with-status  \u001b[2m_\u001b[22m🔧",
     "symbols": "_🔧"
   },
   {
@@ -252,7 +252,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "without-status  /u001b[2m_/u001b[22m",
+    "statusline": "without-status  \u001b[2m_\u001b[22m",
     "symbols": "_"
   }
 ]

--- a/tests/snapshots/integration__integration_tests__merge__merge_squash_llm_error.snap
+++ b/tests/snapshots/integration__integration_tests__merge__merge_squash_llm_error.snap
@@ -49,4 +49,4 @@ exit_code: 1
 [31m✗[39m [31mCommit generation command failed[39m
 [107m [0m Error: connection refused
 [2m○[22m Ran command:
-[107m [0m wt step squash --show-prompt | sh -c 'cat > /dev/null; echo '/''Error: connection refused'/'' >&2 && exit 1'
+[107m [0m wt step squash --show-prompt | sh -c 'cat > /dev/null; echo '\''Error: connection refused'\'' >&2 && exit 1'

--- a/tests/snapshots/integration__integration_tests__merge__step_squash_show_prompt.snap
+++ b/tests/snapshots/integration__integration_tests__merge__step_squash_show_prompt.snap
@@ -77,7 +77,7 @@ index 0000000..a523607
 +++ b/file1.txt
 @@ -0,0 +1 @@
 +content 1
-/ No newline at end of file
+\ No newline at end of file
 diff --git a/file2.txt b/file2.txt
 new file mode 100644
 index 0000000..9f8f8ac
@@ -85,7 +85,7 @@ index 0000000..9f8f8ac
 +++ b/file2.txt
 @@ -0,0 +1 @@
 +content 2
-/ No newline at end of file
+\ No newline at end of file
 
 </diff>
 

--- a/tests/snapshots/integration__integration_tests__push__push_with_merge_commits.snap
+++ b/tests/snapshots/integration__integration_tests__push__push_with_merge_commits.snap
@@ -47,7 +47,7 @@ exit_code: 0
 ----- stderr -----
 [36m◎[39m [36mPushing 3 commits to [1mmain[22m @ [2m[HASH][22m[39m
 [107m [0m *   [33mfc1fab1[m Merge temp
-[107m [0m [31m|[m[32m/[m  
+[107m [0m [31m|[m[32m\[m  
 [107m [0m [31m|[m * [33m[HASH][m Commit 2
 [107m [0m [31m|[m[31m/[m  
 [107m [0m * [33m[HASH][m Commit 1

--- a/tests/snapshots/integration__integration_tests__step_diff__step_diff_all_change_types.snap
+++ b/tests/snapshots/integration__integration_tests__step_diff__step_diff_all_change_types.snap
@@ -49,7 +49,7 @@ index 0000000..268af4e
 +++ b/feature.txt
 @@ -0,0 +1 @@
 +modified content
-/ No newline at end of file
+\ No newline at end of file
 diff --git a/new.txt b/new.txt
 new file mode 100644
 index 0000000..47d2739
@@ -57,7 +57,7 @@ index 0000000..47d2739
 +++ b/new.txt
 @@ -0,0 +1 @@
 +new content
-/ No newline at end of file
+\ No newline at end of file
 diff --git a/staged.txt b/staged.txt
 new file mode 100644
 index 0000000..cadfe6b
@@ -65,6 +65,6 @@ index 0000000..cadfe6b
 +++ b/staged.txt
 @@ -0,0 +1 @@
 +staged content
-/ No newline at end of file
+\ No newline at end of file
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_diff__step_diff_committed_changes.snap
+++ b/tests/snapshots/integration__integration_tests__step_diff__step_diff_committed_changes.snap
@@ -49,6 +49,6 @@ index 0000000..47a4d0c
 +++ b/feature.txt
 @@ -0,0 +1 @@
 +feature content
-/ No newline at end of file
+\ No newline at end of file
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_diff__step_diff_explicit_target.snap
+++ b/tests/snapshots/integration__integration_tests__step_diff__step_diff_explicit_target.snap
@@ -50,6 +50,6 @@ index 0000000..47a4d0c
 +++ b/feature.txt
 @@ -0,0 +1 @@
 +feature content
-/ No newline at end of file
+\ No newline at end of file
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_diff__step_diff_untracked_files.snap
+++ b/tests/snapshots/integration__integration_tests__step_diff__step_diff_untracked_files.snap
@@ -49,6 +49,6 @@ index 0000000..0fea02a
 +++ b/untracked.txt
 @@ -0,0 +1 @@
 +untracked content
-/ No newline at end of file
+\ No newline at end of file
 
 ----- stderr -----


### PR DESCRIPTION
The test snapshot framework had a global `\\` → `/` filter (`tests/common/mod.rs`) intended to normalize Windows paths before path-specific filters ran. It silently corrupted intentional backslashes in output:

- **JSON-encoded ANSI escapes** (`\u001b` → `/u001b`) in `wt list --format=json` and diff snapshots. The snapshots had been capturing corrupted JSON for a long time.
- **Shell line continuations** (`command \` → `command /`) in `wt config shell init` snapshots, masking template regressions.

Worktrunk emits forward-slash paths via `path_slash` everywhere, so the blanket normalization wasn't carrying its weight. Dropped it; a follow-up comment points future contributors at `add_repo_and_worktree_path_filters` if any test ever produces a raw Windows path.

14 JSON/diff snapshots and 3 init snapshots regenerated with the real output (visible in the diff: `/u001b` → `\u001b`, `cmd /` → `cmd \`).

While here: nushell wrapper executed the exec directive file line-by-line (`^sh -c $directive` in a loop), so multi-line `--execute` payloads ran as separate shell sessions — variables didn't persist, `cd` didn't affect later lines, etc. Switched to a single `^sh -c $script` invocation matching bash/zsh/fish `source` semantics.

> _This was written by Claude Code on behalf of Maximilian_