### PR TITLE
Deprecate table form for pre-* hooks

### DIFF
--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -247,20 +247,3 @@
 # ## Hooks
 #
 # See `wt hook` (https://worktrunk.dev/hook/) for hook types, execution order, template variables, and examples. User hooks apply to all projects; project hooks (https://worktrunk.dev/config/#project-configuration) apply only to that repository.
-#
-# Single command:
-#
-# pre-start = "npm ci"
-#
-# Multiple named commands — concurrent for post-*, sequential for pre-*:
-#
-# [pre-merge]
-# test = "npm test"
-# build = "npm run build"
-#
-# Pipeline — list of maps, run in order (each map concurrent):
-#
-# post-start = [
-#     { install = "npm ci" },
-#     { build = "npm run build", server = "npm run dev" }
-# ]

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -347,29 +347,6 @@ squash-template = """
 ## Hooks
 
 See [`wt hook`](@/hook.md) for hook types, execution order, template variables, and examples. User hooks apply to all projects; [project hooks](@/config.md#project-configuration) apply only to that repository.
-
-Single command:
-
-```toml
-pre-start = "npm ci"
-```
-
-Multiple named commands — concurrent for post-*, sequential for pre-*:
-
-```toml
-[pre-merge]
-test = "npm test"
-build = "npm run build"
-```
-
-Pipeline — list of maps, run in order (each map concurrent):
-
-```toml
-post-start = [
-    { install = "npm ci" },
-    { build = "npm run build", server = "npm run dev" }
-]
-```
 <!-- USER_CONFIG_END -->
 <!-- PROJECT_CONFIG_START -->
 # Project Configuration

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -68,19 +68,34 @@ Manage approvals with `wt hook approvals add` and `wt hook approvals clear`.
 
 # Configuration
 
-Hooks can be defined in project config (`.config/wt.toml`) or user config (`~/.config/worktrunk/config.toml`). Both use the same format — a single command or multiple named commands:
+Hooks can be defined in project config (`.config/wt.toml`) or user config (`~/.config/worktrunk/config.toml`). Both use the same format. Hooks take one of three forms.
+
+A string is a single command:
 
 ```toml
-# Single command (string)
 pre-start = "npm install"
-
-# Multiple commands (table)
-[pre-merge]
-test = "cargo test"
-build = "cargo build --release"
 ```
 
-For pre-* hooks, commands in a table run sequentially. For post-* hooks, they run concurrently in the background. Post-* hooks that need ordering guarantees can use [pipeline ordering](#pipeline-ordering).
+A table is multiple commands that run concurrently:
+
+```toml
+[post-start]
+server = "npm run dev"
+watch = "npm run watch"
+```
+
+A pipeline is a list of steps run in order, where each step is an inline table of commands that run concurrently within the step:
+
+```toml
+post-start = [
+    {install = "npm ci"},
+    {build = "npm run build", server = "npm run dev"},
+]
+```
+
+Here `install` runs first, then `build` and `server` run together.
+
+For pre-* hooks, prefer pipeline form over table form. Table form for pre-* hooks currently runs serially rather than concurrently — this inconsistency is deprecated and will change in a future version. Using pipeline form avoids the upcoming behavior change.
 
 ## Project vs user hooks
 
@@ -295,9 +310,10 @@ copy = "wt step copy-ignored"
 Use `pre-start` instead if subsequent hooks need the copied files — for example, copying `node_modules/` before `pnpm install` so the install reuses cached packages:
 
 ```toml
-[pre-start]
-copy = "wt step copy-ignored"
-install = "pnpm install"
+pre-start = [
+    {copy = "wt step copy-ignored"},
+    {install = "pnpm install"},
+]
 ```
 
 ## Dev servers
@@ -363,13 +379,15 @@ The connection string is accessible anywhere — not just in hooks:
 Quick checks before commit, thorough validation before merge:
 
 ```toml
-[pre-commit]
-lint = "npm run lint"
-typecheck = "npm run typecheck"
+pre-commit = [
+    {lint = "npm run lint"},
+    {typecheck = "npm run typecheck"},
+]
 
-[pre-merge]
-test = "npm test"
-build = "npm run build"
+pre-merge = [
+    {test = "npm test"},
+    {build = "npm run build"},
+]
 ```
 
 ## Target-specific behavior
@@ -400,11 +418,24 @@ For copying dependencies and caches between worktrees, see [`wt step copy-ignore
 ## Hook type examples
 
 ```toml
-# Single command (string) — top-level, before any table headers
 post-merge = "cargo install --path ."
 
+pre-start = [
+    {install = "npm ci"},
+    {env = "echo 'PORT={{ branch | hash_port }}' > .env.local"},
+]
+
+pre-commit = [
+    {format = "cargo fmt -- --check"},
+    {lint = "cargo clippy -- -D warnings"},
+]
+
+pre-merge = [
+    {test = "cargo test"},
+    {build = "cargo build --release"},
+]
+
 [pre-switch]
-# Pull if last fetch was more than 6 hours ago
 pull = """
 FETCH_HEAD="$(git rev-parse --git-common-dir)/FETCH_HEAD"
 if [ "$(find "$FETCH_HEAD" -mmin +360 2>/dev/null)" ] || [ ! -f "$FETCH_HEAD" ]; then
@@ -415,24 +446,12 @@ fi
 [post-switch]
 tmux = "[ -n \"$TMUX\" ] && tmux rename-window {{ branch | sanitize }}"
 
-[pre-start]
-install = "npm ci"
-env = "echo 'PORT={{ branch | hash_port }}' > .env.local"
-
 [post-start]
 copy = "wt step copy-ignored"
 server = "npm run dev -- --port {{ branch | hash_port }}"
 
-[pre-commit]
-format = "cargo fmt -- --check"
-lint = "cargo clippy -- -D warnings"
-
 [post-commit]
 notify = "curl -s https://ci.example.com/trigger?branch={{ branch }}"
-
-[pre-merge]
-test = "cargo test"
-build = "cargo build --release"
 
 [pre-remove]
 archive = "tar -czf ~/.wt-logs/{{ branch }}.tar.gz test-results/ logs/ 2>/dev/null || true"

--- a/docs/content/merge.md
+++ b/docs/content/merge.md
@@ -70,9 +70,10 @@ Historically, ensuring tests ran before merging was difficult to enforce locally
 The full workflow: start an agent (one of many) on a task, work elsewhere, return when it's ready. Review the diff, run `wt merge`, move on. Pre-merge hooks validate before merging — if they pass, the branch goes to the default branch and the worktree cleans up.
 
 ```toml
-[pre-merge]
-test = "cargo test"
-lint = "cargo clippy"
+pre-merge = [
+    {test = "cargo test"},
+    {lint = "cargo clippy"},
+]
 ```
 
 ## See also

--- a/docs/content/tips-patterns.md
+++ b/docs/content/tips-patterns.md
@@ -128,9 +128,10 @@ All gitignored files are copied by default. To limit what gets copied, create `.
 `pre-merge` hooks run before merging. Failures abort the merge:
 
 ```toml
-[pre-merge]
-"lint" = "uv run ruff check"
-"test" = "uv run pytest"
+pre-merge = [
+    {"lint" = "uv run ruff check"},
+    {"test" = "uv run pytest"},
+]
 ```
 
 This catches issues locally before pushing — like running CI locally.

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -346,29 +346,6 @@ squash-template = """
 ## Hooks
 
 See [`wt hook`](https://worktrunk.dev/hook/) for hook types, execution order, template variables, and examples. User hooks apply to all projects; [project hooks](https://worktrunk.dev/config/#project-configuration) apply only to that repository.
-
-Single command:
-
-```toml
-pre-start = "npm ci"
-```
-
-Multiple named commands — concurrent for post-*, sequential for pre-*:
-
-```toml
-[pre-merge]
-test = "npm test"
-build = "npm run build"
-```
-
-Pipeline — list of maps, run in order (each map concurrent):
-
-```toml
-post-start = [
-    { install = "npm ci" },
-    { build = "npm run build", server = "npm run dev" }
-]
-```
 <!-- USER_CONFIG_END -->
 <!-- PROJECT_CONFIG_START -->
 # Project Configuration

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -59,19 +59,34 @@ Manage approvals with `wt hook approvals add` and `wt hook approvals clear`.
 
 # Configuration
 
-Hooks can be defined in project config (`.config/wt.toml`) or user config (`~/.config/worktrunk/config.toml`). Both use the same format — a single command or multiple named commands:
+Hooks can be defined in project config (`.config/wt.toml`) or user config (`~/.config/worktrunk/config.toml`). Both use the same format. Hooks take one of three forms.
+
+A string is a single command:
 
 ```toml
-# Single command (string)
 pre-start = "npm install"
-
-# Multiple commands (table)
-[pre-merge]
-test = "cargo test"
-build = "cargo build --release"
 ```
 
-For pre-* hooks, commands in a table run sequentially. For post-* hooks, they run concurrently in the background. Post-* hooks that need ordering guarantees can use [pipeline ordering](#pipeline-ordering).
+A table is multiple commands that run concurrently:
+
+```toml
+[post-start]
+server = "npm run dev"
+watch = "npm run watch"
+```
+
+A pipeline is a list of steps run in order, where each step is an inline table of commands that run concurrently within the step:
+
+```toml
+post-start = [
+    {install = "npm ci"},
+    {build = "npm run build", server = "npm run dev"},
+]
+```
+
+Here `install` runs first, then `build` and `server` run together.
+
+For pre-* hooks, prefer pipeline form over table form. Table form for pre-* hooks currently runs serially rather than concurrently — this inconsistency is deprecated and will change in a future version. Using pipeline form avoids the upcoming behavior change.
 
 ## Project vs user hooks
 
@@ -294,9 +309,10 @@ copy = "wt step copy-ignored"
 Use `pre-start` instead if subsequent hooks need the copied files — for example, copying `node_modules/` before `pnpm install` so the install reuses cached packages:
 
 ```toml
-[pre-start]
-copy = "wt step copy-ignored"
-install = "pnpm install"
+pre-start = [
+    {copy = "wt step copy-ignored"},
+    {install = "pnpm install"},
+]
 ```
 
 ## Dev servers
@@ -364,13 +380,15 @@ $ DATABASE_URL=$(wt config state vars get db_url) npm start
 Quick checks before commit, thorough validation before merge:
 
 ```toml
-[pre-commit]
-lint = "npm run lint"
-typecheck = "npm run typecheck"
+pre-commit = [
+    {lint = "npm run lint"},
+    {typecheck = "npm run typecheck"},
+]
 
-[pre-merge]
-test = "npm test"
-build = "npm run build"
+pre-merge = [
+    {test = "npm test"},
+    {build = "npm run build"},
+]
 ```
 
 ## Target-specific behavior
@@ -401,11 +419,24 @@ For copying dependencies and caches between worktrees, see [`wt step copy-ignore
 ## Hook type examples
 
 ```toml
-# Single command (string) — top-level, before any table headers
 post-merge = "cargo install --path ."
 
+pre-start = [
+    {install = "npm ci"},
+    {env = "echo 'PORT={{ branch | hash_port }}' > .env.local"},
+]
+
+pre-commit = [
+    {format = "cargo fmt -- --check"},
+    {lint = "cargo clippy -- -D warnings"},
+]
+
+pre-merge = [
+    {test = "cargo test"},
+    {build = "cargo build --release"},
+]
+
 [pre-switch]
-# Pull if last fetch was more than 6 hours ago
 pull = """
 FETCH_HEAD="$(git rev-parse --git-common-dir)/FETCH_HEAD"
 if [ "$(find "$FETCH_HEAD" -mmin +360 2>/dev/null)" ] || [ ! -f "$FETCH_HEAD" ]; then
@@ -416,24 +447,12 @@ fi
 [post-switch]
 tmux = "[ -n \"$TMUX\" ] && tmux rename-window {{ branch | sanitize }}"
 
-[pre-start]
-install = "npm ci"
-env = "echo 'PORT={{ branch | hash_port }}' > .env.local"
-
 [post-start]
 copy = "wt step copy-ignored"
 server = "npm run dev -- --port {{ branch | hash_port }}"
 
-[pre-commit]
-format = "cargo fmt -- --check"
-lint = "cargo clippy -- -D warnings"
-
 [post-commit]
 notify = "curl -s https://ci.example.com/trigger?branch={{ branch }}"
-
-[pre-merge]
-test = "cargo test"
-build = "cargo build --release"
 
 [pre-remove]
 archive = "tar -czf ~/.wt-logs/{{ branch }}.tar.gz test-results/ logs/ 2>/dev/null || true"

--- a/skills/worktrunk/reference/merge.md
+++ b/skills/worktrunk/reference/merge.md
@@ -66,9 +66,10 @@ Historically, ensuring tests ran before merging was difficult to enforce locally
 The full workflow: start an agent (one of many) on a task, work elsewhere, return when it's ready. Review the diff, run `wt merge`, move on. Pre-merge hooks validate before merging — if they pass, the branch goes to the default branch and the worktree cleans up.
 
 ```toml
-[pre-merge]
-test = "cargo test"
-lint = "cargo clippy"
+pre-merge = [
+    {test = "cargo test"},
+    {lint = "cargo clippy"},
+]
 ```
 
 ## Command reference

--- a/skills/worktrunk/reference/tips-patterns.md
+++ b/skills/worktrunk/reference/tips-patterns.md
@@ -123,9 +123,10 @@ All gitignored files are copied by default. To limit what gets copied, create `.
 `pre-merge` hooks run before merging. Failures abort the merge:
 
 ```toml
-[pre-merge]
-"lint" = "uv run ruff check"
-"test" = "uv run pytest"
+pre-merge = [
+    {"lint" = "uv run ruff check"},
+    {"test" = "uv run pytest"},
+]
 ```
 
 This catches issues locally before pushing — like running CI locally.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1068,9 +1068,10 @@ Historically, ensuring tests ran before merging was difficult to enforce locally
 The full workflow: start an agent (one of many) on a task, work elsewhere, return when it's ready. Review the diff, run `wt merge`, move on. Pre-merge hooks validate before merging — if they pass, the branch goes to the default branch and the worktree cleans up.
 
 ```toml
-[pre-merge]
-test = "cargo test"
-lint = "cargo clippy"
+pre-merge = [
+    {test = "cargo test"},
+    {lint = "cargo clippy"},
+]
 ```
 
 ## See also
@@ -1257,19 +1258,34 @@ Manage approvals with `wt hook approvals add` and `wt hook approvals clear`.
 
 # Configuration
 
-Hooks can be defined in project config (`.config/wt.toml`) or user config (`~/.config/worktrunk/config.toml`). Both use the same format — a single command or multiple named commands:
+Hooks can be defined in project config (`.config/wt.toml`) or user config (`~/.config/worktrunk/config.toml`). Both use the same format. Hooks take one of three forms.
+
+A string is a single command:
 
 ```toml
-# Single command (string)
 pre-start = "npm install"
-
-# Multiple commands (table)
-[pre-merge]
-test = "cargo test"
-build = "cargo build --release"
 ```
 
-For pre-* hooks, commands in a table run sequentially. For post-* hooks, they run concurrently in the background. Post-* hooks that need ordering guarantees can use [pipeline ordering](#pipeline-ordering).
+A table is multiple commands that run concurrently:
+
+```toml
+[post-start]
+server = "npm run dev"
+watch = "npm run watch"
+```
+
+A pipeline is a list of steps run in order, where each step is an inline table of commands that run concurrently within the step:
+
+```toml
+post-start = [
+    {install = "npm ci"},
+    {build = "npm run build", server = "npm run dev"},
+]
+```
+
+Here `install` runs first, then `build` and `server` run together.
+
+For pre-* hooks, prefer pipeline form over table form. Table form for pre-* hooks currently runs serially rather than concurrently — this inconsistency is deprecated and will change in a future version. Using pipeline form avoids the upcoming behavior change.
 
 ## Project vs user hooks
 
@@ -1492,9 +1508,10 @@ copy = "wt step copy-ignored"
 Use `pre-start` instead if subsequent hooks need the copied files — for example, copying `node_modules/` before `pnpm install` so the install reuses cached packages:
 
 ```toml
-[pre-start]
-copy = "wt step copy-ignored"
-install = "pnpm install"
+pre-start = [
+    {copy = "wt step copy-ignored"},
+    {install = "pnpm install"},
+]
 ```
 
 ## Dev servers
@@ -1562,13 +1579,15 @@ $ DATABASE_URL=$(wt config state vars get db_url) npm start
 Quick checks before commit, thorough validation before merge:
 
 ```toml
-[pre-commit]
-lint = "npm run lint"
-typecheck = "npm run typecheck"
+pre-commit = [
+    {lint = "npm run lint"},
+    {typecheck = "npm run typecheck"},
+]
 
-[pre-merge]
-test = "npm test"
-build = "npm run build"
+pre-merge = [
+    {test = "npm test"},
+    {build = "npm run build"},
+]
 ```
 
 ## Target-specific behavior
@@ -1599,11 +1618,24 @@ For copying dependencies and caches between worktrees, see [`wt step copy-ignore
 ## Hook type examples
 
 ```toml
-# Single command (string) — top-level, before any table headers
 post-merge = "cargo install --path ."
 
+pre-start = [
+    {install = "npm ci"},
+    {env = "echo 'PORT={{ branch | hash_port }}' > .env.local"},
+]
+
+pre-commit = [
+    {format = "cargo fmt -- --check"},
+    {lint = "cargo clippy -- -D warnings"},
+]
+
+pre-merge = [
+    {test = "cargo test"},
+    {build = "cargo build --release"},
+]
+
 [pre-switch]
-# Pull if last fetch was more than 6 hours ago
 pull = """
 FETCH_HEAD="$(git rev-parse --git-common-dir)/FETCH_HEAD"
 if [ "$(find "$FETCH_HEAD" -mmin +360 2>/dev/null)" ] || [ ! -f "$FETCH_HEAD" ]; then
@@ -1614,24 +1646,12 @@ fi
 [post-switch]
 tmux = "[ -n \"$TMUX\" ] && tmux rename-window {{ branch | sanitize }}"
 
-[pre-start]
-install = "npm ci"
-env = "echo 'PORT={{ branch | hash_port }}' > .env.local"
-
 [post-start]
 copy = "wt step copy-ignored"
 server = "npm run dev -- --port {{ branch | hash_port }}"
 
-[pre-commit]
-format = "cargo fmt -- --check"
-lint = "cargo clippy -- -D warnings"
-
 [post-commit]
 notify = "curl -s https://ci.example.com/trigger?branch={{ branch }}"
-
-[pre-merge]
-test = "cargo test"
-build = "cargo build --release"
 
 [pre-remove]
 archive = "tar -czf ~/.wt-logs/{{ branch }}.tar.gz test-results/ logs/ 2>/dev/null || true"
@@ -2004,29 +2024,6 @@ squash-template = """
 ## Hooks
 
 See [`wt hook`](@/hook.md) for hook types, execution order, template variables, and examples. User hooks apply to all projects; [project hooks](@/config.md#project-configuration) apply only to that repository.
-
-Single command:
-
-```toml
-pre-start = "npm ci"
-```
-
-Multiple named commands — concurrent for post-*, sequential for pre-*:
-
-```toml
-[pre-merge]
-test = "npm test"
-build = "npm run build"
-```
-
-Pipeline — list of maps, run in order (each map concurrent):
-
-```toml
-post-start = [
-    { install = "npm ci" },
-    { build = "npm run build", server = "npm run dev" }
-]
-```
 <!-- USER_CONFIG_END -->
 <!-- PROJECT_CONFIG_START -->
 # Project Configuration

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -246,6 +246,8 @@ pub struct Deprecations {
     pub no_ff: bool,
     /// Has `no-cd` in `[switch]` section (use `cd` instead)
     pub no_cd: bool,
+    /// Pre-* hooks using multi-entry table form (will become concurrent in a future version)
+    pub pre_hook_table_form: Vec<String>,
 }
 
 impl Deprecations {
@@ -259,6 +261,7 @@ impl Deprecations {
             && !self.ci_section
             && !self.no_ff
             && !self.no_cd
+            && self.pre_hook_table_form.is_empty()
     }
 }
 
@@ -291,6 +294,7 @@ fn detect_deprecations_from_doc(
         ci_section: find_ci_section_from_doc(doc),
         no_ff: find_negated_bool_from_doc(doc, "merge", "no-ff", "ff"),
         no_cd: find_negated_bool_from_doc(doc, "switch", "no-cd", "cd"),
+        pre_hook_table_form: find_pre_hook_table_form_from_doc(doc),
     }
 }
 
@@ -696,6 +700,58 @@ fn migrate_select_table(table: &mut toml_edit::Table, modified: &mut bool) {
     *modified = true;
 }
 
+/// The 5 canonical pre-* hook keys.
+const PRE_HOOK_KEYS: &[&str] = &[
+    "pre-switch",
+    "pre-start",
+    "pre-commit",
+    "pre-merge",
+    "pre-remove",
+];
+
+/// Check if a table has a multi-entry pre-* hook (table form with 2+ named commands).
+fn collect_pre_hook_table_form_keys(
+    table: &toml_edit::Table,
+    prefix: &str,
+    found: &mut Vec<String>,
+) {
+    for &key in PRE_HOOK_KEYS {
+        if let Some(item) = table.get(key)
+            && item.as_table().is_some_and(|t| t.len() >= 2)
+        {
+            if prefix.is_empty() {
+                found.push(key.to_string());
+            } else {
+                found.push(format!("{prefix}.{key}"));
+            }
+        }
+    }
+}
+
+/// Find pre-* hooks using multi-entry table form.
+///
+/// Hooks are flattened into the top level of user config, project config, and
+/// each `[projects."id"]` subtree. Returns display paths for each deprecated
+/// hook found.
+fn find_pre_hook_table_form_from_doc(doc: &toml_edit::DocumentMut) -> Vec<String> {
+    let mut found = Vec::new();
+
+    // Top-level (user config or project config)
+    collect_pre_hook_table_form_keys(doc.as_table(), "", &mut found);
+
+    // Per-project overrides (user config)
+    if let Some(projects) = doc.get("projects").and_then(|p| p.as_table()) {
+        for (project_key, project_value) in projects.iter() {
+            if let Some(project_table) = project_value.as_table() {
+                let prefix = format!("projects.\"{project_key}\"");
+                collect_pre_hook_table_form_keys(project_table, &prefix, &mut found);
+            }
+        }
+    }
+
+    found
+}
+
 fn find_ci_section_from_doc(doc: &toml_edit::DocumentMut) -> bool {
     // Skip if [forge] already exists
     if doc
@@ -838,6 +894,69 @@ fn migrate_negated_bool_doc(
     modified
 }
 
+/// Convert a multi-entry pre-* table section into a pipeline array within a table.
+///
+/// Removes `[key]` as a table section and inserts `key = [{name = "cmd"}, ...]`
+/// as an array of single-entry inline tables, preserving insertion order.
+fn migrate_pre_hook_table_in(table: &mut toml_edit::Table, modified: &mut bool) {
+    for &key in PRE_HOOK_KEYS {
+        let is_multi_entry_table = table
+            .get(key)
+            .and_then(|item| item.as_table())
+            .is_some_and(|t| t.len() >= 2);
+
+        if !is_multi_entry_table {
+            continue;
+        }
+
+        // Skip if any entry is non-string (malformed config — don't risk data loss)
+        let all_strings = table
+            .get(key)
+            .and_then(|item| item.as_table())
+            .is_some_and(|t| t.iter().all(|(_, v)| v.as_str().is_some()));
+
+        if !all_strings {
+            continue;
+        }
+
+        // Remove the table section and build a pipeline array
+        let old_table = table.remove(key).unwrap();
+        let entries = old_table.as_table().unwrap();
+
+        let mut arr = toml_edit::Array::new();
+        for (name, value) in entries.iter() {
+            let mut inline = toml_edit::InlineTable::new();
+            inline.insert(name, value.as_str().unwrap().into());
+            arr.push(toml_edit::Value::InlineTable(inline));
+        }
+
+        table.insert(key, toml_edit::Item::Value(toml_edit::Value::Array(arr)));
+        *modified = true;
+    }
+}
+
+/// Migrate multi-entry pre-* hook table sections to pipeline arrays.
+///
+/// Hooks are flattened into the top level of user config, project config, and
+/// each `[projects."id"]` subtree.
+fn migrate_pre_hook_table_form_doc(doc: &mut toml_edit::DocumentMut) -> bool {
+    let mut modified = false;
+
+    // Top-level (user config or project config)
+    migrate_pre_hook_table_in(doc.as_table_mut(), &mut modified);
+
+    // Per-project overrides (user config)
+    if let Some(projects) = doc.get_mut("projects").and_then(|p| p.as_table_mut()) {
+        for (_key, project_value) in projects.iter_mut() {
+            if let Some(project_table) = project_value.as_table_mut() {
+                migrate_pre_hook_table_in(project_table, &mut modified);
+            }
+        }
+    }
+
+    modified
+}
+
 /// Apply all structural TOML migrations to a parsed document.
 ///
 /// This is the single source of truth for config migration. Returns true if
@@ -851,6 +970,7 @@ fn migrate_content_doc(doc: &mut toml_edit::DocumentMut) -> bool {
     modified |= migrate_commit_generation_doc(doc);
     modified |= migrate_select_doc(doc);
     modified |= migrate_post_create_doc(doc);
+    modified |= migrate_pre_hook_table_form_doc(doc);
     modified |= migrate_ci_doc(doc);
     modified |= migrate_negated_bool_doc(doc, "merge", "no-ff", "ff");
     modified |= migrate_negated_bool_doc(doc, "switch", "no-cd", "cd");
@@ -1376,6 +1496,18 @@ pub fn format_deprecation_warnings(info: &DeprecationInfo) -> String {
             warning_message(format!(
                 "{} uses deprecated field: [switch] no-cd → cd (inverted)",
                 info.label
+            ))
+        );
+    }
+
+    if !info.deprecations.pre_hook_table_form.is_empty() {
+        let hook_list = info.deprecations.pre_hook_table_form.join(", ");
+        let _ = writeln!(
+            out,
+            "{}",
+            warning_message(format!(
+                "{} uses deprecated table form for pre-* hooks: {} → pipeline form",
+                info.label, hook_list
             ))
         );
     }
@@ -2582,6 +2714,7 @@ approved-commands = ["npm install"]
                 ci_section: false,
                 no_ff: false,
                 no_cd: false,
+                pre_hook_table_form: vec![],
             },
             label: "User config".to_string(),
             main_worktree_path: None,
@@ -2614,6 +2747,7 @@ approved-commands = ["npm install"]
                 ci_section: false,
                 no_ff: false,
                 no_cd: false,
+                pre_hook_table_form: vec![],
             },
             label: "User config".to_string(),
             main_worktree_path: None,
@@ -2647,6 +2781,7 @@ approved-commands = ["npm install"]
             ci_section: false,
             no_ff: false,
             no_cd: false,
+            pre_hook_table_form: vec![],
         };
         let result = write_migration_file(&config_path, content, &deprecations, None, &[]);
         assert!(
@@ -2909,6 +3044,7 @@ branches = true
                 ci_section: false,
                 no_ff: false,
                 no_cd: false,
+                pre_hook_table_form: vec![],
             },
             label: "User config".to_string(),
             main_worktree_path: None,
@@ -2945,6 +3081,7 @@ pager = "delta --paging=never"
             ci_section: false,
             no_ff: false,
             no_cd: false,
+            pre_hook_table_form: vec![],
         };
         let result = write_migration_file(&config_path, content, &deprecations, None, &[]);
         assert!(result.is_some(), "Should write migration file for select");
@@ -3195,6 +3332,7 @@ server = "npm run dev"
                 ci_section: false,
                 no_ff: false,
                 no_cd: false,
+                pre_hook_table_form: vec![],
             },
             label: "Project config".to_string(),
             main_worktree_path: None,
@@ -3231,6 +3369,7 @@ server = "npm run dev"
             ci_section: false,
             no_ff: false,
             no_cd: false,
+            pre_hook_table_form: vec![],
         };
         let result = write_migration_file(&config_path, content, &deprecations, None, &[]);
         assert!(
@@ -3265,6 +3404,7 @@ server = "npm run dev"
                 ci_section: false,
                 no_ff: true,
                 no_cd: true,
+                pre_hook_table_form: vec![],
             },
             label: "User config".to_string(),
             main_worktree_path: None,
@@ -3442,5 +3582,218 @@ ff = true
         unknown.insert("ci".to_string(), toml::Value::Table(toml::map::Map::new()));
         let path = std::env::temp_dir().join("test-deprecated-wrong-config-user.toml");
         warn_unknown_fields::<UserConfig>(&path, &unknown, "User config");
+    }
+
+    // ==================== pre-hook table form tests ====================
+
+    fn find_pre_hook_table_form(content: &str) -> Vec<String> {
+        content
+            .parse::<toml_edit::DocumentMut>()
+            .map(|doc| find_pre_hook_table_form_from_doc(&doc))
+            .unwrap_or_default()
+    }
+
+    fn migrate_pre_hook_table_form(content: &str) -> String {
+        let Ok(mut doc) = content.parse::<toml_edit::DocumentMut>() else {
+            return content.to_string();
+        };
+        if migrate_pre_hook_table_form_doc(&mut doc) {
+            doc.to_string()
+        } else {
+            content.to_string()
+        }
+    }
+
+    #[test]
+    fn test_detect_pre_hook_table_form() {
+        // Multi-entry table → detected
+        let found = find_pre_hook_table_form("[pre-merge]\ntest = \"t\"\nlint = \"l\"\n");
+        assert_eq!(found, vec!["pre-merge"]);
+
+        // Single-entry table → not detected
+        let found = find_pre_hook_table_form("[pre-merge]\ntest = \"t\"\n");
+        assert!(found.is_empty());
+
+        // String form → not detected
+        let found = find_pre_hook_table_form("pre-merge = \"cargo test\"\n");
+        assert!(found.is_empty());
+
+        // Array/pipeline form → not detected
+        let found = find_pre_hook_table_form("pre-merge = [{test = \"t\"}, {lint = \"l\"}]\n");
+        assert!(found.is_empty());
+
+        // Post-* hooks → not detected (table form is canonical for post-*)
+        let found = find_pre_hook_table_form("[post-merge]\ntest = \"t\"\nlint = \"l\"\n");
+        assert!(found.is_empty());
+
+        // All 5 pre-* keys detected
+        let content = r#"
+[pre-switch]
+a = "1"
+b = "2"
+
+[pre-start]
+a = "1"
+b = "2"
+
+[pre-commit]
+a = "1"
+b = "2"
+
+[pre-merge]
+a = "1"
+b = "2"
+
+[pre-remove]
+a = "1"
+b = "2"
+"#;
+        let found = find_pre_hook_table_form(content);
+        assert_eq!(
+            found,
+            vec![
+                "pre-switch",
+                "pre-start",
+                "pre-commit",
+                "pre-merge",
+                "pre-remove"
+            ]
+        );
+    }
+
+    #[test]
+    fn test_detect_pre_hook_table_form_per_project() {
+        // Per-project overrides: hooks are flattened under [projects."id"]
+        let content = r#"
+[projects."github.com/user/repo".pre-start]
+install = "npm ci"
+build = "npm run build"
+"#;
+        let found = find_pre_hook_table_form(content);
+        assert_eq!(found, vec!["projects.\"github.com/user/repo\".pre-start"]);
+    }
+
+    #[test]
+    fn test_migrate_pre_hook_table_form_converts_to_pipeline() {
+        let content = r#"
+[pre-merge]
+test = "cargo test"
+lint = "cargo clippy"
+"#;
+        let result = migrate_pre_hook_table_form(content);
+        // Should produce an array of inline tables
+        assert!(
+            !result.contains("[pre-merge]"),
+            "Table section should be removed: {result}"
+        );
+        assert!(
+            result.contains("pre-merge"),
+            "Key should still exist: {result}"
+        );
+        // Verify it parses back as valid TOML with the right structure
+        let doc: toml_edit::DocumentMut = result.parse().unwrap();
+        let arr = doc["pre-merge"].as_array().expect("should be array");
+        assert_eq!(arr.len(), 2);
+        let first = arr.get(0).unwrap().as_inline_table().unwrap();
+        assert_eq!(first.get("test").unwrap().as_str().unwrap(), "cargo test");
+        let second = arr.get(1).unwrap().as_inline_table().unwrap();
+        assert_eq!(
+            second.get("lint").unwrap().as_str().unwrap(),
+            "cargo clippy"
+        );
+    }
+
+    #[test]
+    fn test_migrate_pre_hook_table_form_preserves_order() {
+        let content = r#"
+[pre-merge]
+first = "1"
+second = "2"
+third = "3"
+"#;
+        let result = migrate_pre_hook_table_form(content);
+        let doc: toml_edit::DocumentMut = result.parse().unwrap();
+        let arr = doc["pre-merge"].as_array().unwrap();
+        let names: Vec<&str> = arr
+            .iter()
+            .map(|v| v.as_inline_table().unwrap().iter().next().unwrap().0)
+            .collect();
+        assert_eq!(names, vec!["first", "second", "third"]);
+    }
+
+    #[test]
+    fn test_migrate_pre_hook_table_form_single_entry_untouched() {
+        let content = "[pre-merge]\ntest = \"t\"\n";
+        let result = migrate_pre_hook_table_form(content);
+        assert_eq!(result, content, "Single-entry table should not be migrated");
+    }
+
+    #[test]
+    fn test_migrate_pre_hook_table_form_per_project() {
+        let content = r#"
+[projects."web".pre-start]
+install = "npm ci"
+build = "npm run build"
+"#;
+        let result = migrate_pre_hook_table_form(content);
+        let doc: toml_edit::DocumentMut = result.parse().unwrap();
+        let project = doc["projects"]["web"].as_table().unwrap();
+        let arr = project["pre-start"].as_array().expect("should be array");
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn test_migrate_pre_hook_table_form_after_post_create_rename() {
+        // post-create → pre-start rename should happen first, then table form migration
+        let content = r#"
+[post-create]
+install = "npm ci"
+build = "npm run build"
+"#;
+        let result = migrate_content(content);
+        // post-create should be renamed to pre-start AND converted to pipeline
+        assert!(
+            !result.contains("post-create"),
+            "post-create should be renamed: {result}"
+        );
+        let doc: toml_edit::DocumentMut = result.parse().unwrap();
+        let arr = doc["pre-start"]
+            .as_array()
+            .expect("should be pipeline array");
+        assert_eq!(arr.len(), 2);
+    }
+
+    #[test]
+    fn test_migrate_content_includes_pre_hook_table_form() {
+        let content = r#"
+[pre-merge]
+test = "cargo test"
+lint = "cargo clippy"
+
+[merge]
+no-ff = true
+"#;
+        let result = migrate_content(content);
+        assert!(
+            !result.contains("[pre-merge]"),
+            "Table section should be migrated: {result}"
+        );
+        assert!(
+            result.contains("ff = false"),
+            "no-ff should also migrate: {result}"
+        );
+    }
+
+    #[test]
+    fn snapshot_migrate_pre_hook_table_form() {
+        let content = r#"[pre-merge]
+test = "cargo test"
+lint = "cargo clippy"
+
+[post-start]
+server = "npm run dev"
+"#;
+        let result = migrate_pre_hook_table_form(content);
+        insta::assert_snapshot!(migration_diff(content, &result));
     }
 }

--- a/src/config/snapshots/worktrunk__config__deprecation__tests__snapshot_migrate_pre_hook_table_form.snap
+++ b/src/config/snapshots/worktrunk__config__deprecation__tests__snapshot_migrate_pre_hook_table_form.snap
@@ -1,0 +1,11 @@
+---
+source: src/config/deprecation.rs
+expression: "migration_diff(content, &result)"
+---
+-[pre-merge]
+-test = "cargo test"
+-lint = "cargo clippy"
++pre-merge = [{ test = "cargo test" }, { lint = "cargo clippy" }]
+ 
+ [post-start]
+ server = "npm run dev"

--- a/tests/integration_tests/approval_pty.rs
+++ b/tests/integration_tests/approval_pty.rs
@@ -119,10 +119,11 @@ fn test_approval_prompt_multiple_commands(repo: TestRepo) {
     repo.run_git(&["remote", "remove", "origin"]);
 
     repo.write_project_config(
-        r#"[pre-start]
-first = "echo 'First command'"
-second = "echo 'Second command'"
-third = "echo 'Third command'"
+        r#"pre-start = [
+    {first = "echo 'First command'"},
+    {second = "echo 'Second command'"},
+    {third = "echo 'Third command'"},
+]
 "#,
     );
     repo.commit("Add config");
@@ -224,10 +225,11 @@ fn test_approval_prompt_named_commands(repo: TestRepo) {
     repo.run_git(&["remote", "remove", "origin"]);
 
     repo.write_project_config(
-        r#"[pre-start]
-install = "echo 'Installing dependencies...'"
-build = "echo 'Building project...'"
-test = "echo 'Running tests...'"
+        r#"pre-start = [
+    {install = "echo 'Installing dependencies...'"},
+    {build = "echo 'Building project...'"},
+    {test = "echo 'Running tests...'"},
+]
 "#,
     );
     repo.commit("Add config");
@@ -266,10 +268,11 @@ fn test_approval_prompt_mixed_approved_unapproved_accept(repo: TestRepo) {
     repo.run_git(&["remote", "remove", "origin"]);
 
     repo.write_project_config(
-        r#"[pre-start]
-first = "echo 'First command'"
-second = "echo 'Second command'"
-third = "echo 'Third command'"
+        r#"pre-start = [
+    {first = "echo 'First command'"},
+    {second = "echo 'Second command'"},
+    {third = "echo 'Third command'"},
+]
 "#,
     );
     repo.commit("Add config");
@@ -322,10 +325,11 @@ fn test_approval_prompt_mixed_approved_unapproved_decline(repo: TestRepo) {
     repo.run_git(&["remote", "remove", "origin"]);
 
     repo.write_project_config(
-        r#"[pre-start]
-first = "echo 'First command'"
-second = "echo 'Second command'"
-third = "echo 'Third command'"
+        r#"pre-start = [
+    {first = "echo 'First command'"},
+    {second = "echo 'Second command'"},
+    {third = "echo 'Third command'"},
+]
 "#,
     );
     repo.commit("Add config");

--- a/tests/integration_tests/approval_ui.rs
+++ b/tests/integration_tests/approval_ui.rs
@@ -385,10 +385,11 @@ fn test_hook_pre_merge_target_is_current_branch(repo: TestRepo) {
 fn test_step_hook_run_named_command(repo: TestRepo) {
     // Config with multiple named commands
     repo.write_project_config(
-        r#"[pre-merge]
-test = "echo 'running test' > test.txt"
-lint = "echo 'running lint' > lint.txt"
-build = "echo 'running build' > build.txt"
+        r#"pre-merge = [
+    {test = "echo 'running test' > test.txt"},
+    {lint = "echo 'running lint' > lint.txt"},
+    {build = "echo 'running build' > build.txt"},
+]
 "#,
     );
     repo.commit("Add pre-merge hooks");
@@ -426,9 +427,10 @@ build = "echo 'running build' > build.txt"
 fn test_step_hook_unknown_name_error(repo: TestRepo) {
     // Config with multiple named commands
     repo.write_project_config(
-        r#"[pre-merge]
-test = "echo 'test'"
-lint = "echo 'lint'"
+        r#"pre-merge = [
+    {test = "echo 'test'"},
+    {lint = "echo 'lint'"},
+]
 "#,
     );
     repo.commit("Add pre-merge hooks");
@@ -510,9 +512,10 @@ test = "echo 'Running project test'"
 #[rstest]
 fn test_project_prefix_all_requires_approval(repo: TestRepo) {
     repo.write_project_config(
-        r#"[pre-merge]
-test = "echo 'Running project test'"
-lint = "echo 'Running project lint'"
+        r#"pre-merge = [
+    {test = "echo 'Running project test'"},
+    {lint = "echo 'Running project lint'"},
+]
 "#,
     );
     repo.commit("Add pre-merge hooks");
@@ -546,10 +549,11 @@ test = "echo 'user test'"
 fn test_step_hook_run_all_commands(repo: TestRepo) {
     // Config with multiple named commands
     repo.write_project_config(
-        r#"[pre-merge]
-first = "echo 'first' >> output.txt"
-second = "echo 'second' >> output.txt"
-third = "echo 'third' >> output.txt"
+        r#"pre-merge = [
+    {first = "echo 'first' >> output.txt"},
+    {second = "echo 'second' >> output.txt"},
+    {third = "echo 'third' >> output.txt"},
+]
 "#,
     );
     repo.commit("Add pre-merge hooks");

--- a/tests/integration_tests/completion.rs
+++ b/tests/integration_tests/completion.rs
@@ -839,10 +839,11 @@ fn test_hook_command_completion_cross_shell_filtering_contract(repo: TestRepo) {
     // Set up a project config with named pre-merge commands
     repo.write_project_config(
         r#"
-[pre-merge]
-test = "cargo test"
-lint = "cargo clippy"
-build = "cargo build"
+pre-merge = [
+    {test = "cargo test"},
+    {lint = "cargo clippy"},
+    {build = "cargo build"},
+]
 "#,
     );
 

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -2962,6 +2962,45 @@ post-create = "ln -sf {{ repo_root }}/node_modules {{ worktree }}/node_modules"
     );
 }
 
+/// `wt config show` displays deprecation details for pre-* hooks in table form.
+/// Uses project config with two multi-entry pre-* tables to cover the
+/// "Project config" label and the multi-hook list form of the warning.
+#[rstest]
+fn test_config_show_displays_pre_hook_table_form_deprecation(
+    mut repo: TestRepo,
+    temp_home: TempDir,
+) {
+    repo.setup_mock_ci_tools_unauthenticated();
+
+    let project_config_dir = repo.root_path().join(".config");
+    fs::create_dir_all(&project_config_dir).unwrap();
+    let project_config_path = project_config_dir.join("wt.toml");
+    fs::write(
+        &project_config_path,
+        r#"[pre-merge]
+test = "cargo test"
+lint = "cargo clippy"
+
+[pre-start]
+install = "npm ci"
+env = "cp .env.example .env"
+"#,
+    )
+    .unwrap();
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        repo.configure_mock_commands(&mut cmd);
+        cmd.arg("config").arg("show").current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+        set_xdg_config_path(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
 /// `wt config update --yes` applies commit-generation section rename
 #[rstest]
 fn test_config_update_applies_commit_generation_migration(repo: TestRepo) {

--- a/tests/integration_tests/hook_show.rs
+++ b/tests/integration_tests/hook_show.rs
@@ -26,12 +26,13 @@ user-lint = "pre-commit run --all-files"
 
     // Create project config with hooks
     repo.write_project_config(
-        r#"[post-start]
-deps = "npm install"
+        r#"pre-merge = [
+    {build = "cargo build"},
+    {test = "cargo test"},
+]
 
-[pre-merge]
-build = "cargo build"
-test = "cargo test"
+[post-start]
+deps = "npm install"
 "#,
     );
     repo.commit("Add project config");
@@ -82,12 +83,13 @@ fn setup_all_hook_types(repo: &TestRepo, temp_home: &TempDir) {
     .unwrap();
 
     repo.write_project_config(
-        r#"[post-start]
-deps = "npm install"
+        r#"pre-merge = [
+    {build = "cargo build"},
+    {test = "cargo test"},
+]
 
-[pre-merge]
-build = "cargo build"
-test = "cargo test"
+[post-start]
+deps = "npm install"
 
 [post-merge]
 deploy = "scripts/deploy.sh"
@@ -208,9 +210,10 @@ approved-commands = ["cargo build"]
 
     // Create project config with approved and unapproved hooks
     repo.write_project_config(
-        r#"[pre-merge]
-build = "cargo build"
-test = "cargo test"
+        r#"pre-merge = [
+    {build = "cargo build"},
+    {test = "cargo test"},
+]
 "#,
     );
     repo.commit("Add project config");

--- a/tests/integration_tests/merge.rs
+++ b/tests/integration_tests/merge.rs
@@ -625,10 +625,11 @@ fn test_merge_pre_merge_command_named(mut repo: TestRepo) {
     fs::write(
         config_dir.join("wt.toml"),
         r#"
-[pre-merge]
-format = "exit 0"
-lint = "exit 0"
-test = "exit 0"
+pre-merge = [
+    {format = "exit 0"},
+    {lint = "exit 0"},
+    {test = "exit 0"},
+]
 "#,
     )
     .unwrap();
@@ -1104,9 +1105,10 @@ fn test_readme_example_complex(mut repo: TestRepo) {
     create_mock_llm_auth(&bin_dir);
 
     let config_content = r#"
-[pre-merge]
-"test" = "cargo test"
-"lint" = "cargo clippy"
+pre-merge = [
+    {"test" = "cargo test"},
+    {"lint" = "cargo clippy"},
+]
 
 [post-merge]
 "install" = "cargo install --path ."

--- a/tests/integration_tests/remove.rs
+++ b/tests/integration_tests/remove.rs
@@ -1558,10 +1558,11 @@ approved-commands = ["echo 'About to remove worktree'"]
 fn test_pre_remove_hook_template_variables(mut repo: TestRepo) {
     // Create project config with template variables
     repo.write_project_config(
-        r#"[pre-remove]
-branch = "echo 'Branch: {{ branch }}'"
-worktree = "echo 'Worktree: {{ worktree_path }}'"
-worktree_name = "echo 'Name: {{ worktree_name }}'"
+        r#"pre-remove = [
+    {branch = "echo 'Branch: {{ branch }}'"},
+    {worktree = "echo 'Worktree: {{ worktree_path }}'"},
+    {worktree_name = "echo 'Name: {{ worktree_name }}'"},
+]
 "#,
     );
     repo.commit("Add config with templates");

--- a/tests/integration_tests/shell_wrapper.rs
+++ b/tests/integration_tests/shell_wrapper.rs
@@ -1041,9 +1041,10 @@ mod unix_tests {
         fs::write(
             config_dir.join("wt.toml"),
             r#"# Blocking commands that run before worktree is ready
-[pre-start]
-install = "echo 'Installing dependencies...'"
-build = "echo 'Building project...'"
+pre-start = [
+    {install = "echo 'Installing dependencies...'"},
+    {build = "echo 'Building project...'"},
+]
 
 # Background commands that run in parallel
 [post-start]
@@ -1091,10 +1092,11 @@ approved-commands = [
         fs::create_dir_all(&config_dir).unwrap();
         fs::write(
             config_dir.join("wt.toml"),
-            r#"[pre-merge]
-format = "echo '✓ Code formatting check passed'"
-lint = "echo '✓ Linting passed - no warnings'"
-test = "echo '✓ All 47 tests passed in 2.3s'"
+            r#"pre-merge = [
+    {format = "echo '✓ Code formatting check passed'"},
+    {lint = "echo '✓ Linting passed - no warnings'"},
+    {test = "echo '✓ All 47 tests passed in 2.3s'"},
+]
 "#,
         )
         .unwrap();
@@ -1144,9 +1146,10 @@ approved-commands = [
         fs::create_dir_all(&config_dir).unwrap();
         fs::write(
             config_dir.join("wt.toml"),
-            r#"[pre-merge]
-format = "echo '✓ Code formatting check passed'"
-test = "echo '✗ Test suite failed: 3 tests failing' && exit 1"
+            r#"pre-merge = [
+    {format = "echo '✓ Code formatting check passed'"},
+    {test = "echo '✗ Test suite failed: 3 tests failing' && exit 1"},
+]
 "#,
         )
         .unwrap();
@@ -1219,9 +1222,10 @@ approved-commands = [
         fs::create_dir_all(&config_dir).unwrap();
         fs::write(
             config_dir.join("wt.toml"),
-            r#"[pre-merge]
-check1 = "./mixed-output.sh check1 3"
-check2 = "./mixed-output.sh check2 3"
+            r#"pre-merge = [
+    {check1 = "./mixed-output.sh check1 3"},
+    {check2 = "./mixed-output.sh check2 3"},
+]
 "#,
         )
         .unwrap();
@@ -2384,9 +2388,10 @@ fi
         }
 
         let config_content = r#"
-[pre-merge]
-"test" = "uv run pytest"
-"lint" = "uv run ruff check"
+pre-merge = [
+    {"test" = "uv run pytest"},
+    {"lint" = "uv run ruff check"},
+]
 "#;
 
         fs::write(config_dir.join("wt.toml"), config_content).unwrap();
@@ -2609,10 +2614,11 @@ fi
 
         // Create project config with named pre-start commands
         repo.write_project_config(
-            r#"[pre-start]
-install = "echo 'Installing dependencies...'"
-build = "echo 'Building project...'"
-test = "echo 'Running tests...'"
+            r#"pre-start = [
+    {install = "echo 'Installing dependencies...'"},
+    {build = "echo 'Building project...'"},
+    {test = "echo 'Running tests...'"},
+]
 "#,
         );
         repo.commit("Add config");

--- a/tests/integration_tests/user_hooks.rs
+++ b/tests/integration_tests/user_hooks.rs
@@ -1506,9 +1506,10 @@ fn test_hook_dry_run_does_not_execute(repo: TestRepo) {
 #[rstest]
 fn test_hook_dry_run_named_hooks(repo: TestRepo) {
     repo.write_project_config(
-        r#"[pre-merge]
-lint = "pre-commit run --all-files"
-test = "cargo test"
+        r#"pre-merge = [
+    {lint = "pre-commit run --all-files"},
+    {test = "cargo test"},
+]
 "#,
     );
 
@@ -1755,10 +1756,11 @@ first = "echo 'FIRST'"
 fn test_hook_multiple_name_filters(repo: TestRepo) {
     // Write project config with three named hooks
     repo.write_project_config(
-        r#"[pre-merge]
-first = "echo FIRST"
-second = "echo SECOND"
-third = "echo THIRD"
+        r#"pre-merge = [
+    {first = "echo FIRST"},
+    {second = "echo SECOND"},
+    {third = "echo THIRD"},
+]
 "#,
     );
 

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_pre_hook_table_form_deprecation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_pre_hook_table_form_deprecation.snap
@@ -1,0 +1,89 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - show
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
+[2m↳[22m [2mNot found; to create one, run [4mwt config create[24m[22m
+
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
+[33m▲[39m [33mProject config uses deprecated table form for pre-* hooks: pre-start, pre-merge → pipeline form[39m
+[2m↳[22m [2mTo apply:[22m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config update
+[107m [0m [1mdiff --git a_REPO_/.config/wt.toml b_REPO_/.config/wt.toml.new[m
+[107m [0m [1mindex 3a61835..0ab06b7 100644[m
+[107m [0m [1m--- a_REPO_/.config/wt.toml[m
+[107m [0m [1m+++ b_REPO_/.config/wt.toml.new[m
+[107m [0m [36m@@ -1,7 +1,2 @@[m
+[107m [0m [31m-[pre-merge][m
+[107m [0m [31m-test = "cargo test"[m
+[107m [0m [31m-lint = "cargo clippy"[m
+[107m [0m [31m-[m
+[107m [0m [31m-[pre-start][m
+[107m [0m [31m-install = "npm ci"[m
+[107m [0m [31m-env = "cp .env.example .env"[m
+[107m [0m [32m+[m[32mpre-start = [{ install = "npm ci" }, { env = "cp .env.example .env" }][m
+[107m [0m [32m+[m[32mpre-merge = [{ test = "cargo test" }, { lint = "cargo clippy" }][m
+[2m○[22m Current config:
+[107m [0m [2m[36m[pre-merge]
+[107m [0m [2mtest = [0m[2m[32m"cargo test"
+[107m [0m [2mlint = [0m[2m[32m"cargo clippy"
+[107m [0m 
+[107m [0m [2m[36m[pre-start]
+[107m [0m [2minstall = [0m[2m[32m"npm ci"
+[107m [0m [2menv = [0m[2m[32m"cp .env.example .env"
+
+[36mSHELL INTEGRATION[39m
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+
+[2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
+[2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
+[2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
+[2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
+
+[36mOTHER[39m
+[2m○[22m wt: [1m[VERSION][22m
+[2m○[22m git: [1m[VERSION][22m
+[2m○[22m Hyperlinks: [1minactive[22m

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -307,23 +307,6 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# ## Hooks[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# See `wt hook` (https://worktrunk.dev/hook/) for hook types, execution order, template variables, and examples. User hooks apply to all projects; project hooks (https://worktrunk.dev/config/#project-configuration) apply only to that repository.[0m
-[107m [0m [2m#[0m
-[107m [0m [2m# Single command:[0m
-[107m [0m [2m#[0m
-[107m [0m [2m# pre-start = "npm ci"[0m
-[107m [0m [2m#[0m
-[107m [0m [2m# Multiple named commands — concurrent for post-*, sequential for pre-*:[0m
-[107m [0m [2m#[0m
-[107m [0m [2m# [pre-merge][0m
-[107m [0m [2m# test = "npm test"[0m
-[107m [0m [2m# build = "npm run build"[0m
-[107m [0m [2m#[0m
-[107m [0m [2m# Pipeline — list of maps, run in order (each map concurrent):[0m
-[107m [0m [2m#[0m
-[107m [0m [2m# post-start = [[0m
-[107m [0m [2m#     { install = "npm ci" },[0m
-[107m [0m [2m#     { build = "npm run build", server = "npm run dev" }[0m
-[107m [0m [2m# ][0m
 
 [1m[32mProject config[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -8,7 +8,7 @@ info:
   env:
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
-    GIT_PAGER: ""
+    GIT_EDITOR: ""
     LANG: C
     LC_ALL: C
     NO_COLOR: ""
@@ -349,23 +349,6 @@ Default template:
 [1m[32mHooks[0m
 
 See [2mwt hook[0m for hook types, execution order, template variables, and examples. User hooks apply to all projects; project hooks apply only to that repository.
-
-Single command:
-
-[107m [0m [2mpre-start = [0m[2m[32m"npm ci"[0m
-
-Multiple named commands — concurrent for post-*, sequential for pre-*:
-
-[107m [0m [2m[36m[pre-merge][0m
-[107m [0m [2mtest = [0m[2m[32m"npm test"[0m
-[107m [0m [2mbuild = [0m[2m[32m"npm run build"[0m
-
-Pipeline — list of maps, run in order (each map concurrent):
-
-[107m [0m [2mpost-start = [[0m
-[107m [0m [2m    { install = [0m[2m[32m"npm ci"[0m[2m },[0m
-[107m [0m [2m    { build = [0m[2m[32m"npm run build"[0m[2m, server = [0m[2m[32m"npm run dev"[0m[2m }[0m
-[107m [0m [2m][0m
 [32mPROJECT CONFIGURATION[0m
 
 Project configuration lets teams share repository-specific settings — hooks, dev server URLs, and other defaults. The file lives in [2m.config/wt.toml[0m and is typically checked into version control.

--- a/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
@@ -162,9 +162,10 @@ Historically, ensuring tests ran before merging was difficult to enforce locally
 The full workflow: start an agent (one of many) on a task, work elsewhere, return when it's ready. Review the diff, run `wt merge`, move on. Pre-merge hooks validate before merging — if they pass, the branch goes to the default branch and the worktree cleans up.
 
 ```toml
-[pre-merge]
-test = "cargo test"
-lint = "cargo clippy"
+pre-merge = [
+    {test = "cargo test"},
+    {lint = "cargo clippy"},
+]
 ```
 
 ## See also

--- a/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
@@ -150,9 +150,10 @@ Historically, ensuring tests ran before merging was difficult to enforce locally
 
 The full workflow: start an agent (one of many) on a task, work elsewhere, return when it's ready. Review the diff, run [2mwt merge[0m, move on. Pre-merge hooks validate before merging — if they pass, the branch goes to the default branch and the worktree cleans up.
 
-[107m [0m [2m[36m[pre-merge][0m
-[107m [0m [2mtest = [0m[2m[32m"cargo test"[0m
-[107m [0m [2mlint = [0m[2m[32m"cargo clippy"[0m
+[107m [0m [2mpre-merge = [[0m
+[107m [0m [2m    {test = [0m[2m[32m"cargo test"[0m[2m},[0m
+[107m [0m [2m    {lint = [0m[2m[32m"cargo clippy"[0m[2m},[0m
+[107m [0m [2m][0m
 
 [1m[32mSee also[0m
 


### PR DESCRIPTION
## Summary

Multi-entry table form for pre-* hooks currently runs serially, while the same form for post-* hooks runs concurrently. The parser produces `HookStep::Concurrent` either way, but the foreground executor flattens steps and runs them serially. To unify the semantics — table form will run concurrently for all hook types in a future version — this deprecates the current form for pre-* hooks and auto-migrates it to pipeline form, which is explicitly serial.

## Implementation

Follows the existing deprecation recipe in `src/config/deprecation.rs`:
- **Detection** and **migration** for top-level hooks (user/project config) and per-project overrides (`[projects."id".pre-*]`).
- **Warning**: matches the terse `{old} → {new}` pattern of existing deprecations (`[merge] no-ff → ff`, `post-create → pre-start`, etc.).
- **Auto-migration** at load time: table form rewrites to pipeline of inline tables so current behavior (serial) is preserved until users run `wt config update`.

## Docs

Replaces the transitional "concurrent for post-*, sequential for pre-*" framing with a neutral three-form description (string / table / pipeline), plus a note recommending pipeline form for pre-* hooks to avoid the upcoming behavior change.

## Tests

- `snapshot_migrate_pre_hook_table_form` — TOML migration diff
- `test_config_show_displays_pre_hook_table_form_deprecation` — full user-facing `wt config show` output, covering the "Project config" label and multi-hook list form
- Unit tests for detection/migration of top-level and per-project variants
- Existing integration test fixtures migrated to canonical pipeline form

> _This was written by Claude Code on behalf of max-sixty_