### PR TITLE
Pipe git diff-tree → patch-id directly in squash detection

### DIFF
--- a/src/git/repository/integration.rs
+++ b/src/git/repository/integration.rs
@@ -3,7 +3,7 @@
 //! Methods for determining if a branch has been integrated into the target
 //! (same commit, ancestor, trees match, etc.).
 
-use anyhow::Context;
+use anyhow::{Context, bail};
 use dashmap::mapref::entry::Entry;
 use serde::{Deserialize, Serialize};
 
@@ -304,38 +304,54 @@ impl Repository {
         };
 
         // Compute the squashed patch-id (combined diff of all branch changes).
-        let branch_diff = self.run_command(&["diff-tree", "-p", &merge_base, branch])?;
-        let branch_output = self.compute_patch_ids(&branch_diff)?;
-        let Some(branch_pid) = branch_output.split_whitespace().next() else {
+        let branch_pids = self.patch_ids_from(&["diff-tree", "-p", &merge_base, branch])?;
+        let Some(branch_pid) = branch_pids.split_whitespace().next() else {
             return Ok(false);
         };
 
         // Get all target commits' patch-ids in one pass.
-        // `git log -p` pipes all patches through `git patch-id --verbatim`.
-        let target_log =
-            self.run_command(&["log", "-p", "--reverse", &format!("{merge_base}..{target}")])?;
-
-        let target_pids = self.compute_patch_ids(&target_log)?;
+        let target_pids =
+            self.patch_ids_from(&["log", "-p", "--reverse", &format!("{merge_base}..{target}")])?;
 
         Ok(target_pids
             .lines()
             .any(|line| line.split_whitespace().next() == Some(branch_pid)))
     }
 
-    /// Pipe diff content through `git patch-id --verbatim` and return the output.
+    /// Pipe the output of `git <args>` directly into `git patch-id --verbatim`
+    /// and return the patch-id output.
     ///
-    /// Uses `--verbatim` (not `--stable`) to avoid false positives from whitespace
-    /// normalization — `--stable` strips whitespace, so tabs-vs-spaces would produce
-    /// matching patch-ids even though the content differs.
-    fn compute_patch_ids(&self, diff: &str) -> anyhow::Result<String> {
-        let output = Cmd::new("git")
+    /// The intermediate diff never passes through this process — it flows from
+    /// one git child to the other via an OS pipe. Keeps raw diffs out of our
+    /// `-vv` debug stream (where `log_output` would otherwise dump every line
+    /// of `git diff-tree -p` / `git log -p`).
+    ///
+    /// Uses `--verbatim` (not `--stable`) to avoid false positives from
+    /// whitespace normalization — `--stable` strips whitespace, so
+    /// tabs-vs-spaces would produce matching patch-ids even though the content
+    /// differs.
+    fn patch_ids_from(&self, args: &[&str]) -> anyhow::Result<String> {
+        let source = Cmd::new("git")
+            .args(args.iter().copied())
+            .current_dir(&self.discovery_path)
+            .context(self.logging_context());
+        let sink = Cmd::new("git")
             .args(["patch-id", "--verbatim"])
             .current_dir(&self.discovery_path)
-            .context(self.logging_context())
-            .stdin_bytes(diff.to_owned())
-            .run()
+            .context(self.logging_context());
+        let (source_output, sink_output) = source
+            .pipe_into(sink)
             .context("Failed to compute patch-id")?;
-        Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+        // A failed source (bad ref, I/O error) truncates the stream fed to
+        // patch-id, which would then emit a bogus non-empty patch-id.
+        if !source_output.status.success() {
+            bail!(
+                "git {} failed: {}",
+                args.join(" "),
+                String::from_utf8_lossy(&source_output.stderr).trim()
+            );
+        }
+        Ok(String::from_utf8_lossy(&sink_output.stdout).into_owned())
     }
 
     /// Combined merge-tree + patch-id integration probe.

--- a/src/shell_exec.rs
+++ b/src/shell_exec.rs
@@ -385,6 +385,59 @@ fn log_output(output: &std::process::Output) {
     }
 }
 
+/// Emit a `[wt-trace]` line plus stdout/stderr for a finished command.
+fn log_command_result(
+    context: Option<&str>,
+    cmd_str: &str,
+    ts: u64,
+    tid: u64,
+    dur_us: u64,
+    result: &std::io::Result<std::process::Output>,
+) {
+    match (result, context) {
+        (Ok(output), Some(ctx)) => {
+            log::debug!(
+                r#"[wt-trace] ts={} tid={} context={} cmd="{}" dur_us={} ok={}"#,
+                ts,
+                tid,
+                ctx,
+                cmd_str,
+                dur_us,
+                output.status.success()
+            );
+            log_output(output);
+        }
+        (Ok(output), None) => {
+            log::debug!(
+                r#"[wt-trace] ts={} tid={} cmd="{}" dur_us={} ok={}"#,
+                ts,
+                tid,
+                cmd_str,
+                dur_us,
+                output.status.success()
+            );
+            log_output(output);
+        }
+        (Err(e), Some(ctx)) => log::debug!(
+            r#"[wt-trace] ts={} tid={} context={} cmd="{}" dur_us={} err="{}""#,
+            ts,
+            tid,
+            ctx,
+            cmd_str,
+            dur_us,
+            e
+        ),
+        (Err(e), None) => log::debug!(
+            r#"[wt-trace] ts={} tid={} cmd="{}" dur_us={} err="{}""#,
+            ts,
+            tid,
+            cmd_str,
+            dur_us,
+            e
+        ),
+    }
+}
+
 /// Implementation of timeout-based command execution.
 ///
 /// Spawns reader threads to drain stdout/stderr concurrently (preventing deadlock when
@@ -826,57 +879,163 @@ impl Cmd {
 
         // Log trace
         let dur_us = t0.elapsed().as_micros() as u64;
-        match (&result, &self.context) {
-            (Ok(output), Some(ctx)) => {
-                log::debug!(
-                    "[wt-trace] ts={} tid={} context={} cmd=\"{}\" dur_us={} ok={}",
-                    ts,
-                    tid,
-                    ctx,
-                    cmd_str,
-                    dur_us,
-                    output.status.success()
-                );
-                log_output(output);
-            }
-            (Ok(output), None) => {
-                log::debug!(
-                    "[wt-trace] ts={} tid={} cmd=\"{}\" dur_us={} ok={}",
-                    ts,
-                    tid,
-                    cmd_str,
-                    dur_us,
-                    output.status.success()
-                );
-                log_output(output);
-            }
-            (Err(e), Some(ctx)) => {
-                log::debug!(
-                    "[wt-trace] ts={} tid={} context={} cmd=\"{}\" dur_us={} err=\"{}\"",
-                    ts,
-                    tid,
-                    ctx,
-                    cmd_str,
-                    dur_us,
-                    e
-                );
-            }
-            (Err(e), None) => {
-                log::debug!(
-                    "[wt-trace] ts={} tid={} cmd=\"{}\" dur_us={} err=\"{}\"",
-                    ts,
-                    tid,
-                    cmd_str,
-                    dur_us,
-                    e
-                );
-            }
-        }
+        log_command_result(self.context.as_deref(), &cmd_str, ts, tid, dur_us, &result);
 
         let exit_code = result.as_ref().ok().and_then(|output| output.status.code());
         external_log.record(exit_code);
 
         result
+    }
+
+    /// Run `self` with its stdout piped directly into `next`'s stdin, and
+    /// return both children's captured output.
+    ///
+    /// The intermediate data (`self`'s stdout) flows between the two child
+    /// processes via an OS pipe — it never lands in our process memory or
+    /// debug logs. This keeps large intermediate outputs (for example
+    /// `git diff-tree -p | git patch-id`) out of the `-vv` trace stream, where
+    /// `log_output` would otherwise dump every line of the raw diff.
+    ///
+    /// Each command is logged and traced individually (same format as
+    /// `.run()`), so `-vv` still shows both commands and their exit status.
+    /// The returned tuple is `(source_output, sink_output)` — callers can
+    /// inspect either child's exit status and stderr. `source_output.stdout`
+    /// is empty (it was routed to the sink via OS pipe).
+    ///
+    /// Timeouts, `stdin_bytes`, and `external()` logging are not supported on
+    /// either side. The pipeline consumes one semaphore permit even though it
+    /// runs two processes concurrently — acquiring two would deadlock under
+    /// `concurrency = 1`.
+    pub fn pipe_into(
+        self,
+        next: Cmd,
+    ) -> std::io::Result<(std::process::Output, std::process::Output)> {
+        assert!(
+            !self.shell_wrap && !next.shell_wrap,
+            "Cmd::shell() commands cannot be used with pipe_into"
+        );
+        assert!(
+            self.stdin_data.is_none(),
+            "pipe_into source cannot also use stdin_bytes"
+        );
+        assert!(
+            next.stdin_data.is_none(),
+            "pipe_into sink cannot use stdin_bytes (stdin comes from source)"
+        );
+        assert!(
+            self.timeout.is_none() && next.timeout.is_none(),
+            "pipe_into does not support timeouts"
+        );
+        assert!(
+            self.external_label.is_none() && next.external_label.is_none(),
+            "pipe_into does not support external() logging"
+        );
+        debug_assert!(
+            self.directive_cd_file.is_none()
+                && self.directive_legacy_file.is_none()
+                && next.directive_cd_file.is_none()
+                && next.directive_legacy_file.is_none(),
+            "directive_*_file is only applied by .stream(), not pipe_into"
+        );
+
+        let first_cmd_str = self.command_string();
+        let second_cmd_str = next.command_string();
+        self.log_run_start(&first_cmd_str);
+        next.log_run_start(&second_cmd_str);
+
+        let _guard = semaphore().acquire();
+
+        let t0 = Instant::now();
+        let ts = t0.duration_since(*trace_epoch()).as_micros() as u64;
+        let tid = thread_id_number();
+
+        let mut first = self.direct_command();
+        self.apply_common_settings(&mut first);
+        first
+            .stdin(Stdio::null())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        let mut first_child = first.spawn()?;
+        let first_stdout = first_child
+            .stdout
+            .take()
+            .expect("stdout was configured as piped");
+
+        let mut second = next.direct_command();
+        next.apply_common_settings(&mut second);
+        second
+            .stdin(Stdio::from(first_stdout))
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped());
+
+        // Spawn `next` before waiting on either child so `self`'s stdout keeps
+        // flowing through the pipe (otherwise a full pipe buffer would wedge
+        // `self`). If the spawn itself fails, clean up `self` before returning.
+        let second_child = match second.spawn() {
+            Ok(child) => child,
+            Err(e) => {
+                let _ = first_child.kill();
+                let _ = first_child.wait();
+                return Err(e);
+            }
+        };
+
+        // `first`'s stderr must be drained concurrently with `second`'s
+        // execution; otherwise pathological stderr volume (~64 KiB pipe
+        // buffer) could block `first` on write, which then never closes its
+        // stdout, which wedges `second`. Scoped thread drains in parallel.
+        let mut first_stderr_pipe = first_child
+            .stderr
+            .take()
+            .expect("stderr was configured as piped");
+
+        let (first_result, second_result, first_dur_us, second_dur_us) = std::thread::scope(|s| {
+            let stderr_thread = s.spawn(move || {
+                let mut buf = Vec::new();
+                first_stderr_pipe.read_to_end(&mut buf).map(|_| buf)
+            });
+
+            // Drain `next` first (its `wait_with_output` reads its own
+            // stdout/stderr), so `first`'s writes can complete.
+            let second_result = second_child.wait_with_output();
+            let second_dur_us = t0.elapsed().as_micros() as u64;
+
+            // Reap `first`. Its stderr is already being drained; combine
+            // the captured stderr with the exit status into an Output.
+            let first_status = first_child.wait();
+            let first_stderr = stderr_thread.join().unwrap();
+            let first_dur_us = t0.elapsed().as_micros() as u64;
+
+            let first_result = first_status.and_then(|status| {
+                first_stderr.map(|stderr| std::process::Output {
+                    status,
+                    stdout: Vec::new(),
+                    stderr,
+                })
+            });
+
+            (first_result, second_result, first_dur_us, second_dur_us)
+        });
+
+        log_command_result(
+            self.context.as_deref(),
+            &first_cmd_str,
+            ts,
+            tid,
+            first_dur_us,
+            &first_result,
+        );
+        log_command_result(
+            next.context.as_deref(),
+            &second_cmd_str,
+            ts,
+            tid,
+            second_dur_us,
+            &second_result,
+        );
+
+        Ok((first_result?, second_result?))
     }
 
     /// Execute the command with streaming output (inherits stdio).


### PR DESCRIPTION
Patch-id-based squash detection used to buffer the entire `git diff-tree -p` / `git log -p` output into this process before piping it to `git patch-id` via stdin. At `-vv` verbosity, `log_output` dumped every line of that raw diff into the terminal, producing thousands of lines per probe when running `wt list -vv`.

This adds `Cmd::pipe_into(self, next)` in `src/shell_exec.rs`, which spawns both children and connects source stdout to sink stdin through an OS pipe — the raw diff never enters our process memory or logs. Both commands are still traced individually at `-vv` with per-child durations; source stderr is drained in a scoped thread to avoid pipe-buffer deadlock under pathological stderr volume. The extracted `log_command_result` helper is shared with `.run()` so both paths emit identical trace lines.

`is_squash_merged_via_patch_id` now calls the new `patch_ids_from` helper, which bails if the source exits non-zero. Without that check a failed `diff-tree` would feed `patch-id` a truncated stream, producing a bogus non-empty patch-id and silently reporting a false-negative squash match.

Verified against the full test suite plus `wt list -vv` on a fresh probe cache: 30 pipeline commands logged, 0 raw-diff lines in the output.

> _This was written by Claude Code on behalf of Maximilian Roos_