### PR TITLE
Warm full feature set + lock check in post-merge build

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -6,7 +6,7 @@ docs = "cd docs && zola serve -p {{ branch | hash_port }}"
 
 [post-merge]
 clippy = "pre-commit run clippy --all-files || true"
-build = "cargo test --no-run --all-targets"
+build = "cargo test --no-run --all-targets --locked --all-features"
 install = "cargo install --path ."
 sync = 'if [ "{{ target }}" = "main" ]; then git pull && git push; fi'
 


### PR DESCRIPTION
Adds `--locked` and `--all-features` to the post-merge `build` step.

- `--locked` guards against `Cargo.lock` drift arriving via the `sync` step's `git pull`.
- `--all-features` matches the clippy pre-commit hook (`--all-targets --all-features`), so the test-binary cache and the clippy cache share dependency compilation. In this repo `--all-features` is equivalent to `--features shell-integration-tests`, but stays correct if features are added later.

Empirically verified: `cargo fmt` produces no `target/` artifacts and `cargo check --locked` after `cargo test --no-run --all-targets` is ~0.5s in this repo, so a separate `cargo check` step wasn't worth adding — folding `--locked` into the existing build step gets the lock guard for free.

> _This was written by Claude Code on behalf of @max-sixty_