### PR TITLE
test(merge): fix race in post-merge marker assertion

### DIFF
--- a/tests/integration_tests/merge.rs
+++ b/tests/integration_tests/merge.rs
@@ -673,7 +673,7 @@ fn test_merge_post_merge_command_success(mut repo: TestRepo) {
     // Verify the command ran in the main worktree (not the feature worktree).
     // post-merge runs in the background, so poll for the file.
     let marker_file = repo.root_path().join("post-merge-ran.txt");
-    wait_for_file(&marker_file);
+    wait_for_file_content(&marker_file);
     let content = fs::read_to_string(&marker_file).unwrap();
     assert!(
         content.contains("merged feature to main"),


### PR DESCRIPTION
`wait_for_file` only checks existence. The shell creates the empty marker file before writing, so the follow-up `read_to_string` could return empty content and fail the `contains(...)` assertion. Swap to `wait_for_file_content`, which polls until the file is non-empty.

> _This was written by Claude Code on behalf of Maximilian Roos_