### PR TITLE
Drop LLM prompt logging to trace, note diff-pipe opportunity

### DIFF
--- a/src/llm.rs
+++ b/src/llm.rs
@@ -291,10 +291,19 @@ const DEFAULT_SQUASH_TEMPLATE: &str = r#"<task>Write a commit message for the co
 /// This is the canonical way to execute LLM commands in this codebase.
 /// All LLM execution should go through this function to maintain consistency.
 pub(crate) fn execute_llm_command(command: &str, prompt: &str) -> anyhow::Result<String> {
-    // Log prompt for debugging (Cmd logs the command itself)
-    log::debug!("  Prompt (stdin):");
+    // TODO(diff-pipe): Consider splitting the prompt template around
+    // `{{ git_diff }}` and piping `git diff` directly into the LLM via
+    // `Cmd::pipe_into` (preamble + epilogue through env vars). Avoids buffering
+    // MB-scale diffs in our process memory and removes them from our logs
+    // entirely. See conversation around PR #2136 for sketch.
+
+    // Log prompt for debugging (Cmd logs the command itself).
+    // One record per line so each is prefixed by env_logger's `[TS LEVEL mod]`
+    // header and stays greppable — matches the `  stdout` continuation style
+    // used in shell_exec::log_output.
+    log::trace!("  Prompt (stdin):");
     for line in prompt.lines() {
-        log::debug!("    {}", line);
+        log::trace!("    {}", line);
     }
 
     let shell = ShellConfig::get()?;


### PR DESCRIPTION
At debug level (`-vv`) `execute_llm_command` logged every line of the prompt — which embeds the full `git diff`. On any non-trivial merge this drowned real debug output. Trace (`-vvv`) is where payload-scale content belongs; debug stays about structural events.

Also adds a TODO noting we could eliminate the diff buffer entirely by splitting the prompt template around `{{ git_diff }}` and piping `git diff` → LLM through `Cmd::pipe_into` (same pattern as #2136). Not done here — it's a separate design question tangled with the broader logging spec being evaluated.

> _This was written by Claude Code on behalf of Maximilian_