### PR TITLE
docs(aliases): teach [[aliases.NAME]] pipeline blocks

### DIFF
--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -842,6 +842,23 @@ git fetch --all --prune && wt step for-each -- '
 
 {{ terminal(cmd="wt step up") }}
 
+Multi-step aliases run commands in order using `[[aliases.NAME]]` blocks. Each block is one step; multiple keys within a block run concurrently.
+
+```toml
+# .config/wt.toml
+[[aliases.release]]
+test = "cargo test"
+
+[[aliases.release]]
+build = "cargo build --release"
+package = "cargo package --no-verify"
+
+[[aliases.release]]
+publish = "cargo publish"
+```
+
+Here `test` runs first, then `build` and `package` run together, then `publish` runs last. A step failure aborts the remaining steps.
+
 When defined in both user and project config, both run — user first, then project. Project-config aliases require [command approval](@/hook.md#wt-hook-approvals) on first run, same as project hooks. User-config aliases are trusted.
 
 Inside an alias body, an inner `wt switch` (or `wt switch --create`) passes its `cd` through to the parent shell, so an alias wrapping `wt switch --create` lands the shell in the new worktree just like running it directly.

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -896,6 +896,23 @@ git fetch --all --prune && wt step for-each -- '
 $ wt step up
 ```
 
+Multi-step aliases run commands in order using `[[aliases.NAME]]` blocks. Each block is one step; multiple keys within a block run concurrently.
+
+```toml
+# .config/wt.toml
+[[aliases.release]]
+test = "cargo test"
+
+[[aliases.release]]
+build = "cargo build --release"
+package = "cargo package --no-verify"
+
+[[aliases.release]]
+publish = "cargo publish"
+```
+
+Here `test` runs first, then `build` and `package` run together, then `publish` runs last. A step failure aborts the remaining steps.
+
 When defined in both user and project config, both run — user first, then project. Project-config aliases require [command approval](https://worktrunk.dev/hook/#wt-hook-approvals) on first run, same as project hooks. User-config aliases are trusted.
 
 Inside an alias body, an inner `wt switch` (or `wt switch --create`) passes its `cd` through to the parent shell, so an alias wrapping `wt switch --create` lands the shell in the new worktree just like running it directly.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1178,6 +1178,23 @@ git fetch --all --prune && wt step for-each -- '
 $ wt step up
 ```
 
+Multi-step aliases run commands in order using `[[aliases.NAME]]` blocks. Each block is one step; multiple keys within a block run concurrently.
+
+```toml
+# .config/wt.toml
+[[aliases.release]]
+test = "cargo test"
+
+[[aliases.release]]
+build = "cargo build --release"
+package = "cargo package --no-verify"
+
+[[aliases.release]]
+publish = "cargo publish"
+```
+
+Here `test` runs first, then `build` and `package` run together, then `publish` runs last. A step failure aborts the remaining steps.
+
 When defined in both user and project config, both run — user first, then project. Project-config aliases require [command approval](@/hook.md#wt-hook-approvals) on first run, same as project hooks. User-config aliases are trusted.
 
 Inside an alias body, an inner `wt switch` (or `wt switch --create`) passes its `cd` through to the parent shell, so an alias wrapping `wt switch --create` lands the shell in the new worktree just like running it directly.

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -172,12 +172,11 @@ pub struct ProjectConfig {
 
     /// \[experimental\] Command aliases for `wt step <name>`.
     ///
-    /// Each alias maps a name to one or more command templates. All hook
-    /// template variables are available (e.g., `{{ branch }}`, `{{ worktree_path }}`).
-    ///
-    /// Uses `CommandConfig` for consistency with hooks. This means the
-    /// named-table format (`[aliases.deploy] build = "..." run = "..."`)
-    /// technically works, but the single-string format is the expected usage.
+    /// Each alias maps a name to a [`CommandConfig`] — a string for a single
+    /// command, a named table (`[aliases.NAME]`) for concurrent commands, or
+    /// `[[aliases.NAME]]` blocks for sequential pipeline steps. All hook
+    /// template variables are available (e.g., `{{ branch }}`,
+    /// `{{ worktree_path }}`).
     ///
     /// ```toml
     /// [aliases]

--- a/tests/snapshots/integration__integration_tests__help__help_step_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_long.snap
@@ -130,6 +130,21 @@ Multi-line aliases work too. This [2mup[0m alias fetches all remotes and rebas
 
 [107m [0m [2m[0m[2m[34mwt[0m[2m step up[0m
 
+Multi-step aliases run commands in order using [2m[[aliases.NAME]][0m blocks. Each block is one step; multiple keys within a block run concurrently.
+
+[107m [0m [2m# .config/wt.toml[0m
+[107m [0m [2m[36m[[aliases.release]][0m
+[107m [0m [2mtest = [0m[2m[32m"cargo test"[0m
+[107m [0m 
+[107m [0m [2m[36m[[aliases.release]][0m
+[107m [0m [2mbuild = [0m[2m[32m"cargo build --release"[0m
+[107m [0m [2mpackage = [0m[2m[32m"cargo package --no-verify"[0m
+[107m [0m 
+[107m [0m [2m[36m[[aliases.release]][0m
+[107m [0m [2mpublish = [0m[2m[32m"cargo publish"[0m
+
+Here [2mtest[0m runs first, then [2mbuild[0m and [2mpackage[0m run together, then [2mpublish[0m runs last. A step failure aborts the remaining steps.
+
 When defined in both user and project config, both run — user first, then project. Project-config aliases require command approval on first run, same as project hooks. User-config aliases are trusted.
 
 Inside an alias body, an inner [2mwt switch[0m (or [2mwt switch --create[0m) passes its [2mcd[0m through to the parent shell, so an alias wrapping [2mwt switch --create[0m lands the shell in the new worktree just like running it directly.


### PR DESCRIPTION
Aliases share the `CommandConfig` deserializer with hooks, so `[[aliases.NAME]]` blocks already deserialize into pipeline steps with zero code changes — analogous to the recent `[[hook]]` cutover in 32bc61787. Teach the block form as the canonical shape for multi-step aliases.

Changes:
- `src/cli/mod.rs` — new paragraph + `[[aliases.release]]` example in the `wt step` Aliases section, explaining sequential blocks with concurrent keys and fail-fast on step failure
- `src/config/project.rs` — rewrite the `aliases` field rustdoc to treat string / named-table / `[[aliases.NAME]]` as three first-class forms (drops the "single-string is the expected usage" framing)
- `docs/content/step.md` + `skills/worktrunk/reference/step.md` — auto-synced
- help snapshot re-accepted

No deserializer work — covered by existing `test_deserialize_pipeline_named_single` in `src/config/commands.rs`.

> _This was written by Claude Code on behalf of max-sixty_