### PR TITLE
Centralise [wt-trace] emitter and fix -vv log verbosity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -192,7 +192,7 @@ let output = Cmd::new("gh")
     .run()?;  // no context for standalone tools
 ```
 
-Never use `cmd.output()` directly. `Cmd` provides debug logging (`$ git status [worktree-name]`) and timing traces (`[wt-trace] cmd="..." dur_us=12300 ok=true`).
+Never use `cmd.output()` directly. `Cmd` provides debug logging (`$ git status [worktree-name]`) and timing traces (`[wt-trace] cmd="..." dur_us=12300 ok=true`). The `[wt-trace]` grammar is owned by `src/trace/emit.rs` — emit new trace records via that module rather than ad-hoc `log::debug!("[wt-trace] ...")` format strings.
 
 For git commands, prefer `Repository::run_command()` which wraps `Cmd` with worktree context.
 

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -492,7 +492,8 @@ Usage: <b><span class=c>wt config</span></b> <span class=c>[OPTIONS]</span> <spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 # Subcommands
@@ -549,7 +550,8 @@ Usage: <b><span class=c>wt config show</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 ## wt config state
@@ -620,7 +622,8 @@ Usage: <b><span class=c>wt config state</span></b> <span class=c>[OPTIONS]</span
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 ## wt config state default-branch
@@ -674,7 +677,8 @@ Usage: <b><span class=c>wt config state default-branch</span></b> <span class=c>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 ## wt config state logs
@@ -763,7 +767,8 @@ Usage: <b><span class=c>wt config state logs</span></b> <span class=c>[OPTIONS]<
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 ## wt config state ci-status
@@ -816,7 +821,8 @@ Usage: <b><span class=c>wt config state ci-status</span></b> <span class=c>[OPTI
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 ## wt config state marker
@@ -881,7 +887,8 @@ Usage: <b><span class=c>wt config state marker</span></b> <span class=c>[OPTIONS
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 ## wt config state vars
@@ -952,7 +959,8 @@ Usage: <b><span class=c>wt config state vars</span></b> <span class=c>[OPTIONS]<
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt config --help-page` -->

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -501,7 +501,8 @@ Usage: <b><span class=c>wt hook</span></b> <span class=c>[OPTIONS]</span> <span 
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 # Subcommands
@@ -550,7 +551,8 @@ Usage: <b><span class=c>wt hook approvals</span></b> <span class=c>[OPTIONS]</sp
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt hook --help-page` -->

--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -282,7 +282,8 @@ Usage: <b><span class=c>wt list</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt list --help-page` -->

--- a/docs/content/merge.md
+++ b/docs/content/merge.md
@@ -150,7 +150,8 @@ Usage: <b><span class=c>wt merge</span></b> <span class=c>[OPTIONS]</span> <span
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt merge --help-page` -->

--- a/docs/content/remove.md
+++ b/docs/content/remove.md
@@ -136,7 +136,8 @@ Usage: <b><span class=c>wt remove</span></b> <span class=c>[OPTIONS]</span> <spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt remove --help-page` -->

--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -75,7 +75,8 @@ Usage: <b><span class=c>wt step</span></b> <span class=c>[OPTIONS]</span> <span 
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 # Subcommands
@@ -155,7 +156,8 @@ Usage: <b><span class=c>wt step commit</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 ## wt step squash
@@ -238,7 +240,8 @@ Usage: <b><span class=c>wt step squash</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 ## wt step diff
@@ -295,7 +298,8 @@ Usage: <b><span class=c>wt step diff</span></b> <span class=c>[OPTIONS]</span> <
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 ## wt step copy-ignored
@@ -426,7 +430,8 @@ Usage: <b><span class=c>wt step copy-ignored</span></b> <span class=c>[OPTIONS]<
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 ## wt step eval
@@ -500,7 +505,8 @@ Usage: <b><span class=c>wt step eval</span></b> <span class=c>[OPTIONS]</span> <
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 ## wt step for-each
@@ -570,7 +576,8 @@ Usage: <b><span class=c>wt step for-each</span></b> <span class=c>[OPTIONS]</spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 ## wt step promote
@@ -643,7 +650,8 @@ Usage: <b><span class=c>wt step promote</span></b> <span class=c>[OPTIONS]</span
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 ## wt step prune
@@ -717,7 +725,8 @@ Usage: <b><span class=c>wt step prune</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 ## wt step relocate
@@ -806,7 +815,8 @@ Usage: <b><span class=c>wt step relocate</span></b> <span class=c>[OPTIONS]</spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 ## Aliases

--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -217,7 +217,8 @@ Usage: <b><span class=c>wt switch</span></b> <span class=c>[OPTIONS]</span> <spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt switch --help-page` -->

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -495,7 +495,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```
 
 # Subcommands
@@ -554,7 +555,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```
 
 ## wt config state
@@ -639,7 +641,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```
 
 ## wt config state default-branch
@@ -695,7 +698,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```
 
 ## wt config state logs
@@ -792,7 +796,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```
 
 ## wt config state ci-status
@@ -845,7 +850,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```
 
 ## wt config state marker
@@ -909,7 +915,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```
 
 ## wt config state vars
@@ -991,5 +998,6 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -494,7 +494,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```
 
 # Subcommands
@@ -549,5 +550,6 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -312,5 +312,6 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```

--- a/skills/worktrunk/reference/merge.md
+++ b/skills/worktrunk/reference/merge.md
@@ -140,5 +140,6 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```

--- a/skills/worktrunk/reference/remove.md
+++ b/skills/worktrunk/reference/remove.md
@@ -135,5 +135,6 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -68,7 +68,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```
 
 # Subcommands
@@ -156,7 +157,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```
 
 ## wt step squash
@@ -243,7 +245,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```
 
 ## wt step diff
@@ -310,7 +313,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```
 
 ## wt step copy-ignored
@@ -441,7 +445,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```
 
 ## wt step eval
@@ -521,7 +526,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```
 
 ## wt step for-each
@@ -599,7 +605,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```
 
 ## wt step promote
@@ -675,7 +682,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```
 
 ## wt step prune
@@ -756,7 +764,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```
 
 ## wt step relocate
@@ -853,7 +862,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```
 
 ## Aliases [experimental]

--- a/skills/worktrunk/reference/switch.md
+++ b/skills/worktrunk/reference/switch.md
@@ -208,5 +208,6 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report;
+          -vvv: trace logs)
 ```

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -246,7 +246,7 @@ pub(crate) struct Cli {
     )]
     pub config: Option<std::path::PathBuf>,
 
-    /// Verbose output (-v: hooks, templates; -vv: debug report)
+    /// Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
     #[arg(
         long,
         short = 'v',

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -291,10 +291,12 @@ const DEFAULT_SQUASH_TEMPLATE: &str = r#"<task>Write a commit message for the co
 /// This is the canonical way to execute LLM commands in this codebase.
 /// All LLM execution should go through this function to maintain consistency.
 pub(crate) fn execute_llm_command(command: &str, prompt: &str) -> anyhow::Result<String> {
-    // Log prompt for debugging (Cmd logs the command itself)
-    log::debug!("  Prompt (stdin):");
+    // Log prompt for debugging (Cmd logs the command itself). LLM prompts can
+    // be thousands of lines (full diffs), so keep them at trace — `-vv`
+    // shouldn't dump them, `-vvv` should.
+    log::trace!("  Prompt (stdin):");
     for line in prompt.lines() {
-        log::debug!("    {}", line);
+        log::trace!("    {}", line);
     }
 
     let shell = ShellConfig::get()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -957,8 +957,9 @@ fn thread_label() -> char {
 }
 
 fn init_logging(verbose_level: u8) {
-    // Configure logging based on --verbose flag or RUST_LOG env var
-    // When -vv is set, also write logs to .git/wt/logs/verbose.log
+    // Configure logging based on --verbose flag or RUST_LOG env var.
+    // Level map: -v → Info, -vv → Debug, -vvv+ → Trace. `.git/wt/logs/verbose.log`
+    // mirrors stderr once we're at Debug or finer — Info records stay on stderr.
     if verbose_level >= 2 {
         verbose_log::init();
     }
@@ -966,12 +967,23 @@ fn init_logging(verbose_level: u8) {
     // Set global verbosity level for styled verbose output
     output::set_verbosity(verbose_level);
 
-    let mut builder = if verbose_level >= 2 {
-        let mut b = env_logger::Builder::new();
-        b.filter_level(log::LevelFilter::Debug);
-        b
-    } else {
-        env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("off"))
+    let mut builder = match verbose_level {
+        0 => env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("off")),
+        1 => {
+            let mut b = env_logger::Builder::new();
+            b.filter_level(log::LevelFilter::Info);
+            b
+        }
+        2 => {
+            let mut b = env_logger::Builder::new();
+            b.filter_level(log::LevelFilter::Debug);
+            b
+        }
+        _ => {
+            let mut b = env_logger::Builder::new();
+            b.filter_level(log::LevelFilter::Trace);
+            b
+        }
     };
 
     builder

--- a/src/shell_exec.rs
+++ b/src/shell_exec.rs
@@ -351,47 +351,60 @@ const LOG_OUTPUT_MAX_BYTES: usize = 64 * 1024;
 /// subprocess bodies (diffs, prompts) don't flood the verbose stream.
 fn log_output(output: &std::process::Output) {
     if log::log_enabled!(log::Level::Trace) {
-        log_stream_full(&output.stdout, "  ");
-        log_stream_full(&output.stderr, "  ! ");
+        for line in format_stream_full(&output.stdout, "  ") {
+            log::trace!("{}", line);
+        }
+        for line in format_stream_full(&output.stderr, "  ! ") {
+            log::trace!("{}", line);
+        }
     } else if log::log_enabled!(log::Level::Debug) {
-        log_stream_bounded(&output.stdout, "  ");
-        log_stream_bounded(&output.stderr, "  ! ");
+        for line in format_stream_bounded(&output.stdout, "  ") {
+            log::debug!("{}", line);
+        }
+        for line in format_stream_bounded(&output.stderr, "  ! ") {
+            log::debug!("{}", line);
+        }
     }
 }
 
-fn log_stream_full(bytes: &[u8], prefix: &str) {
+/// Split captured bytes into prefixed lines — full output, no cap.
+fn format_stream_full(bytes: &[u8], prefix: &str) -> Vec<String> {
     if bytes.is_empty() {
-        return;
+        return Vec::new();
     }
-    for line in String::from_utf8_lossy(bytes).lines() {
-        log::trace!("{}{}", prefix, line);
-    }
+    String::from_utf8_lossy(bytes)
+        .lines()
+        .map(|line| format!("{}{}", prefix, line))
+        .collect()
 }
 
-fn log_stream_bounded(bytes: &[u8], prefix: &str) {
+/// Split captured bytes into prefixed lines with at most [`LOG_OUTPUT_MAX_LINES`]
+/// and [`LOG_OUTPUT_MAX_BYTES`] emitted; remainder replaced by a single
+/// `… (N more lines, M bytes elided — use -vvv for full output)` marker.
+fn format_stream_bounded(bytes: &[u8], prefix: &str) -> Vec<String> {
     if bytes.is_empty() {
-        return;
+        return Vec::new();
     }
     let text = String::from_utf8_lossy(bytes);
     let total_bytes = bytes.len();
 
+    let mut out = Vec::new();
     let mut bytes_emitted = 0;
     let mut lines = text.lines().enumerate();
     for (lines_emitted, line) in &mut lines {
         if lines_emitted >= LOG_OUTPUT_MAX_LINES || bytes_emitted >= LOG_OUTPUT_MAX_BYTES {
             let remaining_lines = 1 + lines.count();
             let remaining_bytes = total_bytes.saturating_sub(bytes_emitted);
-            log::debug!(
+            out.push(format!(
                 "{}… ({} more lines, {} bytes elided — use -vvv for full output)",
-                prefix,
-                remaining_lines,
-                remaining_bytes
-            );
-            return;
+                prefix, remaining_lines, remaining_bytes
+            ));
+            return out;
         }
-        log::debug!("{}{}", prefix, line);
+        out.push(format!("{}{}", prefix, line));
         bytes_emitted += line.len() + 1;
     }
+    out
 }
 
 /// Emit a `[wt-trace]` line plus stdout/stderr for a finished command.
@@ -1682,5 +1695,68 @@ mod tests {
         // Use a signal number that's not SIGINT or SIGTERM
         super::forward_signal_with_escalation(1, 999);
         // No panic = success (function returns early for unknown signals)
+    }
+
+    #[test]
+    fn test_format_stream_full_empty() {
+        assert!(format_stream_full(b"", "  ").is_empty());
+    }
+
+    #[test]
+    fn test_format_stream_full_prefixes_each_line() {
+        let lines = format_stream_full(b"alpha\nbeta\ngamma\n", "  ");
+        assert_eq!(lines, vec!["  alpha", "  beta", "  gamma"]);
+    }
+
+    #[test]
+    fn test_format_stream_full_stderr_prefix() {
+        let lines = format_stream_full(b"err1\nerr2\n", "  ! ");
+        assert_eq!(lines, vec!["  ! err1", "  ! err2"]);
+    }
+
+    #[test]
+    fn test_format_stream_bounded_empty() {
+        assert!(format_stream_bounded(b"", "  ").is_empty());
+    }
+
+    #[test]
+    fn test_format_stream_bounded_below_caps_emits_all() {
+        let lines = format_stream_bounded(b"one\ntwo\nthree\n", "  ");
+        assert_eq!(lines, vec!["  one", "  two", "  three"]);
+    }
+
+    #[test]
+    fn test_format_stream_bounded_line_cap_triggers_elision() {
+        // Build LOG_OUTPUT_MAX_LINES + 5 short lines so the line cap trips first.
+        let input: String = (0..LOG_OUTPUT_MAX_LINES + 5)
+            .map(|i| format!("line{i}\n"))
+            .collect();
+        let lines = format_stream_bounded(input.as_bytes(), "  ");
+
+        assert_eq!(lines.len(), LOG_OUTPUT_MAX_LINES + 1, "cap + 1 marker");
+        let marker = lines.last().unwrap();
+        assert!(
+            marker.starts_with("  … (5 more lines, "),
+            "marker should count the 5 lines past the cap: {marker}"
+        );
+        assert!(marker.contains("use -vvv for full output"));
+    }
+
+    #[test]
+    fn test_format_stream_bounded_byte_cap_triggers_elision() {
+        // One long line past the byte cap, then extra lines.
+        let long = "x".repeat(LOG_OUTPUT_MAX_BYTES + 100);
+        let input = format!("{long}\nafter1\nafter2\n");
+        let lines = format_stream_bounded(input.as_bytes(), "  ");
+
+        // The long first line gets emitted (bytes_emitted==0 at entry); the
+        // byte cap trips on the next iteration and the remaining 2 lines are elided.
+        assert_eq!(lines.len(), 2);
+        assert_eq!(lines[0].len(), 2 + long.len());
+        let marker = &lines[1];
+        assert!(
+            marker.starts_with("  … (2 more lines, "),
+            "marker should count after1 + after2: {marker}"
+        );
     }
 }

--- a/src/shell_exec.rs
+++ b/src/shell_exec.rs
@@ -102,16 +102,6 @@ fn inherited_git_env_overrides() -> &'static [(&'static str, OsString)] {
     })
 }
 
-/// Monotonic epoch for trace timestamps.
-///
-/// Using `Instant` instead of `SystemTime` ensures monotonic timestamps even if
-/// the system clock steps backward. All trace timestamps are relative to this epoch.
-static TRACE_EPOCH: OnceLock<Instant> = OnceLock::new();
-
-fn trace_epoch() -> &'static Instant {
-    TRACE_EPOCH.get_or_init(Instant::now)
-}
-
 /// Default concurrent external commands. Tuned to avoid hitting OS limits
 /// (file descriptors, process limits) while maintaining good parallelism.
 const DEFAULT_CONCURRENT_COMMANDS: usize = 32;
@@ -335,53 +325,72 @@ pub fn set_command_timeout(timeout: Option<Duration>) {
 
 /// Emit an instant trace event (a milestone marker with no duration).
 ///
-/// Instant events appear as vertical lines in Chrome Trace Format visualization tools
-/// (chrome://tracing, Perfetto). Use them to mark significant moments in execution:
-///
-/// ```text
-/// [wt-trace] ts=1234567890 tid=3 event="Showed skeleton"
-/// ```
-///
-/// # Example
-///
-/// ```ignore
-/// use worktrunk::shell_exec::trace_instant;
-///
-/// // Mark when the skeleton UI was displayed
-/// trace_instant("Showed skeleton");
-///
-/// // Or with more context
-/// trace_instant("Progressive render: headers complete");
-/// ```
+/// Re-exported from [`crate::trace::emit::instant`] for convenience at the
+/// call sites that already import from `shell_exec`. Instant events appear as
+/// vertical lines in Chrome Trace Format visualization tools
+/// (chrome://tracing, Perfetto).
 pub fn trace_instant(event: &str) {
-    let ts = Instant::now().duration_since(*trace_epoch()).as_micros() as u64;
-    let tid = thread_id_number();
-
-    log::debug!("[wt-trace] ts={} tid={} event=\"{}\"", ts, tid, event);
+    crate::trace::emit::instant(event);
 }
 
-/// Extract numeric thread ID from ThreadId's debug format.
-/// ThreadId debug format is "ThreadId(N)" where N is the numeric ID.
-fn thread_id_number() -> u64 {
-    let thread_id = std::thread::current().id();
-    let debug_str = format!("{:?}", thread_id);
-    debug_str
-        .strip_prefix("ThreadId(")
-        .and_then(|s| s.strip_suffix(")"))
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0)
-}
+/// Maximum lines of captured stdout/stderr emitted per stream at `log::debug!`.
+/// Exceeded content is elided with a `… (N more lines, M bytes elided)` marker.
+/// Raise the level to `log::trace!` (via `-vvv` or `RUST_LOG=trace`) for full output.
+const LOG_OUTPUT_MAX_LINES: usize = 200;
 
-/// Log command output (stdout/stderr) for debugging.
+/// Maximum bytes of captured stdout/stderr emitted per stream at `log::debug!`.
+/// Applied in addition to [`LOG_OUTPUT_MAX_LINES`].
+const LOG_OUTPUT_MAX_BYTES: usize = 64 * 1024;
+
+/// Log captured stdout/stderr of a finished command.
+///
+/// At `log::trace!` (enabled by `-vvv`) the full output is emitted, one line
+/// per record with indent prefix (`  ` for stdout, `  ! ` for stderr). At
+/// `log::debug!` (`-vv`) the output is capped at [`LOG_OUTPUT_MAX_LINES`] and
+/// [`LOG_OUTPUT_MAX_BYTES`] per stream with an elision marker, so large
+/// subprocess bodies (diffs, prompts) don't flood the verbose stream.
 fn log_output(output: &std::process::Output) {
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let stderr = String::from_utf8_lossy(&output.stderr);
-
-    for line in stdout.lines() {
-        log::debug!("  {}", line);
+    if log::log_enabled!(log::Level::Trace) {
+        log_stream_full(&output.stdout, "  ");
+        log_stream_full(&output.stderr, "  ! ");
+    } else if log::log_enabled!(log::Level::Debug) {
+        log_stream_bounded(&output.stdout, "  ");
+        log_stream_bounded(&output.stderr, "  ! ");
     }
-    for line in stderr.lines() {
-        log::debug!("  ! {}", line);
+}
+
+fn log_stream_full(bytes: &[u8], prefix: &str) {
+    if bytes.is_empty() {
+        return;
+    }
+    for line in String::from_utf8_lossy(bytes).lines() {
+        log::trace!("{}{}", prefix, line);
+    }
+}
+
+fn log_stream_bounded(bytes: &[u8], prefix: &str) {
+    if bytes.is_empty() {
+        return;
+    }
+    let text = String::from_utf8_lossy(bytes);
+    let total_bytes = bytes.len();
+
+    let mut bytes_emitted = 0;
+    let mut lines = text.lines().enumerate();
+    for (lines_emitted, line) in &mut lines {
+        if lines_emitted >= LOG_OUTPUT_MAX_LINES || bytes_emitted >= LOG_OUTPUT_MAX_BYTES {
+            let remaining_lines = 1 + lines.count();
+            let remaining_bytes = total_bytes.saturating_sub(bytes_emitted);
+            log::debug!(
+                "{}… ({} more lines, {} bytes elided — use -vvv for full output)",
+                prefix,
+                remaining_lines,
+                remaining_bytes
+            );
+            return;
+        }
+        log::debug!("{}{}", prefix, line);
+        bytes_emitted += line.len() + 1;
     }
 }
 
@@ -394,47 +403,21 @@ fn log_command_result(
     dur_us: u64,
     result: &std::io::Result<std::process::Output>,
 ) {
-    match (result, context) {
-        (Ok(output), Some(ctx)) => {
-            log::debug!(
-                r#"[wt-trace] ts={} tid={} context={} cmd="{}" dur_us={} ok={}"#,
+    match result {
+        Ok(output) => {
+            crate::trace::emit::command_completed(
+                context,
+                cmd_str,
                 ts,
                 tid,
-                ctx,
-                cmd_str,
                 dur_us,
-                output.status.success()
+                output.status.success(),
             );
             log_output(output);
         }
-        (Ok(output), None) => {
-            log::debug!(
-                r#"[wt-trace] ts={} tid={} cmd="{}" dur_us={} ok={}"#,
-                ts,
-                tid,
-                cmd_str,
-                dur_us,
-                output.status.success()
-            );
-            log_output(output);
+        Err(e) => {
+            crate::trace::emit::command_errored(context, cmd_str, ts, tid, dur_us, e);
         }
-        (Err(e), Some(ctx)) => log::debug!(
-            r#"[wt-trace] ts={} tid={} context={} cmd="{}" dur_us={} err="{}""#,
-            ts,
-            tid,
-            ctx,
-            cmd_str,
-            dur_us,
-            e
-        ),
-        (Err(e), None) => log::debug!(
-            r#"[wt-trace] ts={} tid={} cmd="{}" dur_us={} err="{}""#,
-            ts,
-            tid,
-            cmd_str,
-            dur_us,
-            e
-        ),
     }
 }
 
@@ -841,8 +824,10 @@ impl Cmd {
 
         // Capture timing for tracing
         let t0 = Instant::now();
-        let ts = t0.duration_since(*trace_epoch()).as_micros() as u64;
-        let tid = thread_id_number();
+        let ts = t0
+            .duration_since(crate::trace::emit::trace_epoch())
+            .as_micros() as u64;
+        let tid = crate::trace::emit::thread_id();
 
         let mut cmd = self.direct_command();
         self.apply_common_settings(&mut cmd);
@@ -946,8 +931,10 @@ impl Cmd {
         let _guard = semaphore().acquire();
 
         let t0 = Instant::now();
-        let ts = t0.duration_since(*trace_epoch()).as_micros() as u64;
-        let tid = thread_id_number();
+        let ts = t0
+            .duration_since(crate::trace::emit::trace_epoch())
+            .as_micros() as u64;
+        let tid = crate::trace::emit::thread_id();
 
         let mut first = self.direct_command();
         self.apply_common_settings(&mut first);

--- a/src/trace/emit.rs
+++ b/src/trace/emit.rs
@@ -1,0 +1,125 @@
+//! Authoritative emitter for the `[wt-trace]` log grammar.
+//!
+//! `[wt-trace]` records are structured single-line `key=value` text emitted on
+//! top of the `log` crate and parsed downstream by [`super::parse`] and the
+//! `wt-perf` binary. This module is the single source of truth for the
+//! grammar — any field or formatting change happens here and in `parse.rs`
+//! together.
+//!
+//! # Format
+//!
+//! ```text
+//! [wt-trace] ts=1234567 tid=3 context=worktree cmd="git status" dur_us=12300 ok=true
+//! [wt-trace] ts=1234567 tid=3 cmd="gh pr list" dur_us=45200 ok=false
+//! [wt-trace] ts=1234567 tid=3 context=main cmd="git merge-base" dur_us=100000 err="fatal: ..."
+//! [wt-trace] ts=1234567 tid=3 event="Showed skeleton"
+//! ```
+//!
+//! Records are emitted at `log::debug!`, so `-vv` or `RUST_LOG=debug` makes
+//! them visible. Subprocess stdout/stderr continuations are emitted separately
+//! — full output at `log::trace!` (`-vvv`) and a bounded preview at
+//! `log::debug!` — so raw bodies don't spam `-vv`.
+
+use std::fmt::Display;
+use std::sync::OnceLock;
+use std::time::Instant;
+
+/// Monotonic epoch for trace timestamps. All `ts` fields are microseconds
+/// since this point. `Instant` is monotonic even if the system clock steps.
+static TRACE_EPOCH: OnceLock<Instant> = OnceLock::new();
+
+/// The monotonic epoch all trace timestamps are relative to.
+pub fn trace_epoch() -> Instant {
+    *TRACE_EPOCH.get_or_init(Instant::now)
+}
+
+/// Microseconds since [`trace_epoch`]. Use as the `ts` field for records.
+pub fn now_us() -> u64 {
+    Instant::now().duration_since(trace_epoch()).as_micros() as u64
+}
+
+/// Numeric thread id, extracted from `ThreadId`'s `Debug` representation.
+/// `ThreadId` debug format is `ThreadId(N)`.
+pub fn thread_id() -> u64 {
+    let thread_id = std::thread::current().id();
+    let debug_str = format!("{:?}", thread_id);
+    debug_str
+        .strip_prefix("ThreadId(")
+        .and_then(|s| s.strip_suffix(")"))
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0)
+}
+
+/// Emit a completed-command record (`ok=true`/`ok=false`).
+pub fn command_completed(
+    context: Option<&str>,
+    cmd: &str,
+    ts: u64,
+    tid: u64,
+    dur_us: u64,
+    ok: bool,
+) {
+    match context {
+        Some(ctx) => log::debug!(
+            r#"[wt-trace] ts={} tid={} context={} cmd="{}" dur_us={} ok={}"#,
+            ts,
+            tid,
+            ctx,
+            cmd,
+            dur_us,
+            ok
+        ),
+        None => log::debug!(
+            r#"[wt-trace] ts={} tid={} cmd="{}" dur_us={} ok={}"#,
+            ts,
+            tid,
+            cmd,
+            dur_us,
+            ok
+        ),
+    }
+}
+
+/// Emit a failed-command record (the command didn't run to completion).
+pub fn command_errored(
+    context: Option<&str>,
+    cmd: &str,
+    ts: u64,
+    tid: u64,
+    dur_us: u64,
+    err: impl Display,
+) {
+    match context {
+        Some(ctx) => log::debug!(
+            r#"[wt-trace] ts={} tid={} context={} cmd="{}" dur_us={} err="{}""#,
+            ts,
+            tid,
+            ctx,
+            cmd,
+            dur_us,
+            err
+        ),
+        None => log::debug!(
+            r#"[wt-trace] ts={} tid={} cmd="{}" dur_us={} err="{}""#,
+            ts,
+            tid,
+            cmd,
+            dur_us,
+            err
+        ),
+    }
+}
+
+/// Emit an instant (milestone) event with no duration. Computes `ts` and
+/// `tid` internally — use for one-off markers inside a thread's execution.
+///
+/// Instant events appear as vertical lines in Chrome Trace Format tools
+/// (chrome://tracing, Perfetto).
+pub fn instant(event: &str) {
+    log::debug!(
+        r#"[wt-trace] ts={} tid={} event="{}""#,
+        now_us(),
+        thread_id(),
+        event
+    );
+}

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -32,6 +32,7 @@
 //! ```
 
 pub mod chrome;
+pub mod emit;
 pub mod parse;
 
 // Re-export main types for convenience

--- a/tests/integration_tests/diagnostic.rs
+++ b/tests/integration_tests/diagnostic.rs
@@ -397,10 +397,10 @@ fn test_vv_writes_diagnostic_on_error(mut repo: TestRepo) {
     );
 }
 
-/// With just -v (not -vv), no logging files should be written.
-/// -v is reserved for future use; -vv is required for debug logging.
+/// With just -v, info-level logging goes to stderr but no log files are written.
+/// `-vv` is the threshold for `verbose.log` and `diagnostic.md`.
 #[rstest]
-fn test_v_does_not_enable_logging(repo: TestRepo) {
+fn test_v_does_not_write_log_files(repo: TestRepo) {
     // Run a successful command with just -v
     let output = repo.wt_command().args(["list", "-v"]).output().unwrap();
 

--- a/tests/integration_tests/diagnostic.rs
+++ b/tests/integration_tests/diagnostic.rs
@@ -328,6 +328,36 @@ fn test_verbose_log_file_created(mut repo: TestRepo) {
     );
 }
 
+/// With `-vvv`, subprocess stdout/stderr should appear in `verbose.log` via
+/// `log::trace!` (not just `[wt-trace]` headers). This guards the Trace
+/// branch of `shell_exec::log_output` and the `-vvv` arm of `init_logging`.
+#[rstest]
+fn test_vvv_emits_subprocess_output_at_trace(repo: TestRepo) {
+    repo.wt_command().args(["list", "-vvv"]).output().unwrap();
+
+    let verbose_log_path = repo
+        .root_path()
+        .join(".git")
+        .join("wt/logs")
+        .join("verbose.log");
+    assert!(
+        verbose_log_path.exists(),
+        "verbose.log should be created with -vvv"
+    );
+
+    let content = fs::read_to_string(&verbose_log_path).unwrap();
+    assert!(
+        content.contains("[wt-trace]"),
+        "verbose.log should still contain [wt-trace] records at -vvv"
+    );
+    // At Trace, captured stdout/stderr is emitted line-by-line with the
+    // `  ` / `  ! ` continuation prefix used by log_output.
+    assert!(
+        content.lines().any(|l| l.contains("  worktree ")),
+        "verbose.log should contain `git worktree list --porcelain` stdout lines at -vvv"
+    );
+}
+
 // =============================================================================
 // Tests for -vv verbosity level (always write diagnostic)
 // =============================================================================

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -52,7 +52,7 @@ Usage: [1m[36mwt config create[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 [1m[32mUser config[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -58,7 +58,7 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 [1m[32mExamples[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_shell.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_shell.snap
@@ -49,4 +49,4 @@ Usage: [1m[36mwt config shell[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)

--- a/tests/snapshots/integration__integration_tests__help__help_config_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_short.snap
@@ -50,4 +50,4 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)

--- a/tests/snapshots/integration__integration_tests__help__help_config_show.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_show.snap
@@ -62,7 +62,7 @@ Usage: [1m[36mwt config show[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 Shows location and contents of user config ([2m~/.config/worktrunk/config.toml[0m)
 and project config ([2m.config/wt.toml[0m). Also shows system config if present.

--- a/tests/snapshots/integration__integration_tests__help__help_config_state.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state.snap
@@ -60,7 +60,7 @@ Usage: [1m[36mwt config state[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 State is stored in [2m.git/[0m (config entries and log files), separate from configuration files.
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
@@ -54,7 +54,7 @@ Usage: [1m[36mwt config state ci-status[0m [36m[OPTIONS][0m [36m[COMMAND]
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 Caches GitHub/GitLab CI status for display in [2mwt list[0m.
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_clear.snap
@@ -50,7 +50,7 @@ Usage: [1m[36mwt config state clear[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 Clears all stored state:
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
@@ -55,7 +55,7 @@ Usage: [1m[36mwt config state default-branch[0m [36m[OPTIONS][0m [36m[COMM
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 Useful in scripts to avoid hardcoding [2mmain[0m or [2mmaster[0m:
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_get.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_get.snap
@@ -55,7 +55,7 @@ Usage: [1m[36mwt config state get[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 Shows all stored state including:
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
@@ -54,7 +54,7 @@ Usage: [1m[36mwt config state logs[0m [36m[OPTIONS][0m [36m[COMMAND][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 View and manage log files — hook output, command audit trail, and debug diagnostics.
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
@@ -55,7 +55,7 @@ Usage: [1m[36mwt config state marker[0m [36m[OPTIONS][0m [36m[COMMAND][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 Custom status text or emoji shown in the [2mwt list[0m Status column.
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch.snap
@@ -55,7 +55,7 @@ Usage: [1m[36mwt config state previous-branch[0m [36m[OPTIONS][0m [36m[COM
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 Enables [2mwt switch -[0m to return to the previous worktree, similar to [2mcd -[0m or [2mgit checkout -[0m.
 

--- a/tests/snapshots/integration__integration_tests__help__help_hook_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_approvals.snap
@@ -53,7 +53,7 @@ Usage: [1m[36mwt hook approvals[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 Project hooks require approval on first run to prevent untrusted projects from running arbitrary commands.
 

--- a/tests/snapshots/integration__integration_tests__help__help_hook_approvals_add.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_approvals_add.snap
@@ -53,7 +53,7 @@ Usage: [1m[36mwt hook approvals add[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 Prompts for approval of all project commands and saves them to approvals.toml.
 

--- a/tests/snapshots/integration__integration_tests__help__help_hook_approvals_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_approvals_clear.snap
@@ -53,7 +53,7 @@ Usage: [1m[36mwt hook approvals clear[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 Removes saved approvals, requiring re-approval on next command run.
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -71,7 +71,7 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 Shows uncommitted changes, divergence from the default branch and remote, and optional CI status and LLM summaries.
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -73,7 +73,8 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs 
+          + diagnostic report; -vvv: trace logs)
 
 Shows uncommitted changes, divergence from the default branch and remote, and 
 optional CI status and LLM summaries.

--- a/tests/snapshots/integration__integration_tests__help__help_list_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_short.snap
@@ -51,4 +51,4 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)

--- a/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
@@ -95,7 +95,7 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 Unlike `git merge`, this merges the current branch into the target branch — not the target into current. Similar to clicking "Merge pull request" on GitHub, but locally. The target defaults to the default branch.
 

--- a/tests/snapshots/integration__integration_tests__help__help_md_root.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_root.snap
@@ -57,7 +57,7 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 Getting started
 

--- a/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
@@ -97,7 +97,7 @@ Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 Unlike [2mgit merge[0m, this merges the current branch into the target branch — not the target into current. Similar to clicking "Merge pull request" on GitHub, but locally. The target defaults to the default branch.
 

--- a/tests/snapshots/integration__integration_tests__help__help_merge_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_short.snap
@@ -56,4 +56,4 @@ Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET][0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)

--- a/tests/snapshots/integration__integration_tests__help__help_no_args.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_no_args.snap
@@ -50,4 +50,4 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)

--- a/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
@@ -86,7 +86,7 @@ Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...[0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 [1m[32mExamples[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_remove_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_short.snap
@@ -54,4 +54,4 @@ Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...[0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)

--- a/tests/snapshots/integration__integration_tests__help__help_root_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root_long.snap
@@ -59,7 +59,7 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 Getting started
 

--- a/tests/snapshots/integration__integration_tests__help__help_root_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root_short.snap
@@ -51,4 +51,4 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)

--- a/tests/snapshots/integration__integration_tests__help__help_step_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_long.snap
@@ -63,7 +63,7 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m[COMMAND][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 [1m[32mExamples[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_step_promote.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_promote.snap
@@ -57,7 +57,7 @@ Usage: [1m[36mwt step promote[0m [36m[OPTIONS][0m [36m[BRANCH][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 [1mExperimental.[0m Use promote for temporary testing when the main worktree has special significance (Docker Compose, IDE configs, heavy build artifacts anchored to project root), and hooks & tools aren't yet set up to run on arbitrary worktrees. The idiomatic Worktrunk workflow does not use [2mpromote[0m; instead each worktree has a full environment. [2mpromote[0m is the only Worktrunk command which changes a branch in an existing worktree.
 

--- a/tests/snapshots/integration__integration_tests__help__help_step_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_short.snap
@@ -55,4 +55,4 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -118,7 +118,7 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: hooks, templates; -vv: debug report)
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
 
 Worktrees are addressed by branch name; paths are computed from a configurable template. Unlike [2mgit switch[0m, this navigates between worktrees rather than changing branches in place.
 

--- a/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
@@ -60,4 +60,4 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)

--- a/tests/snapshots/integration__integration_tests__step_alias__step_help_includes_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_help_includes_aliases.snap
@@ -70,4 +70,4 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
 [1m[32mGlobal Options:
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)

--- a/tests/snapshots/integration__integration_tests__step_alias__step_list_no_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_list_no_aliases.snap
@@ -66,4 +66,4 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m[COMMAND]
 [1m[32mGlobal Options:
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)

--- a/tests/snapshots/integration__integration_tests__step_alias__step_list_with_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_list_with_aliases.snap
@@ -71,4 +71,4 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m[COMMAND]
 [1m[32mGlobal Options:
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)


### PR DESCRIPTION
## Summary

Three changes to worktrunk's logging conventions, all motivated by `wt list -vv` dumping raw `git diff-tree -p` bodies into the log stream at debug level:

**1. `src/trace/emit.rs` owns the `[wt-trace]` grammar.** Previously the grammar was emitted via ad-hoc `log::debug!("[wt-trace] ...")` format strings in `shell_exec.rs`, with `src/trace/parse.rs` silently defining it by how it parsed. `trace_instant`, `log_command_result`, the `TRACE_EPOCH` static, and `thread_id_number` moved into the new emitter module so `parse.rs` and the producer share one source. Wire format byte-identical; `wt-perf` parsing unchanged.

**2. Level discipline.** `-v` → Info, `-vv` → Debug, `-vvv` → Trace. Previously `-v` didn't touch the `log` crate at all and `-vvv` didn't exist. The LLM prompt dump (`src/llm.rs`) and captured subprocess stdout/stderr (`log_output` in `shell_exec.rs`) moved to `log::trace!`, so `-vv` stops spilling thousand-line diff bodies and full LLM prompts.

**3. Bounded `log_output`.** At Debug, each stream caps at 200 lines / 64 KB with `… (N more lines, M bytes elided — use -vvv for full output)`. At Trace, uncapped.

## Reviewer navigation

- **New file**: `src/trace/emit.rs` — the single-source emitter. `command_completed`, `command_errored`, `instant` plus `trace_epoch` / `now_us` / `thread_id` helpers.
- **Delete/delegate**: `src/shell_exec.rs` loses its duplicate `TRACE_EPOCH` + `trace_epoch` + `thread_id_number`, and the four `log::debug!("[wt-trace] …")` branches collapse into two calls into `trace::emit`. `log_output` gains `log_stream_full` (Trace) and `log_stream_bounded` (Debug) helpers.
- **Level map**: `src/main.rs:init_logging` has the new match on `verbose_level`.
- **Help + test snapshots**: the `--verbose` help text change in `src/cli/mod.rs:249` drives the large auto-synced snapshot / docs / skill-reference diff.
- **Test rename**: `tests/integration_tests/diagnostic.rs` — `test_v_does_not_enable_logging` → `test_v_does_not_write_log_files` (the old name became inaccurate now that `-v` enables Info logging on stderr).

## Testing

- 969 library unit tests pass.
- Integration tests for `diagnostic`, `step_alias`, `test_help` pass (82 tests).
- Lints clean.

> _This was written by Claude Code on behalf of max-sixty_