### PR TITLE
Clearer deprecation warnings & consolidated diff output

### DIFF
--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -521,7 +521,6 @@ fn render_user_config(out: &mut String, has_system_config: bool) -> anyhow::Resu
         false, // silent mode - we'll format the output ourselves
     ) {
         if let Some(info) = result.info {
-            // Add deprecation details to the output buffer
             out.push_str(&worktrunk::config::format_deprecation_details(&info));
             true
         } else {
@@ -545,13 +544,11 @@ fn render_user_config(out: &mut String, has_system_config: bool) -> anyhow::Resu
         )));
     }
 
-    // Add "Current config" label when deprecations shown (to separate from diff)
-    if has_deprecations {
-        writeln!(out, "{}", info_message("Current config:"))?;
+    // Display TOML with syntax highlighting (gutter at column 0).
+    // Skip when deprecations were shown — the proposed diff already covers it.
+    if !has_deprecations {
+        writeln!(out, "{}", format_toml(&contents))?;
     }
-
-    // Display TOML with syntax highlighting (gutter at column 0)
-    writeln!(out, "{}", format_toml(&contents))?;
 
     if !has_system_config {
         render_system_config_hint(out)?;
@@ -673,7 +670,6 @@ fn render_project_config(out: &mut String) -> anyhow::Result<()> {
         false, // silent mode - we'll format the output ourselves
     ) {
         if let Some(info) = result.info {
-            // Add deprecation details to the output buffer
             out.push_str(&worktrunk::config::format_deprecation_details(&info));
             true
         } else {
@@ -695,13 +691,11 @@ fn render_project_config(out: &mut String) -> anyhow::Result<()> {
         ));
     }
 
-    // Add "Current config" label when deprecations shown (to separate from diff)
-    if has_deprecations {
-        writeln!(out, "{}", info_message("Current config:"))?;
+    // Display TOML with syntax highlighting (gutter at column 0).
+    // Skip when deprecations were shown — the proposed diff already covers it.
+    if !has_deprecations {
+        writeln!(out, "{}", format_toml(&contents))?;
     }
-
-    // Display TOML with syntax highlighting (gutter at column 0)
-    writeln!(out, "{}", format_toml(&contents))?;
 
     Ok(())
 }

--- a/src/commands/config/update.rs
+++ b/src/commands/config/update.rs
@@ -88,10 +88,11 @@ pub fn handle_config_update(yes: bool) -> anyhow::Result<()> {
 fn format_update_preview(info: &DeprecationInfo) -> String {
     let mut out = format_deprecation_warnings(info);
 
-    // Show diff (without the hint that format_deprecation_details adds)
+    // Show diff (without the "To apply" hint that format_deprecation_details adds)
     if let Some(new_path) = &info.migration_path
         && let Some(diff) = format_migration_diff(&info.config_path, new_path)
     {
+        let _ = writeln!(out, "{}", info_message("Proposed diff:"));
         let _ = writeln!(out, "{diff}");
     }
 

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -30,7 +30,7 @@ use shell_escape::unix::escape;
 use crate::config::WorktrunkConfig;
 use crate::shell_exec::Cmd;
 use crate::styling::{
-    eprintln, format_bash_with_gutter, format_with_gutter, hint_message, suggest_command_in_dir,
+    eprintln, format_with_gutter, hint_message, info_message, suggest_command_in_dir,
     warning_message,
 };
 
@@ -1399,24 +1399,24 @@ pub fn format_deprecation_warnings(info: &DeprecationInfo) -> String {
         );
     }
 
-    if !info.deprecations.commit_gen.is_empty() {
-        let mut parts = Vec::new();
-        if info.deprecations.commit_gen.has_top_level {
-            parts.push("[commit-generation] → [commit.generation]".to_string());
-        }
-        for project_key in &info.deprecations.commit_gen.project_keys {
-            parts.push(format!(
-                "[projects.\"{}\".commit-generation] → [projects.\"{}\".commit.generation]",
-                project_key, project_key
-            ));
-        }
+    if info.deprecations.commit_gen.has_top_level {
         let _ = writeln!(
             out,
             "{}",
-            warning_message(format!(
-                "{} uses deprecated config sections: {}",
-                info.label,
-                parts.join(", ")
+            warning_message(cformat!(
+                "{}: <bold>[commit-generation]</> is deprecated in favor of <bold>[commit.generation]</>",
+                info.label
+            ))
+        );
+    }
+    for project_key in &info.deprecations.commit_gen.project_keys {
+        let _ = writeln!(
+            out,
+            "{}",
+            warning_message(cformat!(
+                "{label}: <bold>[projects.\"{k}\".commit-generation]</> is deprecated in favor of <bold>[projects.\"{k}\".commit.generation]</>",
+                label = info.label,
+                k = project_key
             ))
         );
     }
@@ -1449,8 +1449,8 @@ pub fn format_deprecation_warnings(info: &DeprecationInfo) -> String {
         let _ = writeln!(
             out,
             "{}",
-            warning_message(format!(
-                "{} uses deprecated config section: [select] → [switch.picker]",
+            warning_message(cformat!(
+                "{}: <bold>[select]</> is deprecated in favor of <bold>[switch.picker]</>",
                 info.label
             ))
         );
@@ -1460,8 +1460,8 @@ pub fn format_deprecation_warnings(info: &DeprecationInfo) -> String {
         let _ = writeln!(
             out,
             "{}",
-            warning_message(format!(
-                "{} uses deprecated hook name: post-create → pre-start",
+            warning_message(cformat!(
+                "{}: <bold>post-create</> hook is deprecated in favor of <bold>pre-start</>",
                 info.label
             ))
         );
@@ -1471,8 +1471,8 @@ pub fn format_deprecation_warnings(info: &DeprecationInfo) -> String {
         let _ = writeln!(
             out,
             "{}",
-            warning_message(format!(
-                "{} uses deprecated config section: [ci] → [forge]",
+            warning_message(cformat!(
+                "{}: <bold>[ci]</> is deprecated in favor of <bold>[forge]</>",
                 info.label
             ))
         );
@@ -1482,8 +1482,8 @@ pub fn format_deprecation_warnings(info: &DeprecationInfo) -> String {
         let _ = writeln!(
             out,
             "{}",
-            warning_message(format!(
-                "{} uses deprecated field: [merge] no-ff → ff (inverted)",
+            warning_message(cformat!(
+                "{}: <bold>merge.no-ff</> is deprecated in favor of <bold>merge.ff</> (inverted)",
                 info.label
             ))
         );
@@ -1493,21 +1493,28 @@ pub fn format_deprecation_warnings(info: &DeprecationInfo) -> String {
         let _ = writeln!(
             out,
             "{}",
-            warning_message(format!(
-                "{} uses deprecated field: [switch] no-cd → cd (inverted)",
+            warning_message(cformat!(
+                "{}: <bold>switch.no-cd</> is deprecated in favor of <bold>switch.cd</> (inverted)",
                 info.label
             ))
         );
     }
 
     if !info.deprecations.pre_hook_table_form.is_empty() {
-        let hook_list = info.deprecations.pre_hook_table_form.join(", ");
+        let hook_list = info
+            .deprecations
+            .pre_hook_table_form
+            .iter()
+            .map(|h| cformat!("<bold>{h}</>"))
+            .collect::<Vec<_>>()
+            .join(", ");
         let _ = writeln!(
             out,
             "{}",
-            warning_message(format!(
-                "{} uses deprecated table form for pre-* hooks: {} → pipeline form",
-                info.label, hook_list
+            warning_message(cformat!(
+                "{}: table form for {} is deprecated in favor of the pipeline form",
+                info.label,
+                hook_list
             ))
         );
     }
@@ -1527,18 +1534,25 @@ pub fn format_deprecation_details(info: &DeprecationInfo) -> String {
 
     // Migration hint with apply command
     if let Some(new_path) = &info.migration_path {
-        let _ = writeln!(out, "{}", hint_message("To apply:"));
-        let _ = writeln!(out, "{}", format_bash_with_gutter("wt config update"));
+        let _ = writeln!(
+            out,
+            "{}",
+            hint_message(cformat!("To apply: <underline>wt config update</>"))
+        );
 
         // Inline diff — git diff header shows the file paths
         if let Some(diff) = format_migration_diff(&info.config_path, new_path) {
+            let _ = writeln!(out, "{}", info_message("Proposed diff:"));
             let _ = writeln!(out, "{diff}");
         }
     } else if let Some(main_path) = &info.main_worktree_path {
         // In linked worktree — include -C so the command works from here
         let cmd = suggest_command_in_dir(main_path, "config", &["update"], &[]);
-        let _ = writeln!(out, "{}", hint_message("To apply:"));
-        let _ = writeln!(out, "{}", format_bash_with_gutter(&cmd));
+        let _ = writeln!(
+            out,
+            "{}",
+            hint_message(cformat!("To apply: <underline>{cmd}</>"))
+        );
     }
 
     out

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -3001,6 +3001,94 @@ env = "cp .env.example .env"
     });
 }
 
+/// `wt config show` displays deprecation details for `[select]` → `[switch.picker]`.
+/// Uses user config so the warning label reads "User config".
+#[rstest]
+fn test_config_show_displays_select_section_deprecation(mut repo: TestRepo, temp_home: TempDir) {
+    repo.setup_mock_ci_tools_unauthenticated();
+
+    let global_config_dir = temp_home.path().join(".config").join("worktrunk");
+    fs::create_dir_all(&global_config_dir).unwrap();
+    let config_path = global_config_dir.join("config.toml");
+    fs::write(
+        &config_path,
+        r#"[select]
+pager = "delta --paging=never"
+"#,
+    )
+    .unwrap();
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        repo.configure_mock_commands(&mut cmd);
+        cmd.arg("config").arg("show").current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+        set_xdg_config_path(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
+/// `wt config show` displays deprecation details for `[merge] no-ff` → `ff` (inverted).
+#[rstest]
+fn test_config_show_displays_no_ff_deprecation(mut repo: TestRepo, temp_home: TempDir) {
+    repo.setup_mock_ci_tools_unauthenticated();
+
+    let global_config_dir = temp_home.path().join(".config").join("worktrunk");
+    fs::create_dir_all(&global_config_dir).unwrap();
+    let config_path = global_config_dir.join("config.toml");
+    fs::write(
+        &config_path,
+        r#"[merge]
+no-ff = true
+"#,
+    )
+    .unwrap();
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        repo.configure_mock_commands(&mut cmd);
+        cmd.arg("config").arg("show").current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+        set_xdg_config_path(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
+/// `wt config show` displays deprecation details for `[switch] no-cd` → `cd` (inverted).
+#[rstest]
+fn test_config_show_displays_no_cd_deprecation(mut repo: TestRepo, temp_home: TempDir) {
+    repo.setup_mock_ci_tools_unauthenticated();
+
+    let global_config_dir = temp_home.path().join(".config").join("worktrunk");
+    fs::create_dir_all(&global_config_dir).unwrap();
+    let config_path = global_config_dir.join("config.toml");
+    fs::write(
+        &config_path,
+        r#"[switch]
+no-cd = true
+"#,
+    )
+    .unwrap();
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        repo.configure_mock_commands(&mut cmd);
+        cmd.arg("config").arg("show").current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+        set_xdg_config_path(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
 /// `wt config update --yes` applies commit-generation section rename
 #[rstest]
 fn test_config_update_applies_commit_generation_migration(repo: TestRepo) {

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
@@ -49,9 +49,9 @@ exit_code: 0
 
 [36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
 [33m▲[39m [33mProject config uses deprecated template variables: [2mmain_worktree[22m → [1mrepo[22m[39m
-[33m▲[39m [33mProject config uses deprecated hook name: post-create → pre-start[39m
-[2m↳[22m [2mTo apply:[22m
-[107m [0m [2m[0m[2m[34mwt[0m[2m config update
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mTo apply: [4mwt config update[24m[22m
+[2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a_REPO_/.config/wt.toml b_REPO_/.config/wt.toml.new[m
 [107m [0m [1mindex 8fcdb47..7792aac 100644[m
 [107m [0m [1m--- a_REPO_/.config/wt.toml[m
@@ -59,8 +59,6 @@ exit_code: 0
 [107m [0m [36m@@ -1 +1 @@[m
 [107m [0m [31m-post-create = "ln -sf {{ main_worktree }}/node_modules"[m
 [107m [0m [32m+[m[32mpre-start = "ln -sf {{ repo }}/node_modules"[m
-[2m○[22m Current config:
-[107m [0m [2mpost-create = [0m[2m[32m"ln -sf {{ main_worktree }}/node_modules"
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
@@ -46,9 +46,9 @@ exit_code: 0
 ----- stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUser config uses deprecated template variables: [2mrepo_root[22m → [1mrepo_path[22m, [2mmain_worktree[22m → [1mrepo[22m[39m
-[33m▲[39m [33mUser config uses deprecated hook name: post-create → pre-start[39m
-[2m↳[22m [2mTo apply:[22m
-[107m [0m [2m[0m[2m[34mwt[0m[2m config update
+[33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mTo apply: [4mwt config update[24m[22m
+[2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a[TEMP_HOME]/.config/worktrunk/config.toml b[TEMP_HOME]/.config/worktrunk/config.toml.new
 [107m [0m [1mindex d95d100..5eef8a6 100644[m
 [107m [0m [1m--- a[TEMP_HOME]/.config/worktrunk/config.toml
@@ -58,9 +58,6 @@ exit_code: 0
 [107m [0m [31m-post-create = "ln -sf {{ repo_root }}/node_modules"[m
 [107m [0m [32m+[m[32mworktree-path = "../{{ repo }}.{{ branch }}"[m
 [107m [0m [32m+[m[32mpre-start = "ln -sf {{ repo_path }}/node_modules"[m
-[2m○[22m Current config:
-[107m [0m [2mworktree-path = [0m[2m[32m"../{{ main_worktree }}.{{ branch }}"
-[107m [0m [2mpost-create = [0m[2m[32m"ln -sf {{ repo_root }}/node_modules"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_no_cd_deprecation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_no_cd_deprecation.snap
@@ -45,26 +45,21 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
-[2m↳[22m [2mNot found; to create one, run [4mwt config create[24m[22m
-
-[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
-[33m▲[39m [33mProject config: table form for [1mpre-start[22m, [1mpre-merge[22m is deprecated in favor of the pipeline form[39m
+[33m▲[39m [33mUser config: [1mswitch.no-cd[22m is deprecated in favor of [1mswitch.cd[22m (inverted)[39m
 [2m↳[22m [2mTo apply: [4mwt config update[24m[22m
 [2m○[22m Proposed diff:
-[107m [0m [1mdiff --git a_REPO_/.config/wt.toml b_REPO_/.config/wt.toml.new[m
-[107m [0m [1mindex 3a61835..0ab06b7 100644[m
-[107m [0m [1m--- a_REPO_/.config/wt.toml[m
-[107m [0m [1m+++ b_REPO_/.config/wt.toml.new[m
-[107m [0m [36m@@ -1,7 +1,2 @@[m
-[107m [0m [31m-[pre-merge][m
-[107m [0m [31m-test = "cargo test"[m
-[107m [0m [31m-lint = "cargo clippy"[m
-[107m [0m [31m-[m
-[107m [0m [31m-[pre-start][m
-[107m [0m [31m-install = "npm ci"[m
-[107m [0m [31m-env = "cp .env.example .env"[m
-[107m [0m [32m+[m[32mpre-start = [{ install = "npm ci" }, { env = "cp .env.example .env" }][m
-[107m [0m [32m+[m[32mpre-merge = [{ test = "cargo test" }, { lint = "cargo clippy" }][m
+[107m [0m [1mdiff --git a[TEMP_HOME]/.config/worktrunk/config.toml b[TEMP_HOME]/.config/worktrunk/config.toml.new
+[107m [0m [1mindex ec5c19e..2c6162a 100644[m
+[107m [0m [1m--- a[TEMP_HOME]/.config/worktrunk/config.toml
+[107m [0m [1m+++ b[TEMP_HOME]/.config/worktrunk/config.toml.new
+[107m [0m [36m@@ -1,2 +1,2 @@[m
+[107m [0m  [switch][m
+[107m [0m [31m-no-cd = true[m
+[107m [0m [32m+[m[32mcd = false[m
+[2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
+
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
+[2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_no_ff_deprecation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_no_ff_deprecation.snap
@@ -45,26 +45,21 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
-[2m↳[22m [2mNot found; to create one, run [4mwt config create[24m[22m
-
-[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
-[33m▲[39m [33mProject config: table form for [1mpre-start[22m, [1mpre-merge[22m is deprecated in favor of the pipeline form[39m
+[33m▲[39m [33mUser config: [1mmerge.no-ff[22m is deprecated in favor of [1mmerge.ff[22m (inverted)[39m
 [2m↳[22m [2mTo apply: [4mwt config update[24m[22m
 [2m○[22m Proposed diff:
-[107m [0m [1mdiff --git a_REPO_/.config/wt.toml b_REPO_/.config/wt.toml.new[m
-[107m [0m [1mindex 3a61835..0ab06b7 100644[m
-[107m [0m [1m--- a_REPO_/.config/wt.toml[m
-[107m [0m [1m+++ b_REPO_/.config/wt.toml.new[m
-[107m [0m [36m@@ -1,7 +1,2 @@[m
-[107m [0m [31m-[pre-merge][m
-[107m [0m [31m-test = "cargo test"[m
-[107m [0m [31m-lint = "cargo clippy"[m
-[107m [0m [31m-[m
-[107m [0m [31m-[pre-start][m
-[107m [0m [31m-install = "npm ci"[m
-[107m [0m [31m-env = "cp .env.example .env"[m
-[107m [0m [32m+[m[32mpre-start = [{ install = "npm ci" }, { env = "cp .env.example .env" }][m
-[107m [0m [32m+[m[32mpre-merge = [{ test = "cargo test" }, { lint = "cargo clippy" }][m
+[107m [0m [1mdiff --git a[TEMP_HOME]/.config/worktrunk/config.toml b[TEMP_HOME]/.config/worktrunk/config.toml.new
+[107m [0m [1mindex f4de629..27f3868 100644[m
+[107m [0m [1m--- a[TEMP_HOME]/.config/worktrunk/config.toml
+[107m [0m [1m+++ b[TEMP_HOME]/.config/worktrunk/config.toml.new
+[107m [0m [36m@@ -1,2 +1,2 @@[m
+[107m [0m  [merge][m
+[107m [0m [31m-no-ff = true[m
+[107m [0m [32m+[m[32mff = false[m
+[2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
+
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
+[2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
@@ -45,9 +45,9 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
-[33m▲[39m [33mUser config uses deprecated config sections: [projects."github.com/example/repo".commit-generation] → [projects."github.com/example/repo".commit.generation][39m
-[2m↳[22m [2mTo apply:[22m
-[107m [0m [2m[0m[2m[34mwt[0m[2m config update
+[33m▲[39m [33mUser config: [1m[projects."github.com/example/repo".commit-generation][22m is deprecated in favor of [1m[projects."github.com/example/repo".commit.generation][22m[39m
+[2m↳[22m [2mTo apply: [4mwt config update[24m[22m
+[2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a[TEMP_HOME]/.config/worktrunk/config.toml b[TEMP_HOME]/.config/worktrunk/config.toml.new
 [107m [0m [1mindex de80729..131a2fd 100644[m
 [107m [0m [1m--- a[TEMP_HOME]/.config/worktrunk/config.toml
@@ -58,11 +58,6 @@ exit_code: 0
 [107m [0m [31m-[projects."github.com/example/repo".commit-generation][m
 [107m [0m [32m+[m[32m[projects."github.com/example/repo".commit.generation][m
 [107m [0m  command = "llm -m gpt-4"[m
-[2m○[22m Current config:
-[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
-[107m [0m 
-[107m [0m [2m[36m[projects."github.com/example/repo".commit-generation]
-[107m [0m [2mcommand = [0m[2m[32m"llm -m gpt-4"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_select_section_deprecation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_select_section_deprecation.snap
@@ -45,26 +45,21 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
-[2m↳[22m [2mNot found; to create one, run [4mwt config create[24m[22m
-
-[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
-[33m▲[39m [33mProject config: table form for [1mpre-start[22m, [1mpre-merge[22m is deprecated in favor of the pipeline form[39m
+[33m▲[39m [33mUser config: [1m[select][22m is deprecated in favor of [1m[switch.picker][22m[39m
 [2m↳[22m [2mTo apply: [4mwt config update[24m[22m
 [2m○[22m Proposed diff:
-[107m [0m [1mdiff --git a_REPO_/.config/wt.toml b_REPO_/.config/wt.toml.new[m
-[107m [0m [1mindex 3a61835..0ab06b7 100644[m
-[107m [0m [1m--- a_REPO_/.config/wt.toml[m
-[107m [0m [1m+++ b_REPO_/.config/wt.toml.new[m
-[107m [0m [36m@@ -1,7 +1,2 @@[m
-[107m [0m [31m-[pre-merge][m
-[107m [0m [31m-test = "cargo test"[m
-[107m [0m [31m-lint = "cargo clippy"[m
-[107m [0m [31m-[m
-[107m [0m [31m-[pre-start][m
-[107m [0m [31m-install = "npm ci"[m
-[107m [0m [31m-env = "cp .env.example .env"[m
-[107m [0m [32m+[m[32mpre-start = [{ install = "npm ci" }, { env = "cp .env.example .env" }][m
-[107m [0m [32m+[m[32mpre-merge = [{ test = "cargo test" }, { lint = "cargo clippy" }][m
+[107m [0m [1mdiff --git a[TEMP_HOME]/.config/worktrunk/config.toml b[TEMP_HOME]/.config/worktrunk/config.toml.new
+[107m [0m [1mindex 0d6352a..3e94895 100644[m
+[107m [0m [1m--- a[TEMP_HOME]/.config/worktrunk/config.toml
+[107m [0m [1m+++ b[TEMP_HOME]/.config/worktrunk/config.toml.new
+[107m [0m [36m@@ -1,2 +1,2 @@[m
+[107m [0m [31m-[select][m
+[107m [0m [32m+[m[32m[switch.picker][m
+[107m [0m  pager = "delta --paging=never"[m
+[2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
+
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
+[2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
@@ -49,11 +49,8 @@ exit_code: 0
 
 [36mPROJECT CONFIG[39m @ [PROJECT_ID]
 [33m▲[39m [33mProject config uses deprecated template variables: [2mmain_worktree[22m → [1mrepo[22m[39m
-[33m▲[39m [33mProject config uses deprecated hook name: post-create → pre-start[39m
-[2m↳[22m [2mTo apply:[22m
-[107m [0m [2m[0m[2m[34mwt[0m[2m [0m[2m[36m-C[0m[2m _REPO_ config update
-[2m○[22m Current config:
-[107m [0m [2mpost-create = [0m[2m[32m"ln -sf {{ main_worktree }}/node_modules"
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mTo apply: [4mwt -C _REPO_ config update[24m[22m
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_project_config_for_ci.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_project_config_for_ci.snap
@@ -45,9 +45,9 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
-[33m▲[39m [33mUser config uses deprecated config section: [ci] → [forge][39m
-[2m↳[22m [2mTo apply:[22m
-[107m [0m [2m[0m[2m[34mwt[0m[2m config update
+[33m▲[39m [33mUser config: [1m[ci][22m is deprecated in favor of [1m[forge][22m[39m
+[2m↳[22m [2mTo apply: [4mwt config update[24m[22m
+[2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a[TEMP_HOME]/.config/worktrunk/config.toml b[TEMP_HOME]/.config/worktrunk/config.toml.new
 [107m [0m [1mindex 2e0e0bb..9d78d51 100644[m
 [107m [0m [1m--- a[TEMP_HOME]/.config/worktrunk/config.toml
@@ -61,11 +61,6 @@ exit_code: 0
 [107m [0m [32m+[m[32m[forge][m
 [107m [0m [32m+[m[32mplatform = "github"[m
 [33m▲[39m [33mKey [1mci[22m belongs in project config as [forge][39m
-[2m○[22m Current config:
-[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
-[107m [0m 
-[107m [0m [2m[36m[ci]
-[107m [0m [2mplatform = [0m[2m[32m"github"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
@@ -49,9 +49,9 @@ exit_code: 0
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
-[33m▲[39m [33mProject config uses deprecated config sections: [commit-generation] → [commit.generation][39m
-[2m↳[22m [2mTo apply:[22m
-[107m [0m [2m[0m[2m[34mwt[0m[2m config update
+[33m▲[39m [33mProject config: [1m[commit-generation][22m is deprecated in favor of [1m[commit.generation][22m[39m
+[2m↳[22m [2mTo apply: [4mwt config update[24m[22m
+[2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a_REPO_/.config/wt.toml b_REPO_/.config/wt.toml.new[m
 [107m [0m [1mindex 074c30f..bcaf404 100644[m
 [107m [0m [1m--- a_REPO_/.config/wt.toml[m
@@ -63,9 +63,6 @@ exit_code: 0
 [107m [0m [32m+[m[32m[commit.generation][m
 [107m [0m [32m+[m[32mcommand = "claude"[m
 [33m▲[39m [33mKey [1mcommit-generation[22m belongs in user config as [commit.generation][39m
-[2m○[22m Current config:
-[107m [0m [2m[36m[commit-generation]
-[107m [0m [2mcommand = [0m[2m[32m"claude"
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_with_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_with_project_config.snap
@@ -49,9 +49,9 @@ exit_code: 0
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
 
 [36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
-[33m▲[39m [33mProject config uses deprecated hook name: post-create → pre-start[39m
-[2m↳[22m [2mTo apply:[22m
-[107m [0m [2m[0m[2m[34mwt[0m[2m config update
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mTo apply: [4mwt config update[24m[22m
+[2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a_REPO_/.config/wt.toml b_REPO_/.config/wt.toml.new[m
 [107m [0m [1mindex 13d6ba3..6ccc26d 100644[m
 [107m [0m [1m--- a_REPO_/.config/wt.toml[m
@@ -62,11 +62,6 @@ exit_code: 0
 [107m [0m  [m
 [107m [0m  [post-start][m
 [107m [0m  server = "npm run dev"[m
-[2m○[22m Current config:
-[107m [0m [2mpost-create = [0m[2m[32m"npm install"
-[107m [0m 
-[107m [0m [2m[36m[post-start]
-[107m [0m [2mserver = [0m[2m[32m"npm run dev"
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_update_applies_approved_commands_migration.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_update_applies_approved_commands_migration.snap
@@ -47,6 +47,7 @@ exit_code: 0
 ----- stderr -----
 [33m▲[39m [33mUser config has approved-commands in [projects] sections (moved to approvals.toml)[39m
 [2m↳[22m [2mCopied approved commands to [4mapprovals.toml[24m[22m
+[2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a[TEST_CONFIG] b[TEST_CONFIG_NEW][m
 [107m [0m [1mindex 51f8ab1..a30ca31 100644[m
 [107m [0m [1m--- a[TEST_CONFIG][m

--- a/tests/snapshots/integration__integration_tests__config_show__config_update_applies_commit_generation_migration.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_update_applies_commit_generation_migration.snap
@@ -45,7 +45,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mUser config uses deprecated config sections: [commit-generation] → [commit.generation][39m
+[33m▲[39m [33mUser config: [1m[commit-generation][22m is deprecated in favor of [1m[commit.generation][22m[39m
+[2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a[TEST_CONFIG] b[TEST_CONFIG_NEW][m
 [107m [0m [1mindex 40d0385..bc7273c 100644[m
 [107m [0m [1m--- a[TEST_CONFIG][m

--- a/tests/snapshots/integration__integration_tests__config_show__config_update_applies_template_var_migration.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_update_applies_template_var_migration.snap
@@ -46,7 +46,8 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mUser config uses deprecated template variables: [2mrepo_root[22m → [1mrepo_path[22m, [2mworktree[22m → [1mworktree_path[22m, [2mmain_worktree[22m → [1mrepo[22m[39m
-[33m▲[39m [33mUser config uses deprecated hook name: post-create → pre-start[39m
+[33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a[TEST_CONFIG] b[TEST_CONFIG_NEW][m
 [107m [0m [1mindex 89b3165..b3535c5 100644[m
 [107m [0m [1m--- a[TEST_CONFIG][m

--- a/tests/snapshots/integration__integration_tests__config_update_pty__config_update_prompt_accept.snap
+++ b/tests/snapshots/integration__integration_tests__config_update_pty__config_update_prompt_accept.snap
@@ -3,7 +3,8 @@ source: tests/integration_tests/config_update_pty.rs
 expression: "&output"
 ---
 [33m▲[39m [33mUser config uses deprecated template variables: [2mrepo_root[22m → [1mrepo_path[22m, [2mmain_worktree[22m → [1mrepo[22m[39m
-[33m▲[39m [33mUser config uses deprecated hook name: post-create → pre-start[39m
+[33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a[TEST_CONFIG] b[TEST_CONFIG_NEW][m
 [107m [0m [1mindex d95d100..5eef8a6 100644[m
 [107m [0m [1m--- a[TEST_CONFIG][m

--- a/tests/snapshots/integration__integration_tests__config_update_pty__config_update_prompt_decline.snap
+++ b/tests/snapshots/integration__integration_tests__config_update_pty__config_update_prompt_decline.snap
@@ -3,7 +3,8 @@ source: tests/integration_tests/config_update_pty.rs
 expression: "&output"
 ---
 [33m▲[39m [33mUser config uses deprecated template variables: [2mrepo_root[22m → [1mrepo_path[22m, [2mmain_worktree[22m → [1mrepo[22m[39m
-[33m▲[39m [33mUser config uses deprecated hook name: post-create → pre-start[39m
+[33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a[TEST_CONFIG] b[TEST_CONFIG_NEW][m
 [107m [0m [1mindex d95d100..5eef8a6 100644[m
 [107m [0m [1m--- a[TEST_CONFIG][m


### PR DESCRIPTION
Rewrites structural deprecation warnings in a consistent `{label}: X is deprecated in favor of Y` pattern (`[select]`, `[ci]`, `no-ff`, `no-cd`, `post-create`, `[commit-generation]`, pre-hook table form), with config identifiers and commands rendered via `<bold>` / `<underline>` per the output style guide.

The "To apply" hint is now a single line, the migration diff is introduced by an `○ Proposed diff:` info bullet, and the redundant current-config TOML dump is dropped when deprecations are shown — the proposed diff already covers it. The `Proposed diff:` header is also emitted by `wt config update` for consistency.

Adds integration snapshots for the three deprecations that previously lacked them: `[select]` → `[switch.picker]`, `no-ff` → `ff`, `no-cd` → `cd`.

> _This was written by Claude Code on behalf of Maximilian_