### PR TITLE
Silence config deprecation warnings in non-diagnostic contexts

### DIFF
--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -155,6 +155,10 @@ fn format_context_gauge(percentage: f64) -> String {
 /// Output uses `println!` for raw stdout (bypasses anstream color detection).
 /// Shell prompts (PS1) and Claude Code always expect ANSI codes.
 pub fn run(format: OutputFormat) -> Result<()> {
+    // Statusline runs on every prompt redraw — deprecation warnings on stderr
+    // would appear above each prompt.
+    worktrunk::config::suppress_warnings();
+
     // JSON format: output current worktree as JSON
     if matches!(format, OutputFormat::Json) {
         return run_json();

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -22,6 +22,11 @@ pub(crate) fn maybe_handle_env_completion() -> bool {
         return false;
     }
 
+    // Tab-completion output lands above the user's prompt — any stray stderr
+    // warnings would display there. Silence config deprecation/unknown-field
+    // warnings for the duration of this process.
+    worktrunk::config::suppress_warnings();
+
     let mut args: Vec<OsString> = std::env::args_os().collect();
     CONTEXT.with(|ctx| *ctx.borrow_mut() = Some(CompletionContext { args: args.clone() }));
 

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -19,7 +19,7 @@ use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 use std::io::Write;
 use std::path::{Path, PathBuf};
-use std::sync::{LazyLock, Mutex};
+use std::sync::{LazyLock, Mutex, OnceLock};
 
 use color_print::cformat;
 use minijinja::Environment;
@@ -38,6 +38,15 @@ use crate::styling::{
 /// Prevents repeated warnings when config is loaded multiple times.
 static WARNED_DEPRECATED_PATHS: LazyLock<Mutex<HashSet<PathBuf>>> =
     LazyLock::new(|| Mutex::new(HashSet::new()));
+
+/// Latch that silences config deprecation/unknown-field warnings for the rest
+/// of the process. Set by shell completion and picker paths, where stderr
+/// output would appear above the user's prompt or TUI.
+static SUPPRESS_WARNINGS: OnceLock<()> = OnceLock::new();
+
+pub fn suppress_warnings() {
+    let _ = SUPPRESS_WARNINGS.set(());
+}
 
 /// Pre-compiled regexes for deprecated variable word-boundary matching.
 /// Compiled once on first use, shared across all calls to normalize/replace.
@@ -1218,19 +1227,21 @@ pub fn check_and_migrate(
 
     // For brief warnings (non-config-show commands), just show a pointer
     if show_brief_warning {
-        eprintln!("{}", format_brief_warning(label));
+        if SUPPRESS_WARNINGS.get().is_none() {
+            eprintln!("{}", format_brief_warning(label));
 
-        if let Some(approvals_path) = &info.approvals_copied_to {
-            let approvals_filename = approvals_path
-                .file_name()
-                .map(|n| n.to_string_lossy())
-                .unwrap_or_default();
-            eprintln!(
-                "{}",
-                hint_message(cformat!(
-                    "Copied approved commands to <underline>{approvals_filename}</>"
-                ))
-            );
+            if let Some(approvals_path) = &info.approvals_copied_to {
+                let approvals_filename = approvals_path
+                    .file_name()
+                    .map(|n| n.to_string_lossy())
+                    .unwrap_or_default();
+                eprintln!(
+                    "{}",
+                    hint_message(cformat!(
+                        "Copied approved commands to <underline>{approvals_filename}</>"
+                    ))
+                );
+            }
         }
 
         // Still write migration file if needed (first time only)
@@ -1586,7 +1597,7 @@ pub fn warn_unknown_fields<C: WorktrunkConfig>(
     unknown_keys: &HashMap<String, toml::Value>,
     label: &str,
 ) {
-    if unknown_keys.is_empty() {
+    if unknown_keys.is_empty() || SUPPRESS_WARNINGS.get().is_some() {
         return;
     }
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -107,6 +107,7 @@ pub use deprecation::format_deprecation_warnings;
 pub use deprecation::format_migration_diff;
 pub use deprecation::migrate_content;
 pub use deprecation::normalize_template_vars;
+pub use deprecation::suppress_warnings;
 pub use deprecation::write_migration_file;
 pub use deprecation::{
     DEPRECATED_SECTION_KEYS, DeprecatedSection, UnknownKeyKind, classify_unknown_key,

--- a/src/main.rs
+++ b/src/main.rs
@@ -525,6 +525,7 @@ fn handle_list_command(args: ListArgs) -> anyhow::Result<()> {
 fn handle_select_command(branches: bool, remotes: bool) -> anyhow::Result<()> {
     // Deprecated: show warning and delegate to handle_picker
     warn_select_deprecated();
+    worktrunk::config::suppress_warnings();
     handle_picker(branches, remotes, None)
 }
 
@@ -538,6 +539,14 @@ fn handle_select_command(_branches: bool, _remotes: bool) -> anyhow::Result<()> 
 
 fn handle_switch_command(args: SwitchArgs) -> anyhow::Result<()> {
     let verify = resolve_verify(args.verify, args.no_verify_deprecated);
+
+    // With no branch argument, `wt switch` opens a TUI picker — config
+    // deprecation warnings would render above the picker and push it down.
+    // They're still shown by other commands (`wt list`, `wt merge`, …).
+    if args.branch.is_none() {
+        worktrunk::config::suppress_warnings();
+    }
+
     UserConfig::load()
         .context("Failed to load config")
         .and_then(|mut config| {


### PR DESCRIPTION
Tab-completion, the `wt switch` picker, and `wt list statusline` all produce output in places where a stderr warning would display above the user's prompt or TUI. In all three, a "Project config has deprecated settings…" warning is disruptive noise — the user sees it every tab press, every prompt redraw, or pushed above the picker.

Adds a one-way `SUPPRESS_WARNINGS: OnceLock<()>` latch in `config::deprecation`, set by those three entry points. The warning still fires for diagnostic commands (`wt list`, `wt merge`, `wt config show`, etc.), so users still find out their config needs migration.