### PR TITLE
refactor: prefer raw strings over escaped literals

### DIFF
--- a/src/commands/process.rs
+++ b/src/commands/process.rs
@@ -720,14 +720,14 @@ mod tests {
         assert_snapshot!(
             [
                 ("path separator /", sanitize_for_filename("feature/branch")),
-                ("path separator \\", sanitize_for_filename("feature\\branch")),
+                (r"path separator \", sanitize_for_filename(r"feature\branch")),
                 ("colon", sanitize_for_filename("bug:123")),
                 ("angle brackets", sanitize_for_filename("fix<angle>")),
                 ("pipe", sanitize_for_filename("fix|pipe")),
                 ("question mark", sanitize_for_filename("fix?question")),
                 ("wildcard", sanitize_for_filename("fix*wildcard")),
-                ("quotes", sanitize_for_filename("fix\"quotes\"")),
-                ("multiple special", sanitize_for_filename("a/b\\c<d>e:f\"g|h?i*j")),
+                ("quotes", sanitize_for_filename(r#"fix"quotes""#)),
+                ("multiple special", sanitize_for_filename(r#"a/b\c<d>e:f"g|h?i*j"#)),
                 ("already safe", sanitize_for_filename("normal-branch")),
                 ("underscore", sanitize_for_filename("branch_with_underscore")),
                 ("reserved prefix CONSOLE", sanitize_for_filename("CONSOLE")),

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -2252,7 +2252,7 @@ command = "old-command"
 
     #[test]
     fn test_shell_join_with_quotes() {
-        assert_eq!(shell_join(&["echo", "it's"]), "echo 'it'\\''s'");
+        assert_eq!(shell_join(&["echo", "it's"]), r"echo 'it'\''s'");
     }
 
     #[test]

--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -552,9 +552,9 @@ mod tests {
     fn test_sanitize_branch_name() {
         let cases = [
             ("feature/foo", "feature-foo"),
-            ("user\\task", "user-task"),
+            (r"user\task", "user-task"),
             ("feature/user/task", "feature-user-task"),
-            ("feature/user\\task", "feature-user-task"),
+            (r"feature/user\task", "feature-user-task"),
             ("simple-branch", "simple-branch"),
             ("", ""),
             ("///", "---"),
@@ -722,7 +722,7 @@ mod tests {
         let mut vars = HashMap::new();
         vars.insert("path", "my path");
         let expanded = expand_template("cd {{ path }}", &vars, true, &test.repo, "test").unwrap();
-        assert!(expanded.contains("'my path'") || expanded.contains("my\\ path"));
+        assert!(expanded.contains("'my path'") || expanded.contains(r"my\ path"));
 
         // Command injection prevention
         vars.insert("arg", "test;rm -rf");
@@ -920,7 +920,7 @@ mod tests {
         );
 
         // Backslashes are also sanitized
-        vars.insert("branch", "feature\\bar");
+        vars.insert("branch", r"feature\bar");
         assert_eq!(
             expand_template("{{ branch | sanitize }}", &vars, false, &test.repo, "test").unwrap(),
             "feature-bar"
@@ -948,7 +948,7 @@ mod tests {
             expand_template("{{ branch | sanitize }}", &vars, true, &test.repo, "test").unwrap();
         // sanitize replaces / with -, producing "user's-feature"
         // shell_escape wraps it: 'user'\''s-feature' (valid shell for user's-feature)
-        assert_eq!(result, "'user'\\''s-feature'", "sanitize + shell escape");
+        assert_eq!(result, r"'user'\''s-feature'", "sanitize + shell escape");
 
         // Without the fix, pre-escaping would produce corrupted output because
         // sanitize would replace the / and \ in the already-escaped value.
@@ -957,7 +957,7 @@ mod tests {
         let result = expand_template("{{ branch }}", &vars, true, &test.repo, "test").unwrap();
         // shell_escape wraps: 'user'\''s/feature' (valid shell for user's/feature)
         assert_eq!(
-            result, "'user'\\''s/feature'",
+            result, r"'user'\''s/feature'",
             "shell escape without filter"
         );
 

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -261,7 +261,7 @@ mod tests {
         };
         assert_eq!(
             config
-                .format_path("myproject", "feature\\foo", &test.repo, None)
+                .format_path("myproject", r"feature\foo", &test.repo, None)
                 .unwrap(),
             ".worktrees/myproject/feature-foo"
         );
@@ -495,7 +495,7 @@ task2 = "echo 'Task 2 running' > task2.txt"
 
         let mut vars = HashMap::new();
         vars.insert("main_worktree", "myrepo");
-        vars.insert("branch", "feat\\bar");
+        vars.insert("branch", r"feat\bar");
         let result = expand_template(
             ".worktrees/{{ main_worktree }}/{{ branch | sanitize }}",
             &vars,

--- a/src/config/test.rs
+++ b/src/config/test.rs
@@ -180,7 +180,7 @@ fn test_expand_template_backslash_in_branch() {
     let test = test_repo();
     // Use {{ branch | sanitize }} to replace backslashes with dashes
     // Note: shell_escape=false to test sanitize filter in isolation
-    let vars = vars_with_branch("feature\\branch");
+    let vars = vars_with_branch(r"feature\branch");
     let result = expand_template(
         "path/{{ branch | sanitize }}",
         &vars,

--- a/src/config/user/tests.rs
+++ b/src/config/user/tests.rs
@@ -15,7 +15,7 @@ fn test_default_config_path_returns_platform_path() {
     assert!(path.is_some(), "default_config_path should return Some");
     let path = path.unwrap();
     assert!(
-        path.ends_with("worktrunk/config.toml") || path.ends_with("worktrunk\\config.toml"),
+        path.ends_with("worktrunk/config.toml") || path.ends_with(r"worktrunk\config.toml"),
         "Expected path ending in worktrunk/config.toml, got: {path:?}"
     );
 }
@@ -325,7 +325,7 @@ fn test_worktrunk_config_format_path() {
     );
     // Verify it contains parent directory navigation
     assert!(
-        path.contains("/..") || path.contains("\\.."),
+        path.contains("/..") || path.contains(r"\.."),
         "Expected path containing parent navigation, got: {path}"
     );
     // The path should start with the repo path (absolute)

--- a/src/output/global.rs
+++ b/src/output/global.rs
@@ -342,7 +342,7 @@ fn escape_legacy_cd(path: &Path) -> String {
     let escaped = if is_powershell {
         path_str.replace('\'', "''")
     } else {
-        path_str.replace('\'', "'\\''")
+        path_str.replace('\'', r"'\''")
     };
     format!("cd '{}'", escaped)
 }
@@ -725,7 +725,7 @@ mod tests {
     #[test]
     fn test_escape_legacy_cd_single_quotes() {
         let result = escape_legacy_cd(Path::new("/test/it's/path"));
-        assert_eq!(result, "cd '/test/it'\\''s/path'");
+        assert_eq!(result, r"cd '/test/it'\''s/path'");
     }
 
     #[test]
@@ -957,14 +957,14 @@ mod tests {
         // We can't easily test the actual ANSI codes here, but document the issue
         std::println!(
             "Nested reset output: {}",
-            bad_output.replace('\x1b', "\\x1b")
+            bad_output.replace('\x1b', r"\x1b")
         );
 
         // GOOD pattern: compose styles
         let warning_bold = warning.bold();
         let good_output =
             format!("{warning}Text with {warning_bold}composed{warning_bold:#} styles{warning:#}");
-        std::println!("Composed output: {}", good_output.replace('\x1b', "\\x1b"));
+        std::println!("Composed output: {}", good_output.replace('\x1b', r"\x1b"));
 
         // The good pattern maintains color through the bold section
     }

--- a/src/styling/suggest.rs
+++ b/src/styling/suggest.rs
@@ -203,7 +203,7 @@ mod tests {
     fn test_branch_with_single_quote() {
         assert_eq!(
             suggest_command("remove", &["it's-a-branch"], &[]),
-            "wt remove 'it'\\''s-a-branch'"
+            r"wt remove 'it'\''s-a-branch'"
         );
     }
 

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -2536,7 +2536,7 @@ fn test_config_show_powershell_detected_via_psmodulepath(mut repo: TestRepo, tem
         // Set PSModulePath to trigger PowerShell detection fallback
         cmd.env(
             "PSModulePath",
-            "C:\\Users\\user\\Documents\\PowerShell\\Modules",
+            r"C:\Users\user\Documents\PowerShell\Modules",
         );
 
         assert_cmd_snapshot!(cmd);

--- a/tests/integration_tests/doc_templates.rs
+++ b/tests/integration_tests/doc_templates.rs
@@ -74,11 +74,11 @@ fn test_doc_sanitize_filter(repo: TestRepo) {
         "sanitize should replace / with -"
     );
 
-    vars.insert("branch", "user\\task");
+    vars.insert("branch", r"user\task");
     assert_eq!(
         expand_template("{{ branch | sanitize }}", &vars, false, &repository, "test").unwrap(),
         "user-task",
-        "sanitize should replace \\ with -"
+        r"sanitize should replace \ with -"
     );
 
     // Nested paths
@@ -563,7 +563,7 @@ fn test_worktree_path_of_branch_shell_escape(repo: TestRepo) {
     );
     // The escaped path should still reference the worktree
     assert!(
-        result_escaped.contains("My Worktree") || result_escaped.contains("My\\ Worktree"),
+        result_escaped.contains("My Worktree") || result_escaped.contains(r"My\ Worktree"),
         "Escaped path should reference worktree: {result_escaped}"
     );
 

--- a/tests/integration_tests/readme_sync.rs
+++ b/tests/integration_tests/readme_sync.rs
@@ -1695,7 +1695,7 @@ fn sync_frontmatter_description(content: &str, description: &str) -> String {
     static DESC_PATTERN: LazyLock<Regex> =
         LazyLock::new(|| Regex::new(r#"(?m)^description\s*=\s*"[^"]*""#).unwrap());
 
-    let new_field = format!("description = \"{}\"", description.replace('"', "\\\""));
+    let new_field = format!(r#"description = "{}""#, description.replace('"', r#"\""#));
 
     // Check if we're in a TOML frontmatter block
     if !content.starts_with("+++\n") {

--- a/tests/integration_tests/security.rs
+++ b/tests/integration_tests/security.rs
@@ -77,7 +77,7 @@ fn test_git_rejects_nul_in_commit_messages(repo: TestRepo) {
     // Try to commit with NUL in message using shell redirection
     let shell_cmd = format!(
         "printf '{}' | git commit -F -",
-        malicious_message.replace('\0', "\\0")
+        malicious_message.replace('\0', r"\0")
     );
 
     let mut cmd = Command::new("sh");

--- a/tests/integration_tests/shell_wrapper.rs
+++ b/tests/integration_tests/shell_wrapper.rs
@@ -174,7 +174,7 @@ fn quote_arg(arg: &str) -> String {
 /// Always quote a string for shell use, properly escaping single quotes.
 /// Handles paths like `/path/to/worktrunk.'∅'/target/debug/wt`
 fn shell_quote(s: &str) -> String {
-    format!("'{}'", s.replace('\'', "'\\''"))
+    format!("'{}'", s.replace('\'', r"'\''"))
 }
 
 /// Quote a path for PowerShell (escape backticks and single quotes)

--- a/tests/integration_tests/statusline.rs
+++ b/tests/integration_tests/statusline.rs
@@ -145,7 +145,7 @@ fn claude_code_snapshot_settings() -> insta::Settings {
 /// Escape a path for use in JSON strings.
 /// On Windows, backslashes must be escaped as double backslashes.
 fn escape_path_for_json(path: &std::path::Path) -> String {
-    path.display().to_string().replace('\\', "\\\\")
+    path.display().to_string().replace('\\', r"\\")
 }
 
 #[rstest]

--- a/tests/integration_tests/step_alias.rs
+++ b/tests/integration_tests/step_alias.rs
@@ -552,7 +552,7 @@ fn test_alias_passes_directive_file_to_subprocess(repo: TestRepo) {
     // Double backslashes so the Windows path (e.g. `D:\a\worktrunk\...\wt.exe`)
     // parses as literal characters inside a TOML basic string rather than
     // being interpreted as escape sequences (`\a`, `\w`, ...).
-    let wt_toml = wt_str.replace('\\', "\\\\");
+    let wt_toml = wt_str.replace('\\', r"\\");
 
     // Alias body invokes the test wt binary directly (PATH lookup in the
     // subprocess shell wouldn't find it).

--- a/tests/integration_tests/user_hooks.rs
+++ b/tests/integration_tests/user_hooks.rs
@@ -699,7 +699,7 @@ capture = "echo 'branch={{ branch }} worktree_path={{ worktree_path }} worktree_
     // The worktree_path in hook output should end with the worktree directory name
     assert!(
         content.contains(&format!("/{feature_wt_name} "))
-            || content.contains(&format!("\\{feature_wt_name} ")),
+            || content.contains(&format!(r"\{feature_wt_name} ")),
         "worktree_path should end with the removed worktree's name '{feature_wt_name}', got: {content}"
     );
 
@@ -2433,7 +2433,7 @@ capture = "echo 'wt_path={{ worktree_path }} base={{ base }} base_wt={{ base_wor
     // worktree_path should be the destination (Active)
     assert!(
         content.contains(&format!("/{feature_name} "))
-            || content.contains(&format!("\\{feature_name} ")),
+            || content.contains(&format!(r"\{feature_name} ")),
         "worktree_path should point to destination '{feature_name}', got: {content}"
     );
 
@@ -2445,7 +2445,7 @@ capture = "echo 'wt_path={{ worktree_path }} base={{ base }} base_wt={{ base_wor
 
     // cwd should be the source (where the hook actually runs)
     assert!(
-        content.contains(&format!("/{main_name}")) || content.contains(&format!("\\{main_name}")),
+        content.contains(&format!("/{main_name}")) || content.contains(&format!(r"\{main_name}")),
         "cwd should point to source worktree '{main_name}', got: {content}"
     );
 }
@@ -3011,7 +3011,7 @@ fn test_foreground_hook_passes_directive_file(repo: TestRepo) {
         !wt_str.contains('\''),
         "wt binary path should not contain single quotes: {wt_str}"
     );
-    let wt_toml = wt_str.replace('\\', "\\\\");
+    let wt_toml = wt_str.replace('\\', r"\\");
 
     // Pre-start hook that creates a new worktree via `wt switch --create`.
     // If the CD directive file is passed through, the inner wt will write a


### PR DESCRIPTION
Converts ~29 string literals across 16 files from escaped form (`"\\d+"`, `"{\"name\": 1}"`) to raw-string form (`r"\d+"`, `r#"{"name": 1}"#`) where possible. Strings containing control escapes (`\n`, `\t`, `\u{1b}`, etc.) are left alone — raw strings can't represent those.

No behavior change; `cargo check/clippy -D warnings/fmt/test` all clean locally.

> _This was written by Claude Code on behalf of max-sixty_