### PR TITLE
fix(deprecation): emit `[[pre-*]]` blocks when migrating table form

### DIFF
--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -875,43 +875,37 @@ fn migrate_negated_bool_doc(
     modified
 }
 
-/// Convert a multi-entry pre-* table section into a pipeline array within a table.
+/// Convert a multi-entry pre-* table section into an array-of-tables pipeline.
 ///
-/// Removes `[key]` as a table section and inserts `key = [{name = "cmd"}, ...]`
-/// as an array of single-entry inline tables, preserving insertion order.
+/// Removes `[key]` as a table section and inserts `[[key]]` blocks —
+/// one block per named step, preserving insertion order.
+///
+/// Iterates pre-* keys in document order (not [`PRE_HOOK_KEYS`] order) so
+/// migrated sections land in the same relative position they had in the
+/// source file.
 fn migrate_pre_hook_table_in(table: &mut toml_edit::Table, modified: &mut bool) {
-    for &key in PRE_HOOK_KEYS {
-        let is_multi_entry_table = table
-            .get(key)
-            .and_then(|item| item.as_table())
-            .is_some_and(|t| t.len() >= 2);
+    let keys_to_migrate: Vec<String> = table
+        .iter()
+        .filter(|(k, v)| {
+            PRE_HOOK_KEYS.contains(k)
+                && v.as_table()
+                    .is_some_and(|t| t.len() >= 2 && t.iter().all(|(_, v)| v.as_str().is_some()))
+        })
+        .map(|(k, _)| k.to_string())
+        .collect();
 
-        if !is_multi_entry_table {
-            continue;
-        }
+    for key in keys_to_migrate {
+        let item = table.get_mut(&key).unwrap();
+        let entries = item.as_table().unwrap();
 
-        // Skip if any entry is non-string (malformed config — don't risk data loss)
-        let all_strings = table
-            .get(key)
-            .and_then(|item| item.as_table())
-            .is_some_and(|t| t.iter().all(|(_, v)| v.as_str().is_some()));
-
-        if !all_strings {
-            continue;
-        }
-
-        // Remove the table section and build a pipeline array
-        let old_table = table.remove(key).unwrap();
-        let entries = old_table.as_table().unwrap();
-
-        let mut arr = toml_edit::Array::new();
+        let mut arr = toml_edit::ArrayOfTables::new();
         for (name, value) in entries.iter() {
-            let mut inline = toml_edit::InlineTable::new();
-            inline.insert(name, value.as_str().unwrap().into());
-            arr.push(toml_edit::Value::InlineTable(inline));
+            let mut block = toml_edit::Table::new();
+            block.insert(name, toml_edit::value(value.as_str().unwrap()));
+            arr.push(block);
         }
 
-        table.insert(key, toml_edit::Item::Value(toml_edit::Value::Array(arr)));
+        *item = toml_edit::Item::ArrayOfTables(arr);
         *modified = true;
     }
 }
@@ -3624,22 +3618,20 @@ test = "cargo test"
 lint = "cargo clippy"
 "#;
         let result = migrate_pre_hook_table_form(content);
-        // Should produce an array of inline tables
+        // Should produce `[[pre-merge]]` array-of-tables blocks
         assert!(
-            !result.contains("[pre-merge]"),
-            "Table section should be removed: {result}"
-        );
-        assert!(
-            result.contains("pre-merge"),
-            "Key should still exist: {result}"
+            result.contains("[[pre-merge]]"),
+            "Should emit [[pre-merge]] blocks: {result}"
         );
         // Verify it parses back as valid TOML with the right structure
         let doc: toml_edit::DocumentMut = result.parse().unwrap();
-        let arr = doc["pre-merge"].as_array().expect("should be array");
+        let arr = doc["pre-merge"]
+            .as_array_of_tables()
+            .expect("should be array of tables");
         assert_eq!(arr.len(), 2);
-        let first = arr.get(0).unwrap().as_inline_table().unwrap();
+        let first = arr.get(0).unwrap();
         assert_eq!(first.get("test").unwrap().as_str().unwrap(), "cargo test");
-        let second = arr.get(1).unwrap().as_inline_table().unwrap();
+        let second = arr.get(1).unwrap();
         assert_eq!(
             second.get("lint").unwrap().as_str().unwrap(),
             "cargo clippy"
@@ -3656,11 +3648,8 @@ third = "3"
 "#;
         let result = migrate_pre_hook_table_form(content);
         let doc: toml_edit::DocumentMut = result.parse().unwrap();
-        let arr = doc["pre-merge"].as_array().unwrap();
-        let names: Vec<&str> = arr
-            .iter()
-            .map(|v| v.as_inline_table().unwrap().iter().next().unwrap().0)
-            .collect();
+        let arr = doc["pre-merge"].as_array_of_tables().unwrap();
+        let names: Vec<&str> = arr.iter().map(|t| t.iter().next().unwrap().0).collect();
         assert_eq!(names, vec!["first", "second", "third"]);
     }
 
@@ -3681,7 +3670,9 @@ build = "npm run build"
         let result = migrate_pre_hook_table_form(content);
         let doc: toml_edit::DocumentMut = result.parse().unwrap();
         let project = doc["projects"]["web"].as_table().unwrap();
-        let arr = project["pre-start"].as_array().expect("should be array");
+        let arr = project["pre-start"]
+            .as_array_of_tables()
+            .expect("should be array of tables");
         assert_eq!(arr.len(), 2);
     }
 
@@ -3701,8 +3692,8 @@ build = "npm run build"
         );
         let doc: toml_edit::DocumentMut = result.parse().unwrap();
         let arr = doc["pre-start"]
-            .as_array()
-            .expect("should be pipeline array");
+            .as_array_of_tables()
+            .expect("should be pipeline array of tables");
         assert_eq!(arr.len(), 2);
     }
 
@@ -3718,8 +3709,8 @@ no-ff = true
 "#;
         let result = migrate_content(content);
         assert!(
-            !result.contains("[pre-merge]"),
-            "Table section should be migrated: {result}"
+            result.contains("[[pre-merge]]"),
+            "Table section should become [[pre-merge]] blocks: {result}"
         );
         assert!(
             result.contains("ff = false"),

--- a/src/config/snapshots/worktrunk__config__deprecation__tests__snapshot_migrate_pre_hook_table_form.snap
+++ b/src/config/snapshots/worktrunk__config__deprecation__tests__snapshot_migrate_pre_hook_table_form.snap
@@ -3,9 +3,11 @@ source: src/config/deprecation.rs
 expression: "migration_diff(content, &result)"
 ---
 -[pre-merge]
--test = "cargo test"
--lint = "cargo clippy"
-+pre-merge = [{ test = "cargo test" }, { lint = "cargo clippy" }]
++[[pre-merge]]
+ test = "cargo test"
++
++[[pre-merge]]
+ lint = "cargo clippy"
  
  [post-start]
  server = "npm run dev"

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_pre_hook_table_form_deprecation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_pre_hook_table_form_deprecation.snap
@@ -52,19 +52,23 @@ exit_code: 0
 [2m↳[22m [2mTo apply:[22m
 [107m [0m [2m[0m[2m[34mwt[0m[2m config update
 [107m [0m [1mdiff --git a_REPO_/.config/wt.toml b_REPO_/.config/wt.toml.new[m
-[107m [0m [1mindex 3a61835..0ab06b7 100644[m
+[107m [0m [1mindex 3a61835..dc2a222 100644[m
 [107m [0m [1m--- a_REPO_/.config/wt.toml[m
 [107m [0m [1m+++ b_REPO_/.config/wt.toml.new[m
-[107m [0m [36m@@ -1,7 +1,2 @@[m
+[107m [0m [36m@@ -1,7 +1,11 @@[m
 [107m [0m [31m-[pre-merge][m
-[107m [0m [31m-test = "cargo test"[m
-[107m [0m [31m-lint = "cargo clippy"[m
-[107m [0m [31m-[m
+[107m [0m [32m+[m[32m[[pre-merge]][m
+[107m [0m  test = "cargo test"[m
+[107m [0m [32m+[m
+[107m [0m [32m+[m[32m[[pre-merge]][m
+[107m [0m  lint = "cargo clippy"[m
+[107m [0m  [m
 [107m [0m [31m-[pre-start][m
-[107m [0m [31m-install = "npm ci"[m
-[107m [0m [31m-env = "cp .env.example .env"[m
-[107m [0m [32m+[m[32mpre-start = [{ install = "npm ci" }, { env = "cp .env.example .env" }][m
-[107m [0m [32m+[m[32mpre-merge = [{ test = "cargo test" }, { lint = "cargo clippy" }][m
+[107m [0m [32m+[m[32m[[pre-start]][m
+[107m [0m  install = "npm ci"[m
+[107m [0m [32m+[m
+[107m [0m [32m+[m[32m[[pre-start]][m
+[107m [0m  env = "cp .env.example .env"[m
 [2m○[22m Current config:
 [107m [0m [2m[36m[pre-merge]
 [107m [0m [2mtest = [0m[2m[32m"cargo test"


### PR DESCRIPTION
## Summary

- Pre-\* table-form migration now emits `[[pre-merge]]` array-of-tables blocks instead of an inline `pre-merge = [{...}, {...}]` pipeline, matching the block form taught in #2144 for `[[aliases.NAME]]`.
- Sections stay where the user wrote them: iterate pre-\* keys in document order and replace via `get_mut` rather than `remove` + `insert` (which appended at the end).

Generated diff before/after:

```diff
-[pre-merge]
-test = "cargo test"
-lint = "cargo clippy"
+[[pre-merge]]
+test = "cargo test"
+
+[[pre-merge]]
+lint = "cargo clippy"
```

## Test plan

- [x] `cargo test --lib config::deprecation` (139 passed)
- [x] `cargo test --test integration config_show` (97 passed)
- [x] Re-accepted two snapshots (`snapshot_migrate_pre_hook_table_form`, `config_show_displays_pre_hook_table_form_deprecation`)

> _This was written by Claude Code on behalf of max-sixty_