### PR TITLE
fix(config): drop redundant "To configure" hint for outdated shell wrappers

### DIFF
--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -918,8 +918,10 @@ fn render_shell_status(out: &mut String) -> anyhow::Result<()> {
                 } else if shell.is_wrapper_based()
                     && matches!(result.action, ConfigAction::WouldAdd)
                 {
-                    // File exists but has different content (e.g. outdated version)
-                    any_not_configured = true;
+                    // File exists but has different content (e.g. outdated version).
+                    // The per-shell "To update" hint below covers this case, so we
+                    // don't flip `any_not_configured` — the generic "To configure"
+                    // summary would be misleading when the integration is installed.
                     let warning = warning_message(cformat!(
                         "<bold>{shell}</>: Outdated shell extension @ {path}"
                     ));

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_fish_outdated_wrapper.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_fish_outdated_wrapper.snap
@@ -59,7 +59,6 @@ exit_code: 0
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_nushell_outdated_wrapper.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_nushell_outdated_wrapper.snap
@@ -59,7 +59,6 @@ exit_code: 0
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m


### PR DESCRIPTION
When a wrapper-based shell's integration file exists but is outdated (e.g., `wt.nu` drifted from the installed version), `wt config show` printed both a specific `To update, run wt config shell install nu` hint and a generic `To configure, run wt config shell install` summary. The latter is misleading — the integration *is* installed, just stale — and duplicates the action from the per-shell hint.

Keep `any_not_configured` reserved for genuinely-unconfigured shells, so the "To configure" summary only appears when at least one shell needs a fresh install (`Not configured shell extension` / `Not configured completions`).

Two snapshots updated to reflect the dropped line.