### PR TITLE
Unify the last two deprecation warnings to the standard pattern

### DIFF
--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -1362,20 +1362,13 @@ pub fn format_deprecation_warnings(info: &DeprecationInfo) -> String {
     use std::fmt::Write;
     let mut out = String::new();
 
-    if !info.deprecations.vars.is_empty() {
-        let var_list: Vec<String> = info
-            .deprecations
-            .vars
-            .iter()
-            .map(|(old, new)| cformat!("<dim>{}</> → <bold>{}</>", old, new))
-            .collect();
+    for (old, new) in &info.deprecations.vars {
         let _ = writeln!(
             out,
             "{}",
-            warning_message(format!(
-                "{} uses deprecated template variables: {}",
-                info.label,
-                var_list.join(", ")
+            warning_message(cformat!(
+                "{label}: template variable <bold>{old}</> is deprecated in favor of <bold>{new}</>",
+                label = info.label,
             ))
         );
     }
@@ -1406,8 +1399,8 @@ pub fn format_deprecation_warnings(info: &DeprecationInfo) -> String {
         let _ = writeln!(
             out,
             "{}",
-            warning_message(format!(
-                "{} has approved-commands in [projects] sections (moved to approvals.toml)",
+            warning_message(cformat!(
+                "{}: <bold>approved-commands</> under <bold>[projects]</> is deprecated in favor of <bold>approvals.toml</>",
                 info.label
             ))
         );

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
@@ -48,7 +48,7 @@ exit_code: 0
 [2m↳[22m [2mNot found; to create one, run [4mwt config create[24m[22m
 
 [36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
-[33m▲[39m [33mProject config uses deprecated template variables: [2mmain_worktree[22m → [1mrepo[22m[39m
+[33m▲[39m [33mProject config: template variable [1mmain_worktree[22m is deprecated in favor of [1mrepo[22m[39m
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
 [2m↳[22m [2mTo apply: [4mwt config update[24m[22m
 [2m○[22m Proposed diff:

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
@@ -45,7 +45,8 @@ exit_code: 0
 
 ----- stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
-[33m▲[39m [33mUser config uses deprecated template variables: [2mrepo_root[22m → [1mrepo_path[22m, [2mmain_worktree[22m → [1mrepo[22m[39m
+[33m▲[39m [33mUser config: template variable [1mrepo_root[22m is deprecated in favor of [1mrepo_path[22m[39m
+[33m▲[39m [33mUser config: template variable [1mmain_worktree[22m is deprecated in favor of [1mrepo[22m[39m
 [33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
 [2m↳[22m [2mTo apply: [4mwt config update[24m[22m
 [2m○[22m Proposed diff:

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
@@ -48,7 +48,7 @@ exit_code: 0
 [2m↳[22m [2mNot found; to create one, run [4mwt config create[24m[22m
 
 [36mPROJECT CONFIG[39m @ [PROJECT_ID]
-[33m▲[39m [33mProject config uses deprecated template variables: [2mmain_worktree[22m → [1mrepo[22m[39m
+[33m▲[39m [33mProject config: template variable [1mmain_worktree[22m is deprecated in favor of [1mrepo[22m[39m
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
 [2m↳[22m [2mTo apply: [4mwt -C _REPO_ config update[24m[22m
 

--- a/tests/snapshots/integration__integration_tests__config_show__config_update_applies_approved_commands_migration.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_update_applies_approved_commands_migration.snap
@@ -45,7 +45,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mUser config has approved-commands in [projects] sections (moved to approvals.toml)[39m
+[33m▲[39m [33mUser config: [1mapproved-commands[22m under [1m[projects][22m is deprecated in favor of [1mapprovals.toml[22m[39m
 [2m↳[22m [2mCopied approved commands to [4mapprovals.toml[24m[22m
 [2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a[TEST_CONFIG] b[TEST_CONFIG_NEW][m

--- a/tests/snapshots/integration__integration_tests__config_show__config_update_applies_template_var_migration.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_update_applies_template_var_migration.snap
@@ -45,7 +45,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mUser config uses deprecated template variables: [2mrepo_root[22m → [1mrepo_path[22m, [2mworktree[22m → [1mworktree_path[22m, [2mmain_worktree[22m → [1mrepo[22m[39m
+[33m▲[39m [33mUser config: template variable [1mrepo_root[22m is deprecated in favor of [1mrepo_path[22m[39m
+[33m▲[39m [33mUser config: template variable [1mworktree[22m is deprecated in favor of [1mworktree_path[22m[39m
+[33m▲[39m [33mUser config: template variable [1mmain_worktree[22m is deprecated in favor of [1mrepo[22m[39m
 [33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
 [2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a[TEST_CONFIG] b[TEST_CONFIG_NEW][m

--- a/tests/snapshots/integration__integration_tests__config_update_pty__config_update_prompt_accept.snap
+++ b/tests/snapshots/integration__integration_tests__config_update_pty__config_update_prompt_accept.snap
@@ -2,7 +2,8 @@
 source: tests/integration_tests/config_update_pty.rs
 expression: "&output"
 ---
-[33m▲[39m [33mUser config uses deprecated template variables: [2mrepo_root[22m → [1mrepo_path[22m, [2mmain_worktree[22m → [1mrepo[22m[39m
+[33m▲[39m [33mUser config: template variable [1mrepo_root[22m is deprecated in favor of [1mrepo_path[22m[39m
+[33m▲[39m [33mUser config: template variable [1mmain_worktree[22m is deprecated in favor of [1mrepo[22m[39m
 [33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
 [2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a[TEST_CONFIG] b[TEST_CONFIG_NEW][m

--- a/tests/snapshots/integration__integration_tests__config_update_pty__config_update_prompt_decline.snap
+++ b/tests/snapshots/integration__integration_tests__config_update_pty__config_update_prompt_decline.snap
@@ -2,7 +2,8 @@
 source: tests/integration_tests/config_update_pty.rs
 expression: "&output"
 ---
-[33m▲[39m [33mUser config uses deprecated template variables: [2mrepo_root[22m → [1mrepo_path[22m, [2mmain_worktree[22m → [1mrepo[22m[39m
+[33m▲[39m [33mUser config: template variable [1mrepo_root[22m is deprecated in favor of [1mrepo_path[22m[39m
+[33m▲[39m [33mUser config: template variable [1mmain_worktree[22m is deprecated in favor of [1mrepo[22m[39m
 [33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
 [2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a[TEST_CONFIG] b[TEST_CONFIG_NEW][m


### PR DESCRIPTION
PR #2147 left two warnings using their own grammar: template variables used a comma-joined `old → new` list, and approved-commands used "has ... (moved to ...)". Rewrite both to match the `{label}: X is deprecated in favor of Y` form used by every other structural deprecation, with `<bold>` identifiers on both sides.

Template variables now emit one warning per rename (parallel to how commit-generation project keys are already handled). Approved commands names `approvals.toml` as the destination; the existing hint line below the warning clarifies that Y is a file.

Rendering:

```
▲ User config: template variable repo_root is deprecated in favor of repo_path
▲ User config: template variable main_worktree is deprecated in favor of repo
▲ User config: approved-commands under [projects] is deprecated in favor of approvals.toml
↳ Copied approved commands to approvals.toml
```

> _This was written by Claude Code on behalf of max-sixty_