### PR TITLE
docs(hook): tighten pre-* table-form deprecation note

### DIFF
--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -97,7 +97,7 @@ server = "npm run dev"
 
 Here `install` runs first, then `build` and `server` run together.
 
-For pre-* hooks, prefer pipeline form over table form. Table form for pre-* hooks currently runs serially rather than concurrently — this inconsistency is deprecated and will change in a future version. Using pipeline form avoids the upcoming behavior change.
+Table form for pre-* hooks is deprecated and its behavior will change in a future version — use `[[hook]]` blocks instead.
 
 ## Project vs user hooks
 

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -88,7 +88,7 @@ server = "npm run dev"
 
 Here `install` runs first, then `build` and `server` run together.
 
-For pre-* hooks, prefer pipeline form over table form. Table form for pre-* hooks currently runs serially rather than concurrently — this inconsistency is deprecated and will change in a future version. Using pipeline form avoids the upcoming behavior change.
+Table form for pre-* hooks is deprecated and its behavior will change in a future version — use `[[hook]]` blocks instead.
 
 ## Project vs user hooks
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1297,7 +1297,7 @@ server = "npm run dev"
 
 Here `install` runs first, then `build` and `server` run together.
 
-For pre-* hooks, prefer pipeline form over table form. Table form for pre-* hooks currently runs serially rather than concurrently — this inconsistency is deprecated and will change in a future version. Using pipeline form avoids the upcoming behavior change.
+Table form for pre-* hooks is deprecated and its behavior will change in a future version — use `[[hook]]` blocks instead.
 
 ## Project vs user hooks
 


### PR DESCRIPTION
Collapses the three-sentence deprecation note above Project vs user hooks into a single sentence. Now that the preceding section teaches `[[hook]]` blocks as the canonical pipeline form (PR #2149), the note can name them directly and drop the serial-vs-concurrent explanation — that mechanics detail is already covered in Pipeline Ordering further down.

Before:

> For pre-* hooks, prefer pipeline form over table form. Table form for pre-* hooks currently runs serially rather than concurrently — this inconsistency is deprecated and will change in a future version. Using pipeline form avoids the upcoming behavior change.

After:

> Table form for pre-* hooks is deprecated and its behavior will change in a future version — use `[[hook]]` blocks instead.

> _This was written by Claude Code on behalf of Maximilian_