### PR TITLE
Route --help output to stdout

### DIFF
--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -80,8 +80,7 @@ pub fn handle_config_show(full: bool, format: SwitchFormat) -> anyhow::Result<()
     // Display through pager (config show is always long-form output)
     if let Err(e) = show_help_in_pager(&show_output, true) {
         log::debug!("Pager invocation failed: {}", e);
-        // Fall back to direct output via eprintln (matches help behavior)
-        worktrunk::styling::eprintln!("{}", show_output);
+        worktrunk::styling::println!("{}", show_output);
     }
 
     Ok(())

--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -451,9 +451,9 @@ pub fn handle_logs_get(
             let mut out = String::new();
             render_all_log_sections(&mut out, &repo)?;
 
-            // Display through pager (fall back to stderr if pager unavailable)
+            // Display through pager; fall back to direct stdout if pager unavailable
             if show_help_in_pager(&out, true).is_err() {
-                eprintln!("{}", out);
+                println!("{}", out);
             }
         }
         Some(hook_spec) => {
@@ -1161,11 +1161,10 @@ fn handle_state_show_table(repo: &Repository) -> anyhow::Result<()> {
     // Show log files
     render_all_log_sections(&mut out, repo)?;
 
-    // Display through pager (fall back to stderr if pager unavailable)
+    // Display through pager; fall back to direct stdout if pager unavailable
     if let Err(e) = show_help_in_pager(&out, true) {
         log::debug!("Pager invocation failed: {}", e);
-        // Fall back to direct output via eprintln (matches help behavior)
-        eprintln!("{}", out);
+        println!("{}", out);
     }
 
     Ok(())

--- a/src/commands/hook_commands.rs
+++ b/src/commands/hook_commands.rs
@@ -559,9 +559,9 @@ pub fn handle_hook_show(hook_type_filter: Option<&str>, expanded: bool) -> anyho
         ctx.as_ref(),
     )?;
 
-    // Display through pager (fall back to stderr if pager unavailable)
+    // Display through pager; fall back to direct stdout if pager unavailable
     if show_help_in_pager(&output, true).is_err() {
-        worktrunk::styling::eprintln!("{}", output);
+        worktrunk::styling::println!("{}", output);
     }
 
     Ok(())

--- a/src/help.rs
+++ b/src/help.rs
@@ -51,7 +51,7 @@ use ansi_str::AnsiStr;
 use clap::ColorChoice;
 use clap::error::ErrorKind;
 use worktrunk::docs::convert_dollar_console_to_terminal;
-use worktrunk::styling::eprintln;
+use worktrunk::styling::{eprintln, println};
 
 use crate::cli;
 
@@ -159,7 +159,7 @@ pub fn maybe_handle_help_with_pager() -> bool {
                     // use_pager=false for -h (short help), true for --help (long help)
                     if let Err(e) = crate::help_pager::show_help_in_pager(&help, use_pager) {
                         log::debug!("Pager invocation failed: {}", e);
-                        eprintln!("{}", help);
+                        println!("{}", help);
                     }
                     process::exit(0);
                 }

--- a/src/help_pager.rs
+++ b/src/help_pager.rs
@@ -66,41 +66,38 @@ fn detect_help_pager() -> Option<String> {
 ///
 /// The `use_pager` flag controls whether to attempt pager display:
 /// - `true` (--help): Uses pager when available and terminal is detected
-/// - `false` (-h): Always prints directly to stderr, never uses pager
+/// - `false` (-h): Always prints directly to stdout, never uses pager
 ///
 /// This follows git's convention where `-h` never opens a pager (muscle-memory safe)
 /// while `--help` uses a pager for longer content.
 ///
 /// Even when `use_pager=true`, falls back to direct output if:
-/// - No pager configured (prints to stderr)
-/// - Neither stdout nor stderr is a TTY (prints to stderr)
-/// - Pager spawn fails (prints to stderr)
+/// - No pager configured (prints to stdout)
+/// - Neither stdout nor stderr is a TTY (prints to stdout)
+/// - Pager spawn fails (prints to stdout)
 ///
-/// Note: All fallbacks output to stderr for consistency with pager behavior
-/// (which sends output to stderr via `>&2`). This ensures `config show`
-/// works correctly since stdout is reserved for data output.
+/// Help text goes to stdout — POSIX convention (`wt --help | less` should work
+/// without redirection), matching `cargo`, `curl`, `python`, `git <cmd> -h`,
+/// and `--version` (see #2072).
 pub(crate) fn show_help_in_pager(help_text: &str, use_pager: bool) -> std::io::Result<()> {
     // Short help (-h) never uses a pager
     if !use_pager {
-        log::debug!("Short help (-h) requested, printing directly to stderr");
-        eprint!("{}", help_text);
+        log::debug!("Short help (-h) requested, printing directly to stdout");
+        print!("{}", help_text);
         return Ok(());
     }
 
     let Some(pager_cmd) = detect_help_pager() else {
-        log::debug!("No pager configured, printing help directly to stderr");
-        eprint!("{}", help_text);
+        log::debug!("No pager configured, printing help directly to stdout");
+        print!("{}", help_text);
         return Ok(());
     };
 
-    // Check if stdout OR stderr is a TTY
-    // stdout check: direct invocation (cargo run -- --help)
-    // stderr check: shell wrapper (wt --help) redirects stdout but preserves stderr
-    let is_tty = std::io::stdout().is_terminal() || std::io::stderr().is_terminal();
-
-    if !is_tty {
-        log::debug!("Neither stdout nor stderr is a TTY, skipping pager");
-        eprint!("{}", help_text);
+    // Only page when our output destination is a terminal.
+    // If stdout is piped/redirected (e.g., `wt --help | grep foo`), print directly.
+    if !std::io::stdout().is_terminal() {
+        log::debug!("stdout is not a TTY, skipping pager");
+        print!("{}", help_text);
         return Ok(());
     }
 
@@ -108,24 +105,19 @@ pub(crate) fn show_help_in_pager(help_text: &str, use_pager: bool) -> std::io::R
 
     let less_flags = compute_less_flags(std::env::var("LESS").ok().as_deref());
 
-    // Always send pager output to stderr (standard for help text, like git)
-    // This works in all cases: direct invocation, shell wrapper, piping, etc.
-    // Note: pager_cmd is expected to be valid shell code (like git's core.pager).
-    // Users with paths containing special chars must quote them in their config.
-    let final_cmd = format!("{} >&2", pager_cmd);
-
-    // Spawn pager with TTY access (interactive, unlike detached diff renderer)
+    // Spawn pager with TTY access (interactive, unlike detached diff renderer).
+    // Pager output inherits our stdout — no redirection needed.
     // Falls back to direct output if pager unavailable (e.g., less not installed)
     let shell = match ShellConfig::get() {
         Ok(shell) => shell,
         Err(e) => {
             log::debug!("Shell unavailable for pager: {}", e);
-            eprint!("{}", help_text);
+            print!("{}", help_text);
             return Ok(());
         }
     };
     log::debug!("$ {} (pager)", pager_cmd);
-    let mut cmd = shell.command(&final_cmd);
+    let mut cmd = shell.command(&pager_cmd);
     worktrunk::shell_exec::scrub_directive_env_vars(&mut cmd);
     let mut child = match cmd.stdin(Stdio::piped()).env("LESS", &less_flags).spawn() {
         Ok(child) => child,
@@ -136,7 +128,7 @@ pub(crate) fn show_help_in_pager(help_text: &str, use_pager: bool) -> std::io::R
                 shell.name,
                 e
             );
-            eprint!("{}", help_text);
+            print!("{}", help_text);
             return Ok(());
         }
     };

--- a/src/help_pager.rs
+++ b/src/help_pager.rs
@@ -24,6 +24,7 @@
 use std::io::{IsTerminal, Write};
 use std::process::Stdio;
 use worktrunk::shell_exec::ShellConfig;
+use worktrunk::styling::print;
 
 use crate::pager::{git_config_pager, parse_pager_value};
 

--- a/src/help_pager.rs
+++ b/src/help_pager.rs
@@ -74,7 +74,7 @@ fn detect_help_pager() -> Option<String> {
 ///
 /// Even when `use_pager=true`, falls back to direct output if:
 /// - No pager configured (prints to stdout)
-/// - Neither stdout nor stderr is a TTY (prints to stdout)
+/// - stdout is not a TTY (prints to stdout)
 /// - Pager spawn fails (prints to stdout)
 ///
 /// Help text goes to stdout — POSIX convention (`wt --help | less` should work

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -248,16 +248,16 @@ my-lint = "my-lint-tool"
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
 
     // Both hooks should be present (deep merge preserves differently-named keys)
     assert!(
-        stderr.contains("company-lint-tool"),
-        "System hook should be preserved with different name, got:\n{stderr}"
+        stdout.contains("company-lint-tool"),
+        "System hook should be preserved with different name, got:\n{stdout}"
     );
     assert!(
-        stderr.contains("my-lint-tool"),
-        "User hook should be present, got:\n{stderr}"
+        stdout.contains("my-lint-tool"),
+        "User hook should be present, got:\n{stdout}"
     );
 }
 
@@ -300,16 +300,16 @@ lint = "my-lint-tool"
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
 
     // User's command should replace system's for the same name
     assert!(
-        stderr.contains("my-lint-tool"),
-        "User's hook command should be present, got:\n{stderr}"
+        stdout.contains("my-lint-tool"),
+        "User's hook command should be present, got:\n{stdout}"
     );
     assert!(
-        !stderr.contains("company-lint-tool"),
-        "System's hook command should be replaced by user's same-named hook, got:\n{stderr}"
+        !stdout.contains("company-lint-tool"),
+        "System's hook command should be replaced by user's same-named hook, got:\n{stdout}"
     );
 }
 
@@ -355,10 +355,10 @@ my-lint = "my-lint-tool"
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stderr.contains("company-format-tool"),
-        "System's pre-commit hook should be preserved when user doesn't override it, got:\n{stderr}"
+        stdout.contains("company-format-tool"),
+        "System's pre-commit hook should be preserved when user doesn't override it, got:\n{stdout}"
     );
 }
 
@@ -382,18 +382,18 @@ fn test_config_show_system_config_hint_under_user_config(repo: TestRepo, temp_ho
     cmd.arg("config").arg("show").current_dir(repo.root_path());
 
     let output = cmd.output().unwrap();
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
 
     // Should NOT show a full SYSTEM CONFIG heading
     assert!(
-        !stderr.contains("SYSTEM CONFIG"),
-        "Should not show SYSTEM CONFIG section when absent, got:\n{stderr}"
+        !stdout.contains("SYSTEM CONFIG"),
+        "Should not show SYSTEM CONFIG section when absent, got:\n{stdout}"
     );
     // Should show a system config hint under USER CONFIG
     assert!(
-        stderr.contains("Optional system config not found")
-            && stderr.contains("worktrunk/config.toml"),
-        "Expected system config hint in output, got:\n{stderr}"
+        stdout.contains("Optional system config not found")
+            && stdout.contains("worktrunk/config.toml"),
+        "Expected system config hint in output, got:\n{stdout}"
     );
 }
 
@@ -891,10 +891,10 @@ if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)
 
         let output = cmd.output().unwrap();
         assert!(output.status.success());
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
         assert!(
-            stderr.contains("Completions won't work; add to"),
-            "Expected compinit warning, got:\n{stderr}"
+            stdout.contains("Completions won't work; add to"),
+            "Expected compinit warning, got:\n{stdout}"
         );
     });
 }
@@ -940,10 +940,10 @@ if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init zsh)
 
         let output = cmd.output().unwrap();
         assert!(output.status.success());
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
         assert!(
-            !stderr.contains("Completions won't work; add to"),
-            "Expected no compinit warning, got:\n{stderr}"
+            !stdout.contains("Completions won't work; add to"),
+            "Expected no compinit warning, got:\n{stdout}"
         );
     });
 }

--- a/tests/integration_tests/config_state.rs
+++ b/tests/integration_tests/config_state.rs
@@ -533,16 +533,7 @@ fn test_state_get_logs_empty(repo: TestRepo) {
     let output = wt_state_cmd(&repo, "logs", "get", &[]).output().unwrap();
     assert!(output.status.success());
     state_get_settings().bind(|| {
-        assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"
-        [36mCOMMAND LOG[39m @ <PATH>
-        [107m [0m (none)
-
-        [36mHOOK OUTPUT[39m @ <PATH>
-        [107m [0m (none)
-
-        [36mDIAGNOSTIC[39m @ <PATH>
-        [107m [0m (none)
-        ");
+        assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"");
     });
 }
 
@@ -572,21 +563,7 @@ fn test_state_get_logs_with_files(repo: TestRepo) {
     // File sizes and ages vary across environments
     settings.add_filter(r"(?m)\d+[BK]\s+\S+[ \t]*$", "<SIZE>  <AGE>");
     settings.bind(|| {
-        assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"
-        [36mCOMMAND LOG[39m @ <PATH>
-              File      Size  Age   
-         ────────────── ──── ────── 
-         commands.jsonl <SIZE>  <AGE>
-
-        [36mHOOK OUTPUT[39m @ <PATH>
-                          File                   Size  Age   
-         ─────────────────────────────────────── ──── ────── 
-         bugfix-zgc/internal/remove.log          <SIZE>  <AGE>
-         feature-axb/user/post-start/npm-iox.log <SIZE>  <AGE>
-
-        [36mDIAGNOSTIC[39m @ <PATH>
-        [107m [0m (none)
-        ");
+        assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"");
     });
 }
 
@@ -602,16 +579,7 @@ fn test_state_get_logs_dir_exists_no_log_files(repo: TestRepo) {
     let output = wt_state_cmd(&repo, "logs", "get", &[]).output().unwrap();
     assert!(output.status.success());
     state_get_settings().bind(|| {
-        assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"
-        [36mCOMMAND LOG[39m @ <PATH>
-        [107m [0m (none)
-
-        [36mHOOK OUTPUT[39m @ <PATH>
-        [107m [0m (none)
-
-        [36mDIAGNOSTIC[39m @ <PATH>
-        [107m [0m (none)
-        ");
+        assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"");
     });
 }
 
@@ -629,21 +597,21 @@ fn test_state_get_logs_diagnostic_files(repo: TestRepo) {
 
     let output = wt_state_cmd(&repo, "logs", "get", &[]).output().unwrap();
     assert!(output.status.success());
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
 
     // Diagnostic files appear under DIAGNOSTIC, not HOOK OUTPUT
-    assert!(stderr.contains("DIAGNOSTIC"), "Expected DIAGNOSTIC heading");
+    assert!(stdout.contains("DIAGNOSTIC"), "Expected DIAGNOSTIC heading");
     assert!(
-        stderr.contains("verbose.log"),
+        stdout.contains("verbose.log"),
         "Expected verbose.log in output"
     );
     assert!(
-        stderr.contains("diagnostic.md"),
+        stdout.contains("diagnostic.md"),
         "Expected diagnostic.md in output"
     );
 
     // Hook output should have the remove log but not the diagnostic files
-    let hook_section = stderr
+    let hook_section = stdout
         .split("DIAGNOSTIC")
         .next()
         .unwrap()
@@ -899,34 +867,7 @@ fn test_state_get_empty(repo: TestRepo) {
     let output = wt_state_get_cmd(&repo).output().unwrap();
     assert!(output.status.success());
     state_get_settings().bind(|| {
-        assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"
-        [36mDEFAULT BRANCH[39m
-        [107m [0m main
-
-        [36mPREVIOUS BRANCH[39m
-        [107m [0m (none)
-
-        [36mBRANCH MARKERS[39m
-        [107m [0m (none)
-
-        [36mVARS[39m
-        [107m [0m (none)
-
-        [36mCI STATUS CACHE[39m
-        [107m [0m (none)
-
-        [36mHINTS[39m
-        [107m [0m (none)
-
-        [36mCOMMAND LOG[39m @ <PATH>
-        [107m [0m (none)
-
-        [36mHOOK OUTPUT[39m @ <PATH>
-        [107m [0m (none)
-
-        [36mDIAGNOSTIC[39m @ <PATH>
-        [107m [0m (none)
-        ");
+        assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"");
     });
 }
 
@@ -960,7 +901,7 @@ fn test_state_get_with_ci_entries(repo: TestRepo) {
     let output = wt_state_get_cmd(&repo).output().unwrap();
     assert!(output.status.success());
     state_get_settings().bind(|| {
-        assert_snapshot!(String::from_utf8_lossy(&output.stderr));
+        assert_snapshot!(String::from_utf8_lossy(&output.stdout));
     });
 }
 
@@ -1027,7 +968,7 @@ fn test_state_get_comprehensive(repo: TestRepo) {
     let output = wt_state_get_cmd(&repo).output().unwrap();
     assert!(output.status.success());
     state_get_settings().bind(|| {
-        assert_snapshot!(String::from_utf8_lossy(&output.stderr));
+        assert_snapshot!(String::from_utf8_lossy(&output.stdout));
     });
 }
 

--- a/tests/integration_tests/configure_shell.rs
+++ b/tests/integration_tests/configure_shell.rs
@@ -1988,9 +1988,9 @@ fn test_config_show_detects_nushell_integration(mut repo: TestRepo, temp_home: T
     cmd.args(["config", "show"]).current_dir(repo.root_path());
 
     let output = cmd.output().expect("Failed to execute config show");
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stderr.contains("wt.nu") || stderr.contains("nushell"),
-        "config show should detect nushell integration:\n{stderr}"
+        stdout.contains("wt.nu") || stdout.contains("nushell"),
+        "config show should detect nushell integration:\n{stdout}"
     );
 }

--- a/tests/integration_tests/help.rs
+++ b/tests/integration_tests/help.rs
@@ -135,6 +135,25 @@ fn test_help_goes_to_stdout() {
     }
 }
 
+/// When stdout is piped, help must be plain text — no ANSI escapes leaking into
+/// `wt --help > file.txt` or `wt --help | less`. Uses the raw binary so
+/// `CLICOLOR_FORCE` (set by `wt_command`) doesn't override color detection.
+#[test]
+fn test_help_strips_ansi_when_piped() {
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_wt"))
+        .arg("--help")
+        .env_remove("CLICOLOR_FORCE")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("failed to run wt --help");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains('\x1b'),
+        "wt --help piped to a file must not contain ANSI escapes; got: {stdout:?}"
+    );
+}
+
 /// `--version` must write to stdout, not stderr. This is the POSIX convention
 /// and what scripts expect — e.g., `version=$(wt --version)` or test harnesses
 /// that grep for a version string from stdout. See #2072.

--- a/tests/integration_tests/help.rs
+++ b/tests/integration_tests/help.rs
@@ -27,9 +27,9 @@ fn snapshot_help(test_name: &str, args: &[&str]) {
         // Double blanks indicate formatting issues (e.g., HTML comments like
         // `<!-- demo: file.gif -->` with blank lines on both sides).
         let output = cmd.output().expect("failed to run command");
-        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
         assert!(
-            !stderr.contains("\n\n\n"),
+            !stdout.contains("\n\n\n"),
             "Double blank line in help output for `wt {}`",
             args.join(" ")
         );
@@ -108,6 +108,31 @@ fn test_version() {
         cmd.arg("--version");
         assert_cmd_snapshot!("version", cmd);
     });
+}
+
+/// `--help` must write to stdout, not stderr. POSIX convention — matches
+/// `cargo`, `curl`, `python`, and `git <cmd> -h`. Lets users do
+/// `wt --help | less` or `wt --help > help.txt` without redirection.
+#[test]
+fn test_help_goes_to_stdout() {
+    for args in [&["--help"][..], &["-h"][..], &["merge", "--help"][..]] {
+        let output = wt_command()
+            .args(args)
+            .output()
+            .unwrap_or_else(|e| panic!("failed to run wt {args:?}: {e}"));
+
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        assert!(
+            stdout.contains("Usage:"),
+            "wt {args:?} should write help to stdout, but stdout was: {stdout:?} (stderr: {stderr:?})"
+        );
+        assert!(
+            stderr.trim().is_empty(),
+            "wt {args:?} should not write to stderr, but stderr was: {stderr:?}"
+        );
+    }
 }
 
 /// `--version` must write to stdout, not stderr. This is the POSIX convention

--- a/tests/integration_tests/output_system_guard.rs
+++ b/tests/integration_tests/output_system_guard.rs
@@ -1,14 +1,16 @@
 //! Guard test to prevent stdout leaks in command code
 //!
-//! stdout is reserved for data output (e.g., JSON). User-visible messages go to stderr.
-//! When shell integration is active (directive env vars set), directives are written
-//! to files, not stdout.
+//! stdout carries content the user may want to pipe, redirect, or capture:
+//! data (JSON, tables), rendered views (`wt config show`, `wt hook show`),
+//! and shell integration output. Interactive status, progress, and errors
+//! go to stderr. When shell integration is active (directive env vars set),
+//! directives are written to files, not stdout.
 //!
 //! This test enforces: **No accidental stdout writes in command code**
 //!
 //! Allowed:
 //! - `eprintln!` / `eprint!` (stderr is safe)
-//! - `println!` / `print!` in files listed in `STDOUT_ALLOWED_PATHS` (data output)
+//! - `println!` / `print!` in files listed in `STDOUT_ALLOWED_PATHS`
 //!
 //! When adding stdout output:
 //! - Use `worktrunk::styling::println` for color-aware output
@@ -48,6 +50,8 @@ const STDOUT_ALLOWED_PATHS: &[&str] = &[
     "for_each.rs",
     // JSON output for wt merge --format=json
     "merge.rs",
+    // Hook listing output for wt hook show (paged)
+    "hook_commands.rs",
 ];
 
 /// Substrings that indicate the line is a special case (e.g., in a comment or test reference)

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_always_regenerates_migration_file.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mNot found; to create one, run [4mwt config create[24m[22m
 
@@ -75,3 +73,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_claude_available_plugin_not_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_claude_available_plugin_not_installed.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -68,3 +66,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUser config uses deprecated template variables: [2mrepo_root[22m → [1mrepo_path[22m, [2mmain_worktree[22m → [1mrepo[22m[39m
 [33m▲[39m [33mUser config uses deprecated hook name: post-create → pre-start[39m
@@ -79,3 +77,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_no_cd_deprecation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_no_cd_deprecation.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUser config: [1mswitch.no-cd[22m is deprecated in favor of [1mswitch.cd[22m (inverted)[39m
 [2m↳[22m [2mTo apply: [4mwt config update[24m[22m
@@ -74,3 +72,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_no_ff_deprecation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_no_ff_deprecation.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUser config: [1mmerge.no-ff[22m is deprecated in favor of [1mmerge.ff[22m (inverted)[39m
 [2m↳[22m [2mTo apply: [4mwt config update[24m[22m
@@ -74,3 +72,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_pre_hook_table_form_deprecation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_pre_hook_table_form_deprecation.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mNot found; to create one, run [4mwt config create[24m[22m
 
@@ -87,3 +85,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUser config uses deprecated config sections: [projects."github.com/example/repo".commit-generation] → [projects."github.com/example/repo".commit.generation][39m
 [2m↳[22m [2mTo apply:[22m
@@ -81,3 +79,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_select_section_deprecation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_select_section_deprecation.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUser config: [1m[select][22m is deprecated in favor of [1m[switch.picker][22m[39m
 [2m↳[22m [2mTo apply: [4mwt config update[24m[22m
@@ -74,3 +72,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_empty_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_empty_project_config.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -64,3 +62,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_empty_system_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_empty_system_config.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mSYSTEM CONFIG[39m @ [PROJECT_ID]
 [2m↳[22m [2mEmpty file (no system defaults)[22m
 
@@ -66,3 +64,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_fish_outdated_wrapper.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_fish_outdated_wrapper.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
@@ -65,3 +63,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_fish_with_completions.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_fish_with_completions.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
@@ -66,3 +64,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_fish_without_completions.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_fish_without_completions.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
@@ -67,3 +65,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mNot found; to create one, run [4mwt config create[24m[22m
 
@@ -68,3 +66,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_command_not_found.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_command_not_found.snap
@@ -34,7 +34,7 @@ info:
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
-    WORKTRUNK_TEST_LATEST_VERSION: 0.34.1
+    WORKTRUNK_TEST_LATEST_VERSION: 0.36.0
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
@@ -44,8 +44,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [107m [0m 
@@ -78,3 +76,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_not_configured.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_not_configured.snap
@@ -34,7 +34,7 @@ info:
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
-    WORKTRUNK_TEST_LATEST_VERSION: 0.34.1
+    WORKTRUNK_TEST_LATEST_VERSION: 0.36.0
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
@@ -44,8 +44,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -71,3 +69,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_update_available.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_update_available.snap
@@ -44,8 +44,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -71,3 +69,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_version_check_unavailable.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_version_check_unavailable.snap
@@ -44,8 +44,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -71,3 +69,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_github_remote.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_github_remote.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -64,3 +62,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_gitlab_remote.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_gitlab_remote.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -64,3 +62,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_project_toml.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_project_toml.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -70,3 +68,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_system_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_system_config.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mSYSTEM CONFIG[39m @ [PROJECT_ID]
 [31m✗[39m [31mInvalid config[39m
 [107m [0m TOML parse error at line 1, column 16
@@ -72,3 +70,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_user_toml.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_user_toml.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [31m✗[39m [31mInvalid config[39m
 [107m [0m TOML parse error at line 1, column 6
@@ -70,3 +68,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_no_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_no_project_config.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -64,3 +62,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_no_user_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_no_user_config.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mNot found; to create one, run [4mwt config create[24m[22m
 
@@ -63,3 +61,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_nushell_outdated_wrapper.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_nushell_outdated_wrapper.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
@@ -65,3 +63,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_opencode_available_plugin_not_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_opencode_available_plugin_not_installed.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -67,3 +65,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_opencode_plugin_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_opencode_plugin_installed.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -67,3 +65,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_opencode_plugin_outdated.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_opencode_plugin_outdated.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -67,3 +65,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_outside_git_repo.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_outside_git_repo.snap
@@ -37,8 +37,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -58,3 +56,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_partial_shell_config_shows_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_partial_shell_config_shows_hint.snap
@@ -43,8 +43,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
@@ -67,3 +65,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_plugin_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_plugin_installed.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -68,3 +66,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_powershell_detected_via_psmodulepath.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_powershell_detected_via_psmodulepath.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
@@ -66,3 +64,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_shell_active_but_not_in_config_file.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_shell_active_but_not_in_config_file.snap
@@ -43,8 +43,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -64,3 +62,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_shell_integration_active.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_shell_integration_active.snap
@@ -43,8 +43,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -64,3 +62,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_statusline_configured.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_statusline_configured.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -68,3 +66,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_project_config_for_ci.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_project_config_for_ci.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUser config uses deprecated config section: [ci] → [forge][39m
 [2m↳[22m [2mTo apply:[22m
@@ -84,3 +82,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -80,3 +78,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_not_suppressed_by_wrapper.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_not_suppressed_by_wrapper.snap
@@ -43,8 +43,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
@@ -69,3 +67,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_warning.snap
@@ -43,8 +43,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
@@ -68,3 +66,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_project_keys.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_project_keys.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -66,3 +64,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_user_keys.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_user_keys.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [33m▲[39m [33mUnknown key [1mcommit-gen[22m will be ignored[39m
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
@@ -68,3 +66,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_whitespace_only_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_whitespace_only_project_config.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -64,3 +62,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_with_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_with_project_config.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
 [2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
@@ -81,3 +79,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_with_system_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_with_system_config.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mSYSTEM CONFIG[39m @ [PROJECT_ID]
 [107m [0m [2m[36m[merge]
 [107m [0m [2msquash = [0m[2m[33mtrue
@@ -71,3 +69,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_correct_order.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_correct_order.snap
@@ -43,8 +43,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
@@ -66,3 +64,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_warning.snap
@@ -43,8 +43,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mEmpty file (using defaults)[22m
 
@@ -68,3 +66,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_state__state_get_comprehensive.snap
+++ b/tests/snapshots/integration__integration_tests__config_state__state_get_comprehensive.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/integration_tests/config_state.rs
-expression: "String::from_utf8_lossy(&output.stderr)"
+expression: "String::from_utf8_lossy(&output.stdout)"
 ---
 [36mDEFAULT BRANCH[39m
 [107m [0m main

--- a/tests/snapshots/integration__integration_tests__config_state__state_get_with_ci_entries.snap
+++ b/tests/snapshots/integration__integration_tests__config_state__state_get_with_ci_entries.snap
@@ -1,6 +1,6 @@
 ---
 source: tests/integration_tests/config_state.rs
-expression: "String::from_utf8_lossy(&output.stderr)"
+expression: "String::from_utf8_lossy(&output.stdout)"
 ---
 [36mDEFAULT BRANCH[39m
 [107m [0m main

--- a/tests/snapshots/integration__integration_tests__configure_shell__config_show_detects_fish_legacy_conf_d.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__config_show_detects_fish_legacy_conf_d.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mNot found; to create one, run [4mwt config create[24m[22m
 
@@ -65,3 +63,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__configure_shell__config_show_fish_legacy_with_functions_dir.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__config_show_fish_legacy_with_functions_dir.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2mNot found; to create one, run [4mwt config create[24m[22m
 
@@ -65,3 +63,5 @@ exit_code: 0
 [2m○[22m wt: [1m[VERSION][22m
 [2m○[22m git: [1m[VERSION][22m
 [2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -31,8 +31,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt config create - Create configuration file
 
 Usage: [1m[36mwt config create[0m [36m[OPTIONS][0m
@@ -359,3 +357,5 @@ With [2m--project[0m, creates [2m.config/wt.toml[0m in the current repositor
 [107m [0m [2m# url = "echo http://localhost:{{ branch | hash_port }}"[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# Aliases defined here are shared with teammates. For personal aliases, use the user config (https://worktrunk.dev/config/#aliases) `[aliases]` section instead.[0m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -30,8 +30,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt config - Manage user & project configs[0m
 
 Includes shell integration, hooks, and saved state.[0m
@@ -450,4 +448,6 @@ Override the LLM command in CI to use a mock:
  [2mWORKTRUNK_SHELL[0m                   Internal: set by shell wrappers to indicate shell type (e.g., [2mpowershell[0m)               
  [2mWORKTRUNK_MAX_CONCURRENT_COMMANDS[0m Max parallel git commands (default: 32). Lower if hitting file descriptor limits.       
  [2mNO_COLOR[0m                          Disable colored output (standard)                                                       
- [2mCLICOLOR_FORCE[0m                    Force colored output even when not a TTY
+ [2mCLICOLOR_FORCE[0m                    Force colored output even when not a TTY                                                
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_shell.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_shell.snap
@@ -31,8 +31,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt config shell - Shell integration setup
 
 Usage: [1m[36mwt config shell[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
@@ -50,3 +48,5 @@ Usage: [1m[36mwt config shell[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_shell.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_shell.snap
@@ -31,8 +31,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt config shell - Shell integration setup
 
 Usage: [1m[36mwt config shell[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
@@ -50,3 +48,5 @@ Usage: [1m[36mwt config shell[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_short.snap
@@ -30,8 +30,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt config - Manage user & project configs
 
 Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
@@ -51,3 +49,5 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_short.snap
@@ -30,8 +30,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt config - Manage user & project configs
 
 Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
@@ -51,3 +49,5 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_show.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_show.snap
@@ -31,8 +31,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt config show - Show configuration files & locations
 
 Usage: [1m[36mwt config show[0m [36m[OPTIONS][0m
@@ -79,3 +77,5 @@ This tests:
 - [1mCI tool status[0m — Whether [2mgh[0m (GitHub) or [2mglab[0m (GitLab) is installed and authenticated
 - [1mCommit generation[0m — Whether the LLM command can generate commit messages
 - [1mVersion check[0m — Whether a newer version is available on GitHub
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_state.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state.snap
@@ -31,8 +31,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt config state - Manage internal data and cache
 
 Usage: [1m[36mwt config state[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
@@ -95,3 +93,5 @@ Show all stored state:
 
 Clear all stored state:
 [107m [0m [2m[0m[2m[34mwt[0m[2m config state clear[0m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
@@ -32,8 +32,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt config state ci-status - CI status cache
 
 Usage: [1m[36mwt config state ci-status[0m [36m[OPTIONS][0m [36m[COMMAND][0m
@@ -78,3 +76,5 @@ Results cache for 30-60 seconds. Indicators dim when local changes haven't been 
 See [2mwt list[0m CI status for display symbols and colors.
 
 Without a subcommand, runs [2mget[0m for the current branch. Use [2mclear[0m to reset cache for a branch or [2mclear --all[0m to reset all.
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_clear.snap
@@ -32,8 +32,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt config state clear - Clear all stored state
 
 Usage: [1m[36mwt config state clear[0m [36m[OPTIONS][0m
@@ -65,3 +63,5 @@ Clears all stored state:
 
 Use individual subcommands ([2mdefault-branch clear[0m, [2mci-status clear --all[0m, etc.)
 to clear specific state.
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
@@ -32,8 +32,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt config state default-branch - Default branch detection and override
 
 Usage: [1m[36mwt config state default-branch[0m [36m[OPTIONS][0m [36m[COMMAND][0m
@@ -79,3 +77,5 @@ The local inference fallback uses these heuristics in order:
 - For bare repos or empty repos, checks [2msymbolic-ref HEAD[0m
 - Checks [2mgit config init.defaultBranch[0m
 - Looks for common names: [2mmain[0m, [2mmaster[0m, [2mdevelop[0m, [2mtrunk[0m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_get.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_get.snap
@@ -32,8 +32,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt config state get - Get all stored state
 
 Usage: [1m[36mwt config state get[0m [36m[OPTIONS][0m
@@ -68,3 +66,5 @@ Shows all stored state including:
 - [1mLog files[0m: Operation and debug logs
 
 CI cache entries show status, age, and the commit SHA they were fetched for.
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
@@ -32,8 +32,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt config state logs - Operation and debug logs
 
 Usage: [1m[36mwt config state logs[0m [36m[OPTIONS][0m [36m[COMMAND][0m
@@ -114,3 +112,5 @@ View a specific hook log:
 
 Clear all logs:
 [107m [0m [2m[0m[2m[34mwt[0m[2m config state logs clear[0m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
@@ -32,8 +32,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt config state marker - Branch markers
 
 Usage: [1m[36mwt config state marker[0m [36m[OPTIONS][0m [36m[COMMAND][0m
@@ -78,3 +76,5 @@ Stored in git config as [2mworktrunk.state.<branch>.marker[0m. Set directly wi
 [107m [0m [2m[0m[2m[34mgit[0m[2m config worktrunk.state.feature.marker [0m[2m[32m'{"marker":"🚧","set_at":0}'[0m[2m[0m
 
 Without a subcommand, runs [2mget[0m for the current branch. For [2m--branch[0m, use [2mget --branch=NAME[0m.
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch.snap
@@ -32,8 +32,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt config state previous-branch - Previous branch (for [1mwt switch -[0m)
 
 Usage: [1m[36mwt config state previous-branch[0m [36m[OPTIONS][0m [36m[COMMAND][0m
@@ -64,3 +62,5 @@ Enables [2mwt switch -[0m to return to the previous worktree, similar to [2mc
 Updated automatically on every [2mwt switch[0m. Stored in git config as [2mworktrunk.history[0m.
 
 Without a subcommand, runs [2mget[0m. Use [2mset[0m to override or [2mclear[0m to reset.
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_hook_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_approvals.snap
@@ -31,8 +31,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt hook approvals - Manage command approvals
 
 Usage: [1m[36mwt hook approvals[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
@@ -71,3 +69,5 @@ Clear global approvals:
 [1m[32mHow approvals work[0m
 
 Approved commands are saved to [2m~/.config/worktrunk/approvals.toml[0m. Re-approval is required when the command template changes or the project moves. Use [2m--yes[0m to bypass prompts in CI.
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_hook_approvals_add.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_approvals_add.snap
@@ -32,8 +32,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt hook approvals add - Store approvals in approvals.toml
 
 Usage: [1m[36mwt hook approvals add[0m [36m[OPTIONS][0m
@@ -59,3 +57,5 @@ Prompts for approval of all project commands and saves them to approvals.toml.
 
 By default, shows only unapproved commands. Use [2m--all[0m to review all commands
 including previously approved ones.
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_hook_approvals_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_approvals_clear.snap
@@ -32,8 +32,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt hook approvals clear - Clear approved commands from approvals.toml
 
 Usage: [1m[36mwt hook approvals clear[0m [36m[OPTIONS][0m
@@ -59,3 +57,5 @@ Removes saved approvals, requiring re-approval on next command run.
 
 By default, clears approvals for the current project. Use [2m--global[0m to clear
 all approvals across all projects.
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -30,8 +30,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt list - List worktrees and their status
 
 Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
@@ -309,3 +307,5 @@ Missing a field that would be generally useful? Open an issue at https://github.
 [1m[32mSee also[0m
 
 - [2mwt switch[0m — Switch worktrees or open interactive picker
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -30,8 +30,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt list - List worktrees and their status
 
 Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
@@ -346,3 +344,5 @@ https://github.com/max-sixty/worktrunk.
 [1m[32mSee also[0m
 
 - [2mwt switch[0m — Switch worktrees or open interactive picker
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_list_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_short.snap
@@ -30,8 +30,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt list - List worktrees and their status
 
 Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
@@ -52,3 +50,5 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_list_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_short.snap
@@ -30,8 +30,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt list - List worktrees and their status
 
 Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
@@ -52,3 +50,5 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
@@ -30,8 +30,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt merge - Merge current branch into the target branch[0m
 
 Squash & rebase, fast-forward the target branch, remove the worktree.[0m
@@ -160,3 +158,5 @@ The full workflow: start an agent (one of many) on a task, work elsewhere, retur
 - [2mwt step[0m — Run individual operations (commit, squash, rebase, push)
 - [2mwt remove[0m — Remove worktrees without merging
 - [2mwt switch[0m — Navigate to other worktrees
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_merge_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_short.snap
@@ -30,8 +30,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt merge - Merge current branch into the target branch
 
 Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET][0m
@@ -57,3 +55,5 @@ Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET][0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_merge_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_short.snap
@@ -30,8 +30,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt merge - Merge current branch into the target branch
 
 Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET][0m
@@ -57,3 +55,5 @@ Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET][0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_no_args.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_no_args.snap
@@ -28,8 +28,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt - Git worktree management for parallel AI agent workflows
 
 Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
@@ -51,3 +49,5 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_no_args.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_no_args.snap
@@ -28,8 +28,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt - Git worktree management for parallel AI agent workflows
 
 Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
@@ -51,3 +49,5 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
@@ -30,8 +30,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt remove - Remove worktree; delete branch if merged[0m
 
 Defaults to the current worktree.[0m
@@ -157,3 +155,5 @@ Detached worktrees have no branch name. Pass the worktree path instead: [2mwt r
 
 - [2mwt merge[0m — Remove worktree after merging
 - [2mwt list[0m — View all worktrees
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_remove_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_short.snap
@@ -30,8 +30,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt remove - Remove worktree; delete branch if merged
 
 Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...[0m
@@ -55,3 +53,5 @@ Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_remove_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_short.snap
@@ -30,8 +30,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt remove - Remove worktree; delete branch if merged
 
 Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...[0m
@@ -55,3 +53,5 @@ Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_root_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root_long.snap
@@ -29,8 +29,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt - Git worktree management for parallel AI agent workflows
 
 Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
@@ -73,3 +71,5 @@ Run [2mwt config create[0m to customize worktree locations.
 
 Docs: https://worktrunk.dev
 GitHub: https://github.com/max-sixty/worktrunk
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_root_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root_short.snap
@@ -29,8 +29,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt - Git worktree management for parallel AI agent workflows
 
 Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
@@ -52,3 +50,5 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_root_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root_short.snap
@@ -29,8 +29,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt - Git worktree management for parallel AI agent workflows
 
 Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
@@ -52,3 +50,5 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_step_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_long.snap
@@ -30,8 +30,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt step - Run individual operations[0m
 
 The building blocks of [1mwt merge[0m — commit, squash, rebase, push — plus standalone utilities.[0m
@@ -150,3 +148,5 @@ When defined in both user and project config, both run — user first, then proj
 Inside an alias body, an inner [2mwt switch[0m (or [2mwt switch --create[0m) passes its [2mcd[0m through to the parent shell, so an alias wrapping [2mwt switch --create[0m lands the shell in the new worktree just like running it directly.
 
 Alias names that match a built-in step command ([2mcommit[0m, [2msquash[0m, etc.) are shadowed by the built-in and will never run.
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_step_promote.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_promote.snap
@@ -31,8 +31,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt step promote - [experimental] Swap a branch into the main worktree[0m
 
 Exchanges branches and gitignored files between two worktrees.[0m
@@ -92,3 +90,5 @@ Without an argument, promotes the current branch — or restores the default bra
 Gitignored files (build artifacts, [2mnode_modules/[0m, [2m.env[0m) are swapped along with the branches so each worktree keeps the artifacts that belong to its branch. Files are discovered using the same mechanism as [2mcopy-ignored[0m and can be filtered with [2m.worktreeinclude[0m.
 
 The swap uses [2mrename()[0m for each entry — fast regardless of entry size, since only filesystem metadata changes. If the worktree is on a different filesystem from [2m.git/[0m, it falls back to reflink copy.
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_step_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_short.snap
@@ -30,8 +30,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt step - Run individual operations
 
 Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
@@ -56,3 +54,5 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_step_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_short.snap
@@ -30,8 +30,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt step - Run individual operations
 
 Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
@@ -56,3 +54,5 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -30,8 +30,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt switch - Switch to a worktree; create if needed
 
 Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--[0m [36m<EXECUTE_ARGS>...[0m[1m[36m][0m
@@ -221,3 +219,5 @@ To change which branch a worktree is on, use [2mgit switch[0m inside that work
 - [2mwt list[0m — View all worktrees
 - [2mwt remove[0m — Delete worktrees when done
 - [2mwt merge[0m — Integrate changes back to the default branch
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
@@ -30,8 +30,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt switch - Switch to a worktree; create if needed
 
 Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--[0m [36m<EXECUTE_ARGS>...[0m[1m[36m][0m
@@ -61,3 +59,5 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
@@ -30,8 +30,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt switch - Switch to a worktree; create if needed
 
 Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--[0m [36m<EXECUTE_ARGS>...[0m[1m[36m][0m
@@ -61,3 +59,5 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_approval_status.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_approval_status.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER HOOKS[39m @ ~/.config/worktrunk/config.toml
 [2m↳[22m [2m(none configured)[22m
 
@@ -52,3 +50,5 @@ exit_code: 0
 [107m [0m [2m[0m[2m[34mcargo[0m[2m build
 [36m❯[39m pre-merge [1mtest[22m: [2m(requires approval)[22m
 [107m [0m [2m[0m[2m[34mcargo[0m[2m test
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_expanded_syntax_error.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_expanded_syntax_error.snap
@@ -44,8 +44,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
@@ -53,3 +51,5 @@ exit_code: 0
 [36m❯[39m pre-commit [1mbroken[22m: [2m(requires approval)[22m
 [107m [0m [2m# Failed to expand hook preview: syntax error: unexpected end of input, expected end of variable block @ line 1[0m[2m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m{{[0m[2m branch
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_expanded_undefined_var.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_expanded_undefined_var.snap
@@ -44,8 +44,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
@@ -53,3 +51,5 @@ exit_code: 0
 [36m❯[39m pre-commit [1moptional-var[22m: [2m(requires approval)[22m
 [107m [0m [2m# Failed to expand hook preview: undefined value @ line 1[0m[2m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m{{[0m[2m base [0m[2m[32m}}[0m[2m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_expanded_valid_template.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_expanded_valid_template.snap
@@ -44,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
 [36mPROJECT HOOKS[39m @ _REPO_/.config/wt.toml
 [36m❯[39m pre-commit [1mvalid[22m: [2m(requires approval)[22m
 [107m [0m [2m[0m[2m[34mecho[0m[2m branch=main repo=repo
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_filter_by_type.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_filter_by_type.snap
@@ -43,8 +43,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
@@ -53,3 +51,5 @@ exit_code: 0
 [107m [0m [2m[0m[2m[34mcargo[0m[2m build
 [36m❯[39m pre-merge [1mtest[22m: [2m(requires approval)[22m
 [107m [0m [2m[0m[2m[34mcargo[0m[2m test
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_filter_post_merge.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_filter_post_merge.snap
@@ -43,11 +43,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
 [36mPROJECT HOOKS[39m @ _REPO_/.config/wt.toml
 [36m❯[39m post-merge [1mdeploy[22m: [2m(requires approval)[22m
 [107m [0m [2m[0m[2m[34mscripts/deploy.sh[0m[2m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_filter_post_remove.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_filter_post_remove.snap
@@ -43,11 +43,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
 [36mPROJECT HOOKS[39m @ _REPO_/.config/wt.toml
 [36m❯[39m post-remove [1mnotify[22m: [2m(requires approval)[22m
 [107m [0m [2m[0m[2m[34mecho[0m[2m removed
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_filter_pre_remove.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_filter_pre_remove.snap
@@ -43,11 +43,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
 [36mPROJECT HOOKS[39m @ _REPO_/.config/wt.toml
 [36m❯[39m pre-remove [1mcleanup[22m: [2m(requires approval)[22m
 [107m [0m [2m[0m[2m[34mecho[0m[2m cleanup
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_no_hooks.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_no_hooks.snap
@@ -42,10 +42,10 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
 [36mPROJECT HOOKS[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2m(not found)[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_project_config_no_hooks.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_project_config_no_hooks.snap
@@ -42,10 +42,10 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
 [36mPROJECT HOOKS[39m @ _REPO_/.config/wt.toml
 [2m↳[22m [2m(none configured)[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_show_with_both_configs.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_show_with_both_configs.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [36mUSER HOOKS[39m @ [TEST_CONFIG]
 [2m↳[22m [2m(none configured)[22m
 
@@ -54,3 +52,5 @@ exit_code: 0
 [107m [0m [2m[0m[2m[34mcargo[0m[2m build
 [36m❯[39m pre-merge [1mtest[22m: [2m(requires approval)[22m
 [107m [0m [2m[0m[2m[34mcargo[0m[2m test
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_alias__step_help_includes_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_help_includes_aliases.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt step - Run individual operations
 
 Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
@@ -71,3 +69,5 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_alias__step_help_includes_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_help_includes_aliases.snap
@@ -42,8 +42,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt step - Run individual operations
 
 Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
@@ -71,3 +69,5 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_alias__step_list_no_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_list_no_aliases.snap
@@ -41,8 +41,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt step - Run individual operations
 
 Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
@@ -67,3 +65,5 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_alias__step_list_no_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_list_no_aliases.snap
@@ -41,8 +41,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt step - Run individual operations
 
 Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
@@ -67,3 +65,5 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_alias__step_list_with_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_list_with_aliases.snap
@@ -41,8 +41,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt step - Run individual operations
 
 Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
@@ -72,3 +70,5 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: hooks, templates; -vv: debug report)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_alias__step_list_with_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_list_with_aliases.snap
@@ -41,8 +41,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 wt step - Run individual operations
 
 Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
@@ -72,3 +70,5 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report; -vvv: trace logs)
+
+----- stderr -----


### PR DESCRIPTION
Worktrunk sent all help output to stderr. This is an outlier versus most CLIs (cargo, curl, python, `git <cmd> -h` — all stdout) and versus `--version`, which moved to stdout in #2072 for the same reasons. Move help to stdout and canonicalize the shared pager function so its other callers (`wt config show`, `wt hook show`, `wt config state`) emit on stdout too.

The prior rationale — "stdout is reserved for data output" so `wt config show | jq` works — was already self-contradictory: `config show` went through the same pager helper and was landing on stderr.

## What changed

- `src/help_pager.rs` — removed the `>&2` pager redirect and switched fallback prints from `std::print!` to the anstream-aware `worktrunk::styling::print`, so piped/redirected output is plain text rather than raw ANSI. Simplified the TTY guard to check stdout only (the `stdout OR stderr` check was a leftover from the redirect era).
- `src/help.rs` — DisplayHelp fallback prints via `styling::println`.
- `src/commands/config/{show,state}.rs`, `src/commands/hook_commands.rs` — pager fallbacks print to stdout.
- Added `test_help_goes_to_stdout` and `test_help_strips_ansi_when_piped` as regression anchors (parallel to existing `test_version_goes_to_stdout`). Verified the ANSI test catches the bug by reverting temporarily.
- Updated ~90 snapshots where content moved from the `----- stderr -----` section to `----- stdout -----`.

## User-visible behavior change

Scripts that did `wt --help 2>/dev/null | x` previously discarded help and piped nothing; they now pipe the help text. `wt --help > file` captures help instead of leaving the file blank. Both changes align Worktrunk with POSIX conventions. Terminal usage (pager on TTY) is unchanged.

> _This was written by Claude Code on behalf of @max-sixty_