### PR TITLE
feat(config-state): hoist --format to parent subcommands; add absolute path to logs JSON

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -755,6 +755,10 @@ Usage: <b><span class=c>wt config state logs</span></b> <span class=c>[OPTIONS]<
   <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
           Print help (see a summary with &#39;-h&#39;)
 
+<b><span class=g>Output:</span></b>
+      <b><span class=c>--format</span></b><span class=c> &lt;FORMAT&gt;</span>
+          Output format (text, json) [default: text]
+
 <b><span class=g>Global Options:</span></b>
   <b><span class=c>-C</span></b><span class=c> &lt;path&gt;</span>
           Working directory for this command
@@ -807,6 +811,10 @@ Usage: <b><span class=c>wt config state ci-status</span></b> <span class=c>[OPTI
 <b><span class=g>Options:</span></b>
   <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
           Print help (see a summary with &#39;-h&#39;)
+
+<b><span class=g>Output:</span></b>
+      <b><span class=c>--format</span></b><span class=c> &lt;FORMAT&gt;</span>
+          Output format (text, json) [default: text]
 
 <b><span class=g>Global Options:</span></b>
   <b><span class=c>-C</span></b><span class=c> &lt;path&gt;</span>
@@ -872,6 +880,10 @@ Usage: <b><span class=c>wt config state marker</span></b> <span class=c>[OPTIONS
 <b><span class=g>Options:</span></b>
   <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
           Print help (see a summary with &#39;-h&#39;)
+
+<b><span class=g>Output:</span></b>
+      <b><span class=c>--format</span></b><span class=c> &lt;FORMAT&gt;</span>
+          Output format (text, json) [default: text]
 
 <b><span class=g>Global Options:</span></b>
   <b><span class=c>-C</span></b><span class=c> &lt;path&gt;</span>

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -784,6 +784,10 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Output:
+      --format <FORMAT>
+          Output format (text, json) [default: text]
+
 Global Options:
   -C <path>
           Working directory for this command
@@ -836,6 +840,10 @@ Commands:
 Options:
   -h, --help
           Print help (see a summary with '-h')
+
+Output:
+      --format <FORMAT>
+          Output format (text, json) [default: text]
 
 Global Options:
   -C <path>
@@ -900,6 +908,10 @@ Commands:
 Options:
   -h, --help
           Print help (see a summary with '-h')
+
+Output:
+      --format <FORMAT>
+          Output format (text, json) [default: text]
 
 Global Options:
   -C <path>

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -662,6 +662,17 @@ $ wt config state logs clear
     Logs {
         #[command(subcommand)]
         action: Option<LogsAction>,
+
+        /// Output format (text, json) [default: text]
+        #[arg(
+            long,
+            default_value = "text",
+            global = true,
+            hide_possible_values = true,
+            hide_default_value = true,
+            help_heading = "Output"
+        )]
+        format: SwitchFormat,
     },
 
     /// One-time hints shown in this repo
@@ -686,6 +697,17 @@ $ wt config state hints clear NAME   # re-show specific hint
     Hints {
         #[command(subcommand)]
         action: Option<HintsAction>,
+
+        /// Output format (text, json) [default: text]
+        #[arg(
+            long,
+            default_value = "text",
+            global = true,
+            hide_possible_values = true,
+            hide_default_value = true,
+            help_heading = "Output"
+        )]
+        format: SwitchFormat,
     },
 
     /// CI status cache
@@ -717,6 +739,17 @@ Without a subcommand, runs `get` for the current branch. Use `clear` to reset ca
     CiStatus {
         #[command(subcommand)]
         action: Option<CiStatusAction>,
+
+        /// Output format (text, json) [default: text]
+        #[arg(
+            long,
+            default_value = "text",
+            global = true,
+            hide_possible_values = true,
+            hide_default_value = true,
+            help_heading = "Output"
+        )]
+        format: SwitchFormat,
     },
 
     /// Branch markers
@@ -751,6 +784,17 @@ Without a subcommand, runs `get` for the current branch. For `--branch`, use `ge
     Marker {
         #[command(subcommand)]
         action: Option<MarkerAction>,
+
+        /// Output format (text, json) [default: text]
+        #[arg(
+            long,
+            default_value = "text",
+            global = true,
+            hide_possible_values = true,
+            hide_default_value = true,
+            help_heading = "Output"
+        )]
+        format: SwitchFormat,
     },
 
     /// \[experimental\] Custom variables per branch
@@ -901,10 +945,6 @@ $ wt config state ci-status clear && wt config state ci-status get
         /// Target branch (defaults to current)
         #[arg(long, add = crate::completion::branch_value_completer())]
         branch: Option<String>,
-
-        /// Output format (text, json)
-        #[arg(long, default_value = "text", help_heading = "Output")]
-        format: SwitchFormat,
     },
 
     /// Clear CI status cache
@@ -954,10 +994,6 @@ $ wt config state marker get --branch=feature
         /// Target branch (defaults to current)
         #[arg(long, add = crate::completion::branch_value_completer())]
         branch: Option<String>,
-
-        /// Output format (text, json)
-        #[arg(long, default_value = "text", help_heading = "Output")]
-        format: SwitchFormat,
     },
 
     /// Set marker for a branch
@@ -1055,15 +1091,6 @@ $ wt config state logs get --hook=user:post-start:server --branch=feature
         /// Target branch (defaults to current)
         #[arg(long, add = crate::completion::branch_value_completer())]
         branch: Option<String>,
-
-        /// Output format (text, json)
-        #[arg(
-            long,
-            default_value = "text",
-            conflicts_with = "hook",
-            help_heading = "Output"
-        )]
-        format: SwitchFormat,
     },
 
     /// Clear all log files
@@ -1084,11 +1111,7 @@ List shown hints:
 $ wt config state hints
 ```"#
     )]
-    Get {
-        /// Output format (text, json)
-        #[arg(long, default_value = "text", help_heading = "Output")]
-        format: SwitchFormat,
-    },
+    Get,
 
     /// Clear hints (re-show on next trigger)
     #[command(

--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -224,7 +224,11 @@ fn clear_logs(repo: &Repository) -> anyhow::Result<usize> {
 
 /// A row ready to render in the log listing table or emit as JSON.
 struct LogRow {
+    /// Path relative to `wt_logs_dir()` (forward-slashed), for compact display.
+    /// For top-level shared files this is just the filename.
     display_name: String,
+    /// Absolute path (forward-slashed), for consumers that want to open the file directly.
+    path: String,
     size: u64,
     modified_at: Option<u64>,
 }
@@ -233,6 +237,7 @@ impl LogRow {
     fn to_json(&self) -> serde_json::Value {
         serde_json::json!({
             "file": self.display_name,
+            "path": self.path,
             "size": self.size,
             "modified_at": self.modified_at,
         })
@@ -242,6 +247,7 @@ impl LogRow {
 /// Build a `LogRow` for a top-level shared file.
 fn top_level_log_row(entry: &std::fs::DirEntry) -> LogRow {
     let name = entry.file_name().to_string_lossy().into_owned();
+    let path = entry.path().to_slash_lossy().into_owned();
     let meta = entry.metadata().ok();
     let size = meta.as_ref().map(|m| m.len()).unwrap_or(0);
     let modified_at = meta
@@ -250,13 +256,14 @@ fn top_level_log_row(entry: &std::fs::DirEntry) -> LogRow {
         .map(|d| d.as_secs());
     LogRow {
         display_name: name,
+        path,
         size,
         modified_at,
     }
 }
 
 /// Build a `LogRow` for a hook-output file (display uses relative path).
-fn hook_output_log_row(entry: &HookOutputEntry) -> LogRow {
+fn hook_output_log_row(log_dir: &Path, entry: &HookOutputEntry) -> LogRow {
     let size = entry.metadata.len();
     let modified_at = entry
         .metadata
@@ -264,8 +271,13 @@ fn hook_output_log_row(entry: &HookOutputEntry) -> LogRow {
         .ok()
         .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
         .map(|d| d.as_secs());
+    let path = log_dir
+        .join(&entry.relative_display)
+        .to_slash_lossy()
+        .into_owned();
     LogRow {
         display_name: entry.relative_display.clone(),
+        path,
         size,
         modified_at,
     }
@@ -308,7 +320,7 @@ fn partition_log_files_json(
     // Hook output comes from walking the branch subtrees.
     let hook_rows: Vec<LogRow> = walk_hook_output_files(&log_dir)?
         .iter()
-        .map(hook_output_log_row)
+        .map(|e| hook_output_log_row(&log_dir, e))
         .collect();
 
     Ok((
@@ -402,7 +414,7 @@ fn render_hook_output_section(out: &mut String, repo: &Repository) -> anyhow::Re
 
     let rows: Vec<LogRow> = walk_hook_output_files(&log_dir)?
         .iter()
-        .map(hook_output_log_row)
+        .map(|e| hook_output_log_row(&log_dir, e))
         .collect();
     render_log_table(out, &rows)?;
     Ok(())
@@ -479,10 +491,16 @@ pub fn handle_logs_get(
             let log_path = hook_log.path(&log_dir, &branch);
 
             if log_path.exists() {
-                // Output just the path to stdout for easy piping.
                 // Use to_slash_lossy() so Windows paths use forward slashes, consistent
                 // with the relative paths in `logs list` output.
-                println!("{}", log_path.to_slash_lossy());
+                let path_str = log_path.to_slash_lossy().into_owned();
+                if format == SwitchFormat::Json {
+                    let output = serde_json::json!({ "path": path_str });
+                    println!("{}", serde_json::to_string_pretty(&output)?);
+                } else {
+                    // Output just the path to stdout for easy piping.
+                    println!("{}", path_str);
+                }
                 return Ok(());
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -358,35 +358,26 @@ fn handle_state_command(action: StateCommand) -> anyhow::Result<()> {
             }
             Some(PreviousBranchAction::Clear) => handle_state_clear("previous-branch", None, false),
         },
-        StateCommand::CiStatus { action } => match action {
-            Some(CiStatusAction::Get { branch, format }) => {
-                handle_state_get("ci-status", branch, format)
-            }
-            None => handle_state_get("ci-status", None, SwitchFormat::Text),
+        StateCommand::CiStatus { action, format } => match action {
+            Some(CiStatusAction::Get { branch }) => handle_state_get("ci-status", branch, format),
+            None => handle_state_get("ci-status", None, format),
             Some(CiStatusAction::Clear { branch, all }) => {
                 handle_state_clear("ci-status", branch, all)
             }
         },
-        StateCommand::Marker { action } => match action {
-            Some(MarkerAction::Get { branch, format }) => {
-                handle_state_get("marker", branch, format)
-            }
-            None => handle_state_get("marker", None, SwitchFormat::Text),
+        StateCommand::Marker { action, format } => match action {
+            Some(MarkerAction::Get { branch }) => handle_state_get("marker", branch, format),
+            None => handle_state_get("marker", None, format),
             Some(MarkerAction::Set { value, branch }) => handle_state_set("marker", value, branch),
             Some(MarkerAction::Clear { branch, all }) => handle_state_clear("marker", branch, all),
         },
-        StateCommand::Logs { action } => match action {
-            Some(LogsAction::Get {
-                hook,
-                branch,
-                format,
-            }) => handle_logs_get(hook, branch, format),
-            None => handle_logs_get(None, None, SwitchFormat::Text),
+        StateCommand::Logs { action, format } => match action {
+            Some(LogsAction::Get { hook, branch }) => handle_logs_get(hook, branch, format),
+            None => handle_logs_get(None, None, format),
             Some(LogsAction::Clear) => handle_state_clear("logs", None, false),
         },
-        StateCommand::Hints { action } => match action {
-            Some(HintsAction::Get { format }) => handle_hints_get(format),
-            None => handle_hints_get(SwitchFormat::Text),
+        StateCommand::Hints { action, format } => match action {
+            Some(HintsAction::Get) | None => handle_hints_get(format),
             Some(HintsAction::Clear { name }) => handle_hints_clear(name),
         },
         StateCommand::Vars { action } => match action {

--- a/tests/integration_tests/config_state.rs
+++ b/tests/integration_tests/config_state.rs
@@ -1162,6 +1162,7 @@ fn test_state_get_json_with_logs(repo: TestRepo) {
             {
               "file": "commands.jsonl",
               "modified_at": "<MTIME>",
+              "path": "_REPO_/.git/wt/logs/commands.jsonl",
               "size": "<SIZE>"
             }
           ],
@@ -1172,11 +1173,13 @@ fn test_state_get_json_with_logs(repo: TestRepo) {
             {
               "file": "bugfix-zgc/internal/remove.log",
               "modified_at": "<MTIME>",
+              "path": "_REPO_/.git/wt/logs/bugfix-zgc/internal/remove.log",
               "size": "<SIZE>"
             },
             {
               "file": "feature-axb/user/post-start/npm-iox.log",
               "modified_at": "<MTIME>",
+              "path": "_REPO_/.git/wt/logs/feature-axb/user/post-start/npm-iox.log",
               "size": "<SIZE>"
             }
           ],
@@ -1470,6 +1473,36 @@ fn test_state_logs_get_hook_returns_path(repo: TestRepo) {
     assert!(
         stdout.contains(&expected),
         "Expected {expected} in stdout: {stdout}",
+    );
+}
+
+#[rstest]
+fn test_state_logs_get_hook_format_json(repo: TestRepo) {
+    // `--hook=...` combined with `--format=json` emits a JSON object
+    // containing the absolute path, not a bare path line.
+    let git_dir = repo.root_path().join(".git");
+    let log_dir = git_dir.join("wt/logs");
+    std::fs::create_dir_all(&log_dir).unwrap();
+    let relative = hook_log_rel_path("main", "user", "post-start", "server");
+    write_log_at(&log_dir, &relative, "server output");
+
+    let output = wt_state_cmd(
+        &repo,
+        "logs",
+        "get",
+        &["--hook=user:post-start:server", "--format=json"],
+    )
+    .output()
+    .unwrap();
+    assert!(output.status.success());
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&stdout).expect("stdout should be valid JSON");
+    let path = parsed["path"].as_str().expect("path field missing");
+    assert!(
+        path.ends_with(&rel_display(&relative)),
+        "path {path} should end with the relative log path"
     );
 }
 
@@ -2031,6 +2064,26 @@ fn test_logs_get_json_empty(repo: TestRepo) {
     let output = wt_state_cmd(&repo, "logs", "get", &["--format=json"])
         .output()
         .unwrap();
+    assert!(output.status.success());
+    assert_snapshot!(String::from_utf8_lossy(&output.stdout), @r#"
+    {
+      "command_log": [],
+      "diagnostic": [],
+      "hook_output": []
+    }
+    "#);
+}
+
+/// `--format=json` on the bareword subcommand (no `get`) routes to the
+/// same list view. `--format` is `global = true` on the parent, so all three
+/// call shapes — `logs --format=json`, `logs --format=json get`,
+/// `logs get --format=json` — produce JSON.
+#[rstest]
+fn test_logs_bare_format_json(repo: TestRepo) {
+    let mut cmd = repo.wt_command();
+    cmd.args(["config", "state", "logs", "--format=json"]);
+    cmd.current_dir(repo.root_path());
+    let output = cmd.output().unwrap();
     assert!(output.status.success());
     assert_snapshot!(String::from_utf8_lossy(&output.stdout), @r#"
     {

--- a/tests/snapshots/integration__integration_tests__config_state__logs_get_json_with_files.snap
+++ b/tests/snapshots/integration__integration_tests__config_state__logs_get_json_with_files.snap
@@ -7,6 +7,7 @@ expression: "String::from_utf8_lossy(&output.stdout)"
     {
       "file": "commands.jsonl",
       "modified_at": "<TIMESTAMP>",
+      "path": "_REPO_/.git/wt/logs/commands.jsonl",
       "size": "<SIZE>"
     }
   ],
@@ -14,6 +15,7 @@ expression: "String::from_utf8_lossy(&output.stdout)"
     {
       "file": "diagnostic.md",
       "modified_at": "<TIMESTAMP>",
+      "path": "_REPO_/.git/wt/logs/diagnostic.md",
       "size": "<SIZE>"
     }
   ],
@@ -21,6 +23,7 @@ expression: "String::from_utf8_lossy(&output.stdout)"
     {
       "file": "main-<HASH>/user/post-start/server-<HASH>.log",
       "modified_at": "<TIMESTAMP>",
+      "path": "_REPO_/.git/wt/logs/main-<HASH>/user/post-start/server-<HASH>.log",
       "size": "<SIZE>"
     }
   ]

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
@@ -46,6 +46,10 @@ Usage: [1m[36mwt config state ci-status[0m [36m[OPTIONS][0m [36m[COMMAND]
   [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
+[1m[32mOutput:[0m
+      [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m
+          Output format (text, json) [default: text]
+
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
@@ -46,6 +46,10 @@ Usage: [1m[36mwt config state logs[0m [36m[OPTIONS][0m [36m[COMMAND][0m
   [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
+[1m[32mOutput:[0m
+      [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m
+          Output format (text, json) [default: text]
+
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
@@ -47,6 +47,10 @@ Usage: [1m[36mwt config state marker[0m [36m[OPTIONS][0m [36m[COMMAND][0m
   [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')
 
+[1m[32mOutput:[0m
+      [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m
+          Output format (text, json) [default: text]
+
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m
           Working directory for this command


### PR DESCRIPTION
Previously `wt config state logs --format=json` errored with "unexpected argument '--format'" — the flag only existed on the `get` action, even though the bare form dispatches to the same list view. Same shape on `hints`, `ci-status`, `marker`.

Consolidates `--format` to a single `global = true` flag on each parent; drops the now-duplicate field from the `Get` actions. `--format=json` now works regardless of ordering: `logs --format=json`, `logs --format=json get`, `logs get --format=json`.

Logs JSON entries now include `path` (absolute, forward-slashed) alongside `file` (relative), so consumers don't need to join with `wt_logs_dir()` to open the file:

```json
{
  "file": "main-vfz/user/post-switch/zellij-tab-xtr.log",
  "path": "/Users/.../.git/wt/logs/main-vfz/user/post-switch/zellij-tab-xtr.log",
  "size": 124,
  "modified_at": 1776041854
}
```

`logs get --hook=X --format=json` also emits `{"path": "..."}` instead of a bare path line, so JSON consumers get a uniform shape whether they're listing all logs or resolving one hook.

> _This was written by Claude Code on behalf of Maximilian Roos_