### PR TITLE
Skip hash suffix for already-safe log filenames

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -245,7 +245,7 @@ Hook output logs are centralized in `.git/wt/logs/` (main worktree's git directo
 - **Background hooks**: `{branch}/{source}/{hook-type}/{name}.log` (source: `user` or `project`)
 - **Background removal**: `{branch}/internal/remove.log`
 
-Top-level *files* are shared logs (`commands.jsonl*`, `verbose.log`, `diagnostic.md`); top-level *directories* are per-branch log trees. Branch and hook names are sanitized via `sanitize_for_filename` (invalid characters → `-`; short collision-avoidance hash appended).
+Top-level *files* are shared logs (`commands.jsonl*`, `verbose.log`, `diagnostic.md`); top-level *directories* are per-branch log trees. Branch and hook names are sanitized via `sanitize_for_filename`: already-safe names pass through unchanged; names with invalid characters have them replaced with `-` and a short collision-avoidance hash appended.
 
 ## Coverage
 

--- a/docs/content/remove.md
+++ b/docs/content/remove.md
@@ -63,7 +63,7 @@ Without `--force`, removal fails if the worktree contains untracked files. Witho
 
 Removal runs in the background by default — the command returns immediately. The worktree is renamed into `.git/wt/trash/` (instant same-filesystem rename), git metadata is pruned, the branch is deleted, and a detached `rm -rf` finishes cleanup. Cross-filesystem worktrees fall back to `git worktree remove`. Logs: `.git/wt/logs/{branch}/internal/remove.log`. Use `--foreground` to run in the foreground.
 
-After each `wt remove`, entries in `.git/wt/trash/` older than 24 hours are swept by a detached `rm -rf` — eventual cleanup for directories orphaned when a previous background removal was interrupted (SIGKILL, reboot, disk full). The sweep's log lives at `.git/wt/logs/wt-boj/internal/trash-sweep.log` (the `wt` pseudo-branch is sanitized via `sanitize_for_filename` like any other branch name).
+After each `wt remove`, entries in `.git/wt/trash/` older than 24 hours are swept by a detached `rm -rf` — eventual cleanup for directories orphaned when a previous background removal was interrupted (SIGKILL, reboot, disk full).
 
 ## Hooks
 

--- a/skills/worktrunk/reference/remove.md
+++ b/skills/worktrunk/reference/remove.md
@@ -67,7 +67,7 @@ Without `--force`, removal fails if the worktree contains untracked files. Witho
 
 Removal runs in the background by default — the command returns immediately. The worktree is renamed into `.git/wt/trash/` (instant same-filesystem rename), git metadata is pruned, the branch is deleted, and a detached `rm -rf` finishes cleanup. Cross-filesystem worktrees fall back to `git worktree remove`. Logs: `.git/wt/logs/{branch}/internal/remove.log`. Use `--foreground` to run in the foreground.
 
-After each `wt remove`, entries in `.git/wt/trash/` older than 24 hours are swept by a detached `rm -rf` — eventual cleanup for directories orphaned when a previous background removal was interrupted (SIGKILL, reboot, disk full). The sweep's log lives at `.git/wt/logs/wt-boj/internal/trash-sweep.log` (the `wt` pseudo-branch is sanitized via `sanitize_for_filename` like any other branch name).
+After each `wt remove`, entries in `.git/wt/trash/` older than 24 hours are swept by a detached `rm -rf` — eventual cleanup for directories orphaned when a previous background removal was interrupted (SIGKILL, reboot, disk full).
 
 ## Hooks
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -973,7 +973,7 @@ Without `--force`, removal fails if the worktree contains untracked files. Witho
 
 Removal runs in the background by default — the command returns immediately. The worktree is renamed into `.git/wt/trash/` (instant same-filesystem rename), git metadata is pruned, the branch is deleted, and a detached `rm -rf` finishes cleanup. Cross-filesystem worktrees fall back to `git worktree remove`. Logs: `.git/wt/logs/{branch}/internal/remove.log`. Use `--foreground` to run in the foreground.
 
-After each `wt remove`, entries in `.git/wt/trash/` older than 24 hours are swept by a detached `rm -rf` — eventual cleanup for directories orphaned when a previous background removal was interrupted (SIGKILL, reboot, disk full). The sweep's log lives at `.git/wt/logs/wt-boj/internal/trash-sweep.log` (the `wt` pseudo-branch is sanitized via `sanitize_for_filename` like any other branch name).
+After each `wt remove`, entries in `.git/wt/trash/` older than 24 hours are swept by a detached `rm -rf` — eventual cleanup for directories orphaned when a previous background removal was interrupted (SIGKILL, reboot, disk full).
 
 ## Hooks
 

--- a/src/commands/process.rs
+++ b/src/commands/process.rs
@@ -41,8 +41,9 @@ pub enum InternalOp {
 /// - Example: `feature/internal/remove.log`
 ///
 /// Branch and hook names are sanitized for filesystem safety via
-/// `sanitize_for_filename`, which replaces invalid characters and appends a
-/// short collision-avoidance hash.
+/// `sanitize_for_filename`. Already-safe names pass through unchanged; names
+/// containing invalid characters have them replaced and a short
+/// collision-avoidance hash appended.
 ///
 /// # CLI format for lookup
 ///
@@ -556,6 +557,10 @@ pub fn sweep_stale_trash(repo: &Repository) {
         .collect();
     let command = format!("rm -rf -- {}", escaped.join(" "));
 
+    // TODO: the sweep is global (not branch-scoped), but `HookLog::path()`
+    // always prefixes with a branch segment, so we pass a fake `"wt"` here.
+    // Cleaner would be a top-level variant resolving to `internal/{op}.log`
+    // alongside the other shared logs (`commands.jsonl`, `verbose.log`, etc.).
     if let Err(e) = spawn_detached(
         repo,
         &repo.wt_dir(),
@@ -747,10 +752,10 @@ mod tests {
         wildcard: fix-wildcard-38y
         quotes: fix-quotes-2xu
         multiple special: a-b-c-d-e-f-g-h-i-j-obi
-        already safe: normal-branch-83y
-        underscore: branch_with_underscore-b65
-        reserved prefix CONSOLE: CONSOLE-8fv
-        reserved prefix COM10: COM10-1s2
+        already safe: normal-branch
+        underscore: branch_with_underscore
+        reserved prefix CONSOLE: CONSOLE
+        reserved prefix COM10: COM10
         "
         );
 
@@ -862,20 +867,20 @@ mod tests {
         let log = HookLog::hook(HookSource::User, HookType::PostStart, "server");
         assert_snapshot!(
             log.path(log_dir, "main").to_slash_lossy(),
-            @"/repo/.git/wt/logs/main-vfz/user/post-start/server-f4t.log"
+            @"/repo/.git/wt/logs/main/user/post-start/server.log"
         );
 
         // Slash in branch name gets sanitized (feature/auth → feature-auth-{hash})
         assert_snapshot!(
             log.path(log_dir, "feature/auth").to_slash_lossy(),
-            @"/repo/.git/wt/logs/feature-auth-j34/user/post-start/server-f4t.log"
+            @"/repo/.git/wt/logs/feature-auth-j34/user/post-start/server.log"
         );
 
         // Project source
         let log = HookLog::hook(HookSource::Project, HookType::PreStart, "build");
         assert_snapshot!(
             log.path(log_dir, "main").to_slash_lossy(),
-            @"/repo/.git/wt/logs/main-vfz/project/pre-start/build-seq.log"
+            @"/repo/.git/wt/logs/main/project/pre-start/build.log"
         );
 
         // Constructor and parse produce identical paths
@@ -889,14 +894,14 @@ mod tests {
         // Internal operation path: {log_dir}/{sanitized-branch}/internal/{op}.log
         assert_snapshot!(
             HookLog::internal(InternalOp::Remove).path(log_dir, "main").to_slash_lossy(),
-            @"/repo/.git/wt/logs/main-vfz/internal/remove.log"
+            @"/repo/.git/wt/logs/main/internal/remove.log"
         );
 
         // Non-branch-scoped internal ops (like TrashSweep) use a pseudo-branch
         // at the top level — `wt remove` calls this with branch = "wt".
         assert_snapshot!(
             HookLog::internal(InternalOp::TrashSweep).path(log_dir, "wt").to_slash_lossy(),
-            @"/repo/.git/wt/logs/wt-boj/internal/trash-sweep.log"
+            @"/repo/.git/wt/logs/wt/internal/trash-sweep.log"
         );
     }
 

--- a/src/path.rs
+++ b/src/path.rs
@@ -140,14 +140,15 @@ pub fn format_path_for_display(path: &Path) -> String {
 /// Sanitize a string for use as a filename on all platforms.
 ///
 /// Uses `sanitize-filename` crate to handle invalid characters, control characters,
-/// Windows reserved names (CON, PRN, etc.), and trailing dots/spaces. Appends a
-/// 3-character hash suffix for collision avoidance.
+/// Windows reserved names (CON, PRN, etc.), and trailing dots/spaces.
 ///
-/// The hash ensures unique outputs for inputs that would otherwise collide
-/// (e.g., `origin/feature` and `origin-feature` both sanitize to `origin-feature`
-/// but get different hash suffixes).
+/// If the input is already a safe filename, it is returned unchanged. Otherwise
+/// a 3-character hash suffix (computed from the original input) is appended so
+/// that inputs which would otherwise collide produce distinct outputs (e.g.,
+/// `origin/feature` → `origin-feature-<hash>` does not collide with the
+/// already-safe `origin-feature`).
 pub fn sanitize_for_filename(value: &str) -> String {
-    let mut result = sanitize_with_options(
+    let sanitized = sanitize_with_options(
         value,
         SanitizeOptions {
             windows: true,
@@ -156,11 +157,15 @@ pub fn sanitize_for_filename(value: &str) -> String {
         },
     );
 
-    if result.is_empty() {
-        result = "_empty".to_string();
+    if sanitized == value && !value.is_empty() {
+        return sanitized;
     }
 
-    // Append hash suffix for collision avoidance (computed from original input)
+    let mut result = if sanitized.is_empty() {
+        "_empty".to_string()
+    } else {
+        sanitized
+    };
     if !result.ends_with('-') {
         result.push('-');
     }
@@ -313,13 +318,26 @@ mod tests {
 
     #[test]
     fn test_sanitize_for_filename_avoids_collisions() {
-        // These would collide without the hash suffix
+        // Already-safe names pass through unchanged; only sanitized inputs get
+        // a hash suffix. This still avoids collisions because the suffix makes
+        // the sanitized form distinct from any plausible already-safe name.
         let a = sanitize_for_filename("origin/feature");
         let b = sanitize_for_filename("origin-feature");
 
         assert_ne!(a, b, "collision: {a} == {b}");
         assert!(a.starts_with("origin-feature-"));
-        assert!(b.starts_with("origin-feature-"));
+        assert_eq!(b, "origin-feature");
+    }
+
+    #[test]
+    fn test_sanitize_for_filename_passes_through_safe_names() {
+        assert_eq!(sanitize_for_filename("main"), "main");
+        assert_eq!(sanitize_for_filename("feature-x"), "feature-x");
+        assert_eq!(
+            sanitize_for_filename("rust-doc-comments"),
+            "rust-doc-comments"
+        );
+        assert_eq!(sanitize_for_filename("post-merge"), "post-merge");
     }
 
     #[test]

--- a/tests/integration_tests/config_state.rs
+++ b/tests/integration_tests/config_state.rs
@@ -579,10 +579,10 @@ fn test_state_get_logs_with_files(repo: TestRepo) {
          commands.jsonl <SIZE>  <AGE>
 
         [36mHOOK OUTPUT[39m @ <PATH>
-                          File                   Size  Age   
-         ─────────────────────────────────────── ──── ────── 
-         bugfix-zgc/internal/remove.log          <SIZE>  <AGE>
-         feature-axb/user/post-start/npm-iox.log <SIZE>  <AGE>
+                      File               Size  Age   
+         ─────────────────────────────── ──── ────── 
+         bugfix/internal/remove.log      <SIZE>  <AGE>
+         feature/user/post-start/npm.log <SIZE>  <AGE>
 
         [36mDIAGNOSTIC[39m @ <PATH>
         [107m [0m (none)
@@ -1170,12 +1170,12 @@ fn test_state_get_json_with_logs(repo: TestRepo) {
           "hints": [],
           "hook_output": [
             {
-              "file": "bugfix-zgc/internal/remove.log",
+              "file": "bugfix/internal/remove.log",
               "modified_at": "<MTIME>",
               "size": "<SIZE>"
             },
             {
-              "file": "feature-axb/user/post-start/npm-iox.log",
+              "file": "feature/user/post-start/npm.log",
               "modified_at": "<MTIME>",
               "size": "<SIZE>"
             }

--- a/tests/snapshots/integration__integration_tests__config_state__logs_get_json_with_files.snap
+++ b/tests/snapshots/integration__integration_tests__config_state__logs_get_json_with_files.snap
@@ -19,7 +19,7 @@ expression: "String::from_utf8_lossy(&output.stdout)"
   ],
   "hook_output": [
     {
-      "file": "main-<HASH>/user/post-start/server-<HASH>.log",
+      "file": "main/user/post-start/server.log",
       "modified_at": "<TIMESTAMP>",
       "size": "<SIZE>"
     }

--- a/tests/snapshots/integration__integration_tests__config_state__state_get_comprehensive.snap
+++ b/tests/snapshots/integration__integration_tests__config_state__state_get_comprehensive.snap
@@ -32,10 +32,10 @@ expression: "String::from_utf8_lossy(&output.stderr)"
 [107m [0m (none)
 
 [36mHOOK OUTPUT[39m @ <PATH>
-                  File                   Size  Age   
- ─────────────────────────────────────── ──── ────── 
- bugfix-zgc/internal/remove.log          13B  future 
- feature-axb/user/post-start/npm-iox.log 10B  future
+              File               Size  Age   
+ ─────────────────────────────── ──── ────── 
+ bugfix/internal/remove.log      13B  future 
+ feature/user/post-start/npm.log 10B  future
 
 [36mDIAGNOSTIC[39m @ <PATH>
 [107m [0m (none)

--- a/tests/snapshots/integration__integration_tests__config_state__state_logs_get_hook_not_found.snap
+++ b/tests/snapshots/integration__integration_tests__config_state__state_logs_get_hook_not_found.snap
@@ -3,5 +3,5 @@ source: tests/integration_tests/config_state.rs
 expression: "String::from_utf8_lossy(&output.stderr)"
 ---
 [31m✗[39m [31mNo log file matches [1muser:post-start:server[22m for branch [1mmain[22m[39m
-[107m [0m Expected: main-vfz/user/post-start/server-f4t.log
-[107m [0m Available: main-vfz/user/post-start/other-4n1.log
+[107m [0m Expected: main/user/post-start/server.log
+[107m [0m Available: main/user/post-start/other.log

--- a/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
@@ -143,7 +143,7 @@ Without [2m--force[0m, removal fails if the worktree contains untracked files.
 
 Removal runs in the background by default — the command returns immediately. The worktree is renamed into [2m.git/wt/trash/[0m (instant same-filesystem rename), git metadata is pruned, the branch is deleted, and a detached [2mrm -rf[0m finishes cleanup. Cross-filesystem worktrees fall back to [2mgit worktree remove[0m. Logs: [2m.git/wt/logs/{branch}/internal/remove.log[0m. Use [2m--foreground[0m to run in the foreground.
 
-After each [2mwt remove[0m, entries in [2m.git/wt/trash/[0m older than 24 hours are swept by a detached [2mrm -rf[0m — eventual cleanup for directories orphaned when a previous background removal was interrupted (SIGKILL, reboot, disk full). The sweep's log lives at [2m.git/wt/logs/wt-boj/internal/trash-sweep.log[0m (the [2mwt[0m pseudo-branch is sanitized via [2msanitize_for_filename[0m like any other branch name).
+After each [2mwt remove[0m, entries in [2m.git/wt/trash/[0m older than 24 hours are swept by a detached [2mrm -rf[0m — eventual cleanup for directories orphaned when a previous background removal was interrupted (SIGKILL, reboot, disk full).
 
 [1m[32mHooks[0m
 


### PR DESCRIPTION
`sanitize_for_filename` previously always appended a 3-char hash, giving logs like `main-vfz/project/post-merge/clippy-vif.log`. Clean names now pass through unchanged, so the common case reads `main/project/post-merge/clippy.log`. Inputs that actually require sanitization (path separators, invalid chars, empty input) still get the hash suffix so they can't collide with an already-safe name.

Also adds a TODO noting that the trash-sweep log shouldn't be branch-scoped — it piggybacks on `HookLog` with a fake `"wt"` pseudo-branch, so its actual on-disk path is the awkward `.git/wt/logs/wt/internal/trash-sweep.log`. Cleaner would be a top-level `internal/trash-sweep.log` alongside the other shared logs (`commands.jsonl`, `verbose.log`, `diagnostic.md`).

Snapshot tests updated to reflect the new pass-through behavior.

> _This was written by Claude Code on behalf of Maximilian_