### PR TITLE
test: reduce flakes under load

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -12,15 +12,9 @@
 #   cargo test --test integration --features shell-integration-tests
 
 [profile.default]
-slow-timeout = { period = "60s", terminate-after = 1 }
+slow-timeout = { period = "180s", terminate-after = 1 }
 status-level = "fail"
 success-output = "never"
 
 [profile.default.junit]
 path = "junit.xml"
-
-# The source_flag test runs `cargo run` inside a PTY, which can take longer than
-# 60s when cargo needs to check/compile dependencies on slow CI runners.
-[[profile.default.overrides]]
-filter = 'test(/test_source_flag_forwards_errors/)'
-slow-timeout = { period = "180s", terminate-after = 1 }

--- a/tests/integration_tests/post_start_commands.rs
+++ b/tests/integration_tests/post_start_commands.rs
@@ -916,8 +916,9 @@ approved-commands = ["echo 'stdout output' && echo 'stderr output' >&2"]
         })
         .expect("Should have a cmd-0 log file");
 
-    // Wait for content to be written (background command might still be writing)
-    wait_for_file_content(&cmd_log);
+    // Wait for both lines — `&&` sequences two writes (stdout, then stderr),
+    // so file size > 0 can hit after only the first landed.
+    wait_for_file_lines(&cmd_log, 2);
 
     let log_contents = fs::read_to_string(&cmd_log).unwrap();
 


### PR DESCRIPTION
Two small fixes from investigating flakes that surfaced in ~30 local 3135-test nextest runs.

**`test_post_start_log_file_captures_output`** — the hook runs `echo 'stdout output' && echo 'stderr output' >&2`, writing to the same log file via two FDs. `wait_for_file_content` returned as soon as the first write landed, so the snapshot read sometimes captured only `stdout output`. Switched to `wait_for_file_lines(&cmd_log, 2)` (helper already exists at `src/testing/mod.rs:2300` and is the prescribed pattern in `tests/CLAUDE.md`).

**nextest `slow-timeout`** — raised from 60s to 180s globally and dropped the per-test `test_source_flag_forwards_errors` override. `test_copy_ignored_many_directories_no_emfile` (2000 files), `test_bare_repo_merge_workflow`, and `test_bare_repo_background_logs_location` legitimately exceed 60s under 16-way parallelism. Tests still enforce their own 15s `wait_for` internal timeouts, so infinite hangs still fail fast.

Not fixed here: `wait_for`'s 15s `BG_TIMEOUT` in `src/testing/mod.rs:235` triggers its own class of flakes (e.g. `test_bare_repo_merge_workflow` failing with "Condition not met within 15s: feature worktree removed" under load). That's a separate change worth discussing.

The signal tests (`test_pre_merge_hook_receives_sig{int,term}`) that kicked off this investigation did not flake in ~750 invocations; no changes proposed there.