### PR TITLE
test: raise BG_TIMEOUT to 30s for flakes under parallel load

### DIFF
--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -232,7 +232,7 @@ pub const TEST_EPOCH: u64 = 1735776000;
 
 /// Default timeout for background hook/command completion.
 /// Generous to avoid flakiness under CI load; exponential backoff means fast tests when things work.
-const BG_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+const BG_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Static environment variables shared by all test isolation helpers.
 ///

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -86,7 +86,7 @@ Use the helpers in `tests/common/mod.rs`:
 ```rust
 use crate::common::{wait_for_file, wait_for_file_count, wait_for_file_content};
 
-// ✅ Poll for file existence (15-second default timeout)
+// ✅ Poll for file existence (30-second default timeout)
 wait_for_file(&log_file);
 
 // ✅ Poll for multiple files
@@ -96,7 +96,7 @@ wait_for_file_count(&log_dir, "log", 3);
 wait_for_file_content(&marker_file);
 ```
 
-These use exponential backoff (10ms → 500ms cap) for fast initial checks that back off on slow CI. The 15-second default timeout is generous enough to avoid flakiness under CI load.
+These use exponential backoff (10ms → 500ms cap) for fast initial checks that back off on slow CI. The 30-second default timeout is generous enough to avoid flakiness under CI load.
 
 **Exception - testing absence:** When verifying something did NOT happen, polling doesn't work. Use a fixed 500ms+ sleep:
 


### PR DESCRIPTION
15s was tight under local 16-way test parallelism — `test_bare_repo_merge_workflow` and `test_remove_background_fallback_on_rename_failure` occasionally hit the `wait_for` timeout when background worktree removal was slowed by CPU/IO contention. 30s absorbs the load without masking real hangs (the nextest `slow-timeout` is 180s, so genuine deadlocks still fail well within budget).

Exponential backoff means fast tests stay fast — the cap only matters when the background work is actually slow.

> _This was written by Claude Code on behalf of Maximilian_