### PR TITLE
chore(config): adopt [[pre-merge]] array form in .config/wt.toml

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -10,9 +10,9 @@ build = "cargo test --no-run --all-targets --locked --all-features"
 install = "cargo install --path ."
 sync = 'if [ "{{ target }}" = "main" ]; then git pull && git push; fi'
 
-[pre-merge]
-pre-commit = "if [ -n \"$MSYSTEM\" ]; then SKIP=lychee-system pre-commit run --all-files; else pre-commit run --all-files; fi"
-insta = "RUSTFLAGS='-D warnings' NEXTEST_NO_INPUT_HANDLER=1 cargo insta test --test-runner nextest --dnd --check $([ \"$(uname)\" = 'Linux' ] && echo '--unreferenced reject') --features shell-integration-tests"
+[[pre-merge]]
+pre-commit = 'if [ -n "$MSYSTEM" ]; then SKIP=lychee-system pre-commit run --all-files; else pre-commit run --all-files; fi'
+insta = """RUSTFLAGS='-D warnings' NEXTEST_NO_INPUT_HANDLER=1 cargo insta test --test-runner nextest --dnd --check $([ "$(uname)" = 'Linux' ] && echo '--unreferenced reject') --features shell-integration-tests"""
 doctest = "RUSTDOCFLAGS='-Dwarnings' cargo test --doc"
 doc = "RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps --document-private-items"
 


### PR DESCRIPTION
## Summary
- Migrate `.config/wt.toml` from the deprecated `[pre-merge]` table form to the canonical `[[pre-merge]]` array-of-tables form (matches the shape emitted by the deprecation migrator).
- Switch to single-quoted and triple-quoted strings to avoid backslash-escaping inner double quotes. Command bodies are unchanged.

## Test plan
- [x] `wt hook pre-merge --yes` loads and dispatches commands with the new form.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)