### PR TITLE
fix(config): polish fish completions and false-negative report in `config show`

### DIFF
--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -859,12 +859,16 @@ fn render_shell_status(out: &mut String) -> anyhow::Result<()> {
                             ))
                         )?;
                     } else {
-                        any_not_configured = true;
-                        writeln!(
-                            out,
-                            "{}",
-                            hint_message(format!("{shell}: Not configured completions"))
-                        )?;
+                        // Missing completions are a fish-specific problem with a specific
+                        // remediation. Don't flip `any_not_configured` — the generic
+                        // "To configure" summary is for shells with no integration at all.
+                        let warning = warning_message(cformat!(
+                            "<bold>{shell}</>: Completions not configured @ {completion_display}"
+                        ));
+                        let hint = hint_message(cformat!(
+                            "To configure completions, run <underline>{cmd} config shell install {shell}</>"
+                        ));
+                        writeln!(out, "{warning}\n{hint}")?;
                     }
                 }
 
@@ -1081,15 +1085,12 @@ fn render_shell_status(out: &mut String) -> anyhow::Result<()> {
         }
     }
 
-    // Check if any shell has config already (eval line present)
-    let has_any_configured = scan_result
-        .configured
-        .iter()
-        .any(|r| matches!(r.action, ConfigAction::AlreadyExists));
-
-    // If we have unmatched candidates but no configured shells, suggest raising an issue
-    // Apply the same confirmed_paths filter used above to avoid including wrapper files
-    if has_any_unmatched && !has_any_configured {
+    // Whenever there are unmatched candidates, offer the false-negative report link.
+    // A real detector miss in one config file is worth reporting even if another shell
+    // is correctly detected — the `confirmed_paths` filter already excludes wrapper files,
+    // and the narrow phrasing ("meant to load") steers non-integration lines (plain aliases)
+    // away from reporting themselves as bugs.
+    if has_any_unmatched {
         let unmatched_summary: Vec<_> = detection_results
             .iter()
             .filter(|r| {
@@ -1129,7 +1130,7 @@ fn render_shell_status(out: &mut String) -> anyhow::Result<()> {
             out,
             "{}",
             hint_message(format!(
-                "If {quoted} is shell integration, report a false negative: {issue_url}"
+                "If {quoted} is meant to load Worktrunk shell integration, report a false negative: {issue_url}"
             ))
         )?;
     }

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_fish_without_completions.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_fish_without_completions.snap
@@ -56,12 +56,12 @@ exit_code: 0
 
 [2m○[22m [1mfish[22m: Already configured shell extension @ ~/.config/fish/functions/wt.fish:7
 [107m [0m [2m[0m[2m[34mcommand[0m[2m wt config shell init fish [0m[2m[36m|[0m[2m [0m[2m[34msource[0m[2m
-[2m↳[22m [2mfish: Not configured completions[22m
+[33m▲[39m [33m[1mfish[22m: Completions not configured @ ~/.config/fish/completions/wt.fish[39m
+[2m↳[22m [2mTo configure completions, run [4mwt config shell install fish[24m[22m
 [2m↳[22m [2mTo verify wrapper loaded: [4mtype wt[24m[22m
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_not_suppressed_by_wrapper.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_not_suppressed_by_wrapper.snap
@@ -63,7 +63,7 @@ exit_code: 0
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [33m▲[39m [33mFound [1mwt[22m in [1m~/.bashrc:2[22m but not detected as integration:[39m
 [107m [0m [2m[0m[2m[34malias[0m[2m wt=[0m[2m[32m"git worktree"[0m[2m
-[2m↳[22m [2mIf `alias wt="git worktree"` is shell integration, report a false negative: https://github.com/max-sixty/worktrunk/issues/new?title=Shell%20integration%20detection%20false%20negative&body=Shell%20integration%20not%20detected%20despite%20config%20containing%20%60wt%60.%0A%0A%2A%2AUnmatched%20lines%3A%2A%2A%0A%60%60%60%0Aalias%20wt%3D%22git%20worktree%22%0A%60%60%60%0A%0A%2A%2AExpected%20behavior%3A%2A%2A%20These%20lines%20should%20be%20detected%20as%20shell%20integration.[22m
+[2m↳[22m [2mIf `alias wt="git worktree"` is meant to load Worktrunk shell integration, report a false negative: https://github.com/max-sixty/worktrunk/issues/new?title=Shell%20integration%20detection%20false%20negative&body=Shell%20integration%20not%20detected%20despite%20config%20containing%20%60wt%60.%0A%0A%2A%2AUnmatched%20lines%3A%2A%2A%0A%60%60%60%0Aalias%20wt%3D%22git%20worktree%22%0A%60%60%60%0A%0A%2A%2AExpected%20behavior%3A%2A%2A%20These%20lines%20should%20be%20detected%20as%20shell%20integration.[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_warning.snap
@@ -62,7 +62,7 @@ exit_code: 0
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [33m▲[39m [33mFound [1mwt[22m in [1m~/.bashrc:3[22m but not detected as integration:[39m
 [107m [0m [2m[0m[2m[34malias[0m[2m wt=[0m[2m[32m"git worktree"[0m[2m
-[2m↳[22m [2mIf `alias wt="git worktree"` is shell integration, report a false negative: https://github.com/max-sixty/worktrunk/issues/new?title=Shell%20integration%20detection%20false%20negative&body=Shell%20integration%20not%20detected%20despite%20config%20containing%20%60wt%60.%0A%0A%2A%2AUnmatched%20lines%3A%2A%2A%0A%60%60%60%0Aalias%20wt%3D%22git%20worktree%22%0A%60%60%60%0A%0A%2A%2AExpected%20behavior%3A%2A%2A%20These%20lines%20should%20be%20detected%20as%20shell%20integration.[22m
+[2m↳[22m [2mIf `alias wt="git worktree"` is meant to load Worktrunk shell integration, report a false negative: https://github.com/max-sixty/worktrunk/issues/new?title=Shell%20integration%20detection%20false%20negative&body=Shell%20integration%20not%20detected%20despite%20config%20containing%20%60wt%60.%0A%0A%2A%2AUnmatched%20lines%3A%2A%2A%0A%60%60%60%0Aalias%20wt%3D%22git%20worktree%22%0A%60%60%60%0A%0A%2A%2AExpected%20behavior%3A%2A%2A%20These%20lines%20should%20be%20detected%20as%20shell%20integration.[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m


### PR DESCRIPTION
Two independent fixes to the SHELL INTEGRATION section of `wt config show`.

## Fish completions messaging

A missing fish completions file previously printed a hint-style `↳ fish: Not configured completions` nested under the parent `○ fish: Already configured shell extension` line, and flipped the generic `any_not_configured` flag so `↳ To configure, run wt config shell install` appeared at the bottom. The nested hint was structurally confusing, and the generic summary was misleading when the only issue was fish-specific.

Now prints a warning with the specific remediation, mirroring the "Outdated shell extension" pattern:

```
▲ fish: Completions not configured @ ~/.config/fish/completions/wt.fish
↳ To configure completions, run wt config shell install fish
```

and does not flip the generic flag.

## False-negative report link gating

The "report a false negative" issue link was gated on `!has_any_configured` — a detector miss in `.zshrc` while `.bashrc` was correctly detected would print the `Found wt in X but not detected as integration` warning but swallow the actionable report link.

Ungate the link so it fires whenever `has_any_unmatched` is true (the existing `confirmed_paths` filter still excludes wrapper files). Narrow the phrasing to `If {line} is meant to load Worktrunk shell integration, report a false negative: {url}` so plain aliases don't read as bugs.

Three snapshots updated.