### PR TITLE
docs(extending): simplify hook-log alias body; drop brittle hash match

### DIFF
--- a/docs/content/extending.md
+++ b/docs/content/extending.md
@@ -140,10 +140,16 @@ Alias names that collide with built-in step commands (`commit`, `squash`, `rebas
 [aliases]
 # Tail the current worktree's post-start hook named {{ name }}:
 #   wt step hook-log --name=server
-hook-log = '''tail -f "$(wt config state logs --format=json | jq -r --arg name "{{ name }}" '.hook_output[] | select(.branch == "{{ branch }}" and .hook_type == "post-start" and (.name == $name or (.name | startswith($name + "-")))) | .path' | head -1)"'''
+hook-log = '''
+tail -f "$(wt config state logs --format=json | jq -r --arg name "{{ name }}" '
+  .hook_output[]
+  | select(.branch == "{{ branch }}" and .hook_type == "post-start" and .name == $name)
+  | .path
+' | head -1)"
+'''
 ```
 
-The `startswith($name + "-")` branch matches the sanitized-with-hash form (`server-abc`) so the same alias works for hook names that required sanitization.
+Hook names that required sanitization (had invalid filename characters) pick up a short hash suffix on disk, e.g. `server-abc` for configured name `server`. The alias matches on the exact on-disk `name`, so pass the sanitized form when filtering those.
 
 ### Recipe: move or copy in-progress changes to a new worktree
 

--- a/skills/worktrunk/reference/extending.md
+++ b/skills/worktrunk/reference/extending.md
@@ -137,10 +137,16 @@ Alias names that collide with built-in step commands (`commit`, `squash`, `rebas
 [aliases]
 # Tail the current worktree's post-start hook named {{ name }}:
 #   wt step hook-log --name=server
-hook-log = '''tail -f "$(wt config state logs --format=json | jq -r --arg name "{{ name }}" '.hook_output[] | select(.branch == "{{ branch }}" and .hook_type == "post-start" and (.name == $name or (.name | startswith($name + "-")))) | .path' | head -1)"'''
+hook-log = '''
+tail -f "$(wt config state logs --format=json | jq -r --arg name "{{ name }}" '
+  .hook_output[]
+  | select(.branch == "{{ branch }}" and .hook_type == "post-start" and .name == $name)
+  | .path
+' | head -1)"
+'''
 ```
 
-The `startswith($name + "-")` branch matches the sanitized-with-hash form (`server-abc`) so the same alias works for hook names that required sanitization.
+Hook names that required sanitization (had invalid filename characters) pick up a short hash suffix on disk, e.g. `server-abc` for configured name `server`. The alias matches on the exact on-disk `name`, so pass the sanitized form when filtering those.
 
 ### Recipe: move or copy in-progress changes to a new worktree
 


### PR DESCRIPTION
Two small polish changes to the `hook-log` alias recipe added in #2161:

- **Multi-line the alias body** so the 217-char pipeline becomes readable in the rendered docs. The jq expression lives inside single quotes, so literal newlines are safe; the outer shell pipeline reads top-to-bottom without wrapping.
- **Drop the `startswith($name + "-")` branch.** It was meant to also match the sanitized-with-hash form, but only covers the specific 3-char suffix shape and would misfire on hook names that naturally end in `-<3alnum>`. The limitation is documented instead: users with hook names that required sanitization should pass the on-disk sanitized form.

A follow-up PR (dispatched separately) adds a `sanitize_hash` template filter so the alias can pre-sanitize its input and match reliably across all hook names.

> _This was written by Claude Code on behalf of Maximilian Roos_