### PR TITLE
feat(config): show deprecation details on every command

### DIFF
--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -509,7 +509,7 @@ fn render_user_config(out: &mut String, has_system_config: bool) -> anyhow::Resu
         return Ok(());
     }
 
-    // Check for deprecations with show_brief_warning=false (silent mode)
+    // Check for deprecations with emit_inline_warnings=false (silent mode)
     // User config is global, not tied to any repository
     let has_deprecations = if let Ok(result) = worktrunk::config::check_and_migrate(
         &config_path,
@@ -657,7 +657,7 @@ fn render_project_config(out: &mut String) -> anyhow::Result<()> {
         return Ok(());
     }
 
-    // Check for deprecations with show_brief_warning=false (silent mode)
+    // Check for deprecations with emit_inline_warnings=false (silent mode)
     // Only write migration file in main worktree, not linked worktrees
     let is_main_worktree = !repo.current_worktree().is_linked().unwrap_or(true);
     let has_deprecations = if let Ok(result) = worktrunk::config::check_and_migrate(

--- a/src/commands/config/update.rs
+++ b/src/commands/config/update.rs
@@ -111,7 +111,7 @@ fn check_user_config() -> anyhow::Result<Option<UpdateCandidate>> {
 
     let content = std::fs::read_to_string(&config_path).context("Failed to read user config")?;
 
-    // Use check_and_migrate in silent mode (show_brief_warning=false) which:
+    // Use check_and_migrate in silent mode (emit_inline_warnings=false) which:
     // - Detects deprecations
     // - Copies approved-commands to approvals.toml
     // - Writes the .new migration file

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -39,6 +39,10 @@ use crate::styling::{
 static WARNED_DEPRECATED_PATHS: LazyLock<Mutex<HashSet<PathBuf>>> =
     LazyLock::new(|| Mutex::new(HashSet::new()));
 
+/// Set once the "Run wt config show..." hint has been emitted this process,
+/// so multiple deprecated configs (user + project) share a single hint line.
+static DEPRECATION_HINT_EMITTED: OnceLock<()> = OnceLock::new();
+
 /// Latch that silences config deprecation/unknown-field warnings for the rest
 /// of the process. Set by shell completion and picker paths, where stderr
 /// output would appear above the user's prompt or TUI.
@@ -1120,8 +1124,9 @@ fn migration_path(path: &Path) -> PathBuf {
 /// (global, not repo-specific), pass `None` and the function will check if the `.new`
 /// file already exists instead.
 ///
-/// When `show_brief_warning` is true, only a brief pointer to `wt config show` is emitted
-/// instead of full deprecation details. Use this for commands other than `config show`.
+/// When `emit_inline_warnings` is true, per-kind deprecation warnings are printed to stderr
+/// with a hint pointing at `wt config show`/`wt config update`. When false, nothing is
+/// printed and the caller is expected to render via `format_deprecation_details`. Use this for commands other than `config show`.
 ///
 /// Warnings are deduplicated per path per process.
 ///
@@ -1133,7 +1138,7 @@ pub fn check_and_migrate(
     warn_and_migrate: bool,
     label: &str,
     repo: Option<&crate::git::Repository>,
-    show_brief_warning: bool,
+    emit_inline_warnings: bool,
 ) -> anyhow::Result<CheckAndMigrateResult> {
     // Parse once — shared by detection and migration
     let (deprecations, migrated_content, template_strings) =
@@ -1164,11 +1169,11 @@ pub fn check_and_migrate(
 
     let new_path = migration_path(path);
 
-    // Skip writing if: (a) this is a brief warning (not `wt config show`), AND
+    // Skip writing if: (a) caller emits inline (not `wt config show`), AND
     //                  (b) migration file already exists
     // This means first-time deprecation gets automatic file write, after that
     // users run `wt config show` to get/update the migration file.
-    let should_skip_write = show_brief_warning && new_path.exists();
+    let should_skip_write = emit_inline_warnings && new_path.exists();
 
     // Build deprecation info for return
     let mut info = DeprecationInfo {
@@ -1219,10 +1224,19 @@ pub fn check_and_migrate(
         info.approvals_copied_to = copy_approved_commands_to_approvals_file(path);
     }
 
-    // For brief warnings (non-config-show commands), just show a pointer
-    if show_brief_warning {
+    // For non-config-show commands, emit per-kind warnings but skip the diff.
+    // The diff is reserved for `wt config show`, where the user has opted into details.
+    if emit_inline_warnings {
         if SUPPRESS_WARNINGS.get().is_none() {
-            eprintln!("{}", format_brief_warning(label));
+            eprint!("{}", format_deprecation_warnings(&info));
+            if DEPRECATION_HINT_EMITTED.set(()).is_ok() {
+                eprintln!(
+                    "{}",
+                    hint_message(cformat!(
+                        "Run <bold>wt config show</> for details or <bold>wt config update</> to apply updates"
+                    ))
+                );
+            }
 
             if let Some(approvals_path) = &info.approvals_copied_to {
                 let approvals_filename = approvals_path
@@ -1263,18 +1277,6 @@ pub fn check_and_migrate(
         info: Some(info),
         migrated_content,
     })
-}
-
-/// Format brief warning for normal config loading.
-///
-/// Returns a formatted warning string. Does not print anything;
-/// caller is responsible for output.
-pub fn format_brief_warning(label: &str) -> String {
-    warning_message(cformat!(
-        "{} has deprecated settings. Run <bold>wt config show</> for details or <bold>wt config update</> to apply updates",
-        label
-    ))
-    .to_string()
 }
 
 /// Write migration file with all fixes applied.
@@ -1491,7 +1493,10 @@ pub fn format_deprecation_warnings(info: &DeprecationInfo) -> String {
             out,
             "{}",
             warning_message(cformat!(
-                "{}: table form for {} is deprecated in favor of the pipeline form",
+                "{}: table form for {} is deprecated in favor of the pipeline form. \
+                 We're unifying pre-hooks, post-hooks, and aliases so that list form always runs serially \
+                 and table form always runs in parallel — migrate now to keep the current serial behavior \
+                 once the table form is repurposed.",
                 info.label,
                 hook_list
             ))

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -1233,7 +1233,7 @@ pub fn check_and_migrate(
                 eprintln!(
                     "{}",
                     hint_message(cformat!(
-                        "Run <bold>wt config show</> for details or <bold>wt config update</> to apply updates"
+                        "To see details, run <underline>wt config show</>; to apply updates, run <underline>wt config update</>"
                     ))
                 );
             }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -101,7 +101,6 @@ pub use deprecation::DeprecationInfo;
 pub use deprecation::Deprecations;
 pub use deprecation::check_and_migrate;
 pub use deprecation::detect_deprecations;
-pub use deprecation::format_brief_warning;
 pub use deprecation::format_deprecation_details;
 pub use deprecation::format_deprecation_warnings;
 pub use deprecation::format_migration_diff;

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -210,7 +210,7 @@ impl ProjectConfig {
 
         // Check for deprecated template variables and create migration file if needed
         // Only write migration file in main worktree, not linked worktrees
-        // Use show_brief_warning=true to emit a brief pointer to `wt config show`
+        // emit_inline_warnings=true: print per-kind warnings inline during config load
         let is_main_worktree = !repo.current_worktree().is_linked().unwrap_or(true);
         let repo_for_hints = if write_hints { Some(repo) } else { None };
         let _ = super::deprecation::check_and_migrate(
@@ -219,7 +219,7 @@ impl ProjectConfig {
             is_main_worktree,
             "Project config",
             repo_for_hints,
-            true, // show_brief_warning
+            true, // emit_inline_warnings
         );
 
         // Warn about unknown fields (only in main worktree where it's actionable)

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -1685,8 +1685,8 @@ fn test_deprecated_template_variables_hint_deduplication(repo: TestRepo, temp_ho
             stderr
         );
         assert!(
-            stderr.contains("deprecated settings"),
-            "Second run should show brief warning, got: {stderr}"
+            stderr.contains("is deprecated"),
+            "Second run should show deprecation warning, got: {stderr}"
         );
         assert!(
             !stderr.contains("Wrote migrated"),
@@ -1886,7 +1886,7 @@ fn test_fixing_deprecated_config_clears_hint_for_future_deprecations(
         assert!(output.status.success());
         let stderr = String::from_utf8_lossy(&output.stderr);
         assert!(
-            stderr.contains("deprecated settings"),
+            stderr.contains("is deprecated"),
             "New deprecation should show warning, got: {stderr}"
         );
     }
@@ -2004,10 +2004,10 @@ fn test_user_config_deprecated_variables_deduplication(repo: TestRepo, temp_home
             "Second run should succeed: {:?}",
             stderr
         );
-        // Should show brief warning (deprecated settings) but NOT write file
+        // Should still show deprecation warning but NOT write file
         assert!(
-            stderr.contains("User config has deprecated settings"),
-            "Second run should show brief warning, got: {stderr}"
+            stderr.contains("User config:") && stderr.contains("is deprecated"),
+            "Second run should show deprecation warning, got: {stderr}"
         );
         assert!(
             !stderr.contains("Wrote migrated"),

--- a/tests/snapshots/integration__integration_tests__approval_ui__already_approved_skip_prompt.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__already_approved_skip_prompt.snap
@@ -46,7 +46,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.test-approved[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'approved'[0m[2m [0m[2m[36m>[0m[2m output.txt
 [0m[32m✓[39m [32mCreated branch [1mtest-approved[22m from [1mmain[22m and worktree @ [1m_REPO_.test-approved[22m[39m

--- a/tests/snapshots/integration__integration_tests__approval_ui__already_approved_skip_prompt.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__already_approved_skip_prompt.snap
@@ -45,7 +45,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.test-approved[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'approved'[0m[2m [0m[2m[36m>[0m[2m output.txt
 [0m[32m✓[39m [32mCreated branch [1mtest-approved[22m from [1mmain[22m and worktree @ [1m_REPO_.test-approved[22m[39m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_fails_in_non_tty.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_fails_in_non_tty.snap
@@ -46,7 +46,7 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_fails_in_non_tty.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_fails_in_non_tty.snap
@@ -45,7 +45,8 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_mixed_approved_unapproved.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_mixed_approved_unapproved.snap
@@ -6,7 +6,8 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [33m▲[39m [33m[1mrepo[22m needs approval to execute [1m2[22m commands:[39m
 [2m○[22m pre-start [1mfirst[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'First command'[0m[2m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_mixed_approved_unapproved.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_mixed_approved_unapproved.snap
@@ -7,7 +7,7 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [33m▲[39m [33m[1mrepo[22m needs approval to execute [1m2[22m commands:[39m
 [2m○[22m pre-start [1mfirst[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'First command'[0m[2m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_multiple_commands.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_multiple_commands.snap
@@ -7,7 +7,7 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m4[22m commands:[39m
 [2m○[22m pre-start [1mbranch[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Branch: {{ branch }}'[0m[2m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_multiple_commands.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_multiple_commands.snap
@@ -6,7 +6,8 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m4[22m commands:[39m
 [2m○[22m pre-start [1mbranch[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Branch: {{ branch }}'[0m[2m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_named_commands.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_named_commands.snap
@@ -7,7 +7,7 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m3[22m commands:[39m
 [2m○[22m pre-start [1minstall[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Installing dependencies...'[0m[2m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_named_commands.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_named_commands.snap
@@ -6,7 +6,8 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m3[22m commands:[39m
 [2m○[22m pre-start [1minstall[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Installing dependencies...'[0m[2m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_single_command.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_single_command.snap
@@ -6,7 +6,8 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Worktree path: {{ worktree_path }}'[0m[2m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_single_command.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_single_command.snap
@@ -7,7 +7,7 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Worktree path: {{ worktree_path }}'[0m[2m

--- a/tests/snapshots/integration__integration_tests__approval_ui__decline_approval_skips_only_unapproved.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__decline_approval_skips_only_unapproved.snap
@@ -6,7 +6,8 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [33m▲[39m [33m[1mrepo[22m needs approval to execute [1m2[22m commands:[39m
 [2m○[22m pre-start [1mfirst[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'First command'[0m[2m

--- a/tests/snapshots/integration__integration_tests__approval_ui__decline_approval_skips_only_unapproved.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__decline_approval_skips_only_unapproved.snap
@@ -7,7 +7,7 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [33m▲[39m [33m[1mrepo[22m needs approval to execute [1m2[22m commands:[39m
 [2m○[22m pre-start [1mfirst[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'First command'[0m[2m

--- a/tests/snapshots/integration__integration_tests__approval_ui__yes_bypasses_tty_check.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__yes_bypasses_tty_check.snap
@@ -47,7 +47,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.test-yes-tty[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m
 [0mtest command

--- a/tests/snapshots/integration__integration_tests__approval_ui__yes_bypasses_tty_check.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__yes_bypasses_tty_check.snap
@@ -46,7 +46,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.test-yes-tty[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m
 [0mtest command

--- a/tests/snapshots/integration__integration_tests__approval_ui__yes_does_not_save_approvals_first_run.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__yes_does_not_save_approvals_first_run.snap
@@ -46,7 +46,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.test-yes[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m [0m[2m[36m>[0m[2m output.txt
 [0m[32m✓[39m [32mCreated branch [1mtest-yes[22m from [1mmain[22m and worktree @ [1m_REPO_.test-yes[22m[39m

--- a/tests/snapshots/integration__integration_tests__approval_ui__yes_does_not_save_approvals_first_run.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__yes_does_not_save_approvals_first_run.snap
@@ -47,7 +47,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.test-yes[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m [0m[2m[36m>[0m[2m output.txt
 [0m[32m✓[39m [32mCreated branch [1mtest-yes[22m from [1mmain[22m and worktree @ [1m_REPO_.test-yes[22m[39m

--- a/tests/snapshots/integration__integration_tests__approval_ui__yes_does_not_save_approvals_second_run.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__yes_does_not_save_approvals_second_run.snap
@@ -6,7 +6,8 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m [0m[2m[36m>[0m[2m output.txt

--- a/tests/snapshots/integration__integration_tests__approval_ui__yes_does_not_save_approvals_second_run.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__yes_does_not_save_approvals_second_run.snap
@@ -7,7 +7,7 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m [0m[2m[36m>[0m[2m output.txt

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_already_approved.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_already_approved.snap
@@ -45,7 +45,8 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test'[0m[2m

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_already_approved.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_already_approved.snap
@@ -46,7 +46,7 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test'[0m[2m

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_none_approved.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_none_approved.snap
@@ -46,7 +46,8 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test'[0m[2m

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_none_approved.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_none_approved.snap
@@ -47,7 +47,7 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test'[0m[2m

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_invalid_platform_override.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_invalid_platform_override.snap
@@ -53,7 +53,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1m[ci][22m is deprecated in favor of [1m[forge][22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [2m[W][22m Invalid CI platform in config: 'invalid_platform'. Expected 'github' or 'gitlab'.
 [2m[W][22m Invalid CI platform in config: 'invalid_platform'. Expected 'github' or 'gitlab'.
 [2m[W][22m Invalid CI platform in config: 'invalid_platform'. Expected 'github' or 'gitlab'.

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_invalid_platform_override.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_invalid_platform_override.snap
@@ -52,7 +52,8 @@ exit_code: 0
 [2m○[22m [2mShowing 5 worktrees, 1 with changes, 3 ahead
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1m[ci][22m is deprecated in favor of [1m[forge][22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [2m[W][22m Invalid CI platform in config: 'invalid_platform'. Expected 'github' or 'gitlab'.
 [2m[W][22m Invalid CI platform in config: 'invalid_platform'. Expected 'github' or 'gitlab'.
 [2m[W][22m Invalid CI platform in config: 'invalid_platform'. Expected 'github' or 'gitlab'.

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_platform_override_github.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_platform_override_github.snap
@@ -52,4 +52,5 @@ exit_code: 0
 [2m○[22m [2mShowing 5 worktrees, 1 with changes, 3 ahead
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1m[ci][22m is deprecated in favor of [1m[forge][22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_platform_override_github.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_platform_override_github.snap
@@ -53,4 +53,4 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1m[ci][22m is deprecated in favor of [1m[forge][22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_pre_hook_table_form_deprecation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_pre_hook_table_form_deprecation.snap
@@ -46,7 +46,7 @@ exit_code: 0
 [2m↳[22m [2mNot found; to create one, run [4mwt config create[24m[22m
 
 [36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
-[33m▲[39m [33mProject config: table form for [1mpre-start[22m, [1mpre-merge[22m is deprecated in favor of the pipeline form[39m
+[33m▲[39m [33mProject config: table form for [1mpre-start[22m, [1mpre-merge[22m is deprecated in favor of the pipeline form. We're unifying pre-hooks, post-hooks, and aliases so that list form always runs serially and table form always runs in parallel — migrate now to keep the current serial behavior once the table form is repurposed.[39m
 [2m↳[22m [2mTo apply: [4mwt config update[24m[22m
 [2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a_REPO_/.config/wt.toml b_REPO_/.config/wt.toml.new[m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_approved_commands_copies_to_approvals_file.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_approved_commands_copies_to_approvals_file.snap
@@ -52,5 +52,5 @@ exit_code: 0
 ----- stderr -----
 [33m▲[39m [33mUser config: [1mapproved-commands[22m under [1m[projects][22m is deprecated in favor of [1mapprovals.toml[22m[39m
 [2m↳[22m [2mCopied approved commands to [4mapprovals.toml[24m[22m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [2m↳[22m [2mCopied approved commands to [4mapprovals.toml[24m[22m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_approved_commands_copies_to_approvals_file.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_approved_commands_copies_to_approvals_file.snap
@@ -50,5 +50,7 @@ exit_code: 0
 [2m○[22m [2mShowing 4 worktrees, 3 ahead
 
 ----- stderr -----
-[33m▲[39m [33mUser config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mUser config: [1mapproved-commands[22m under [1m[projects][22m is deprecated in favor of [1mapprovals.toml[22m[39m
+[2m↳[22m [2mCopied approved commands to [4mapprovals.toml[24m[22m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [2m↳[22m [2mCopied approved commands to [4mapprovals.toml[24m[22m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_project_level_shows_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_project_level_shows_warning.snap
@@ -50,4 +50,5 @@ exit_code: 0
 [2m○[22m [2mShowing 4 worktrees, 3 ahead
 
 ----- stderr -----
-[33m▲[39m [33mUser config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mUser config: [1m[projects."github.com/example/repo".commit-generation][22m is deprecated in favor of [1m[projects."github.com/example/repo".commit.generation][22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_project_level_shows_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_project_level_shows_warning.snap
@@ -51,4 +51,4 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mUser config: [1m[projects."github.com/example/repo".commit-generation][22m is deprecated in favor of [1m[projects."github.com/example/repo".commit.generation][22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_section_shows_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_section_shows_warning.snap
@@ -50,4 +50,5 @@ exit_code: 0
 [2m○[22m [2mShowing 4 worktrees, 3 ahead
 
 ----- stderr -----
-[33m▲[39m [33mUser config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mUser config: [1m[commit-generation][22m is deprecated in favor of [1m[commit.generation][22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_section_shows_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_section_shows_warning.snap
@@ -51,4 +51,4 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mUser config: [1m[commit-generation][22m is deprecated in favor of [1m[commit.generation][22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_show_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_show_warning.snap
@@ -54,4 +54,4 @@ exit_code: 0
 [33m▲[39m [33mUser config: template variable [1mworktree[22m is deprecated in favor of [1mworktree_path[22m[39m
 [33m▲[39m [33mUser config: template variable [1mmain_worktree[22m is deprecated in favor of [1mrepo[22m[39m
 [33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_show_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_show_warning.snap
@@ -50,4 +50,8 @@ exit_code: 0
 [2m○[22m [2mShowing 4 worktrees, 3 ahead
 
 ----- stderr -----
-[33m▲[39m [33mUser config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mUser config: template variable [1mrepo_root[22m is deprecated in favor of [1mrepo_path[22m[39m
+[33m▲[39m [33mUser config: template variable [1mworktree[22m is deprecated in favor of [1mworktree_path[22m[39m
+[33m▲[39m [33mUser config: template variable [1mmain_worktree[22m is deprecated in favor of [1mrepo[22m[39m
+[33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_verbose_shows_content.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_verbose_shows_content.snap
@@ -51,7 +51,11 @@ exit_code: 0
 [2m○[22m [2mShowing 4 worktrees, 3 ahead
 
 ----- stderr -----
-[33m▲[39m [33mUser config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mUser config: template variable [1mrepo_root[22m is deprecated in favor of [1mrepo_path[22m[39m
+[33m▲[39m [33mUser config: template variable [1mworktree[22m is deprecated in favor of [1mworktree_path[22m[39m
+[33m▲[39m [33mUser config: template variable [1mmain_worktree[22m is deprecated in favor of [1mrepo[22m[39m
+[33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [2m○[22m Expanding [1mworktree-path[22m
 [107m [0m [2m[0m[2m[34m../[0m[2m[32m{{[0m[2m[34m[0m[2m main_worktree [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[32m}}[0m[2m
 [107m [0m [2m→[22m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_verbose_shows_content.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_verbose_shows_content.snap
@@ -55,7 +55,7 @@ exit_code: 0
 [33m▲[39m [33mUser config: template variable [1mworktree[22m is deprecated in favor of [1mworktree_path[22m[39m
 [33m▲[39m [33mUser config: template variable [1mmain_worktree[22m is deprecated in favor of [1mrepo[22m[39m
 [33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [2m○[22m Expanding [1mworktree-path[22m
 [107m [0m [2m[0m[2m[34m../[0m[2m[32m{{[0m[2m[34m[0m[2m main_worktree [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[32m}}[0m[2m
 [107m [0m [2m→[22m

--- a/tests/snapshots/integration__integration_tests__config_show__wt_list_skips_migration_file_after_first_write.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__wt_list_skips_migration_file_after_first_write.snap
@@ -50,4 +50,6 @@ exit_code: 0
 [2m○[22m [2mShowing 4 worktrees, 1 with changes, 3 ahead
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: template variable [1mmain_worktree[22m is deprecated in favor of [1mrepo[22m[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m

--- a/tests/snapshots/integration__integration_tests__config_show__wt_list_skips_migration_file_after_first_write.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__wt_list_skips_migration_file_after_first_write.snap
@@ -52,4 +52,4 @@ exit_code: 0
 ----- stderr -----
 [33m▲[39m [33mProject config: template variable [1mmain_worktree[22m is deprecated in favor of [1mrepo[22m[39m
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__both_create_and_start.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__both_create_and_start.snap
@@ -46,7 +46,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setup done'[0m[2m [0m[2m[36m>[0m[2m setup.txt
 [0m[32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__both_create_and_start.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__both_create_and_start.snap
@@ -45,7 +45,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setup done'[0m[2m [0m[2m[36m>[0m[2m setup.txt
 [0m[32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_base_variables.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_base_variables.snap
@@ -48,7 +48,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [36m◎[39m [36mRunning pre-start [1mproject:base[22m @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Base: main'[0m[2m [0m[2m[36m>[0m[2m base_info.txt
 [0m[36m◎[39m [36mRunning pre-start [1mproject:base_path[22m @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_base_variables.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_base_variables.snap
@@ -47,7 +47,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [36m◎[39m [36mRunning pre-start [1mproject:base[22m @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Base: main'[0m[2m [0m[2m[36m>[0m[2m base_info.txt
 [0m[36m◎[39m [36mRunning pre-start [1mproject:base_path[22m @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_default_branch_template.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_default_branch_template.snap
@@ -46,7 +46,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Default: main'[0m[2m [0m[2m[36m>[0m[2m default.txt
 [0m[32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_default_branch_template.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_default_branch_template.snap
@@ -47,7 +47,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Default: main'[0m[2m [0m[2m[36m>[0m[2m default.txt
 [0m[32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_failing_command.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_failing_command.snap
@@ -45,7 +45,8 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mexit[0m[2m 1
 [0m[31m✗[39m [31mpre-start command failed: exit status: 1[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_failing_command.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_failing_command.snap
@@ -46,7 +46,7 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mexit[0m[2m 1
 [0m[31m✗[39m [31mpre-start command failed: exit status: 1[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_git_variables_template.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_git_variables_template.snap
@@ -47,7 +47,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [36m◎[39m [36mRunning pre-start [1mproject:commit[22m @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Commit: f9680d376e0968fcb45a0029cf83898054742923'[0m[2m [0m[2m[36m>[0m[2m git_vars.txt
 [0m[36m◎[39m [36mRunning pre-start [1mproject:short[22m @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_git_variables_template.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_git_variables_template.snap
@@ -46,7 +46,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [36m◎[39m [36mRunning pre-start [1mproject:commit[22m @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Commit: f9680d376e0968fcb45a0029cf83898054742923'[0m[2m [0m[2m[36m>[0m[2m git_vars.txt
 [0m[36m◎[39m [36mRunning pre-start [1mproject:short[22m @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_multiline_control_structure.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_multiline_control_structure.snap
@@ -45,7 +45,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[35mif[0m[2m [ ! -f test.txt ]; [0m[2m[35mthen[0m[2m
 [107m [0m [2m  [0m[2m[34mecho[0m[2m [0m[2m[32m'File does not exist'[0m[2m [0m[2m[36m>[0m[2m result.txt

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_multiline_control_structure.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_multiline_control_structure.snap
@@ -46,7 +46,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[35mif[0m[2m [ ! -f test.txt ]; [0m[2m[35mthen[0m[2m
 [107m [0m [2m  [0m[2m[34mecho[0m[2m [0m[2m[32m'File does not exist'[0m[2m [0m[2m[36m>[0m[2m result.txt

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_named_commands.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_named_commands.snap
@@ -46,7 +46,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [36m◎[39m [36mRunning pre-start [1mproject:install[22m @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Installing deps'[0m[2m
 [0mInstalling deps

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_named_commands.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_named_commands.snap
@@ -45,7 +45,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [36m◎[39m [36mRunning pre-start [1mproject:install[22m @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Installing deps'[0m[2m
 [0mInstalling deps

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_single_command.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_single_command.snap
@@ -46,7 +46,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setup complete'[0m[2m
 [0mSetup complete

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_single_command.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_single_command.snap
@@ -45,7 +45,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setup complete'[0m[2m
 [0mSetup complete

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_template_expansion.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_template_expansion.snap
@@ -46,7 +46,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [36m◎[39m [36mRunning pre-start [1mproject:repo[22m @ [1m_REPO_.feature-test[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Repo: repo'[0m[2m [0m[2m[36m>[0m[2m info.txt
 [0m[36m◎[39m [36mRunning pre-start [1mproject:branch[22m @ [1m_REPO_.feature-test[22m[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_template_expansion.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_template_expansion.snap
@@ -45,7 +45,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [36m◎[39m [36mRunning pre-start [1mproject:repo[22m @ [1m_REPO_.feature-test[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Repo: repo'[0m[2m [0m[2m[36m>[0m[2m info.txt
 [0m[36m◎[39m [36mRunning pre-start [1mproject:branch[22m @ [1m_REPO_.feature-test[22m[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_upstream_conditional.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_upstream_conditional.snap
@@ -47,7 +47,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'no-upstream'[0m[2m [0m[2m[36m>[0m[2m upstream.txt
 [0m[32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_upstream_conditional.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_upstream_conditional.snap
@@ -46,7 +46,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'no-upstream'[0m[2m [0m[2m[36m>[0m[2m upstream.txt
 [0m[32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_upstream_template.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_upstream_template.snap
@@ -47,7 +47,7 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [31m✗[39m [31mFailed to expand project pre-start hook: undefined value @ line 1[39m
 [107m [0m echo 'Upstream: {{ upstream }}' > upstream.txt
 [2m↳[22m [2mAvailable variables: [4mbase[24m, [4mbase_worktree_path[24m, [4mbranch[24m, [4mcommit[24m, [4mcwd[24m, [4mdefault_branch[24m, [4mhook_type[24m, [4mmain_worktree[24m, [4mmain_worktree_path[24m, [4mprimary_worktree_path[24m, [4mremote[24m, [4mremote_url[24m, [4mrepo[24m, [4mrepo_path[24m, [4mrepo_root[24m, [4mshort_commit[24m, [4mworktree[24m, [4mworktree_name[24m, [4mworktree_path[24m[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_upstream_template.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_upstream_template.snap
@@ -46,7 +46,8 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [31m✗[39m [31mFailed to expand project pre-start hook: undefined value @ line 1[39m
 [107m [0m echo 'Upstream: {{ upstream }}' > upstream.txt
 [2m↳[22m [2mAvailable variables: [4mbase[24m, [4mbase_worktree_path[24m, [4mbranch[24m, [4mcommit[24m, [4mcwd[24m, [4mdefault_branch[24m, [4mhook_type[24m, [4mmain_worktree[24m, [4mmain_worktree_path[24m, [4mprimary_worktree_path[24m, [4mremote[24m, [4mremote_url[24m, [4mrepo[24m, [4mrepo_path[24m, [4mrepo_root[24m, [4mshort_commit[24m, [4mworktree[24m, [4mworktree_name[24m, [4mworktree_path[24m[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_verbose_template_expansion.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_verbose_template_expansion.snap
@@ -46,7 +46,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [2m○[22m Expanding [1mworktree-path[22m
 [107m [0m [2m[0m[2m[34m../[0m[2m[32m{{[0m[2m[34m[0m[2m repo [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34msanitize[0m[2m [0m[2m[32m}}[0m[2m
 [107m [0m [2m→[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_verbose_template_expansion.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_verbose_template_expansion.snap
@@ -47,7 +47,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [2m○[22m Expanding [1mworktree-path[22m
 [107m [0m [2m[0m[2m[34m../[0m[2m[32m{{[0m[2m[34m[0m[2m repo [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34msanitize[0m[2m [0m[2m[32m}}[0m[2m
 [107m [0m [2m→[22m

--- a/tests/snapshots/integration__integration_tests__user_hooks__no_hooks_skips_all_hooks.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__no_hooks_skips_all_hooks.snap
@@ -46,7 +46,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mUser config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__user_hooks__no_hooks_skips_all_hooks.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__no_hooks_skips_all_hooks.snap
@@ -47,7 +47,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_hook_template_vars.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_hook_template_vars.snap
@@ -45,7 +45,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mUser config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [36m◎[39m [36mRunning pre-start [1muser:vars[22m @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'repo=repo branch=feature'[0m[2m [0m[2m[36m>[0m[2m template_vars.txt
 [0m[32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_hook_template_vars.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_hook_template_vars.snap
@@ -46,7 +46,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [36m◎[39m [36mRunning pre-start [1muser:vars[22m @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'repo=repo branch=feature'[0m[2m [0m[2m[36m>[0m[2m template_vars.txt
 [0m[32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_before_project.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_before_project.snap
@@ -45,8 +45,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mUser config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
-[33m▲[39m [33mProject config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
 [36m◎[39m [36mRunning pre-start [1muser:log[22m @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'USER_HOOK'[0m[2m [0m[2m[36m>>[0m[2m hook_order.txt
 [0m[36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_before_project.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_before_project.snap
@@ -46,7 +46,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
 [36m◎[39m [36mRunning pre-start [1muser:log[22m @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'USER_HOOK'[0m[2m [0m[2m[36m>>[0m[2m hook_order.txt

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_no_approval.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_no_approval.snap
@@ -46,7 +46,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [36m◎[39m [36mRunning pre-start [1muser:setup[22m @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'NO_APPROVAL_NEEDED'[0m[2m [0m[2m[36m>[0m[2m no_approval.txt
 [0m[32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_no_approval.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_no_approval.snap
@@ -45,7 +45,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mUser config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [36m◎[39m [36mRunning pre-start [1muser:setup[22m @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'NO_APPROVAL_NEEDED'[0m[2m [0m[2m[36m>[0m[2m no_approval.txt
 [0m[32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_preserve_order.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_preserve_order.snap
@@ -45,7 +45,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mUser config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [36m◎[39m [36mRunning pre-start [1muser:vscode[22m @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'1'[0m[2m [0m[2m[36m>>[0m[2m hook_order.txt
 [0m[36m◎[39m [36mRunning pre-start [1muser:claude[22m @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_preserve_order.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_hooks_preserve_order.snap
@@ -46,7 +46,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [36m◎[39m [36mRunning pre-start [1muser:vscode[22m @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'1'[0m[2m [0m[2m[36m>>[0m[2m hook_order.txt
 [0m[36m◎[39m [36mRunning pre-start [1muser:claude[22m @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_post_create_executes.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_post_create_executes.snap
@@ -45,7 +45,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mUser config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [36m◎[39m [36mRunning pre-start [1muser:log[22m @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'USER_POST_CREATE_RAN'[0m[2m [0m[2m[36m>[0m[2m user_hook_marker.txt
 [0m[32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_post_create_executes.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_post_create_executes.snap
@@ -46,7 +46,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [36m◎[39m [36mRunning pre-start [1muser:log[22m @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'USER_POST_CREATE_RAN'[0m[2m [0m[2m[36m>[0m[2m user_hook_marker.txt
 [0m[32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_post_create_failure.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_post_create_failure.snap
@@ -46,7 +46,7 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
+[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [36m◎[39m [36mRunning pre-start [1muser:failing[22m @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mexit[0m[2m 1
 [0m[31m✗[39m [31mpre-start command failed: [1mfailing[22m: exit status: 1[39m

--- a/tests/snapshots/integration__integration_tests__user_hooks__user_post_create_failure.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__user_post_create_failure.snap
@@ -45,7 +45,8 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mUser config has deprecated settings. Run [1mwt config show[22m for details or [1mwt config update[22m to apply updates[39m
+[33m▲[39m [33mUser config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
+[2m↳[22m [2mRun [1mwt config show[22m for details or [1mwt config update[22m to apply updates[22m
 [36m◎[39m [36mRunning pre-start [1muser:failing[22m @ [1m_REPO_.feature[22m[39m
 [107m [0m [2m[0m[2m[34mexit[0m[2m 1
 [0m[31m✗[39m [31mpre-start command failed: [1mfailing[22m: exit status: 1[39m


### PR DESCRIPTION
## Summary

Deprecation warnings now surface their rationale on every command, not just `wt config show`.

- **Per-kind warnings everywhere**: Previously `wt switch`, `wt list`, and other commands emitted only a vague *"Project config has deprecated settings. Run `wt config show` for details..."*. They now emit the same per-kind warnings that `wt config show` does (e.g. *"Project config: `post-create` hook is deprecated in favor of `pre-start`"*), while the diff + apply flow stay reserved for `wt config show`.
- **Single, dedup'd hint**: a single *"To see details, run `wt config show`; to apply updates, run `wt config update`"* is emitted once per process via a `OnceLock`, so user + project configs sharing deprecations produce one hint line. Commands use `<underline>` (not `<bold>`) per writing-user-outputs guidance — `<bold>` resets dim styling in hints.
- **`pre-hook` table-form rationale**: the warning now explains *why* — pre-hooks, post-hooks, and aliases are being aligned on a single rule (list = serial, table = parallel), so today's table form will change meaning and users should migrate now to preserve current serial behavior.
- **Internal rename**: `show_brief_warning` → `emit_inline_warnings` and `format_brief_warning` is deleted, since the flag no longer selects between "brief" and "detailed" output — it selects between "emit inline at load time" and "silent (caller renders)".

## Test plan

- [x] `cargo test --lib` (977 passed)
- [x] `cargo test --test integration` (1447 passed)
- [x] `cargo clippy --all-targets` clean
- [x] Snapshot tests across 40+ affected call sites regenerated and reviewed

🤖 Generated with [Claude Code](https://claude.com/claude-code)