### PR TITLE
feat(config): add `sanitize_hash` template filter

### DIFF
--- a/docs/content/extending.md
+++ b/docs/content/extending.md
@@ -132,19 +132,6 @@ When both user and project config define the same alias name, both run — user 
 
 Alias names that collide with built-in step commands (`commit`, `squash`, `rebase`, etc.) are shadowed by the built-in.
 
-### Recipe: tail a specific hook log
-
-`wt config state logs --format=json` emits structured entries — `branch`, `source`, `hook_type`, `name`, `path`. Pipe through `jq` to resolve one entry, then wrap in an alias for quick access:
-
-```toml
-[aliases]
-# Tail the current worktree's post-start hook named {{ name }}:
-#   wt step hook-log --name=server
-hook-log = '''tail -f "$(wt config state logs --format=json | jq -r --arg name "{{ name }}" '.hook_output[] | select(.branch == "{{ branch }}" and .hook_type == "post-start" and (.name == $name or (.name | startswith($name + "-")))) | .path' | head -1)"'''
-```
-
-The `startswith($name + "-")` branch matches the sanitized-with-hash form (`server-abc`) so the same alias works for hook names that required sanitization.
-
 ### Recipe: move or copy in-progress changes to a new worktree
 
 Aliases compose existing commands into richer workflows. These three aliases wrap `wt switch --create` with git's stash and diff plumbing so staged, unstaged, and untracked changes can follow you into a new worktree:
@@ -174,6 +161,19 @@ How they work:
 - **`copy-staged`** writes `git diff --cached` to a tempfile and applies it with `git apply --index` in the new worktree. A diff (rather than `git stash --staged`) handles files where staged and unstaged hunks overlap on the same lines.
 
 Because an inner `wt switch --create` inside an alias [propagates its `cd` to the parent shell](@/step.md#aliases), all three drop the shell in the new worktree directly.
+
+### Recipe: tail a specific hook log
+
+`wt config state logs --format=json` emits structured entries — `branch`, `source`, `hook_type`, `name`, `path`. Pipe through `jq` to resolve one entry, then wrap in an alias for quick access:
+
+```toml
+[aliases]
+# Tail the current worktree's post-start hook named {{ name }} (handles sanitization):
+#   wt step hook-log --name=feature/auth
+hook-log = '''tail -f "$(wt config state logs --format=json | jq -r --arg name "{{ name | sanitize_hash }}" '.hook_output[] | select(.branch == "{{ branch | sanitize_hash }}" and .hook_type == "post-start" and .name == $name) | .path' | head -1)"'''
+```
+
+The `sanitize_hash` filter produces a filesystem-safe name with a hash suffix that keeps distinct originals unique — the same transformation Worktrunk applies on disk — so the alias resolves the right log even for branch and hook names containing characters like `/`.
 
 See [`wt step` — Aliases](@/step.md#aliases) for the full reference.
 

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -171,9 +171,10 @@ Templates support Jinja2 filters for transforming values:
 |--------|---------|-------------|
 | `sanitize` | `{{ branch \| sanitize }}` | Replace `/` and `\` with `-` |
 | `sanitize_db` | `{{ branch \| sanitize_db }}` | Database-safe identifier with hash suffix (`[a-z0-9_]`, max 63 chars) |
+| `sanitize_hash` | `{{ branch \| sanitize_hash }}` | Filesystem-safe name with hash suffix for uniqueness |
 | `hash_port` | `{{ branch \| hash_port }}` | Hash to port 10000-19999 |
 
-The `sanitize` filter makes branch names safe for filesystem paths. The `sanitize_db` filter produces database-safe identifiers — lowercase alphanumeric and underscores, no leading digits, with a 3-character hash suffix to avoid collisions and reserved words. The `hash_port` filter is useful for running dev servers on unique ports per worktree:
+The `sanitize` filter makes branch names safe for filesystem paths. The `sanitize_db` filter produces database-safe identifiers — lowercase alphanumeric and underscores, no leading digits, with a 3-character hash suffix to avoid collisions and reserved words. The `sanitize_hash` filter produces a filesystem-safe name and appends a 3-character hash suffix when sanitization changed the input, so distinct originals never collide — already-safe names pass through unchanged. The `hash_port` filter is useful for running dev servers on unique ports per worktree:
 
 ```toml
 [post-start]

--- a/skills/worktrunk/reference/extending.md
+++ b/skills/worktrunk/reference/extending.md
@@ -129,19 +129,6 @@ When both user and project config define the same alias name, both run — user 
 
 Alias names that collide with built-in step commands (`commit`, `squash`, `rebase`, etc.) are shadowed by the built-in.
 
-### Recipe: tail a specific hook log
-
-`wt config state logs --format=json` emits structured entries — `branch`, `source`, `hook_type`, `name`, `path`. Pipe through `jq` to resolve one entry, then wrap in an alias for quick access:
-
-```toml
-[aliases]
-# Tail the current worktree's post-start hook named {{ name }}:
-#   wt step hook-log --name=server
-hook-log = '''tail -f "$(wt config state logs --format=json | jq -r --arg name "{{ name }}" '.hook_output[] | select(.branch == "{{ branch }}" and .hook_type == "post-start" and (.name == $name or (.name | startswith($name + "-")))) | .path' | head -1)"'''
-```
-
-The `startswith($name + "-")` branch matches the sanitized-with-hash form (`server-abc`) so the same alias works for hook names that required sanitization.
-
 ### Recipe: move or copy in-progress changes to a new worktree
 
 Aliases compose existing commands into richer workflows. These three aliases wrap `wt switch --create` with git's stash and diff plumbing so staged, unstaged, and untracked changes can follow you into a new worktree:
@@ -171,6 +158,19 @@ How they work:
 - **`copy-staged`** writes `git diff --cached` to a tempfile and applies it with `git apply --index` in the new worktree. A diff (rather than `git stash --staged`) handles files where staged and unstaged hunks overlap on the same lines.
 
 Because an inner `wt switch --create` inside an alias [propagates its `cd` to the parent shell](https://worktrunk.dev/step/#aliases), all three drop the shell in the new worktree directly.
+
+### Recipe: tail a specific hook log
+
+`wt config state logs --format=json` emits structured entries — `branch`, `source`, `hook_type`, `name`, `path`. Pipe through `jq` to resolve one entry, then wrap in an alias for quick access:
+
+```toml
+[aliases]
+# Tail the current worktree's post-start hook named {{ name }} (handles sanitization):
+#   wt step hook-log --name=feature/auth
+hook-log = '''tail -f "$(wt config state logs --format=json | jq -r --arg name "{{ name | sanitize_hash }}" '.hook_output[] | select(.branch == "{{ branch | sanitize_hash }}" and .hook_type == "post-start" and .name == $name) | .path' | head -1)"'''
+```
+
+The `sanitize_hash` filter produces a filesystem-safe name with a hash suffix that keeps distinct originals unique — the same transformation Worktrunk applies on disk — so the alias resolves the right log even for branch and hook names containing characters like `/`.
 
 See [`wt step` — Aliases](https://worktrunk.dev/step/#aliases) for the full reference.
 

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -162,9 +162,10 @@ Templates support Jinja2 filters for transforming values:
 |--------|---------|-------------|
 | `sanitize` | `{{ branch \| sanitize }}` | Replace `/` and `\` with `-` |
 | `sanitize_db` | `{{ branch \| sanitize_db }}` | Database-safe identifier with hash suffix (`[a-z0-9_]`, max 63 chars) |
+| `sanitize_hash` | `{{ branch \| sanitize_hash }}` | Filesystem-safe name with hash suffix for uniqueness |
 | `hash_port` | `{{ branch \| hash_port }}` | Hash to port 10000-19999 |
 
-The `sanitize` filter makes branch names safe for filesystem paths. The `sanitize_db` filter produces database-safe identifiers — lowercase alphanumeric and underscores, no leading digits, with a 3-character hash suffix to avoid collisions and reserved words. The `hash_port` filter is useful for running dev servers on unique ports per worktree:
+The `sanitize` filter makes branch names safe for filesystem paths. The `sanitize_db` filter produces database-safe identifiers — lowercase alphanumeric and underscores, no leading digits, with a 3-character hash suffix to avoid collisions and reserved words. The `sanitize_hash` filter produces a filesystem-safe name and appends a 3-character hash suffix when sanitization changed the input, so distinct originals never collide — already-safe names pass through unchanged. The `hash_port` filter is useful for running dev servers on unique ports per worktree:
 
 ```toml
 [post-start]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1371,9 +1371,10 @@ Templates support Jinja2 filters for transforming values:
 |--------|---------|-------------|
 | `sanitize` | `{{ branch \| sanitize }}` | Replace `/` and `\` with `-` |
 | `sanitize_db` | `{{ branch \| sanitize_db }}` | Database-safe identifier with hash suffix (`[a-z0-9_]`, max 63 chars) |
+| `sanitize_hash` | `{{ branch \| sanitize_hash }}` | Filesystem-safe name with hash suffix for uniqueness |
 | `hash_port` | `{{ branch \| hash_port }}` | Hash to port 10000-19999 |
 
-The `sanitize` filter makes branch names safe for filesystem paths. The `sanitize_db` filter produces database-safe identifiers — lowercase alphanumeric and underscores, no leading digits, with a 3-character hash suffix to avoid collisions and reserved words. The `hash_port` filter is useful for running dev servers on unique ports per worktree:
+The `sanitize` filter makes branch names safe for filesystem paths. The `sanitize_db` filter produces database-safe identifiers — lowercase alphanumeric and underscores, no leading digits, with a 3-character hash suffix to avoid collisions and reserved words. The `sanitize_hash` filter produces a filesystem-safe name and appends a 3-character hash suffix when sanitization changed the input, so distinct originals never collide — already-safe names pass through unchanged. The `hash_port` filter is useful for running dev servers on unique ports per worktree:
 
 ```toml
 [post-start]

--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -323,6 +323,9 @@ fn setup_template_env(repo: &Repository) -> Environment<'static> {
     env.add_filter("sanitize_db", |value: Value| -> String {
         sanitize_db(value.as_str().unwrap_or_default())
     });
+    env.add_filter("sanitize_hash", |value: Value| -> String {
+        crate::path::sanitize_for_filename(value.as_str().unwrap_or_default())
+    });
     env.add_filter("hash_port", |value: String| string_to_port(&value));
 
     // Register worktree_path_of_branch function for looking up branch worktree paths.
@@ -413,6 +416,7 @@ pub fn validate_template(
 /// # Filters
 /// - `sanitize` — Replace `/` and `\` with `-` for filesystem-safe paths
 /// - `sanitize_db` — Transform to database-safe identifier (`[a-z0-9_]`, max 63 chars)
+/// - `sanitize_hash` — Filesystem-safe name with hash suffix so distinct inputs never collide
 /// - `hash_port` — Hash to deterministic port number (10000-19999)
 ///
 /// # Functions
@@ -1349,6 +1353,7 @@ mod tests {
         // Filters
         assert!(validate_template("{{ branch | sanitize }}", &test.repo, "test").is_ok());
         assert!(validate_template("{{ branch | sanitize_db }}", &test.repo, "test").is_ok());
+        assert!(validate_template("{{ branch | sanitize_hash }}", &test.repo, "test").is_ok());
         assert!(validate_template("{{ branch | hash_port }}", &test.repo, "test").is_ok());
 
         // Conditionals with optional vars

--- a/src/config/test.rs
+++ b/src/config/test.rs
@@ -52,6 +52,50 @@ fn test_expand_template_branch_with_slashes() {
 }
 
 #[test]
+fn test_expand_template_sanitize_hash_filter() {
+    let test = test_repo();
+
+    // Already-safe names pass through unchanged (no hash suffix)
+    let vars = vars_with_branch("server");
+    let result = expand_template(
+        "{{ branch | sanitize_hash }}",
+        &vars,
+        false,
+        &test.repo,
+        "test",
+    )
+    .unwrap();
+    assert_eq!(result, "server");
+
+    // Unsafe characters are replaced and a 3-char hash suffix is appended
+    let vars = vars_with_branch("feature/auth");
+    let result = expand_template(
+        "{{ branch | sanitize_hash }}",
+        &vars,
+        false,
+        &test.repo,
+        "test",
+    )
+    .unwrap();
+    assert!(result.starts_with("feature-auth-"), "got: {result}");
+    assert_eq!(result.len(), "feature-auth-".len() + 3, "got: {result}");
+
+    // Empty input becomes "_empty-<hash>"
+    let mut vars = HashMap::new();
+    vars.insert("name", "");
+    let result = expand_template(
+        "{{ name | sanitize_hash }}",
+        &vars,
+        false,
+        &test.repo,
+        "test",
+    )
+    .unwrap();
+    assert!(result.starts_with("_empty-"), "got: {result}");
+    assert_eq!(result.len(), "_empty-".len() + 3, "got: {result}");
+}
+
+#[test]
 fn test_expand_template_branch_raw_with_slashes() {
     let test = test_repo();
     // Raw branch preserves slashes


### PR DESCRIPTION
## Summary

Adds a `sanitize_hash` minijinja filter — a pass-through wrapper for `worktrunk::path::sanitize_for_filename`. Produces a filesystem-safe name with a 3-char hash suffix so distinct originals never collide; already-safe names pass through unchanged.

Uses it in a `hook-log` alias recipe in `docs/content/extending.md` so `wt config state logs --format=json | jq ... select(.name == $name)` matches the exact on-disk hook log filename even when the configured branch or hook name contains characters like `/`.

## Test plan

- [x] New unit test `test_expand_template_sanitize_hash_filter` covers safe passthrough, unsafe-char replacement + hash suffix, and empty input
- [x] `validate_template` test extended with `{{ branch | sanitize_hash }}`
- [x] `test_command_pages_and_skill_files_are_in_sync` passes (auto-syncs `docs/content/hook.md` and `skills/worktrunk/reference/*.md` mirrors)
- [x] `pre-commit run --all-files` clean
- [x] Help snapshots regenerated

🤖 Generated with [Claude Code](https://claude.com/claude-code)