### PR TITLE
feat(config-state): reject --format with set/clear actions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -338,6 +338,23 @@ fn handle_step_command(action: StepCommand) -> anyhow::Result<()> {
     }
 }
 
+/// Exit with a clap-style `ArgumentConflict` error when `--format` is combined
+/// with a write action (set/clear) on the state subcommands where it has no
+/// effect. Clap accepts the flag because `--format` is declared `global = true`
+/// on the parent so the bareword and `get` forms work, but write actions don't
+/// emit structured output — silent acceptance is a surprise.
+fn reject_format_with_write_action(action_name: &str, format: SwitchFormat) {
+    if format == SwitchFormat::Text {
+        return;
+    }
+    let mut cmd = cli::build_command();
+    cmd.error(
+        ClapErrorKind::ArgumentConflict,
+        format!("the argument '--format <FORMAT>' cannot be used with '{action_name}'"),
+    )
+    .exit()
+}
+
 fn handle_state_command(action: StateCommand) -> anyhow::Result<()> {
     match action {
         StateCommand::DefaultBranch { action } => match action {
@@ -362,22 +379,35 @@ fn handle_state_command(action: StateCommand) -> anyhow::Result<()> {
             Some(CiStatusAction::Get { branch }) => handle_state_get("ci-status", branch, format),
             None => handle_state_get("ci-status", None, format),
             Some(CiStatusAction::Clear { branch, all }) => {
+                reject_format_with_write_action("clear", format);
                 handle_state_clear("ci-status", branch, all)
             }
         },
         StateCommand::Marker { action, format } => match action {
             Some(MarkerAction::Get { branch }) => handle_state_get("marker", branch, format),
             None => handle_state_get("marker", None, format),
-            Some(MarkerAction::Set { value, branch }) => handle_state_set("marker", value, branch),
-            Some(MarkerAction::Clear { branch, all }) => handle_state_clear("marker", branch, all),
+            Some(MarkerAction::Set { value, branch }) => {
+                reject_format_with_write_action("set", format);
+                handle_state_set("marker", value, branch)
+            }
+            Some(MarkerAction::Clear { branch, all }) => {
+                reject_format_with_write_action("clear", format);
+                handle_state_clear("marker", branch, all)
+            }
         },
         StateCommand::Logs { action, format } => match action {
             Some(LogsAction::Get) | None => handle_logs_list(format),
-            Some(LogsAction::Clear) => handle_state_clear("logs", None, false),
+            Some(LogsAction::Clear) => {
+                reject_format_with_write_action("clear", format);
+                handle_state_clear("logs", None, false)
+            }
         },
         StateCommand::Hints { action, format } => match action {
             Some(HintsAction::Get) | None => handle_hints_get(format),
-            Some(HintsAction::Clear { name }) => handle_hints_clear(name),
+            Some(HintsAction::Clear { name }) => {
+                reject_format_with_write_action("clear", format);
+                handle_hints_clear(name)
+            }
         },
         StateCommand::Vars { action } => match action {
             VarsAction::Get { key, branch } => handle_vars_get(&key, branch),

--- a/tests/integration_tests/config_state.rs
+++ b/tests/integration_tests/config_state.rs
@@ -2074,3 +2074,52 @@ fn test_hints_get_json_with_values(repo: TestRepo) {
     ]
     "#);
 }
+
+// ============================================================================
+// --format rejected on write actions (set/clear)
+// ============================================================================
+
+/// Build `wt config state <key> [args...]` without injecting an action name.
+/// Unlike `wt_state_cmd`, this lets tests pass `--format=json` *before* the
+/// action to exercise the `global = true` propagation path that silently
+/// accepted the flag prior to gating.
+fn wt_state_raw_cmd(repo: &TestRepo, key: &str, args: &[&str]) -> Command {
+    let mut cmd = wt_command();
+    repo.configure_wt_cmd(&mut cmd);
+    cmd.args(["config", "state", key]);
+    cmd.args(args);
+    cmd.current_dir(repo.root_path());
+    cmd
+}
+
+#[rstest]
+#[case::logs_clear_flag_after("logs", &["clear", "--format=json"], "clear")]
+#[case::logs_clear_flag_before("logs", &["--format=json", "clear"], "clear")]
+#[case::hints_clear_flag_after("hints", &["clear", "--format=json"], "clear")]
+#[case::hints_clear_flag_before("hints", &["--format=json", "clear"], "clear")]
+#[case::marker_set_flag_after("marker", &["set", "foo", "--format=json"], "set")]
+#[case::marker_set_flag_before("marker", &["--format=json", "set", "foo"], "set")]
+#[case::marker_clear_flag_after("marker", &["clear", "--format=json"], "clear")]
+#[case::marker_clear_flag_before("marker", &["--format=json", "clear"], "clear")]
+#[case::ci_status_clear_flag_after("ci-status", &["clear", "--format=json"], "clear")]
+#[case::ci_status_clear_flag_before("ci-status", &["--format=json", "clear"], "clear")]
+fn test_format_rejected_on_write_actions(
+    repo: TestRepo,
+    #[case] key: &str,
+    #[case] args: &[&str],
+    #[case] action: &str,
+) {
+    let output = wt_state_raw_cmd(&repo, key, args).output().unwrap();
+    assert!(
+        !output.status.success(),
+        "expected failure for {key} {args:?}"
+    );
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains(&format!(
+            "the argument '--format <FORMAT>' cannot be used with '{action}'"
+        )),
+        "stderr did not contain expected conflict message: {stderr}"
+    );
+}


### PR DESCRIPTION
\`--format\` is declared \`global = true\` on the four \`wt config state\` subcommands that emit structured output (\`logs\`, \`hints\`, \`marker\`, \`ci-status\`). That propagation is what lets the bareword form (\`wt config state logs --format=json\`) and \`get --format=json\` both parse — but it also silently accepted the flag on \`set\`/\`clear\`, where no JSON is ever emitted. Codex review flagged it as a UX wart.

Clap has no declarative way to conflict a global arg with a specific subcommand variant, and dropping \`global = true\` only catches \`logs clear --format=json\` at parse time — \`logs --format=json clear\` still parses because the flag lands on the parent before the subcommand. So the check lives in \`handle_state_command\`, which emits a clap-style \`ArgumentConflict\` via \`Cli::command().error(...).exit()\` — same exit code and usage footer as a native conflict.

The CLI schema and help snapshots are unchanged. 10 rstest cases cover each \`{logs,hints,marker,ci-status} × {set,clear} × {flag-before, flag-after}\` combination.