### PR TITLE
refactor(config-state): style format-gating error natively

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -343,16 +343,30 @@ fn handle_step_command(action: StepCommand) -> anyhow::Result<()> {
 /// effect. Clap accepts the flag because `--format` is declared `global = true`
 /// on the parent so the bareword and `get` forms work, but write actions don't
 /// emit structured output — silent acceptance is a surprise.
-fn reject_format_with_write_action(action_name: &str, format: SwitchFormat) {
+///
+/// Populates `InvalidArg` / `PriorArg` context rather than passing a raw
+/// message so clap renders the arg name and subcommand with its own `invalid`
+/// style, matching native conflict errors byte-for-byte.
+fn guard_format_on_write(action_name: &str, format: SwitchFormat) {
     if format == SwitchFormat::Text {
         return;
     }
     let mut cmd = cli::build_command();
-    cmd.error(
-        ClapErrorKind::ArgumentConflict,
-        format!("the argument '--format <FORMAT>' cannot be used with '{action_name}'"),
-    )
-    .exit()
+    let usage = cmd.render_usage();
+    let mut err = clap::Error::new(ClapErrorKind::ArgumentConflict).with_cmd(&cmd);
+    err.insert(
+        clap::error::ContextKind::InvalidArg,
+        clap::error::ContextValue::String("--format <FORMAT>".to_owned()),
+    );
+    err.insert(
+        clap::error::ContextKind::PriorArg,
+        clap::error::ContextValue::String(action_name.to_owned()),
+    );
+    err.insert(
+        clap::error::ContextKind::Usage,
+        clap::error::ContextValue::StyledStr(usage),
+    );
+    err.exit()
 }
 
 fn handle_state_command(action: StateCommand) -> anyhow::Result<()> {
@@ -379,7 +393,7 @@ fn handle_state_command(action: StateCommand) -> anyhow::Result<()> {
             Some(CiStatusAction::Get { branch }) => handle_state_get("ci-status", branch, format),
             None => handle_state_get("ci-status", None, format),
             Some(CiStatusAction::Clear { branch, all }) => {
-                reject_format_with_write_action("clear", format);
+                guard_format_on_write("clear", format);
                 handle_state_clear("ci-status", branch, all)
             }
         },
@@ -387,25 +401,25 @@ fn handle_state_command(action: StateCommand) -> anyhow::Result<()> {
             Some(MarkerAction::Get { branch }) => handle_state_get("marker", branch, format),
             None => handle_state_get("marker", None, format),
             Some(MarkerAction::Set { value, branch }) => {
-                reject_format_with_write_action("set", format);
+                guard_format_on_write("set", format);
                 handle_state_set("marker", value, branch)
             }
             Some(MarkerAction::Clear { branch, all }) => {
-                reject_format_with_write_action("clear", format);
+                guard_format_on_write("clear", format);
                 handle_state_clear("marker", branch, all)
             }
         },
         StateCommand::Logs { action, format } => match action {
             Some(LogsAction::Get) | None => handle_logs_list(format),
             Some(LogsAction::Clear) => {
-                reject_format_with_write_action("clear", format);
+                guard_format_on_write("clear", format);
                 handle_state_clear("logs", None, false)
             }
         },
         StateCommand::Hints { action, format } => match action {
             Some(HintsAction::Get) | None => handle_hints_get(format),
             Some(HintsAction::Clear { name }) => {
-                reject_format_with_write_action("clear", format);
+                guard_format_on_write("clear", format);
                 handle_hints_clear(name)
             }
         },

--- a/tests/integration_tests/config_state.rs
+++ b/tests/integration_tests/config_state.rs
@@ -2115,11 +2115,13 @@ fn test_format_rejected_on_write_actions(
         "expected failure for {key} {args:?}"
     );
     assert_eq!(output.status.code(), Some(2));
+    // Tolerate the ANSI `invalid` styling clap wraps around `--format <FORMAT>`
+    // and the action name by checking the fixed substrings between/around them.
     let stderr = String::from_utf8_lossy(&output.stderr);
-    assert!(
-        stderr.contains(&format!(
-            "the argument '--format <FORMAT>' cannot be used with '{action}'"
-        )),
-        "stderr did not contain expected conflict message: {stderr}"
-    );
+    for needle in ["--format <FORMAT>", "cannot be used with", action] {
+        assert!(
+            stderr.contains(needle),
+            "stderr missing {needle:?}: {stderr}"
+        );
+    }
 }


### PR DESCRIPTION
Follow-up to #2173. The previous commit used \`cmd.error(ErrorKind, message)\` with a raw message string, so the conflict text rendered plain — clap's native conflict errors highlight the arg name and subcommand in its \`invalid\` style.

This switches to \`clap::Error::new(kind).with_cmd(&cmd)\` and populates \`ContextKind::{InvalidArg, PriorArg, Usage}\` directly, matching what clap's internal \`argument_conflict\` constructor does. Output is now byte-identical to a native conflict: \`--format <FORMAT>\` and the action name (\`'set'\` / \`'clear'\`) render bold-yellow, and the \`Usage:\` block is preserved by rendering it from the top-level \`Cli\` command.

Also renames \`reject_format_with_write_action\` → \`guard_format_on_write\` (reviewer taste from #2173). Test assertions switch from a single \`contains(full string)\` to per-token substring checks because ANSI now wraps the styled segments.