### PR TITLE
fix(nix): update flake lock so Nix build meets Rust 1.93 MSRV

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -64,11 +64,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1767926800,
-        "narHash": "sha256-x0n73J6ufD/EhDlVdcoAmF0OQHZ+b0a2cKDc8RZyt+o=",
+        "lastModified": 1776050130,
+        "narHash": "sha256-/f/6/1WOfBJaGMfqV3VxWD9lpFRbPpF+Cx4MO+0mGok=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "499e9eed88ff9494b6604205b42847e847dfeb91",
+        "rev": "3c27f4c92a7d977556dd2c10bb564d9c61b375e9",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
## Problem

After the recent minimal supported Rust version bump to Rust 1.93, the Nix dev/build path is still pulling in Rust 1.92 from the locked `rust-overlay`, so `nix develop -c cargo build` fails with:  `worktrunk requires rustc 1.93`

## Cause

  `Cargo.toml` now requires Rust 1.93, but `flake.lock` still points to an older `rust-overlay` revision, and `flake.nix` uses `pkgs.rust-bin.stable.latest.default`.

## Fix

Refresh the locked `rust-overlay` input so the flake provides a Rust toolchain that satisfies the current MSRV.

## Validation

Run:

- `nix build .#worktrunk`