### PR TITLE
Combine `wt list` timeout warning with blocked tasks list

### DIFF
--- a/skills/worktrunk/reference/troubleshooting.md
+++ b/skills/worktrunk/reference/troubleshooting.md
@@ -81,8 +81,7 @@ post-start = "npm run build"
 The timeout warning names the tasks that didn't finish:
 
 ```
-wt list timed out after 120s (170 results received)
-Blocked tasks:
+wt list timed out after 120s (170 results received); blocked tasks:
   <branch>: working-tree-diff, working-tree-conflicts
 ```
 

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -1035,7 +1035,7 @@ pub fn collect(
         );
 
         if !items_with_missing.is_empty() {
-            diag.push_str("\nBlocked tasks:");
+            diag.push_str("; blocked tasks:");
             let missing_lines: Vec<String> = items_with_missing
                 .iter()
                 .take(5)


### PR DESCRIPTION
"Blocked tasks:" previously sat on its own line with no symbol or gutter, violating the "every user-facing message needs a symbol or gutter" convention. Join it to the preceding line with a semicolon so the gutter directly follows a labelled warning.

Before:
```
▲ wt list timed out after 120s (151 results received)
Blocked tasks:
   ┃ picker-preview-pool: working-tree-diff, working-tree-conflicts
   ...
```

After:
```
▲ wt list timed out after 120s (151 results received); blocked tasks:
   ┃ picker-preview-pool: working-tree-diff, working-tree-conflicts
   ...
```

> _This was written by Claude Code on behalf of Maximilian_