### PR TITLE
Report pending count in `wt list` stall footer

### DIFF
--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -292,6 +292,33 @@ pub enum ShowConfig {
     },
 }
 
+/// Build the progressive-table footer shown while the drain is stalled.
+///
+/// Pure so it can be snapshot-tested without spinning up the live table.
+/// `first_name` is a branch / display name from the pending set;
+/// `pending_count` is the total outstanding-result count (≥ 1).
+fn format_stall_footer(
+    footer_base: &str,
+    completed: usize,
+    total: usize,
+    pending_count: usize,
+    first_kind: TaskKind,
+    first_name: &str,
+) -> String {
+    let dim = Style::new().dimmed();
+    let kind_str: &'static str = first_kind.into();
+    let waiting_clause = if pending_count == 1 {
+        cformat!("waiting on <underline>{kind_str}</> for <underline>{first_name}</>")
+    } else {
+        cformat!(
+            "waiting on {pending_count} tasks, including <underline>{kind_str}</> for <underline>{first_name}</>"
+        )
+    };
+    cformat!(
+        "{INFO_SYMBOL} {dim}{footer_base} ({completed}/{total} loaded, no recent progress; {waiting_clause}){dim:#}"
+    )
+}
+
 /// Collect worktree data with optional progressive rendering.
 ///
 /// When `show_progress` is true, renders a skeleton immediately and updates as data arrives.
@@ -982,16 +1009,22 @@ pub fn collect(
                         log::debug!("Progressive table reveal flush failed: {}", e);
                     }
                 }
-                results::DrainEvent::Stall { pending } => {
+                results::DrainEvent::Stall {
+                    pending_count,
+                    first_kind,
+                    first_name,
+                } => {
                     // No task has completed for at least `STALL_TIMINGS.threshold`.
                     // Name the signal (silence) rather than claiming "stalled":
-                    // the event fires on any 5s lull and points at the first
-                    // pending hint, not a root cause.
-                    let completed = s.completed_results;
-                    let kind_str: &'static str = pending.kind.into();
-                    let footer_msg = cformat!(
-                        "{INFO_SYMBOL} {dim}{footer_base} ({completed}/{total_results} loaded, no recent progress; waiting on <underline>{kind_str}</> for <underline>{name}</>){dim:#}",
-                        name = pending.name
+                    // the event fires on any 5s lull and reports outstanding
+                    // work, not a root cause.
+                    let footer_msg = format_stall_footer(
+                        &footer_base,
+                        s.completed_results,
+                        total_results,
+                        pending_count,
+                        first_kind,
+                        first_name,
                     );
                     if s.table.update_footer(footer_msg)
                         && let Err(e) = s.table.flush()
@@ -1370,4 +1403,51 @@ pub fn populate_item(
     item.finalize_display();
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Strip ANSI escape sequences so snapshots read as plain text.
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut chars = s.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c != '\x1b' {
+                out.push(c);
+                continue;
+            }
+            // CSI: ESC [ ... (letter terminator)
+            if chars.peek() == Some(&'[') {
+                chars.next();
+                for next in chars.by_ref() {
+                    if next.is_ascii_alphabetic() {
+                        break;
+                    }
+                }
+            }
+        }
+        out
+    }
+
+    #[test]
+    fn test_format_stall_footer_single_pending() {
+        let rendered =
+            format_stall_footer("Showing 3 worktrees", 5, 12, 1, TaskKind::CiStatus, "feat");
+        insta::assert_snapshot!(
+            strip_ansi(&rendered),
+            @"○ Showing 3 worktrees (5/12 loaded, no recent progress; waiting on ci-status for feat)"
+        );
+    }
+
+    #[test]
+    fn test_format_stall_footer_many_pending() {
+        let rendered =
+            format_stall_footer("Showing 3 worktrees", 5, 12, 3, TaskKind::CiStatus, "feat");
+        insta::assert_snapshot!(
+            strip_ansi(&rendered),
+            @"○ Showing 3 worktrees (5/12 loaded, no recent progress; waiting on 3 tasks, including ci-status for feat)"
+        );
+    }
 }

--- a/src/commands/list/collect/results.rs
+++ b/src/commands/list/collect/results.rs
@@ -42,14 +42,6 @@ pub(super) struct StallTimings {
     pub tick: Duration,
 }
 
-/// A single task the drain is still waiting on — surfaced to the caller when
-/// no results have arrived in the last `STALL_TIMINGS.threshold`.
-#[derive(Debug, Clone, Copy)]
-pub(super) struct PendingHint<'a> {
-    pub kind: TaskKind,
-    pub name: &'a str,
-}
-
 /// Events emitted by `drain_results`. A single callback handles every
 /// event kind so the caller can share state (e.g. the progressive table)
 /// across them without fighting the borrow checker.
@@ -62,31 +54,40 @@ pub(super) enum DrainEvent<'a> {
     /// The `reveal_at` deadline passed — fires exactly once. `wt list` uses
     /// this to promote blank placeholders to the `·` loading indicator.
     Reveal { items: &'a [ListItem] },
-    /// No results for at least `STALL_TIMINGS.threshold`; here's one task
-    /// we're still waiting on. Fires repeatedly (each `STALL_TIMINGS.tick`)
-    /// while stalled.
-    Stall { pending: PendingHint<'a> },
+    /// No results for at least `STALL_TIMINGS.threshold`. `pending_count`
+    /// is the total number of expected-but-not-yet-received results
+    /// (includes both queued and running tasks); `first_kind` / `first_name`
+    /// identify one of them deterministically. Fires repeatedly (each
+    /// `STALL_TIMINGS.tick`) while stalled.
+    Stall {
+        pending_count: usize,
+        first_kind: TaskKind,
+        first_name: &'a str,
+    },
 }
 
-/// Return the first pending `(item_idx, kind)` pair — an expected result
-/// that has not yet been received. Iteration order mirrors how work items
-/// were registered, giving a deterministic pick when multiple are pending.
+/// Tally pending results (expected minus received) and pick the first as an
+/// exemplar. Iteration order mirrors how work items were registered, giving
+/// a deterministic pick when multiple are pending.
 fn pick_pending_hint<'a>(
     expected: &ExpectedResults,
     received_by_item: &[Vec<TaskKind>],
     items: &'a [ListItem],
-) -> Option<PendingHint<'a>> {
-    for ((item_idx, received), item) in received_by_item.iter().enumerate().zip(items.iter()) {
-        for kind in expected.results_for(item_idx) {
-            if !received.contains(&kind) {
-                return Some(PendingHint {
-                    kind,
-                    name: item.display_name(),
-                });
-            }
-        }
-    }
-    None
+) -> (usize, Option<(TaskKind, &'a str)>) {
+    let received_count: usize = received_by_item.iter().map(|v| v.len()).sum();
+    let pending_count = expected.count().saturating_sub(received_count);
+    let first = received_by_item
+        .iter()
+        .enumerate()
+        .zip(items.iter())
+        .find_map(|((item_idx, received), item)| {
+            expected
+                .results_for(item_idx)
+                .into_iter()
+                .find(|kind| !received.contains(kind))
+                .map(|kind| (kind, item.display_name()))
+        });
+    (pending_count, first)
 }
 
 /// Drain task results from the channel and apply them to items.
@@ -216,15 +217,20 @@ pub(super) fn drain_results_with_timings(
             Err(chan::RecvTimeoutError::Timeout) => {
                 // Nothing arrived within the tick. If we've been silent for
                 // at least `stall_timings.threshold`, emit a stall event
-                // pointing at one task we're still waiting on. Fires
+                // with the pending count plus one exemplar. Fires
                 // repeatedly while stalled — `update_footer` is idempotent
                 // for same content. The loop top handles firing any
                 // due one-shot tick and re-checks the real deadline.
-                if last_result_time.elapsed() >= stall_timings.threshold
-                    && let Some(pending) =
-                        pick_pending_hint(expected_results, &received_by_item, items)
-                {
-                    on_event(DrainEvent::Stall { pending });
+                if last_result_time.elapsed() >= stall_timings.threshold {
+                    let (pending_count, first) =
+                        pick_pending_hint(expected_results, &received_by_item, items);
+                    if let Some((first_kind, first_name)) = first {
+                        on_event(DrainEvent::Stall {
+                            pending_count,
+                            first_kind,
+                            first_name,
+                        });
+                    }
                 }
                 continue;
             }
@@ -692,9 +698,10 @@ mod tests {
 
     #[test]
     fn test_drain_results_fires_stall_when_silent_past_threshold() {
-        // No results arrive; the drain should emit a Stall event pointing at
-        // the first pending task once `stall_threshold` elapses, and keep
-        // firing on each tick until the deadline.
+        // No results arrive; the drain should emit a Stall event reporting
+        // the pending count plus a deterministic exemplar once
+        // `stall_threshold` elapses, and keep firing on each tick until
+        // the deadline.
         let (_tx, rx) = crossbeam_channel::unbounded();
         let mut items = vec![
             ListItem::new_branch("abc123".into(), "feat".into()),
@@ -706,7 +713,7 @@ mod tests {
         expected.expect(0, TaskKind::AheadBehind);
         expected.expect(1, TaskKind::CommitDetails);
 
-        let mut stall_events: Vec<(TaskKind, String)> = Vec::new();
+        let mut stall_events: Vec<(usize, TaskKind, String)> = Vec::new();
         let outcome = drain_results_with_timings(
             rx,
             &mut items,
@@ -719,8 +726,13 @@ mod tests {
                 tick: Duration::from_millis(20),
             },
             |event| {
-                if let DrainEvent::Stall { pending } = event {
-                    stall_events.push((pending.kind, pending.name.to_string()));
+                if let DrainEvent::Stall {
+                    pending_count,
+                    first_kind,
+                    first_name,
+                } = event
+                {
+                    stall_events.push((pending_count, first_kind, first_name.to_string()));
                 }
             },
             None,
@@ -731,7 +743,8 @@ mod tests {
             !stall_events.is_empty(),
             "expected at least one stall event before the deadline"
         );
-        let (kind, name) = &stall_events[0];
+        let (count, kind, name) = &stall_events[0];
+        assert_eq!(*count, 2);
         assert_eq!(*kind, TaskKind::AheadBehind);
         assert_eq!(name, "feat");
     }


### PR DESCRIPTION
## Summary

Extends the 5s-stall footer hint to report how many tasks are outstanding alongside the named exemplar.

Before: `no recent progress; waiting on ci-status for feat`
After (many pending): `no recent progress; waiting on 3 tasks, including ci-status for feat`

The count comes from `expected − received` — data the drain already owned — so no new tracking infrastructure. `pick_pending_hint` now returns `(pending_count, Option<(TaskKind, &str)>)` and the `Stall` variant carries the three fields directly. Extracted `format_stall_footer` as a pure function with two inline snapshots covering the single- and multi-pending cases.

## Test plan

- [x] `cargo run -- hook pre-merge --yes` green (3178 tests)
- [x] `wt list` renders normally under light load
