### PR TITLE
Drop unreachable rayon::spawn fallback in picker orchestrator

### DIFF
--- a/src/commands/picker/preview_orchestrator.rs
+++ b/src/commands/picker/preview_orchestrator.rs
@@ -28,19 +28,20 @@ impl Drop for PendingGuard {
 
 pub(super) struct PreviewOrchestrator {
     pub(super) cache: PreviewCache,
-    pool: Option<Arc<rayon::ThreadPool>>,
+    pool: Arc<rayon::ThreadPool>,
     pending: Arc<AtomicUsize>,
 }
 
 impl PreviewOrchestrator {
     pub(super) fn new() -> Self {
         let cache = Arc::new(DashMap::new());
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(crate::rayon_thread_count())
-            .thread_name(|i| format!("picker-preview-{i}"))
-            .build()
-            .ok()
-            .map(Arc::new);
+        let pool = Arc::new(
+            rayon::ThreadPoolBuilder::new()
+                .num_threads(crate::rayon_thread_count())
+                .thread_name(|i| format!("picker-preview-{i}"))
+                .build()
+                .expect("failed to build picker preview rayon pool"),
+        );
         Self {
             cache,
             pool,
@@ -91,10 +92,7 @@ impl PreviewOrchestrator {
             let _g = guard;
             task();
         };
-        match &self.pool {
-            Some(pool) => pool.spawn(wrapped),
-            None => rayon::spawn(wrapped),
-        }
+        self.pool.spawn(wrapped);
     }
 
     /// Block until all spawned tasks complete.


### PR DESCRIPTION
Follow-up to #2210. \`PreviewOrchestrator::new()\` used \`.ok().map(Arc::new)\` so \`pool\` was \`Option<Arc<ThreadPool>>\`, with a \`None\` branch in \`spawn_task\` that fell back to \`rayon::spawn\` on the global pool — exactly the contention the dedicated pool was added to avoid. The branch is only reachable if \`ThreadPoolBuilder::build()\` fails (process-start resource exhaustion) and no realistic test covers it.

Build with \`.expect(...)\` at construction so \`pool\` becomes \`Arc<ThreadPool>\`. If rayon can't spawn threads the picker can't do useful work either, and failing at construction beats silently fanning tasks onto the global pool.

> _This was written by Claude Code on behalf of max-sixty_