### PR TITLE
test: use standard config override to disable picker timeout in tests

### DIFF
--- a/src/config/user/sections.rs
+++ b/src/config/user/sections.rs
@@ -351,13 +351,8 @@ impl SwitchPickerConfig {
     }
 
     /// Wall-clock budget for picker data collection (default: 500ms).
-    /// Returns `None` when disabled (timeout_ms = 0 or WORKTRUNK_TEST_PICKER_NO_TIMEOUT set).
+    /// Returns `None` when disabled (timeout_ms = 0).
     pub fn timeout(&self) -> Option<std::time::Duration> {
-        // Env var bypass for test reliability — config file loading is unreliable
-        // in PTY subprocesses on macOS CI, so tests disable the timeout directly.
-        if std::env::var_os("WORKTRUNK_TEST_PICKER_NO_TIMEOUT").is_some() {
-            return None;
-        }
         match self.timeout_ms {
             Some(0) => None,
             Some(ms) => Some(std::time::Duration::from_millis(ms)),

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -888,10 +888,10 @@ impl TestRepo {
                 self.test_approvals_path().display().to_string(),
             ),
             // Disable picker collect timeout to prevent flaky snapshots on slow
-            // CI runners (especially macOS). Bypasses config file loading.
+            // CI runners (especially macOS).
             (
-                "WORKTRUNK_TEST_PICKER_NO_TIMEOUT".to_string(),
-                "1".to_string(),
+                "WORKTRUNK__SWITCH__PICKER__TIMEOUT_MS".to_string(),
+                "0".to_string(),
             ),
         ]);
 


### PR DESCRIPTION
Replaces the test-only `WORKTRUNK_TEST_PICKER_NO_TIMEOUT` env var with the typed config override `WORKTRUNK__SWITCH__PICKER__TIMEOUT_MS=0`, and deletes the bypass branch in `SwitchPickerConfig::timeout()`.

The bypass was justified by a claim that config file loading was unreliable in PTY subprocesses on macOS CI, but tests already rely on `WORKTRUNK_CONFIG_PATH` being honored there. Using the standard typed-override path removes a test-only code path from library code. All 3188 tests pass locally including the 17 switch-picker PTY tests.

> _This was written by Claude Code on behalf of Maximilian_