### PR TITLE
Narrow LLM semaphore to the LLM call only

### DIFF
--- a/src/commands/list/collect/tasks.rs
+++ b/src/commands/list/collect/tasks.rs
@@ -766,9 +766,6 @@ impl Task for SummaryGenerateTask {
         let branch = ctx.branch_ref.branch.as_deref().unwrap_or("(detached)");
         let worktree_path = ctx.branch_ref.worktree_path.as_deref();
 
-        // Acquire semaphore before any LLM call (cache hits return before calling LLM)
-        let _permit = crate::summary::LLM_SEMAPHORE.acquire();
-
         let summary = crate::summary::generate_summary_core(
             branch,
             &ctx.branch_ref.commit_sha,

--- a/src/commands/picker/summary.rs
+++ b/src/commands/picker/summary.rs
@@ -9,7 +9,6 @@ use worktrunk::git::Repository;
 use super::super::list::model::ListItem;
 use super::items::PreviewCacheKey;
 use super::preview::PreviewMode;
-use crate::summary::LLM_SEMAPHORE;
 
 /// Render LLM summary for terminal display using the project's markdown theme.
 ///
@@ -36,14 +35,15 @@ pub(super) fn render_summary(text: &str, width: usize) -> String {
 }
 
 /// Generate a summary for one item and insert it into the preview cache.
-/// Acquires the LLM semaphore to limit concurrent calls across rayon tasks.
+///
+/// `generate_summary_core` acquires `LLM_SEMAPHORE` internally, so the
+/// no-changes and cache-hit fast paths return without contending.
 pub(super) fn generate_and_cache_summary(
     item: &ListItem,
     llm_command: &str,
     preview_cache: &DashMap<PreviewCacheKey, String>,
     repo: &Repository,
 ) {
-    let _permit = LLM_SEMAPHORE.acquire();
     let branch = item.branch_name();
     let worktree_path = item.worktree_data().map(|d| d.path.as_path());
     let summary =

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -25,7 +25,7 @@ use crate::llm::{execute_llm_command, prepare_diff};
 /// provider. 8 permits balances parallelism with resource usage — LLM calls
 /// are I/O-bound (1-5s network waits), so more permits than the CPU-bound
 /// `HEAVY_OPS_SEMAPHORE` (4) but still bounded.
-pub(crate) static LLM_SEMAPHORE: LazyLock<Semaphore> = LazyLock::new(|| Semaphore::new(8));
+static LLM_SEMAPHORE: LazyLock<Semaphore> = LazyLock::new(|| Semaphore::new(8));
 
 /// Cached summary stored in `.git/wt/cache/summaries/<branch>.json`
 #[derive(Serialize, Deserialize)]
@@ -216,6 +216,12 @@ pub(crate) fn generate_summary_core(
     // Prepare diff (filter large diffs)
     let prepared = prepare_diff(combined.diff, combined.stat);
     let prompt = render_prompt(&prepared.diff, &prepared.stat)?;
+
+    // Acquire the LLM permit only around the actual LLM call. The no-changes
+    // and cache-hit fast paths above return without contending — otherwise a
+    // clean `main` branch sits behind up to 8 slow summary calls and misses
+    // the picker's collect deadline, surfacing as a `·` in the Summary column.
+    let _permit = LLM_SEMAPHORE.acquire();
     let summary = execute_llm_command(llm_command, &prompt)?;
 
     // Write cache


### PR DESCRIPTION
`SummaryGenerateTask` was acquiring `LLM_SEMAPHORE` before `compute_combined_diff` and the cache check, so the no-changes and cache-hit fast paths sat behind up to 8 slow LLM calls. In the picker (500ms collect deadline), a clean `main` row stayed `None` and rendered as the `·` "timed out" placeholder even though there was nothing to summarize. In `wt list --full` (~10s deadline) it eventually cleared — producing the inconsistency between the two views.

Move the permit acquisition into `generate_summary_core`, just before `execute_llm_command`. Fast paths now return immediately; concurrent LLM-provider load is unchanged.

> _This was written by Claude Code on behalf of Maximilian_