### PR TITLE
fix(picker): make skim-tuikit alt-screen enter/exit symmetric

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -177,12 +177,31 @@ inherits = "release"
 lto = "thin"
 
 [patch.crates-io]
-# Local fork of skim-tuikit 0.6.6 with a one-line fix for a dropped-bytes
-# bug in `Output::flush` — it used `write()` instead of `write_all()`, so
-# when the kernel accepted a partial write (common under load or in tmux
-# PTYs with small pipe buffers) the remainder of the buffer was dropped by
-# the subsequent `buffer.clear()`, leaving the picker's first render
-# missing whichever rows didn't fit in the first chunk. Upstream fix
-# proposed in skim-rs/skim#1056; drop this patch once merged and released.
-# See vendor/skim-tuikit/src/output.rs and `task vendor-diff`.
+# Local fork of skim-tuikit 0.6.6 carrying two small fixes. Run
+# `task vendor-diff` to see the full diff against the upstream tarball.
+#
+# Upstream status: skim-tuikit is effectively abandoned. Upstream skim
+# migrated to ratatui in skim-rs/skim#864 (merged 2026-01-12) and has
+# shipped several releases on the new backend; crates.io skim-tuikit is
+# frozen at 0.6.6 (Aug 2025) and will not receive another release. Both
+# bugs below are resolved in ratatui-era skim but not in the vendored
+# tuikit. These patches are load-bearing until we either migrate our
+# picker to a post-ratatui skim (breaking API change in
+# `src/commands/picker/`) or drop skim entirely.
+#
+# 1. Dropped-bytes bug in `Output::flush` — it used `write()` instead of
+#    `write_all()`, so when the kernel accepted a partial write (common
+#    under load or in tmux PTYs with small pipe buffers) the remainder of
+#    the buffer was dropped by the subsequent `buffer.clear()`, leaving
+#    the picker's first render missing whichever rows didn't fit in the
+#    first chunk. See vendor/skim-tuikit/src/output.rs.
+#
+# 2. Asymmetric alternate-screen enter/exit in partial-height mode — in
+#    full-height mode tuikit emits smcup on enter and rmcup on exit, but
+#    in partial-height mode (e.g. `height("90%")`) it skips smcup yet
+#    still emits rmcup on shutdown, leaving terminal artifacts. Fixed by
+#    tracking whether smcup was actually emitted and gating rmcup on that
+#    flag. See vendor/skim-tuikit/src/term.rs. Upstream bug was
+#    skim-rs/skim#880, resolved via the ratatui migration rather than a
+#    tuikit patch.
 skim-tuikit = { path = "vendor/skim-tuikit" }

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -451,10 +451,6 @@ pub fn handle_picker(
     // Configure skim options with Rust-based preview and mode switching keybindings
     let options = SkimOptionsBuilder::default()
         .height("90%".to_string())
-        // Workaround for skim-tuikit bug: partial-height mode skips smcup but
-        // cleanup still sends rmcup, leaving artifacts. no_clear_start forces
-        // cursor_goto + erase_down cleanup instead. See skim-rs/skim#880.
-        .no_clear_start(true)
         .layout("reverse".to_string())
         .header_lines(1) // Make first line (header) non-selectable
         .multi(false)

--- a/vendor/skim-tuikit/src/term.rs
+++ b/vendor/skim-tuikit/src/term.rs
@@ -684,7 +684,13 @@ impl TermLock {
             output.show_cursor();
             if self.clear_on_exit || !exiting {
                 // clear drawn contents
-                if !self.disable_alternate_screen {
+                //
+                // Only send rmcup if we actually sent smcup in `ensure_height`;
+                // otherwise use cursor_goto + erase_down. Previously this gated
+                // on `!self.disable_alternate_screen`, which emitted rmcup even
+                // in partial-height mode (where smcup was skipped), leaving
+                // terminal artifacts. See skim-rs/skim#880.
+                if self.alternate_screen {
                     output.quit_alternate_screen();
                 } else {
                     output.cursor_goto(self.cursor_row, 0);
@@ -719,11 +725,13 @@ impl TermLock {
         let (mut cursor_row, cursor_col) = cursor_pos;
         if height_to_be >= screen_height {
             // whole screen
-            self.alternate_screen = true;
             self.bottom_intact = false;
             self.cursor_row = 0;
             if !self.disable_alternate_screen {
                 output.enter_alternate_screen();
+                // Track that smcup was actually emitted so `pause` can emit
+                // rmcup symmetrically. See skim-rs/skim#880.
+                self.alternate_screen = true;
             }
         } else {
             // only use part of the screen


### PR DESCRIPTION
## Summary

In partial-height mode (`SkimOptionsBuilder::height("90%")`), skim-tuikit's `ensure_height` correctly skips `smcup` but `pause` still emits `rmcup` on shutdown, leaving terminal artifacts after the picker exits. The gate on `!disable_alternate_screen` reflects the config option, not the actual runtime state, so enter/exit aren't symmetric.

Fix: in `pause`, gate `rmcup` on `self.alternate_screen` (the "smcup was actually emitted" flag), and set that flag in `ensure_height` only inside the `!disable_alternate_screen` branch where `enter_alternate_screen()` is called. With the underlying bug fixed, the `no_clear_start(true)` workaround in `src/commands/picker/mod.rs` is dropped.

## Upstream status

Resolved upstream in skim-rs/skim#864 by replacing tuikit with ratatui (merged 2026-01-12). The `skim-tuikit` crate on crates.io is frozen at 0.6.6 and will not receive another release — these vendor patches are permanent until we migrate off tuikit. The `[patch.crates-io]` comment block in `Cargo.toml` is updated to reflect that.

## Test plan

- [x] `cargo run -- hook pre-merge --yes` — 3188 tests passed, including `shell-integration-tests`
- [x] Drove `wt switch` in a tmux pane: picker renders, Enter selects, shell returns with no stale rendering left behind
- [x] `task vendor-diff` produces a clean diff showing both the existing `write_all` fix and the new symmetry fix

> _This was written by Claude Code on behalf of Maximilian Roos_