### PR TITLE
fix(picker): vendor skim-tuikit with saturating_sub in Term::on_resize

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -185,16 +185,16 @@ inherits = "release"
 lto = "thin"
 
 [patch.crates-io]
-# Local fork of skim-tuikit 0.6.6 carrying two small fixes. Run
+# Local fork of skim-tuikit 0.6.6 carrying three small fixes. Run
 # `task vendor-diff` to see the full diff against the upstream tarball.
 #
 # Upstream status: skim-tuikit is effectively abandoned. Upstream skim
 # migrated to ratatui in skim-rs/skim#864 (merged 2026-01-12) and has
 # shipped several releases on the new backend; crates.io skim-tuikit is
-# frozen at 0.6.6 (Aug 2025) and will not receive another release. Both
-# bugs below are resolved in ratatui-era skim but not in the vendored
-# tuikit. These patches are load-bearing until we either migrate our
-# picker to a post-ratatui skim (breaking API change in
+# frozen at 0.6.6 (Aug 2025) and will not receive another release. The
+# bugs below are resolved (or moot) in ratatui-era skim but not in the
+# vendored tuikit. These patches are permanent until we either migrate
+# our picker to a post-ratatui skim (breaking API change in
 # `src/commands/picker/`) or drop skim entirely.
 #
 # 1. Dropped-bytes bug in `Output::flush` — it used `write()` instead of
@@ -212,4 +212,13 @@ lto = "thin"
 #    flag. See vendor/skim-tuikit/src/term.rs. Upstream bug was
 #    skim-rs/skim#880, resolved via the ratatui migration rather than a
 #    tuikit patch.
+#
+# 3. `usize` underflow panic in `Term::on_resize` — when the terminal is
+#    smaller than the picker's preferred height, `screen_height - height`
+#    underflowed and panicked with "attempt to subtract with overflow".
+#    Reachable by running `wt switch` under `script(1)` with stdin closed,
+#    or in any sufficiently small tmux pane. Fixed with `saturating_sub`,
+#    which clamps `cursor_row` to 0 — matching the full-screen fallback
+#    `ensure_height` already uses. See vendor/skim-tuikit/src/term.rs. No
+#    known upstream tracking issue; moot post-ratatui.
 skim-tuikit = { path = "vendor/skim-tuikit" }

--- a/vendor/skim-tuikit/src/term.rs
+++ b/vendor/skim-tuikit/src/term.rs
@@ -640,7 +640,13 @@ impl TermLock {
         }
 
         if self.bottom_intact {
-            self.cursor_row = screen_height - height;
+            // Saturating subtraction: when the terminal is smaller than the
+            // picker's preferred height, `height > screen_height` and the
+            // original `screen_height - height` underflows on `usize` and
+            // panics. Clamp to 0 (top of screen) — matches the
+            // `cursor_row = 0` fallback `ensure_height` already uses for the
+            // full-screen case.
+            self.cursor_row = screen_height.saturating_sub(height);
         }
 
         // clear the screen


### PR DESCRIPTION
`Term::on_resize` computed `screen_height - height` on `usize` when the terminal was smaller than the picker's preferred height, panicking with `attempt to subtract with overflow`. Reachable via `wt switch` under `script(1)` with stdin closed, or in any sufficiently small tmux pane.

Switch to `saturating_sub`, which clamps `cursor_row` to 0 — matching the full-screen fallback `ensure_height` already uses. Update the `[patch.crates-io]` comment block to describe all three vendor patches and note that they are permanent (skim migrated to ratatui upstream and `skim-tuikit` on crates.io is frozen at 0.6.6).

> _This was written by Claude Code on behalf of Maximilian_