### PR TITLE
feat(config): deprecate switch.picker.timeout-ms

### DIFF
--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -117,7 +117,6 @@
 #
 # [switch.picker]
 # pager = "delta --paging=never"   # Example: override git's core.pager for diff preview
-# timeout-ms = 0   # Deprecated. Accepted for backward compatibility, currently ignored.
 #
 # ### Step
 #

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -206,7 +206,6 @@ cd = true          # Change directory after switching (--no-cd to skip)
 
 [switch.picker]
 pager = "delta --paging=never"   # Example: override git's core.pager for diff preview
-timeout-ms = 0   # Deprecated. Accepted for backward compatibility, currently ignored.
 ```
 
 ### Step

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -205,7 +205,6 @@ cd = true          # Change directory after switching (--no-cd to skip)
 
 [switch.picker]
 pager = "delta --paging=never"   # Example: override git's core.pager for diff preview
-timeout-ms = 0   # Deprecated. Accepted for backward compatibility, currently ignored.
 ```
 
 ### Step

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1903,7 +1903,6 @@ cd = true          # Change directory after switching (--no-cd to skip)
 
 [switch.picker]
 pager = "delta --paging=never"   # Example: override git's core.pager for diff preview
-timeout-ms = 0   # Deprecated. Accepted for backward compatibility, currently ignored.
 ```
 
 ### Step

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -347,8 +347,7 @@ pub fn handle_picker(
     // Progressive rendering means the picker never blocks waiting for
     // collect — so there's no UI-freeze budget to bound. The drain runs
     // until its results channel closes or the fallback DRAIN_TIMEOUT
-    // (120s) fires. The legacy `switch.picker.timeout-ms` config field is
-    // still parsed for schema compat but no longer read.
+    // (120s) fires.
 
     // List width depends on the preview position. Right splits the terminal
     // ~50/50; Down gives the list the full width. Passed to `collect` so

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -262,6 +262,8 @@ pub struct Deprecations {
     pub no_cd: bool,
     /// Pre-* hooks using multi-entry table form (will become concurrent in a future version)
     pub pre_hook_table_form: Vec<String>,
+    /// Has `timeout-ms` under `[switch.picker]` (removed — picker now renders progressively)
+    pub switch_picker_timeout_ms: bool,
 }
 
 impl Deprecations {
@@ -276,6 +278,7 @@ impl Deprecations {
             && !self.no_ff
             && !self.no_cd
             && self.pre_hook_table_form.is_empty()
+            && !self.switch_picker_timeout_ms
     }
 }
 
@@ -309,6 +312,7 @@ fn detect_deprecations_from_doc(
         no_ff: find_negated_bool_from_doc(doc, "merge", "no-ff", "ff"),
         no_cd: find_negated_bool_from_doc(doc, "switch", "no-cd", "cd"),
         pre_hook_table_form: find_pre_hook_table_form_from_doc(doc),
+        switch_picker_timeout_ms: find_switch_picker_timeout_from_doc(doc),
     }
 }
 
@@ -963,6 +967,77 @@ fn migrate_content_doc(doc: &mut toml_edit::DocumentMut) -> bool {
     modified |= migrate_ci_doc(doc);
     modified |= migrate_negated_bool_doc(doc, "merge", "no-ff", "ff");
     modified |= migrate_negated_bool_doc(doc, "switch", "no-cd", "cd");
+    modified |= migrate_switch_picker_timeout_doc(doc);
+    modified
+}
+
+/// Check if a table has `timeout-ms` under `[switch.picker]`.
+///
+/// `[switch.picker]` can be written either as a section (regular table) or
+/// inline (`picker = { ... }`); `toml_edit` surfaces these as different node
+/// types, so both branches are needed.
+fn has_switch_picker_timeout(table: &toml_edit::Table) -> bool {
+    table
+        .get("switch")
+        .and_then(|s| s.as_table())
+        .and_then(|t| t.get("picker"))
+        .and_then(|p| match p {
+            toml_edit::Item::Table(t) => Some(t.contains_key("timeout-ms")),
+            toml_edit::Item::Value(toml_edit::Value::InlineTable(it)) => {
+                Some(it.contains_key("timeout-ms"))
+            }
+            _ => None,
+        })
+        .unwrap_or(false)
+}
+
+fn find_switch_picker_timeout_from_doc(doc: &toml_edit::DocumentMut) -> bool {
+    if has_switch_picker_timeout(doc.as_table()) {
+        return true;
+    }
+    if let Some(projects) = doc.get("projects").and_then(|p| p.as_table()) {
+        for (_key, project_value) in projects.iter() {
+            if let Some(project_table) = project_value.as_table()
+                && has_switch_picker_timeout(project_table)
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// Remove `timeout-ms` from `[switch.picker]` in a table (top-level or project).
+fn remove_switch_picker_timeout_in(table: &mut toml_edit::Table) -> bool {
+    let Some(picker) = table
+        .get_mut("switch")
+        .and_then(|s| s.as_table_mut())
+        .and_then(|t| t.get_mut("picker"))
+    else {
+        return false;
+    };
+    match picker {
+        toml_edit::Item::Table(t) => t.remove("timeout-ms").is_some(),
+        toml_edit::Item::Value(toml_edit::Value::InlineTable(it)) => {
+            it.remove("timeout-ms").is_some()
+        }
+        _ => false,
+    }
+}
+
+/// Remove deprecated `timeout-ms` from `[switch.picker]` sections.
+///
+/// Strips the key at both the top level and under `[projects."..."]`. Empty
+/// `[switch.picker]` sections are left in place — they round-trip harmlessly.
+fn migrate_switch_picker_timeout_doc(doc: &mut toml_edit::DocumentMut) -> bool {
+    let mut modified = remove_switch_picker_timeout_in(doc.as_table_mut());
+    if let Some(projects) = doc.get_mut("projects").and_then(|p| p.as_table_mut()) {
+        for (_key, project_value) in projects.iter_mut() {
+            if let Some(project_table) = project_value.as_table_mut() {
+                modified |= remove_switch_picker_timeout_in(project_table);
+            }
+        }
+    }
     modified
 }
 
@@ -1391,6 +1466,17 @@ pub fn format_deprecation_warnings(info: &DeprecationInfo) -> String {
             "{}",
             warning_message(cformat!(
                 "{}: <bold>switch.no-cd</> is deprecated in favor of <bold>switch.cd</> (inverted)",
+                info.label
+            ))
+        );
+    }
+
+    if info.deprecations.switch_picker_timeout_ms {
+        let _ = writeln!(
+            out,
+            "{}",
+            warning_message(cformat!(
+                "{}: <bold>switch.picker.timeout-ms</> is no longer used — the picker now renders progressively",
                 info.label
             ))
         );
@@ -2622,6 +2708,7 @@ approved-commands = ["npm install"]
                 no_ff: false,
                 no_cd: false,
                 pre_hook_table_form: vec![],
+                switch_picker_timeout_ms: false,
             },
             label: "User config".to_string(),
             main_worktree_path: None,
@@ -2904,6 +2991,7 @@ pager = "delta --paging=never"
                 no_ff: false,
                 no_cd: false,
                 pre_hook_table_form: vec![],
+                switch_picker_timeout_ms: false,
             },
             label: "User config".to_string(),
             main_worktree_path: None,
@@ -3099,6 +3187,139 @@ pre-start = "npm install"
         assert_eq!(result, content, "No post-create means no migration");
     }
 
+    fn migrate_switch_picker_timeout(content: &str) -> String {
+        let Ok(mut doc) = content.parse::<toml_edit::DocumentMut>() else {
+            return content.to_string();
+        };
+        if migrate_switch_picker_timeout_doc(&mut doc) {
+            doc.to_string()
+        } else {
+            content.to_string()
+        }
+    }
+
+    #[test]
+    fn test_detect_switch_picker_timeout_top_level() {
+        let content = r#"
+[switch.picker]
+pager = "delta"
+timeout-ms = 500
+"#;
+        let deprecations = detect_deprecations(content);
+        assert!(deprecations.switch_picker_timeout_ms);
+        assert!(!deprecations.is_empty());
+    }
+
+    #[test]
+    fn test_detect_switch_picker_timeout_project_level() {
+        let content = r#"
+[projects."github.com/user/repo".switch.picker]
+timeout-ms = 300
+"#;
+        let deprecations = detect_deprecations(content);
+        assert!(deprecations.switch_picker_timeout_ms);
+    }
+
+    #[test]
+    fn test_detect_switch_picker_timeout_inline_table() {
+        let content = r#"
+[switch]
+picker = { pager = "delta", timeout-ms = 500 }
+"#;
+        let deprecations = detect_deprecations(content);
+        assert!(deprecations.switch_picker_timeout_ms);
+    }
+
+    #[test]
+    fn test_migrate_switch_picker_timeout_inline_table() {
+        let content = r#"
+[switch]
+picker = { pager = "delta", timeout-ms = 500 }
+"#;
+        let result = migrate_switch_picker_timeout(content);
+        assert!(!result.contains("timeout-ms"));
+        assert!(result.contains("pager"));
+    }
+
+    #[test]
+    fn test_detect_switch_picker_timeout_absent() {
+        let content = r#"
+[switch.picker]
+pager = "delta"
+"#;
+        let deprecations = detect_deprecations(content);
+        assert!(!deprecations.switch_picker_timeout_ms);
+    }
+
+    #[test]
+    fn test_migrate_switch_picker_timeout_removes_key() {
+        let content = r#"
+[switch.picker]
+pager = "delta"
+timeout-ms = 500
+"#;
+        let result = migrate_switch_picker_timeout(content);
+        assert!(
+            !result.contains("timeout-ms"),
+            "Should strip timeout-ms: {result}"
+        );
+        assert!(
+            result.contains("pager"),
+            "Should preserve sibling keys: {result}"
+        );
+    }
+
+    #[test]
+    fn test_migrate_switch_picker_timeout_project_level() {
+        let content = r#"
+[projects."github.com/user/repo".switch.picker]
+pager = "bat"
+timeout-ms = 100
+"#;
+        let result = migrate_switch_picker_timeout(content);
+        assert!(!result.contains("timeout-ms"));
+        assert!(result.contains("pager"));
+    }
+
+    #[test]
+    fn test_migrate_switch_picker_timeout_noop_when_absent() {
+        let content = r#"
+[switch.picker]
+pager = "delta"
+"#;
+        let result = migrate_switch_picker_timeout(content);
+        assert_eq!(result, content);
+    }
+
+    #[test]
+    fn test_migrate_switch_picker_timeout_invalid_toml() {
+        let content = "this is { not valid toml";
+        let result = migrate_switch_picker_timeout(content);
+        assert_eq!(result, content);
+    }
+
+    #[test]
+    fn test_format_deprecation_warnings_switch_picker_timeout() {
+        let info = DeprecationInfo {
+            config_path: std::path::PathBuf::from("/tmp/test-config.toml"),
+            deprecations: Deprecations {
+                switch_picker_timeout_ms: true,
+                ..Deprecations::default()
+            },
+            label: "User config".to_string(),
+            main_worktree_path: None,
+        };
+        let output = format_deprecation_warnings(&info);
+        assert!(
+            output.contains("switch.picker.timeout-ms"),
+            "Should mention the field: {output}"
+        );
+        assert!(
+            output.contains("no longer used"),
+            "Should explain deprecation reason: {output}"
+        );
+    }
+
     #[test]
     fn test_detect_deprecations_includes_post_create() {
         let content = r#"
@@ -3136,6 +3357,7 @@ server = "npm run dev"
                 no_ff: false,
                 no_cd: false,
                 pre_hook_table_form: vec![],
+                switch_picker_timeout_ms: false,
             },
             label: "Project config".to_string(),
             main_worktree_path: None,
@@ -3185,6 +3407,7 @@ server = "npm run dev"
                 no_ff: true,
                 no_cd: true,
                 pre_hook_table_form: vec![],
+                switch_picker_timeout_ms: false,
             },
             label: "User config".to_string(),
             main_worktree_path: None,

--- a/src/config/user/resolved.rs
+++ b/src/config/user/resolved.rs
@@ -22,7 +22,6 @@ use super::sections::{
 /// let squash = resolved.merge.squash();                     // bool, default applied
 /// let stage = resolved.commit.stage();                      // StageMode, default applied
 /// let pager = resolved.switch_picker.pager();               // Option<&str>
-/// let timeout = resolved.switch_picker.timeout();           // Option<Duration>, parsed but unused
 /// let cd = resolved.switch.cd();                              // bool, default applied
 /// ```
 #[derive(Debug, Clone, PartialEq)]

--- a/src/config/user/sections.rs
+++ b/src/config/user/sections.rs
@@ -331,15 +331,6 @@ pub struct SwitchPickerConfig {
     /// Example: `pager = "delta --paging=never"`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pager: Option<String>,
-
-    /// Accepted for backward compatibility; currently ignored.
-    ///
-    /// Previously bounded how long the picker blocked before rendering.
-    /// The picker now renders its skeleton immediately and fills rows in
-    /// place as results arrive, so there's no UI-freeze budget to tune.
-    /// Left in the schema so existing configs keep parsing without error.
-    #[serde(rename = "timeout-ms", skip_serializing_if = "Option::is_none")]
-    pub timeout_ms: Option<u64>,
 }
 
 impl SwitchPickerConfig {
@@ -347,24 +338,12 @@ impl SwitchPickerConfig {
     pub fn pager(&self) -> Option<&str> {
         self.pager.as_deref()
     }
-
-    /// Parses the legacy `timeout-ms` field. Kept for schema round-tripping;
-    /// the picker no longer consults it (progressive rendering made the
-    /// UI-freeze budget obsolete).
-    pub fn timeout(&self) -> Option<std::time::Duration> {
-        match self.timeout_ms {
-            Some(0) => None,
-            Some(ms) => Some(std::time::Duration::from_millis(ms)),
-            None => Some(std::time::Duration::from_millis(500)),
-        }
-    }
 }
 
 impl Merge for SwitchPickerConfig {
     fn merge_with(&self, other: &Self) -> Self {
         Self {
             pager: other.pager.clone().or_else(|| self.pager.clone()),
-            timeout_ms: other.timeout_ms.or(self.timeout_ms),
         }
     }
 }

--- a/src/config/user/tests.rs
+++ b/src/config/user/tests.rs
@@ -1035,43 +1035,11 @@ fn test_switch_picker_config_accessor_methods() {
 
     let config = SwitchPickerConfig::default();
     assert!(config.pager().is_none());
-    // Default wall-clock budget is 500ms
-    assert_eq!(
-        config.timeout(),
-        Some(std::time::Duration::from_millis(500))
-    );
 
     let config = SwitchPickerConfig {
         pager: Some("delta --paging=never".to_string()),
-        timeout_ms: Some(1000),
     };
     assert_eq!(config.pager(), Some("delta --paging=never"));
-    assert_eq!(
-        config.timeout(),
-        Some(std::time::Duration::from_millis(1000))
-    );
-}
-
-#[test]
-fn test_switch_picker_timeout_zero_disables() {
-    use crate::config::user::SwitchPickerConfig;
-
-    let config = SwitchPickerConfig {
-        timeout_ms: Some(0),
-        ..Default::default()
-    };
-    assert!(config.timeout().is_none());
-}
-
-#[test]
-fn test_switch_picker_timeout_none_uses_default() {
-    use crate::config::user::SwitchPickerConfig;
-
-    let config = SwitchPickerConfig::default();
-    assert_eq!(
-        config.timeout(),
-        Some(std::time::Duration::from_millis(500))
-    );
 }
 
 #[test]
@@ -1079,12 +1047,10 @@ fn test_switch_picker_config_parse_toml() {
     let content = r#"
 [switch.picker]
 pager = "delta --paging=never"
-timeout-ms = 300
 "#;
     let config: UserConfig = toml::from_str(content).unwrap();
     let picker = config.switch.picker.as_ref().unwrap();
     assert_eq!(picker.pager.as_deref(), Some("delta --paging=never"));
-    assert_eq!(picker.timeout_ms, Some(300));
 }
 
 #[test]
@@ -1093,16 +1059,13 @@ fn test_switch_picker_merge() {
 
     let base = SwitchPickerConfig {
         pager: Some("delta".to_string()),
-        timeout_ms: Some(500),
     };
     let override_config = SwitchPickerConfig {
-        pager: None,         // Fall back to base
-        timeout_ms: Some(0), // Override: disable timeout
+        pager: None, // Fall back to base
     };
 
     let merged = base.merge_with(&override_config);
     assert_eq!(merged.pager.as_deref(), Some("delta"));
-    assert_eq!(merged.timeout_ms, Some(0));
 }
 
 #[test]
@@ -1113,15 +1076,11 @@ fn test_switch_config_merge() {
     let base = SwitchConfig {
         picker: Some(SwitchPickerConfig {
             pager: Some("delta".to_string()),
-            timeout_ms: None,
         }),
         ..Default::default()
     };
     let other = SwitchConfig {
-        picker: Some(SwitchPickerConfig {
-            pager: None,
-            timeout_ms: Some(300),
-        }),
+        picker: Some(SwitchPickerConfig { pager: None }),
         ..Default::default()
     };
     let merged = base.merge_with(&other);
@@ -1129,7 +1088,6 @@ fn test_switch_config_merge() {
         merged.picker.as_ref().unwrap().pager.as_deref(),
         Some("delta")
     );
-    assert_eq!(merged.picker.as_ref().unwrap().timeout_ms, Some(300));
 
     // Base has picker, other doesn't
     let other_none = SwitchConfig::default();
@@ -1251,12 +1209,6 @@ pager = "bat"
             .and_then(|picker| picker.pager.as_deref()),
         Some("bat")
     );
-    // timeout_ms not available from select, so default applies
-    assert_eq!(picker.timeout_ms, None);
-    assert_eq!(
-        picker.timeout(),
-        Some(std::time::Duration::from_millis(500))
-    );
 }
 
 #[test]
@@ -1265,7 +1217,6 @@ fn test_switch_picker_prefers_new_over_select() {
         r#"
 [switch.picker]
 pager = "delta"
-timeout-ms = 100
 
 [select]
 pager = "bat"
@@ -1275,7 +1226,6 @@ pager = "bat"
 
     let picker = config.switch_picker(None);
     assert_eq!(picker.pager.as_deref(), Some("delta"));
-    assert_eq!(picker.timeout_ms, Some(100));
 }
 
 #[test]
@@ -1286,7 +1236,6 @@ fn test_switch_picker_project_override() {
         switch: SwitchConfig {
             picker: Some(SwitchPickerConfig {
                 pager: Some("delta".to_string()),
-                timeout_ms: Some(200),
             }),
             ..Default::default()
         },
@@ -1299,7 +1248,6 @@ fn test_switch_picker_project_override() {
             switch: SwitchConfig {
                 picker: Some(SwitchPickerConfig {
                     pager: Some("bat".to_string()),
-                    timeout_ms: None, // Fall back to global
                 }),
                 ..Default::default()
             },
@@ -1309,7 +1257,6 @@ fn test_switch_picker_project_override() {
 
     let picker = config.switch_picker(Some("github.com/user/repo"));
     assert_eq!(picker.pager.as_deref(), Some("bat")); // From project
-    assert_eq!(picker.timeout_ms, Some(200)); // From global
 }
 
 #[test]
@@ -1318,7 +1265,6 @@ fn test_switch_picker_project_fallback_from_select() {
         r#"
 [switch.picker]
 pager = "delta"
-timeout-ms = 300
 
 [projects."github.com/user/repo".select]
 pager = "bat"
@@ -1328,7 +1274,6 @@ pager = "bat"
 
     let picker = config.switch_picker(Some("github.com/user/repo"));
     assert_eq!(picker.pager.as_deref(), Some("bat"));
-    assert_eq!(picker.timeout_ms, Some(300));
     // [select] is migrated to [switch.picker] at the TOML level before parsing,
     // so it ends up in the switch.picker field, not select
     assert!(
@@ -1365,7 +1310,6 @@ fn test_resolved_config_for_project() {
         switch: SwitchConfig {
             picker: Some(SwitchPickerConfig {
                 pager: Some("less".to_string()),
-                timeout_ms: Some(300),
             }),
             ..Default::default()
         },
@@ -1381,7 +1325,6 @@ fn test_resolved_config_for_project() {
     assert!(resolved.merge.commit()); // Default true
     assert_eq!(resolved.commit.stage(), StageMode::None);
     assert_eq!(resolved.switch_picker.pager(), Some("less"));
-    assert_eq!(resolved.switch_picker.timeout_ms, Some(300));
     assert!(resolved.switch.cd()); // Default true
 }
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -175,7 +175,6 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m#[0m
 [107m [0m [2m# [switch.picker][0m
 [107m [0m [2m# pager = "delta --paging=never"   # Example: override git's core.pager for diff preview[0m
-[107m [0m [2m# timeout-ms = 0   # Deprecated. Accepted for backward compatibility, currently ignored.[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# ### Step[0m
 [107m [0m [2m#[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -221,7 +221,6 @@ Most flags are on by default. Set to false to change default behavior.
 [107m [0m 
 [107m [0m [2m[36m[switch.picker][0m
 [107m [0m [2mpager = [0m[2m[32m"delta --paging=never"[0m[2m   [0m[2m# Example: override git's core.pager for diff preview[0m
-[107m [0m [2mtimeout-ms = [0m[2m[33m0[0m[2m   [0m[2m# Deprecated. Accepted for backward compatibility, currently ignored.[0m
 
 [32mStep[0m
 


### PR DESCRIPTION
`switch.picker.timeout-ms` bounded how long the picker blocked before rendering. After #2231 landed progressive rendering, the field was parsed but silently ignored — violating the CLAUDE.md rule against silently dropping old config keys.

Wired through the standard deprecation path in `src/config/deprecation.rs`: detection flags the field at top-level and under `[projects."X".switch.picker]`, migration strips it, and the warning points users at `wt config update`. Handles both `[switch.picker]` section form and inline `picker = { ... }` form, matching existing helpers.

Also removed the `SwitchPickerConfig::timeout_ms` field and `timeout()` accessor — migration strips the key before serde sees it, so the struct field is no longer needed. Tests referencing the old field updated or dropped. Example TOMLs and the picker comment cleaned up accordingly.

> _This was written by Claude Code on behalf of Maximilian_