### PR TITLE
test(completion): bypass shell startup files to keep PATH hermetic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.37.1
+
+### Improved
+
+- **Progressive rendering in `wt switch` picker**: The picker now mirrors `wt list`'s skeleton-first model — branch and path render immediately, while status, diff stats, counts, and summaries fill in in place as they resolve. Replaces the previous ~500ms blocking freeze before first render. ([#2231](https://github.com/max-sixty/worktrunk/pull/2231))
+
+- **Clean rows no longer flash the timeout glyph in the picker**: The LLM semaphore is now acquired only around the actual LLM call, so the no-changes and cache-hit fast paths return immediately instead of sitting behind up to 8 concurrent LLM calls. A clean `main` row in the picker now renders blank rather than the `·` "timed out" placeholder. ([#2222](https://github.com/max-sixty/worktrunk/pull/2222))
+
+### Fixed
+
+- **Picker preview styling bleed**: `color_print`'s `</>` emits SGR 22 to reset `<bold>`/`<dim>`, which skim 0.20's ANSI parser silently drops. Preview spans now emit an explicit full reset (`\x1b[0m`), so dim and bold no longer bleed across the rest of the preview pane. ([#2232](https://github.com/max-sixty/worktrunk/pull/2232))
+
+- **Picker alt-screen enter/exit asymmetry**: In partial-height mode (`height=90%`), skim-tuikit skipped `smcup` on startup but still emitted `rmcup` on exit, corrupting the outer terminal's scrollback. The vendored tuikit now pairs enter/exit symmetrically. ([#2230](https://github.com/max-sixty/worktrunk/pull/2230))
+
+- **Partial first render under tmux**: Under tmux PTY pressure, rows past the first ~1024 bytes would silently vanish because `Output::flush` used `write` instead of `write_all`. Vendored skim-tuikit fixes the short-write bug. ([#2226](https://github.com/max-sixty/worktrunk/pull/2226))
+
+### Library
+
+- **Expose worktree removal API from the `worktrunk` library**: `remove_worktree_with_cleanup`, `RemoveOptions`, and `BranchDeletionMode` are now public, letting external tools reuse the canonical removal flow (fsmonitor cleanup, trash-path staging) instead of reimplementing it with raw git commands. Motivated by [`worktrunk-sync`](https://github.com/pablospe/worktrunk-sync). ([#2227](https://github.com/max-sixty/worktrunk/pull/2227), thanks @pablospe for the request in [#2053](https://github.com/max-sixty/worktrunk/issues/2053))
+
+### Documentation
+
+- **Document `worktrunk-sync`**: Linked from the Extending page and the FAQ as a community-maintained companion tool for rebasing stacked worktree branches. ([#2225](https://github.com/max-sixty/worktrunk/pull/2225))
+
+- **Catalog vendored skim patches**: `vendor/skim-tuikit/PATCHES.md` now records both landed and candidate patches against skim-tuikit, and a Cargo.toml comment records why skim is pinned to 0.20.x. ([#2228](https://github.com/max-sixty/worktrunk/pull/2228), [#2229](https://github.com/max-sixty/worktrunk/pull/2229))
+
+### Internal
+
+- **Drop unreachable `rayon::spawn` fallback** in the picker orchestrator. ([#2216](https://github.com/max-sixty/worktrunk/pull/2216))
+
 ## 0.37.0
 
 ### Improved

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3126,7 +3126,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "worktrunk"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "ansi-str",
  "ansi-to-html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = [".", "tests/helpers/mock-stub", "tests/helpers/wt-perf"]
 
 [package]
 name = "worktrunk"
-version = "0.37.0"
+version = "0.37.1"
 edition = "2024"
 rust-version = "1.93"
 build = "build.rs"

--- a/docs/static/.well-known/agent-skills/index.json
+++ b/docs/static/.well-known/agent-skills/index.json
@@ -6,7 +6,7 @@
       "type": "skill-md",
       "description": "Guidance for Worktrunk, a CLI tool for managing git worktrees. Covers configuration (user config at ~/.config/worktrunk/config.toml and project hooks at .config/wt.toml), usage, and troubleshooting. Use for \"setting up commit message generation\", \"configuring hooks\", \"automating tasks\", or general worktrunk questions.",
       "url": "./worktrunk/SKILL.md",
-      "digest": "sha256:b867fe437bd0762bbac22bd267fc160aa54b4fbbe0e2ab66f5a956ecd52622df"
+      "digest": "sha256:d0ffe760d8c3d12fcb5490893e1af12a75e831eb3a2960518e95c2881673c5ac"
     }
   ]
 }

--- a/skills/worktrunk/SKILL.md
+++ b/skills/worktrunk/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: worktrunk
 description: Guidance for Worktrunk, a CLI tool for managing git worktrees. Covers configuration (user config at ~/.config/worktrunk/config.toml and project hooks at .config/wt.toml), usage, and troubleshooting. Use for "setting up commit message generation", "configuring hooks", "automating tasks", or general worktrunk questions.
-version: 0.37.0
+version: 0.37.1
 license: MIT OR Apache-2.0
 compatibility: Requires worktrunk CLI (https://worktrunk.dev)
 ---

--- a/tests/integration_tests/shell_wrapper.rs
+++ b/tests/integration_tests/shell_wrapper.rs
@@ -2974,11 +2974,12 @@ fi
     /// output as external subcommands.
     ///
     /// NOTE: passing this via `.env("PATH", ...)` is not enough when spawning
-    /// an interactive/login shell: zsh startup files (`/etc/zprofile` runs
-    /// `path_helper`, plus any user `~/.zshenv`) and fish universal vars
-    /// re-prepend `~/.cargo/bin` and friends. Invoke the shell with its
-    /// config-bypass flag (`zsh -f`, `bash --noprofile --norc`,
-    /// `fish --no-config`) alongside the PATH override.
+    /// a shell whose startup files mutate PATH: a typical `~/.zshenv` sources
+    /// `~/.cargo/env` (even for non-interactive `zsh -c`), and `~/.bashrc` or
+    /// `~/.bash_profile` can do the same. Invoke the shell with its
+    /// rc-bypass flag (`zsh -f`, `bash --noprofile --norc`) alongside the
+    /// PATH override. `/etc/zshenv` is always sourced and cannot be bypassed,
+    /// but it doesn't typically touch PATH on the environments we care about.
     fn completion_test_path(wt_bin: &std::path::Path) -> (tempfile::TempDir, String) {
         let dir = tempfile::tempdir().unwrap();
         std::os::unix::fs::symlink(wt_bin, dir.path().join("wt")).unwrap();
@@ -3019,8 +3020,9 @@ _wt_lazy_complete
         // helper) doesn't leak into completion output as an external subcommand.
         let (_dir, clean_path) = completion_test_path(&wt_bin);
 
-        // `-f` skips /etc/zshenv, /etc/zprofile (path_helper), and ~/.zshenv
-        // so our clean PATH isn't polluted with ~/.cargo/bin etc.
+        // `-f` skips ~/.zshenv (which typically sources ~/.cargo/env and
+        // re-prepends ~/.cargo/bin). `/etc/zshenv` is still read — it can't
+        // be bypassed — but doesn't touch PATH in our test environments.
         let output = std::process::Command::new("zsh")
             .args(["-f", "-c"])
             .arg(&script)

--- a/tests/integration_tests/shell_wrapper.rs
+++ b/tests/integration_tests/shell_wrapper.rs
@@ -2972,6 +2972,13 @@ fi
     /// from that dir + system dirs (excluding cargo target directories). This
     /// prevents co-built binaries like `wt-perf` from leaking into completion
     /// output as external subcommands.
+    ///
+    /// NOTE: passing this via `.env("PATH", ...)` is not enough when spawning
+    /// an interactive/login shell: zsh startup files (`/etc/zprofile` runs
+    /// `path_helper`, plus any user `~/.zshenv`) and fish universal vars
+    /// re-prepend `~/.cargo/bin` and friends. Invoke the shell with its
+    /// config-bypass flag (`zsh -f`, `bash --noprofile --norc`,
+    /// `fish --no-config`) alongside the PATH override.
     fn completion_test_path(wt_bin: &std::path::Path) -> (tempfile::TempDir, String) {
         let dir = tempfile::tempdir().unwrap();
         std::os::unix::fs::symlink(wt_bin, dir.path().join("wt")).unwrap();
@@ -3012,8 +3019,10 @@ _wt_lazy_complete
         // helper) doesn't leak into completion output as an external subcommand.
         let (_dir, clean_path) = completion_test_path(&wt_bin);
 
+        // `-f` skips /etc/zshenv, /etc/zprofile (path_helper), and ~/.zshenv
+        // so our clean PATH isn't polluted with ~/.cargo/bin etc.
         let output = std::process::Command::new("zsh")
-            .arg("-c")
+            .args(["-f", "-c"])
             .arg(&script)
             .env("PATH", &clean_path)
             .output()
@@ -3045,8 +3054,10 @@ for c in "${{COMPREPLY[@]}}"; do echo "${{c%%	*}}"; done
 
         let (_dir, clean_path) = completion_test_path(&wt_bin);
 
+        // `--noprofile --norc` skips ~/.bash_profile, ~/.bashrc, /etc/profile
+        // so our clean PATH isn't polluted with ~/.cargo/bin etc.
         let output = std::process::Command::new("bash")
-            .arg("-c")
+            .args(["--noprofile", "--norc", "-c"])
             .arg(&script)
             .env("PATH", &clean_path)
             .output()
@@ -3189,7 +3200,7 @@ for c in "${{COMPREPLY[@]}}"; do echo "${{c%%	*}}"; done
         );
 
         let output = std::process::Command::new("bash")
-            .arg("-c")
+            .args(["--noprofile", "--norc", "-c"])
             .arg(&script)
             .env("PATH", &clean_path)
             .output()


### PR DESCRIPTION
`test_zsh_completion_subcommands` (and the bash siblings) pass a clean PATH via `.env("PATH", ...)`, but `zsh -c` still runs `/etc/zprofile` (which calls `path_helper`) and `~/.zshenv`, which re-prepend `~/.cargo/bin` before the script runs. If the user has `wt-sync` installed there, clap-complete's external-subcommand discovery emits an extra `sync` entry and the snapshot test fails locally.

Fix: invoke `zsh -f` and `bash --noprofile --norc` in the three tests that spawn shells, so startup files don't run and PATH stays exactly what the test sets. The fish/nushell tests run the `wt` binary directly (no shell in between) and were already hermetic.

## Test plan

- [x] `cargo test --test integration --features shell-integration-tests completion` — 66/66 pass locally with `~/.cargo/bin/wt-sync` present
- [x] Snapshots unchanged (visible subcommands remain `switch list remove merge step hook config`)

> _This was written by Claude Code on behalf of Maximilian_