### PR TITLE
feat(cargo): add `cli` feature to unbundle CLI-only deps

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,6 +44,29 @@ jobs:
     - name: 🔍 Pre-commit hooks
       uses: pre-commit/action@v3.0.1
 
+  feature-check:
+    # Guards the library/CLI cleave: the `cli` feature gates clap, skim,
+    # crossterm, termimad, env_logger, humantime. If anything reachable from
+    # `pub mod` in src/lib.rs starts using one of those crates, library
+    # consumers (e.g. worktrunk-sync) would silently regain the transitive
+    # dependency graph. These checks fail before that can ship.
+    runs-on: ubuntu-24.04
+    steps:
+    - name: 📂 Checkout code
+      uses: actions/checkout@v6
+
+    - name: 💰 Cache
+      uses: Swatinem/rust-cache@v2
+
+    - name: Library builds without any features
+      run: cargo check --lib --no-default-features
+
+    - name: Library builds with syntax-highlighting only
+      run: cargo check --lib --no-default-features --features syntax-highlighting
+
+    - name: Binary builds without syntax-highlighting
+      run: cargo check --bin wt --no-default-features --features cli
+
   test:
     strategy:
       fail-fast: false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,20 @@ normal = ["which"]
 # tier-2-integration-tests = []
 # Enable syntax highlighting for bash commands in output (requires tree-sitter)
 # This is optional to avoid C compilation issues on some platforms
-default = ["syntax-highlighting"]
+default = ["cli", "syntax-highlighting"]
+# Enables the `wt` binary and everything specific to the CLI: argument parsing,
+# interactive picker, rich terminal rendering, and the markdown help pager.
+# Library consumers (e.g. `worktrunk-sync`) should depend on worktrunk with
+# `default-features = false` to avoid pulling these in.
+cli = [
+    "dep:clap",
+    "dep:clap_complete",
+    "dep:crossterm",
+    "dep:env_logger",
+    "dep:humantime",
+    "dep:skim",
+    "dep:termimad",
+]
 syntax-highlighting = ["dep:tree-sitter", "dep:tree-sitter-bash", "dep:tree-sitter-highlight"]
 # Enable shell/PTY integration tests (requires bash, zsh, fish installed on system)
 # Includes: shell wrapper tests, PTY-based approval prompts, TUI select, progressive rendering
@@ -51,6 +64,7 @@ path = "src/lib.rs"
 [[bin]]
 name = "wt"
 path = "src/main.rs"
+required-features = ["cli"]
 
 # Also install as git-wt so `git wt <command>` works as a git subcommand.
 # Primarily useful on Windows where `wt` conflicts with Windows Terminal.
@@ -59,7 +73,7 @@ path = "src/main.rs"
 [[bin]]
 name = "git-wt"
 path = "src/git_wt.rs"
-required-features = ["git-wt"]
+required-features = ["cli", "git-wt"]
 
 [dependencies]
 anyhow = "1.0"
@@ -69,11 +83,11 @@ ansi-str = "0.9"
 color-print = "0.3"
 askama = { version = "0.15", default-features = false, features = ["derive", "std"] }
 chrono = "0.4"
-clap = { version = "4.6", features = ["derive", "unstable-ext", "wrap_help"] }
-clap_complete = { version = "4.6", features = ["unstable-dynamic"] }
+clap = { version = "4.6", features = ["derive", "unstable-ext", "wrap_help"], optional = true }
+clap_complete = { version = "4.6", features = ["unstable-dynamic"], optional = true }
 crossbeam-channel = "0.5"
-crossterm = "0.29"
-env_logger = "0.11"
+crossterm = { version = "0.29", optional = true }
+env_logger = { version = "0.11", optional = true }
 indexmap = { version = "2.14", features = ["serde"] }
 etcetera = "0.11"
 log = "0.4"
@@ -93,7 +107,7 @@ toml_edit = { version = "0.25", features = ["serde"] }
 # tree-sitter and tree-sitter-highlight should use matching versions.
 # tree-sitter-bash may lag behind (0.25.x works with tree-sitter 0.26.x).
 # These are optional dependencies controlled by the "syntax-highlighting" feature.
-# To build without C compilation requirements, use: cargo install worktrunk --no-default-features
+# To build without C compilation requirements, use: cargo install worktrunk --no-default-features --features cli
 tree-sitter = { version = "0.26", optional = true }
 tree-sitter-bash = { version = "0.25.1", optional = true }
 tree-sitter-highlight = { version = "0.26", optional = true }
@@ -102,7 +116,7 @@ wrap-ansi = "0.1"
 osc8 = "0.1.0"
 supports-hyperlinks = "3"
 home = "0.5.12"
-humantime = "2.2"
+humantime = { version = "2.2", optional = true }
 once_cell = "1.21"
 dirs = "6.0"
 normalize-path = "0.2.1"
@@ -112,7 +126,7 @@ which = "8.0"
 # Cross-platform path canonicalization that avoids Windows verbatim paths (\\?\)
 # which external tools like git cannot handle. On Unix, it's a no-op wrapper.
 dunce = "1.0"
-termimad = "0.34.1"
+termimad = { version = "0.34.1", optional = true }
 urlencoding = "2.1"
 regex = "1.12"
 ignore = "0.4"
@@ -134,7 +148,7 @@ wait-timeout = "0.2"
 # versions, so an upgrade blocks on upstream relaxing those pins.
 # Windows picker support (worktrunk#2223) landed in skim v4.3.0 but is
 # gated by the same constraint.
-skim = "0.20"
+skim = { version = "0.20", optional = true }
 nix = { version = "0.31", default-features = false, features = ["process", "signal"] }
 signal-hook = "0.4"
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -231,7 +231,7 @@ For full details on the detection mechanism, see `wt config state default-branch
 
 Errors related to tree-sitter or C compilation (C99 mode, `le16toh` undefined) can be avoided by installing without syntax highlighting:
 
-{{ terminal(cmd="cargo install worktrunk --no-default-features") }}
+{{ terminal(cmd="cargo install worktrunk --no-default-features --features cli") }}
 
 This disables bash syntax highlighting in command output but keeps all core functionality. The syntax highlighting feature requires C99 compiler support and can fail on older systems or minimal Docker images.
 

--- a/skills/worktrunk/reference/faq.md
+++ b/skills/worktrunk/reference/faq.md
@@ -225,7 +225,7 @@ For full details on the detection mechanism, see `wt config state default-branch
 Errors related to tree-sitter or C compilation (C99 mode, `le16toh` undefined) can be avoided by installing without syntax highlighting:
 
 ```bash
-cargo install worktrunk --no-default-features
+cargo install worktrunk --no-default-features --features cli
 ```
 
 This disables bash syntax highlighting in command output but keeps all core functionality. The syntax highlighting feature requires C99 compiler support and can fail on older systems or minimal Docker images.

--- a/src/config/user/sections.rs
+++ b/src/config/user/sections.rs
@@ -15,17 +15,9 @@ use crate::config::is_default;
 
 /// What to stage before committing
 #[derive(
-    Debug,
-    Clone,
-    Copy,
-    Default,
-    PartialEq,
-    Eq,
-    clap::ValueEnum,
-    serde::Serialize,
-    serde::Deserialize,
-    JsonSchema,
+    Debug, Clone, Copy, Default, PartialEq, Eq, serde::Serialize, serde::Deserialize, JsonSchema,
 )]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[serde(rename_all = "kebab-case")]
 pub enum StageMode {
     /// Stage everything: untracked files + unstaged tracked changes

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -374,13 +374,13 @@ pub fn branch_tracks_ref(
     Copy,
     PartialEq,
     Eq,
-    clap::ValueEnum,
     serde::Serialize,
     serde::Deserialize,
     strum::Display,
     strum::EnumString,
     strum::EnumIter,
 )]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[serde(rename_all = "kebab-case")]
 #[strum(serialize_all = "kebab-case")]
 pub enum HookType {

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -27,17 +27,18 @@ pub use utils::{current_shell, detect_zsh_compinit, extract_filename_from_path};
 ///
 /// On Windows, Git Bash users should use `bash` for shell integration.
 /// PowerShell integration is available for native Windows users without Git Bash.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum, strum::Display, strum::EnumString)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, strum::Display, strum::EnumString)]
+#[cfg_attr(feature = "cli", derive(clap::ValueEnum))]
 #[strum(serialize_all = "kebab-case", ascii_case_insensitive)]
 pub enum Shell {
     Bash,
     Fish,
     #[strum(serialize = "nu")]
-    #[clap(name = "nu")]
+    #[cfg_attr(feature = "cli", clap(name = "nu"))]
     Nushell,
     Zsh,
     #[strum(serialize = "powershell")]
-    #[clap(name = "powershell")]
+    #[cfg_attr(feature = "cli", clap(name = "powershell"))]
     PowerShell,
 }
 


### PR DESCRIPTION
The `worktrunk` crate is also consumed as a library (e.g. by `worktrunk-sync`). Everything reachable from `src/lib.rs` previously pulled in `clap`, `skim` (with its exact-version pins), `crossterm`, `termimad`, `env_logger`, `humantime` transitively — even though none of them are used in library code.

This adds a `cli` feature (on by default) that gates those deps. Library consumers doing `default-features = false` now drop from 195 to 126 transitive crates: −64 from `cli`, −5 from `syntax-highlighting` (already gated). Binary users see no change.

The cleave sits at the module boundary: the CLI modules (`cli/`, `commands/`) are declared only in `main.rs`, and `[[bin]] wt` now has `required-features = ["cli"]`, so they're never opened when the feature is off. The only in-lib gating is three `cfg_attr`'d `clap::ValueEnum` derives on `git::HookType`, `shell::Shell`, and `config::user::sections::StageMode`.

Added a `feature-check` CI job that runs `cargo check` across the no-cli and cli-only-without-syntax-highlighting combinations, so the cleave can't silently regress. After merge, worth adding this job to the required status checks in the branch ruleset.

The FAQ's C-compilation workaround previously recommended `cargo install worktrunk --no-default-features`, which now produces no binary. Updated to `--no-default-features --features cli`.

## Deliberately kept ungated

`wrap-ansi`, `synoptic`, `anstream`/`anstyle` family, `schemars`, `minijinja`, `askama`, `color-print` stay as unconditional library deps. They appear in public library signatures — `pub fn styling::wrap_styled_text`, `pub fn styling::format_toml`, `shell::ShellInit::generate() -> Result<_, askama::Error>`, `JsonSchema` derives — so gating them would be a library-API break for a smaller dep-graph win.

## Test plan

- [x] `cargo check --lib --no-default-features` — library builds without `cli` or `syntax-highlighting`
- [x] `cargo check --lib --no-default-features --features syntax-highlighting`
- [x] `cargo check --bin wt --no-default-features --features cli` — binary builds without syntax-highlighting
- [x] `cargo check --all-targets` (default features)
- [x] `cargo test --lib --bins` — 574/574 pass
- [x] `pre-commit run --all-files` — clean
- [x] `cargo run -- hook pre-merge --yes` — clean except pre-existing `test_zsh_completion_subcommands` failure (unrelated; local `wt-sync` binary polluting test PATH filter; reproduces on clean `main`)