### PR TITLE
test(picker): remove dead disable_picker_timeout helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,35 @@
 # Changelog
 
+## 0.37.1
+
+### Improved
+
+- **Progressive rendering in `wt switch` picker**: The picker now mirrors `wt list`'s skeleton-first model — branch and path render immediately, while status, diff stats, counts, and summaries fill in in place as they resolve. Replaces the previous ~500ms blocking freeze before first render. ([#2231](https://github.com/max-sixty/worktrunk/pull/2231))
+
+- **Clean rows no longer flash the timeout glyph in the picker**: The LLM semaphore is now acquired only around the actual LLM call, so the no-changes and cache-hit fast paths return immediately instead of sitting behind up to 8 concurrent LLM calls. A clean `main` row in the picker now renders blank rather than the `·` "timed out" placeholder. ([#2222](https://github.com/max-sixty/worktrunk/pull/2222))
+
+### Fixed
+
+- **Picker preview styling bleed**: `color_print`'s `</>` emits SGR 22 to reset `<bold>`/`<dim>`, which skim 0.20's ANSI parser silently drops. Preview spans now emit an explicit full reset (`\x1b[0m`), so dim and bold no longer bleed across the rest of the preview pane. ([#2232](https://github.com/max-sixty/worktrunk/pull/2232))
+
+- **Picker alt-screen enter/exit asymmetry**: In partial-height mode (`height=90%`), skim-tuikit skipped `smcup` on startup but still emitted `rmcup` on exit, corrupting the outer terminal's scrollback. The vendored tuikit now pairs enter/exit symmetrically. ([#2230](https://github.com/max-sixty/worktrunk/pull/2230))
+
+- **Partial first render under tmux**: Under tmux PTY pressure, rows past the first ~1024 bytes would silently vanish because `Output::flush` used `write` instead of `write_all`. Vendored skim-tuikit fixes the short-write bug. ([#2226](https://github.com/max-sixty/worktrunk/pull/2226))
+
+### Library
+
+- **Expose worktree removal API from the `worktrunk` library**: `remove_worktree_with_cleanup`, `RemoveOptions`, and `BranchDeletionMode` are now public, letting external tools reuse the canonical removal flow (fsmonitor cleanup, trash-path staging) instead of reimplementing it with raw git commands. Motivated by [`worktrunk-sync`](https://github.com/pablospe/worktrunk-sync). ([#2227](https://github.com/max-sixty/worktrunk/pull/2227), thanks @pablospe for the request in [#2053](https://github.com/max-sixty/worktrunk/issues/2053))
+
+### Documentation
+
+- **Document `worktrunk-sync`**: Linked from the Extending page and the FAQ as a community-maintained companion tool for rebasing stacked worktree branches. ([#2225](https://github.com/max-sixty/worktrunk/pull/2225))
+
+- **Catalog vendored skim patches**: `vendor/skim-tuikit/PATCHES.md` now records both landed and candidate patches against skim-tuikit, and a Cargo.toml comment records why skim is pinned to 0.20.x. ([#2228](https://github.com/max-sixty/worktrunk/pull/2228), [#2229](https://github.com/max-sixty/worktrunk/pull/2229))
+
+### Internal
+
+- **Drop unreachable `rayon::spawn` fallback** in the picker orchestrator. ([#2216](https://github.com/max-sixty/worktrunk/pull/2216))
+
 ## 0.37.0
 
 ### Improved

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3126,7 +3126,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "worktrunk"
-version = "0.37.0"
+version = "0.37.1"
 dependencies = [
  "ansi-str",
  "ansi-to-html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = [".", "tests/helpers/mock-stub", "tests/helpers/wt-perf"]
 
 [package]
 name = "worktrunk"
-version = "0.37.0"
+version = "0.37.1"
 edition = "2024"
 rust-version = "1.93"
 build = "build.rs"

--- a/docs/static/.well-known/agent-skills/index.json
+++ b/docs/static/.well-known/agent-skills/index.json
@@ -6,7 +6,7 @@
       "type": "skill-md",
       "description": "Guidance for Worktrunk, a CLI tool for managing git worktrees. Covers configuration (user config at ~/.config/worktrunk/config.toml and project hooks at .config/wt.toml), usage, and troubleshooting. Use for \"setting up commit message generation\", \"configuring hooks\", \"automating tasks\", or general worktrunk questions.",
       "url": "./worktrunk/SKILL.md",
-      "digest": "sha256:b867fe437bd0762bbac22bd267fc160aa54b4fbbe0e2ab66f5a956ecd52622df"
+      "digest": "sha256:d0ffe760d8c3d12fcb5490893e1af12a75e831eb3a2960518e95c2881673c5ac"
     }
   ]
 }

--- a/skills/worktrunk/SKILL.md
+++ b/skills/worktrunk/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: worktrunk
 description: Guidance for Worktrunk, a CLI tool for managing git worktrees. Covers configuration (user config at ~/.config/worktrunk/config.toml and project hooks at .config/wt.toml), usage, and troubleshooting. Use for "setting up commit message generation", "configuring hooks", "automating tasks", or general worktrunk questions.
-version: 0.37.0
+version: 0.37.1
 license: MIT OR Apache-2.0
 compatibility: Requires worktrunk CLI (https://worktrunk.dev)
 ---

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -888,9 +888,6 @@ fn test_switch_picker_respects_list_config(mut repo: TestRepo) {
         r#"
 [list]
 branches = true
-
-[switch-picker]
-timeout-ms = 0
 "#,
     );
 

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -484,20 +484,6 @@ fn wait_for_stable_with_content(
     );
 }
 
-/// Disable the picker's 500ms data collection timeout so all task results
-/// arrive before rendering. Without this, slow CI runners (especially macOS)
-/// can show `·` stale placeholders for columns whose data didn't arrive in
-/// time, causing non-deterministic snapshots.
-fn disable_picker_timeout(repo: &TestRepo) {
-    let existing = std::fs::read_to_string(repo.test_config_path()).unwrap_or_default();
-    let config = if existing.is_empty() {
-        "skip-commit-generation-prompt = true\n\n[switch-picker]\ntimeout-ms = 0\n".to_string()
-    } else {
-        format!("{existing}\n[switch-picker]\ntimeout-ms = 0\n")
-    };
-    std::fs::write(repo.test_config_path(), config).unwrap();
-}
-
 /// Create insta settings with filters for switch picker snapshot stability.
 ///
 /// Replaces the manual `normalize_output()` approach with declarative insta filters.
@@ -536,8 +522,6 @@ fn test_switch_picker_abort_with_escape(mut repo: TestRepo) {
     repo.remove_fixture_worktrees();
     // Remove origin so snapshots don't show origin/main
     repo.run_git(&["remote", "remove", "origin"]);
-    disable_picker_timeout(&repo);
-
     let env_vars = repo.test_env_vars();
     let result = exec_in_pty_capture_before_abort(
         wt_bin().to_str().unwrap(),
@@ -562,8 +546,6 @@ fn test_switch_picker_with_multiple_worktrees(mut repo: TestRepo) {
     repo.remove_fixture_worktrees();
     // Remove origin so snapshots don't show origin/main
     repo.run_git(&["remote", "remove", "origin"]);
-    disable_picker_timeout(&repo);
-
     repo.add_worktree("feature-one");
     repo.add_worktree("feature-two");
 
@@ -592,8 +574,6 @@ fn test_switch_picker_with_branches(mut repo: TestRepo) {
     repo.remove_fixture_worktrees();
     // Remove origin so snapshots don't show origin/main
     repo.run_git(&["remote", "remove", "origin"]);
-    disable_picker_timeout(&repo);
-
     repo.add_worktree("active-worktree");
     // Create a branch without a worktree
     let output = repo
@@ -630,8 +610,6 @@ fn test_switch_picker_preview_panel_uncommitted(mut repo: TestRepo) {
     repo.remove_fixture_worktrees();
     // Remove origin so snapshots don't show origin/main
     repo.run_git(&["remote", "remove", "origin"]);
-    disable_picker_timeout(&repo);
-
     let feature_path = repo.add_worktree("feature");
 
     // First, create and commit a file so we have something to modify
@@ -691,8 +669,6 @@ fn test_switch_picker_preview_panel_log(mut repo: TestRepo) {
     repo.remove_fixture_worktrees();
     // Remove origin so snapshots don't show origin/main
     repo.run_git(&["remote", "remove", "origin"]);
-    disable_picker_timeout(&repo);
-
     let feature_path = repo.add_worktree("feature");
 
     // Make several commits in the feature worktree
@@ -751,8 +727,6 @@ fn test_switch_picker_preview_panel_main_diff(mut repo: TestRepo) {
     repo.remove_fixture_worktrees();
     // Remove origin so snapshots don't show origin/main
     repo.run_git(&["remote", "remove", "origin"]);
-    disable_picker_timeout(&repo);
-
     let feature_path = repo.add_worktree("feature");
 
     // Make commits in the feature worktree that differ from main
@@ -844,8 +818,6 @@ fn test_switch_picker_preview_panel_summary(mut repo: TestRepo) {
     repo.remove_fixture_worktrees();
     // Remove origin so snapshots don't show origin/main
     repo.run_git(&["remote", "remove", "origin"]);
-    disable_picker_timeout(&repo);
-
     let feature_path = repo.add_worktree("feature");
 
     // Make a commit so there's content to potentially summarize


### PR DESCRIPTION
The helper in `tests/integration_tests/switch_picker.rs` wrote to top-level `[switch-picker]` (with a hyphen), which the config loader has always silently ignored — the real section is `[switch.picker]`. On top of that, progressive rendering (#2231) removed the picker's reliance on any timeout, and `switch.picker.timeout-ms` was formally deprecated in #2236.

So the helper has been a no-op for multiple reasons. Removed the function and all 7 call sites. Picker tests still pass without it.

> _This was written by Claude Code on behalf of Maximilian_