### PR TITLE
style(picker): align empty summary with other preview empty states

### DIFF
--- a/src/commands/picker/summary.rs
+++ b/src/commands/picker/summary.rs
@@ -460,7 +460,7 @@ mod tests {
             "echo 'should not run'",
             &repo,
         );
-        assert_snapshot!(summary, @"[2mNo changes to summarize on main.[22m");
+        assert_snapshot!(summary, @"[2m○[22m[0m [1mmain[22m[0m has no changes to summarize");
     }
 
     #[test]

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -12,11 +12,13 @@ use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
+use anstyle::Reset;
 use color_print::cformat;
 use minijinja::Environment;
 use serde::{Deserialize, Serialize};
 use worktrunk::git::Repository;
 use worktrunk::path::sanitize_for_filename;
+use worktrunk::styling::INFO_SYMBOL;
 use worktrunk::sync::Semaphore;
 
 use crate::llm::{execute_llm_command, prepare_diff};
@@ -252,7 +254,10 @@ pub(crate) fn generate_summary(
 ) -> String {
     match generate_summary_core(branch, head, worktree_path, llm_command, repo) {
         Ok(Some(summary)) => summary,
-        Ok(None) => cformat!("<dim>No changes to summarize on {branch}.</>"),
+        Ok(None) => {
+            let reset = Reset;
+            cformat!("{INFO_SYMBOL}{reset} <bold>{branch}</>{reset} has no changes to summarize\n")
+        }
         Err(e) => format!("Error: {e}"),
     }
 }


### PR DESCRIPTION
The Summary tab's empty state rendered as a fully dimmed sentence (`No changes to summarize on <branch>.`), while every other preview tab uses the `○ <bold>branch</> …` shape. Switch to the same form so all five tabs share one visual shape.

> _This was written by Claude Code on behalf of max-sixty_