### PR TITLE
docs(hook): use concurrent form in multi-key hook examples

### DIFF
--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -389,14 +389,10 @@ Quick checks before commit, thorough validation before merge:
 ```toml
 [[pre-commit]]
 lint = "npm run lint"
-
-[[pre-commit]]
 typecheck = "npm run typecheck"
 
 [[pre-merge]]
 test = "npm test"
-
-[[pre-merge]]
 build = "npm run build"
 ```
 
@@ -432,20 +428,14 @@ post-merge = "cargo install --path ."
 
 [[pre-start]]
 install = "npm ci"
-
-[[pre-start]]
 env = "echo 'PORT={{ branch | hash_port }}' > .env.local"
 
 [[pre-commit]]
 format = "cargo fmt -- --check"
-
-[[pre-commit]]
 lint = "cargo clippy -- -D warnings"
 
 [[pre-merge]]
 test = "cargo test"
-
-[[pre-merge]]
 build = "cargo build --release"
 
 [pre-switch]

--- a/docs/content/merge.md
+++ b/docs/content/merge.md
@@ -72,8 +72,6 @@ The full workflow: start an agent (one of many) on a task, work elsewhere, retur
 ```toml
 [[pre-merge]]
 test = "cargo test"
-
-[[pre-merge]]
 lint = "cargo clippy"
 ```
 

--- a/docs/content/tips-patterns.md
+++ b/docs/content/tips-patterns.md
@@ -131,8 +131,6 @@ All gitignored files are copied by default. To limit what gets copied, create `.
 ```toml
 [[pre-merge]]
 lint = "uv run ruff check"
-
-[[pre-merge]]
 test = "uv run pytest"
 ```
 

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -389,14 +389,10 @@ Quick checks before commit, thorough validation before merge:
 ```toml
 [[pre-commit]]
 lint = "npm run lint"
-
-[[pre-commit]]
 typecheck = "npm run typecheck"
 
 [[pre-merge]]
 test = "npm test"
-
-[[pre-merge]]
 build = "npm run build"
 ```
 
@@ -432,20 +428,14 @@ post-merge = "cargo install --path ."
 
 [[pre-start]]
 install = "npm ci"
-
-[[pre-start]]
 env = "echo 'PORT={{ branch | hash_port }}' > .env.local"
 
 [[pre-commit]]
 format = "cargo fmt -- --check"
-
-[[pre-commit]]
 lint = "cargo clippy -- -D warnings"
 
 [[pre-merge]]
 test = "cargo test"
-
-[[pre-merge]]
 build = "cargo build --release"
 
 [pre-switch]

--- a/skills/worktrunk/reference/merge.md
+++ b/skills/worktrunk/reference/merge.md
@@ -68,8 +68,6 @@ The full workflow: start an agent (one of many) on a task, work elsewhere, retur
 ```toml
 [[pre-merge]]
 test = "cargo test"
-
-[[pre-merge]]
 lint = "cargo clippy"
 ```
 

--- a/skills/worktrunk/reference/tips-patterns.md
+++ b/skills/worktrunk/reference/tips-patterns.md
@@ -126,8 +126,6 @@ All gitignored files are copied by default. To limit what gets copied, create `.
 ```toml
 [[pre-merge]]
 lint = "uv run ruff check"
-
-[[pre-merge]]
 test = "uv run pytest"
 ```
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1060,8 +1060,6 @@ The full workflow: start an agent (one of many) on a task, work elsewhere, retur
 ```toml
 [[pre-merge]]
 test = "cargo test"
-
-[[pre-merge]]
 lint = "cargo clippy"
 ```
 
@@ -1597,14 +1595,10 @@ Quick checks before commit, thorough validation before merge:
 ```toml
 [[pre-commit]]
 lint = "npm run lint"
-
-[[pre-commit]]
 typecheck = "npm run typecheck"
 
 [[pre-merge]]
 test = "npm test"
-
-[[pre-merge]]
 build = "npm run build"
 ```
 
@@ -1640,20 +1634,14 @@ post-merge = "cargo install --path ."
 
 [[pre-start]]
 install = "npm ci"
-
-[[pre-start]]
 env = "echo 'PORT={{ branch | hash_port }}' > .env.local"
 
 [[pre-commit]]
 format = "cargo fmt -- --check"
-
-[[pre-commit]]
 lint = "cargo clippy -- -D warnings"
 
 [[pre-merge]]
 test = "cargo test"
-
-[[pre-merge]]
 build = "cargo build --release"
 
 [pre-switch]

--- a/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
@@ -164,8 +164,6 @@ The full workflow: start an agent (one of many) on a task, work elsewhere, retur
 ```toml
 [[pre-merge]]
 test = "cargo test"
-
-[[pre-merge]]
 lint = "cargo clippy"
 ```
 

--- a/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
@@ -150,8 +150,6 @@ The full workflow: start an agent (one of many) on a task, work elsewhere, retur
 
 [107m [0m [2m[36m[[pre-merge]][0m
 [107m [0m [2mtest = [0m[2m[32m"cargo test"[0m
-[107m [0m 
-[107m [0m [2m[36m[[pre-merge]][0m
 [107m [0m [2mlint = [0m[2m[32m"cargo clippy"[0m
 
 [1m[32mSee also[0m


### PR DESCRIPTION
The `wt hook` page and tips/merge examples paired two `[[pre-*]]` blocks with one command each, which runs them serially. For independent commands like `cargo fmt --check` + `cargo clippy`, that taught the wrong lesson.

Collapsed each pair into a single `[[pre-*]]` block with both keys (runs concurrently). The multi-entry `[pre-*]` table form is deprecated (`src/config/deprecation.rs`), so the single-element array form is the non-deprecated way to express concurrent commands.

Affected: `src/cli/mod.rs` (merge local-CI, hook progressive-validation, hook-type-examples), `docs/content/tips-patterns.md` (local CI gate). Generated docs, skill mirrors, and help snapshots synced.

> _This was written by Claude Code on behalf of @max-sixty_