### PR TITLE
style(perf): rename total_extra_calls to extra_calls in cache-check JSON

### DIFF
--- a/tests/helpers/wt-perf/src/main.rs
+++ b/tests/helpers/wt-perf/src/main.rs
@@ -326,7 +326,7 @@ fn cache_check(entries: &[worktrunk::trace::TraceEntry]) {
         "contexts": contexts.len(),
         "total_time_us": total_time_us,
         "duplicated_commands": dup_count,
-        "total_extra_calls": dup_total,
+        "extra_calls": dup_total,
         "same_context_duplicates": duplicates,
         "same_context_extra_calls": total_extra,
         "same_context_extra_us": total_extra_us,


### PR DESCRIPTION
Disambiguates from `same_context_extra_calls` — the top-level `extra_calls` counts all extra calls regardless of context, while `same_context_extra_calls` is the subset within same context.

Follow-up to #2253.

> _This was written by Claude Code on behalf of @max-sixty_