### PR TITLE
perf(list): batch upstream lookups and prime ref/SHA caches

### DIFF
--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -168,11 +168,8 @@
 //! - `AheadBehind` — batch-optimized via single `git for-each-ref %(ahead-behind:main)`
 //!   (~11ms for all branches); per-branch tasks read the in-memory cache
 //! - `CommittedTreesMatch` — single `git rev-parse` resolving both tree SHAs (~1ms)
-//!
-//! ### Cacheable but uncached
-//!
-//! - `Upstream` — `ahead_behind()` against the tracking branch; same SHA-pair
-//!   pattern as `sha_cache`, just not wired up yet
+//! - `Upstream` — upstream names batch-fetched via single `git for-each-ref
+//!   %(upstream:short)`; per-branch tasks read the in-memory cache
 //!
 //! ### Cached via tree SHA
 //!
@@ -988,6 +985,11 @@ pub fn collect(
     // `git for-each-ref` call. Primes the Repository cache so each
     // `AheadBehindTask` hits the cache instead of spawning its own
     // `git rev-list --count`. One git call replaces N.
+    //
+    // Note: `resolved_refs` and `commit_shas` are already primed by
+    // `list_local_branches()` (called during pre-skeleton phase).
+    // Upstream tracking branches are lazily loaded on first `Branch::upstream()`
+    // call via `OnceCell`.
     //
     // On git < 2.36 (no `%(ahead-behind:)` support) or if default_branch is
     // unknown, skip the batch — individual tasks fall back to direct calls.

--- a/src/git/repository/branch.rs
+++ b/src/git/repository/branch.rs
@@ -100,7 +100,7 @@ impl<'a> Branch<'a> {
             .repo
             .cache
             .upstreams
-            .get_or_init(|| self.repo.fetch_all_upstreams());
+            .get_or_try_init(|| self.repo.fetch_all_upstreams())?;
         Ok(upstreams.get(&self.name).cloned().unwrap_or(None))
     }
 

--- a/src/git/repository/branch.rs
+++ b/src/git/repository/branch.rs
@@ -96,17 +96,12 @@ impl<'a> Branch<'a> {
     ///
     /// [1]: https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-emltaboranchgtemuaboranchgtupaboranchgtupstream
     pub fn upstream(&self) -> anyhow::Result<Option<String>> {
-        let result =
-            self.repo
-                .run_command(&["rev-parse", "--abbrev-ref", &format!("{}@{{u}}", self.name)]);
-
-        match result {
-            Ok(upstream) => {
-                let trimmed = upstream.trim();
-                Ok((!trimmed.is_empty()).then(|| trimmed.to_string()))
-            }
-            Err(_) => Ok(None), // No upstream configured
-        }
+        let upstreams = self
+            .repo
+            .cache
+            .upstreams
+            .get_or_init(|| self.repo.fetch_all_upstreams());
+        Ok(upstreams.get(&self.name).cloned().unwrap_or(None))
     }
 
     /// Unset the upstream tracking branch for this branch.

--- a/src/git/repository/branches.rs
+++ b/src/git/repository/branches.rs
@@ -121,20 +121,14 @@ impl Repository {
     /// Returns a map from local branch name to upstream ref (or None if no
     /// upstream is configured). Called lazily via `OnceCell` on first
     /// `Branch::upstream()` access.
-    pub(super) fn fetch_all_upstreams(&self) -> HashMap<String, Option<String>> {
-        let output = match self.run_command(&[
+    pub(super) fn fetch_all_upstreams(&self) -> anyhow::Result<HashMap<String, Option<String>>> {
+        let output = self.run_command(&[
             "for-each-ref",
             "--format=%(refname:lstrip=2)\t%(upstream:short)",
             "refs/heads/",
-        ]) {
-            Ok(output) => output,
-            Err(e) => {
-                log::debug!("fetch_all_upstreams: git for-each-ref failed: {e}");
-                return HashMap::new();
-            }
-        };
+        ])?;
 
-        output
+        Ok(output
             .lines()
             .filter_map(|line| {
                 let (branch, upstream) = line.split_once('\t')?;
@@ -145,7 +139,7 @@ impl Repository {
                 };
                 Some((branch.to_string(), value))
             })
-            .collect()
+            .collect())
     }
 
     /// List remote branches that aren't tracked by any local branch.

--- a/src/git/repository/branches.rs
+++ b/src/git/repository/branches.rs
@@ -42,6 +42,10 @@ impl Repository {
 
     /// List all local branches with their HEAD commit SHA.
     /// Returns a vector of (branch_name, commit_sha) tuples.
+    ///
+    /// As a side effect, primes `resolved_refs` and `commit_shas` caches so
+    /// later `resolve_preferring_branch()` and `rev_parse_commit()` calls hit
+    /// the cache instead of spawning per-branch `git rev-parse` commands.
     pub fn list_local_branches(&self) -> anyhow::Result<Vec<(String, String)>> {
         let output = self.run_command(&[
             "for-each-ref",
@@ -53,6 +57,14 @@ impl Repository {
             .lines()
             .filter_map(|line| {
                 let (branch, sha) = line.split_once(' ')?;
+                let qualified = format!("refs/heads/{branch}");
+                self.cache
+                    .resolved_refs
+                    .insert(branch.to_string(), qualified.clone());
+                self.cache.commit_shas.insert(qualified, sha.to_string());
+                self.cache
+                    .commit_shas
+                    .insert(branch.to_string(), sha.to_string());
                 Some((branch.to_string(), sha.to_string()))
             })
             .collect();
@@ -102,6 +114,38 @@ impl Repository {
             .collect();
 
         Ok(upstreams)
+    }
+
+    /// Fetch all upstream tracking branches in a single `git for-each-ref` call.
+    ///
+    /// Returns a map from local branch name to upstream ref (or None if no
+    /// upstream is configured). Called lazily via `OnceCell` on first
+    /// `Branch::upstream()` access.
+    pub(super) fn fetch_all_upstreams(&self) -> HashMap<String, Option<String>> {
+        let output = match self.run_command(&[
+            "for-each-ref",
+            "--format=%(refname:lstrip=2)\t%(upstream:short)",
+            "refs/heads/",
+        ]) {
+            Ok(output) => output,
+            Err(e) => {
+                log::debug!("fetch_all_upstreams: git for-each-ref failed: {e}");
+                return HashMap::new();
+            }
+        };
+
+        output
+            .lines()
+            .filter_map(|line| {
+                let (branch, upstream) = line.split_once('\t')?;
+                let value = if upstream.is_empty() {
+                    None
+                } else {
+                    Some(upstream.to_string())
+                };
+                Some((branch.to_string(), value))
+            })
+            .collect()
     }
 
     /// List remote branches that aren't tracked by any local branch.

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -62,6 +62,7 @@
 //! The picker also maintains a `PreviewCache` (`Arc<DashMap>` in `commands/picker/items.rs`)
 //! for rendered preview output, scoped to a single picker session.
 
+use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
@@ -252,6 +253,11 @@ pub(super) struct RepoCache {
     /// The commit SHA for a given ref doesn't change during a command.
     /// Used by `rev_parse_commit()` to key the persistent `sha_cache` by SHA.
     pub(super) commit_shas: DashMap<String, String>,
+
+    /// Upstream tracking branch cache: local branch -> upstream (e.g., "origin/main").
+    /// None means "no upstream configured". Lazily loaded on first access via
+    /// `Branch::upstream()` → `batch_upstreams()`.
+    pub(super) upstreams: OnceCell<HashMap<String, Option<String>>>,
 
     // ========== Per-worktree values (keyed by path) ==========
     /// Per-worktree git directory: worktree_path -> canonicalized git dir

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -256,7 +256,7 @@ pub(super) struct RepoCache {
 
     /// Upstream tracking branch cache: local branch -> upstream (e.g., "origin/main").
     /// None means "no upstream configured". Lazily loaded on first access via
-    /// `Branch::upstream()` → `batch_upstreams()`.
+    /// `Branch::upstream()` → `fetch_all_upstreams()`.
     pub(super) upstreams: OnceCell<HashMap<String, Option<String>>>,
 
     // ========== Per-worktree values (keyed by path) ==========


### PR DESCRIPTION
Trace analysis (`wt-perf trace` over `wt list` on a typical-8 benchmark repo) showed 53 `rev-parse` calls totaling 587ms of subprocess time. Many were redundant — resolving branch names and SHAs that `for-each-ref` had already returned.

Three changes to use data we already have:

**`list_local_branches()` primes ref/SHA caches.** The `for-each-ref` call already returns `(branch_name, commit_sha)` pairs. Now it also seeds `resolved_refs` (branch → `refs/heads/` form) and `commit_shas` (both bare and qualified ref → SHA). Later `resolve_preferring_branch()` and `rev_parse_commit()` calls hit the cache instead of spawning per-branch `git rev-parse` commands.

**`Branch::upstream()` uses lazy batch loading.** A new `fetch_all_upstreams()` method loads all upstream tracking branches via a single `for-each-ref --format='%(upstream:short)'` call. `upstream()` triggers this lazily via `OnceCell` on first access, replacing N individual `git rev-parse --abbrev-ref X@{u}` commands with one batch call.

Results on typical-8 (8 worktrees, 500 commits, warm cache):

| Metric | Before | After |
|--------|--------|-------|
| Commands | 124 | 99 |
| rev-parse calls | 53 | 27 |
| Wall time | ~162ms | ~147ms |

Remaining opportunities noted during the audit (not addressed here): duplicate `git status --porcelain` per worktree (medium complexity), deriving root/git-dir from worktree list data (medium complexity), unifying `list_tracked_upstreams` with the new upstream cache (low complexity but marginal gain).

> _This was written by Claude Code on behalf of @max-sixty_