### PR TITLE
docs(perf): drop redundant grep wt-trace from wt-perf pipelines

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -150,7 +150,6 @@ sed -i '' "s|REPLACE_WITH_CWD|$PWD|" /tmp/statusline-input.json
 
 RUST_LOG=debug cargo run --release -- list statusline --claude-code \
   < /tmp/statusline-input.json 2>&1 \
-  | grep wt-trace \
   | cargo run -p wt-perf -- cache-check
 ```
 

--- a/benches/CLAUDE.md
+++ b/benches/CLAUDE.md
@@ -88,8 +88,8 @@ cargo run -p wt-perf -- invalidate /tmp/wt-perf-typical-8/main
 
 ```bash
 # Generate trace.json for Perfetto/Chrome
-RUST_LOG=debug wt list --branches 2>&1 | grep '\[wt-trace\]' | \
-  cargo run -p wt-perf -- trace > trace.json
+RUST_LOG=debug wt list --branches 2>&1 \
+  | cargo run -p wt-perf -- trace > trace.json
 
 # Open in https://ui.perfetto.dev or chrome://tracing
 ```
@@ -196,8 +196,8 @@ trace_processor trace.json -q /tmp/q.sql
 
 ```bash
 # Trace on rust-lang/rust (must run benchmark first to clone)
-RUST_LOG=debug cargo run --release -q -- -C target/bench-repos/rust list --branches 2>&1 | \
-  grep '\[wt-trace\]' | cargo run -p wt-perf -- trace > rust-trace.json
+RUST_LOG=debug cargo run --release -q -- -C target/bench-repos/rust list --branches 2>&1 \
+  | cargo run -p wt-perf -- trace > rust-trace.json
 ```
 
 ## Key Performance Insights

--- a/src/trace/chrome.rs
+++ b/src/trace/chrome.rs
@@ -11,7 +11,7 @@
 //! # Usage
 //!
 //! ```bash
-//! RUST_LOG=debug wt list 2>&1 | grep wt-trace | analyze-trace > trace.json
+//! RUST_LOG=debug wt list 2>&1 | cargo run -p wt-perf -- trace > trace.json
 //! # Then open trace.json in chrome://tracing or https://ui.perfetto.dev
 //! ```
 //!

--- a/src/trace/mod.rs
+++ b/src/trace/mod.rs
@@ -13,7 +13,7 @@
 //!
 //! ```bash
 //! # Generate Chrome Trace Format
-//! RUST_LOG=debug wt list 2>&1 | grep wt-trace | cargo run -p wt-perf -- trace > trace.json
+//! RUST_LOG=debug wt list 2>&1 | cargo run -p wt-perf -- trace > trace.json
 //!
 //! # Visualize: open trace.json in chrome://tracing or https://ui.perfetto.dev
 //!

--- a/tests/helpers/wt-perf/src/lib.rs
+++ b/tests/helpers/wt-perf/src/lib.rs
@@ -29,7 +29,7 @@
 //! cargo run -p wt-perf -- invalidate /path/to/repo
 //!
 //! # Parse trace logs
-//! RUST_LOG=debug wt list 2>&1 | grep wt-trace | cargo run -p wt-perf -- trace
+//! RUST_LOG=debug wt list 2>&1 | cargo run -p wt-perf -- trace
 //! ```
 
 use std::path::{Path, PathBuf};

--- a/tests/helpers/wt-perf/src/main.rs
+++ b/tests/helpers/wt-perf/src/main.rs
@@ -10,7 +10,7 @@
 //! wt-perf invalidate /tmp/bench/main
 //!
 //! # Parse trace logs (pipe from wt command)
-//! RUST_LOG=debug wt list 2>&1 | grep wt-trace | wt-perf trace > trace.json
+//! RUST_LOG=debug wt list 2>&1 | wt-perf trace > trace.json
 //!
 //! # Set up picker test environment
 //! wt-perf setup picker-test
@@ -55,7 +55,7 @@ enum Commands {
     /// Parse trace logs and output Chrome Trace Format JSON
     #[command(after_long_help = r#"EXAMPLES:
   # Generate trace from wt command
-  RUST_LOG=debug wt list 2>&1 | grep wt-trace | wt-perf trace > trace.json
+  RUST_LOG=debug wt list 2>&1 | wt-perf trace > trace.json
 
   # Then either:
   #   - Open trace.json in chrome://tracing or https://ui.perfetto.dev
@@ -75,15 +75,15 @@ enum Commands {
     /// Analyze trace logs for duplicate commands (cache effectiveness)
     #[command(after_long_help = r#"EXAMPLES:
   # Check cache effectiveness for wt list
-  RUST_LOG=debug wt list 2>&1 | grep wt-trace | wt-perf cache-check
+  RUST_LOG=debug wt list 2>&1 | wt-perf cache-check
 
   # From a file
   wt-perf cache-check trace.log
 
   # With a benchmark repo
   cargo run -p wt-perf -- setup typical-8 --persist
-  RUST_LOG=debug wt -C /tmp/wt-perf-typical-8 list 2>&1 | \
-    grep wt-trace | cargo run -p wt-perf -- cache-check
+  RUST_LOG=debug wt -C /tmp/wt-perf-typical-8 list 2>&1 \
+    | cargo run -p wt-perf -- cache-check
 "#)]
     CacheCheck {
         /// Path to trace log file (reads from stdin if omitted)
@@ -139,7 +139,7 @@ fn main() {
             eprintln!("Created: {}", parts.join(", "));
             eprintln!();
             eprintln!(
-                "  RUST_LOG=debug wt -C {} list 2>&1 | grep wt-trace | wt-perf trace > trace.json",
+                "  RUST_LOG=debug wt -C {} list 2>&1 | wt-perf trace > trace.json",
                 base_path.display()
             );
             eprintln!("  wt-perf invalidate {}", base_path.display());
@@ -202,7 +202,7 @@ fn read_trace_entries(file: Option<&std::path::Path>) -> Vec<worktrunk::trace::T
                     "\
 Reading from stdin... (pipe trace data or use Ctrl+D to end)
 
-Hint: RUST_LOG=debug wt list 2>&1 | grep wt-trace | wt-perf <subcommand>"
+Hint: RUST_LOG=debug wt list 2>&1 | wt-perf <subcommand>"
                 );
             }
 
@@ -227,7 +227,7 @@ Trace lines should look like:
   [wt-trace] ts=1234567890 tid=3 event=\"Showed skeleton\"
 
 To capture traces, run with RUST_LOG=debug:
-  RUST_LOG=debug wt list 2>&1 | grep wt-trace | wt-perf <subcommand>"
+  RUST_LOG=debug wt list 2>&1 | wt-perf <subcommand>"
         );
         std::process::exit(1);
     }


### PR DESCRIPTION
The trace parser already filters for the `[wt-trace]` marker internally (`parse_lines` → `parse_line` uses `line.find("[wt-trace] ")?`), so the upstream `grep` was redundant. Dropping it makes the documented pipelines shorter and removes an inconsistency between callers that used `grep wt-trace` vs `grep '\[wt-trace\]'`.

Changes span 12 sites across 6 files: module docs, `wt-perf`'s own CLI help (trace/cache-check subcommands, setup eprintln, stdin hint, empty-input error), `benches/CLAUDE.md`, and the `running-tend` skill. Also fixed a stale reference in `src/trace/chrome.rs` to the old `analyze-trace` binary name (now `cargo run -p wt-perf -- trace`).

Verified end-to-end: `RUST_LOG=debug wt list 2>&1 | wt-perf trace` produces valid Chrome Trace JSON, and `| wt-perf cache-check` produces the expected structured report.