### PR TITLE
fix(list): treat [gone] upstream as no upstream

### DIFF
--- a/src/git/repository/branches.rs
+++ b/src/git/repository/branches.rs
@@ -119,20 +119,25 @@ impl Repository {
     /// Fetch all upstream tracking branches in a single `git for-each-ref` call.
     ///
     /// Returns a map from local branch name to upstream ref (or None if no
-    /// upstream is configured). Called lazily via `OnceCell` on first
+    /// upstream is configured, or if the configured upstream ref no longer
+    /// exists on the remote — git reports that as `[gone]` via
+    /// `%(upstream:track)`). Called lazily via `OnceCell` on first
     /// `Branch::upstream()` access.
     pub(super) fn fetch_all_upstreams(&self) -> anyhow::Result<HashMap<String, Option<String>>> {
         let output = self.run_command(&[
             "for-each-ref",
-            "--format=%(refname:lstrip=2)\t%(upstream:short)",
+            "--format=%(refname:lstrip=2)\t%(upstream:short)\t%(upstream:track)",
             "refs/heads/",
         ])?;
 
         Ok(output
             .lines()
             .filter_map(|line| {
-                let (branch, upstream) = line.split_once('\t')?;
-                let value = if upstream.is_empty() {
+                let mut parts = line.splitn(3, '\t');
+                let branch = parts.next()?;
+                let upstream = parts.next()?;
+                let track = parts.next()?;
+                let value = if upstream.is_empty() || track == "[gone]" {
                     None
                 } else {
                     Some(upstream.to_string())

--- a/tests/integration_tests/list.rs
+++ b/tests/integration_tests/list.rs
@@ -565,6 +565,13 @@ fn test_list_with_upstream_tracking(mut repo: TestRepo) {
     // isn't ready when wt list tries to read commit timestamps.
     repo.run_git_in(&no_upstream_wt, &["status", "--porcelain"]);
 
+    // Scenario 6: Upstream configured but remote ref deleted (git's [gone] state).
+    // Should be treated as no upstream — blank Remote column, no error.
+    let gone_wt = repo.add_worktree("gone-upstream");
+    repo.run_git_in(&gone_wt, &["push", "-u", "origin", "gone-upstream"]);
+    repo.run_git(&["push", "origin", "--delete", "gone-upstream"]);
+    repo.run_git_in(&gone_wt, &["fetch", "--prune", "origin"]);
+
     // Run list --branches --full to show all columns including Remote
     assert_cmd_snapshot!("with_upstream_tracking", {
         let mut cmd = wt_command();

--- a/tests/snapshots/integration__integration_tests__list__with_upstream_tracking.snap
+++ b/tests/snapshots/integration__integration_tests__list__with_upstream_tracking.snap
@@ -43,17 +43,18 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m       [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCI[0m  [1mPath[0m                 [1mCommit[0m    [1mAge[0m   [1mMessage
-@ main             [2m^[22m[2m⇡[22m                                    [32m⇡1[0m          .                    [2m01cab36c[0m  [2m1d[0m    [2mInitial commit on main
-+ feature-a        [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m                    ../repo.feature-a    [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
-+ feature-b        [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m                    ../repo.feature-b    [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file
-+ feature-c        [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m                    ../repo.feature-c    [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
-+ ahead            [2m↑[22m[2m⇡[22m                [32m↑2[0m        [32m+2[0m        [32m⇡2[0m          ../repo.ahead        [2ma25eff2a[0m  [2m1d[0m    [2mAhead commit 2
-+ [2mbehind[0m           [2m_[22m[2m⇣[22m                                        [2m[31m⇣1[0m      [2m../repo.behind[0m       [2m01cab36c[0m  [2m1d[0m    [2mInitial commit on main
-+ diverged         [2m↑[22m[2m⇅[22m                [32m↑1[0m        [32m+1[0m        [32m⇡1[0m  [2m[31m⇣1[0m      ../repo.diverged     [2mf035d2c5[0m  [2m1d[0m    [2mDiverged local commit
-+ [2min-sync[0m          [2m_[22m[2m|[22m                                      [2m|[0m         [2m../repo.in-sync[0m      [2m01cab36c[0m  [2m1d[0m    [2mInitial commit on main
-+ [2mno-upstream[0m      [2m_[22m                                                 [2m../repo.no-upstream[0m  [2m01cab36c[0m  [2m1d[0m    [2mInitial commit on main
+  [1mBranch[0m         [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCI[0m  [1mPath[0m                   [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main               [2m^[22m[2m⇡[22m                                    [32m⇡1[0m          .                      [2m01cab36c[0m  [2m1d[0m    [2mInitial commit on main
++ feature-a          [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m                    ../repo.feature-a      [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
++ feature-b          [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m                    ../repo.feature-b      [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file
++ feature-c          [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m                    ../repo.feature-c      [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
++ ahead              [2m↑[22m[2m⇡[22m                [32m↑2[0m        [32m+2[0m        [32m⇡2[0m          ../repo.ahead          [2ma25eff2a[0m  [2m1d[0m    [2mAhead commit 2
++ [2mbehind[0m             [2m_[22m[2m⇣[22m                                        [2m[31m⇣1[0m      [2m../repo.behind[0m         [2m01cab36c[0m  [2m1d[0m    [2mInitial commit on main
++ diverged           [2m↑[22m[2m⇅[22m                [32m↑1[0m        [32m+1[0m        [32m⇡1[0m  [2m[31m⇣1[0m      ../repo.diverged       [2mf035d2c5[0m  [2m1d[0m    [2mDiverged local commit
++ [2mgone-upstream[0m      [2m_[22m                                                 [2m../repo.gone-upstream[0m  [2m01cab36c[0m  [2m1d[0m    [2mInitial commit on main
++ [2min-sync[0m            [2m_[22m[2m|[22m                                      [2m|[0m         [2m../repo.in-sync[0m        [2m01cab36c[0m  [2m1d[0m    [2mInitial commit on main
++ [2mno-upstream[0m        [2m_[22m                                                 [2m../repo.no-upstream[0m    [2m01cab36c[0m  [2m1d[0m    [2mInitial commit on main
 
-[2m○[22m [2mShowing 9 worktrees, 5 ahead
+[2m○[22m [2mShowing 10 worktrees, 5 ahead
 
 ----- stderr -----


### PR DESCRIPTION
## Summary

When a branch's configured upstream ref is gone — remote branch deleted, local tracking ref pruned — `wt list` was surfacing a raw git error in the Remote column:

```
<branch>: upstream (fatal: ambiguous argument 'origin/<branch>': unknown revision or path not in the working tree.)
```

`ahead_behind()` ran `git rev-parse` on a ref that no longer exists. `fetch_all_upstreams` now also reads `%(upstream:track)` — git's literal `[gone]` value is treated the same as an unconfigured upstream (returns `None` for the branch), so the Remote column blanks gracefully.

One change point, one choke point: `Branch::upstream()` goes through this cache, and everything downstream (`ahead_behind`, column rendering) already handles `None`. No new state, no new code path.

## Test plan

- [x] Added scenario 6 to `test_list_with_upstream_tracking` — push branch with `-u`, delete on remote, `fetch --prune`, verify the row renders identically to the existing no-upstream case.
- [x] Full suite: 1473 tests pass.
- [x] Lints: `cargo clippy --all-targets -- -D warnings` and `pre-commit run --all-files` clean.
- [x] Verified live against the originally failing repo — error gone, row renders cleanly.

> _This was written by Claude Code on behalf of Maximilian._