### PR TITLE
fix: use a crane dummy source for the vendored patch to skim

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1767744144,
-        "narHash": "sha256-9/9ntI0D+HbN4G0TrK3KmHbTvwgswz7p8IEJsWyef8Q=",
+        "lastModified": 1775839657,
+        "narHash": "sha256-SPm9ck7jh3Un9nwPuMGbRU04UroFmOHjLP56T10MOeM=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "2fb033290bf6b23f226d4c8b32f7f7a16b043d7e",
+        "rev": "7cf72d978629469c4bd4206b95c402514c1f6000",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -101,7 +101,8 @@
               src = commonArgs.src;
               extraDummyScript = ''
                 rm -rf $out/vendor
-                cp -r --no-preserve=mode ${vendorSrc}/vendor $out/vendor
+                cp -r ${vendorSrc}/vendor $out/vendor
+                chmod -R u+w $out/vendor
               '';
             };
           }

--- a/flake.nix
+++ b/flake.nix
@@ -49,6 +49,19 @@
             || (baseNameOf (dirOf p) == "dev");
         };
 
+        # Vendored path dependencies (vendor/skim-tuikit) need their real
+        # source preserved during buildDepsOnly — crane's mkDummySrc stubs
+        # all .rs files, but [patch.crates-io] path deps must compile for
+        # downstream crates (skim) to resolve their imports. Kept as a
+        # separate derivation so non-vendor source edits don't invalidate
+        # the dependency cache.
+        vendorSrc = pkgs.lib.cleanSourceWith {
+          src = ./.;
+          filter =
+            path: _type:
+            pkgs.lib.hasInfix "/vendor/" path || pkgs.lib.hasSuffix "/vendor" path;
+        };
+
         # Common arguments for crane builds
         commonArgs = {
           inherit src;
@@ -78,8 +91,21 @@
             self.shortRev or self.dirtyShortRev or "nix-${self.lastModifiedDate or "unknown"}";
         };
 
-        # Build just the cargo dependencies for caching
-        cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+        # Build just the cargo dependencies for caching.
+        # extraDummyScript restores vendor/ after mkDummySrc stubs all .rs
+        # files — without this, [patch.crates-io] path deps are empty crates.
+        cargoArtifacts = craneLib.buildDepsOnly (
+          commonArgs
+          // {
+            dummySrc = craneLib.mkDummySrc {
+              src = commonArgs.src;
+              extraDummyScript = ''
+                rm -rf $out/vendor
+                cp -r --no-preserve=mode ${vendorSrc}/vendor $out/vendor
+              '';
+            };
+          }
+        );
 
         # Build the actual package
         worktrunk = craneLib.buildPackage (


### PR DESCRIPTION
I got this error after updating a flake input for worktrunk:

```
error: Cannot build '/nix/store/ifhf8rfr15vpcb8017s6a59bgi98wa74-worktrunk-deps-0.38.0.drv'.
       Reason: builder failed with exit code 101.
       Output paths:
         /nix/store/y74n19gc50vvlgggb71wgjxmyymxq09l-worktrunk-deps-0.38.0
       Last 25 log lines:
       >  -->
/nix/store/af6bxic375mz42dkf2h9k494aqjy3r9a-vendor-cargo-deps/c19b7c6f923b580ac259164a89f2577984ad5ab09ee9d583b888f934adbbe8d0/skim-0.20.5/src/
       >   |
       > 4 | use skim_tuikit::prelude::*;
       >   |                  ^^^^^^^ could not find `prelude` in `skim_tuikit`
       >
       > error[E0432]: unresolved import `skim_tuikit::prelude`
       >  -->
/nix/store/af6bxic375mz42dkf2h9k494aqjy3r9a-vendor-cargo-deps/c19b7c6f923b580ac259164a89f2577984ad5ab09ee9d583b888f934adbbe8d0/skim-0.20.5/src/
       >   |
       > 7 | use skim_tuikit::prelude::{Event as TermEvent, *};
       >   |                  ^^^^^^^ could not find `prelude` in `skim_tuikit`
       >
       > error[E0432]: unresolved import `skim_tuikit::prelude`
       >  -->
/nix/store/af6bxic375mz42dkf2h9k494aqjy3r9a-vendor-cargo-deps/c19b7c6f923b580ac259164a89f2577984ad5ab09ee9d583b888f934adbbe8d0/skim-0.20.5/src/theme.rs:5:18
       >   |
       > 5 | use skim_tuikit::prelude::*;
       >   |                  ^^^^^^^ could not find `prelude` in `skim_tuikit`
       >
       > error[E0432]: unresolved import `skim_tuikit::key`
       >   -->
/nix/store/af6bxic375mz42dkf2h9k494aqjy3r9a-vendor-cargo-deps/c19b7c6f923b580ac259164a89f2577984ad5ab09ee9d583b888f934adbbe8d0/skim-0.20.5/src/tmux.rs:13:18
       >    |
       > 13 | use skim_tuikit::key::Key;
       >    |                  ^^^ could not find `key` in `skim_tuikit`
       >
       > error[E0432]: unresolved import `skim_tuikit::prelude`
       >   --> /nix/store/af6bxic375mz42dkf2h9k494aqjy3r9a-vendor-cargo-deps/c19b7c6f923b580ac259164a89f257
       For full logs, run:
         nix log /nix/store/ifhf8rfr15vpcb8017s6a59bgi98wa74-worktrunk-deps-0.38.0.drv
```

I had an agent investigate and it said that there is an issue with how crane was handling the vendored patch for skim. I don't know rust or crane so I'm not sure if this patch is correct, the patch was written by an agent -- but it seems reasonable to me. I'm able to build the package now.