### PR TITLE
feat(config): add WORKTRUNK_PROJECT_CONFIG_PATH override

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -454,6 +454,7 @@ Override the LLM command in CI to use a mock:
 | `WORKTRUNK_BIN` | Override binary path for shell wrappers; useful for testing dev builds |
 | `WORKTRUNK_CONFIG_PATH` | Override user config file location |
 | `WORKTRUNK_SYSTEM_CONFIG_PATH` | Override system config file location |
+| `WORKTRUNK_PROJECT_CONFIG_PATH` | Override project config file location (defaults to `.config/wt.toml`) |
 | `XDG_CONFIG_DIRS` | Colon-separated system config directories (default: `/etc/xdg`) |
 | `WORKTRUNK_DIRECTIVE_CD_FILE` | Internal: set by shell wrappers. wt writes a raw path; the wrapper `cd`s to it |
 | `WORKTRUNK_DIRECTIVE_EXEC_FILE` | Internal: set by shell wrappers. wt writes shell commands; the wrapper sources the file |

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -457,6 +457,7 @@ $ WORKTRUNK_COMMIT__GENERATION__COMMAND="echo 'test: automated commit'" wt merge
 | `WORKTRUNK_BIN` | Override binary path for shell wrappers; useful for testing dev builds |
 | `WORKTRUNK_CONFIG_PATH` | Override user config file location |
 | `WORKTRUNK_SYSTEM_CONFIG_PATH` | Override system config file location |
+| `WORKTRUNK_PROJECT_CONFIG_PATH` | Override project config file location (defaults to `.config/wt.toml`) |
 | `XDG_CONFIG_DIRS` | Colon-separated system config directories (default: `/etc/xdg`) |
 | `WORKTRUNK_DIRECTIVE_CD_FILE` | Internal: set by shell wrappers. wt writes a raw path; the wrapper `cd`s to it |
 | `WORKTRUNK_DIRECTIVE_EXEC_FILE` | Internal: set by shell wrappers. wt writes shell commands; the wrapper sources the file |

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2075,6 +2075,7 @@ $ WORKTRUNK_COMMIT__GENERATION__COMMAND="echo 'test: automated commit'" wt merge
 | `WORKTRUNK_BIN` | Override binary path for shell wrappers; useful for testing dev builds |
 | `WORKTRUNK_CONFIG_PATH` | Override user config file location |
 | `WORKTRUNK_SYSTEM_CONFIG_PATH` | Override system config file location |
+| `WORKTRUNK_PROJECT_CONFIG_PATH` | Override project config file location (defaults to `.config/wt.toml`) |
 | `XDG_CONFIG_DIRS` | Colon-separated system config directories (default: `/etc/xdg`) |
 | `WORKTRUNK_DIRECTIVE_CD_FILE` | Internal: set by shell wrappers. wt writes a raw path; the wrapper `cd`s to it |
 | `WORKTRUNK_DIRECTIVE_EXEC_FILE` | Internal: set by shell wrappers. wt writes shell commands; the wrapper sources the file |

--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -96,12 +96,9 @@ fn handle_config_show_json() -> anyhow::Result<()> {
     };
 
     let (project_path, project_config) = if let Ok(repo) = Repository::current() {
-        let path = repo.current_worktree().root()?.join(".config/wt.toml");
+        let path = repo.project_config_path()?;
         let config = repo.load_project_config()?;
-        (
-            Some(path),
-            config.map(|c| serde_json::to_value(&c)).transpose()?,
-        )
+        (path, config.map(|c| serde_json::to_value(&c)).transpose()?)
     } else {
         (None, None)
     };

--- a/src/git/repository/config.rs
+++ b/src/git/repository/config.rs
@@ -466,11 +466,20 @@ impl Repository {
 
     /// Return the path for the project config file.
     ///
-    /// Uses the current worktree when inside one (both normal and bare repos).
-    /// For bare repos at the bare root (outside any worktree), falls back to
-    /// the primary worktree. Returns `None` when no worktree can be determined
-    /// (bare repo with no linked worktrees).
+    /// If `WORKTRUNK_PROJECT_CONFIG_PATH` is set, returns that path (used for
+    /// test isolation so the spawned `wt` does not pick up this repo's
+    /// `.config/wt.toml`). A missing file at that path still resolves to
+    /// `Ok(None)` via `ProjectConfig::load`, matching the no-config case.
+    ///
+    /// Otherwise: uses the current worktree when inside one (both normal and
+    /// bare repos). For bare repos at the bare root (outside any worktree),
+    /// falls back to the primary worktree. Returns `None` when no worktree can
+    /// be determined (bare repo with no linked worktrees).
     pub fn project_config_path(&self) -> anyhow::Result<Option<PathBuf>> {
+        if let Ok(path) = std::env::var("WORKTRUNK_PROJECT_CONFIG_PATH") {
+            return Ok(Some(PathBuf::from(path)));
+        }
+
         let in_worktree = self
             .current_worktree()
             .run_command(&["rev-parse", "--is-inside-work-tree"])

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -368,6 +368,11 @@ pub fn configure_cli_command(cmd: &mut Command) {
         "WORKTRUNK_SYSTEM_CONFIG_PATH",
         "/etc/xdg/worktrunk/config.toml",
     );
+    // `WORKTRUNK_PROJECT_CONFIG_PATH` is intentionally left unset so tests
+    // can pick up `.config/wt.toml` in their own test repo via the default
+    // lookup. Host leakage is prevented by the `WORKTRUNK_*` env_remove loop
+    // above. Tests needing full project-config isolation (e.g., completion
+    // tests that must not see this repo's aliases) should set it explicitly.
     cmd.env(
         "WORKTRUNK_APPROVALS_PATH",
         "/nonexistent/test/approvals.toml",

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -530,6 +530,10 @@ pub fn add_standard_env_redactions(settings: &mut insta::Settings) {
     settings.add_redaction(".env.GIT_CONFIG_GLOBAL", "[TEST_GIT_CONFIG]");
     settings.add_redaction(".env.WORKTRUNK_CONFIG_PATH", "[TEST_CONFIG]");
     settings.add_redaction(".env.WORKTRUNK_SYSTEM_CONFIG_PATH", "[TEST_SYSTEM_CONFIG]");
+    settings.add_redaction(
+        ".env.WORKTRUNK_PROJECT_CONFIG_PATH",
+        "[TEST_PROJECT_CONFIG]",
+    );
     settings.add_redaction(".env.WORKTRUNK_APPROVALS_PATH", "[TEST_APPROVALS]");
     settings.add_redaction(".env.WORKTRUNK_DIRECTIVE_CD_FILE", "[DIRECTIVE_CD_FILE]");
     settings.add_redaction(

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -3761,3 +3761,71 @@ fn test_config_show_json_outside_repo(repo: TestRepo, temp_home: TempDir) {
     assert!(!json["project"]["exists"].as_bool().unwrap());
     assert!(json["project"]["config"].is_null());
 }
+
+/// `WORKTRUNK_PROJECT_CONFIG_PATH` overrides the default `.config/wt.toml`
+/// lookup. Mirrors `WORKTRUNK_CONFIG_PATH` / `WORKTRUNK_SYSTEM_CONFIG_PATH`
+/// for project config — used to isolate tests (including completion tests)
+/// from any `[aliases]` in the developer's own project config.
+#[rstest]
+fn test_project_config_path_env_var_override(repo: TestRepo, temp_home: TempDir) {
+    // Write a project config in the repo that should be *ignored* when the
+    // override points elsewhere.
+    let in_repo_config = repo.root_path().join(".config").join("wt.toml");
+    fs::create_dir_all(in_repo_config.parent().unwrap()).unwrap();
+    fs::write(&in_repo_config, "post-create = \"in-repo-hook\"\n").unwrap();
+
+    // Write the override project config at an arbitrary path.
+    let override_dir = tempfile::tempdir().unwrap();
+    let override_path = override_dir.path().join("override.toml");
+    fs::write(&override_path, "post-create = \"override-hook\"\n").unwrap();
+
+    let mut cmd = wt_command();
+    repo.configure_wt_cmd(&mut cmd);
+    set_xdg_config_path(&mut cmd, temp_home.path());
+    set_temp_home_env(&mut cmd, temp_home.path());
+    cmd.env("WORKTRUNK_PROJECT_CONFIG_PATH", &override_path);
+    cmd.args(["config", "show", "--format=json"])
+        .current_dir(repo.root_path());
+
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).unwrap();
+    assert_eq!(
+        json["project"]["config"]["post-create"], "override-hook",
+        "expected override config to be loaded, got: {}",
+        json["project"]
+    );
+
+    // And a missing override path resolves to no project config (same as a
+    // missing `.config/wt.toml`) — doesn't silently fall back to the repo's
+    // own file.
+    let mut cmd = wt_command();
+    repo.configure_wt_cmd(&mut cmd);
+    set_xdg_config_path(&mut cmd, temp_home.path());
+    set_temp_home_env(&mut cmd, temp_home.path());
+    cmd.env(
+        "WORKTRUNK_PROJECT_CONFIG_PATH",
+        override_dir.path().join("nonexistent.toml"),
+    );
+    cmd.args(["config", "show", "--format=json"])
+        .current_dir(repo.root_path());
+
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).unwrap();
+    assert!(
+        json["project"]["config"].is_null(),
+        "missing override path should resolve to no project config, got: {}",
+        json["project"]["config"]
+    );
+}

--- a/tests/integration_tests/shell_wrapper.rs
+++ b/tests/integration_tests/shell_wrapper.rs
@@ -2990,20 +2990,16 @@ fi
         (dir, path)
     }
 
-    /// Point the spawned `wt` (and its child shells) at an empty config so
-    /// user-config aliases don't leak into completion output. Aliases now
-    /// surface as top-level completion candidates, so without this isolation
-    /// any global aliases in the developer's `~/.config/worktrunk/config.toml`
-    /// would pollute the snapshot.
-    ///
-    /// Project config (`.config/wt.toml`) is not isolated — the spawned `wt`
-    /// runs in this repo's working directory and reads its project config.
-    /// Today the project has no `[aliases]` so the snapshot is stable; if a
-    /// future contributor adds an alias to this repo's own `.config/wt.toml`,
-    /// that alias will start showing up in completion output. Watch for it.
-    fn set_empty_user_config(cmd: &mut std::process::Command) {
+    /// Point the spawned `wt` (and its child shells) at empty user, system,
+    /// and project configs so aliases don't leak into completion output.
+    /// Aliases surface as top-level completion candidates, so without this
+    /// isolation any aliases in the developer's
+    /// `~/.config/worktrunk/config.toml`, a system config, or this repo's own
+    /// `.config/wt.toml` would pollute the snapshot.
+    fn set_empty_configs(cmd: &mut std::process::Command) {
         cmd.env("WORKTRUNK_CONFIG_PATH", "/dev/null");
         cmd.env("WORKTRUNK_SYSTEM_CONFIG_PATH", "/dev/null");
+        cmd.env("WORKTRUNK_PROJECT_CONFIG_PATH", "/dev/null");
     }
 
     /// Black-box test: zsh completion produces correct subcommands.
@@ -3041,7 +3037,7 @@ _wt_lazy_complete
         // be bypassed — but doesn't touch PATH in our test environments.
         let mut cmd = std::process::Command::new("zsh");
         cmd.args(["-f", "-c"]).arg(&script).env("PATH", &clean_path);
-        set_empty_user_config(&mut cmd);
+        set_empty_configs(&mut cmd);
         let output = cmd.output().unwrap();
 
         assert_snapshot!(String::from_utf8_lossy(&output.stdout));
@@ -3076,7 +3072,7 @@ for c in "${{COMPREPLY[@]}}"; do echo "${{c%%	*}}"; done
         cmd.args(["--noprofile", "--norc", "-c"])
             .arg(&script)
             .env("PATH", &clean_path);
-        set_empty_user_config(&mut cmd);
+        set_empty_configs(&mut cmd);
         let output = cmd.output().unwrap();
 
         assert_snapshot!(String::from_utf8_lossy(&output.stdout));
@@ -3095,7 +3091,7 @@ for c in "${{COMPREPLY[@]}}"; do echo "${{c%%	*}}"; done
             .env("COMPLETE", "fish")
             .env("_CLAP_COMPLETE_INDEX", "1")
             .env("PATH", &clean_path);
-        set_empty_user_config(&mut cmd);
+        set_empty_configs(&mut cmd);
         let output = cmd.output().unwrap();
 
         // Fish format is "value\tdescription" - extract just values
@@ -3120,7 +3116,7 @@ for c in "${{COMPREPLY[@]}}"; do echo "${{c%%	*}}"; done
         cmd.args(["--", "wt", ""])
             .env("COMPLETE", "nu")
             .env("PATH", &clean_path);
-        set_empty_user_config(&mut cmd);
+        set_empty_configs(&mut cmd);
         let output = cmd.output().unwrap();
 
         // Nushell format is "value\tdescription" - extract just values

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -441,6 +441,7 @@ Override the LLM command in CI to use a mock:
  [2mWORKTRUNK_BIN[0m                     Override binary path for shell wrappers; useful for testing dev builds                  
  [2mWORKTRUNK_CONFIG_PATH[0m             Override user config file location                                                      
  [2mWORKTRUNK_SYSTEM_CONFIG_PATH[0m      Override system config file location                                                    
+ [2mWORKTRUNK_PROJECT_CONFIG_PATH[0m     Override project config file location (defaults to [2m.config/wt.toml[0m)                     
  [2mXDG_CONFIG_DIRS[0m                   Colon-separated system config directories (default: [2m/etc/xdg[0m)                           
  [2mWORKTRUNK_DIRECTIVE_CD_FILE[0m       Internal: set by shell wrappers. wt writes a raw path; the wrapper [2mcd[0ms to it            
  [2mWORKTRUNK_DIRECTIVE_EXEC_FILE[0m     Internal: set by shell wrappers. wt writes shell commands; the wrapper sources the file 


### PR DESCRIPTION
Adds a \`WORKTRUNK_PROJECT_CONFIG_PATH\` environment variable that overrides the project config path, mirroring the existing \`WORKTRUNK_CONFIG_PATH\` (user) and \`WORKTRUNK_SYSTEM_CONFIG_PATH\` (system) overrides. Missing files at the overridden path resolve to no project config — same as a missing \`.config/wt.toml\` today.

Uses it to fully isolate completion tests in \`tests/integration_tests/shell_wrapper.rs\`, which previously only isolated user and system config. After #2266 made aliases appear as top-level completion candidates at \`wt <Tab>\`, any \`[aliases]\` added to this repo's own \`.config/wt.toml\` would silently pollute completion snapshots. The helper \`set_empty_user_config\` is renamed \`set_empty_configs\` and now points all three env vars at \`/dev/null\`.

Also cleans up \`wt config show --format=json\` to use \`project_config_path()\` for the \`project.path\` field (was hardcoded \`.config/wt.toml\`), so the override is reflected in both path and config.

\`configure_cli_command\` intentionally leaves \`WORKTRUNK_PROJECT_CONFIG_PATH\` unset — the \`WORKTRUNK_*\` env_remove loop prevents host leakage, and setting it would break tests that rely on the default \`.config/wt.toml\` lookup in their own test repo. Completion tests opt in explicitly via \`set_empty_configs\`.

## Test plan

- [x] \`cargo run --quiet --bin wt -- hook pre-merge --yes\` — 3222/3222 green
- [x] New integration test \`test_project_config_path_env_var_override\` covers override-to-different-file and override-to-missing-file