### PR TITLE
docs: trim filler sentences from prose docs

### DIFF
--- a/docs/content/extending.md
+++ b/docs/content/extending.md
@@ -108,8 +108,6 @@ See [Tips & Patterns](@/tips-patterns.md) for more recipes: dev server per workt
 
 ## Aliases
 
-<span class="badge-experimental"></span>
-
 Aliases are custom commands invoked as `wt <name>`. They share the same template variables and approval model as hooks.
 
 ```toml
@@ -182,8 +180,6 @@ Run with `wt move-changes --to=feature-xyz`. The leading guard avoids touching a
 
 To copy instead of move (source keeps its changes too), add `git stash apply --index --quiet` right after the push. For staged-only flows, swap the stash for `git diff --cached` written to a tempfile and applied with `git apply --index` in the new worktree — that handles files where staged and unstaged hunks overlap on the same lines, where `git stash --staged` falls short.
 
-Because an inner `wt switch --create` inside an alias propagates its `cd` to the parent shell, the alias drops you in the new worktree directly.
-
 ### Recipe: tail a specific hook log
 
 `wt config state logs --format=json` emits structured entries — `branch`, `source`, `hook_type`, `name`, `path`. Pipe through `jq` to resolve one entry, then wrap in an alias for quick access:
@@ -210,8 +206,6 @@ Any executable named `wt-<name>` on `PATH` becomes available as `wt <name>` — 
 {{ terminal(cmd="wt sync origin              # runs: wt-sync origin|||wt -C /tmp/repo sync        # -C is forwarded as the child's working directory") }}
 
 Arguments pass through verbatim, stdio is inherited, and the child's exit code propagates unchanged. Custom subcommands don't have access to template variables.
-
-If nothing matches — no built-in, no alias, no `wt-<name>` on `PATH` — wt prints a "not a wt command" error with a typo suggestion.
 
 ### Examples
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -221,7 +221,7 @@ Yes. Core commands, shell integration, and tab completion work in both Git Bash 
 
 ## How does Worktrunk determine the default branch?
 
-Worktrunk checks the local git cache first, queries the remote if needed, and falls back to local inference when no remote exists. The result is cached for fast subsequent lookups.
+Worktrunk checks the local git cache first, queries the remote if needed, and falls back to local inference when no remote exists.
 
 If the remote's default branch has changed (e.g., renamed from master to main), clear the cache with `wt config state default-branch clear`.
 

--- a/docs/content/tips-patterns.md
+++ b/docs/content/tips-patterns.md
@@ -230,8 +230,6 @@ Branch from current HEAD instead of the default branch:
 
 {{ terminal(cmd="wt switch --create feature-part2 --base=@") }}
 
-Creates a worktree that builds on the current branch's changes.
-
 ## Agent handoffs
 
 Spawn a worktree with an agent CLI running in the background. Examples below use `claude`; for OpenCode, replace `claude` with `'opencode run'`.
@@ -253,7 +251,7 @@ from the worktrunk skill.
 
 ## Tmux session per worktree
 
-Each worktree gets its own tmux session with a multi-pane layout. Sessions are named after the branch for easy identification.
+Each worktree gets its own tmux session with a multi-pane layout.
 
 ```toml
 # .config/wt.toml

--- a/skills/worktrunk/reference/extending.md
+++ b/skills/worktrunk/reference/extending.md
@@ -101,8 +101,6 @@ See [Tips & Patterns](https://worktrunk.dev/tips-patterns/) for more recipes: de
 
 ## Aliases
 
-[experimental]
-
 Aliases are custom commands invoked as `wt <name>`. They share the same template variables and approval model as hooks.
 
 ```toml
@@ -179,8 +177,6 @@ Run with `wt move-changes --to=feature-xyz`. The leading guard avoids touching a
 
 To copy instead of move (source keeps its changes too), add `git stash apply --index --quiet` right after the push. For staged-only flows, swap the stash for `git diff --cached` written to a tempfile and applied with `git apply --index` in the new worktree — that handles files where staged and unstaged hunks overlap on the same lines, where `git stash --staged` falls short.
 
-Because an inner `wt switch --create` inside an alias propagates its `cd` to the parent shell, the alias drops you in the new worktree directly.
-
 ### Recipe: tail a specific hook log
 
 `wt config state logs --format=json` emits structured entries — `branch`, `source`, `hook_type`, `name`, `path`. Pipe through `jq` to resolve one entry, then wrap in an alias for quick access:
@@ -210,8 +206,6 @@ wt -C /tmp/repo sync        # -C is forwarded as the child's working directory
 ```
 
 Arguments pass through verbatim, stdio is inherited, and the child's exit code propagates unchanged. Custom subcommands don't have access to template variables.
-
-If nothing matches — no built-in, no alias, no `wt-<name>` on `PATH` — wt prints a "not a wt command" error with a typo suggestion.
 
 ### Examples
 

--- a/skills/worktrunk/reference/faq.md
+++ b/skills/worktrunk/reference/faq.md
@@ -214,7 +214,7 @@ Yes. Core commands, shell integration, and tab completion work in both Git Bash 
 
 ## How does Worktrunk determine the default branch?
 
-Worktrunk checks the local git cache first, queries the remote if needed, and falls back to local inference when no remote exists. The result is cached for fast subsequent lookups.
+Worktrunk checks the local git cache first, queries the remote if needed, and falls back to local inference when no remote exists.
 
 If the remote's default branch has changed (e.g., renamed from master to main), clear the cache with `wt config state default-branch clear`.
 

--- a/skills/worktrunk/reference/tips-patterns.md
+++ b/skills/worktrunk/reference/tips-patterns.md
@@ -241,8 +241,6 @@ Branch from current HEAD instead of the default branch:
 wt switch --create feature-part2 --base=@
 ```
 
-Creates a worktree that builds on the current branch's changes.
-
 ## Agent handoffs
 
 Spawn a worktree with an agent CLI running in the background. Examples below use `claude`; for OpenCode, replace `claude` with `'opencode run'`.
@@ -270,7 +268,7 @@ from the worktrunk skill.
 
 ## Tmux session per worktree
 
-Each worktree gets its own tmux session with a multi-pane layout. Sessions are named after the branch for easy identification.
+Each worktree gets its own tmux session with a multi-pane layout.
 
 ```toml
 # .config/wt.toml


### PR DESCRIPTION
Remove sentences that restate obvious fallback/error behavior, duplicate nearby prose, or add visual weight without information.

- `extending.md` — drop the "not a wt command" error note, the experimental badge on Aliases, and a duplicate recap of the `cd`-to-parent-shell behavior at the end of a recipe.
- `faq.md` — drop "The result is cached for fast subsequent lookups" padding after the default-branch detection explanation.
- `tips-patterns.md` — drop "Creates a worktree that builds on the current branch's changes" (restated by the section heading) and "Sessions are named after the branch for easy identification" (visible in the code).

Skill reference files auto-synced via `test_command_pages_and_skill_files_are_in_sync`.