### PR TITLE
docs(tips-patterns): trim two redundant sentences

### DIFF
--- a/docs/content/tips-patterns.md
+++ b/docs/content/tips-patterns.md
@@ -192,7 +192,7 @@ With `summary = true` and [`commit.generation`](@/config.md#commit) configured, 
 summary = true
 ```
 
-Summaries are cached and regenerated only when the diff changes. See [LLM Commits](@/llm-commits.md#branch-summaries) for details.
+See [LLM Commits](@/llm-commits.md#branch-summaries) for details.
 
 ## JSON API
 
@@ -278,8 +278,6 @@ echo "✓ Session '$S' — attach with: tmux attach -t $S"
 [pre-remove]
 tmux = "tmux kill-session -t {{ branch | sanitize }} 2>/dev/null || true"
 ```
-
-`pre-remove` stops all services when the worktree is removed.
 
 To create a worktree and immediately attach:
 

--- a/skills/worktrunk/reference/tips-patterns.md
+++ b/skills/worktrunk/reference/tips-patterns.md
@@ -193,7 +193,7 @@ With `summary = true` and [`commit.generation`](https://worktrunk.dev/config/#co
 summary = true
 ```
 
-Summaries are cached and regenerated only when the diff changes. See [LLM Commits](https://worktrunk.dev/llm-commits/#branch-summaries) for details.
+See [LLM Commits](https://worktrunk.dev/llm-commits/#branch-summaries) for details.
 
 ## JSON API
 
@@ -295,8 +295,6 @@ echo "✓ Session '$S' — attach with: tmux attach -t $S"
 [pre-remove]
 tmux = "tmux kill-session -t {{ branch | sanitize }} 2>/dev/null || true"
 ```
-
-`pre-remove` stops all services when the worktree is removed.
 
 To create a worktree and immediately attach:
 


### PR DESCRIPTION
Two more filler sentences caught on a second pass:

- Drop "Summaries are cached and regenerated only when the diff changes." — duplicates the authoritative sentence in `llm-commits.md`, which the adjacent "See LLM Commits for details" link already points to.
- Drop "`pre-remove` stops all services when the worktree is removed." — visible from the `[pre-remove]` block above, and "all services" overstates what the one-line `kill-session` command does.

Follows #2271.