### PR TITLE
fix: encode `/` in branch names for git config keys

### DIFF
--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -560,7 +560,10 @@ pub fn handle_state_get(
             };
             if format == SwitchFormat::Json {
                 // Read raw config to get both marker and set_at
-                let config_key = format!("worktrunk.state.{branch_name}.marker");
+                let config_key = format!(
+                    "worktrunk.state.{}.marker",
+                    encode_branch_for_config(&branch_name)
+                );
                 let raw = repo
                     .run_command(&["config", "--get", &config_key])
                     .ok()
@@ -684,7 +687,10 @@ pub fn handle_state_set(key: &str, value: String, branch: Option<String>) -> any
                 "set_at": now
             });
 
-            let config_key = format!("worktrunk.state.{branch_name}.marker");
+            let config_key = format!(
+                "worktrunk.state.{}.marker",
+                encode_branch_for_config(&branch_name)
+            );
             repo.run_command(&["config", &config_key, &json.to_string()])?;
 
             eprintln!(
@@ -744,7 +750,10 @@ pub fn handle_state_clear(key: &str, branch: Option<String>, all: bool) -> anyho
                     Some(b) => b,
                     None => repo.require_current_branch("clear ci-status for current branch")?,
                 };
-                let config_key = format!("worktrunk.state.{branch_name}.ci-status");
+                let config_key = format!(
+                    "worktrunk.state.{}.ci-status",
+                    encode_branch_for_config(&branch_name)
+                );
                 if repo
                     .run_command(&["config", "--unset", &config_key])
                     .is_ok()
@@ -792,7 +801,10 @@ pub fn handle_state_clear(key: &str, branch: Option<String>, all: bool) -> anyho
                     None => repo.require_current_branch("clear marker for current branch")?,
                 };
 
-                let config_key = format!("worktrunk.state.{branch_name}.marker");
+                let config_key = format!(
+                    "worktrunk.state.{}.marker",
+                    encode_branch_for_config(&branch_name)
+                );
                 if repo
                     .run_command(&["config", "--unset", &config_key])
                     .is_ok()
@@ -1174,18 +1186,20 @@ fn handle_state_show_table(repo: &Repository) -> anyhow::Result<()> {
 
 // ==================== Vars Operations ====================
 
-/// Validate a vars key name: letters, digits, hyphens, underscores only.
+fn encode_branch_for_config(branch: &str) -> String {
+    branch.replace('/', "..")
+}
+
+fn decode_branch_from_config(encoded: &str) -> String {
+    encoded.replace("..", "/")
+}
+
 fn validate_vars_key(key: &str) -> anyhow::Result<()> {
     if key.is_empty() {
         anyhow::bail!("Key cannot be empty");
     }
-    if !key
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-    {
-        anyhow::bail!(
-            "Invalid key {key:?}: keys must contain only letters, digits, hyphens, and underscores"
-        );
+    if !key.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+        anyhow::bail!("Invalid key {key:?}: keys must contain only letters, digits, and hyphens");
     }
     Ok(())
 }
@@ -1199,7 +1213,10 @@ pub fn handle_vars_get(key: &str, branch: Option<String>) -> anyhow::Result<()> 
         None => repo.require_current_branch("get variable for current branch")?,
     };
 
-    let config_key = format!("worktrunk.state.{branch_name}.vars.{key}");
+    let config_key = format!(
+        "worktrunk.state.{}.vars.{key}",
+        encode_branch_for_config(&branch_name)
+    );
     if let Some(value) = repo.config_value(&config_key)? {
         println!("{value}");
     }
@@ -1215,7 +1232,10 @@ pub fn handle_vars_set(key: &str, value: &str, branch: Option<String>) -> anyhow
         None => repo.require_current_branch("set variable for current branch")?,
     };
 
-    let config_key = format!("worktrunk.state.{branch_name}.vars.{key}");
+    let config_key = format!(
+        "worktrunk.state.{}.vars.{key}",
+        encode_branch_for_config(&branch_name)
+    );
     repo.run_command(&["config", &config_key, value])?;
 
     eprintln!(
@@ -1279,8 +1299,9 @@ pub fn handle_vars_clear(
             );
         } else {
             let count = entries.len();
+            let encoded = encode_branch_for_config(&branch_name);
             for (key, _) in entries {
-                let config_key = format!("worktrunk.state.{branch_name}.vars.{key}");
+                let config_key = format!("worktrunk.state.{encoded}.vars.{key}");
                 let _ = repo.run_command(&["config", "--unset", &config_key]);
             }
             eprintln!(
@@ -1294,7 +1315,10 @@ pub fn handle_vars_clear(
     } else {
         let key = key.expect("key required when --all not set");
         validate_vars_key(key)?;
-        let config_key = format!("worktrunk.state.{branch_name}.vars.{key}");
+        let config_key = format!(
+            "worktrunk.state.{}.vars.{key}",
+            encode_branch_for_config(&branch_name)
+        );
         if repo
             .run_command(&["config", "--unset", &config_key])
             .is_ok()
@@ -1322,8 +1346,9 @@ fn clear_all_vars(repo: &Repository) -> anyhow::Result<usize> {
     let all_vars = repo.all_vars_entries();
     let mut cleared = 0;
     for (branch, entries) in &all_vars {
+        let encoded = encode_branch_for_config(branch);
         for key in entries.keys() {
-            let config_key = format!("worktrunk.state.{branch}.vars.{key}");
+            let config_key = format!("worktrunk.state.{encoded}.vars.{key}");
             let _ = repo.run_command(&["config", "--unset", &config_key]);
             cleared += 1;
         }
@@ -1366,7 +1391,7 @@ pub(super) fn all_markers(repo: &Repository) -> Vec<MarkerEntry> {
         };
         let set_at = parsed.get("set_at").and_then(|v| v.as_u64()).unwrap_or(0);
         markers.push(MarkerEntry {
-            branch: branch.to_string(),
+            branch: decode_branch_from_config(branch),
             marker: marker.to_string(),
             set_at,
         });

--- a/src/git/repository/config.rs
+++ b/src/git/repository/config.rs
@@ -9,6 +9,20 @@ use crate::config::ProjectConfig;
 
 use super::{DefaultBranchName, GitError, Repository};
 
+/// Encode a branch name for use in a git config key path.
+///
+/// Branch names may contain `/` which git config rejects in key names.
+/// We encode `/` as `..` (two dots), which is safe because git branch
+/// names cannot contain `..` (git-check-ref-format rule).
+fn encode_branch_for_config(branch: &str) -> String {
+    branch.replace('/', "..")
+}
+
+/// Decode a branch name encoded by `encode_branch_for_config`.
+fn decode_branch_from_config(encoded: &str) -> String {
+    encoded.replace("..", "/")
+}
+
 impl Repository {
     /// Get a git config value. Returns None if the key doesn't exist.
     ///
@@ -42,7 +56,10 @@ impl Repository {
             marker: Option<String>,
         }
 
-        let config_key = format!("worktrunk.state.{branch}.marker");
+        let config_key = format!(
+            "worktrunk.state.{}.marker",
+            encode_branch_for_config(branch)
+        );
         let raw = self
             .run_command(&["config", "--get", &config_key])
             .ok()
@@ -63,13 +80,14 @@ impl Repository {
     /// Returns a `BTreeMap` so it serializes to a minijinja object for template access
     /// via `{{ vars.key }}`.
     pub fn vars_entries(&self, branch: &str) -> std::collections::BTreeMap<String, String> {
-        let escaped = regex::escape(branch);
+        let encoded = encode_branch_for_config(branch);
+        let escaped = regex::escape(&encoded);
         let pattern = format!(r"^worktrunk\.state\.{escaped}\.vars\.");
         let output = self
             .run_command(&["config", "--get-regexp", &pattern])
             .unwrap_or_default();
 
-        let prefix = format!("worktrunk.state.{branch}.vars.");
+        let prefix = format!("worktrunk.state.{encoded}.vars.");
         output
             .lines()
             .filter_map(|line| {
@@ -105,11 +123,11 @@ impl Repository {
             // Use rsplit_once: var keys cannot contain dots (validated by
             // validate_vars_key), so the last `.vars.` is always the real separator.
             // split_once would misparse branch names containing `.vars.`.
-            let Some((branch, key)) = rest.rsplit_once(".vars.") else {
+            let Some((branch_encoded, key)) = rest.rsplit_once(".vars.") else {
                 continue;
             };
             result
-                .entry(branch.to_string())
+                .entry(decode_branch_from_config(branch_encoded))
                 .or_default()
                 .insert(key.to_string(), value.to_string());
         }

--- a/tests/integration_tests/config_state.rs
+++ b/tests/integration_tests/config_state.rs
@@ -1573,7 +1573,7 @@ fn test_vars_invalid_key(repo: TestRepo) {
         .output()
         .unwrap();
     assert!(!output.status.success());
-    assert_snapshot!(String::from_utf8_lossy(&output.stderr), @r#"[31m✗[39m [31mInvalid key "foo.bar": keys must contain only letters, digits, hyphens, and underscores[39m"#);
+    assert_snapshot!(String::from_utf8_lossy(&output.stderr), @r#"[31m✗[39m [31mInvalid key "foo.bar": keys must contain only letters, digits, and hyphens[39m"#);
 }
 
 #[rstest]
@@ -1600,6 +1600,40 @@ fn test_vars_branch_flag(repo: TestRepo) {
 
     // Current branch should not have the value
     let output = wt_state_cmd(&repo, "vars", "get", &["env"])
+        .output()
+        .unwrap();
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "");
+}
+
+#[rstest]
+fn test_vars_slash_branch(repo: TestRepo) {
+    // Branch names with `/` must be stored and retrieved correctly.
+    // git config rejects `/` in key names so we encode it as `..`.
+    repo.run_git(&["branch", "feature/my-task"]);
+
+    let output = wt_state_cmd(
+        &repo,
+        "vars",
+        "set",
+        &["port=4000", "--branch=feature/my-task"],
+    )
+    .output()
+    .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let output = wt_state_cmd(&repo, "vars", "get", &["port", "--branch=feature/my-task"])
+        .output()
+        .unwrap();
+    assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "4000");
+
+    // A branch whose name decodes to the same string must not collide
+    // (git forbids `..` in branch names, so no real collision is possible,
+    // but verify the scoping is correct).
+    let output = wt_state_cmd(&repo, "vars", "get", &["port"])
         .output()
         .unwrap();
     assert_eq!(String::from_utf8_lossy(&output.stdout).trim(), "");


### PR DESCRIPTION
## Problem

`wt config state vars set key=value` fails for branches containing `/` (e.g. `feature/my-task`):

```
✗ Invalid key "worktrunk.state.feature/my-task.vars.key": ...
```

Git config rejects `/` in key path segments, so any slash-branch silently broke the entire vars feature.

## Solution

Encode `/` as `..` when writing branch names into git config keys, decode on read.

**Why `..`?** Git forbids `..` in branch names via `git-check-ref-format`, making it a collision-free, reversible encoding. Other safe-in-config characters (`-`, alphanumeric) are also valid in branch names and would cause collisions.

Also tightens `validate_vars_key` to reject `_`, which git config likewise forbids in variable names (last segment must match `[a-zA-Z][a-zA-Z0-9-]*`).

## Changes

- `src/git/repository/config.rs`: encode branch in `branch_marker`, `vars_entries`, `all_vars_entries`
- `src/commands/config/state.rs`: encode branch in all `worktrunk.state.*` key constructions; decode when reading back in `all_markers`
- `tests/integration_tests/config_state.rs`: new `test_vars_slash_branch` test; updated `test_vars_invalid_key` snapshot