### PR TITLE
docs(cli): trim filler in list and step help text

### DIFF
--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -24,7 +24,7 @@ The table renders progressively: branch names, paths, and commit hashes appear i
 
 ## Full mode
 
-`--full` adds columns that require network access or LLM calls: [CI status](#ci-status) (GitHub/GitLab pipeline pass/fail), line diffs since the merge-base, and [LLM-generated summaries](#llm-summaries) of each branch's changes. The table displays instantly and columns fill in as results arrive.
+`--full` adds columns that require network access or LLM calls: [CI status](#ci-status) (GitHub/GitLab pipeline pass/fail), line diffs since the merge-base, and [LLM-generated summaries](#llm-summaries) of each branch's changes.
 
 ## Examples
 

--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -34,7 +34,7 @@ Manual merge workflow with review between steps:
 - [`promote`](#wt-step-promote) — <span class="badge-experimental"></span> Swap a branch into the main worktree
 - [`prune`](#wt-step-prune) — Remove worktrees and branches merged into the default branch
 - [`relocate`](#wt-step-relocate) — <span class="badge-experimental"></span> Move worktrees to expected paths
-- [`<alias>`](@/extending.md#aliases) — <span class="badge-experimental"></span> Run a configured command alias (see [Aliases](@/extending.md#aliases))
+- [`<alias>`](@/extending.md#aliases) — Run a configured command alias
 
 ## See also
 

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -8,7 +8,7 @@ The table renders progressively: branch names, paths, and commit hashes appear i
 
 ## Full mode
 
-`--full` adds columns that require network access or LLM calls: [CI status](#ci-status) (GitHub/GitLab pipeline pass/fail), line diffs since the merge-base, and [LLM-generated summaries](#llm-summaries) of each branch's changes. The table displays instantly and columns fill in as results arrive.
+`--full` adds columns that require network access or LLM calls: [CI status](#ci-status) (GitHub/GitLab pipeline pass/fail), line diffs since the merge-base, and [LLM-generated summaries](#llm-summaries) of each branch's changes.
 
 ## Examples
 

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -32,7 +32,7 @@ $ wt step push
 - [`promote`](#wt-step-promote) — [experimental] Swap a branch into the main worktree
 - [`prune`](#wt-step-prune) — Remove worktrees and branches merged into the default branch
 - [`relocate`](#wt-step-relocate) — [experimental] Move worktrees to expected paths
-- [`<alias>`](https://worktrunk.dev/extending/#aliases) — [experimental] Run a configured command alias (see [Aliases](https://worktrunk.dev/extending/#aliases))
+- [`<alias>`](https://worktrunk.dev/extending/#aliases) — Run a configured command alias
 
 ## Command reference
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -657,7 +657,7 @@ The table renders progressively: branch names, paths, and commit hashes appear i
 
 ## Full mode
 
-`--full` adds columns that require network access or LLM calls: [CI status](#ci-status) (GitHub/GitLab pipeline pass/fail), line diffs since the merge-base, and [LLM-generated summaries](#llm-summaries) of each branch's changes. The table displays instantly and columns fill in as results arrive.
+`--full` adds columns that require network access or LLM calls: [CI status](#ci-status) (GitHub/GitLab pipeline pass/fail), line diffs since the merge-base, and [LLM-generated summaries](#llm-summaries) of each branch's changes.
 
 ## Examples
 
@@ -1125,7 +1125,7 @@ $ wt step push
 - [`promote`](#wt-step-promote) — [experimental] Swap a branch into the main worktree
 - [`prune`](#wt-step-prune) — Remove worktrees and branches merged into the default branch
 - [`relocate`](#wt-step-relocate) — [experimental] Move worktrees to expected paths
-- [`<alias>`](@/extending.md#aliases) — [experimental] Run a configured command alias (see [Aliases](@/extending.md#aliases))
+- [`<alias>`](@/extending.md#aliases) — Run a configured command alias
 
 ## See also
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -77,7 +77,7 @@ The table renders progressively: branch names, paths, and commit hashes appear i
 
 [1m[32mFull mode[0m
 
-[2m--full[0m adds columns that require network access or LLM calls: CI status (GitHub/GitLab pipeline pass/fail), line diffs since the merge-base, and LLM-generated summaries of each branch's changes. The table displays instantly and columns fill in as results arrive.
+[2m--full[0m adds columns that require network access or LLM calls: CI status (GitHub/GitLab pipeline pass/fail), line diffs since the merge-base, and LLM-generated summaries of each branch's changes.
 
 [1m[32mExamples[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -85,8 +85,7 @@ git operations complete.
 
 [2m--full[0m adds columns that require network access or LLM calls: CI status 
 (GitHub/GitLab pipeline pass/fail), line diffs since the merge-base, and 
-LLM-generated summaries of each branch's changes. The table displays instantly 
-and columns fill in as results arrive.
+LLM-generated summaries of each branch's changes.
 
 [1m[32mExamples[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_step_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_long.snap
@@ -89,7 +89,7 @@ Manual merge workflow with review between steps:
 - [2mpromote[0m — [experimental] Swap a branch into the main worktree
 - [2mprune[0m — Remove worktrees and branches merged into the default branch
 - [2mrelocate[0m — [experimental] Move worktrees to expected paths
-- [2m<alias>[0m — [experimental] Run a configured command alias (see Aliases)
+- [2m<alias>[0m — Run a configured command alias
 
 [1m[32mSee also[0m
 


### PR DESCRIPTION
Third pass over the docs, this round in `src/cli/mod.rs` (which generates the command pages).

- **`list`** — drop "The table displays instantly and columns fill in as results arrive." from the `--full` paragraph. The opening paragraph of `list`'s `after_long_help` already says: "The table renders progressively: branch names, paths, and commit hashes appear immediately, then status, divergence, and other columns fill in as background git operations complete." Full mode inherits that behavior.

- **`step`** — trim the `<alias>` bullet to match the two other alias references in the file (lines 1843, 2020, both just "Command templates that run as `wt <name>`."). Drop the now-stale `[experimental]` tag — the Aliases section in `extending.md` stopped being marked experimental in #2271, leaving this the only remaining reference — and drop the `(see [Aliases](...))` parenthetical that linked to the same anchor as the bullet name.

Snapshots updated via `cargo insta test --accept`.

Follows #2271 and #2272.