### PR TITLE
feat(cli): promote --yes to a global flag

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -494,6 +494,9 @@ Usage: <b><span class=c>wt config</span></b> <span class=c>[OPTIONS]</span> <spa
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 # Subcommands
@@ -552,6 +555,9 @@ Usage: <b><span class=c>wt config show</span></b> <span class=c>[OPTIONS]</span>
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 ## wt config state
@@ -624,6 +630,9 @@ Usage: <b><span class=c>wt config state</span></b> <span class=c>[OPTIONS]</span
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 ## wt config state default-branch
@@ -679,6 +688,9 @@ Usage: <b><span class=c>wt config state default-branch</span></b> <span class=c>
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 ## wt config state logs
@@ -781,6 +793,9 @@ Usage: <b><span class=c>wt config state logs</span></b> <span class=c>[OPTIONS]<
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 ## wt config state ci-status
@@ -839,6 +854,9 @@ Usage: <b><span class=c>wt config state ci-status</span></b> <span class=c>[OPTI
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 ## wt config state marker
@@ -909,6 +927,9 @@ Usage: <b><span class=c>wt config state marker</span></b> <span class=c>[OPTIONS
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 ## wt config state vars
@@ -981,6 +1002,9 @@ Usage: <b><span class=c>wt config state vars</span></b> <span class=c>[OPTIONS]<
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt config --help-page` -->

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -607,6 +607,9 @@ Usage: <b><span class=c>wt config approvals</span></b> <span class=c>[OPTIONS]</
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 ## wt config state

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -499,6 +499,9 @@ Usage: <b><span class=c>wt hook</span></b> <span class=c>[OPTIONS]</span> <span 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt hook --help-page` -->

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -500,6 +500,9 @@ Usage: <b><span class=c>wt hook</span></b> <span class=c>[OPTIONS]</span> <span 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 # Subcommands
@@ -550,6 +553,9 @@ Usage: <b><span class=c>wt hook approvals</span></b> <span class=c>[OPTIONS]</sp
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt hook --help-page` -->

--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -283,6 +283,9 @@ Usage: <b><span class=c>wt list</span></b> <span class=c>[OPTIONS]</span>
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt list --help-page` -->

--- a/docs/content/merge.md
+++ b/docs/content/merge.md
@@ -124,9 +124,6 @@ Usage: <b><span class=c>wt merge</span></b> <span class=c>[OPTIONS]</span> <span
           Print help (see a summary with &#39;-h&#39;)
 
 <b><span class=g>Automation:</span></b>
-  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
-          Skip approval prompts
-
       <b><span class=c>--no-hooks</span></b>
           Skip hooks
 
@@ -151,6 +148,9 @@ Usage: <b><span class=c>wt merge</span></b> <span class=c>[OPTIONS]</span> <span
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt merge --help-page` -->

--- a/docs/content/remove.md
+++ b/docs/content/remove.md
@@ -111,9 +111,6 @@ Usage: <b><span class=c>wt remove</span></b> <span class=c>[OPTIONS]</span> <spa
           Print help (see a summary with &#39;-h&#39;)
 
 <b><span class=g>Automation:</span></b>
-  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
-          Skip approval prompts
-
       <b><span class=c>--no-hooks</span></b>
           Skip hooks
 
@@ -138,6 +135,9 @@ Usage: <b><span class=c>wt remove</span></b> <span class=c>[OPTIONS]</span> <spa
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt remove --help-page` -->

--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -129,6 +129,9 @@ Usage: <b><span class=c>wt step commit</span></b> <span class=c>[OPTIONS]</span>
   <b><span class=c>-b</span></b>, <b><span class=c>--branch</span></b><span class=c> &lt;BRANCH&gt;</span>
           Branch to operate on (defaults to current worktree)
 
+      <b><span class=c>--no-hooks</span></b>
+          Skip hooks
+
       <b><span class=c>--stage</span></b><span class=c> &lt;STAGE&gt;</span>
           What to stage before committing [default: all]
 
@@ -144,10 +147,6 @@ Usage: <b><span class=c>wt step commit</span></b> <span class=c>[OPTIONS]</span>
 
   <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
           Print help (see a summary with &#39;-h&#39;)
-
-<b><span class=g>Automation:</span></b>
-      <b><span class=c>--no-hooks</span></b>
-          Skip hooks
 
 <b><span class=g>Global Options:</span></b>
   <b><span class=c>-C</span></b><span class=c> &lt;path&gt;</span>
@@ -213,6 +212,9 @@ Usage: <b><span class=c>wt step squash</span></b> <span class=c>[OPTIONS]</span>
           Defaults to default branch.
 
 <b><span class=g>Options:</span></b>
+      <b><span class=c>--no-hooks</span></b>
+          Skip hooks
+
       <b><span class=c>--stage</span></b><span class=c> &lt;STAGE&gt;</span>
           What to stage before committing [default: all]
 
@@ -228,10 +230,6 @@ Usage: <b><span class=c>wt step squash</span></b> <span class=c>[OPTIONS]</span>
 
   <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
           Print help (see a summary with &#39;-h&#39;)
-
-<b><span class=g>Automation:</span></b>
-      <b><span class=c>--no-hooks</span></b>
-          Skip hooks
 
 <b><span class=g>Global Options:</span></b>
   <b><span class=c>-C</span></b><span class=c> &lt;path&gt;</span>
@@ -568,10 +566,6 @@ Usage: <b><span class=c>wt step for-each</span></b> <span class=c>[OPTIONS]</spa
           Command template (see --help for all variables)
 
 <b><span class=g>Options:</span></b>
-  <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
-          Print help (see a summary with &#39;-h&#39;)
-
-<b><span class=g>Automation:</span></b>
       <b><span class=c>--format</span></b><span class=c> &lt;FORMAT&gt;</span>
           Output format (text, json)
 
@@ -580,6 +574,9 @@ Usage: <b><span class=c>wt step for-each</span></b> <span class=c>[OPTIONS]</spa
           - <b><span class=c>json</span></b>: JSON output
 
           [default: text]
+
+  <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
+          Print help (see a summary with &#39;-h&#39;)
 
 <b><span class=g>Global Options:</span></b>
   <b><span class=c>-C</span></b><span class=c> &lt;path&gt;</span>
@@ -720,10 +717,6 @@ Usage: <b><span class=c>wt step prune</span></b> <span class=c>[OPTIONS]</span>
       <b><span class=c>--foreground</span></b>
           Run removal in foreground (block until complete)
 
-  <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
-          Print help (see a summary with &#39;-h&#39;)
-
-<b><span class=g>Automation:</span></b>
       <b><span class=c>--format</span></b><span class=c> &lt;FORMAT&gt;</span>
           Output format (text, json)
 
@@ -732,6 +725,9 @@ Usage: <b><span class=c>wt step prune</span></b> <span class=c>[OPTIONS]</span>
           - <b><span class=c>json</span></b>: JSON output
 
           [default: text]
+
+  <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
+          Print help (see a summary with &#39;-h&#39;)
 
 <b><span class=g>Global Options:</span></b>
   <b><span class=c>-C</span></b><span class=c> &lt;path&gt;</span>

--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -78,6 +78,9 @@ Usage: <b><span class=c>wt step</span></b> <span class=c>[OPTIONS]</span> <span 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 # Subcommands
@@ -143,9 +146,6 @@ Usage: <b><span class=c>wt step commit</span></b> <span class=c>[OPTIONS]</span>
           Print help (see a summary with &#39;-h&#39;)
 
 <b><span class=g>Automation:</span></b>
-  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
-          Skip approval prompts
-
       <b><span class=c>--no-hooks</span></b>
           Skip hooks
 
@@ -159,6 +159,9 @@ Usage: <b><span class=c>wt step commit</span></b> <span class=c>[OPTIONS]</span>
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 ## wt step squash
@@ -227,9 +230,6 @@ Usage: <b><span class=c>wt step squash</span></b> <span class=c>[OPTIONS]</span>
           Print help (see a summary with &#39;-h&#39;)
 
 <b><span class=g>Automation:</span></b>
-  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
-          Skip approval prompts
-
       <b><span class=c>--no-hooks</span></b>
           Skip hooks
 
@@ -243,6 +243,9 @@ Usage: <b><span class=c>wt step squash</span></b> <span class=c>[OPTIONS]</span>
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 ## wt step diff
@@ -301,6 +304,9 @@ Usage: <b><span class=c>wt step diff</span></b> <span class=c>[OPTIONS]</span> <
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 ## wt step copy-ignored
@@ -433,6 +439,9 @@ Usage: <b><span class=c>wt step copy-ignored</span></b> <span class=c>[OPTIONS]<
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 ## wt step eval
@@ -508,6 +517,9 @@ Usage: <b><span class=c>wt step eval</span></b> <span class=c>[OPTIONS]</span> <
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 ## wt step for-each
@@ -579,6 +591,9 @@ Usage: <b><span class=c>wt step for-each</span></b> <span class=c>[OPTIONS]</spa
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 ## wt step promote
@@ -653,6 +668,9 @@ Usage: <b><span class=c>wt step promote</span></b> <span class=c>[OPTIONS]</span
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 ## wt step prune
@@ -706,9 +724,6 @@ Usage: <b><span class=c>wt step prune</span></b> <span class=c>[OPTIONS]</span>
           Print help (see a summary with &#39;-h&#39;)
 
 <b><span class=g>Automation:</span></b>
-  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
-          Skip approval prompts
-
       <b><span class=c>--format</span></b><span class=c> &lt;FORMAT&gt;</span>
           Output format (text, json)
 
@@ -728,6 +743,9 @@ Usage: <b><span class=c>wt step prune</span></b> <span class=c>[OPTIONS]</span>
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 ## wt step relocate
@@ -818,6 +836,9 @@ Usage: <b><span class=c>wt step relocate</span></b> <span class=c>[OPTIONS]</spa
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt step --help-page` -->

--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -194,9 +194,6 @@ Usage: <b><span class=c>wt switch</span></b> <span class=c>[OPTIONS]</span> <spa
           Include remote branches
 
 <b><span class=g>Automation:</span></b>
-  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
-          Skip approval prompts
-
       <b><span class=c>--no-hooks</span></b>
           Skip hooks
 
@@ -222,6 +219,9 @@ Usage: <b><span class=c>wt switch</span></b> <span class=c>[OPTIONS]</span> <spa
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
 {% end %}
 
 <!-- END AUTO-GENERATED from `wt switch --help-page` -->

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -497,6 +497,9 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```
 
 # Subcommands
@@ -557,6 +560,9 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```
 
 ## wt config state
@@ -643,6 +649,9 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```
 
 ## wt config state default-branch
@@ -700,6 +709,9 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```
 
 ## wt config state logs
@@ -812,6 +824,9 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```
 
 ## wt config state ci-status
@@ -870,6 +885,9 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```
 
 ## wt config state marker
@@ -939,6 +957,9 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```
 
 ## wt config state vars
@@ -1022,4 +1043,7 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -618,6 +618,9 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```
 
 ## wt config state

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -493,6 +493,9 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```
 
 # Subcommands
@@ -549,4 +552,7 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -492,4 +492,7 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -313,4 +313,7 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```

--- a/skills/worktrunk/reference/merge.md
+++ b/skills/worktrunk/reference/merge.md
@@ -114,9 +114,6 @@ Options:
           Print help (see a summary with '-h')
 
 Automation:
-  -y, --yes
-          Skip approval prompts
-
       --no-hooks
           Skip hooks
 
@@ -141,4 +138,7 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```

--- a/skills/worktrunk/reference/remove.md
+++ b/skills/worktrunk/reference/remove.md
@@ -110,9 +110,6 @@ Options:
           Print help (see a summary with '-h')
 
 Automation:
-  -y, --yes
-          Skip approval prompts
-
       --no-hooks
           Skip hooks
 
@@ -137,4 +134,7 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -70,6 +70,9 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```
 
 # Subcommands
@@ -143,9 +146,6 @@ Options:
           Print help (see a summary with '-h')
 
 Automation:
-  -y, --yes
-          Skip approval prompts
-
       --no-hooks
           Skip hooks
 
@@ -159,6 +159,9 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```
 
 ## wt step squash
@@ -231,9 +234,6 @@ Options:
           Print help (see a summary with '-h')
 
 Automation:
-  -y, --yes
-          Skip approval prompts
-
       --no-hooks
           Skip hooks
 
@@ -247,6 +247,9 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```
 
 ## wt step diff
@@ -315,6 +318,9 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```
 
 ## wt step copy-ignored
@@ -447,6 +453,9 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```
 
 ## wt step eval
@@ -528,6 +537,9 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```
 
 ## wt step for-each
@@ -607,6 +619,9 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```
 
 ## wt step promote
@@ -684,6 +699,9 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```
 
 ## wt step prune
@@ -744,9 +762,6 @@ Options:
           Print help (see a summary with '-h')
 
 Automation:
-  -y, --yes
-          Skip approval prompts
-
       --format <FORMAT>
           Output format (text, json)
 
@@ -766,6 +781,9 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```
 
 ## wt step relocate
@@ -864,4 +882,7 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -129,6 +129,9 @@ Options:
   -b, --branch <BRANCH>
           Branch to operate on (defaults to current worktree)
 
+      --no-hooks
+          Skip hooks
+
       --stage <STAGE>
           What to stage before committing [default: all]
 
@@ -144,10 +147,6 @@ Options:
 
   -h, --help
           Print help (see a summary with '-h')
-
-Automation:
-      --no-hooks
-          Skip hooks
 
 Global Options:
   -C <path>
@@ -217,6 +216,9 @@ Arguments:
           Defaults to default branch.
 
 Options:
+      --no-hooks
+          Skip hooks
+
       --stage <STAGE>
           What to stage before committing [default: all]
 
@@ -232,10 +234,6 @@ Options:
 
   -h, --help
           Print help (see a summary with '-h')
-
-Automation:
-      --no-hooks
-          Skip hooks
 
 Global Options:
   -C <path>
@@ -596,10 +594,6 @@ Arguments:
           Command template (see --help for all variables)
 
 Options:
-  -h, --help
-          Print help (see a summary with '-h')
-
-Automation:
       --format <FORMAT>
           Output format (text, json)
 
@@ -608,6 +602,9 @@ Automation:
           - json: JSON output
 
           [default: text]
+
+  -h, --help
+          Print help (see a summary with '-h')
 
 Global Options:
   -C <path>
@@ -758,10 +755,6 @@ Options:
       --foreground
           Run removal in foreground (block until complete)
 
-  -h, --help
-          Print help (see a summary with '-h')
-
-Automation:
       --format <FORMAT>
           Output format (text, json)
 
@@ -770,6 +763,9 @@ Automation:
           - json: JSON output
 
           [default: text]
+
+  -h, --help
+          Print help (see a summary with '-h')
 
 Global Options:
   -C <path>

--- a/skills/worktrunk/reference/switch.md
+++ b/skills/worktrunk/reference/switch.md
@@ -186,9 +186,6 @@ Picker Options:
           Include remote branches
 
 Automation:
-  -y, --yes
-          Skip approval prompts
-
       --no-hooks
           Skip hooks
 
@@ -214,4 +211,7 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
           + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 ```

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -74,10 +74,6 @@ Use --yes to skip confirmation."#
         #[arg(value_enum)]
         shell: Option<Shell>,
 
-        /// Skip confirmation prompt
-        #[arg(short, long)]
-        yes: bool,
-
         /// Show what would be changed
         #[arg(long)]
         dry_run: bool,
@@ -122,10 +118,6 @@ Detects various forms of the integration pattern regardless of:
         /// Shell to uninstall (default: all)
         #[arg(value_enum)]
         shell: Option<Shell>,
-
-        /// Skip confirmation prompt
-        #[arg(short, long)]
-        yes: bool,
 
         /// Show what would be changed
         #[arg(long)]
@@ -178,11 +170,7 @@ $ wt config plugins opencode install --yes
 The plugin is written to `~/.config/opencode/plugins/worktrunk.ts`.
 Override with the `OPENCODE_CONFIG_DIR` environment variable."#
     )]
-    Install {
-        /// Skip confirmation prompt
-        #[arg(short, long)]
-        yes: bool,
-    },
+    Install,
 
     /// Remove the activity tracking plugin
     #[command(
@@ -194,11 +182,7 @@ Override with the `OPENCODE_CONFIG_DIR` environment variable."#
 $ wt config plugins opencode uninstall
 ```"#
     )]
-    Uninstall {
-        /// Skip confirmation prompt
-        #[arg(short, long)]
-        yes: bool,
-    },
+    Uninstall,
 }
 
 // Ordering: action + inverse adjacent (add, clear).
@@ -295,11 +279,7 @@ $ claude plugin install worktrunk@worktrunk
 
 Requires `claude` CLI. Skips gracefully if already installed."#
     )]
-    Install {
-        /// Skip confirmation prompt
-        #[arg(short, long)]
-        yes: bool,
-    },
+    Install,
 
     /// Remove the Worktrunk plugin
     #[command(
@@ -309,11 +289,7 @@ Requires `claude` CLI. Skips gracefully if already installed."#
 $ claude plugin uninstall worktrunk@worktrunk
 ```"#
     )]
-    Uninstall {
-        /// Skip confirmation prompt
-        #[arg(short, long)]
-        yes: bool,
-    },
+    Uninstall,
 
     /// Configure the Claude Code statusline
     #[command(
@@ -328,11 +304,7 @@ Preserves existing settings. Creates the `.claude/` directory and `settings.json
 
 Skips gracefully if the statusline is already configured."#
     )]
-    InstallStatusline {
-        /// Skip confirmation prompt
-        #[arg(short, long)]
-        yes: bool,
-    },
+    InstallStatusline,
 }
 
 // Ordering: user journey — shell (install integration), create (bootstrap
@@ -422,12 +394,8 @@ $ wt config update --print
 ```"#
     )]
     Update {
-        /// Skip confirmation prompt
-        #[arg(short, long)]
-        yes: bool,
-
         /// Print the migrated config to stdout instead of writing it
-        #[arg(long, conflicts_with = "yes")]
+        #[arg(long)]
         print: bool,
     },
 

--- a/src/cli/hook.rs
+++ b/src/cli/hook.rs
@@ -405,10 +405,6 @@ pub enum HookCommand {
         #[arg(add = crate::completion::hook_command_name_completer())]
         name: Vec<String>,
 
-        /// Skip approval prompts
-        #[arg(short, long, help_heading = "Automation")]
-        yes: bool,
-
         /// Show what would run without executing
         #[arg(long)]
         dry_run: bool,
@@ -428,10 +424,6 @@ pub enum HookCommand {
         /// `user:` alone runs all user hooks; `project:` alone runs all project hooks.
         #[arg(add = crate::completion::hook_command_name_completer())]
         name: Vec<String>,
-
-        /// Skip approval prompts
-        #[arg(short, long, help_heading = "Automation")]
-        yes: bool,
 
         /// Show what would run without executing
         #[arg(long)]
@@ -458,10 +450,6 @@ pub enum HookCommand {
         #[arg(add = crate::completion::hook_command_name_completer())]
         name: Vec<String>,
 
-        /// Skip approval prompts
-        #[arg(short, long, help_heading = "Automation")]
-        yes: bool,
-
         /// Show what would run without executing
         #[arg(long)]
         dry_run: bool,
@@ -481,10 +469,6 @@ pub enum HookCommand {
         /// `user:` alone runs all user hooks; `project:` alone runs all project hooks.
         #[arg(add = crate::completion::hook_command_name_completer())]
         name: Vec<String>,
-
-        /// Skip approval prompts
-        #[arg(short, long, help_heading = "Automation")]
-        yes: bool,
 
         /// Show what would run without executing
         #[arg(long)]
@@ -508,10 +492,6 @@ pub enum HookCommand {
         #[arg(add = crate::completion::hook_command_name_completer())]
         name: Vec<String>,
 
-        /// Skip approval prompts
-        #[arg(short, long, help_heading = "Automation")]
-        yes: bool,
-
         /// Show what would run without executing
         #[arg(long)]
         dry_run: bool,
@@ -531,10 +511,6 @@ pub enum HookCommand {
         /// `user:` alone runs all user hooks; `project:` alone runs all project hooks.
         #[arg(add = crate::completion::hook_command_name_completer())]
         name: Vec<String>,
-
-        /// Skip approval prompts
-        #[arg(short, long, help_heading = "Automation")]
-        yes: bool,
 
         /// Show what would run without executing
         #[arg(long)]
@@ -558,10 +534,6 @@ pub enum HookCommand {
         #[arg(add = crate::completion::hook_command_name_completer())]
         name: Vec<String>,
 
-        /// Skip approval prompts
-        #[arg(short, long, help_heading = "Automation")]
-        yes: bool,
-
         /// Show what would run without executing
         #[arg(long)]
         dry_run: bool,
@@ -581,10 +553,6 @@ pub enum HookCommand {
         /// `user:` alone runs all user hooks; `project:` alone runs all project hooks.
         #[arg(add = crate::completion::hook_command_name_completer())]
         name: Vec<String>,
-
-        /// Skip approval prompts
-        #[arg(short, long, help_heading = "Automation")]
-        yes: bool,
 
         /// Show what would run without executing
         #[arg(long)]
@@ -608,10 +576,6 @@ pub enum HookCommand {
         #[arg(add = crate::completion::hook_command_name_completer())]
         name: Vec<String>,
 
-        /// Skip approval prompts
-        #[arg(short, long, help_heading = "Automation")]
-        yes: bool,
-
         /// Show what would run without executing
         #[arg(long)]
         dry_run: bool,
@@ -631,10 +595,6 @@ pub enum HookCommand {
         /// `user:` alone runs all user hooks; `project:` alone runs all project hooks.
         #[arg(add = crate::completion::hook_command_name_completer())]
         name: Vec<String>,
-
-        /// Skip approval prompts
-        #[arg(short, long, help_heading = "Automation")]
-        yes: bool,
 
         /// Show what would run without executing
         #[arg(long)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -257,6 +257,16 @@ pub(crate) struct Cli {
     )]
     pub verbose: u8,
 
+    /// Skip approval prompts
+    #[arg(
+        long,
+        short = 'y',
+        global = true,
+        display_order = 103,
+        help_heading = "Global Options"
+    )]
+    pub yes: bool,
+
     #[command(subcommand)]
     pub command: Option<Commands>,
 }
@@ -342,10 +352,6 @@ pub(crate) struct SwitchArgs {
     #[arg(long, overrides_with = "no_cd", hide = true)]
     pub(crate) cd: bool,
 
-    /// Skip approval prompts
-    #[arg(short, long, help_heading = "Automation")]
-    pub(crate) yes: bool,
-
     /// Skip hooks
     #[arg(long = "no-hooks", action = clap::ArgAction::SetFalse, default_value_t = true, help_heading = "Automation")]
     pub(crate) verify: bool,
@@ -413,10 +419,6 @@ pub(crate) struct RemoveArgs {
     /// Run removal in foreground (block until complete)
     #[arg(long)]
     pub(crate) foreground: bool,
-
-    /// Skip approval prompts
-    #[arg(short, long, help_heading = "Automation")]
-    pub(crate) yes: bool,
 
     /// Skip hooks
     #[arg(long = "no-hooks", action = clap::ArgAction::SetFalse, default_value_t = true, help_heading = "Automation")]
@@ -487,10 +489,6 @@ pub(crate) struct MergeArgs {
     /// Allow fast-forward (default)
     #[arg(long, overrides_with = "no_ff", hide = true)]
     pub(crate) ff: bool,
-
-    /// Skip approval prompts
-    #[arg(short, long, help_heading = "Automation")]
-    pub(crate) yes: bool,
 
     /// Force running hooks
     #[arg(long, overrides_with_all = ["no_hooks", "no_verify"], hide = true)]

--- a/src/cli/step.rs
+++ b/src/cli/step.rs
@@ -7,7 +7,7 @@ pub struct CommitArgs {
     pub(crate) branch: Option<String>,
 
     /// Skip hooks
-    #[arg(long = "no-hooks", action = clap::ArgAction::SetFalse, default_value_t = true, help_heading = "Automation")]
+    #[arg(long = "no-hooks", action = clap::ArgAction::SetFalse, default_value_t = true)]
     pub(crate) verify: bool,
 
     /// Skip hooks (deprecated alias for --no-hooks)
@@ -34,7 +34,7 @@ pub struct SquashArgs {
     pub(crate) target: Option<String>,
 
     /// Skip hooks
-    #[arg(long = "no-hooks", action = clap::ArgAction::SetFalse, default_value_t = true, help_heading = "Automation")]
+    #[arg(long = "no-hooks", action = clap::ArgAction::SetFalse, default_value_t = true)]
     pub(crate) verify: bool,
 
     /// Skip hooks (deprecated alias for --no-hooks)
@@ -450,7 +450,7 @@ Note: This command is experimental and may change in future versions.
     )]
     ForEach {
         /// Output format (text, json)
-        #[arg(long, default_value = "text", help_heading = "Automation")]
+        #[arg(long, default_value = "text")]
         format: crate::cli::SwitchFormat,
 
         /// Command template (see --help for all variables)
@@ -557,7 +557,7 @@ $ wt step prune
         foreground: bool,
 
         /// Output format (text, json)
-        #[arg(long, default_value = "text", help_heading = "Automation")]
+        #[arg(long, default_value = "text")]
         format: crate::cli::SwitchFormat,
     },
 

--- a/src/cli/step.rs
+++ b/src/cli/step.rs
@@ -6,10 +6,6 @@ pub struct CommitArgs {
     #[arg(short, long, add = crate::completion::worktree_only_completer())]
     pub(crate) branch: Option<String>,
 
-    /// Skip approval prompts
-    #[arg(short, long, help_heading = "Automation")]
-    pub(crate) yes: bool,
-
     /// Skip hooks
     #[arg(long = "no-hooks", action = clap::ArgAction::SetFalse, default_value_t = true, help_heading = "Automation")]
     pub(crate) verify: bool,
@@ -36,10 +32,6 @@ pub struct SquashArgs {
     /// Defaults to default branch.
     #[arg(add = crate::completion::branch_value_completer())]
     pub(crate) target: Option<String>,
-
-    /// Skip approval prompts
-    #[arg(short, long, help_heading = "Automation")]
-    pub(crate) yes: bool,
 
     /// Skip hooks
     #[arg(long = "no-hooks", action = clap::ArgAction::SetFalse, default_value_t = true, help_heading = "Automation")]
@@ -555,10 +547,6 @@ $ wt step prune
         /// Show what would be removed
         #[arg(long)]
         dry_run: bool,
-
-        /// Skip approval prompts
-        #[arg(short, long, help_heading = "Automation")]
-        yes: bool,
 
         /// Skip worktrees younger than this
         #[arg(long, default_value = "1h")]

--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -263,12 +263,15 @@ fn load_merged_aliases(
 /// non-alias `rest` (positional args meant for a `wt-<name>` PATH binary)
 /// doesn't surface as a parse error.
 ///
+/// `global_yes` is the top-level `--yes`/`-y` flag, passed through to
+/// `run_alias`.
+///
 /// Alias execution needs a git repository; without one this returns `Ok(None)`
 /// so the caller falls through to PATH lookup. Config load errors propagate —
 /// a broken `wt.toml` should fail loudly here just as it does for `wt list`,
 /// rather than silently turning into an "unrecognized subcommand" once we
 /// fall through to PATH lookup.
-pub fn try_alias(name: String, rest: Vec<String>) -> anyhow::Result<Option<()>> {
+pub fn try_alias(name: String, rest: Vec<String>, global_yes: bool) -> anyhow::Result<Option<()>> {
     let Ok(repo) = Repository::current() else {
         return Ok(None);
     };
@@ -282,12 +285,15 @@ pub fn try_alias(name: String, rest: Vec<String>) -> anyhow::Result<Option<()>> 
     alias_args.push(name);
     alias_args.extend(rest);
     let opts = AliasOptions::parse(alias_args)?;
-    run_alias(opts, repo, user_config, project_config, aliases).map(Some)
+    run_alias(opts, repo, user_config, project_config, aliases, global_yes).map(Some)
 }
 
 /// Run a configured alias from `wt step <name>`. Errors with a clap-style
 /// "unrecognized subcommand" if the alias isn't configured.
-pub fn step_alias(opts: AliasOptions) -> anyhow::Result<()> {
+///
+/// `global_yes` is the top-level `--yes`/`-y` flag, passed through to
+/// `run_alias`.
+pub fn step_alias(opts: AliasOptions, global_yes: bool) -> anyhow::Result<()> {
     let repo = Repository::current()?;
     let user_config = UserConfig::load()?;
     let project_config = ProjectConfig::load(&repo, true)?;
@@ -306,7 +312,7 @@ pub fn step_alias(opts: AliasOptions) -> anyhow::Result<()> {
             .collect();
         unknown_step_command_exit(&opts.name, &alias_names);
     }
-    run_alias(opts, repo, user_config, project_config, aliases)
+    run_alias(opts, repo, user_config, project_config, aliases, global_yes)
 }
 
 /// Return alias names for use as suggestions when a top-level subcommand is
@@ -331,16 +337,24 @@ pub fn alias_names_for_suggestions() -> Vec<String> {
 
 /// Execute `cmd_config` for `opts.name`. Caller must have already verified
 /// `aliases.contains_key(&opts.name)`.
+///
+/// `global_yes` is the top-level `--yes`/`-y` flag; it OR's with `opts.yes`
+/// (the post-alias `--yes` parsed by `AliasOptions`) so either form skips
+/// approval. The post-alias form is kept intact for now — removing it is a
+/// separate cleanup.
 fn run_alias(
     opts: AliasOptions,
     repo: Repository,
     user_config: UserConfig,
     project_config: Option<ProjectConfig>,
     aliases: BTreeMap<String, CommandConfig>,
+    global_yes: bool,
 ) -> anyhow::Result<()> {
     let cmd_config = aliases
         .get(&opts.name)
         .expect("caller verified alias is configured");
+
+    let skip_approval = global_yes || opts.yes;
 
     // Check if this alias needs project-config approval (skip for --dry-run).
     // project_id is required for approval — re-derive with error propagation
@@ -352,7 +366,7 @@ fn run_alias(
             .project_identifier()
             .context("Cannot determine project identifier for alias approval")?;
         let approved =
-            approve_alias_commands(&project_commands, &opts.name, &project_id, opts.yes)?;
+            approve_alias_commands(&project_commands, &opts.name, &project_id, skip_approval)?;
         if !approved {
             return Ok(());
         }

--- a/src/commands/custom.rs
+++ b/src/commands/custom.rs
@@ -39,7 +39,9 @@ use crate::enhance_and_exit_error;
 /// `args[0]` is the subcommand name; `args[1..]` are the arguments to pass
 /// through. `working_dir`, if set, is the value of the top-level `-C <path>`
 /// flag — applied as the child's current directory so global `-C` works the
-/// same for custom subcommands as it does for built-ins.
+/// same for custom subcommands as it does for built-ins. `yes` is the global
+/// `--yes`/`-y` flag, passed to alias dispatch so it can skip approval prompts
+/// for project-config aliases.
 ///
 /// On success (child exit code 0), returns `Ok(())`. On non-zero exit, returns
 /// `WorktrunkError::AlreadyDisplayed` with the child's exit code so `main`
@@ -49,6 +51,7 @@ use crate::enhance_and_exit_error;
 pub(crate) fn handle_custom_command(
     args: Vec<OsString>,
     working_dir: Option<PathBuf>,
+    yes: bool,
 ) -> Result<()> {
     let mut iter = args.into_iter();
     let name_os = iter
@@ -77,7 +80,7 @@ pub(crate) fn handle_custom_command(
         .map(|a| a.to_str().map(|s| s.to_owned()))
         .collect();
     if let Some(alias_args) = alias_args
-        && let Some(()) = try_alias(name.clone(), alias_args)?
+        && let Some(()) = try_alias(name.clone(), alias_args, yes)?
     {
         return Ok(());
     }
@@ -241,7 +244,7 @@ mod tests {
         // with a non-UTF-8 argv could in principle reach this path. We
         // construct the same `Vec<OsString>` shape directly.
         let bad_name = OsString::from_vec(vec![0xFF, 0xFE]);
-        let err = handle_custom_command(vec![bad_name], None).unwrap_err();
+        let err = handle_custom_command(vec![bad_name], None, false).unwrap_err();
         let msg = err.to_string();
         assert!(
             msg.contains("not valid UTF-8"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -158,7 +158,7 @@ fn resolve_verify(verify: bool, no_verify_deprecated: bool) -> bool {
     }
 }
 
-fn handle_hook_command(action: HookCommand) -> anyhow::Result<()> {
+fn handle_hook_command(action: HookCommand, yes: bool) -> anyhow::Result<()> {
     match action {
         HookCommand::Show {
             hook_type,
@@ -166,65 +166,55 @@ fn handle_hook_command(action: HookCommand) -> anyhow::Result<()> {
         } => handle_hook_show(hook_type.as_deref(), expanded),
         HookCommand::PreSwitch {
             name,
-            yes,
             dry_run,
             vars,
         } => run_non_toggle_hook(HookType::PreSwitch, yes, dry_run, &name, &vars),
         HookCommand::PostSwitch {
             name,
-            yes,
             dry_run,
             foreground,
             vars,
         } => run_toggleable_hook(HookType::PostSwitch, yes, dry_run, foreground, &name, &vars),
         HookCommand::PreStart {
             name,
-            yes,
             dry_run,
             vars,
         } => run_non_toggle_hook(HookType::PreStart, yes, dry_run, &name, &vars),
         HookCommand::PostStart {
             name,
-            yes,
             dry_run,
             foreground,
             vars,
         } => run_toggleable_hook(HookType::PostStart, yes, dry_run, foreground, &name, &vars),
         HookCommand::PreCommit {
             name,
-            yes,
             dry_run,
             vars,
         } => run_non_toggle_hook(HookType::PreCommit, yes, dry_run, &name, &vars),
         HookCommand::PostCommit {
             name,
-            yes,
             dry_run,
             foreground,
             vars,
         } => run_toggleable_hook(HookType::PostCommit, yes, dry_run, foreground, &name, &vars),
         HookCommand::PreMerge {
             name,
-            yes,
             dry_run,
             vars,
         } => run_non_toggle_hook(HookType::PreMerge, yes, dry_run, &name, &vars),
         HookCommand::PostMerge {
             name,
-            yes,
             dry_run,
             foreground,
             vars,
         } => run_toggleable_hook(HookType::PostMerge, yes, dry_run, foreground, &name, &vars),
         HookCommand::PreRemove {
             name,
-            yes,
             dry_run,
             vars,
         } => run_non_toggle_hook(HookType::PreRemove, yes, dry_run, &name, &vars),
         HookCommand::PostRemove {
             name,
-            yes,
             dry_run,
             foreground,
             vars,
@@ -244,11 +234,11 @@ fn handle_hook_command(action: HookCommand) -> anyhow::Result<()> {
     }
 }
 
-fn handle_step_command(action: StepCommand) -> anyhow::Result<()> {
+fn handle_step_command(action: StepCommand, yes: bool) -> anyhow::Result<()> {
     match action {
         StepCommand::Commit(args) => {
             let verify = resolve_verify(args.verify, args.no_verify_deprecated);
-            step_commit(args.branch, args.yes, verify, args.stage, args.show_prompt)
+            step_commit(args.branch, yes, verify, args.stage, args.show_prompt)
         }
         StepCommand::Squash(args) => {
             let verify = resolve_verify(args.verify, args.no_verify_deprecated);
@@ -257,7 +247,7 @@ fn handle_step_command(action: StepCommand) -> anyhow::Result<()> {
                 commands::step_show_squash_prompt(args.target.as_deref())
             } else {
                 // Approval is handled inside handle_squash (like step_commit)
-                handle_squash(args.target.as_deref(), args.yes, verify, args.stage).map(|result| {
+                handle_squash(args.target.as_deref(), yes, verify, args.stage).map(|result| {
                     match result {
                         SquashResult::Squashed | SquashResult::NoNetChanges => {}
                         SquashResult::NoCommitsAhead(branch) => {
@@ -322,7 +312,6 @@ fn handle_step_command(action: StepCommand) -> anyhow::Result<()> {
         }
         StepCommand::Prune {
             dry_run,
-            yes,
             min_age,
             foreground,
             format,
@@ -334,7 +323,7 @@ fn handle_step_command(action: StepCommand) -> anyhow::Result<()> {
             clobber,
         } => step_relocate(branches, dry_run, commit, clobber),
         StepCommand::External(args) => {
-            commands::AliasOptions::parse(args).and_then(commands::step_alias)
+            commands::AliasOptions::parse(args).and_then(|opts| commands::step_alias(opts, yes))
         }
     }
 }
@@ -440,7 +429,7 @@ fn handle_state_command(action: StateCommand) -> anyhow::Result<()> {
     }
 }
 
-fn handle_config_shell_command(action: ConfigShellCommand) -> anyhow::Result<()> {
+fn handle_config_shell_command(action: ConfigShellCommand, yes: bool) -> anyhow::Result<()> {
     match action {
         ConfigShellCommand::Init { shell, cmd } => {
             // Generate shell code to stdout
@@ -449,7 +438,6 @@ fn handle_config_shell_command(action: ConfigShellCommand) -> anyhow::Result<()>
         }
         ConfigShellCommand::Install {
             shell,
-            yes,
             dry_run,
             cmd,
         } => {
@@ -474,11 +462,7 @@ fn handle_config_shell_command(action: ConfigShellCommand) -> anyhow::Result<()>
                     crate::output::print_shell_install_result(&scan_result)
                 })
         }
-        ConfigShellCommand::Uninstall {
-            shell,
-            yes,
-            dry_run,
-        } => {
+        ConfigShellCommand::Uninstall { shell, dry_run } => {
             let explicit_shell = shell.is_some();
             handle_unconfigure_shell(shell, yes, dry_run, &binary_name())
                 .map_err(|e| anyhow::anyhow!("{}", e))
@@ -496,29 +480,27 @@ fn handle_config_shell_command(action: ConfigShellCommand) -> anyhow::Result<()>
     }
 }
 
-fn handle_config_command(action: ConfigCommand) -> anyhow::Result<()> {
+fn handle_config_command(action: ConfigCommand, yes: bool) -> anyhow::Result<()> {
     match action {
-        ConfigCommand::Shell { action } => handle_config_shell_command(action),
+        ConfigCommand::Shell { action } => handle_config_shell_command(action, yes),
         ConfigCommand::Create { project } => handle_config_create(project),
         ConfigCommand::Show { full, format } => handle_config_show(full, format),
-        ConfigCommand::Update { yes, print } => handle_config_update(yes, print),
-        ConfigCommand::Plugins { action } => handle_plugins_command(action),
+        ConfigCommand::Update { print } => handle_config_update(yes, print),
+        ConfigCommand::Plugins { action } => handle_plugins_command(action, yes),
         ConfigCommand::State { action } => handle_state_command(action),
     }
 }
 
-fn handle_plugins_command(action: ConfigPluginsCommand) -> anyhow::Result<()> {
+fn handle_plugins_command(action: ConfigPluginsCommand, yes: bool) -> anyhow::Result<()> {
     match action {
         ConfigPluginsCommand::Claude { action } => match action {
-            ConfigPluginsClaudeCommand::Install { yes } => handle_claude_install(yes),
-            ConfigPluginsClaudeCommand::Uninstall { yes } => handle_claude_uninstall(yes),
-            ConfigPluginsClaudeCommand::InstallStatusline { yes } => {
-                handle_claude_install_statusline(yes)
-            }
+            ConfigPluginsClaudeCommand::Install => handle_claude_install(yes),
+            ConfigPluginsClaudeCommand::Uninstall => handle_claude_uninstall(yes),
+            ConfigPluginsClaudeCommand::InstallStatusline => handle_claude_install_statusline(yes),
         },
         ConfigPluginsCommand::Opencode { action } => match action {
-            ConfigPluginsOpencodeCommand::Install { yes } => handle_opencode_install(yes),
-            ConfigPluginsOpencodeCommand::Uninstall { yes } => handle_opencode_uninstall(yes),
+            ConfigPluginsOpencodeCommand::Install => handle_opencode_install(yes),
+            ConfigPluginsOpencodeCommand::Uninstall => handle_opencode_uninstall(yes),
         },
     }
 }
@@ -569,7 +551,7 @@ fn handle_select_command(_branches: bool, _remotes: bool) -> anyhow::Result<()> 
     Err(WorktrunkError::AlreadyDisplayed { exit_code: 1 }.into())
 }
 
-fn handle_switch_command(args: SwitchArgs) -> anyhow::Result<()> {
+fn handle_switch_command(args: SwitchArgs, yes: bool) -> anyhow::Result<()> {
     let verify = resolve_verify(args.verify, args.no_verify_deprecated);
 
     // With no branch argument, `wt switch` opens a TUI picker — config
@@ -609,7 +591,7 @@ fn handle_switch_command(args: SwitchArgs) -> anyhow::Result<()> {
                     base: args.base.as_deref(),
                     execute: args.execute.as_deref(),
                     execute_args: &args.execute_args,
-                    yes: args.yes,
+                    yes,
                     clobber: args.clobber,
                     change_dir: change_dir_flag,
                     verify,
@@ -772,7 +754,7 @@ fn validate_remove_targets(
 ///    in `.git/wt/trash/` older than 24 hours are removed by a detached
 ///    `rm -rf`. Runs last so it never delays the user-visible progress or
 ///    success message. See [`commands::process::sweep_stale_trash`].
-fn handle_remove_command(args: RemoveArgs) -> anyhow::Result<()> {
+fn handle_remove_command(args: RemoveArgs, yes: bool) -> anyhow::Result<()> {
     let json_mode = args.format == SwitchFormat::Json;
     let verify = resolve_verify(args.verify, args.no_verify_deprecated);
     UserConfig::load()
@@ -840,7 +822,7 @@ fn handle_remove_command(args: RemoveArgs) -> anyhow::Result<()> {
                 }
 
                 // "Approve at the Gate": approval happens AFTER validation passes
-                let run_hooks = verify && approve_remove(args.yes)?;
+                let run_hooks = verify && approve_remove(yes)?;
 
                 handle_remove_output(&result, args.foreground, run_hooks, false, false)?;
                 if json_mode {
@@ -875,7 +857,7 @@ fn handle_remove_command(args: RemoveArgs) -> anyhow::Result<()> {
                 // Approve hooks (only if we have valid plans)
                 // TODO(pre-remove-context): Approval context uses current worktree,
                 // but hooks execute in each target worktree.
-                let run_hooks = verify && approve_remove(args.yes)?;
+                let run_hooks = verify && approve_remove(yes)?;
 
                 // Execute all validated plans: others first, branch-only next, current last
                 let show_branch =
@@ -1122,7 +1104,7 @@ fn init_logging(verbose_level: u8) {
         .init();
 }
 
-fn handle_merge_command(args: MergeArgs) -> anyhow::Result<()> {
+fn handle_merge_command(args: MergeArgs, yes: bool) -> anyhow::Result<()> {
     if args.no_verify {
         eprintln!(
             "{}",
@@ -1137,7 +1119,7 @@ fn handle_merge_command(args: MergeArgs) -> anyhow::Result<()> {
         remove: flag_pair(args.remove, args.no_remove),
         ff: flag_pair(args.ff, args.no_ff),
         verify: flag_pair(args.verify, args.no_hooks || args.no_verify),
-        yes: args.yes,
+        yes,
         stage: args.stage,
         format: args.format,
     })
@@ -1146,20 +1128,21 @@ fn handle_merge_command(args: MergeArgs) -> anyhow::Result<()> {
 fn dispatch_command(
     command: Commands,
     working_dir: Option<std::path::PathBuf>,
+    yes: bool,
 ) -> anyhow::Result<()> {
     match command {
-        Commands::Config { action } => handle_config_command(action),
-        Commands::Step { action } => handle_step_command(action),
-        Commands::Hook { action } => handle_hook_command(action),
+        Commands::Config { action } => handle_config_command(action, yes),
+        Commands::Step { action } => handle_step_command(action, yes),
+        Commands::Hook { action } => handle_hook_command(action, yes),
         Commands::Select { branches, remotes } => handle_select_command(branches, remotes),
         Commands::List(args) => handle_list_command(args),
-        Commands::Switch(args) => handle_switch_command(args),
-        Commands::Remove(args) => handle_remove_command(args),
-        Commands::Merge(args) => handle_merge_command(args),
+        Commands::Switch(args) => handle_switch_command(args, yes),
+        Commands::Remove(args) => handle_remove_command(args, yes),
+        Commands::Merge(args) => handle_merge_command(args, yes),
         // `working_dir` is the top-level `-C <path>` flag, applied as the
         // child's current directory so global `-C` works for custom
         // subcommands the same way it does for built-ins.
-        Commands::Custom(args) => handle_custom_command(args, working_dir),
+        Commands::Custom(args) => handle_custom_command(args, working_dir, yes),
     }
 }
 
@@ -1262,6 +1245,7 @@ fn main() {
         directory,
         config,
         verbose,
+        yes,
         command,
     } = cli;
     // Globals were already applied in `parse_cli` before help rendering;
@@ -1278,7 +1262,7 @@ fn main() {
         return;
     };
 
-    let result = dispatch_command(command, directory);
+    let result = dispatch_command(command, directory, yes);
 
     match result {
         Ok(()) => finish_command(verbose, &command_line, None),

--- a/tests/integration_tests/approval_ui.rs
+++ b/tests/integration_tests/approval_ui.rs
@@ -583,3 +583,158 @@ fn test_step_hook_run_all_commands(repo: TestRepo) {
         "All commands should have run in order"
     );
 }
+
+/// The global `-y` / `--yes` flag skips approval when placed before the
+/// subcommand (e.g. `wt -y switch --create …`), not only in the per-command
+/// position where it used to live. Non-TTY invocations would fail on an
+/// approval prompt, so a clean exit confirms `-y` was honored.
+#[rstest]
+fn test_global_yes_before_subcommand(repo: TestRepo) {
+    repo.write_project_config(r#"post-create = "echo 'test command'""#);
+    repo.commit("Add config");
+
+    // Place `-y` before the subcommand name.
+    let output = repo
+        .wt_command()
+        .args(["-y", "switch", "--create", "feature-global-y"])
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("Failed to run wt -y switch");
+
+    assert!(
+        output.status.success(),
+        "wt -y switch failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// The global `--yes` flag skips approval for `wt hook <type>`, matching the
+/// per-command form at the same position.
+#[rstest]
+fn test_global_yes_for_hook(repo: TestRepo) {
+    repo.write_project_config(r#"pre-merge = "echo 'ran' > marker.txt""#);
+    repo.commit("Add pre-merge hook");
+
+    let output = repo
+        .wt_command()
+        .args(["--yes", "hook", "pre-merge"])
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("Failed to run wt --yes hook pre-merge");
+
+    assert!(
+        output.status.success(),
+        "wt --yes hook pre-merge failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let marker = repo.root_path().join("marker.txt");
+    let content = std::fs::read_to_string(&marker).expect("marker.txt should exist");
+    assert_eq!(content.trim(), "ran");
+}
+
+/// The global `-y` flag skips approval for project-config aliases, matching
+/// the post-alias `--yes` form.
+#[rstest]
+fn test_global_yes_for_alias(repo: TestRepo) {
+    repo.write_project_config(
+        r#"[aliases]
+deploy = "echo 'ran' > marker.txt"
+"#,
+    );
+    repo.commit("Add alias");
+
+    let output = repo
+        .wt_command()
+        .args(["-y", "deploy"])
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("Failed to run wt -y deploy");
+
+    assert!(
+        output.status.success(),
+        "wt -y deploy failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let marker = repo.root_path().join("marker.txt");
+    let content = std::fs::read_to_string(&marker).expect("marker.txt should exist");
+    assert_eq!(content.trim(), "ran");
+}
+
+/// The post-alias `--yes` form (`wt deploy --yes`) still works via
+/// `AliasOptions::parse`, intentionally preserved for backwards compatibility
+/// until the hand-rolled parser is removed in a later cleanup.
+#[rstest]
+fn test_post_alias_yes_still_works(repo: TestRepo) {
+    repo.write_project_config(
+        r#"[aliases]
+deploy = "echo 'ran' > marker.txt"
+"#,
+    );
+    repo.commit("Add alias");
+
+    let output = repo
+        .wt_command()
+        .args(["deploy", "--yes"])
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("Failed to run wt deploy --yes");
+
+    assert!(
+        output.status.success(),
+        "wt deploy --yes failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let marker = repo.root_path().join("marker.txt");
+    let content = std::fs::read_to_string(&marker).expect("marker.txt should exist");
+    assert_eq!(content.trim(), "ran");
+}
+
+/// The global `-y` flag skips approval when dispatched through
+/// `wt step <alias>`, covering the `step_alias` threading path.
+#[rstest]
+fn test_global_yes_for_step_alias(repo: TestRepo) {
+    repo.write_project_config(
+        r#"[aliases]
+deploy = "echo 'ran' > marker.txt"
+"#,
+    );
+    repo.commit("Add alias");
+
+    let output = repo
+        .wt_command()
+        .args(["-y", "step", "deploy"])
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("Failed to run wt -y step deploy");
+
+    assert!(
+        output.status.success(),
+        "wt -y step deploy failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let marker = repo.root_path().join("marker.txt");
+    let content = std::fs::read_to_string(&marker).expect("marker.txt should exist");
+    assert_eq!(content.trim(), "ran");
+}
+
+/// Commands without approval prompts accept `-y` without erroring — e.g.
+/// `wt -y list` is a valid no-op.
+#[rstest]
+fn test_global_yes_on_command_without_approval(repo: TestRepo) {
+    let output = repo
+        .wt_command()
+        .args(["-y", "list"])
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("Failed to run wt -y list");
+
+    assert!(
+        output.status.success(),
+        "wt -y list failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}

--- a/tests/snapshots/integration__integration_tests__help__help_config_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_approvals.snap
@@ -53,6 +53,9 @@ Usage: [1m[36mwt config approvals[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 Project hooks and project aliases prompt for approval on first run to prevent untrusted projects from running arbitrary commands. Approvals from both flows are stored together.
 
 [1m[32mExamples[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -52,6 +52,9 @@ Usage: [1m[36mwt config create[0m [36m[OPTIONS][0m
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 [1m[32mUser config[0m
 
 Creates [2m~/.config/worktrunk/config.toml[0m with the following content:

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -58,6 +58,9 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 [1m[32mExamples[0m
 
 Install shell integration (required for directory switching):

--- a/tests/snapshots/integration__integration_tests__help__help_config_shell.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_shell.snap
@@ -48,5 +48,6 @@ Usage: [1m[36mwt config shell[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_short.snap
@@ -49,5 +49,6 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_show.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_show.snap
@@ -62,6 +62,9 @@ Usage: [1m[36mwt config show[0m [36m[OPTIONS][0m
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 Shows location and contents of user config ([2m~/.config/worktrunk/config.toml[0m)
 and project config ([2m.config/wt.toml[0m). Also shows system config if present.
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state.snap
@@ -60,6 +60,9 @@ Usage: [1m[36mwt config state[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 State is stored in [2m.git/[0m (config entries and log files), separate from configuration files.
 
 [1m[32mKeys[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
@@ -58,6 +58,9 @@ Usage: [1m[36mwt config state ci-status[0m [36m[OPTIONS][0m [36m[COMMAND]
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 Caches GitHub/GitLab CI status for display in [2mwt list[0m.
 
 Requires [2mgh[0m (GitHub) or [2mglab[0m (GitLab) CLI, authenticated. Platform auto-detects from remote URL; override with [2mforge.platform = "github"[0m in [2m.config/wt.toml[0m for SSH host aliases or self-hosted instances. For GitHub Enterprise or self-hosted GitLab, also set [2mforge.hostname[0m.

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_clear.snap
@@ -50,6 +50,9 @@ Usage: [1m[36mwt config state clear[0m [36m[OPTIONS][0m
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 Clears all stored state:
 
 - Default branch cache

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
@@ -55,6 +55,9 @@ Usage: [1m[36mwt config state default-branch[0m [36m[OPTIONS][0m [36m[COMM
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 Useful in scripts to avoid hardcoding [2mmain[0m or [2mmaster[0m:
 
 [107m [0m [2m[0m[2m[34mgit[0m[2m rebase $([0m[2m[34mwt[0m[2m config state default-branch)[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_get.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_get.snap
@@ -55,6 +55,9 @@ Usage: [1m[36mwt config state get[0m [36m[OPTIONS][0m
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 Shows all stored state including:
 
 - [1mDefault branch[0m: Cached result of querying remote for default branch

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
@@ -58,6 +58,9 @@ Usage: [1m[36mwt config state logs[0m [36m[OPTIONS][0m [36m[COMMAND][0m
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 View and manage log files — hook output, command audit trail, and debug diagnostics.
 
 [1m[32mWhat's logged[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
@@ -59,6 +59,9 @@ Usage: [1m[36mwt config state marker[0m [36m[OPTIONS][0m [36m[COMMAND][0m
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 Custom status text or emoji shown in the [2mwt list[0m Status column.
 
 [1m[32mDisplay[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch.snap
@@ -55,6 +55,9 @@ Usage: [1m[36mwt config state previous-branch[0m [36m[OPTIONS][0m [36m[COM
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 Enables [2mwt switch -[0m to return to the previous worktree, similar to [2mcd -[0m or [2mgit checkout -[0m.
 
 [1m[32mHow it works[0m

--- a/tests/snapshots/integration__integration_tests__help__help_hook_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_approvals.snap
@@ -53,6 +53,9 @@ Usage: [1m[36mwt hook approvals[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 Project hooks require approval on first run to prevent untrusted projects from running arbitrary commands.
 
 [1m[32mExamples[0m

--- a/tests/snapshots/integration__integration_tests__help__help_hook_approvals_add.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_approvals_add.snap
@@ -53,6 +53,9 @@ Usage: [1m[36mwt hook approvals add[0m [36m[OPTIONS][0m
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 Prompts for approval of all project commands and saves them to approvals.toml.
 
 By default, shows only unapproved commands. Use [2m--all[0m to review all commands

--- a/tests/snapshots/integration__integration_tests__help__help_hook_approvals_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_hook_approvals_clear.snap
@@ -53,6 +53,9 @@ Usage: [1m[36mwt hook approvals clear[0m [36m[OPTIONS][0m
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 Removes saved approvals, requiring re-approval on next command run.
 
 By default, clears approvals for the current project. Use [2m--global[0m to clear

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -71,6 +71,9 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 Shows uncommitted changes, divergence from the default branch and remote, and optional CI status and LLM summaries.
 
 The table renders progressively: branch names, paths, and commit hashes appear immediately, then status, divergence, and other columns fill in as background git operations complete.

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -74,6 +74,9 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs 
           + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 Shows uncommitted changes, divergence from the default branch and remote, and 
 optional CI status and LLM summaries.
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_short.snap
@@ -50,5 +50,6 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
@@ -70,9 +70,6 @@ Options:
           Print help (see a summary with '-h')
 
 Automation:
-  -y, --yes
-          Skip approval prompts
-
       --no-hooks
           Skip hooks
 
@@ -96,6 +93,9 @@ Global Options:
 
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+
+  -y, --yes
+          Skip approval prompts
 
 Unlike `git merge`, this merges the current branch into the target branch — not the target into current. Similar to clicking "Merge pull request" on GitHub, but locally. The target defaults to the default branch.
 

--- a/tests/snapshots/integration__integration_tests__help__help_md_root.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_root.snap
@@ -59,6 +59,9 @@ Global Options:
   -v, --verbose...
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  -y, --yes
+          Skip approval prompts
+
 Getting started
 
   wt switch --create feature    # Create worktree and branch

--- a/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
@@ -70,9 +70,6 @@ Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET][0m
           Print help (see a summary with '-h')
 
 [1m[32mAutomation:[0m
-  [1m[36m-y[0m, [1m[36m--yes[0m
-          Skip approval prompts
-
       [1m[36m--no-hooks[0m
           Skip hooks
 
@@ -96,6 +93,9 @@ Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET][0m
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
 
 Unlike [2mgit merge[0m, this merges the current branch into the target branch — not the target into current. Similar to clicking "Merge pull request" on GitHub, but locally. The target defaults to the default branch.
 

--- a/tests/snapshots/integration__integration_tests__help__help_merge_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_short.snap
@@ -47,7 +47,6 @@ Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET][0m
   [1m[36m-h[0m, [1m[36m--help[0m           Print help (see more with '--help')
 
 [1m[32mAutomation:[0m
-  [1m[36m-y[0m, [1m[36m--yes[0m              Skip approval prompts
       [1m[36m--no-hooks[0m         Skip hooks
       [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m  Output format [default: text] [possible values: text, json]
 
@@ -55,5 +54,6 @@ Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET][0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_no_args.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_no_args.snap
@@ -49,5 +49,6 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
@@ -59,9 +59,6 @@ Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...[0m
           Print help (see a summary with '-h')
 
 [1m[32mAutomation:[0m
-  [1m[36m-y[0m, [1m[36m--yes[0m
-          Skip approval prompts
-
       [1m[36m--no-hooks[0m
           Skip hooks
 
@@ -85,6 +82,9 @@ Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...[0m
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
 
 [1m[32mExamples[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_remove_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_short.snap
@@ -45,7 +45,6 @@ Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...[0m
   [1m[36m-h[0m, [1m[36m--help[0m              Print help (see more with '--help')
 
 [1m[32mAutomation:[0m
-  [1m[36m-y[0m, [1m[36m--yes[0m              Skip approval prompts
       [1m[36m--no-hooks[0m         Skip hooks
       [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m  Output format [default: text] [possible values: text, json]
 
@@ -53,5 +52,6 @@ Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_root_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root_long.snap
@@ -59,6 +59,9 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 Getting started
 
   wt switch --create feature    # Create worktree and branch

--- a/tests/snapshots/integration__integration_tests__help__help_root_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root_short.snap
@@ -50,5 +50,6 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_step_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_long.snap
@@ -63,6 +63,9 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 [1m[32mExamples[0m
 
 Commit with LLM-generated message:

--- a/tests/snapshots/integration__integration_tests__help__help_step_promote.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_promote.snap
@@ -57,6 +57,9 @@ Usage: [1m[36mwt step promote[0m [36m[OPTIONS][0m [36m[BRANCH][0m
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
 [1mExperimental.[0m Use promote for temporary testing when the main worktree has special significance (Docker Compose, IDE configs, heavy build artifacts anchored to project root), and hooks & tools aren't yet set up to run on arbitrary worktrees. The idiomatic Worktrunk workflow does not use [2mpromote[0m; instead each worktree has a full environment. [2mpromote[0m is the only Worktrunk command which changes a branch in an existing worktree.
 
 [1m[32mExample[0m

--- a/tests/snapshots/integration__integration_tests__help__help_step_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_short.snap
@@ -54,5 +54,6 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -91,9 +91,6 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
           Include remote branches
 
 [1m[32mAutomation:[0m
-  [1m[36m-y[0m, [1m[36m--yes[0m
-          Skip approval prompts
-
       [1m[36m--no-hooks[0m
           Skip hooks
 
@@ -117,6 +114,9 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
 
 Worktrees are addressed by branch name; paths are computed from a configurable template. Unlike [2mgit switch[0m, this navigates between worktrees rather than changing branches in place.
 

--- a/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
@@ -51,7 +51,6 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
       [1m[36m--remotes[0m   Include remote branches
 
 [1m[32mAutomation:[0m
-  [1m[36m-y[0m, [1m[36m--yes[0m              Skip approval prompts
       [1m[36m--no-hooks[0m         Skip hooks
       [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m  Output format [default: text] [possible values: text, json]
 
@@ -59,5 +58,6 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_alias__step_help_includes_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_help_includes_aliases.snap
@@ -69,5 +69,6 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_alias__step_list_no_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_list_no_aliases.snap
@@ -65,5 +65,6 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_alias__step_list_with_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_list_with_aliases.snap
@@ -70,5 +70,6 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----


### PR DESCRIPTION
## Summary

`-y, --yes` is now a top-level global clap flag. It moves off every subcommand's clap args and lives once on `Cli`, so `wt -y <anything>`, `wt <anything> --yes`, and `wt --yes <anything>` all skip any approval or confirmation prompt for that invocation.

## Why

Follow-up to the top-level alias dispatch (#2266). The long-term plan is to unify approval-bypass behavior — `-y` should be a true global rather than duplicated across switch, remove, merge, commit, squash, prune, all ten hook subcommands, shell install/uninstall, plugin install/uninstall, and config update. A single canonical flag removes ~50 lines of duplicated clap definitions and one source of drift.

## Call-site survey

Approval and confirmation prompt sources, as surfaced by `rg -l 'approve_|requires_approval|confirm_'`:

- `approve_hooks` / `approve_hooks_filtered` — reads `ctx.yes`, already threaded via `CommandContext::new(..., yes)`. No change needed; the global now feeds those call sites from `handle_*_command` in `main.rs`.
- `approve_command_batch` (merge, config `hook approvals add`) — takes `yes: bool`. Receives the global.
- `approve_alias_commands` — takes `yes: bool`. Receives `global_yes || opts.yes` (see "Alias compat" below).
- `handle_configure_shell` / `handle_unconfigure_shell` / `handle_config_update` / `handle_claude_install[_statusline]` / `handle_claude_uninstall` / `handle_opencode_install` / `handle_opencode_uninstall` — take `yes: bool` for confirmation-prompt bypass. All receive the global.

## Alias compat

`AliasOptions` is hand-rolled (not clap) so it doesn't conflict with the clap global. Its post-alias `--yes` parsing is intentionally preserved here — `run_alias` does `let skip_approval = global_yes || opts.yes;` so both `wt -y deploy` and `wt deploy --yes` work unchanged. Removing the post-alias form is a separate cleanup, tracked by the user's long-term simplification plan.

## Navigating the diff

- `src/cli/mod.rs` — new `yes: bool` on `Cli` with `global = true`, `short = 'y'`, `help_heading = "Global Options"`, `display_order = 103` (slots after `-v`). Removed the per-command `yes` field from `SwitchArgs`, `RemoveArgs`, `MergeArgs`.
- `src/cli/step.rs` — removed `yes` from `CommitArgs`, `SquashArgs`, and `StepCommand::Prune`. Also dropped `help_heading = "Automation"` from the four step subcommands where the group was left with a single flag (`commit`, `squash`, `for-each`, `prune`); those flags now render under default Options instead of a single-item group.
- `src/cli/hook.rs` — removed `yes` from all ten hook subcommands (`pre-switch`, `post-switch`, `pre-start`, `post-start`, `pre-commit`, `post-commit`, `pre-merge`, `post-merge`, `pre-remove`, `post-remove`). `--yes` stays in `KNOWN_HOOK_LONG_FLAGS` so the shorthand rewriter still recognizes it as a real flag rather than a template variable.
- `src/cli/config.rs` — removed `yes` from `ConfigShellCommand::Install/Uninstall`, `ConfigCommand::Update` (and its now-redundant `conflicts_with = "yes"` on `--print`), `ConfigPluginsOpencodeCommand::Install/Uninstall`, `ConfigPluginsClaudeCommand::Install/Uninstall/InstallStatusline`.
- `src/main.rs` — `dispatch_command` takes `yes: bool`; each `handle_*_command` accepts and threads it. `Cli` destructure adds `yes`.
- `src/commands/alias.rs` — `try_alias`, `step_alias`, `run_alias` take `global_yes: bool`. `run_alias` OR's with `opts.yes` before calling `approve_alias_commands`.
- `src/commands/custom.rs` — `handle_custom_command` accepts and passes the global to `try_alias`.
- `docs/content/` + `skills/worktrunk/reference/` — auto-generated from `--help-page`; the global appears under "Global Options" on every subcommand.
- `tests/integration_tests/approval_ui.rs` — six new tests: `test_global_yes_before_subcommand`, `test_global_yes_for_hook`, `test_global_yes_for_alias`, `test_post_alias_yes_still_works`, `test_global_yes_for_step_alias`, `test_global_yes_on_command_without_approval`.

## Notes

- Does not remove `AliasOptions::yes` — deferred cleanup per the task brief.
- Snapshot churn (~27 help files) is the expected fallout of adding a global flag; each subcommand's `--help` now shows `-y, --yes` under Global Options.

## Test plan

- [x] 3242 tests pass (`cargo run -- hook pre-merge --yes`)
- [x] Lints clean (clippy, cargo fmt, pre-commit)
- [x] Doc sync test passes after regeneration
- [x] New approval_ui tests cover before-subcommand, after-subcommand, alias, post-alias, step-alias, and no-approval positions

> _This was written by Claude Code on behalf of Maximilian_

🤖 Generated with [Claude Code](https://claude.com/claude-code)