### PR TITLE
feat(cli): move approvals subcommand from hook to config

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -473,12 +473,13 @@ Includes shell integration, hooks, and saved state.
 Usage: <b><span class=c>wt config</span></b> <span class=c>[OPTIONS]</span> <span class=c>&lt;COMMAND&gt;</span>
 
 <b><span class=g>Commands:</span></b>
-  <b><span class=c>shell</span></b>    Shell integration setup
-  <b><span class=c>create</span></b>   Create configuration file
-  <b><span class=c>show</span></b>     Show configuration files &amp; locations
-  <b><span class=c>update</span></b>   Update deprecated config settings
-  <b><span class=c>plugins</span></b>  Plugin management
-  <b><span class=c>state</span></b>    Manage internal data and cache
+  <b><span class=c>shell</span></b>      Shell integration setup
+  <b><span class=c>create</span></b>     Create configuration file
+  <b><span class=c>show</span></b>       Show configuration files &amp; locations
+  <b><span class=c>update</span></b>     Update deprecated config settings
+  <b><span class=c>approvals</span></b>  Manage command approvals
+  <b><span class=c>plugins</span></b>    Plugin management
+  <b><span class=c>state</span></b>      Manage internal data and cache
 
 <b><span class=g>Options:</span></b>
   <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
@@ -541,6 +542,54 @@ Usage: <b><span class=c>wt config show</span></b> <span class=c>[OPTIONS]</span>
           - <b><span class=c>json</span></b>: JSON output
 
           [default: text]
+
+<b><span class=g>Global Options:</span></b>
+  <b><span class=c>-C</span></b><span class=c> &lt;path&gt;</span>
+          Working directory for this command
+
+      <b><span class=c>--config</span></b><span class=c> &lt;path&gt;</span>
+          User config file path
+
+  <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
+          + trace.log/output.log under .git/wt/logs/)
+{% end %}
+
+## wt config approvals
+
+Manage command approvals.
+
+Project hooks and project aliases prompt for approval on first run to prevent untrusted projects from running arbitrary commands. Approvals from both flows are stored together.
+
+### Examples
+
+Pre-approve all hook and alias commands for current project:
+{{ terminal(cmd="wt config approvals add") }}
+
+Clear approvals for current project:
+{{ terminal(cmd="wt config approvals clear") }}
+
+Clear global approvals:
+{{ terminal(cmd="wt config approvals clear --global") }}
+
+### How approvals work
+
+Approved commands are saved to `~/.config/worktrunk/approvals.toml`. Re-approval is required when the command template changes or the project moves. Use `--yes` to bypass prompts in CI.
+
+### Command reference
+
+{% terminal() %}
+wt config approvals - Manage command approvals
+
+Usage: <b><span class=c>wt config approvals</span></b> <span class=c>[OPTIONS]</span> <span class=c>&lt;COMMAND&gt;</span>
+
+<b><span class=g>Commands:</span></b>
+  <b><span class=c>add</span></b>    Store approvals in approvals.toml
+  <b><span class=c>clear</span></b>  Clear approved commands from approvals.toml
+
+<b><span class=g>Options:</span></b>
+  <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
+          Print help (see a summary with &#39;-h&#39;)
 
 <b><span class=g>Global Options:</span></b>
   <b><span class=c>-C</span></b><span class=c> &lt;path&gt;</span>

--- a/docs/content/extending.md
+++ b/docs/content/extending.md
@@ -42,7 +42,7 @@ Hooks are shell commands that run at key points in the worktree lifecycle. Ten h
 Hooks live in two places:
 
 - **User config** (`~/.config/worktrunk/config.toml`) — personal, applies everywhere, trusted
-- **Project config** (`.config/wt.toml`) — shared with the team, requires [approval](@/hook.md#wt-hook-approvals) on first run
+- **Project config** (`.config/wt.toml`) — shared with the team, requires [approval](@/config.md#wt-config-approvals) on first run
 
 Three formats, from simplest to most expressive.
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -88,7 +88,7 @@ Created by `wt switch <branch>` when switching to a branch that doesn't have a w
 | File | Created by | Purpose |
 |------|------------|---------|
 | `~/.config/worktrunk/config.toml` | `wt config create` | User preferences |
-| `~/.config/worktrunk/approvals.toml` | Approving project commands | Approved hook commands |
+| `~/.config/worktrunk/approvals.toml` | Approving project commands | Approved hook and alias commands |
 | `.config/wt.toml` | `wt config create --project` | Project hooks (checked into repo) |
 
 User config location: `$XDG_CONFIG_HOME/worktrunk/` (or `~/.config/worktrunk/`) on Linux/macOS, `%APPDATA%\worktrunk\` on Windows.
@@ -176,7 +176,7 @@ Worktrunk runs `git` commands internally and optionally runs `gh` (GitHub) or `g
 3. **LLM commands** (`~/.config/worktrunk/config.toml`) — Commit message generation and [branch summaries](@/llm-commits.md#branch-summaries)
 4. **--execute flag** — Explicitly provided commands
 
-User hooks don't require approval (you defined them). Commands from project hooks require approval on first run. Approved commands are saved to the approvals file (`approvals.toml`). If a command changes, Worktrunk requires new approval.
+User hooks and user aliases don't require approval (you defined them). Commands from project hooks and project aliases require approval on first run. Approved commands are saved to the approvals file (`approvals.toml`). If a command changes, Worktrunk requires new approval.
 
 ### Example approval prompt
 

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -64,7 +64,7 @@ Project commands require approval on first run:
 - Use `--yes` to bypass prompts — useful for CI and automation
 - Use `--no-hooks` to skip hooks
 
-Manage approvals with `wt hook approvals add` and `wt hook approvals clear`.
+Manage approvals with `wt config approvals add` and `wt config approvals clear`.
 
 # Configuration
 
@@ -462,7 +462,7 @@ remove-db = "docker stop {{ repo }}-{{ branch | sanitize }}-postgres 2>/dev/null
 
 - [`wt merge`](@/merge.md) — Runs hooks automatically during merge
 - [`wt switch`](@/switch.md) — Runs pre-start/post-start hooks on `--create`
-- [`wt config`](@/config.md) — Manage hook approvals
+- [`wt config approvals`](@/config.md#wt-config-approvals) — Manage approvals
 - [`wt config state logs`](@/config.md#wt-config-state-logs) — Access background hook logs
 
 ## Command reference
@@ -484,57 +484,6 @@ Usage: <b><span class=c>wt hook</span></b> <span class=c>[OPTIONS]</span> <span 
   <b><span class=c>post-merge</span></b>   Run post-merge hooks
   <b><span class=c>pre-remove</span></b>   Run pre-remove hooks
   <b><span class=c>post-remove</span></b>  Run post-remove hooks
-  <b><span class=c>approvals</span></b>    Manage command approvals
-
-<b><span class=g>Options:</span></b>
-  <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
-          Print help (see a summary with &#39;-h&#39;)
-
-<b><span class=g>Global Options:</span></b>
-  <b><span class=c>-C</span></b><span class=c> &lt;path&gt;</span>
-          Working directory for this command
-
-      <b><span class=c>--config</span></b><span class=c> &lt;path&gt;</span>
-          User config file path
-
-  <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
-{% end %}
-
-# Subcommands
-
-## wt hook approvals
-
-Manage command approvals.
-
-Project hooks require approval on first run to prevent untrusted projects from running arbitrary commands.
-
-### Examples
-
-Pre-approve all commands for current project:
-{{ terminal(cmd="wt hook approvals add") }}
-
-Clear approvals for current project:
-{{ terminal(cmd="wt hook approvals clear") }}
-
-Clear global approvals:
-{{ terminal(cmd="wt hook approvals clear --global") }}
-
-### How approvals work
-
-Approved commands are saved to `~/.config/worktrunk/approvals.toml`. Re-approval is required when the command template changes or the project moves. Use `--yes` to bypass prompts in CI.
-
-### Command reference
-
-{% terminal() %}
-wt hook approvals - Manage command approvals
-
-Usage: <b><span class=c>wt hook approvals</span></b> <span class=c>[OPTIONS]</span> <span class=c>&lt;COMMAND&gt;</span>
-
-<b><span class=g>Commands:</span></b>
-  <b><span class=c>add</span></b>    Store approvals in approvals.toml
-  <b><span class=c>clear</span></b>  Clear approved commands from approvals.toml
 
 <b><span class=g>Options:</span></b>
   <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -476,12 +476,13 @@ Includes shell integration, hooks, and saved state.
 Usage: wt config [OPTIONS] <COMMAND>
 
 Commands:
-  shell    Shell integration setup
-  create   Create configuration file
-  show     Show configuration files & locations
-  update   Update deprecated config settings
-  plugins  Plugin management
-  state    Manage internal data and cache
+  shell      Shell integration setup
+  create     Create configuration file
+  show       Show configuration files & locations
+  update     Update deprecated config settings
+  approvals  Manage command approvals
+  plugins    Plugin management
+  state      Manage internal data and cache
 
 Options:
   -h, --help
@@ -546,6 +547,60 @@ Output:
           - json: JSON output
 
           [default: text]
+
+Global Options:
+  -C <path>
+          Working directory for this command
+
+      --config <path>
+          User config file path
+
+  -v, --verbose...
+          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
+          + trace.log/output.log under .git/wt/logs/)
+```
+
+## wt config approvals
+
+Manage command approvals.
+
+Project hooks and project aliases prompt for approval on first run to prevent untrusted projects from running arbitrary commands. Approvals from both flows are stored together.
+
+### Examples
+
+Pre-approve all hook and alias commands for current project:
+```bash
+$ wt config approvals add
+```
+
+Clear approvals for current project:
+```bash
+$ wt config approvals clear
+```
+
+Clear global approvals:
+```bash
+$ wt config approvals clear --global
+```
+
+### How approvals work
+
+Approved commands are saved to `~/.config/worktrunk/approvals.toml`. Re-approval is required when the command template changes or the project moves. Use `--yes` to bypass prompts in CI.
+
+### Command reference
+
+```
+wt config approvals - Manage command approvals
+
+Usage: wt config approvals [OPTIONS] <COMMAND>
+
+Commands:
+  add    Store approvals in approvals.toml
+  clear  Clear approved commands from approvals.toml
+
+Options:
+  -h, --help
+          Print help (see a summary with '-h')
 
 Global Options:
   -C <path>

--- a/skills/worktrunk/reference/extending.md
+++ b/skills/worktrunk/reference/extending.md
@@ -35,7 +35,7 @@ Hooks are shell commands that run at key points in the worktree lifecycle. Ten h
 Hooks live in two places:
 
 - **User config** (`~/.config/worktrunk/config.toml`) — personal, applies everywhere, trusted
-- **Project config** (`.config/wt.toml`) — shared with the team, requires [approval](https://worktrunk.dev/hook/#wt-hook-approvals) on first run
+- **Project config** (`.config/wt.toml`) — shared with the team, requires [approval](https://worktrunk.dev/config/#wt-config-approvals) on first run
 
 Three formats, from simplest to most expressive.
 

--- a/skills/worktrunk/reference/faq.md
+++ b/skills/worktrunk/reference/faq.md
@@ -81,7 +81,7 @@ Created by `wt switch <branch>` when switching to a branch that doesn't have a w
 | File | Created by | Purpose |
 |------|------------|---------|
 | `~/.config/worktrunk/config.toml` | `wt config create` | User preferences |
-| `~/.config/worktrunk/approvals.toml` | Approving project commands | Approved hook commands |
+| `~/.config/worktrunk/approvals.toml` | Approving project commands | Approved hook and alias commands |
 | `.config/wt.toml` | `wt config create --project` | Project hooks (checked into repo) |
 
 User config location: `$XDG_CONFIG_HOME/worktrunk/` (or `~/.config/worktrunk/`) on Linux/macOS, `%APPDATA%\worktrunk\` on Windows.
@@ -171,7 +171,7 @@ Worktrunk runs `git` commands internally and optionally runs `gh` (GitHub) or `g
 3. **LLM commands** (`~/.config/worktrunk/config.toml`) — Commit message generation and [branch summaries](https://worktrunk.dev/llm-commits/#branch-summaries)
 4. **--execute flag** — Explicitly provided commands
 
-User hooks don't require approval (you defined them). Commands from project hooks require approval on first run. Approved commands are saved to the approvals file (`approvals.toml`). If a command changes, Worktrunk requires new approval.
+User hooks and user aliases don't require approval (you defined them). Commands from project hooks and project aliases require approval on first run. Approved commands are saved to the approvals file (`approvals.toml`). If a command changes, Worktrunk requires new approval.
 
 ### Example approval prompt
 

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -55,7 +55,7 @@ Project commands require approval on first run:
 - Use `--yes` to bypass prompts — useful for CI and automation
 - Use `--no-hooks` to skip hooks
 
-Manage approvals with `wt hook approvals add` and `wt hook approvals clear`.
+Manage approvals with `wt config approvals add` and `wt config approvals clear`.
 
 # Configuration
 
@@ -477,63 +477,6 @@ Commands:
   post-merge   Run post-merge hooks
   pre-remove   Run pre-remove hooks
   post-remove  Run post-remove hooks
-  approvals    Manage command approvals
-
-Options:
-  -h, --help
-          Print help (see a summary with '-h')
-
-Global Options:
-  -C <path>
-          Working directory for this command
-
-      --config <path>
-          User config file path
-
-  -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
-```
-
-# Subcommands
-
-## wt hook approvals
-
-Manage command approvals.
-
-Project hooks require approval on first run to prevent untrusted projects from running arbitrary commands.
-
-### Examples
-
-Pre-approve all commands for current project:
-```bash
-$ wt hook approvals add
-```
-
-Clear approvals for current project:
-```bash
-$ wt hook approvals clear
-```
-
-Clear global approvals:
-```bash
-$ wt hook approvals clear --global
-```
-
-### How approvals work
-
-Approved commands are saved to `~/.config/worktrunk/approvals.toml`. Re-approval is required when the command template changes or the project moves. Use `--yes` to bypass prompts in CI.
-
-### Command reference
-
-```
-wt hook approvals - Manage command approvals
-
-Usage: wt hook approvals [OPTIONS] <COMMAND>
-
-Commands:
-  add    Store approvals in approvals.toml
-  clear  Clear approved commands from approvals.toml
 
 Options:
   -h, --help

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -336,8 +336,9 @@ Skips gracefully if the statusline is already configured."#
 }
 
 // Ordering: user journey — shell (install integration), create (bootstrap
-// config files), show (inspect), update (migrate deprecations), plugins
-// (optional add-ons), state (advanced diagnostics).
+// config files), show (inspect), update (migrate deprecations), approvals
+// (security policy for project commands), plugins (optional add-ons), state
+// (advanced diagnostics).
 #[derive(Subcommand)]
 pub enum ConfigCommand {
     /// Shell integration setup
@@ -429,6 +430,36 @@ $ wt config update --print
         /// Print the migrated config to stdout instead of writing it
         #[arg(long, conflicts_with = "yes")]
         print: bool,
+    },
+
+    /// Manage command approvals
+    #[command(
+        after_long_help = r#"Project hooks and project aliases prompt for approval on first run to prevent untrusted projects from running arbitrary commands. Approvals from both flows are stored together.
+
+## Examples
+
+Pre-approve all hook and alias commands for current project:
+```console
+$ wt config approvals add
+```
+
+Clear approvals for current project:
+```console
+$ wt config approvals clear
+```
+
+Clear global approvals:
+```console
+$ wt config approvals clear --global
+```
+
+## How approvals work
+
+Approved commands are saved to `~/.config/worktrunk/approvals.toml`. Re-approval is required when the command template changes or the project moves. Use `--yes` to bypass prompts in CI."#
+    )]
+    Approvals {
+        #[command(subcommand)]
+        action: ApprovalsCommand,
     },
 
     /// Plugin management

--- a/src/cli/hook.rs
+++ b/src/cli/hook.rs
@@ -6,8 +6,9 @@ use super::config::ApprovalsCommand;
 
 /// Hook subcommands that accept `--var KEY=VALUE` (and the `--KEY=VALUE` shorthand).
 ///
-/// Excludes `show`, `approvals`, and `run-pipeline`, which don't expand
-/// template variables. `post-create` is the deprecated alias for `pre-start`.
+/// Excludes `show`, `run-pipeline`, and the deprecated `approvals` (now under
+/// `wt config approvals`), which don't expand template variables. `post-create`
+/// is the deprecated alias for `pre-start`.
 const HOOK_SUBCOMMANDS_WITH_VARS: &[&str] = &[
     "pre-switch",
     "post-switch",
@@ -376,8 +377,7 @@ mod tests {
 
 // Ordering: worktree lifecycle phases (switch → start → commit → merge →
 // remove), with each phase's `pre-` immediately before its `post-`. `show`
-// first (read-only introspection), `approvals` last (administration). Hidden
-// commands last.
+// first (read-only introspection). Hidden commands last.
 /// Run configured hooks
 #[derive(Subcommand)]
 pub enum HookCommand {
@@ -653,31 +653,8 @@ pub enum HookCommand {
     #[command(hide = true, name = "run-pipeline")]
     RunPipeline,
 
-    /// Manage command approvals
-    #[command(
-        after_long_help = r#"Project hooks require approval on first run to prevent untrusted projects from running arbitrary commands.
-
-## Examples
-
-Pre-approve all commands for current project:
-```console
-$ wt hook approvals add
-```
-
-Clear approvals for current project:
-```console
-$ wt hook approvals clear
-```
-
-Clear global approvals:
-```console
-$ wt hook approvals clear --global
-```
-
-## How approvals work
-
-Approved commands are saved to `~/.config/worktrunk/approvals.toml`. Re-approval is required when the command template changes or the project moves. Use `--yes` to bypass prompts in CI."#
-    )]
+    /// Deprecated: use `wt config approvals` instead
+    #[command(hide = true)]
     Approvals {
         #[command(subcommand)]
         action: ApprovalsCommand,

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1203,7 +1203,7 @@ Project commands require approval on first run:
 - Use `--yes` to bypass prompts — useful for CI and automation
 - Use `--no-hooks` to skip hooks
 
-Manage approvals with `wt hook approvals add` and `wt hook approvals clear`.
+Manage approvals with `wt config approvals add` and `wt config approvals clear`.
 
 # Configuration
 
@@ -1610,10 +1610,8 @@ remove-db = "docker stop {{ repo }}-{{ branch | sanitize }}-postgres 2>/dev/null
 
 - [`wt merge`](@/merge.md) — Runs hooks automatically during merge
 - [`wt switch`](@/switch.md) — Runs pre-start/post-start hooks on `--create`
-- [`wt config`](@/config.md) — Manage hook approvals
+- [`wt config approvals`](@/config.md#wt-config-approvals) — Manage approvals
 - [`wt config state logs`](@/config.md#wt-config-state-logs) — Access background hook logs
-
-<!-- subdoc: approvals -->
 "#
     )]
     Hook {
@@ -2088,6 +2086,7 @@ $ WORKTRUNK_COMMIT__GENERATION__COMMAND="echo 'test: automated commit'" wt merge
 | `NO_COLOR` | Disable colored output ([standard](https://no-color.org/)) |
 | `CLICOLOR_FORCE` | Force colored output even when not a TTY |
 <!-- subdoc: show -->
+<!-- subdoc: approvals -->
 <!-- subdoc: state -->"#)]
     Config {
         #[command(subcommand)]

--- a/src/commands/hook_commands.rs
+++ b/src/commands/hook_commands.rs
@@ -32,7 +32,7 @@ use super::hooks::{
     HookCommandSpec, check_name_filter_matched, count_sourced_commands, prepare_background_hooks,
     prepare_sourced_steps, run_hook_with_filter, spawn_hook_pipeline,
 };
-use super::project_config::collect_commands_for_hooks;
+use super::project_config::{collect_commands_for_aliases, collect_commands_for_hooks};
 
 fn run_filtered_hook(
     ctx: &CommandContext,
@@ -388,7 +388,7 @@ pub fn run_hook(
     }
 }
 
-/// Handle `wt hook approvals add` command - approve all commands in the project
+/// Handle `wt config approvals add` command - approve all hook and alias commands in the project
 pub fn add_approvals(show_all: bool) -> anyhow::Result<()> {
     use super::command_approval::approve_command_batch;
 
@@ -404,9 +404,11 @@ pub fn add_approvals(show_all: bool) -> anyhow::Result<()> {
         .load_project_config()?
         .ok_or(GitError::ProjectConfigNotFound { config_path })?;
 
-    // Collect all commands from the project config
+    // Collect all commands from the project config: hooks first (lifecycle order),
+    // then aliases (alphabetical via BTreeMap).
     let all_hooks: Vec<_> = HookType::iter().collect();
-    let commands = collect_commands_for_hooks(&project_config, &all_hooks);
+    let mut commands = collect_commands_for_hooks(&project_config, &all_hooks);
+    commands.extend(collect_commands_for_aliases(&project_config));
 
     if commands.is_empty() {
         eprintln!("{}", info_message("No commands configured in project"));
@@ -447,7 +449,7 @@ pub fn add_approvals(show_all: bool) -> anyhow::Result<()> {
     Ok(())
 }
 
-/// Handle `wt hook approvals clear` command - clear approved commands
+/// Handle `wt config approvals clear` command - clear approved commands
 pub fn clear_approvals(global: bool) -> anyhow::Result<()> {
     let mut approvals = Approvals::load().context("Failed to load approvals")?;
 

--- a/src/commands/project_config.rs
+++ b/src/commands/project_config.rs
@@ -43,6 +43,26 @@ pub fn collect_commands_for_hooks(
     commands
 }
 
+/// Collect commands for every project-config alias, in `BTreeMap` (alphabetical) order.
+///
+/// Mirrors `approve_alias_commands` in `command_approval.rs`: unnamed steps within
+/// an alias inherit the alias name, so users see a stable label in approval prompts.
+pub fn collect_commands_for_aliases(project_config: &ProjectConfig) -> Vec<ApprovableCommand> {
+    project_config
+        .aliases
+        .iter()
+        .flat_map(|(alias_name, alias_cfg)| {
+            alias_cfg.commands().map(move |cmd| ApprovableCommand {
+                phase: Phase::Alias,
+                command: Command::new(
+                    Some(cmd.name.clone().unwrap_or_else(|| alias_name.clone())),
+                    cmd.template.clone(),
+                ),
+            })
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -748,7 +748,7 @@ impl GitError {
             }
 
             GitError::NotInteractive => {
-                let approvals_cmd = suggest_command("hook", &["approvals", "add"], &[]);
+                let approvals_cmd = suggest_command("config", &["approvals", "add"], &[]);
                 write!(
                     f,
                     "{}\n{}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -237,10 +237,16 @@ fn handle_hook_command(action: HookCommand) -> anyhow::Result<()> {
             &vars,
         ),
         HookCommand::RunPipeline => commands::run_pipeline(),
-        HookCommand::Approvals { action } => match action {
-            ApprovalsCommand::Add { all } => add_approvals(all),
-            ApprovalsCommand::Clear { global } => clear_approvals(global),
-        },
+        HookCommand::Approvals { action } => {
+            eprintln!(
+                "{}",
+                warning_message("wt hook approvals is deprecated; use wt config approvals instead")
+            );
+            match action {
+                ApprovalsCommand::Add { all } => add_approvals(all),
+                ApprovalsCommand::Clear { global } => clear_approvals(global),
+            }
+        }
     }
 }
 
@@ -502,6 +508,10 @@ fn handle_config_command(action: ConfigCommand) -> anyhow::Result<()> {
         ConfigCommand::Create { project } => handle_config_create(project),
         ConfigCommand::Show { full, format } => handle_config_show(full, format),
         ConfigCommand::Update { yes, print } => handle_config_update(yes, print),
+        ConfigCommand::Approvals { action } => match action {
+            ApprovalsCommand::Add { all } => add_approvals(all),
+            ApprovalsCommand::Clear { global } => clear_approvals(global),
+        },
         ConfigCommand::Plugins { action } => handle_plugins_command(action),
         ConfigCommand::State { action } => handle_state_command(action),
     }

--- a/tests/integration_tests/approvals.rs
+++ b/tests/integration_tests/approvals.rs
@@ -12,7 +12,7 @@ use worktrunk::config::Approvals;
 fn snapshot_add_approvals(test_name: &str, repo: &TestRepo, args: &[&str]) {
     let settings = setup_snapshot_settings(repo);
     settings.bind(|| {
-        let mut cmd = make_snapshot_cmd(repo, "hook", &[], None);
+        let mut cmd = make_snapshot_cmd(repo, "config", &[], None);
         cmd.arg("approvals").arg("add").args(args);
         assert_cmd_snapshot!(test_name, cmd);
     });
@@ -22,7 +22,7 @@ fn snapshot_add_approvals(test_name: &str, repo: &TestRepo, args: &[&str]) {
 fn snapshot_clear_approvals(test_name: &str, repo: &TestRepo, args: &[&str]) {
     let settings = setup_snapshot_settings(repo);
     settings.bind(|| {
-        let mut cmd = make_snapshot_cmd(repo, "hook", &[], None);
+        let mut cmd = make_snapshot_cmd(repo, "config", &[], None);
         cmd.arg("approvals").arg("clear").args(args);
         assert_cmd_snapshot!(test_name, cmd);
     });
@@ -51,6 +51,21 @@ fn test_add_approvals_empty_config(repo: TestRepo) {
     repo.commit("Add empty config");
 
     snapshot_add_approvals("add_approvals_empty_config", &repo, &[]);
+}
+
+/// Regression: `wt config approvals add` must walk project aliases as well as
+/// hooks. With only an alias declared (no hook commands), the alias should
+/// appear in the approval batch.
+#[rstest]
+fn test_add_approvals_includes_aliases(repo: TestRepo) {
+    repo.write_project_config(
+        r#"[aliases]
+deploy = "echo deploying {{ branch }}"
+"#,
+    );
+    repo.commit("Add alias-only project config");
+
+    snapshot_add_approvals("add_approvals_includes_aliases", &repo, &[]);
 }
 
 // ============================================================================
@@ -137,7 +152,7 @@ fn test_clear_approvals_after_clear(repo: TestRepo) {
         .unwrap();
 
     // Clear approvals
-    let mut cmd = make_snapshot_cmd(&repo, "hook", &[], None);
+    let mut cmd = make_snapshot_cmd(&repo, "config", &[], None);
     cmd.arg("approvals").arg("clear");
     cmd.output().unwrap();
 
@@ -232,7 +247,7 @@ url = "http://localhost:8080"
 // bare repository tests
 // ============================================================================
 
-/// Regression test for #1744: `wt hook approvals add` should find project config
+/// Regression test for #1744: `wt config approvals add` should find project config
 /// in a bare repo's primary worktree. `config create --project` should place it
 /// there (not in the bare repo root), consistent with `ProjectConfig::load`.
 #[test]
@@ -254,11 +269,11 @@ fn test_add_approvals_bare_repo_config_in_primary_worktree() {
 
     let settings = setup_temp_snapshot_settings(test.temp_path());
     settings.bind(|| {
-        // Run `wt hook approvals add --all` from the main worktree
+        // Run `wt config approvals add --all` from the main worktree
         let mut cmd = wt_command();
         test.configure_wt_cmd(&mut cmd);
         cmd.current_dir(&main_worktree)
-            .args(["hook", "approvals", "add", "--all"]);
+            .args(["config", "approvals", "add", "--all"]);
         assert_cmd_snapshot!("add_approvals_bare_repo_config_in_primary_worktree", cmd);
     });
 }
@@ -290,21 +305,21 @@ fn test_config_create_project_bare_repo_no_worktrees_errors() {
     );
 }
 
-/// `hook approvals add` and `hook list` should error in a bare repo with
+/// `config approvals add` and `hook show` should error in a bare repo with
 /// no linked worktrees (project_config_path returns None).
 #[test]
 fn test_hook_commands_bare_repo_no_worktrees_errors() {
     let test = BareRepoTest::new();
 
-    // hook approvals add --all should fail
+    // config approvals add --all should fail
     let mut cmd = wt_command();
     test.configure_wt_cmd(&mut cmd);
     cmd.current_dir(test.bare_repo_path())
-        .args(["hook", "approvals", "add", "--all"]);
+        .args(["config", "approvals", "add", "--all"]);
     let output = cmd.output().unwrap();
     assert!(
         !output.status.success(),
-        "hook approvals add should fail with no worktrees"
+        "config approvals add should fail with no worktrees"
     );
 
     // hook show should fail

--- a/tests/integration_tests/approvals.rs
+++ b/tests/integration_tests/approvals.rs
@@ -53,6 +53,25 @@ fn test_add_approvals_empty_config(repo: TestRepo) {
     snapshot_add_approvals("add_approvals_empty_config", &repo, &[]);
 }
 
+/// `wt hook approvals` is the deprecated alias for `wt config approvals`.
+/// Both `add` and `clear` must emit the deprecation warning and still forward
+/// to the same handler.
+#[rstest]
+#[case::add("add", "hook_approvals_deprecated_add")]
+#[case::clear("clear", "hook_approvals_deprecated_clear")]
+fn test_hook_approvals_emits_deprecation_warning(
+    repo: TestRepo,
+    #[case] action: &str,
+    #[case] snapshot_name: &str,
+) {
+    let settings = setup_snapshot_settings(&repo);
+    settings.bind(|| {
+        let mut cmd = make_snapshot_cmd(&repo, "hook", &[], None);
+        cmd.arg("approvals").arg(action);
+        assert_cmd_snapshot!(snapshot_name, cmd);
+    });
+}
+
 /// Regression: `wt config approvals add` must walk project aliases as well as
 /// hooks. With only an alias declared (no hook commands), the alias should
 /// appear in the approval batch.

--- a/tests/integration_tests/completion.rs
+++ b/tests/integration_tests/completion.rs
@@ -810,11 +810,10 @@ fn test_complete_hook_subcommands(repo: TestRepo) {
     assert!(subcommands.contains(&"post-merge"), "Missing post-merge");
     assert!(subcommands.contains(&"pre-remove"), "Missing pre-remove");
     assert!(subcommands.contains(&"post-remove"), "Missing post-remove");
-    assert!(subcommands.contains(&"approvals"), "Missing approvals");
     assert_eq!(
         subcommands.len(),
-        12,
-        "Should have exactly 12 hook subcommands"
+        11,
+        "Should have exactly 11 hook subcommands"
     );
 
     // Test 2: Partial input "po" - filters to post-* subcommands

--- a/tests/integration_tests/help.rs
+++ b/tests/integration_tests/help.rs
@@ -78,9 +78,9 @@ fn snapshot_help(test_name: &str, args: &[&str]) {
 #[case("help_config_state_logs", "config state logs --help")]
 #[case("help_config_state_get", "config state get --help")]
 #[case("help_config_state_clear", "config state clear --help")]
-#[case("help_hook_approvals", "hook approvals --help")]
-#[case("help_hook_approvals_add", "hook approvals add --help")]
-#[case("help_hook_approvals_clear", "hook approvals clear --help")]
+#[case("help_config_approvals", "config approvals --help")]
+#[case("help_config_approvals_add", "config approvals add --help")]
+#[case("help_config_approvals_clear", "config approvals clear --help")]
 fn test_help(#[case] test_name: &str, #[case] args_str: &str) {
     let args: Vec<&str> = if args_str.is_empty() {
         vec![]

--- a/tests/integration_tests/hook_show.rs
+++ b/tests/integration_tests/hook_show.rs
@@ -313,7 +313,7 @@ lint = "pre-commit run"
     });
 }
 
-/// Test `wt hook clear` when no approvals exist for the project.
+/// Test `wt config approvals clear` when no approvals exist for the project.
 #[rstest]
 fn test_hook_clear_no_approvals(repo: TestRepo, temp_home: TempDir) {
     // Remove origin so project_identifier uses full canonical path
@@ -335,7 +335,7 @@ fn test_hook_clear_no_approvals(repo: TestRepo, temp_home: TempDir) {
         let mut cmd = wt_command();
         repo.configure_wt_cmd(&mut cmd);
         cmd.env("WORKTRUNK_CONFIG_PATH", &config_path);
-        cmd.args(["hook", "approvals", "clear"])
+        cmd.args(["config", "approvals", "clear"])
             .current_dir(repo.root_path());
         set_temp_home_env(&mut cmd, temp_home.path());
 
@@ -343,7 +343,7 @@ fn test_hook_clear_no_approvals(repo: TestRepo, temp_home: TempDir) {
     });
 }
 
-/// Test `wt hook clear` when project has approvals to clear.
+/// Test `wt config approvals clear` when project has approvals to clear.
 #[rstest]
 fn test_hook_clear_with_approvals(repo: TestRepo, temp_home: TempDir) {
     // Remove origin so project_identifier uses full canonical path
@@ -372,7 +372,7 @@ approved-commands = ["cargo build", "cargo test", "npm install"]
         let mut cmd = wt_command();
         repo.configure_wt_cmd(&mut cmd);
         cmd.env("WORKTRUNK_CONFIG_PATH", &config_path);
-        cmd.args(["hook", "approvals", "clear"])
+        cmd.args(["config", "approvals", "clear"])
             .current_dir(repo.root_path());
         set_temp_home_env(&mut cmd, temp_home.path());
 

--- a/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__not_interactive.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__not_interactive.snap
@@ -3,4 +3,4 @@ source: tests/integration_tests/git_error_display.rs
 expression: err.to_string()
 ---
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt hook approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_fails_in_non_tty.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_fails_in_non_tty.snap
@@ -51,4 +51,4 @@ exit_code: 1
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt hook approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_mixed_approved_unapproved.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_mixed_approved_unapproved.snap
@@ -14,4 +14,4 @@ exit_code: 1
 [2m○[22m pre-start [1mthird[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Third command'[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt hook approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_multiple_commands.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_multiple_commands.snap
@@ -18,4 +18,4 @@ exit_code: 1
 [2m○[22m pre-start [1mpwd[22m:
 [107m [0m [2m[0m[2m[34mcd[0m[2m [0m[2m[32m{{[0m[2m worktree_path [0m[2m[32m}}[0m[2m [0m[2m[36m&&[0m[2m [0m[2m[34mpwd[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt hook approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_named_commands.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_named_commands.snap
@@ -16,4 +16,4 @@ exit_code: 1
 [2m○[22m pre-start [1mtest[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Running tests...'[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt hook approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_single_command.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_single_command.snap
@@ -12,4 +12,4 @@ exit_code: 1
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Worktree path: {{ worktree_path }}'[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt hook approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__decline_approval_skips_only_unapproved.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__decline_approval_skips_only_unapproved.snap
@@ -14,4 +14,4 @@ exit_code: 1
 [2m○[22m pre-start [1mthird[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Third command'[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt hook approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__project_prefix_all_requires_approval.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__project_prefix_all_requires_approval.snap
@@ -12,4 +12,4 @@ exit_code: 1
 [2m○[22m pre-merge [1mlint[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Running project lint'[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt hook approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__project_prefix_requires_approval.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__project_prefix_requires_approval.snap
@@ -10,4 +10,4 @@ exit_code: 1
 [2m○[22m pre-merge [1mtest[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Running project test'[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt hook approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__run_hook_post_merge_requires_approval.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__run_hook_post_merge_requires_approval.snap
@@ -10,4 +10,4 @@ exit_code: 1
 [2m○[22m post-merge:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Post-merge cleanup for {{ branch }}'[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt hook approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__run_hook_pre_merge_requires_approval.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__run_hook_pre_merge_requires_approval.snap
@@ -10,4 +10,4 @@ exit_code: 1
 [2m○[22m pre-merge:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Running pre-merge checks on {{ branch }}'[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt hook approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__yes_does_not_save_approvals_second_run.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__yes_does_not_save_approvals_second_run.snap
@@ -12,4 +12,4 @@ exit_code: 1
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m [0m[2m[36m>[0m[2m output.txt
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt hook approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_already_approved.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_already_approved.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/approvals.rs
 info:
   program: wt
   args:
-    - hook
+    - config
     - approvals
     - add
   env:
@@ -51,4 +51,4 @@ exit_code: 1
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test'[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt hook approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_bare_repo_config_in_primary_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_bare_repo_config_in_primary_worktree.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/approvals.rs
 info:
   program: wt
   args:
-    - hook
+    - config
     - approvals
     - add
     - "--all"
@@ -43,4 +43,4 @@ exit_code: 1
 ○ pre-start:
   echo 'hello'
 ✗ Cannot prompt for approval in non-interactive environment
-↳ To skip prompts in CI/CD, add --yes; to pre-approve commands, run wt hook approvals add
+↳ To skip prompts in CI/CD, add --yes; to pre-approve commands, run wt config approvals add

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_empty_config.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_empty_config.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/approvals.rs
 info:
   program: wt
   args:
-    - hook
+    - config
     - approvals
     - add
   env:

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_includes_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_includes_aliases.snap
@@ -6,7 +6,6 @@ info:
     - config
     - approvals
     - add
-    - "--all"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -46,10 +45,8 @@ exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mProject config: [1mpost-create[22m hook is deprecated in favor of [1mpre-start[22m[39m
-[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
-[2m○[22m pre-start:
-[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test'[0m[2m
+[2m○[22m alias [1mdeploy[22m:
+[107m [0m [2m[0m[2m[34mecho[0m[2m deploying [0m[2m[32m{{[0m[2m branch [0m[2m[32m}}[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
 [2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_no_commands.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_no_commands.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/approvals.rs
 info:
   program: wt
   args:
-    - hook
+    - config
     - approvals
     - add
   env:

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_no_config.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_no_config.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/approvals.rs
 info:
   program: wt
   args:
-    - hook
+    - config
     - approvals
     - add
   env:

--- a/tests/snapshots/integration__integration_tests__approvals__clear_approvals_after_clear.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__clear_approvals_after_clear.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/approvals.rs
 info:
   program: wt
   args:
-    - hook
+    - config
     - approvals
     - clear
   env:

--- a/tests/snapshots/integration__integration_tests__approvals__clear_approvals_global_no_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__clear_approvals_global_no_approvals.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/approvals.rs
 info:
   program: wt
   args:
-    - hook
+    - config
     - approvals
     - clear
     - "--global"

--- a/tests/snapshots/integration__integration_tests__approvals__clear_approvals_global_with_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__clear_approvals_global_with_approvals.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/approvals.rs
 info:
   program: wt
   args:
-    - hook
+    - config
     - approvals
     - clear
     - "--global"

--- a/tests/snapshots/integration__integration_tests__approvals__clear_approvals_multiple_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__clear_approvals_multiple_approvals.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/approvals.rs
 info:
   program: wt
   args:
-    - hook
+    - config
     - approvals
     - clear
   env:

--- a/tests/snapshots/integration__integration_tests__approvals__clear_approvals_no_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__clear_approvals_no_approvals.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/approvals.rs
 info:
   program: wt
   args:
-    - hook
+    - config
     - approvals
     - clear
   env:

--- a/tests/snapshots/integration__integration_tests__approvals__clear_approvals_with_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__clear_approvals_with_approvals.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/approvals.rs
 info:
   program: wt
   args:
-    - hook
+    - config
     - approvals
     - clear
   env:

--- a/tests/snapshots/integration__integration_tests__approvals__hook_approvals_deprecated_add.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__hook_approvals_deprecated_add.snap
@@ -1,0 +1,50 @@
+---
+source: tests/integration_tests/approvals.rs
+info:
+  program: wt
+  args:
+    - hook
+    - approvals
+    - add
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[33m▲[39m [33mwt hook approvals is deprecated; use wt config approvals instead[39m
+[31m✗[39m [31mNo project configuration found[39m
+[2m↳[22m [2mCreate a config file at: [4m_REPO_/.config/wt.toml[24m[22m

--- a/tests/snapshots/integration__integration_tests__approvals__hook_approvals_deprecated_clear.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__hook_approvals_deprecated_clear.snap
@@ -1,0 +1,49 @@
+---
+source: tests/integration_tests/approvals.rs
+info:
+  program: wt
+  args:
+    - hook
+    - approvals
+    - clear
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[33m▲[39m [33mwt hook approvals is deprecated; use wt config approvals instead[39m
+[2m○[22m No approvals to clear for this project

--- a/tests/snapshots/integration__integration_tests__help__help_config_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_approvals.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/help.rs
 info:
   program: wt
   args:
-    - hook
+    - config
     - approvals
     - "--help"
   env:
@@ -31,9 +31,9 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-wt hook approvals - Manage command approvals
+wt config approvals - Manage command approvals
 
-Usage: [1m[36mwt hook approvals[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
+Usage: [1m[36mwt config approvals[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 
 [1m[32mCommands:[0m
   [1m[36madd[0m    Store approvals in approvals.toml
@@ -53,18 +53,18 @@ Usage: [1m[36mwt hook approvals[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
           Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
-Project hooks require approval on first run to prevent untrusted projects from running arbitrary commands.
+Project hooks and project aliases prompt for approval on first run to prevent untrusted projects from running arbitrary commands. Approvals from both flows are stored together.
 
 [1m[32mExamples[0m
 
-Pre-approve all commands for current project:
-[107m [0m [2m[0m[2m[34mwt[0m[2m hook approvals add[0m
+Pre-approve all hook and alias commands for current project:
+[107m [0m [2m[0m[2m[34mwt[0m[2m config approvals add[0m
 
 Clear approvals for current project:
-[107m [0m [2m[0m[2m[34mwt[0m[2m hook approvals clear[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config approvals clear[0m
 
 Clear global approvals:
-[107m [0m [2m[0m[2m[34mwt[0m[2m hook approvals clear [0m[2m[36m--global[0m[2m[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m config approvals clear [0m[2m[36m--global[0m[2m[0m
 
 [1m[32mHow approvals work[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_approvals_add.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_approvals_add.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/help.rs
 info:
   program: wt
   args:
-    - hook
+    - config
     - approvals
     - add
     - "--help"
@@ -32,9 +32,9 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-wt hook approvals add - Store approvals in approvals.toml
+wt config approvals add - Store approvals in approvals.toml
 
-Usage: [1m[36mwt hook approvals add[0m [36m[OPTIONS][0m
+Usage: [1m[36mwt config approvals add[0m [36m[OPTIONS][0m
 
 [1m[32mOptions:[0m
       [1m[36m--all[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_approvals_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_approvals_clear.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/help.rs
 info:
   program: wt
   args:
-    - hook
+    - config
     - approvals
     - clear
     - "--help"
@@ -32,9 +32,9 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-wt hook approvals clear - Clear approved commands from approvals.toml
+wt config approvals clear - Clear approved commands from approvals.toml
 
-Usage: [1m[36mwt hook approvals clear[0m [36m[OPTIONS][0m
+Usage: [1m[36mwt config approvals clear[0m [36m[OPTIONS][0m
 
 [1m[32mOptions:[0m
   [1m[36m-g[0m, [1m[36m--global[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -37,12 +37,13 @@ Includes shell integration, hooks, and saved state.[0m
 Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 
 [1m[32mCommands:[0m
-  [1m[36mshell[0m    Shell integration setup
-  [1m[36mcreate[0m   Create configuration file
-  [1m[36mshow[0m     Show configuration files & locations
-  [1m[36mupdate[0m   Update deprecated config settings
-  [1m[36mplugins[0m  Plugin management
-  [1m[36mstate[0m    Manage internal data and cache
+  [1m[36mshell[0m      Shell integration setup
+  [1m[36mcreate[0m     Create configuration file
+  [1m[36mshow[0m       Show configuration files & locations
+  [1m[36mupdate[0m     Update deprecated config settings
+  [1m[36mapprovals[0m  Manage command approvals
+  [1m[36mplugins[0m    Plugin management
+  [1m[36mstate[0m      Manage internal data and cache
 
 [1m[32mOptions:[0m
   [1m[36m-h[0m, [1m[36m--help[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_short.snap
@@ -35,12 +35,13 @@ wt config - Manage user & project configs
 Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 
 [1m[32mCommands:[0m
-  [1m[36mshell[0m    Shell integration setup
-  [1m[36mcreate[0m   Create configuration file
-  [1m[36mshow[0m     Show configuration files & locations
-  [1m[36mupdate[0m   Update deprecated config settings
-  [1m[36mplugins[0m  Plugin management
-  [1m[36mstate[0m    Manage internal data and cache
+  [1m[36mshell[0m      Shell integration setup
+  [1m[36mcreate[0m     Create configuration file
+  [1m[36mshow[0m       Show configuration files & locations
+  [1m[36mupdate[0m     Update deprecated config settings
+  [1m[36mapprovals[0m  Manage command approvals
+  [1m[36mplugins[0m    Plugin management
+  [1m[36mstate[0m      Manage internal data and cache
 
 [1m[32mOptions:[0m
   [1m[36m-h[0m, [1m[36m--help[0m  Print help (see more with '--help')

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_clear_no_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_clear_no_approvals.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/hook_show.rs
 info:
   program: wt
   args:
-    - hook
+    - config
     - approvals
     - clear
   env:

--- a/tests/snapshots/integration__integration_tests__hook_show__hook_clear_with_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__hook_show__hook_clear_with_approvals.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/hook_show.rs
 info:
   program: wt
   args:
-    - hook
+    - config
     - approvals
     - clear
   env:

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_approval_decline.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_approval_decline.snap
@@ -10,4 +10,4 @@ exit_code: 1
 [2m○[22m alias [1mdeploy[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m deploying
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt hook approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_approval_project_config_prompts.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_approval_project_config_prompts.snap
@@ -48,4 +48,4 @@ exit_code: 1
 [2m○[22m alias [1mdeploy[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m deploying [0m[2m[32m{{[0m[2m branch [0m[2m[32m}}[0m[2m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt hook approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_approval_yes_second_run_prompts.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_approval_yes_second_run_prompts.snap
@@ -48,4 +48,4 @@ exit_code: 1
 [2m○[22m alias [1mdeploy[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m deploying
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt hook approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m


### PR DESCRIPTION
Approvals cover both project hooks and project aliases (via `approve_alias_commands`), so `wt hook approvals` mis-scoped the command. Canonicalize the home to `wt config approvals`; keep `wt hook approvals` as a hidden alias that emits a deprecation warning and forwards.

`add` now walks both hook and alias commands. A project that only declares aliases can bulk-pre-approve them in one shot — see `test_add_approvals_includes_aliases`. The shared `approvals.toml` and the per-run interactive flow are unchanged; only the CLI namespace and the `add` collector moved.

Reviewer notes:
- `src/cli/config.rs` — new `Approvals` variant on `ConfigCommand` with help text and the `<!-- subdoc: approvals -->` placeholder added in `src/cli/mod.rs` so the config docs page renders the subcommand inline.
- `src/cli/hook.rs` — old `Approvals` variant marked `hide = true`; `src/main.rs` emits the warning before forwarding to the same handlers.
- `src/commands/project_config.rs` — new `collect_commands_for_aliases` mirrors the per-step name fallback in `approve_alias_commands` so the prompt label is stable.
- `src/git/error.rs:751` — non-interactive hint now points at `wt config approvals add`.
- Tests retargeted to the canonical path; the `wt hook` completion test loses one entry (12 → 11) since the deprecated subcommand is hidden.

> _This was written by Claude Code on behalf of Maximilian Roos_