### PR TITLE
fix: reject underscore in vars keys (invalid git config variable name)

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -1001,7 +1001,7 @@ dev = "npm start -- --port {{ vars.config.port }}"
 
 ### Storage format
 
-Stored in git config as `worktrunk.state.<branch>.vars.<key>`. Keys must contain only letters, digits, hyphens, and underscores — dots conflict with git config's section separator.
+Stored in git config as `worktrunk.state.<branch>.vars.<key>`. Keys must contain only letters, digits and hyphens — dots conflict with git config's section separator, underscores with its variable name format.
 
 ### Command reference
 

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -1048,7 +1048,7 @@ dev = "npm start -- --port {{ vars.config.port }}"
 
 ### Storage format
 
-Stored in git config as `worktrunk.state.<branch>.vars.<key>`. Keys must contain only letters, digits, hyphens, and underscores — dots conflict with git config's section separator.
+Stored in git config as `worktrunk.state.<branch>.vars.<key>`. Keys must contain only letters, digits and hyphens — dots conflict with git config's section separator, underscores with its variable name format.
 
 ### Command reference
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -900,7 +900,7 @@ dev = "npm start -- --port {{ vars.config.port }}"
 
 ## Storage format
 
-Stored in git config as `worktrunk.state.<branch>.vars.<key>`. Keys must contain only letters, digits, hyphens, and underscores — dots conflict with git config's section separator."#
+Stored in git config as `worktrunk.state.<branch>.vars.<key>`. Keys must contain only letters, digits and hyphens — dots conflict with git config's section separator, underscores with its variable name format."#
     )]
     Vars {
         #[command(subcommand)]

--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -1174,18 +1174,13 @@ fn handle_state_show_table(repo: &Repository) -> anyhow::Result<()> {
 
 // ==================== Vars Operations ====================
 
-/// Validate a vars key name: letters, digits, hyphens, underscores only.
+/// Validate a vars key name: letters, digits, and hyphens only.
 fn validate_vars_key(key: &str) -> anyhow::Result<()> {
     if key.is_empty() {
         anyhow::bail!("Key cannot be empty");
     }
-    if !key
-        .chars()
-        .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
-    {
-        anyhow::bail!(
-            "Invalid key {key:?}: keys must contain only letters, digits, hyphens, and underscores"
-        );
+    if !key.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+        anyhow::bail!("Invalid key {key:?}: keys must contain only letters, digits, and hyphens");
     }
     Ok(())
 }

--- a/tests/integration_tests/config_state.rs
+++ b/tests/integration_tests/config_state.rs
@@ -1573,7 +1573,7 @@ fn test_vars_invalid_key(repo: TestRepo) {
         .output()
         .unwrap();
     assert!(!output.status.success());
-    assert_snapshot!(String::from_utf8_lossy(&output.stderr), @r#"[31m✗[39m [31mInvalid key "foo.bar": keys must contain only letters, digits, hyphens, and underscores[39m"#);
+    assert_snapshot!(String::from_utf8_lossy(&output.stderr), @r#"[31m✗[39m [31mInvalid key "foo.bar": keys must contain only letters, digits, and hyphens[39m"#);
 }
 
 #[rstest]


### PR DESCRIPTION
## Problem

`wt config state vars set db_suffix=foo` silently passes validation but then fails with a cryptic git error:

```
error: invalid key: worktrunk.state.main.vars.db_suffix
```

Git config variable names (the last `.`-separated segment) must match `[a-zA-Z][a-zA-Z0-9-]*` — underscores are not allowed at that position.

## Fix

Reject `_` in `validate_vars_key` early, with a clear message pointing users to use hyphens instead:

```
Invalid key "db_suffix": keys must contain only letters, digits, and hyphens
```

No other changes — branch names with `/` already work correctly via git's quoted subsection form.