### PR TITLE
docs: trim needless parenthetical qualifiers

### DIFF
--- a/docs/content/claude-code.md
+++ b/docs/content/claude-code.md
@@ -72,7 +72,7 @@ Claude Code agents can run in isolated worktrees (`isolation: "worktree"`). By d
 
 ## Statusline
 
-`wt list statusline --format=claude-code` outputs a single-line status for the Claude Code statusline. This may fetch CI status from the network when the cache is stale (often ~1–2 seconds), making it suitable for async statuslines but too slow for synchronous shell prompts. If a faster version would be helpful, please [open an issue](https://github.com/max-sixty/worktrunk/issues).
+`wt list statusline --format=claude-code` outputs a single-line status for the Claude Code statusline. When the CI status cache is stale, this fetches from the network — typically 1–2 seconds — making it suitable for async statuslines but too slow for synchronous shell prompts. If a faster version would be helpful, please [open an issue](https://github.com/max-sixty/worktrunk/issues).
 
 <code>~/w/myproject.feature-auth  !🤖  @<span style='color:#0a0'>+42</span> <span style='color:#a00'>-8</span>  <span style='color:#0a0'>↑3</span>  <span style='color:#0a0'>⇡1</span>  <span style='color:#0a0'>●</span>  | Opus 🌔 65%</code>
 

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -701,9 +701,9 @@ Without a subcommand, runs `get`. Use `set` to override, or `clear` then `get` t
 
 Worktrunk detects the default branch automatically:
 
-1. **Worktrunk cache** — Checks `git config worktrunk.default-branch` (single command)
+1. **Worktrunk cache** — Checks `git config worktrunk.default-branch`
 2. **Git cache** — Detects primary remote and checks its HEAD (e.g., `origin/HEAD`)
-3. **Remote query** — If not cached, queries `git ls-remote` (100ms–2s)
+3. **Remote query** — If not cached, queries `git ls-remote` — typically 100ms–2s
 4. **Local inference** — If no remote, infers from local branches
 
 Once detected, the result is cached in `worktrunk.default-branch` for fast access.

--- a/skills/worktrunk/reference/claude-code.md
+++ b/skills/worktrunk/reference/claude-code.md
@@ -66,7 +66,7 @@ Claude Code agents can run in isolated worktrees (`isolation: "worktree"`). By d
 
 ## Statusline
 
-`wt list statusline --format=claude-code` outputs a single-line status for the Claude Code statusline. This may fetch CI status from the network when the cache is stale (often ~1–2 seconds), making it suitable for async statuslines but too slow for synchronous shell prompts. If a faster version would be helpful, please [open an issue](https://github.com/max-sixty/worktrunk/issues).
+`wt list statusline --format=claude-code` outputs a single-line status for the Claude Code statusline. When the CI status cache is stale, this fetches from the network — typically 1–2 seconds — making it suitable for async statuslines but too slow for synchronous shell prompts. If a faster version would be helpful, please [open an issue](https://github.com/max-sixty/worktrunk/issues).
 
 <code>~/w/myproject.feature-auth  !🤖  @<span style='color:#0a0'>+42</span> <span style='color:#a00'>-8</span>  <span style='color:#0a0'>↑3</span>  <span style='color:#0a0'>⇡1</span>  <span style='color:#0a0'>●</span>  | Opus 🌔 65%</code>
 

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -728,9 +728,9 @@ Without a subcommand, runs `get`. Use `set` to override, or `clear` then `get` t
 
 Worktrunk detects the default branch automatically:
 
-1. **Worktrunk cache** — Checks `git config worktrunk.default-branch` (single command)
+1. **Worktrunk cache** — Checks `git config worktrunk.default-branch`
 2. **Git cache** — Detects primary remote and checks its HEAD (e.g., `origin/HEAD`)
-3. **Remote query** — If not cached, queries `git ls-remote` (100ms–2s)
+3. **Remote query** — If not cached, queries `git ls-remote` — typically 100ms–2s
 4. **Local inference** — If no remote, infers from local branches
 
 Once detected, the result is cached in `worktrunk.default-branch` for fast access.

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -568,9 +568,9 @@ Without a subcommand, runs `get`. Use `set` to override, or `clear` then `get` t
 
 Worktrunk detects the default branch automatically:
 
-1. **Worktrunk cache** — Checks `git config worktrunk.default-branch` (single command)
+1. **Worktrunk cache** — Checks `git config worktrunk.default-branch`
 2. **Git cache** — Detects primary remote and checks its HEAD (e.g., `origin/HEAD`)
-3. **Remote query** — If not cached, queries `git ls-remote` (100ms–2s)
+3. **Remote query** — If not cached, queries `git ls-remote` — typically 100ms–2s
 4. **Local inference** — If no remote, infers from local branches
 
 Once detected, the result is cached in `worktrunk.default-branch` for fast access.

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
@@ -68,9 +68,9 @@ Without a subcommand, runs [2mget[0m. Use [2mset[0m to override, or [2mclea
 
 Worktrunk detects the default branch automatically:
 
-1. [1mWorktrunk cache[0m — Checks [2mgit config worktrunk.default-branch[0m (single command)
+1. [1mWorktrunk cache[0m — Checks [2mgit config worktrunk.default-branch[0m
 2. [1mGit cache[0m — Detects primary remote and checks its HEAD (e.g., [2morigin/HEAD[0m)
-3. [1mRemote query[0m — If not cached, queries [2mgit ls-remote[0m (100ms–2s)
+3. [1mRemote query[0m — If not cached, queries [2mgit ls-remote[0m — typically 100ms–2s
 4. [1mLocal inference[0m — If no remote, infers from local branches
 
 Once detected, the result is cached in [2mworktrunk.default-branch[0m for fast access.


### PR DESCRIPTION
Parenthetical examples (e.g., `origin/HEAD`) read naturally, but qualifiers and conditions belong in prose. This trims three cases:

- `Checks git config worktrunk.default-branch (single command)` → drop the redundant `(single command)` (the command fragment already shows it's a single command).
- `queries git ls-remote (100ms–2s)` → `queries git ls-remote — typically 100ms–2s`.
- Statusline doc: `fetches from the network (often ~1–2 seconds), making it suitable for async...` → em-dash clause so the timing detail doesn't interrupt the main claim.

Auto-synced: `docs/content/config.md`, both `skills/worktrunk/reference/*.md` copies, and the `help_config_state_default_branch.snap` help snapshot.

> _This was written by Claude Code on behalf of Maximilian_