### PR TITLE
refactor(cli): drop post-alias --yes from hand-rolled parser

### DIFF
--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -81,7 +81,6 @@ const TOP_LEVEL_BUILTINS: &[&str] = &[
 pub struct AliasOptions {
     pub name: String,
     pub dry_run: bool,
-    pub yes: bool,
     pub vars: Vec<(String, String)>,
     /// Non-flag positional tokens passed after the alias name. Forwarded into
     /// the template context as `{{ args }}` (a `ShellArgs` sequence). Appear
@@ -94,13 +93,19 @@ impl AliasOptions {
     /// Parse alias options from `wt step <alias>` args.
     ///
     /// First element is the alias name, remaining tokens are either flags:
-    /// `--dry-run`, `--yes`/`-y`, `--var KEY=VALUE`, or `--KEY=VALUE`; or
-    /// positional args that get forwarded to the template as `{{ args }}`.
+    /// `--dry-run`, `--var KEY=VALUE`, or `--KEY=VALUE`; or positional args
+    /// that get forwarded to the template as `{{ args }}`.
     ///
     /// Unknown `--key=value` flags are treated as template variable assignments,
     /// so `--env=staging` is equivalent to `--var env=staging`. The `=` is
     /// required — bare `--key` flags (without a value) are rejected. Use
     /// `--var KEY=VALUE` if a variable name collides with a built-in flag.
+    ///
+    /// `--yes`/`-y` is a top-level global flag (`wt -y <alias>`) and is not
+    /// recognized after the alias name — clap's `global = true` does not
+    /// propagate flags across an `external_subcommand` boundary. A post-alias
+    /// `--yes` errors here as an unknown flag; `-y` (single-dash) falls into
+    /// the positional-args branch and gets forwarded to `{{ args }}` as `"-y"`.
     ///
     /// Hyphens in variable names are canonicalized to underscores so users can
     /// write `--my-var=value` and reference `{{ my_var }}` in templates
@@ -111,14 +116,12 @@ impl AliasOptions {
         };
 
         let mut dry_run = false;
-        let mut yes = false;
         let mut vars = Vec::new();
         let mut positional_args = Vec::new();
         let mut i = 1;
         while i < args.len() {
             match args[i].as_str() {
                 "--dry-run" => dry_run = true,
-                "--yes" | "-y" => yes = true,
                 "--var" => {
                     i += 1;
                     if i >= args.len() {
@@ -155,7 +158,6 @@ impl AliasOptions {
         Ok(Self {
             name,
             dry_run,
-            yes,
             vars,
             positional_args,
         })
@@ -346,10 +348,9 @@ pub fn alias_names_for_suggestions() -> Vec<String> {
 /// Execute `cmd_config` for `opts.name`. Caller must have already verified
 /// `aliases.contains_key(&opts.name)`.
 ///
-/// `global_yes` is the top-level `--yes`/`-y` flag; it OR's with `opts.yes`
-/// (the post-alias `--yes` parsed by `AliasOptions`) so either form skips
-/// approval. The post-alias form is kept intact for now — removing it is a
-/// separate cleanup.
+/// `global_yes` is the top-level `--yes`/`-y` flag and is the only source for
+/// skipping approval — the post-alias form (`wt deploy --yes`) is no longer
+/// recognized. Use `wt -y deploy` or `wt --yes deploy` instead.
 fn run_alias(
     opts: AliasOptions,
     repo: Repository,
@@ -362,7 +363,7 @@ fn run_alias(
         .get(&opts.name)
         .expect("caller verified alias is configured");
 
-    let skip_approval = global_yes || opts.yes;
+    let skip_approval = global_yes;
 
     // Check if this alias needs project-config approval (skip for --dry-run).
     // project_id is required for approval — re-derive with error propagation
@@ -813,7 +814,6 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: false,
-            yes: false,
             vars: [],
             positional_args: [],
         }
@@ -822,25 +822,6 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: true,
-            yes: false,
-            vars: [],
-            positional_args: [],
-        }
-        "#);
-        assert_debug_snapshot!(parse(&["deploy", "--yes"]).unwrap(), @r#"
-        AliasOptions {
-            name: "deploy",
-            dry_run: false,
-            yes: true,
-            vars: [],
-            positional_args: [],
-        }
-        "#);
-        assert_debug_snapshot!(parse(&["deploy", "-y"]).unwrap(), @r#"
-        AliasOptions {
-            name: "deploy",
-            dry_run: false,
-            yes: true,
             vars: [],
             positional_args: [],
         }
@@ -849,7 +830,6 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: false,
-            yes: false,
             vars: [
                 (
                     "key",
@@ -864,7 +844,6 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: false,
-            yes: false,
             vars: [
                 (
                     "key",
@@ -879,7 +858,6 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: false,
-            yes: false,
             vars: [
                 (
                     "url",
@@ -894,7 +872,6 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: true,
-            yes: false,
             vars: [
                 (
                     "a",
@@ -913,7 +890,6 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: false,
-            yes: false,
             vars: [
                 (
                     "key",
@@ -928,7 +904,6 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: false,
-            yes: false,
             vars: [
                 (
                     "env",
@@ -943,7 +918,6 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: false,
-            yes: false,
             vars: [
                 (
                     "url",
@@ -958,7 +932,6 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: true,
-            yes: false,
             vars: [
                 (
                     "env",
@@ -977,7 +950,6 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: false,
-            yes: false,
             vars: [
                 (
                     "env",
@@ -992,7 +964,6 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: false,
-            yes: false,
             vars: [
                 (
                     "my_var",
@@ -1007,7 +978,6 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: false,
-            yes: false,
             vars: [
                 (
                     "my_var",
@@ -1022,7 +992,6 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: false,
-            yes: false,
             vars: [
                 (
                     "my_var",
@@ -1037,7 +1006,6 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: false,
-            yes: false,
             vars: [
                 (
                     "my_var",
@@ -1052,7 +1020,6 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: false,
-            yes: false,
             vars: [
                 (
                     "long_var_name",
@@ -1067,7 +1034,6 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: false,
-            yes: false,
             vars: [
                 (
                     "region",
@@ -1082,7 +1048,6 @@ cmd = [
         AliasOptions {
             name: "s",
             dry_run: false,
-            yes: false,
             vars: [],
             positional_args: [
                 "some-branch",
@@ -1094,7 +1059,6 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: false,
-            yes: false,
             vars: [],
             positional_args: [
                 "one",
@@ -1108,7 +1072,6 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: true,
-            yes: false,
             vars: [],
             positional_args: [
                 "foo",
@@ -1122,11 +1085,24 @@ cmd = [
         AliasOptions {
             name: "deploy",
             dry_run: false,
-            yes: false,
             vars: [],
             positional_args: [
                 "foo bar",
                 "x;rm -rf /",
+            ],
+        }
+        "#);
+        // Post-alias `-y` (single-dash) is no longer a flag — it falls into
+        // the positional branch and gets forwarded to `{{ args }}` literally.
+        // `wt deploy -y` skips approval only when `-y` is in the global
+        // position (`wt -y deploy`), parsed by clap before this function runs.
+        assert_debug_snapshot!(parse(&["deploy", "-y"]).unwrap(), @r#"
+        AliasOptions {
+            name: "deploy",
+            dry_run: false,
+            vars: [],
+            positional_args: [
+                "-y",
             ],
         }
         "#);
@@ -1141,6 +1117,11 @@ cmd = [
         assert_snapshot!(parse(&["deploy", "--verbose"]).unwrap_err(), @"Unknown flag '--verbose' for alias 'deploy' (use --verbose=VALUE to pass a variable)");
         assert_snapshot!(parse(&["deploy", "--var", "=value"]).unwrap_err(), @"invalid KEY=VALUE: key cannot be empty");
         assert_snapshot!(parse(&["deploy", "--=value"]).unwrap_err(), @"invalid KEY=VALUE: key cannot be empty");
+        // Post-alias `--yes` is no longer recognized — `-y`/`--yes` must appear
+        // before the alias name so clap captures it as the global. The long
+        // form errors as an unknown flag; `-y` (single-dash) falls through to
+        // the positional-args branch and gets forwarded to `{{ args }}`.
+        assert_snapshot!(parse(&["deploy", "--yes"]).unwrap_err(), @"Unknown flag '--yes' for alias 'deploy' (use --yes=VALUE to pass a variable)");
     }
 
     /// Verify BUILTIN_STEP_COMMANDS stays in sync with the actual StepCommand variants.

--- a/tests/integration_tests/approval_ui.rs
+++ b/tests/integration_tests/approval_ui.rs
@@ -662,11 +662,14 @@ deploy = "echo 'ran' > marker.txt"
     assert_eq!(content.trim(), "ran");
 }
 
-/// The post-alias `--yes` form (`wt deploy --yes`) still works via
-/// `AliasOptions::parse`, intentionally preserved for backwards compatibility
-/// until the hand-rolled parser is removed in a later cleanup.
+/// The post-alias `--yes` form (`wt deploy --yes`) is no longer supported —
+/// clap's `global = true` does not propagate flags across an
+/// `external_subcommand` boundary, so the post-alias position never reached
+/// the global parser. `AliasOptions::parse` previously consumed it as a
+/// special case; that double-path was removed in favor of the canonical
+/// pre-alias form (`wt -y deploy` / `wt --yes deploy`).
 #[rstest]
-fn test_post_alias_yes_still_works(repo: TestRepo) {
+fn test_post_alias_yes_no_longer_supported(repo: TestRepo) {
     repo.write_project_config(
         r#"[aliases]
 deploy = "echo 'ran' > marker.txt"
@@ -682,14 +685,20 @@ deploy = "echo 'ran' > marker.txt"
         .expect("Failed to run wt deploy --yes");
 
     assert!(
-        output.status.success(),
-        "wt deploy --yes failed: {}",
-        String::from_utf8_lossy(&output.stderr)
+        !output.status.success(),
+        "wt deploy --yes should error now that the post-alias form is removed"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Unknown flag '--yes'"),
+        "expected unknown-flag error, got: {stderr}"
     );
 
     let marker = repo.root_path().join("marker.txt");
-    let content = std::fs::read_to_string(&marker).expect("marker.txt should exist");
-    assert_eq!(content.trim(), "ran");
+    assert!(
+        !marker.exists(),
+        "alias must not run when --yes is rejected"
+    );
 }
 
 /// The global `-y` flag skips approval when dispatched through

--- a/tests/integration_tests/bare_repository.rs
+++ b/tests/integration_tests/bare_repository.rs
@@ -309,11 +309,12 @@ fn test_bare_repo_repo_path_with_inherited_relative_git_dir() {
     let main_worktree = test.create_worktree("main", "main");
     test.commit_in(&main_worktree, "Initial commit");
 
-    // Helper: run `wt step print-repo-path --yes` and extract the
+    // Helper: run `wt step print-repo-path` and extract the
     // `REPO_PATH=...` value emitted by the alias. We compare these as-is
     // so platform-specific path formatting (e.g. msys-style paths that
     // Git Bash uses on Windows for `echo`) doesn't affect the test — we
     // only assert that both invocations produce the *same* value.
+    // No `-y` needed: user-config aliases skip approval entirely.
     let extract_repo_path = |out: &std::process::Output| -> String {
         let combined = format!(
             "{}{}",
@@ -331,7 +332,7 @@ fn test_bare_repo_repo_path_with_inherited_relative_git_dir() {
     test.configure_wt_cmd(&mut baseline);
     baseline
         .env("WORKTRUNK_CONFIG_PATH", &user_config)
-        .args(["step", "print-repo-path", "--yes"])
+        .args(["step", "print-repo-path"])
         .current_dir(&main_worktree);
     let baseline_out = baseline.output().unwrap();
     assert!(
@@ -359,7 +360,7 @@ fn test_bare_repo_repo_path_with_inherited_relative_git_dir() {
         .env("WORKTRUNK_CONFIG_PATH", &user_config)
         .env("GIT_DIR", &relative_git_dir)
         .env("GIT_PREFIX", "")
-        .args(["step", "print-repo-path", "--yes"])
+        .args(["step", "print-repo-path"])
         .current_dir(&main_worktree);
     let via_alias_out = via_alias.output().unwrap();
     assert!(
@@ -483,7 +484,7 @@ fn test_repo_path_via_real_git_alias_bare_dot_git_layout() {
     let mut baseline = Command::new(wt_bin());
     apply_wt_env(&mut baseline);
     baseline
-        .args(["step", "print-repo-path", "--yes"])
+        .args(["step", "print-repo-path"])
         .current_dir(&repo_dir);
     let baseline_out = baseline.output().unwrap();
     assert!(
@@ -494,14 +495,14 @@ fn test_repo_path_via_real_git_alias_bare_dot_git_layout() {
     );
     let baseline_repo_path = extract_repo_path(&baseline_out);
 
-    // Via the real git alias: `git wt step print-repo-path --yes`. From the
+    // Via the real git alias: `git wt step print-repo-path`. From the
     // `repo/` dir (not inside the worktree), git sets `GIT_DIR=.git`
     // (relative) when exporting the alias environment — the exact bug vector
     // from #1914.
     let mut via_alias = Command::new("git");
     apply_wt_env(&mut via_alias);
     via_alias
-        .args(["wt", "step", "print-repo-path", "--yes"])
+        .args(["wt", "step", "print-repo-path"])
         .current_dir(&repo_dir);
     let via_alias_out = via_alias.output().unwrap();
     assert!(

--- a/tests/integration_tests/step_alias.rs
+++ b/tests/integration_tests/step_alias.rs
@@ -1,15 +1,15 @@
 //! Integration tests for `wt step <alias>`
 
 use crate::common::{
-    TestRepo, configure_directive_files, directive_files, make_snapshot_cmd, repo,
-    setup_snapshot_settings, wt_bin,
+    TestRepo, configure_directive_files, directive_files, make_snapshot_cmd,
+    make_snapshot_cmd_with_global_flags, repo, setup_snapshot_settings, wt_bin,
 };
 use insta_cmd::assert_cmd_snapshot;
 use rstest::rstest;
 use std::io::Write;
 use std::process::Stdio;
 
-/// Alias from project config runs with template expansion (--yes bypasses approval)
+/// Alias from project config runs with template expansion (-y bypasses approval)
 #[rstest]
 fn test_step_alias_from_project_config(mut repo: TestRepo) {
     repo.write_project_config(
@@ -24,11 +24,12 @@ hello = "echo Hello from {{ branch }}"
     let settings = setup_snapshot_settings(&repo);
     let _guard = settings.bind_to_scope();
 
-    assert_cmd_snapshot!(make_snapshot_cmd(
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
         &repo,
         "step",
-        &["hello", "--yes"],
+        &["hello"],
         Some(&feature_path),
+        &["-y"],
     ));
 }
 
@@ -120,7 +121,7 @@ fn test_step_alias_unknown_no_aliases(mut repo: TestRepo) {
     ));
 }
 
-/// --var flag adds extra template variables (--yes bypasses approval)
+/// --var flag adds extra template variables (-y bypasses approval)
 #[rstest]
 fn test_step_alias_with_var(mut repo: TestRepo) {
     repo.write_project_config(
@@ -135,11 +136,12 @@ greet = "echo Hello {{ name }} from {{ branch }}"
     let settings = setup_snapshot_settings(&repo);
     let _guard = settings.bind_to_scope();
 
-    assert_cmd_snapshot!(make_snapshot_cmd(
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
         &repo,
         "step",
-        &["greet", "--dry-run", "--var", "name=World", "--yes"],
+        &["greet", "--dry-run", "--var", "name=World"],
         Some(&feature_path),
+        &["-y"],
     ));
 }
 
@@ -158,15 +160,16 @@ greet = "echo Hello {{ name }} from {{ branch }}"
     let settings = setup_snapshot_settings(&repo);
     let _guard = settings.bind_to_scope();
 
-    assert_cmd_snapshot!(make_snapshot_cmd(
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
         &repo,
         "step",
-        &["greet", "--dry-run", "--name=World", "--yes"],
+        &["greet", "--dry-run", "--name=World"],
         Some(&feature_path),
+        &["-y"],
     ));
 }
 
-/// Alias command failure propagates exit code (--yes bypasses approval)
+/// Alias command failure propagates exit code (-y bypasses approval)
 #[rstest]
 fn test_step_alias_exit_code(mut repo: TestRepo) {
     repo.write_project_config(
@@ -181,11 +184,12 @@ fail = "exit 42"
     let settings = setup_snapshot_settings(&repo);
     let _guard = settings.bind_to_scope();
 
-    assert_cmd_snapshot!(make_snapshot_cmd(
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
         &repo,
         "step",
-        &["fail", "--yes"],
+        &["fail"],
         Some(&feature_path),
+        &["-y"],
     ));
 }
 
@@ -228,11 +232,12 @@ hello = "echo Hello from {{ branch }}"
     let settings = setup_snapshot_settings(&repo);
     let _guard = settings.bind_to_scope();
 
-    assert_cmd_snapshot!(make_snapshot_cmd(
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
         &repo,
         "hello",
-        &["--yes"],
+        &[],
         Some(&feature_path),
+        &["-y"],
     ));
 }
 
@@ -253,11 +258,12 @@ commit = "echo custom-commit"
     let settings = setup_snapshot_settings(&repo);
     let _guard = settings.bind_to_scope();
 
-    assert_cmd_snapshot!(make_snapshot_cmd(
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
         &repo,
         "commit",
-        &["--yes"],
+        &[],
         Some(&feature_path),
+        &["-y"],
     ));
 }
 
@@ -340,14 +346,15 @@ shared = "echo user-version"
         )
     );
 
-    // Project alias available (--yes bypasses approval for project-config aliases)
+    // Project alias available (-y bypasses approval for project-config aliases)
     assert_cmd_snapshot!(
         "project_alias",
-        make_snapshot_cmd(
+        make_snapshot_cmd_with_global_flags(
             &repo,
             "step",
-            &["project-cmd", "--dry-run", "--yes"],
+            &["project-cmd", "--dry-run"],
             Some(&feature_path),
+            &["-y"],
         )
     );
 
@@ -383,12 +390,13 @@ greet = "echo USER"
     let settings = setup_snapshot_settings(&repo);
     let _guard = settings.bind_to_scope();
 
-    // Both commands execute: user first, then project (--yes approves project alias)
-    assert_cmd_snapshot!(make_snapshot_cmd(
+    // Both commands execute: user first, then project (-y approves project alias)
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
         &repo,
         "step",
-        &["greet", "--yes"],
+        &["greet"],
         Some(&feature_path),
+        &["-y"],
     ));
 }
 
@@ -534,16 +542,17 @@ deploy = "echo user deploy"
     let settings = setup_snapshot_settings(&repo);
     let _guard = settings.bind_to_scope();
 
-    // Both run with --yes: user first, then project (project needs approval)
-    assert_cmd_snapshot!(make_snapshot_cmd(
+    // Both run with -y: user first, then project (project needs approval)
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
         &repo,
         "step",
-        &["deploy", "--yes"],
+        &["deploy"],
         Some(&feature_path),
+        &["-y"],
     ));
 }
 
-/// --yes bypasses approval for project-config alias without saving
+/// -y bypasses approval for project-config alias without saving
 #[rstest]
 fn test_alias_approval_yes_bypasses(mut repo: TestRepo) {
     repo.write_project_config(
@@ -558,13 +567,19 @@ deploy = "echo deploying"
     let settings = setup_snapshot_settings(&repo);
     let _guard = settings.bind_to_scope();
 
-    // First run with --yes succeeds
+    // First run with -y succeeds
     assert_cmd_snapshot!(
         "alias_approval_yes_first_run",
-        make_snapshot_cmd(&repo, "step", &["deploy", "--yes"], Some(&feature_path),)
+        make_snapshot_cmd_with_global_flags(
+            &repo,
+            "step",
+            &["deploy"],
+            Some(&feature_path),
+            &["-y"],
+        )
     );
 
-    // Second run without --yes should still prompt (--yes doesn't save approval)
+    // Second run without -y should still prompt (-y doesn't save approval)
     assert_cmd_snapshot!(
         "alias_approval_yes_second_run_prompts",
         make_snapshot_cmd(&repo, "step", &["deploy"], Some(&feature_path),)
@@ -1055,12 +1070,13 @@ deploy = [
     let _guard = settings.bind_to_scope();
 
     // Must succeed: dry-run must not require vars.* to be resolvable.
-    // --yes bypasses approval for project-config aliases.
-    assert_cmd_snapshot!(make_snapshot_cmd(
+    // -y bypasses approval for project-config aliases.
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
         &repo,
         "step",
-        &["deploy", "--dry-run", "--yes"],
+        &["deploy", "--dry-run"],
         Some(&feature_path),
+        &["-y"],
     ));
 }
 
@@ -1079,7 +1095,7 @@ broken = "echo {{ vars..target }}"
 
     let output = repo
         .wt_command()
-        .args(["step", "broken", "--dry-run", "--yes"])
+        .args(["-y", "step", "broken", "--dry-run"])
         .current_dir(&feature_path)
         .output()
         .unwrap();
@@ -1241,11 +1257,12 @@ run = "echo got {{ args }}"
     let settings = setup_snapshot_settings(&repo);
     let _guard = settings.bind_to_scope();
 
-    assert_cmd_snapshot!(make_snapshot_cmd(
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
         &repo,
         "run",
-        &["one", "two three", "four", "--yes"],
+        &["one", "two three", "four"],
         Some(&feature_path),
+        &["-y"],
     ));
 }
 
@@ -1265,11 +1282,12 @@ show = '''echo first={{ args[0] }}; echo count={{ args | length }}; echo each={%
     let settings = setup_snapshot_settings(&repo);
     let _guard = settings.bind_to_scope();
 
-    assert_cmd_snapshot!(make_snapshot_cmd(
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
         &repo,
         "show",
-        &["alpha", "beta gamma", "--yes"],
+        &["alpha", "beta gamma"],
         Some(&feature_path),
+        &["-y"],
     ));
 }
 
@@ -1289,11 +1307,12 @@ run = "echo [{{ args }}]"
     let settings = setup_snapshot_settings(&repo);
     let _guard = settings.bind_to_scope();
 
-    assert_cmd_snapshot!(make_snapshot_cmd(
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
         &repo,
         "run",
-        &["--yes"],
+        &[],
         Some(&feature_path),
+        &["-y"],
     ));
 }
 
@@ -1314,11 +1333,12 @@ s = "wt switch {{ args }}"
     let settings = setup_snapshot_settings(&repo);
     let _guard = settings.bind_to_scope();
 
-    assert_cmd_snapshot!(make_snapshot_cmd(
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
         &repo,
         "s",
-        &["target-branch", "--dry-run", "--yes"],
+        &["target-branch", "--dry-run"],
         Some(&feature_path),
+        &["-y"],
     ));
 }
 


### PR DESCRIPTION
PR #2279 promoted `-y`/`--yes` to a top-level global clap flag. The hand-rolled `AliasOptions::parse` kept consuming a post-alias `--yes` for back-compat — that's the deferred cleanup landing here. `run_alias` now reads only the global flag (`skip_approval = global_yes`).

This is a real cutover, not a no-op. Clap's `global = true` does not propagate flags across an `external_subcommand` boundary (verified against clap 4.6 — `wt deploy --yes` results in `Custom(["deploy", "--yes"])` with `global_yes = false`). So the post-alias form was never reaching the global parser; it only worked because `AliasOptions::parse` consumed it. Removing the field removes user-visible behavior:

| Form | Before | After |
|---|---|---|
| `wt -y deploy` | skips approval | skips approval |
| `wt --yes deploy` | skips approval | skips approval |
| `wt deploy --yes` | skips approval | errors: "Unknown flag '--yes'" |
| `wt deploy -y` | skips approval | silently forwards `-y` as `{{ args }}` positional |

The `--yes` / `-y` asymmetry on the post-alias side is documented in the `AliasOptions::parse` docstring and locked in by parser tests.

## Test changes

- `test_post_alias_yes_still_works` → `test_post_alias_yes_no_longer_supported` (asserts the new error)
- 14 call sites in `tests/integration_tests/step_alias.rs` migrated from `&[..., "--yes"]` to `make_snapshot_cmd_with_global_flags(..., &["-y"])`
- 4 unnecessary `--yes` flags removed from `tests/integration_tests/bare_repository.rs` (the `print-repo-path` user-config alias never required approval)

> _This was written by Claude Code on behalf of Maximilian_