### PR TITLE
test(approvals): fix project_id mismatch in clear-approvals tests

### DIFF
--- a/tests/integration_tests/approvals.rs
+++ b/tests/integration_tests/approvals.rs
@@ -101,18 +101,18 @@ fn test_clear_approvals_no_approvals(repo: TestRepo) {
 
 #[rstest]
 fn test_clear_approvals_with_approvals(repo: TestRepo) {
-    // Remove origin so project_id uses directory name (matches test expectation)
+    // Remove origin so project_identifier uses the canonical worktree path —
+    // matches what `Repository::project_identifier` computes at runtime.
     repo.run_git(&["remote", "remove", "origin"]);
-    let project_id = format!("{}/origin", repo.root_path().display());
     repo.commit("Initial commit");
     repo.write_project_config(r#"post-create = "echo 'test'""#);
     repo.commit("Add config");
 
-    // Manually approve the command by writing to test config
+    // Manually approve the command using the same project id wt will compute.
     let mut approvals = Approvals::default();
     approvals
         .approve_command(
-            project_id,
+            repo.project_id(),
             "echo 'test'".to_string(),
             Some(repo.test_approvals_path()),
         )
@@ -156,18 +156,18 @@ fn test_clear_approvals_global_with_approvals(repo: TestRepo) {
 
 #[rstest]
 fn test_clear_approvals_after_clear(repo: TestRepo) {
-    // Remove origin so project_id uses directory name (matches test expectation)
+    // Remove origin so project_identifier uses the canonical worktree path —
+    // matches what `Repository::project_identifier` computes at runtime.
     repo.run_git(&["remote", "remove", "origin"]);
-    let project_id = format!("{}/origin", repo.root_path().display());
     repo.commit("Initial commit");
     repo.write_project_config(r#"post-create = "echo 'test'""#);
     repo.commit("Add config");
 
-    // Manually approve the command
+    // Manually approve the command using the same project id wt will compute.
     let mut approvals = Approvals::default();
     approvals
         .approve_command(
-            project_id.clone(),
+            repo.project_id(),
             "echo 'test'".to_string(),
             Some(repo.test_approvals_path()),
         )
@@ -223,7 +223,8 @@ approved-commands = ["cargo build", "cargo test", "npm install"]
 
 #[rstest]
 fn test_clear_approvals_multiple_approvals(repo: TestRepo) {
-    // Remove origin so project_id uses directory name (matches test expectation)
+    // Remove origin so project_identifier uses the canonical worktree path —
+    // matches what `Repository::project_identifier` computes at runtime.
     repo.run_git(&["remote", "remove", "origin"]);
     repo.write_project_config(
         r#"
@@ -235,8 +236,8 @@ lint = "echo 'third'"
     );
     repo.commit("Add config with multiple commands");
 
-    // Manually approve all commands
-    let project_id = format!("{}/origin", repo.root_path().display());
+    // Manually approve all commands using the same project id wt will compute.
+    let project_id = repo.project_id();
     let mut approvals = Approvals::default();
     approvals
         .approve_command(

--- a/tests/snapshots/integration__integration_tests__approvals__clear_approvals_multiple_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__clear_approvals_multiple_approvals.snap
@@ -45,4 +45,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m No approvals to clear for this project
+[32m✓[39m [32mCleared 3 approvals for this project[39m

--- a/tests/snapshots/integration__integration_tests__approvals__clear_approvals_with_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__clear_approvals_with_approvals.snap
@@ -45,4 +45,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m No approvals to clear for this project
+[32m✓[39m [32mCleared 1 approval for this project[39m


### PR DESCRIPTION
Three clear-approvals tests fabricated `format!(\"{}/origin\", root)` as the project_id, which doesn't match what `Repository::project_identifier` computes after `git remote remove origin`. The manually-written approvals were stored under the wrong key, so the tests silently exercised the "no approvals to clear" branch instead of the count branch their names imply.

Replaced with `repo.project_id()`, the same fix already applied to `test_add_approvals_all_already_approved` in #2286. Snapshots now show "Cleared 1 approval" and "Cleared 3 approvals" — the `after_clear` snapshot is unchanged but now actually exercises the clear-then-clear-again path.

> _This was written by Claude Code on behalf of @max-sixty_