### PR TITLE
feat(merge): combine user+project post-merge into one announce line

### DIFF
--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -9,7 +9,7 @@ use super::command_executor::CommandContext;
 use super::command_executor::FailureStrategy;
 use super::commit::CommitOptions;
 use super::context::CommandEnv;
-use super::hooks::{execute_hook, prepare_background_hooks, spawn_hook_pipeline};
+use super::hooks::{announce_and_spawn_background_hooks, execute_hook, prepare_background_hooks};
 use super::project_config::{ApprovableCommand, collect_commands_for_hooks};
 use super::repository_ext::{
     RepositoryCliExt, check_not_default_branch, compute_integration_reason, is_primary_worktree,
@@ -358,9 +358,12 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
             extra.push(("short_commit", sc));
         }
 
-        for steps in prepare_background_hooks(&ctx, HookType::PostMerge, &extra, display_path)? {
-            spawn_hook_pipeline(&ctx, steps)?;
-        }
+        let pipelines: Vec<_> =
+            prepare_background_hooks(&ctx, HookType::PostMerge, &extra, display_path)?
+                .into_iter()
+                .map(|g| (ctx, g))
+                .collect();
+        announce_and_spawn_background_hooks(pipelines, false)?;
     }
 
     if json_mode {

--- a/tests/integration_tests/user_hooks.rs
+++ b/tests/integration_tests/user_hooks.rs
@@ -521,6 +521,36 @@ notify = "echo 'USER_POST_MERGE_RAN' > user_postmerge.txt"
     wait_for_file(&marker_file);
 }
 
+#[rstest]
+fn test_combined_user_and_project_post_merge(mut repo: TestRepo) {
+    repo.write_project_config(
+        r#"[post-merge]
+install = "echo 'PROJECT_RAN' > project_postmerge.txt"
+"#,
+    );
+    repo.commit("Add project config");
+
+    let feature_wt =
+        repo.add_worktree_with_commit("feature", "feature.txt", "feature content", "Add feature");
+
+    repo.write_test_config(
+        r#"[post-merge]
+sync = "echo 'USER_RAN' > user_postmerge.txt"
+"#,
+    );
+
+    snapshot_merge(
+        "combined_user_and_project_post_merge",
+        &repo,
+        &["main", "--yes", "--no-remove"],
+        Some(&feature_wt),
+    );
+
+    let main_worktree = repo.root_path();
+    wait_for_file(&main_worktree.join("user_postmerge.txt"));
+    wait_for_file(&main_worktree.join("project_postmerge.txt"));
+}
+
 // ============================================================================
 // User Pre-Remove Hook Tests
 // ============================================================================

--- a/tests/snapshots/integration__integration_tests__user_hooks__combined_user_and_project_post_merge.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__combined_user_and_project_post_merge.snap
@@ -1,0 +1,55 @@
+---
+source: tests/integration_tests/user_hooks.rs
+info:
+  program: wt
+  args:
+    - merge
+    - main
+    - "--yes"
+    - "--no-remove"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mMerging 1 commit to [1mmain[22m @ [2m[HASH][22m (no commit/squash/rebase needed)[39m
+[107m [0m * [33m[HASH][m Add feature
+[107m [0m  feature.txt | 1 [32m+[m
+[107m [0m  1 file changed, 1 insertion(+)
+[32m✓[39m [32mMerged to [1mmain[22m [90m(1 commit, 1 file, [32m+1[39m[39m[90m)[39m[39m
+[2m○[22m Worktree preserved (--no-remove)
+[36m◎[39m [36mRunning post-merge: [1muser:sync[22m, [1mproject:install[22m @ [1m_REPO_[22m[39m


### PR DESCRIPTION
When both user and project hooks fire on post-merge, the pre-change output showed two separate announce lines:

```
◎ Running post-merge: user:sync
◎ Running post-merge: project:install; project:write, project:publish
```

The merge loop was calling `spawn_hook_pipeline` once per source group. Switching to `announce_and_spawn_background_hooks` — the same pattern `handle_switch` already uses for post-switch + post-start — collapses both into:

```
◎ Running post-merge: user:sync, project:install; project:write, project:publish @ <path>
```

Also adds `test_combined_user_and_project_post_merge`; no existing post-merge test exercised both sources together, which is why the original behavior survived unnoticed.

> _This was written by Claude Code on behalf of Maximilian_