### PR TITLE
feat(cli): reject alias args unused by template

### DIFF
--- a/docs/content/extending.md
+++ b/docs/content/extending.md
@@ -122,6 +122,8 @@ open = "open http://localhost:{{ branch | hash_port }}"
 
 Hyphens in variable names are canonicalized to underscores at parse time, so `--my-var=value` is referenced as `{{ my_var }}` in templates. This lets flags use natural kebab-case while avoiding the minijinja parser's interpretation of `{{ my-var }}` as subtraction.
 
+Assignments for variables that no template step references are rejected — `wt deploy --env=prod` errors when no template in `deploy` uses `{{ env }}`, rather than silently discarding the value.
+
 ### Forwarding positional arguments
 
 Non-flag tokens after the alias name are forwarded to the template as `{{ args }}`. Bare `{{ args }}` renders as a space-joined, shell-escaped string ready to append to a command line — so `wt s some-branch` with `s = "wt switch {{ args }}"` expands to `wt switch some-branch`.
@@ -134,6 +136,8 @@ s = "wt switch {{ args }}"
 {{ terminal(cmd="wt s some-branch|||wt s feature/api  # multiple tokens pass through in order|||wt s 'has a space'  # spaces and metacharacters are escaped safely") }}
 
 Access elements with `{{ args[0] }}`, iterate with `{% for a in args %}…{% endfor %}`, or count with `{{ args | length }}`. Each element is individually shell-escaped, so `wt run 'a b' 'c;d'` splices in as `'a b' 'c;d'` without shell injection.
+
+Positional tokens passed to an alias whose templates never reference `{{ args }}` are rejected — the alias errors rather than silently dropping them. The reference check unions across every step in a pipeline, so one step using `{{ args }}` is enough.
 
 An `up` alias that fetches all remotes and rebases each worktree onto its upstream:
 

--- a/skills/worktrunk/reference/extending.md
+++ b/skills/worktrunk/reference/extending.md
@@ -119,6 +119,8 @@ wt deploy --env=staging
 
 Hyphens in variable names are canonicalized to underscores at parse time, so `--my-var=value` is referenced as `{{ my_var }}` in templates. This lets flags use natural kebab-case while avoiding the minijinja parser's interpretation of `{{ my-var }}` as subtraction.
 
+Assignments for variables that no template step references are rejected — `wt deploy --env=prod` errors when no template in `deploy` uses `{{ env }}`, rather than silently discarding the value.
+
 ### Forwarding positional arguments
 
 Non-flag tokens after the alias name are forwarded to the template as `{{ args }}`. Bare `{{ args }}` renders as a space-joined, shell-escaped string ready to append to a command line — so `wt s some-branch` with `s = "wt switch {{ args }}"` expands to `wt switch some-branch`.
@@ -135,6 +137,8 @@ wt s 'has a space'  # spaces and metacharacters are escaped safely
 ```
 
 Access elements with `{{ args[0] }}`, iterate with `{% for a in args %}…{% endfor %}`, or count with `{{ args | length }}`. Each element is individually shell-escaped, so `wt run 'a b' 'c;d'` splices in as `'a b' 'c;d'` without shell injection.
+
+Positional tokens passed to an alias whose templates never reference `{{ args }}` are rejected — the alias errors rather than silently dropping them. The reference check unions across every step in a pipeline, so one step using `{{ args }}` is enough.
 
 An `up` alias that fetches all remotes and rebases each worktree onto its upstream:
 

--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -30,7 +30,7 @@
 //! the EXEC directive file is scrubbed so alias bodies cannot inject
 //! arbitrary shell into the interactive session.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, HashMap, HashSet};
 
 use anyhow::{Context, bail};
 use clap::error::{ContextKind, ContextValue, ErrorKind};
@@ -177,6 +177,69 @@ fn alias_needs_approval(
         .as_ref()
         .and_then(|pc| pc.aliases.get(alias_name))
         .cloned()
+}
+
+/// Collect the union of template variable names referenced across every
+/// command in `cmd_config`. Returns `None` if any template fails to parse —
+/// callers should then skip unused-argument validation so the real syntax
+/// error surfaces during expansion instead of being masked by a spurious
+/// "unused" diagnostic.
+///
+/// Uses minijinja's AST walk via `undeclared_variables(false)`, which correctly
+/// reports free variables across every form users write: `{{ args }}`,
+/// `{{ args[0] }}`, `{{ args | length }}`, `{% for a in args %}…{% endfor %}`,
+/// `{% if args %}…{% endif %}`.
+fn referenced_template_vars(cmd_config: &CommandConfig) -> Option<HashSet<String>> {
+    let env = minijinja::Environment::new();
+    let mut refs = HashSet::new();
+    for cmd in cmd_config.commands() {
+        let tmpl = env.template_from_str(&cmd.template).ok()?;
+        refs.extend(tmpl.undeclared_variables(false));
+    }
+    Some(refs)
+}
+
+/// Reject positional args and `--key=value` assignments that no template in
+/// the alias references. Silent-drop of user input violates the project's
+/// fail-fast principle, and catching it at the edge surfaces typos like
+/// `wt deploy prod` (with no `{{ args }}`) as an error rather than a no-op.
+///
+/// Runs before both the approval prompt and the `--dry-run` branch, so a
+/// dry-run still fails on unused input — the template preview wouldn't show
+/// dropped values anyway.
+///
+/// Templates that fail to parse cause the check to be skipped entirely so
+/// the real syntax error surfaces during expansion.
+fn reject_unused_args(opts: &AliasOptions, cmd_config: &CommandConfig) -> anyhow::Result<()> {
+    let Some(referenced) = referenced_template_vars(cmd_config) else {
+        return Ok(());
+    };
+    if !opts.positional_args.is_empty() && !referenced.contains(ALIAS_ARGS_KEY) {
+        bail!(cformat!(
+            "alias <bold>{}</> has no {{{{ args }}}} in template; unused: {}",
+            opts.name,
+            opts.positional_args.join(" "),
+        ));
+    }
+    let unused: Vec<&str> = opts
+        .vars
+        .iter()
+        .filter(|(k, _)| !referenced.contains(k.as_str()))
+        .map(|(k, _)| k.as_str())
+        .collect();
+    if !unused.is_empty() {
+        let list = unused
+            .iter()
+            .map(|k| format!("{{{{ {k} }}}}"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        bail!(cformat!(
+            "alias <bold>{}</> does not reference: {}",
+            opts.name,
+            list,
+        ));
+    }
+    Ok(())
 }
 
 /// Synthesize clap's native `InvalidSubcommand` error for `wt step <name>`
@@ -362,6 +425,8 @@ fn run_alias(
     let cmd_config = aliases
         .get(&opts.name)
         .expect("caller verified alias is configured");
+
+    reject_unused_args(&opts, cmd_config)?;
 
     let skip_approval = global_yes;
 

--- a/tests/integration_tests/step_alias.rs
+++ b/tests/integration_tests/step_alias.rs
@@ -1342,6 +1342,187 @@ s = "wt switch {{ args }}"
     ));
 }
 
+/// Positional args are rejected when the alias template has no `{{ args }}`.
+/// Silent-drop of user input violates the fail-fast principle — users who type
+/// extra tokens almost always meant them to go somewhere.
+#[rstest]
+fn test_step_alias_rejects_unused_positional(mut repo: TestRepo) {
+    repo.write_project_config(
+        r#"
+[aliases]
+run = "echo hello"
+"#,
+    );
+    repo.commit("Add alias config");
+    let feature_path = repo.add_worktree("feature");
+
+    let settings = setup_snapshot_settings(&repo);
+    let _guard = settings.bind_to_scope();
+
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
+        &repo,
+        "run",
+        &["extra", "junk"],
+        Some(&feature_path),
+        &["-y"],
+    ));
+}
+
+/// `--key=value` assignments are rejected when the alias template does not
+/// reference `{{ key }}` — same footgun as unused positional args.
+#[rstest]
+fn test_step_alias_rejects_unused_key_value(mut repo: TestRepo) {
+    repo.write_project_config(
+        r#"
+[aliases]
+run = "echo hello"
+"#,
+    );
+    repo.commit("Add alias config");
+    let feature_path = repo.add_worktree("feature");
+
+    let settings = setup_snapshot_settings(&repo);
+    let _guard = settings.bind_to_scope();
+
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
+        &repo,
+        "run",
+        &["--env=prod"],
+        Some(&feature_path),
+        &["-y"],
+    ));
+}
+
+/// Multiple unused `--key=value` assignments are reported together in a
+/// single error so users can fix them in one pass.
+#[rstest]
+fn test_step_alias_rejects_multiple_unused_key_values(mut repo: TestRepo) {
+    repo.write_project_config(
+        r#"
+[aliases]
+run = "echo hello"
+"#,
+    );
+    repo.commit("Add alias config");
+    let feature_path = repo.add_worktree("feature");
+
+    let settings = setup_snapshot_settings(&repo);
+    let _guard = settings.bind_to_scope();
+
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
+        &repo,
+        "run",
+        &["--env=prod", "--region=us-east"],
+        Some(&feature_path),
+        &["-y"],
+    ));
+}
+
+/// Pipeline where only one step references `{{ args }}` still accepts
+/// positional args — the reference check unions across all commands.
+#[rstest]
+fn test_step_alias_pipeline_union_accepts_args(mut repo: TestRepo) {
+    repo.write_project_config(
+        r#"
+[aliases]
+build = ["echo first step", "echo running {{ args }}"]
+"#,
+    );
+    repo.commit("Add alias config");
+    let feature_path = repo.add_worktree("feature");
+
+    let settings = setup_snapshot_settings(&repo);
+    let _guard = settings.bind_to_scope();
+
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
+        &repo,
+        "build",
+        &["payload"],
+        Some(&feature_path),
+        &["-y"],
+    ));
+}
+
+/// A multi-step pipeline where no step references `{{ args }}` rejects
+/// positional args — the union check correctly reports "not referenced"
+/// across all steps, not just the first.
+#[rstest]
+fn test_step_alias_pipeline_rejects_when_no_step_uses_args(mut repo: TestRepo) {
+    repo.write_project_config(
+        r#"
+[aliases]
+build = ["echo first", "echo second"]
+"#,
+    );
+    repo.commit("Add alias config");
+    let feature_path = repo.add_worktree("feature");
+
+    let settings = setup_snapshot_settings(&repo);
+    let _guard = settings.bind_to_scope();
+
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
+        &repo,
+        "build",
+        &["payload"],
+        Some(&feature_path),
+        &["-y"],
+    ));
+}
+
+/// A conditional reference `{% if args %}…{% endif %}` counts as a
+/// reference — minijinja's AST walk catches the free variable regardless
+/// of whether it's in an expression, a filter, an index, a loop, or a
+/// conditional.
+#[rstest]
+fn test_step_alias_conditional_args_counts_as_referenced(mut repo: TestRepo) {
+    repo.write_project_config(
+        r#"
+[aliases]
+maybe = "echo{% if args %} got={{ args }}{% endif %}"
+"#,
+    );
+    repo.commit("Add alias config");
+    let feature_path = repo.add_worktree("feature");
+
+    let settings = setup_snapshot_settings(&repo);
+    let _guard = settings.bind_to_scope();
+
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
+        &repo,
+        "maybe",
+        &["value"],
+        Some(&feature_path),
+        &["-y"],
+    ));
+}
+
+/// Post-alias `-y` (single-dash) falls into the positional-args branch
+/// (clap only captures `--yes`/`-y` at the global position). With the
+/// unused-arg check, an alias whose template has no `{{ args }}` now
+/// surfaces the mistake instead of silently forwarding `-y` as a token.
+#[rstest]
+fn test_step_alias_rejects_post_alias_dash_y(mut repo: TestRepo) {
+    repo.write_project_config(
+        r#"
+[aliases]
+run = "echo hello"
+"#,
+    );
+    repo.commit("Add alias config");
+    let feature_path = repo.add_worktree("feature");
+
+    let settings = setup_snapshot_settings(&repo);
+    let _guard = settings.bind_to_scope();
+
+    assert_cmd_snapshot!(make_snapshot_cmd_with_global_flags(
+        &repo,
+        "run",
+        &["-y"],
+        Some(&feature_path),
+        &["-y"],
+    ));
+}
+
 /// Declining approval prevents alias execution
 #[rstest]
 fn test_alias_approval_decline(mut repo: TestRepo) {

--- a/tests/snapshots/integration__integration_tests__step_alias__step_alias_conditional_args_counts_as_referenced.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_alias_conditional_args_counts_as_referenced.snap
@@ -1,0 +1,49 @@
+---
+source: tests/integration_tests/step_alias.rs
+info:
+  program: wt
+  args:
+    - "-y"
+    - maybe
+    - value
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mRunning alias [1mmaybe[22m[39m
+[0mgot=value

--- a/tests/snapshots/integration__integration_tests__step_alias__step_alias_pipeline_rejects_when_no_step_uses_args.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_alias_pipeline_rejects_when_no_step_uses_args.snap
@@ -1,0 +1,48 @@
+---
+source: tests/integration_tests/step_alias.rs
+info:
+  program: wt
+  args:
+    - "-y"
+    - build
+    - payload
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[31m✗[39m [31malias [1mbuild[22m has no {{ args }} in template; unused: payload[39m

--- a/tests/snapshots/integration__integration_tests__step_alias__step_alias_pipeline_union_accepts_args.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_alias_pipeline_union_accepts_args.snap
@@ -1,0 +1,50 @@
+---
+source: tests/integration_tests/step_alias.rs
+info:
+  program: wt
+  args:
+    - "-y"
+    - build
+    - payload
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mRunning alias [1mbuild[22m[39m
+[0mfirst step
+[0mrunning payload

--- a/tests/snapshots/integration__integration_tests__step_alias__step_alias_rejects_multiple_unused_key_values.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_alias_rejects_multiple_unused_key_values.snap
@@ -1,0 +1,49 @@
+---
+source: tests/integration_tests/step_alias.rs
+info:
+  program: wt
+  args:
+    - "-y"
+    - run
+    - "--env=prod"
+    - "--region=us-east"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[31m✗[39m [31malias [1mrun[22m does not reference: {{ env }}, {{ region }}[39m

--- a/tests/snapshots/integration__integration_tests__step_alias__step_alias_rejects_post_alias_dash_y.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_alias_rejects_post_alias_dash_y.snap
@@ -1,0 +1,48 @@
+---
+source: tests/integration_tests/step_alias.rs
+info:
+  program: wt
+  args:
+    - "-y"
+    - run
+    - "-y"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[31m✗[39m [31malias [1mrun[22m has no {{ args }} in template; unused: -y[39m

--- a/tests/snapshots/integration__integration_tests__step_alias__step_alias_rejects_unused_key_value.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_alias_rejects_unused_key_value.snap
@@ -1,0 +1,48 @@
+---
+source: tests/integration_tests/step_alias.rs
+info:
+  program: wt
+  args:
+    - "-y"
+    - run
+    - "--env=prod"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[31m✗[39m [31malias [1mrun[22m does not reference: {{ env }}[39m

--- a/tests/snapshots/integration__integration_tests__step_alias__step_alias_rejects_unused_positional.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_alias_rejects_unused_positional.snap
@@ -1,0 +1,49 @@
+---
+source: tests/integration_tests/step_alias.rs
+info:
+  program: wt
+  args:
+    - "-y"
+    - run
+    - extra
+    - junk
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 1
+----- stdout -----
+
+----- stderr -----
+[31m✗[39m [31malias [1mrun[22m has no {{ args }} in template; unused: extra junk[39m


### PR DESCRIPTION
Closes a silent-drop footgun: `wt deploy production` with `deploy = "echo hello"` discarded `production` with no feedback; same for `wt deploy --env=prod` when the template had no `{{ env }}`. Both now error at the edge.

The check computes the union of referenced template variables across every command in the alias pipeline via `minijinja::Environment::template_from_str().undeclared_variables(false)` — the same AST-based primitive already used in `template_references_var`, `deprecation.rs`, and `hook_commands.rs`. One step referencing `{{ args }}` is enough to accept positionals for the whole pipeline. Templates that fail to parse skip the check entirely so the real syntax error still surfaces during expansion.

Runs before both the approval prompt and the `--dry-run` branch, so dry-run previews also fail on unused input — silently-dropped values wouldn't be visible in the preview anyway.

Secondary: `wt deploy -y` with no `{{ args }}` used to silently forward `-y` as a positional token; it now errors, pointing toward the `wt -y deploy` form the parser docstring already documents.

### Tests

Seven new integration tests in `tests/integration_tests/step_alias.rs` covering the three rejection cases (positional, single `--key=value`, multiple `--key=value`), post-alias `-y`, multi-step pipeline rejection, single-step pipeline union acceptance, and conditional `{% if args %}` references.

> _This was written by Claude Code on behalf of Maximilian Roos_