### PR TITLE
test(approvals): fix project_id mismatch in clear-approvals --global test

### DIFF
--- a/tests/integration_tests/approvals.rs
+++ b/tests/integration_tests/approvals.rs
@@ -129,18 +129,18 @@ fn test_clear_approvals_global_no_approvals(repo: TestRepo) {
 
 #[rstest]
 fn test_clear_approvals_global_with_approvals(repo: TestRepo) {
-    // Remove origin so project_id uses directory name (matches test expectation)
+    // Remove origin so project_identifier uses the canonical worktree path —
+    // matches what `Repository::project_identifier` computes at runtime.
     repo.run_git(&["remote", "remove", "origin"]);
-    let project_id = format!("{}/origin", repo.root_path().display());
     repo.commit("Initial commit");
     repo.write_project_config(r#"post-create = "echo 'test'""#);
     repo.commit("Add config");
 
-    // Manually approve the command
+    // Manually approve the command using the same project id wt will compute.
     let mut approvals = Approvals::default();
     approvals
         .approve_command(
-            project_id,
+            repo.project_id(),
             "echo 'test'".to_string(),
             Some(repo.test_approvals_path()),
         )


### PR DESCRIPTION
Follow-up to #2293. `test_clear_approvals_global_with_approvals` had the same fabricated `format!("{}/origin", root)` project_id, but its snapshot didn't surface the bug because `--global` clears every project regardless of ID. The test was exercising the global-flag branch only by coincidence, not by design.

Replaced with `repo.project_id()`. Snapshot unchanged — purely a test-correctness fix.

> _This was written by Claude Code on behalf of @max-sixty_