### PR TITLE
fix(alias): error on template parse failure in referenced_vars_for_config

### DIFF
--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -321,7 +321,7 @@ pub fn try_alias(name: String, rest: Vec<String>, global_yes: bool) -> anyhow::R
     let Some(cmd_config) = aliases.get(&name) else {
         return Ok(None);
     };
-    let referenced = referenced_vars_for_config(cmd_config);
+    let referenced = referenced_vars_for_config(cmd_config)?;
     let mut alias_args = Vec::with_capacity(1 + rest.len());
     alias_args.push(name);
     alias_args.extend(rest);
@@ -361,7 +361,7 @@ pub fn step_alias(args: Vec<String>, global_yes: bool) -> anyhow::Result<()> {
             .collect();
         unknown_step_command_exit(&name, &alias_names);
     };
-    let referenced = referenced_vars_for_config(cmd_config);
+    let referenced = referenced_vars_for_config(cmd_config)?;
     let opts = AliasOptions::parse(args, &referenced)?;
     run_alias(opts, repo, user_config, project_config, aliases, global_yes)
 }
@@ -1235,7 +1235,7 @@ cmd = [
 
     /// `referenced_vars_for_config` unions across pipeline steps so a var
     /// referenced in any one command is a binding candidate for the whole
-    /// alias. Single-step templates that fail to parse contribute nothing.
+    /// alias.
     #[test]
     fn test_referenced_vars_for_config_unions_steps() {
         let cfg = cfg_from_toml(
@@ -1246,7 +1246,7 @@ cmd = [
 ]
 "#,
         );
-        let refs = worktrunk::config::referenced_vars_for_config(&cfg);
+        let refs = worktrunk::config::referenced_vars_for_config(&cfg).unwrap();
         let names: Vec<&str> = refs.iter().map(String::as_str).collect();
         assert_eq!(names, vec!["args", "env", "target"]);
     }

--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -12,6 +12,7 @@ use std::borrow::Cow;
 use std::fmt::{self, Write};
 use std::sync::Arc;
 
+use anyhow::Context;
 use color_print::cformat;
 use minijinja::value::{Enumerator, Object, ObjectRepr};
 use minijinja::{Environment, ErrorKind, UndefinedBehavior, Value};
@@ -484,18 +485,19 @@ pub fn template_references_var(template: &str, var: &str) -> bool {
 ///
 /// Drives alias-arg routing in `AliasOptions::parse`: a `--KEY=VALUE` token
 /// binds to `{{ KEY }}` only when KEY appears in this set; otherwise it
-/// forwards as a positional. Templates that fail to parse contribute nothing
-/// (the deferred expansion path will surface the syntax error at execution
-/// time).
-pub fn referenced_vars_for_config(cfg: &super::CommandConfig) -> BTreeSet<String> {
+/// forwards as a positional. A syntax error in any template fails here so the
+/// user sees it before flags are routed — a silent skip could mask a typo and
+/// silently change how subsequent CLI args bind.
+pub fn referenced_vars_for_config(cfg: &super::CommandConfig) -> anyhow::Result<BTreeSet<String>> {
     let env = minijinja::Environment::new();
     let mut out = BTreeSet::new();
     for cmd in cfg.commands() {
-        if let Ok(tmpl) = env.template_from_str(&cmd.template) {
-            out.extend(tmpl.undeclared_variables(false));
-        }
+        let tmpl = env
+            .template_from_str(&cmd.template)
+            .with_context(|| format!("Failed to parse template: {:?}", cmd.template))?;
+        out.extend(tmpl.undeclared_variables(false));
     }
-    out
+    Ok(out)
 }
 
 /// Parse-only syntax check for a template.
@@ -1735,6 +1737,15 @@ mod tests {
         let err = validate_template("{{ unclosed", ValidationScope::Alias, &test.repo, "test")
             .unwrap_err();
         assert!(err.message.contains("syntax error"), "got: {}", err.message);
+    }
+
+    #[test]
+    fn test_referenced_vars_for_config_syntax_error_propagates() {
+        let cfg = super::super::CommandConfig::single("echo {{ unclosed");
+        let err = referenced_vars_for_config(&cfg).unwrap_err();
+        let msg = format!("{err:#}");
+        assert!(msg.contains("Failed to parse template"), "got: {msg}");
+        assert!(msg.contains("syntax error"), "got: {msg}");
     }
 
     #[test]


### PR DESCRIPTION
Drops the silent `if let Ok(tmpl) = ...` skip in `referenced_vars_for_config` so a syntax error in any alias step surfaces before flags are routed. Previously, a malformed template made that step contribute no names to the referenced-var set, which silently changed how `--KEY=VALUE` tokens bound vs. forwarded as positionals — the deferred expansion path would only surface the syntax error later, after args may have been routed wrong.

The helper now returns `anyhow::Result<BTreeSet<String>>`; callers in `try_alias` and `step_alias` propagate with `?`. New unit test covers the error path.

Follow-up from review of #2287.

> _This was written by Claude Code on behalf of Maximilian_