### PR TITLE
docs(skill): expand worktrunk description with lexical triggers

### DIFF
--- a/docs/static/.well-known/agent-skills/index.json
+++ b/docs/static/.well-known/agent-skills/index.json
@@ -4,9 +4,9 @@
     {
       "name": "worktrunk",
       "type": "skill-md",
-      "description": "Guidance for Worktrunk, a CLI tool for managing git worktrees. Covers configuration (user config at ~/.config/worktrunk/config.toml and project hooks at .config/wt.toml), usage, and troubleshooting. Use for \"setting up commit message generation\", \"configuring hooks\", \"automating tasks\", or general worktrunk questions.",
+      "description": "Guidance for Worktrunk (the `wt` CLI) — git worktree management, hooks, and config. Load when editing .config/wt.toml or ~/.config/worktrunk/config.toml; adding, modifying, or debugging hooks (post-merge, post-start, pre-commit, pre-merge, post-switch, etc.); configuring commit message generation or command aliases; or troubleshooting wt behavior. Also answers general worktrunk/wt questions.",
       "url": "./worktrunk/SKILL.md",
-      "digest": "sha256:40b87e60c1729dbd2aec31986acda7a7aa5d31e4e51511c55f8fbfae972ec742"
+      "digest": "sha256:4e4be44b2216b4c7fdc1fd842ec76158a8b2174e23a9ea7e9509fcb540f0d828"
     }
   ]
 }

--- a/skills/worktrunk/SKILL.md
+++ b/skills/worktrunk/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: worktrunk
-description: Guidance for Worktrunk, a CLI tool for managing git worktrees. Covers configuration (user config at ~/.config/worktrunk/config.toml and project hooks at .config/wt.toml), usage, and troubleshooting. Use for "setting up commit message generation", "configuring hooks", "automating tasks", or general worktrunk questions.
+description: Guidance for Worktrunk (the `wt` CLI) — git worktree management, hooks, and config. Load when editing .config/wt.toml or ~/.config/worktrunk/config.toml; adding, modifying, or debugging hooks (post-merge, post-start, pre-commit, pre-merge, post-switch, etc.); configuring commit message generation or command aliases; or troubleshooting wt behavior. Also answers general worktrunk/wt questions.
 version: 0.39.0
 license: MIT OR Apache-2.0
 compatibility: Requires worktrunk CLI (https://worktrunk.dev)


### PR DESCRIPTION
The prior description relied on quoted example phrases ("configuring hooks", "automating tasks") that rarely match real user phrasing, and never mentioned `wt` — the CLI name users actually type. I recently skipped loading this skill while editing `~/.config/worktrunk/config.toml` to add a post-merge push hook, which prompted the update.

New description drops the quoted phrases and uses direct trigger criteria: both config file paths, explicit hook event names (`post-merge`, `post-start`, `pre-commit`, `pre-merge`, `post-switch`), and task verbs (adding, modifying, debugging).

> _This was written by Claude Code on behalf of Maximilian_