### PR TITLE
docs(hook): group template variables by kind and align ordering

### DIFF
--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -114,31 +114,31 @@ Skip all hooks with `--no-hooks`. To run a specific hook when user and project b
 
 Hooks can use template variables that expand at runtime:
 
-| Variable | Description |
-|----------|-------------|
-| `{{ branch }}` | Active branch name |
-| `{{ worktree_path }}` | Active worktree path |
-| `{{ worktree_name }}` | Active worktree directory name |
-| `{{ commit }}` | Active branch HEAD SHA |
-| `{{ short_commit }}` | Active branch HEAD SHA (7 chars) |
-| `{{ upstream }}` | Active branch upstream (if tracking a remote) |
-| `{{ base }}` | Base branch name |
-| `{{ base_worktree_path }}` | Base worktree path |
-| `{{ target }}` | Target branch name |
-| `{{ target_worktree_path }}` | Target worktree path |
-| `{{ cwd }}` | Directory where the hook command runs |
-| `{{ repo }}` | Repository directory name |
-| `{{ repo_path }}` | Absolute path to repository root |
-| `{{ owner }}` | Primary remote owner path (may include subgroups) |
-| `{{ primary_worktree_path }}` | Primary worktree path |
-| `{{ default_branch }}` | Default branch name |
-| `{{ remote }}` | Primary remote name |
-| `{{ remote_url }}` | Remote URL |
-| `{{ pr_number }}` | PR/MR number (when creating via `pr:N` / `mr:N`) |
-| `{{ pr_url }}` | PR/MR web URL (when creating via `pr:N` / `mr:N`) |
-| `{{ hook_type }}` | Hook type being run (e.g. `pre-start`, `pre-merge`) |
-| `{{ hook_name }}` | Hook command name (if named) |
-| `{{ vars.<key> }}` | Per-branch variables from [`wt config state vars`](@/config.md#wt-config-state-vars) |
+| Kind | Variable | Description |
+|------|----------|-------------|
+| active    | `{{ branch }}`                | Branch name |
+|           | `{{ worktree_path }}`         | Worktree path |
+|           | `{{ worktree_name }}`         | Worktree directory name |
+|           | `{{ commit }}`                | Branch HEAD SHA |
+|           | `{{ short_commit }}`          | Branch HEAD SHA (7 chars) |
+|           | `{{ upstream }}`              | Branch upstream (if tracking a remote) |
+| operation | `{{ base }}`                  | Base branch name |
+|           | `{{ base_worktree_path }}`    | Base worktree path |
+|           | `{{ target }}`                | Target branch name |
+|           | `{{ target_worktree_path }}`  | Target worktree path |
+|           | `{{ pr_number }}`             | PR/MR number (when creating via `pr:N` / `mr:N`) |
+|           | `{{ pr_url }}`                | PR/MR web URL (when creating via `pr:N` / `mr:N`) |
+| repo      | `{{ repo }}`                  | Repository directory name |
+|           | `{{ repo_path }}`             | Absolute path to repository root |
+|           | `{{ owner }}`                 | Primary remote owner path (may include subgroups) |
+|           | `{{ primary_worktree_path }}` | Primary worktree path |
+|           | `{{ default_branch }}`        | Default branch name |
+|           | `{{ remote }}`                | Primary remote name |
+|           | `{{ remote_url }}`            | Remote URL |
+| exec      | `{{ cwd }}`                   | Directory where the hook command runs |
+|           | `{{ hook_type }}`             | Hook type being run (e.g. `pre-start`, `pre-merge`) |
+|           | `{{ hook_name }}`             | Hook command name (if named) |
+| user      | `{{ vars.<key> }}`            | Per-branch variables from [`wt config state vars`](@/config.md#wt-config-state-vars) |
 
 Bare variables (`branch`, `worktree_path`, `commit`) refer to the branch the operation acts on: the destination for switch/create, the source for merge/remove. `base` and `target` give the other side:
 

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -105,31 +105,31 @@ Skip all hooks with `--no-hooks`. To run a specific hook when user and project b
 
 Hooks can use template variables that expand at runtime:
 
-| Variable | Description |
-|----------|-------------|
-| `{{ branch }}` | Active branch name |
-| `{{ worktree_path }}` | Active worktree path |
-| `{{ worktree_name }}` | Active worktree directory name |
-| `{{ commit }}` | Active branch HEAD SHA |
-| `{{ short_commit }}` | Active branch HEAD SHA (7 chars) |
-| `{{ upstream }}` | Active branch upstream (if tracking a remote) |
-| `{{ base }}` | Base branch name |
-| `{{ base_worktree_path }}` | Base worktree path |
-| `{{ target }}` | Target branch name |
-| `{{ target_worktree_path }}` | Target worktree path |
-| `{{ cwd }}` | Directory where the hook command runs |
-| `{{ repo }}` | Repository directory name |
-| `{{ repo_path }}` | Absolute path to repository root |
-| `{{ owner }}` | Primary remote owner path (may include subgroups) |
-| `{{ primary_worktree_path }}` | Primary worktree path |
-| `{{ default_branch }}` | Default branch name |
-| `{{ remote }}` | Primary remote name |
-| `{{ remote_url }}` | Remote URL |
-| `{{ pr_number }}` | PR/MR number (when creating via `pr:N` / `mr:N`) |
-| `{{ pr_url }}` | PR/MR web URL (when creating via `pr:N` / `mr:N`) |
-| `{{ hook_type }}` | Hook type being run (e.g. `pre-start`, `pre-merge`) |
-| `{{ hook_name }}` | Hook command name (if named) |
-| `{{ vars.<key> }}` | Per-branch variables from [`wt config state vars`](https://worktrunk.dev/config/#wt-config-state-vars) |
+| Kind | Variable | Description |
+|------|----------|-------------|
+| active    | `{{ branch }}`                | Branch name |
+|           | `{{ worktree_path }}`         | Worktree path |
+|           | `{{ worktree_name }}`         | Worktree directory name |
+|           | `{{ commit }}`                | Branch HEAD SHA |
+|           | `{{ short_commit }}`          | Branch HEAD SHA (7 chars) |
+|           | `{{ upstream }}`              | Branch upstream (if tracking a remote) |
+| operation | `{{ base }}`                  | Base branch name |
+|           | `{{ base_worktree_path }}`    | Base worktree path |
+|           | `{{ target }}`                | Target branch name |
+|           | `{{ target_worktree_path }}`  | Target worktree path |
+|           | `{{ pr_number }}`             | PR/MR number (when creating via `pr:N` / `mr:N`) |
+|           | `{{ pr_url }}`                | PR/MR web URL (when creating via `pr:N` / `mr:N`) |
+| repo      | `{{ repo }}`                  | Repository directory name |
+|           | `{{ repo_path }}`             | Absolute path to repository root |
+|           | `{{ owner }}`                 | Primary remote owner path (may include subgroups) |
+|           | `{{ primary_worktree_path }}` | Primary worktree path |
+|           | `{{ default_branch }}`        | Default branch name |
+|           | `{{ remote }}`                | Primary remote name |
+|           | `{{ remote_url }}`            | Remote URL |
+| exec      | `{{ cwd }}`                   | Directory where the hook command runs |
+|           | `{{ hook_type }}`             | Hook type being run (e.g. `pre-start`, `pre-merge`) |
+|           | `{{ hook_name }}`             | Hook command name (if named) |
+| user      | `{{ vars.<key> }}`            | Per-branch variables from [`wt config state vars`](https://worktrunk.dev/config/#wt-config-state-vars) |
 
 Bare variables (`branch`, `worktree_path`, `commit`) refer to the branch the operation acts on: the destination for switch/create, the source for merge/remove. `base` and `target` give the other side:
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1252,31 +1252,31 @@ Skip all hooks with `--no-hooks`. To run a specific hook when user and project b
 
 Hooks can use template variables that expand at runtime:
 
-| Variable | Description |
-|----------|-------------|
-| `{{ branch }}` | Active branch name |
-| `{{ worktree_path }}` | Active worktree path |
-| `{{ worktree_name }}` | Active worktree directory name |
-| `{{ commit }}` | Active branch HEAD SHA |
-| `{{ short_commit }}` | Active branch HEAD SHA (7 chars) |
-| `{{ upstream }}` | Active branch upstream (if tracking a remote) |
-| `{{ base }}` | Base branch name |
-| `{{ base_worktree_path }}` | Base worktree path |
-| `{{ target }}` | Target branch name |
-| `{{ target_worktree_path }}` | Target worktree path |
-| `{{ cwd }}` | Directory where the hook command runs |
-| `{{ repo }}` | Repository directory name |
-| `{{ repo_path }}` | Absolute path to repository root |
-| `{{ owner }}` | Primary remote owner path (may include subgroups) |
-| `{{ primary_worktree_path }}` | Primary worktree path |
-| `{{ default_branch }}` | Default branch name |
-| `{{ remote }}` | Primary remote name |
-| `{{ remote_url }}` | Remote URL |
-| `{{ pr_number }}` | PR/MR number (when creating via `pr:N` / `mr:N`) |
-| `{{ pr_url }}` | PR/MR web URL (when creating via `pr:N` / `mr:N`) |
-| `{{ hook_type }}` | Hook type being run (e.g. `pre-start`, `pre-merge`) |
-| `{{ hook_name }}` | Hook command name (if named) |
-| `{{ vars.<key> }}` | Per-branch variables from [`wt config state vars`](@/config.md#wt-config-state-vars) |
+| Kind | Variable | Description |
+|------|----------|-------------|
+| active    | `{{ branch }}`                | Branch name |
+|           | `{{ worktree_path }}`         | Worktree path |
+|           | `{{ worktree_name }}`         | Worktree directory name |
+|           | `{{ commit }}`                | Branch HEAD SHA |
+|           | `{{ short_commit }}`          | Branch HEAD SHA (7 chars) |
+|           | `{{ upstream }}`              | Branch upstream (if tracking a remote) |
+| operation | `{{ base }}`                  | Base branch name |
+|           | `{{ base_worktree_path }}`    | Base worktree path |
+|           | `{{ target }}`                | Target branch name |
+|           | `{{ target_worktree_path }}`  | Target worktree path |
+|           | `{{ pr_number }}`             | PR/MR number (when creating via `pr:N` / `mr:N`) |
+|           | `{{ pr_url }}`                | PR/MR web URL (when creating via `pr:N` / `mr:N`) |
+| repo      | `{{ repo }}`                  | Repository directory name |
+|           | `{{ repo_path }}`             | Absolute path to repository root |
+|           | `{{ owner }}`                 | Primary remote owner path (may include subgroups) |
+|           | `{{ primary_worktree_path }}` | Primary worktree path |
+|           | `{{ default_branch }}`        | Default branch name |
+|           | `{{ remote }}`                | Primary remote name |
+|           | `{{ remote_url }}`            | Remote URL |
+| exec      | `{{ cwd }}`                   | Directory where the hook command runs |
+|           | `{{ hook_type }}`             | Hook type being run (e.g. `pre-start`, `pre-merge`) |
+|           | `{{ hook_name }}`             | Hook command name (if named) |
+| user      | `{{ vars.<key> }}`            | Per-branch variables from [`wt config state vars`](@/config.md#wt-config-state-vars) |
 
 Bare variables (`branch`, `worktree_path`, `commit`) refer to the branch the operation acts on: the destination for switch/create, the source for merge/remove. `base` and `target` give the other side:
 

--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -31,20 +31,30 @@ use crate::styling::{
 /// Populated by `build_hook_context()` in `command_executor.rs`. `upstream`
 /// is conditional on branch tracking configuration but is included here so
 /// templates may reference it in any context (guarded by `{% if upstream %}`).
+///
+/// Ordered to match the user-facing help table in `src/cli/mod.rs`
+/// (`## Template variables`): active-context vars first, then repo/remote
+/// metadata, then the always-available portion of execution context (`cwd`).
+/// Operation-context vars (`base`, `target`, `pr_*`) and infrastructure
+/// vars (`hook_type`, `hook_name`) are not in `BASE_VARS` — they're added
+/// per-scope by `hook_extras` and `HOOK_INFRASTRUCTURE_VARS`.
 pub const BASE_VARS: &[&str] = &[
-    "repo",
-    "owner",
+    // Active context
     "branch",
-    "worktree_name",
-    "repo_path",
     "worktree_path",
-    "default_branch",
-    "primary_worktree_path",
+    "worktree_name",
     "commit",
     "short_commit",
+    "upstream",
+    // Repo / remote metadata
+    "repo",
+    "repo_path",
+    "owner",
+    "primary_worktree_path",
+    "default_branch",
     "remote",
     "remote_url",
-    "upstream",
+    // Execution context (always-available portion)
     "cwd",
 ];
 
@@ -93,6 +103,11 @@ pub enum ValidationScope {
 /// These are the vars injected by callers via `extra_vars` when running a
 /// hook. Keeping the mapping in one place means "which vars work in a
 /// `post-merge` hook?" is answerable without chasing inline comments.
+///
+/// Each arm's order must be a prefix-ordered subset of the operation-context
+/// block in the user-facing help table (`src/cli/mod.rs`, `## Template
+/// variables`): `base, base_worktree_path, target, target_worktree_path,
+/// pr_number, pr_url`.
 fn hook_extras(hook_type: HookType) -> &'static [&'static str] {
     use HookType::*;
     match hook_type {


### PR DESCRIPTION
## Summary

The hook template-variable surface had drifted: `BASE_VARS`, `hook_extras`, and the user-facing help table each used a different order. After #2300 added `pr_number`/`pr_url`, that drift got worse — the new vars landed at the bottom of the help table next to hook infrastructure, even though semantically they're operation context (they travel with `base`/`target`, populated by the same `pr:N`/`mr:N` code path).

This PR reorganises around five semantic groups and applies the same ordering everywhere:

| Kind | Vars |
|------|------|
| `active` | branch, worktree_path, worktree_name, commit, short_commit, upstream |
| `operation` | base, base_worktree_path, target, target_worktree_path, pr_number, pr_url |
| `repo` | repo, repo_path, owner, primary_worktree_path, default_branch, remote, remote_url |
| `exec` | cwd, hook_type, hook_name |
| `user` | vars.\<key\> |

## Changes

- `BASE_VARS` reordered into active → repo/remote → exec(`cwd`), with a doc-comment pointing at the help table as the canonical order.
- `hook_extras` doc-comment requires each arm to be a prefix-ordered subset of the operation-context block.
- Help table gains a `Kind` column printed once per group (blank on continuation rows). `pr_number`/`pr_url` move up to `operation`; `cwd` moves down to `exec`; the word "Active" is dropped from the first six descriptions since `Kind` now carries that signal.
- Auto-generated docs (`docs/content/hook.md`, `skills/worktrunk/reference/hook.md`) re-synced by `test_command_pages_and_skill_files_are_in_sync`.

No behaviour change — ordering only, plus the new Kind column.

## Follow-ups (not in this PR)

Add a test that enforces alignment across the three sites — the help-table row order, `BASE_VARS`, and each `hook_extras()` arm must all be prefix-subsets of one canonical ordered list. Would prevent the drift that #2300 introduced.

## Test plan

- [x] `cargo run -- hook pre-merge --yes` — clippy + 3272 tests + doctests + `RUSTDOCFLAGS=-Dwarnings cargo doc`
- [x] `test_command_pages_and_skill_files_are_in_sync` passes
- [x] `test_help` rstest suite passes (no changes — it doesn't cover `wt hook --help`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)