### PR TITLE
fix(alias): unify typo error format across config alias show/dry-run

### DIFF
--- a/src/commands/config/alias.rs
+++ b/src/commands/config/alias.rs
@@ -18,10 +18,12 @@
 //! natural home alongside `show`.
 
 use std::collections::{BTreeSet, HashMap};
+use std::io::Write;
 use std::process;
 
 use anyhow::Context;
-use color_print::{ceprintln, cformat};
+use clap::error::{ContextKind, ContextValue, ErrorKind};
+use color_print::cformat;
 use worktrunk::config::{
     ALIAS_ARGS_KEY, CommandConfig, ProjectConfig, UserConfig, append_aliases,
     referenced_vars_for_config, template_references_var, validate_template_syntax,
@@ -168,14 +170,17 @@ fn entries_for_name(
 /// Render an "unrecognized alias 'X'" error matching clap's `InvalidSubcommand`
 /// layout — same `error:` / `tip:` / `Usage:` block and exit code 2 as
 /// `wt <typo>` and `wt step <typo>` — then exit. `sub` is `"show"` or
-/// `"dry-run"`, used to render the Usage line from the real clap subcommand.
+/// `"dry-run"`, anchoring the error on the real clap subcommand so the Usage
+/// line reads `Usage: wt config alias <sub> <NAME>`.
 ///
-/// Rendered manually rather than through clap because `ErrorKind::InvalidSubcommand`
-/// bakes the word "subcommand" into its message. The alias name is a
-/// positional arg, not a subcommand, so "unrecognized alias" reads more
-/// honestly at this surface. Styling mirrors clap's default subcommand
-/// rendering (plain red `error:`, green `tip:`, bold+underline `Usage:`) so
-/// the four surfaces share one visual shape.
+/// Built as a real `clap::Error` with `ErrorKind::InvalidSubcommand`, rendered
+/// by clap, then string-substituted to say "alias" instead of "subcommand" —
+/// the positional is an alias name, not a subcommand, so the tighter wording
+/// reads more honestly at this surface. Going through clap's rendering gets
+/// NO_COLOR / TTY detection, singular-vs-plural "similar" phrasing, and
+/// styling correct automatically; modifying the final string is cheaper than
+/// reimplementing those. Plural `subcommands` is rewritten before singular
+/// `subcommand` so the substring match doesn't leave `aliass`.
 fn unknown_alias_exit(
     repo: &Repository,
     user_config: &UserConfig,
@@ -202,23 +207,30 @@ fn unknown_alias_exit(
     // synthesize the error ahead of that, set it to the display_name
     // `apply_help_template_recursive` would apply.
     sub_cmd.set_bin_name(format!("wt config alias {sub}"));
-    let usage = sub_cmd.render_usage().ansi().to_string();
+    let usage = sub_cmd.render_usage();
 
-    let tip_block = if suggestions.is_empty() {
-        String::new()
-    } else {
-        let joined: String = suggestions
-            .iter()
-            .map(|s| cformat!("'<green>{s}</>'"))
-            .collect::<Vec<_>>()
-            .join(", ");
-        cformat!("\n  <green>tip:</> some similar aliases exist: {joined}\n")
-    };
-
-    ceprintln!(
-        "<bold,red>error:</> unrecognized alias '<yellow>{name}</>'\n{tip_block}\n{usage}\n\nFor more information, try '<bold>--help</>'.",
+    let mut err = clap::Error::new(ErrorKind::InvalidSubcommand).with_cmd(sub_cmd);
+    err.insert(
+        ContextKind::InvalidSubcommand,
+        ContextValue::String(name.to_string()),
     );
+    if !suggestions.is_empty() {
+        err.insert(
+            ContextKind::SuggestedSubcommand,
+            ContextValue::Strings(suggestions),
+        );
+    }
+    err.insert(ContextKind::Usage, ContextValue::StyledStr(usage));
 
+    let rewritten = err
+        .render()
+        .ansi()
+        .to_string()
+        .replace("subcommands", "aliases")
+        .replace("subcommand", "alias");
+
+    let mut stream = anstream::AutoStream::auto(std::io::stderr());
+    let _ = write!(stream, "{rewritten}");
     process::exit(2)
 }
 

--- a/src/commands/config/alias.rs
+++ b/src/commands/config/alias.rs
@@ -19,7 +19,6 @@
 
 use std::collections::{BTreeSet, HashMap};
 use std::io::Write;
-use std::process;
 
 use anyhow::Context;
 use clap::error::{ContextKind, ContextValue, ErrorKind};
@@ -28,7 +27,7 @@ use worktrunk::config::{
     ALIAS_ARGS_KEY, CommandConfig, ProjectConfig, UserConfig, append_aliases,
     referenced_vars_for_config, template_references_var, validate_template_syntax,
 };
-use worktrunk::git::Repository;
+use worktrunk::git::{Repository, WorktrunkError};
 use worktrunk::styling::{format_bash_with_gutter, info_message, println};
 
 use crate::commands::alias::{AliasOptions, AliasSource};
@@ -48,7 +47,13 @@ pub fn handle_alias_show(name: String) -> anyhow::Result<()> {
     let entries = entries_for_name(&repo, &user_config, project_config.as_ref(), &name);
 
     if entries.is_empty() {
-        unknown_alias_exit(&repo, &user_config, project_config.as_ref(), &name, "show");
+        return Err(unknown_alias_error(
+            &repo,
+            &user_config,
+            project_config.as_ref(),
+            &name,
+            "show",
+        ));
     }
 
     for (i, (cfg, source)) in entries.iter().enumerate() {
@@ -75,13 +80,13 @@ pub fn handle_alias_dry_run(name: String, args: Vec<String>) -> anyhow::Result<(
     let entries = entries_for_name(&repo, &user_config, project_config.as_ref(), &name);
 
     if entries.is_empty() {
-        unknown_alias_exit(
+        return Err(unknown_alias_error(
             &repo,
             &user_config,
             project_config.as_ref(),
             &name,
             "dry-run",
-        );
+        ));
     }
 
     // Reuse the real parser so previews stay aligned with runtime parsing —
@@ -167,11 +172,11 @@ fn entries_for_name(
     entries
 }
 
-/// Render an "unrecognized alias 'X'" error matching clap's `InvalidSubcommand`
+/// Print an "unrecognized alias 'X'" error matching clap's `InvalidSubcommand`
 /// layout — same `error:` / `tip:` / `Usage:` block and exit code 2 as
-/// `wt <typo>` and `wt step <typo>` — then exit. `sub` is `"show"` or
-/// `"dry-run"`, anchoring the error on the real clap subcommand so the Usage
-/// line reads `Usage: wt config alias <sub> <NAME>`.
+/// `wt <typo>` and `wt step <typo>`. `sub` is `"show"` or `"dry-run"`,
+/// anchoring the error on the real clap subcommand so the Usage line reads
+/// `Usage: wt config alias <sub> <NAME>`.
 ///
 /// Built as a real `clap::Error` with `ErrorKind::InvalidSubcommand`, rendered
 /// by clap, then string-substituted to say "alias" instead of "subcommand" —
@@ -179,15 +184,24 @@ fn entries_for_name(
 /// reads more honestly at this surface. Going through clap's rendering gets
 /// NO_COLOR / TTY detection, singular-vs-plural "similar" phrasing, and
 /// styling correct automatically; modifying the final string is cheaper than
-/// reimplementing those. Plural `subcommands` is rewritten before singular
-/// `subcommand` so the substring match doesn't leave `aliass`.
-fn unknown_alias_exit(
+/// reimplementing those.
+///
+/// Substitutions are scoped to clap's fixed phrases, never the bare word
+/// "subcommand" — otherwise an alias or typo containing the literal string
+/// `subcommand` (e.g. `my-subcommand`) would be mangled when echoed into
+/// the error. Plural `subcommands` is rewritten before singular `subcommand`
+/// because `"similar subcommand"` is a prefix of `"similar subcommands"`.
+///
+/// Returns `AlreadyDisplayed { exit_code: 2 }` rather than calling
+/// `process::exit`, so `main`'s `finish_command` still runs `terminate_output`
+/// (ANSI reset for shell integration) and `diagnostic::write_if_verbose`.
+fn unknown_alias_error(
     repo: &Repository,
     user_config: &UserConfig,
     project_config: Option<&ProjectConfig>,
     name: &str,
     sub: &str,
-) -> ! {
+) -> anyhow::Error {
     let project_id = repo.project_identifier().ok();
     let mut merged = user_config.aliases(project_id.as_deref());
     if let Some(pc) = project_config {
@@ -226,12 +240,13 @@ fn unknown_alias_exit(
         .render()
         .ansi()
         .to_string()
-        .replace("subcommands", "aliases")
-        .replace("subcommand", "alias");
+        .replace("unrecognized subcommand", "unrecognized alias")
+        .replace("similar subcommands", "similar aliases")
+        .replace("similar subcommand", "similar alias");
 
     let mut stream = anstream::AutoStream::auto(std::io::stderr());
     let _ = write!(stream, "{rewritten}");
-    process::exit(2)
+    WorktrunkError::AlreadyDisplayed { exit_code: 2 }.into()
 }
 
 /// Format one alias entry: `○ Alias <name> (<source>)[ <verb>]:` header

--- a/src/commands/config/alias.rs
+++ b/src/commands/config/alias.rs
@@ -18,9 +18,10 @@
 //! natural home alongside `show`.
 
 use std::collections::{BTreeSet, HashMap};
+use std::process;
 
 use anyhow::Context;
-use color_print::cformat;
+use color_print::{ceprintln, cformat};
 use worktrunk::config::{
     ALIAS_ARGS_KEY, CommandConfig, ProjectConfig, UserConfig, append_aliases,
     referenced_vars_for_config, template_references_var, validate_template_syntax,
@@ -45,12 +46,7 @@ pub fn handle_alias_show(name: String) -> anyhow::Result<()> {
     let entries = entries_for_name(&repo, &user_config, project_config.as_ref(), &name);
 
     if entries.is_empty() {
-        return Err(unknown_alias_error(
-            &repo,
-            &user_config,
-            project_config.as_ref(),
-            &name,
-        ));
+        unknown_alias_exit(&repo, &user_config, project_config.as_ref(), &name, "show");
     }
 
     for (i, (cfg, source)) in entries.iter().enumerate() {
@@ -77,12 +73,13 @@ pub fn handle_alias_dry_run(name: String, args: Vec<String>) -> anyhow::Result<(
     let entries = entries_for_name(&repo, &user_config, project_config.as_ref(), &name);
 
     if entries.is_empty() {
-        return Err(unknown_alias_error(
+        unknown_alias_exit(
             &repo,
             &user_config,
             project_config.as_ref(),
             &name,
-        ));
+            "dry-run",
+        );
     }
 
     // Reuse the real parser so previews stay aligned with runtime parsing —
@@ -168,33 +165,61 @@ fn entries_for_name(
     entries
 }
 
-/// Build an anyhow error for an unknown alias, with a clap-style "did you mean"
-/// tail pulled from the merged alias name set.
+/// Render an "unrecognized alias 'X'" error matching clap's `InvalidSubcommand`
+/// layout — same `error:` / `tip:` / `Usage:` block and exit code 2 as
+/// `wt <typo>` and `wt step <typo>` — then exit. `sub` is `"show"` or
+/// `"dry-run"`, used to render the Usage line from the real clap subcommand.
 ///
-/// Uses `anyhow::Error::context` so the top-level handler formats the first
-/// line as a header and the suggestion list in the error gutter.
-fn unknown_alias_error(
+/// Rendered manually rather than through clap because `ErrorKind::InvalidSubcommand`
+/// bakes the word "subcommand" into its message. The alias name is a
+/// positional arg, not a subcommand, so "unrecognized alias" reads more
+/// honestly at this surface. Styling mirrors clap's default subcommand
+/// rendering (plain red `error:`, green `tip:`, bold+underline `Usage:`) so
+/// the four surfaces share one visual shape.
+fn unknown_alias_exit(
     repo: &Repository,
     user_config: &UserConfig,
     project_config: Option<&ProjectConfig>,
     name: &str,
-) -> anyhow::Error {
+    sub: &str,
+) -> ! {
     let project_id = repo.project_identifier().ok();
     let mut merged = user_config.aliases(project_id.as_deref());
     if let Some(pc) = project_config {
         append_aliases(&mut merged, &pc.aliases);
     }
     let suggestions = did_you_mean(name, merged.into_keys());
-    let header = format!("unknown alias '{name}'");
-    if suggestions.is_empty() {
-        anyhow::anyhow!(header)
+
+    let mut top = crate::cli::build_command();
+    let sub_cmd = top
+        .find_subcommand_mut("config")
+        .expect("`config` subcommand is defined in the CLI")
+        .find_subcommand_mut("alias")
+        .expect("`config alias` subcommand is defined in the CLI")
+        .find_subcommand_mut(sub)
+        .unwrap_or_else(|| panic!("`config alias {sub}` subcommand is defined in the CLI"));
+    // `render_usage` needs `bin_name`; clap only sets it on match, so when we
+    // synthesize the error ahead of that, set it to the display_name
+    // `apply_help_template_recursive` would apply.
+    sub_cmd.set_bin_name(format!("wt config alias {sub}"));
+    let usage = sub_cmd.render_usage().ansi().to_string();
+
+    let tip_block = if suggestions.is_empty() {
+        String::new()
     } else {
-        let mut detail = String::from("a similar alias exists:");
-        for s in &suggestions {
-            detail.push_str(&format!("\n  {s}"));
-        }
-        anyhow::Error::msg(detail).context(header)
-    }
+        let joined: String = suggestions
+            .iter()
+            .map(|s| cformat!("'<green>{s}</>'"))
+            .collect::<Vec<_>>()
+            .join(", ");
+        cformat!("\n  <green>tip:</> some similar aliases exist: {joined}\n")
+    };
+
+    ceprintln!(
+        "<bold,red>error:</> unrecognized alias '<yellow>{name}</>'\n{tip_block}\n{usage}\n\nFor more information, try '<bold>--help</>'.",
+    );
+
+    process::exit(2)
 }
 
 /// Format one alias entry: `○ Alias <name> (<source>)[ <verb>]:` header

--- a/tests/integration_tests/step_alias.rs
+++ b/tests/integration_tests/step_alias.rs
@@ -1265,7 +1265,9 @@ deploy = "make deploy BRANCH={{ branch }}"
     ));
 }
 
-/// Unknown alias name triggers a did-you-mean suggestion.
+/// Unknown alias name triggers a did-you-mean suggestion. Format mirrors
+/// `wt <typo>` and `wt step <typo>`: clap-native `InvalidSubcommand` with a
+/// `tip:` line — same shape at every alias-typo surface.
 #[rstest]
 fn test_config_alias_show_unknown_suggests(mut repo: TestRepo) {
     repo.write_project_config(
@@ -1285,6 +1287,31 @@ hello = "echo hi"
         &repo,
         "config",
         &["alias", "show", "deplyo"],
+        Some(&feature_path),
+    ));
+}
+
+/// `wt config alias dry-run <typo>` produces the same clap-native typo error
+/// as `show` — consistent format across both introspection subcommands.
+#[rstest]
+fn test_config_alias_dry_run_unknown_suggests(mut repo: TestRepo) {
+    repo.write_project_config(
+        r#"
+[aliases]
+deploy = "make deploy"
+hello = "echo hi"
+"#,
+    );
+    repo.commit("Add alias config");
+    let feature_path = repo.add_worktree("feature");
+
+    let settings = setup_snapshot_settings(&repo);
+    let _guard = settings.bind_to_scope();
+
+    assert_cmd_snapshot!(make_snapshot_cmd(
+        &repo,
+        "config",
+        &["alias", "dry-run", "deplyo"],
         Some(&feature_path),
     ));
 }

--- a/tests/integration_tests/step_alias.rs
+++ b/tests/integration_tests/step_alias.rs
@@ -1291,6 +1291,30 @@ hello = "echo hi"
     ));
 }
 
+/// Single-match case: tip phrasing switches to the singular form
+/// ("a similar alias exists") — mirrors clap's own singular rendering.
+#[rstest]
+fn test_config_alias_show_unknown_singular_suggestion(mut repo: TestRepo) {
+    repo.write_project_config(
+        r#"
+[aliases]
+deploy = "make deploy"
+"#,
+    );
+    repo.commit("Add alias config");
+    let feature_path = repo.add_worktree("feature");
+
+    let settings = setup_snapshot_settings(&repo);
+    let _guard = settings.bind_to_scope();
+
+    assert_cmd_snapshot!(make_snapshot_cmd(
+        &repo,
+        "config",
+        &["alias", "show", "deplyo"],
+        Some(&feature_path),
+    ));
+}
+
 /// `wt config alias dry-run <typo>` produces the same clap-native typo error
 /// as `show` — consistent format across both introspection subcommands.
 #[rstest]

--- a/tests/integration_tests/step_alias.rs
+++ b/tests/integration_tests/step_alias.rs
@@ -1291,6 +1291,34 @@ hello = "echo hi"
     ));
 }
 
+/// Aliases or typos that literally contain `subcommand` must be echoed
+/// verbatim — the word-substitution pass that rewrites clap's
+/// "unrecognized subcommand" to "unrecognized alias" must only touch
+/// clap's fixed phrases, not the user's input.
+#[rstest]
+fn test_config_alias_show_unknown_preserves_user_input(mut repo: TestRepo) {
+    repo.write_project_config(
+        r#"
+[aliases]
+"my-subcommand" = "echo hi"
+"#,
+    );
+    repo.commit("Add alias config");
+    let feature_path = repo.add_worktree("feature");
+
+    let settings = setup_snapshot_settings(&repo);
+    let _guard = settings.bind_to_scope();
+
+    // Typo `my-subcommond` is close enough to `my-subcommand` to suggest it —
+    // both the echoed typo and the suggestion must keep `subcommand` intact.
+    assert_cmd_snapshot!(make_snapshot_cmd(
+        &repo,
+        "config",
+        &["alias", "show", "my-subcommond"],
+        Some(&feature_path),
+    ));
+}
+
 /// Single-match case: tip phrasing switches to the singular form
 /// ("a similar alias exists") — mirrors clap's own singular rendering.
 #[rstest]

--- a/tests/snapshots/integration__integration_tests__step_alias__config_alias_dry_run_unknown_suggests.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__config_alias_dry_run_unknown_suggests.snap
@@ -5,8 +5,8 @@ info:
   args:
     - config
     - alias
-    - show
-    - zzzzzzzz
+    - dry-run
+    - deplyo
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -46,8 +46,10 @@ exit_code: 2
 ----- stdout -----
 
 ----- stderr -----
-[31m[1merror:[39m[22m unrecognized alias '[33mzzzzzzzz[39m'
+[31m[1merror:[39m[22m unrecognized alias '[33mdeplyo[39m'
 
-[1m[4mUsage:[0m [1mwt config alias show[0m <NAME>
+  [32mtip:[39m some similar aliases exist: '[32mdeploy[39m', '[32mhello[39m'
+
+[1m[4mUsage:[0m [1mwt config alias dry-run[0m <NAME> [1m[--[0m <ARGS>...[1m]
 
 For more information, try '[1m--help[22m'.

--- a/tests/snapshots/integration__integration_tests__step_alias__config_alias_show_unknown_no_suggestions.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__config_alias_show_unknown_no_suggestions.snap
@@ -46,8 +46,8 @@ exit_code: 2
 ----- stdout -----
 
 ----- stderr -----
-[31m[1merror:[39m[22m unrecognized alias '[33mzzzzzzzz[39m'
+[1m[31merror:[0m unrecognized alias '[33mzzzzzzzz[0m'
 
 [1m[4mUsage:[0m [1mwt config alias show[0m <NAME>
 
-For more information, try '[1m--help[22m'.
+For more information, try '[1m--help[0m'.

--- a/tests/snapshots/integration__integration_tests__step_alias__config_alias_show_unknown_preserves_user_input.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__config_alias_show_unknown_preserves_user_input.snap
@@ -1,0 +1,55 @@
+---
+source: tests/integration_tests/step_alias.rs
+info:
+  program: wt
+  args:
+    - config
+    - alias
+    - show
+    - my-subcommond
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: false
+exit_code: 2
+----- stdout -----
+
+----- stderr -----
+[1m[31merror:[0m unrecognized alias '[33mmy-subcommond[0m'
+
+  [32mtip:[0m a similar alias exists: '[32mmy-subcommand[0m'
+
+[1m[4mUsage:[0m [1mwt config alias show[0m <NAME>
+
+For more information, try '[1m--help[0m'.

--- a/tests/snapshots/integration__integration_tests__step_alias__config_alias_show_unknown_singular_suggestion.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__config_alias_show_unknown_singular_suggestion.snap
@@ -5,7 +5,7 @@ info:
   args:
     - config
     - alias
-    - dry-run
+    - show
     - deplyo
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
@@ -48,8 +48,8 @@ exit_code: 2
 ----- stderr -----
 [1m[31merror:[0m unrecognized alias '[33mdeplyo[0m'
 
-  [32mtip:[0m some similar aliases exist: '[32mdeploy[0m', '[32mhello[0m'
+  [32mtip:[0m a similar alias exists: '[32mdeploy[0m'
 
-[1m[4mUsage:[0m [1mwt config alias dry-run[0m <NAME> [1m[--[0m <ARGS>...[1m]
+[1m[4mUsage:[0m [1mwt config alias show[0m <NAME>
 
 For more information, try '[1m--help[0m'.

--- a/tests/snapshots/integration__integration_tests__step_alias__config_alias_show_unknown_suggests.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__config_alias_show_unknown_suggests.snap
@@ -42,11 +42,14 @@ info:
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: false
-exit_code: 1
+exit_code: 2
 ----- stdout -----
 
 ----- stderr -----
-[31m✗[39m [31munknown alias 'deplyo'[39m
-[107m [0m a similar alias exists:
-[107m [0m   deploy
-[107m [0m   hello
+[31m[1merror:[39m[22m unrecognized alias '[33mdeplyo[39m'
+
+  [32mtip:[39m some similar aliases exist: '[32mdeploy[39m', '[32mhello[39m'
+
+[1m[4mUsage:[0m [1mwt config alias show[0m <NAME>
+
+For more information, try '[1m--help[22m'.

--- a/tests/snapshots/integration__integration_tests__step_alias__config_alias_show_unknown_suggests.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__config_alias_show_unknown_suggests.snap
@@ -46,10 +46,10 @@ exit_code: 2
 ----- stdout -----
 
 ----- stderr -----
-[31m[1merror:[39m[22m unrecognized alias '[33mdeplyo[39m'
+[1m[31merror:[0m unrecognized alias '[33mdeplyo[0m'
 
-  [32mtip:[39m some similar aliases exist: '[32mdeploy[39m', '[32mhello[39m'
+  [32mtip:[0m some similar aliases exist: '[32mdeploy[0m', '[32mhello[0m'
 
 [1m[4mUsage:[0m [1mwt config alias show[0m <NAME>
 
-For more information, try '[1m--help[22m'.
+For more information, try '[1m--help[0m'.


### PR DESCRIPTION
## Summary

Four alias-typo surfaces rendered in two formats. After #2304's round-2 review, this aligns `config alias show/dry-run` with `wt <typo>` and `wt step <typo>`.

Before:
- `wt deplyo` / `wt step deplyo` → clap-native `error: unrecognized subcommand 'X'` + `tip: …`, exit 2
- `wt config alias show deplyo` / `dry-run deplyo` → custom anyhow gutter `✗ unknown alias 'X'` + gutter bars, exit 1

After (all four surfaces):
- Same clap-native `error:` / `tip:` / `Usage:` layout, exit 2
- `config alias show/dry-run` say "alias" / "aliases" instead of "subcommand" / "subcommands" — the positional is an alias name, not a subcommand

## How

`unknown_alias_error` builds a real `clap::Error` with `ErrorKind::InvalidSubcommand`, renders it through clap, then substitutes clap's fixed phrases (`unrecognized subcommand` → `unrecognized alias`, `similar subcommands` → `similar aliases`, `similar subcommand` → `similar alias`). Writing through `anstream::AutoStream::auto(stderr)` gets NO_COLOR / TTY detection and clap's singular-vs-plural phrasing automatically. Returns `WorktrunkError::AlreadyDisplayed { exit_code: 2 }` so `main`'s `finish_command` still runs `terminate_output` + `write_if_verbose`.

Substitutions are deliberately narrow — an alias name or typo containing the literal substring `subcommand` (e.g. `my-subcommand`) is echoed verbatim, not mangled.

## Changes

- `src/commands/config/alias.rs`: replace the anyhow-returning `unknown_alias_error` (exit 1, custom gutter) with a clap-rendering version (exit 2, matches clap-native surfaces). Parameterized by `sub` so the Usage line reads `wt config alias <sub> <NAME>`.
- New tests: `test_config_alias_dry_run_unknown_suggests`, `test_config_alias_show_unknown_singular_suggestion`, `test_config_alias_show_unknown_preserves_user_input`.
- Refreshed `test_config_alias_show_unknown_suggests` and `test_config_alias_show_unknown_no_suggestions` snapshots.

## Test plan

- [x] `cargo test --test integration step_alias` (58 pass)
- [x] `cargo test --lib --bins` (598 pass)
- [x] `pre-commit run --all-files` clean
- [x] Manual smoke on all four paths (exit 2; ANSI stripped under `NO_COLOR=1 | cat`; preserved under `CLICOLOR_FORCE=1`)
- [x] Aliases containing `subcommand` echoed verbatim under typo