### PR TITLE
fix(alias): run finish_command cleanup on typo error paths

### DIFF
--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -267,12 +267,12 @@ fn alias_needs_approval(
 }
 
 /// Synthesize clap's native `InvalidSubcommand` error for `wt step <name>`
-/// and exit through `enhance_and_exit_error`, so the output matches what
+/// and return it via `enhance_clap_error`, so the output matches what
 /// `wt <typo>` produces at the top level. Suggestion candidates include both
 /// the visible built-in `wt step` subcommands and the user's configured
 /// aliases — `SuggestedSubcommand` takes arbitrary strings, so aliases show
 /// up in the `tip:` line for typos like `wt step deplyo` → `'deploy'`.
-fn unknown_step_command_exit(name: &str, alias_names: &[&str]) -> ! {
+fn unknown_step_command_error(name: &str, alias_names: &[&str]) -> anyhow::Error {
     let mut top = crate::cli::build_command();
     let step_cmd = top
         .find_subcommand_mut("step")
@@ -305,7 +305,7 @@ fn unknown_step_command_exit(name: &str, alias_names: &[&str]) -> ! {
         );
     }
     err.insert(ContextKind::Usage, ContextValue::StyledStr(usage));
-    crate::enhance_and_exit_error(err)
+    crate::enhance_clap_error(err)
 }
 
 /// Format the "Running alias …" announcement.
@@ -430,7 +430,7 @@ pub fn step_alias(args: Vec<String>, global_yes: bool) -> anyhow::Result<()> {
             .filter(|k| !BUILTIN_STEP_COMMANDS.contains(&k.as_str()))
             .map(|k| k.as_str())
             .collect();
-        unknown_step_command_exit(&name, &alias_names);
+        return Err(unknown_step_command_error(&name, &alias_names));
     };
     let referenced = referenced_vars_for_config(cmd_config)?;
     if !referenced.contains("help") && help_flag_requested(&args[1..]) {

--- a/src/commands/custom.rs
+++ b/src/commands/custom.rs
@@ -12,11 +12,13 @@
 //!    the remaining args, inheriting stdio, and propagate the exit code.
 //!    Mirrors how `git foo` finds `git-foo`.
 //! 3. Otherwise, synthesize clap's native `InvalidSubcommand` error (with
-//!    aliases included in the "did you mean" candidates) and route it through
-//!    `enhance_and_exit_error` so the output matches what clap would have
-//!    produced without `external_subcommand` — same formatting, suggestions,
-//!    Usage line, and nested-subcommand tip (e.g. `wt squash` →
-//!    `perhaps wt step squash?`).
+//!    aliases included in the "did you mean" candidates) and return it via
+//!    `enhance_clap_error` so the output matches what clap would have produced
+//!    without `external_subcommand` — same formatting, suggestions, Usage
+//!    line, and nested-subcommand tip (e.g. `wt squash` →
+//!    `perhaps wt step squash?`). Returning (rather than exiting) lets
+//!    `finish_command` run its cleanup (diagnostic writes, ANSI reset for
+//!    shell integration).
 //!
 //! Built-in subcommands always take precedence — clap only dispatches
 //! `Commands::Custom` when no built-in matched, so there is no way for an
@@ -32,7 +34,7 @@ use worktrunk::git::WorktrunkError;
 
 use crate::cli::build_command;
 use crate::commands::{alias_names_for_suggestions, did_you_mean, try_alias};
-use crate::enhance_and_exit_error;
+use crate::enhance_clap_error;
 
 /// Handle a `Commands::Custom` invocation.
 ///
@@ -46,8 +48,8 @@ use crate::enhance_and_exit_error;
 /// On success (child exit code 0), returns `Ok(())`. On non-zero exit, returns
 /// `WorktrunkError::AlreadyDisplayed` with the child's exit code so `main`
 /// can propagate it without printing an extra error line. When the command
-/// isn't found on PATH, diverges via `enhance_and_exit_error` with clap's
-/// standard exit code 2.
+/// isn't found on PATH, returns `AlreadyDisplayed` via `enhance_clap_error`
+/// with clap's standard exit code 2.
 pub(crate) fn handle_custom_command(
     args: Vec<OsString>,
     working_dir: Option<PathBuf>,
@@ -86,7 +88,7 @@ pub(crate) fn handle_custom_command(
     }
 
     // Fall through to `wt-<name>` PATH binary. Nested-subcommand hints
-    // (`wt squash` → `wt step squash`) are applied by `enhance_and_exit_error`
+    // (`wt squash` → `wt step squash`) are applied by `enhance_clap_error`
     // when we fall through below, so a name that matches a nested subcommand
     // still gets its tip even though we look at PATH before erroring (nested
     // names aren't expected to collide with real `wt-*` binaries, and if they
@@ -97,10 +99,12 @@ pub(crate) fn handle_custom_command(
     }
 
     // Not an alias and not on PATH — emit clap's native `InvalidSubcommand`
-    // error. Routing through `enhance_and_exit_error` keeps the rendering
+    // error. Routing through `enhance_clap_error` keeps the rendering
     // consistent with every other clap error (same tip/Usage formatting) and
-    // layers the wt-specific nested-subcommand hint on top.
-    enhance_and_exit_error(unrecognized_subcommand_error(&name));
+    // layers the wt-specific nested-subcommand hint on top. Returning
+    // `AlreadyDisplayed` (rather than calling `process::exit`) lets
+    // `finish_command` run its cleanup before wt exits.
+    Err(enhance_clap_error(unrecognized_subcommand_error(&name)))
 }
 
 /// Build a `clap::Error` that mirrors what clap itself would have raised for

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,8 @@ use color_print::{ceprintln, cformat};
 use std::process;
 use worktrunk::config::{UserConfig, set_config_path};
 use worktrunk::git::{
-    Repository, ResolvedWorktree, current_or_recover, cwd_removed_hint, exit_code, set_base_path,
+    Repository, ResolvedWorktree, WorktrunkError, current_or_recover, cwd_removed_hint, exit_code,
+    set_base_path,
 };
 use worktrunk::styling::{
     eprintln, error_message, format_with_gutter, hint_message, info_message, warning_message,
@@ -70,12 +71,12 @@ use cli::{
 };
 use worktrunk::HookType;
 
-/// Enhance clap errors with command-specific hints, then exit.
-///
-/// For unrecognized subcommands that match nested commands, suggests the full path.
-pub(crate) fn enhance_and_exit_error(err: clap::Error) -> ! {
-    // For unrecognized subcommands, check if they match a nested subcommand
-    // e.g., `wt squash` -> suggest `wt step squash`
+/// Render a clap error to stderr, appending a wt-specific nested-subcommand
+/// tip when the unknown name matches something under `wt step` / `wt hook`
+/// (e.g., `wt squash` → `wt step squash`). Shared between the diverging
+/// `enhance_and_exit_error` (pre-dispatch) and the non-diverging
+/// `enhance_clap_error` (post-dispatch).
+fn print_enhanced_clap_error(err: &clap::Error) {
     if err.kind() == ClapErrorKind::InvalidSubcommand
         && let Some(unknown) = err.get(clap::error::ContextKind::InvalidSubcommand)
     {
@@ -86,14 +87,31 @@ pub(crate) fn enhance_and_exit_error(err: clap::Error) -> ! {
   <yellow>tip:</>  perhaps <cyan,bold>{suggestion}</cyan,bold>?",
                 err.render().ansi()
             );
-            process::exit(2);
+            return;
         }
     }
+    let _ = err.print();
+}
 
-    // Note: `wt switch` without arguments now opens the interactive picker,
-    // so this error enhancement is no longer triggered for that case.
+/// Enhance clap errors with command-specific hints, then exit.
+///
+/// Used by the pre-dispatch parse path, where no `finish_command` cleanup has
+/// been set up yet — `process::exit` directly is fine. Post-dispatch callers
+/// (e.g. alias typos from `wt step <typo>` / `wt <typo>`) use
+/// [`enhance_clap_error`] so they flow back through `handle_command_failure`
+/// and run the diagnostic/output-reset cleanup.
+pub(crate) fn enhance_and_exit_error(err: clap::Error) -> ! {
+    print_enhanced_clap_error(&err);
+    process::exit(err.exit_code());
+}
 
-    err.exit()
+/// Print an enhanced clap error and return `AlreadyDisplayed` so the caller
+/// can propagate it through normal error handling, letting `finish_command`
+/// run (diagnostic writes, ANSI reset for shell integration).
+pub(crate) fn enhance_clap_error(err: clap::Error) -> anyhow::Error {
+    let exit_code = err.exit_code();
+    print_enhanced_clap_error(&err);
+    WorktrunkError::AlreadyDisplayed { exit_code }.into()
 }
 
 #[cfg(not(unix))]


### PR DESCRIPTION
## Summary

`wt step <typo>` and `wt <typo>` previously exited through `enhance_and_exit_error` → `process::exit(2)`, skipping `finish_command`'s diagnostic dump and ANSI-reset for shell integration. The same issue applied to `wt config alias show/dry-run <typo>` and was fixed on #2306 by returning `WorktrunkError::AlreadyDisplayed` so the error flows back through `handle_command_failure`. This PR applies the same fix to the other two typo surfaces.

- Split `enhance_and_exit_error` into a shared `print_enhanced_clap_error` helper plus a non-diverging `enhance_clap_error` that returns `AlreadyDisplayed` with clap's exit code.
- Route `wt step <typo>` (via `unknown_step_command_error`) and `wt <typo>` (via `handle_custom_command`) through `enhance_clap_error`.
- The pre-dispatch parse path in `parse_cli` keeps the diverging variant (no `finish_command` setup yet at that point).

User-visible output is unchanged: `err.print()` (called by the shared helper when no nested-subcommand tip applies) produces the same stderr content as `err.exit()` minus the process exit, and `err.exit_code()` returns 2 for `InvalidSubcommand` errors.

## Test plan

- [x] `cargo check --bin wt` passes
- [x] `cargo clippy --bin wt` clean
- [x] Typo/suggestion integration tests pass (`nested_subcommand`, `step_alias` unrecognized cases)
- [x] `help::` integration tests still pass — pre-dispatch parse path untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)