### PR TITLE
Show resolved template variables under `-v` for hooks

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -494,8 +494,9 @@ Usage: <b><span class=c>wt config</span></b> <span class=c>[OPTIONS]</span> <spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -555,8 +556,9 @@ Usage: <b><span class=c>wt config show</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -606,8 +608,9 @@ Usage: <b><span class=c>wt config approvals</span></b> <span class=c>[OPTIONS]</
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -650,8 +653,9 @@ Usage: <b><span class=c>wt config alias</span></b> <span class=c>[OPTIONS]</span
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -725,8 +729,9 @@ Usage: <b><span class=c>wt config state</span></b> <span class=c>[OPTIONS]</span
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -783,8 +788,9 @@ Usage: <b><span class=c>wt config state default-branch</span></b> <span class=c>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -888,8 +894,9 @@ Usage: <b><span class=c>wt config state logs</span></b> <span class=c>[OPTIONS]<
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -949,8 +956,9 @@ Usage: <b><span class=c>wt config state ci-status</span></b> <span class=c>[OPTI
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -1022,8 +1030,9 @@ Usage: <b><span class=c>wt config state marker</span></b> <span class=c>[OPTIONS
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -1097,8 +1106,9 @@ Usage: <b><span class=c>wt config state vars</span></b> <span class=c>[OPTIONS]<
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -159,6 +159,8 @@ Some variables are conditional: `upstream` requires remote tracking; `base` only
 sync = "{% if upstream %}git fetch && git rebase {{ upstream }}{% endif %}"
 ```
 
+Run any hook-firing command with `-v` to see the resolved variables for the actual invocation — each hook prints a `template variables:` block showing every in-scope variable and its value (`(unset)` for conditional vars that didn't populate, like `target_worktree_path` during `wt switch -`).
+
 Variables use dot access and the `default` filter for missing keys. JSON object/array values are parsed automatically, so `{{ vars.config.port }}` works when the value is `{"port": 3000}`:
 
 ```toml
@@ -500,8 +502,9 @@ Usage: <b><span class=c>wt hook</span></b> <span class=c>[OPTIONS]</span> <span 
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts

--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -281,8 +281,9 @@ Usage: <b><span class=c>wt list</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts

--- a/docs/content/merge.md
+++ b/docs/content/merge.md
@@ -146,8 +146,9 @@ Usage: <b><span class=c>wt merge</span></b> <span class=c>[OPTIONS]</span> <span
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts

--- a/docs/content/remove.md
+++ b/docs/content/remove.md
@@ -133,8 +133,9 @@ Usage: <b><span class=c>wt remove</span></b> <span class=c>[OPTIONS]</span> <spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts

--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -76,8 +76,9 @@ Usage: <b><span class=c>wt step</span></b> <span class=c>[OPTIONS]</span> <span 
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -156,8 +157,9 @@ Usage: <b><span class=c>wt step commit</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -239,8 +241,9 @@ Usage: <b><span class=c>wt step squash</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -300,8 +303,9 @@ Usage: <b><span class=c>wt step diff</span></b> <span class=c>[OPTIONS]</span> <
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -435,8 +439,9 @@ Usage: <b><span class=c>wt step copy-ignored</span></b> <span class=c>[OPTIONS]<
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -513,8 +518,9 @@ Usage: <b><span class=c>wt step eval</span></b> <span class=c>[OPTIONS]</span> <
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -586,8 +592,9 @@ Usage: <b><span class=c>wt step for-each</span></b> <span class=c>[OPTIONS]</spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -663,8 +670,9 @@ Usage: <b><span class=c>wt step promote</span></b> <span class=c>[OPTIONS]</span
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -737,8 +745,9 @@ Usage: <b><span class=c>wt step prune</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -830,8 +839,9 @@ Usage: <b><span class=c>wt step relocate</span></b> <span class=c>[OPTIONS]</spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts

--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -217,8 +217,9 @@ Usage: <b><span class=c>wt switch</span></b> <span class=c>[OPTIONS]</span> <spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -497,8 +497,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -560,8 +561,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -617,8 +619,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -666,8 +669,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -755,8 +759,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -815,8 +820,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -930,8 +936,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -991,8 +998,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -1063,8 +1071,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -1149,8 +1158,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -150,6 +150,8 @@ Some variables are conditional: `upstream` requires remote tracking; `base` only
 sync = "{% if upstream %}git fetch && git rebase {{ upstream }}{% endif %}"
 ```
 
+Run any hook-firing command with `-v` to see the resolved variables for the actual invocation — each hook prints a `template variables:` block showing every in-scope variable and its value (`(unset)` for conditional vars that didn't populate, like `target_worktree_path` during `wt switch -`).
+
 Variables use dot access and the `default` filter for missing keys. JSON object/array values are parsed automatically, so `{{ vars.config.port }}` works when the value is `{"port": 3000}`:
 
 ```toml
@@ -493,8 +495,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -311,8 +311,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts

--- a/skills/worktrunk/reference/merge.md
+++ b/skills/worktrunk/reference/merge.md
@@ -136,8 +136,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts

--- a/skills/worktrunk/reference/remove.md
+++ b/skills/worktrunk/reference/remove.md
@@ -132,8 +132,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -68,8 +68,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -156,8 +157,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -243,8 +245,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -314,8 +317,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -449,8 +453,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -533,8 +538,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -614,8 +620,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -694,8 +701,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -775,8 +783,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -876,8 +885,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts

--- a/skills/worktrunk/reference/switch.md
+++ b/skills/worktrunk/reference/switch.md
@@ -209,8 +209,9 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report
-          + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for
+          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
+          .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -247,7 +247,7 @@ pub(crate) struct Cli {
     )]
     pub config: Option<std::path::PathBuf>,
 
-    /// Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+    /// Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
     #[arg(
         long,
         short = 'v',
@@ -1296,6 +1296,8 @@ Some variables are conditional: `upstream` requires remote tracking; `base` only
 # Rebase onto upstream if tracking a remote branch (e.g., wt switch --create feature origin/feature)
 sync = "{% if upstream %}git fetch && git rebase {{ upstream }}{% endif %}"
 ```
+
+Run any hook-firing command with `-v` to see the resolved variables for the actual invocation — each hook prints a `template variables:` block showing every in-scope variable and its value (`(unset)` for conditional vars that didn't populate, like `target_worktree_path` during `wt switch -`).
 
 Variables use dot access and the `default` filter for missing keys. JSON object/array values are parsed automatically, so `{{ vars.config.port }}` works when the value is `{"port": 3000}`:
 

--- a/src/commands/command_executor.rs
+++ b/src/commands/command_executor.rs
@@ -485,8 +485,6 @@ fn announce_command(cmd: &PreparedCommand, origin: &CommandOrigin) {
                 }
                 None => full_label,
             };
-            eprintln!("{}", progress_message(message));
-            eprintln!("{}", format_bash_with_gutter(&cmd.expanded));
             if verbosity() >= 1 {
                 let ctx: HashMap<String, String> = serde_json::from_str(&cmd.context_json)
                     .expect("context_json is always serialized from a HashMap<String, String>");
@@ -494,6 +492,8 @@ fn announce_command(cmd: &PreparedCommand, origin: &CommandOrigin) {
                 eprintln!("{}", info_message("template variables:"));
                 eprintln!("{}", format_with_gutter(&vars, None));
             }
+            eprintln!("{}", progress_message(message));
+            eprintln!("{}", format_bash_with_gutter(&cmd.expanded));
         }
         CommandOrigin::Alias { .. } => {}
     }

--- a/src/commands/command_executor.rs
+++ b/src/commands/command_executor.rs
@@ -5,12 +5,15 @@ use anyhow::{Context, Result, bail};
 use color_print::cformat;
 use worktrunk::HookType;
 use worktrunk::config::{
-    Command, CommandConfig, HookStep, UserConfig, expand_template, template_references_var,
-    validate_template_syntax,
+    Command, CommandConfig, HookStep, UserConfig, expand_template, format_hook_variables,
+    template_references_var, validate_template_syntax,
 };
 use worktrunk::git::{Repository, WorktrunkError, interrupt_exit_code};
 use worktrunk::path::{format_path_for_display, to_posix_path};
-use worktrunk::styling::{eprintln, error_message, format_bash_with_gutter, progress_message};
+use worktrunk::styling::{
+    eprintln, error_message, format_bash_with_gutter, format_with_gutter, info_message,
+    progress_message, verbosity,
+};
 
 use super::format_command_label;
 use super::hook_filter::HookSource;
@@ -484,6 +487,13 @@ fn announce_command(cmd: &PreparedCommand, origin: &CommandOrigin) {
             };
             eprintln!("{}", progress_message(message));
             eprintln!("{}", format_bash_with_gutter(&cmd.expanded));
+            if verbosity() >= 1 {
+                let ctx: HashMap<String, String> = serde_json::from_str(&cmd.context_json)
+                    .expect("context_json is always serialized from a HashMap<String, String>");
+                let vars = format_hook_variables(*hook_type, &ctx);
+                eprintln!("{}", info_message("template variables:"));
+                eprintln!("{}", format_with_gutter(&vars, None));
+            }
         }
         CommandOrigin::Alias { .. } => {}
     }

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -336,11 +336,10 @@ pub fn announce_and_spawn_background_hooks(
         }
         None => format!("Running {combined}"),
     };
-    eprintln!("{}", progress_message(message));
-
     if verbosity() >= 1 {
         print_background_variable_tables(&non_empty);
     }
+    eprintln!("{}", progress_message(message));
 
     for (ctx, group) in non_empty {
         spawn_hook_pipeline_quiet(&ctx, group)?;

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -362,12 +362,12 @@ fn print_background_variable_tables(pipelines: &[(CommandContext<'_>, Vec<Source
             if seen.contains(&sourced.hook_type) {
                 continue;
             }
-            let Some(cmd) = first_prepared_command(&sourced.step) else {
-                continue;
+            let cmd = match &sourced.step {
+                PreparedStep::Single(cmd) => cmd,
+                PreparedStep::Concurrent(cmds) => &cmds[0],
             };
-            let Ok(ctx) = serde_json::from_str::<HashMap<String, String>>(&cmd.context_json) else {
-                continue;
-            };
+            let ctx: HashMap<String, String> = serde_json::from_str(&cmd.context_json)
+                .expect("context_json is always serialized from a HashMap<String, String>");
             eprintln!("{}", info_message("template variables:"));
             eprintln!(
                 "{}",
@@ -375,13 +375,6 @@ fn print_background_variable_tables(pipelines: &[(CommandContext<'_>, Vec<Source
             );
             seen.push(sourced.hook_type);
         }
-    }
-}
-
-fn first_prepared_command(step: &PreparedStep) -> Option<&PreparedCommand> {
-    match step {
-        PreparedStep::Single(cmd) => Some(cmd),
-        PreparedStep::Concurrent(cmds) => cmds.first(),
     }
 }
 

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -1,11 +1,14 @@
+use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 use color_print::cformat;
 use worktrunk::HookType;
-use worktrunk::config::CommandConfig;
+use worktrunk::config::{CommandConfig, format_hook_variables};
 use worktrunk::path::format_path_for_display;
-use worktrunk::styling::{eprintln, progress_message, warning_message};
+use worktrunk::styling::{
+    eprintln, format_with_gutter, info_message, progress_message, verbosity, warning_message,
+};
 
 use super::command_executor::{
     CommandContext, CommandOrigin, FailureStrategy, ForegroundStep, PreparedCommand, PreparedStep,
@@ -335,11 +338,52 @@ pub fn announce_and_spawn_background_hooks(
     };
     eprintln!("{}", progress_message(message));
 
+    if verbosity() >= 1 {
+        print_background_variable_tables(&non_empty);
+    }
+
     for (ctx, group) in non_empty {
         spawn_hook_pipeline_quiet(&ctx, group)?;
     }
 
     Ok(())
+}
+
+/// Emit a `template variables:` block per distinct hook type in `pipelines`.
+///
+/// Background hooks don't flow through `announce_command` (which prints the
+/// table in the foreground path), so this is the symmetric entry point: once
+/// per hook type, using the first command's context. `hook_name` within a
+/// table reflects that first command — the combined announce line above
+/// already enumerates the rest.
+fn print_background_variable_tables(pipelines: &[(CommandContext<'_>, Vec<SourcedStep>)]) {
+    let mut seen: Vec<HookType> = Vec::new();
+    for (_, group) in pipelines {
+        for sourced in group {
+            if seen.contains(&sourced.hook_type) {
+                continue;
+            }
+            let Some(cmd) = first_prepared_command(&sourced.step) else {
+                continue;
+            };
+            let Ok(ctx) = serde_json::from_str::<HashMap<String, String>>(&cmd.context_json) else {
+                continue;
+            };
+            eprintln!("{}", info_message("template variables:"));
+            eprintln!(
+                "{}",
+                format_with_gutter(&format_hook_variables(sourced.hook_type, &ctx), None)
+            );
+            seen.push(sourced.hook_type);
+        }
+    }
+}
+
+fn first_prepared_command(step: &PreparedStep) -> Option<&PreparedCommand> {
+    match step {
+        PreparedStep::Single(cmd) => Some(cmd),
+        PreparedStep::Concurrent(cmds) => cmds.first(),
+    }
 }
 
 /// Prepare and spawn all source-group pipelines for a single hook type.

--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -9,7 +9,9 @@
 //! See `wt hook --help` for available filters and functions.
 
 use std::borrow::Cow;
+use std::collections::{BTreeSet, HashMap};
 use std::fmt::{self, Write};
+use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
 use anyhow::Context;
@@ -26,27 +28,22 @@ use crate::styling::{
     info_message, verbosity,
 };
 
-/// Template variables available in every context.
+/// Active-context vars: point at the branch the operation acts on.
 ///
-/// Populated by `build_hook_context()` in `command_executor.rs`. `upstream`
-/// is conditional on branch tracking configuration but is included here so
-/// templates may reference it in any context (guarded by `{% if upstream %}`).
-///
-/// Ordered to match the user-facing help table in `src/cli/mod.rs`
-/// (`## Template variables`): active-context vars first, then repo/remote
-/// metadata, then the always-available portion of execution context (`cwd`).
-/// Operation-context vars (`base`, `target`, `pr_*`) and infrastructure
-/// vars (`hook_type`, `hook_name`) are not in `BASE_VARS` — they're added
-/// per-scope by `hook_extras` and `HOOK_INFRASTRUCTURE_VARS`.
-pub const BASE_VARS: &[&str] = &[
-    // Active context
+/// `upstream` is conditional on branch tracking configuration but is listed
+/// here so templates may reference it in any context (guarded by
+/// `{% if upstream %}`).
+pub const ACTIVE_VARS: &[&str] = &[
     "branch",
     "worktree_path",
     "worktree_name",
     "commit",
     "short_commit",
     "upstream",
-    // Repo / remote metadata
+];
+
+/// Repo/remote-metadata vars: describe the repository hosting the operation.
+pub const REPO_VARS: &[&str] = &[
     "repo",
     "repo_path",
     "owner",
@@ -54,9 +51,28 @@ pub const BASE_VARS: &[&str] = &[
     "default_branch",
     "remote",
     "remote_url",
-    // Execution context (always-available portion)
-    "cwd",
 ];
+
+/// Exec-context vars always available outside hook infrastructure.
+///
+/// `cwd` is populated for every template expansion; `hook_type`/`hook_name`
+/// are added by the hook runner itself (`HOOK_INFRASTRUCTURE_VARS`).
+pub const EXEC_BASE_VARS: &[&str] = &["cwd"];
+
+/// Template variables available in every context: the concatenation of
+/// [`ACTIVE_VARS`], [`REPO_VARS`], and [`EXEC_BASE_VARS`].
+///
+/// Populated by `build_hook_context()` in `command_executor.rs`. Operation-
+/// context vars (`base`, `target`, `pr_*`) and infrastructure vars
+/// (`hook_type`, `hook_name`) are not in the base set — they're added per-
+/// scope by `hook_extras` and the hook runner itself.
+pub fn base_vars() -> Vec<&'static str> {
+    let mut v = Vec::with_capacity(ACTIVE_VARS.len() + REPO_VARS.len() + EXEC_BASE_VARS.len());
+    v.extend_from_slice(ACTIVE_VARS);
+    v.extend_from_slice(REPO_VARS);
+    v.extend_from_slice(EXEC_BASE_VARS);
+    v
+}
 
 /// Reserved context key carrying a JSON-encoded `Vec<String>` of positional
 /// CLI args forwarded to an alias. The key flows through
@@ -98,7 +114,7 @@ pub enum ValidationScope {
     Alias,
 }
 
-/// Hook-type-specific extras that sit on top of [`BASE_VARS`].
+/// Hook-type-specific extras that sit on top of [`base_vars`].
 ///
 /// These are the vars injected by callers via `extra_vars` when running a
 /// hook. Keeping the mapping in one place means "which vars work in a
@@ -151,11 +167,11 @@ const HOOK_INFRASTRUCTURE_VARS: &[&str] = &["hook_type", "hook_name"];
 
 /// All template variables available in a given scope.
 ///
-/// The returned list is `BASE_VARS` + scope-specific extras + deprecated
+/// The returned list is [`base_vars`] + scope-specific extras + deprecated
 /// aliases. Used by [`validate_template`] to build the placeholder context
 /// and by error messages to list what the user could have typed.
 pub fn vars_available_in(scope: ValidationScope) -> Vec<&'static str> {
-    let mut vars: Vec<&'static str> = BASE_VARS.to_vec();
+    let mut vars: Vec<&'static str> = base_vars();
     match scope {
         ValidationScope::Hook(hook_type) => {
             vars.extend(HOOK_INFRASTRUCTURE_VARS);
@@ -172,8 +188,46 @@ pub fn vars_available_in(scope: ValidationScope) -> Vec<&'static str> {
     vars
 }
 
-use std::collections::{BTreeSet, HashMap};
-use std::hash::{Hash, Hasher};
+/// Format the resolved template variables for a hook invocation as an
+/// aligned `name = value` block — no heading, no indent, caller wraps.
+///
+/// Ordered per the `## Template variables` help table in `src/cli/mod.rs`:
+/// active, operation, repo, exec. A variable appears if it's in scope for
+/// `hook_type` per [`vars_available_in`]. Values come from `ctx`; vars that
+/// are in-scope but absent from `ctx` render as `(unset)` — this surfaces
+/// operation-specific gaps (e.g., `target_worktree_path` during
+/// `wt switch -`, `upstream` when the branch doesn't track a remote).
+///
+/// `(unset)` relies on an invariant in `build_hook_context`: optional vars
+/// are omitted from the map rather than inserted as empty strings. If a
+/// future caller starts inserting `""`, revisit the empty-vs-absent
+/// distinction here.
+///
+/// Deprecated aliases and `vars.*` (user state) are intentionally omitted.
+pub fn format_hook_variables(hook_type: HookType, ctx: &HashMap<String, String>) -> String {
+    // Flat list in the canonical docs order: active, operation, repo, exec.
+    let vars: Vec<&'static str> = ACTIVE_VARS
+        .iter()
+        .chain(hook_extras(hook_type))
+        .chain(REPO_VARS)
+        .chain(EXEC_BASE_VARS)
+        .chain(HOOK_INFRASTRUCTURE_VARS)
+        .copied()
+        .collect();
+
+    let max_name = vars.iter().map(|v| v.len()).max().unwrap_or(0);
+
+    vars.iter()
+        .map(|var| {
+            let value = match ctx.get(*var) {
+                Some(v) => v.as_str(),
+                None => "(unset)",
+            };
+            format!("{var:<max_name$} = {value}")
+        })
+        .collect::<Vec<_>>()
+        .join("\n")
+}
 
 /// Positional CLI args forwarded from `wt <alias> a b c` into the alias's
 /// template context. Bare `{{ args }}` renders as a space-joined,
@@ -1832,5 +1886,64 @@ mod tests {
         // Should list available vars in hint
         assert!(!err.available_vars.is_empty(), "should list available vars");
         assert!(err.available_vars.contains(&"branch".to_string()));
+    }
+
+    #[test]
+    fn test_format_hook_variables_groups_and_unset() {
+        let mut ctx: HashMap<String, String> = HashMap::new();
+        ctx.insert("branch".into(), "feature".into());
+        ctx.insert("worktree_path".into(), "/tmp/feature".into());
+        ctx.insert("worktree_name".into(), "feature".into());
+        ctx.insert("base".into(), "main".into());
+        ctx.insert("base_worktree_path".into(), "/tmp/main".into());
+        ctx.insert("target".into(), "-".into());
+        // target_worktree_path deliberately absent — mimics `wt switch -`
+        ctx.insert("repo".into(), "demo".into());
+        ctx.insert("repo_path".into(), "/tmp/demo".into());
+        ctx.insert("cwd".into(), "/tmp/feature".into());
+        ctx.insert("hook_type".into(), "pre-switch".into());
+        ctx.insert("hook_name".into(), "show-variables".into());
+
+        assert_snapshot!(format_hook_variables(HookType::PreSwitch, &ctx), @r"
+        branch                = feature
+        worktree_path         = /tmp/feature
+        worktree_name         = feature
+        commit                = (unset)
+        short_commit          = (unset)
+        upstream              = (unset)
+        base                  = main
+        base_worktree_path    = /tmp/main
+        target                = -
+        target_worktree_path  = (unset)
+        pr_number             = (unset)
+        pr_url                = (unset)
+        repo                  = demo
+        repo_path             = /tmp/demo
+        owner                 = (unset)
+        primary_worktree_path = (unset)
+        default_branch        = (unset)
+        remote                = (unset)
+        remote_url            = (unset)
+        cwd                   = /tmp/feature
+        hook_type             = pre-switch
+        hook_name             = show-variables
+        ");
+    }
+
+    #[test]
+    fn test_format_hook_variables_scope_filters_operation() {
+        // pre-commit only has `target` in operation scope — no base*, pr_*, etc.
+        let mut ctx: HashMap<String, String> = HashMap::new();
+        ctx.insert("target".into(), "main".into());
+        let out = format_hook_variables(HookType::PreCommit, &ctx);
+        assert!(out.contains("target                = main"), "got: {out}");
+        assert!(
+            !out.contains("base "),
+            "pre-commit has no `base`; got: {out}"
+        );
+        assert!(
+            !out.contains("pr_number"),
+            "pre-commit has no `pr_number`; got: {out}"
+        );
     }
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -121,10 +121,10 @@ pub use deprecation::{
     key_belongs_in, warn_unknown_fields,
 };
 pub use expansion::{
-    ALIAS_ARGS_KEY, BASE_VARS, DEPRECATED_TEMPLATE_VARS, TemplateExpandError, ValidationScope,
-    expand_template, redact_credentials, referenced_vars_for_config, sanitize_branch_name,
-    sanitize_db, short_hash, template_references_var, validate_template, validate_template_syntax,
-    vars_available_in,
+    ACTIVE_VARS, ALIAS_ARGS_KEY, DEPRECATED_TEMPLATE_VARS, EXEC_BASE_VARS, REPO_VARS,
+    TemplateExpandError, ValidationScope, base_vars, expand_template, format_hook_variables,
+    redact_credentials, referenced_vars_for_config, sanitize_branch_name, sanitize_db, short_hash,
+    template_references_var, validate_template, validate_template_syntax, vars_available_in,
 };
 pub use hooks::HooksConfig;
 pub use project::{ProjectCiConfig, ProjectConfig, ProjectListConfig, valid_project_config_keys};

--- a/tests/integration_tests/user_hooks.rs
+++ b/tests/integration_tests/user_hooks.rs
@@ -7,8 +7,8 @@
 //! - Skipped together with project hooks via --no-hooks
 
 use crate::common::{
-    TestRepo, make_snapshot_cmd, repo, resolve_git_common_dir, setup_snapshot_settings,
-    wait_for_file, wait_for_file_content, wait_for_file_count,
+    TestRepo, make_snapshot_cmd, make_snapshot_cmd_with_global_flags, repo, resolve_git_common_dir,
+    setup_snapshot_settings, wait_for_file, wait_for_file_content, wait_for_file_count,
 };
 use insta_cmd::assert_cmd_snapshot;
 use rstest::rstest;
@@ -3252,4 +3252,23 @@ test = "echo TEST"
         stderr.contains("│ LINT") && stderr.contains("│ TEST"),
         "single [[pre-merge]] block should run concurrently: {stderr}",
     );
+}
+
+/// Under `-v`, hooks print a grouped table of resolved template variables —
+/// see issue #2309 for why this helps users understand scope-dependent gaps.
+#[rstest]
+fn test_hook_verbose_prints_variable_table(mut repo: TestRepo) {
+    repo.add_worktree("feature");
+    repo.write_test_config(
+        r#"[pre-switch]
+noop = "true"
+"#,
+    );
+
+    let settings = setup_snapshot_settings(&repo);
+    settings.bind(|| {
+        let mut cmd =
+            make_snapshot_cmd_with_global_flags(&repo, "switch", &["feature"], None, &["-v"]);
+        assert_cmd_snapshot!("hook_verbose_variable_table", cmd);
+    });
 }

--- a/tests/integration_tests/user_hooks.rs
+++ b/tests/integration_tests/user_hooks.rs
@@ -3272,3 +3272,32 @@ noop = "true"
         assert_cmd_snapshot!("hook_verbose_variable_table", cmd);
     });
 }
+
+/// Background-path variable dump dedups per hook type when both user and
+/// project configs contribute to the same hook — the table prints once, not
+/// once per source. Also exercises the `PreparedStep::Single` arm of
+/// `print_background_variable_tables`, which the all-named-commands case in
+/// `test_post_start_verbose_shows_per_hook_output` doesn't hit.
+#[rstest]
+fn test_hook_verbose_background_dedups_across_sources(repo: TestRepo) {
+    repo.write_test_config(r#"post-start = "echo user-hook""#);
+    repo.write_project_config(r#"post-start = "echo project-hook""#);
+    repo.commit("add post-start");
+    repo.write_test_approvals(
+        r#"[projects."../origin"]
+approved-commands = ["echo project-hook"]
+"#,
+    );
+
+    let settings = setup_snapshot_settings(&repo);
+    settings.bind(|| {
+        let mut cmd = make_snapshot_cmd_with_global_flags(
+            &repo,
+            "switch",
+            &["--create", "feature"],
+            None,
+            &["-v"],
+        );
+        assert_cmd_snapshot!("hook_verbose_background_dedup", cmd);
+    });
+}

--- a/tests/snapshots/integration__integration_tests__help__help_config_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_approvals.snap
@@ -51,7 +51,7 @@ Usage: [1m[36mwt config approvals[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_approvals_add.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_approvals_add.snap
@@ -51,7 +51,7 @@ Usage: [1m[36mwt config approvals add[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_approvals_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_approvals_clear.snap
@@ -51,7 +51,7 @@ Usage: [1m[36mwt config approvals clear[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -50,7 +50,7 @@ Usage: [1m[36mwt config create[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -58,7 +58,7 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_shell.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_shell.snap
@@ -47,7 +47,7 @@ Usage: [1m[36mwt config shell[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_short.snap
@@ -50,7 +50,7 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_show.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_show.snap
@@ -60,7 +60,7 @@ Usage: [1m[36mwt config show[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_state.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state.snap
@@ -58,7 +58,7 @@ Usage: [1m[36mwt config state[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
@@ -56,7 +56,7 @@ Usage: [1m[36mwt config state ci-status[0m [36m[OPTIONS][0m [36m[COMMAND]
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_clear.snap
@@ -48,7 +48,7 @@ Usage: [1m[36mwt config state clear[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
@@ -53,7 +53,7 @@ Usage: [1m[36mwt config state default-branch[0m [36m[OPTIONS][0m [36m[COMM
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_get.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_get.snap
@@ -53,7 +53,7 @@ Usage: [1m[36mwt config state get[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
@@ -56,7 +56,7 @@ Usage: [1m[36mwt config state logs[0m [36m[OPTIONS][0m [36m[COMMAND][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
@@ -57,7 +57,7 @@ Usage: [1m[36mwt config state marker[0m [36m[OPTIONS][0m [36m[COMMAND][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch.snap
@@ -53,7 +53,7 @@ Usage: [1m[36mwt config state previous-branch[0m [36m[OPTIONS][0m [36m[COM
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -69,7 +69,7 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -71,8 +71,9 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs 
-          + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved 
+          template variables for each hook invocation; -vv: debug logs + 
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_list_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_short.snap
@@ -49,7 +49,7 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
@@ -92,7 +92,7 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_md_root.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_root.snap
@@ -57,7 +57,7 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
@@ -92,7 +92,7 @@ Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_merge_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_short.snap
@@ -53,7 +53,7 @@ Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET][0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_no_args.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_no_args.snap
@@ -48,7 +48,7 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
@@ -81,7 +81,7 @@ Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...[0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_remove_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_short.snap
@@ -51,7 +51,7 @@ Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...[0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_root_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root_long.snap
@@ -57,7 +57,7 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_root_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root_short.snap
@@ -49,7 +49,7 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_step_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_long.snap
@@ -61,7 +61,7 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_step_promote.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_promote.snap
@@ -55,7 +55,7 @@ Usage: [1m[36mwt step promote[0m [36m[OPTIONS][0m [36m[BRANCH][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_step_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_short.snap
@@ -53,7 +53,7 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -113,7 +113,7 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
@@ -57,7 +57,7 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_verbose_template_expansion.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_verbose_template_expansion.snap
@@ -58,6 +58,29 @@ exit_code: 0
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setting up verbose-hooks in _REPO_.verbose-hooks'[0m[2m
 [36m◎[39m [36mRunning pre-start [1mproject:setup[22m @ [1m_REPO_.verbose-hooks[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setting up verbose-hooks in _REPO_.verbose-hooks'[0m[2m
+[2m○[22m template variables:
+[107m [0m branch                = verbose-hooks
+[107m [0m worktree_path         = _REPO_.verbose-hooks
+[107m [0m worktree_name         = repo.verbose-hooks
+[107m [0m commit                = 8b2a39bbbeb5897579b4db89e4785539fd72278d
+[107m [0m short_commit          = 8b2a39b
+[107m [0m upstream              = (unset)
+[107m [0m base                  = main
+[107m [0m base_worktree_path    = _REPO_
+[107m [0m target                = verbose-hooks
+[107m [0m target_worktree_path  = _REPO_.verbose-hooks
+[107m [0m pr_number             = (unset)
+[107m [0m pr_url                = (unset)
+[107m [0m repo                  = repo
+[107m [0m repo_path             = _REPO_
+[107m [0m owner                 = (unset)
+[107m [0m primary_worktree_path = _REPO_
+[107m [0m default_branch        = main
+[107m [0m remote                = origin
+[107m [0m remote_url            = ../origin.git
+[107m [0m cwd                   = _REPO_.verbose-hooks
+[107m [0m hook_type             = pre-start
+[107m [0m hook_name             = setup
 [0mSetting up verbose-hooks in _REPO_.verbose-hooks
 [32m✓[39m [32mCreated branch [1mverbose-hooks[22m from [1mmain[22m and worktree @ [1m_REPO_.verbose-hooks[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_create_verbose_template_expansion.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_create_verbose_template_expansion.snap
@@ -56,8 +56,6 @@ exit_code: 0
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setting up {{ branch | sanitize }} in {{ worktree_path }}'[0m[2m
 [107m [0m [2m→[22m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setting up verbose-hooks in _REPO_.verbose-hooks'[0m[2m
-[36m◎[39m [36mRunning pre-start [1mproject:setup[22m @ [1m_REPO_.verbose-hooks[22m[39m
-[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setting up verbose-hooks in _REPO_.verbose-hooks'[0m[2m
 [2m○[22m template variables:
 [107m [0m branch                = verbose-hooks
 [107m [0m worktree_path         = _REPO_.verbose-hooks
@@ -81,6 +79,8 @@ exit_code: 0
 [107m [0m cwd                   = _REPO_.verbose-hooks
 [107m [0m hook_type             = pre-start
 [107m [0m hook_name             = setup
+[36m◎[39m [36mRunning pre-start [1mproject:setup[22m @ [1m_REPO_.verbose-hooks[22m[39m
+[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setting up verbose-hooks in _REPO_.verbose-hooks'[0m[2m
 [0mSetting up verbose-hooks in _REPO_.verbose-hooks
 [32m✓[39m [32mCreated branch [1mverbose-hooks[22m from [1mmain[22m and worktree @ [1m_REPO_.verbose-hooks[22m[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_verbose_output.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_verbose_output.snap
@@ -58,7 +58,6 @@ exit_code: 0
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'verbose test'[0m[2m [0m[2m[36m>[0m[2m verbose.txt
 [107m [0m [2m→[22m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'verbose test'[0m[2m [0m[2m[36m>[0m[2m verbose.txt
-[36m◎[39m [36mRunning post-start: [1mproject:setup[22m @ [1m_REPO_.feature[22m[39m
 [2m○[22m template variables:
 [107m [0m branch                = feature
 [107m [0m worktree_path         = _REPO_.feature
@@ -82,3 +81,4 @@ exit_code: 0
 [107m [0m cwd                   = _REPO_.feature
 [107m [0m hook_type             = post-start
 [107m [0m hook_name             = setup
+[36m◎[39m [36mRunning post-start: [1mproject:setup[22m @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__step_alias__step_help_includes_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_help_includes_aliases.snap
@@ -68,7 +68,7 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
 [1m[32mGlobal Options:
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_alias__step_list_no_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_list_no_aliases.snap
@@ -64,7 +64,7 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
 [1m[32mGlobal Options:
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_alias__step_list_with_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_list_with_aliases.snap
@@ -69,7 +69,7 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
 [1m[32mGlobal Options:
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__user_hooks__hook_verbose_background_dedup.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__hook_verbose_background_dedup.snap
@@ -1,0 +1,88 @@
+---
+source: tests/integration_tests/user_hooks.rs
+info:
+  program: wt
+  args:
+    - "-v"
+    - switch
+    - "--create"
+    - feature
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[2m○[22m Expanding [1mworktree-path[22m
+[107m [0m [2m[0m[2m[32m{{[0m[2m[0m[2m repo_path [0m[2m[32m}}[0m[2m/../[0m[2m[32m{{[0m[2m repo [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34msanitize[0m[2m [0m[2m[32m}}[0m[2m
+[107m [0m [2m→[22m
+[107m [0m [2m[0m[2m[34m_REPO_/../repo.feature[0m[2m
+[32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m
+[2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
+[33m▲[39m [33mCannot change directory — shell integration not installed[39m
+[2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
+[2m○[22m Expanding [1muser post-start hook[22m
+[107m [0m [2m[0m[2m[34mecho[0m[2m user-hook
+[107m [0m [2m→[22m
+[107m [0m [2m[0m[2m[34mecho[0m[2m user-hook
+[2m○[22m Expanding [1mproject post-start hook[22m
+[107m [0m [2m[0m[2m[34mecho[0m[2m project-hook
+[107m [0m [2m→[22m
+[107m [0m [2m[0m[2m[34mecho[0m[2m project-hook
+[2m○[22m template variables:
+[107m [0m branch                = feature
+[107m [0m worktree_path         = _REPO_.feature
+[107m [0m worktree_name         = repo.feature
+[107m [0m commit                = 26c70caa73d841981f190bafd2a2a6e1d4eed34e
+[107m [0m short_commit          = 26c70ca
+[107m [0m upstream              = (unset)
+[107m [0m base                  = main
+[107m [0m base_worktree_path    = _REPO_
+[107m [0m target                = feature
+[107m [0m target_worktree_path  = _REPO_.feature
+[107m [0m pr_number             = (unset)
+[107m [0m pr_url                = (unset)
+[107m [0m repo                  = repo
+[107m [0m repo_path             = _REPO_
+[107m [0m owner                 = (unset)
+[107m [0m primary_worktree_path = _REPO_
+[107m [0m default_branch        = main
+[107m [0m remote                = origin
+[107m [0m remote_url            = ../origin.git
+[107m [0m cwd                   = _REPO_.feature
+[107m [0m hook_type             = post-start
+[107m [0m hook_name             = (unset)
+[36m◎[39m [36mRunning post-start: [1muser[22m, [1mproject[22m @ [1m_REPO_.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__user_hooks__hook_verbose_variable_table.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__hook_verbose_variable_table.snap
@@ -49,8 +49,6 @@ exit_code: 0
 [107m [0m [2m[0m[2m[34mtrue[0m[2m
 [107m [0m [2m→[22m
 [107m [0m [2m[0m[2m[34mtrue[0m[2m
-[36m◎[39m [36mRunning pre-switch [1muser:noop[22m[39m
-[107m [0m [2m[0m[2m[34mtrue[0m[2m
 [2m○[22m template variables:
 [107m [0m branch                = feature
 [107m [0m worktree_path         = _REPO_.feature
@@ -74,6 +72,8 @@ exit_code: 0
 [107m [0m cwd                   = _REPO_
 [107m [0m hook_type             = pre-switch
 [107m [0m hook_name             = noop
+[36m◎[39m [36mRunning pre-switch [1muser:noop[22m[39m
+[107m [0m [2m[0m[2m[34mtrue[0m[2m
 [0m[2m○[22m Expanding [1mworktree-path[22m
 [107m [0m [2m[0m[2m[32m{{[0m[2m[0m[2m repo_path [0m[2m[32m}}[0m[2m/../[0m[2m[32m{{[0m[2m repo [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34msanitize[0m[2m [0m[2m[32m}}[0m[2m
 [107m [0m [2m→[22m

--- a/tests/snapshots/integration__integration_tests__user_hooks__hook_verbose_variable_table.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__hook_verbose_variable_table.snap
@@ -1,11 +1,10 @@
 ---
-source: tests/integration_tests/post_start_commands.rs
+source: tests/integration_tests/user_hooks.rs
 info:
   program: wt
   args:
-    - switch
     - "-v"
-    - "--create"
+    - switch
     - feature
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
@@ -46,25 +45,18 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m Expanding [1mworktree-path[22m
-[107m [0m [2m[0m[2m[32m{{[0m[2m[0m[2m repo_path [0m[2m[32m}}[0m[2m/../[0m[2m[32m{{[0m[2m repo [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34msanitize[0m[2m [0m[2m[32m}}[0m[2m
+[2m○[22m Expanding [1muser:noop[22m
+[107m [0m [2m[0m[2m[34mtrue[0m[2m
 [107m [0m [2m→[22m
-[107m [0m [2m[0m[2m[34m_REPO_/../repo.feature[0m[2m
-[32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m
-[2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
-[33m▲[39m [33mCannot change directory — shell integration not installed[39m
-[2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
-[2m○[22m Expanding [1mproject:setup[22m
-[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'verbose test'[0m[2m [0m[2m[36m>[0m[2m verbose.txt
-[107m [0m [2m→[22m
-[107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'verbose test'[0m[2m [0m[2m[36m>[0m[2m verbose.txt
-[36m◎[39m [36mRunning post-start: [1mproject:setup[22m @ [1m_REPO_.feature[22m[39m
+[107m [0m [2m[0m[2m[34mtrue[0m[2m
+[36m◎[39m [36mRunning pre-switch [1muser:noop[22m[39m
+[107m [0m [2m[0m[2m[34mtrue[0m[2m
 [2m○[22m template variables:
 [107m [0m branch                = feature
 [107m [0m worktree_path         = _REPO_.feature
 [107m [0m worktree_name         = repo.feature
-[107m [0m commit                = d545a78b148af245c616612b474fd2049705c00c
-[107m [0m short_commit          = d545a78
+[107m [0m commit                = 05a4a45d0b981dad5c27db59dca482836d59f89e
+[107m [0m short_commit          = 05a4a45
 [107m [0m upstream              = (unset)
 [107m [0m base                  = main
 [107m [0m base_worktree_path    = _REPO_
@@ -79,6 +71,12 @@ exit_code: 0
 [107m [0m default_branch        = main
 [107m [0m remote                = origin
 [107m [0m remote_url            = ../origin.git
-[107m [0m cwd                   = _REPO_.feature
-[107m [0m hook_type             = post-start
-[107m [0m hook_name             = setup
+[107m [0m cwd                   = _REPO_
+[107m [0m hook_type             = pre-switch
+[107m [0m hook_name             = noop
+[0m[2m○[22m Expanding [1mworktree-path[22m
+[107m [0m [2m[0m[2m[32m{{[0m[2m[0m[2m repo_path [0m[2m[32m}}[0m[2m/../[0m[2m[32m{{[0m[2m repo [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34msanitize[0m[2m [0m[2m[32m}}[0m[2m
+[107m [0m [2m→[22m
+[107m [0m [2m[0m[2m[34m_REPO_/../repo.feature[0m[2m
+[33m▲[39m [33mWorktree for [1mfeature[22m @ [1m_REPO_.feature[22m, but cannot change directory — shell integration not installed[39m
+[2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m


### PR DESCRIPTION
Closes #2309.

When a hook fires under `-v`, `wt` now prints a `template variables:` block listing every variable in scope for that hook type and the value it resolved to for this specific invocation. Vars that are in scope but not populated render as `(unset)` — which is exactly how `target_worktree_path` surfaces during `wt switch -`, the thing the issue reporter hand-rolled an echo-hook to discover.

The block prints *before* the `◎ Running …` announce line so it describes what the hook is about to see, not what already ran. Works in both paths: the foreground path (`announce_command`, one block per command) and the background path (`announce_and_spawn_background_hooks`, one block per distinct hook type in the pipeline batch).

## Key files

- `src/config/expansion.rs` — `format_hook_variables(hook_type, ctx)` emits the aligned `name = value` block ordered per the docs table (active → operation → repo → exec). `BASE_VARS` is split into `ACTIVE_VARS` / `REPO_VARS` / `EXEC_BASE_VARS` with a `base_vars()` helper, so `vars_available_in` and the printer share one source of truth.
- `src/commands/command_executor.rs` — foreground wiring in `announce_command`, gated on `verbosity() >= 1`.
- `src/commands/hooks.rs` — background wiring in `announce_and_spawn_background_hooks`; prints one table per distinct hook type (since within a pipeline only `hook_name` varies).
- `src/cli/mod.rs` — updates the global `-v` help text and adds a pointer under `## Template variables` in the hook help.

## Testing

- Unit: `test_format_hook_variables_groups_and_unset` snapshots a pre-switch context with `target_worktree_path` omitted so `(unset)` is covered; `test_format_hook_variables_scope_filters_operation` confirms pre-commit's narrower operation scope.
- Integration: `test_hook_verbose_prints_variable_table` covers the foreground path; the existing `test_post_start_verbose_shows_per_hook_output` now also exercises the background path.

No new CLI surface, no new config keys — only behavior added behind the existing `-v` flag.