### PR TITLE
fix(docs): exclude alternate pages from sitemap and add trailing slashes to nav

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -23,7 +23,7 @@ rust_crate = "worktrunk"
 github_repo = "max-sixty/worktrunk"
 site_description = "CLI for Git worktree management, designed for parallel AI agent workflows."
 extra_menu = [
-    { title = "Worktrunk", link = "/worktrunk" },
-    { title = "Tips", link = "/tips-patterns" },
+    { title = "Worktrunk", link = "/worktrunk/" },
+    { title = "Tips", link = "/tips-patterns/" },
     { title = "GitHub", link = "https://github.com/max-sixty/worktrunk" },
 ]

--- a/docs/templates/sitemap.xml
+++ b/docs/templates/sitemap.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
  {%- for sitemap_entry in entries %}
+ {#- Skip pages that declare a non-self canonical — only canonical URLs belong in the sitemap. #}
+ {%- if not sitemap_entry.extra.canonical %}
  <url>
  <loc>{{ sitemap_entry.permalink | escape_xml | safe }}</loc>
  {%- if sitemap_entry.updated %}
@@ -9,5 +11,6 @@
  <lastmod>{{ now() | date(format="%Y-%m-%d") }}</lastmod>
  {%- endif %}
  </url>
+ {%- endif %}
  {%- endfor %}
 </urlset>


### PR DESCRIPTION
Search Console flagged two indexing issues on worktrunk.dev:

**"Alternate page with proper canonical tag"**: the sitemap listed `/worktrunk/`, which canonicalizes to `/` (its content is rendered on the homepage via `templates/index.html`). Only canonicals belong in a sitemap. Skip sitemap entries whose frontmatter declares a canonical.

**"Page with redirect"**: the `extra_menu` links `/worktrunk` and `/tips-patterns` had no trailing slash, so every page's nav triggered a 301 on GitHub Pages. Added the trailing slashes.

Verified locally with `zola build`: sitemap goes from 14 to 13 entries (no more `/worktrunk/`), `/worktrunk/` page still served with canonical = `/`, and built nav hrefs now have trailing slashes.

Search Console also reported "Not found (404)" — those are old renamed URLs (`/why-worktrunk/`, `/quickstart/`, `/advanced/`) that no longer exist. Left alone here: a static 404 is correct, and adding meta-refresh redirect stubs would just create new "Page with redirect" entries.

> _This was written by Claude Code on behalf of @max-sixty_