### PR TITLE
docs(hook): consolidate copy-ignored recipe and trim redundant examples

### DIFF
--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -392,7 +392,7 @@ remove-db = "docker stop {{ repo }}-{{ branch | sanitize }}-postgres 2>/dev/null
 
 ## More recipes
 
-- Copy gitignored files between worktrees: `wt step copy-ignored` in `post-start` shares build caches and dependencies; use a `[[post-start]]` pipeline when a later hook depends on the copy — https://worktrunk.dev/tips-patterns/#eliminate-cold-starts
+- Copy gitignored files between worktrees: `wt step copy-ignored` in `post-start` shares build caches and dependencies; use a `[[post-start]]` pipeline when a later hook depends on the copy — see [Tips & Patterns](@/tips-patterns.md#eliminate-cold-starts)
 - Dev server per worktree: `hash_port` in `post-start` for launch and `post-remove` for cleanup, with optional subdomain routing — see [Tips & Patterns](@/tips-patterns.md#dev-server-per-worktree)
 - Database per worktree: a `post-start` pipeline stores container name, port, and connection string as [per-branch vars](@/config.md#wt-config-state-vars) that later hooks reference — see [Tips & Patterns](@/tips-patterns.md#database-per-worktree)
 

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -319,16 +319,6 @@ Git worktrees share the repository but not untracked files. [`wt step copy-ignor
 copy = "wt step copy-ignored"
 ```
 
-Use `pre-start` instead if subsequent hooks need the copied files — for example, copying `node_modules/` before `pnpm install` so the install reuses cached packages:
-
-```toml
-[[pre-start]]
-copy = "wt step copy-ignored"
-
-[[pre-start]]
-install = "pnpm install"
-```
-
 ## Progressive validation
 
 Quick checks before commit, thorough validation before merge:
@@ -356,17 +346,6 @@ elif [ {{ target }} = staging ]; then
 fi
 """
 ```
-
-## Python virtual environments
-
-Use `uv sync` to recreate virtual environments, or `python -m venv .venv && .venv/bin/pip install -r requirements.txt` for pip-based projects:
-
-```toml
-[pre-start]
-install = "uv sync"
-```
-
-For copying dependencies and caches between worktrees, see [`wt step copy-ignored`](@/step.md#language-specific-notes).
 
 ## Hook type examples
 
@@ -413,6 +392,7 @@ remove-db = "docker stop {{ repo }}-{{ branch | sanitize }}-postgres 2>/dev/null
 
 ## More recipes
 
+- Copy gitignored files between worktrees: `wt step copy-ignored` in `post-start` shares build caches and dependencies; use a `[[post-start]]` pipeline when a later hook depends on the copy — https://worktrunk.dev/tips-patterns/#eliminate-cold-starts
 - Dev server per worktree: `hash_port` in `post-start` for launch and `post-remove` for cleanup, with optional subdomain routing — see [Tips & Patterns](@/tips-patterns.md#dev-server-per-worktree)
 - Database per worktree: a `post-start` pipeline stores container name, port, and connection string as [per-branch vars](@/config.md#wt-config-state-vars) that later hooks reference — see [Tips & Patterns](@/tips-patterns.md#database-per-worktree)
 

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -347,49 +347,6 @@ fi
 """
 ```
 
-## Hook type examples
-
-```toml
-post-merge = "cargo install --path ."
-
-[[pre-start]]
-install = "npm ci"
-env = "echo 'PORT={{ branch | hash_port }}' > .env.local"
-
-[[pre-commit]]
-format = "cargo fmt -- --check"
-lint = "cargo clippy -- -D warnings"
-
-[[pre-merge]]
-test = "cargo test"
-build = "cargo build --release"
-
-[pre-switch]
-pull = """
-FETCH_HEAD="$(git rev-parse --git-common-dir)/FETCH_HEAD"
-if [ "$(find "$FETCH_HEAD" -mmin +360 2>/dev/null)" ] || [ ! -f "$FETCH_HEAD" ]; then
-    git pull
-fi
-"""
-
-[post-switch]
-tmux = "[ -n \"$TMUX\" ] && tmux rename-window {{ branch | sanitize }}"
-
-[post-start]
-copy = "wt step copy-ignored"
-server = "npm run dev -- --port {{ branch | hash_port }}"
-
-[post-commit]
-notify = "curl -s https://ci.example.com/trigger?branch={{ branch }}"
-
-[pre-remove]
-archive = "tar -czf ~/.wt-logs/{{ branch }}.tar.gz test-results/ logs/ 2>/dev/null || true"
-
-[post-remove]
-kill-server = "lsof -ti :{{ branch | hash_port }} -sTCP:LISTEN | xargs kill 2>/dev/null || true"
-remove-db = "docker stop {{ repo }}-{{ branch | sanitize }}-postgres 2>/dev/null || true"
-```
-
 ## More recipes
 
 - Copy gitignored files between worktrees: `wt step copy-ignored` in `post-start` shares build caches and dependencies; use a `[[post-start]]` pipeline when a later hook depends on the copy — see [Tips & Patterns](@/tips-patterns.md#eliminate-cold-starts)

--- a/docs/content/tips-patterns.md
+++ b/docs/content/tips-patterns.md
@@ -134,18 +134,6 @@ Use `pre-start` instead when an `--execute` command needs the copied files immed
 
 All gitignored files are copied by default. To limit what gets copied, create `.worktreeinclude` with patterns — files must be both gitignored and listed. See [`wt step copy-ignored`](@/step.md#wt-step-copy-ignored) for details.
 
-## Local CI gate
-
-`pre-merge` hooks run before merging. Failures abort the merge:
-
-```toml
-[[pre-merge]]
-lint = "uv run ruff check"
-test = "uv run pytest"
-```
-
-This catches issues locally before pushing — like running CI locally.
-
 ## Manual commit messages
 
 The `commit.generation.command` receives the rendered prompt on stdin and returns the commit message on stdout. To write commit messages by hand instead of using an LLM, point it at `$EDITOR`:

--- a/docs/content/tips-patterns.md
+++ b/docs/content/tips-patterns.md
@@ -120,7 +120,17 @@ Use [`wt step copy-ignored`](@/step.md#wt-step-copy-ignored) to copy gitignored 
 copy = "wt step copy-ignored"
 ```
 
-Use `pre-start` instead if subsequent hooks or `--execute` command need the copied files immediately.
+When another hook depends on the copy — for example, copying `node_modules/` before `pnpm install` so the install reuses cached packages — sequence them with a `[[post-start]]` pipeline:
+
+```toml
+[[post-start]]
+copy = "wt step copy-ignored"
+
+[[post-start]]
+install = "pnpm install"
+```
+
+Use `pre-start` instead when an `--execute` command needs the copied files immediately.
 
 All gitignored files are copied by default. To limit what gets copied, create `.worktreeinclude` with patterns — files must be both gitignored and listed. See [`wt step copy-ignored`](@/step.md#wt-step-copy-ignored) for details.
 

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -346,49 +346,6 @@ fi
 """
 ```
 
-## Hook type examples
-
-```toml
-post-merge = "cargo install --path ."
-
-[[pre-start]]
-install = "npm ci"
-env = "echo 'PORT={{ branch | hash_port }}' > .env.local"
-
-[[pre-commit]]
-format = "cargo fmt -- --check"
-lint = "cargo clippy -- -D warnings"
-
-[[pre-merge]]
-test = "cargo test"
-build = "cargo build --release"
-
-[pre-switch]
-pull = """
-FETCH_HEAD="$(git rev-parse --git-common-dir)/FETCH_HEAD"
-if [ "$(find "$FETCH_HEAD" -mmin +360 2>/dev/null)" ] || [ ! -f "$FETCH_HEAD" ]; then
-    git pull
-fi
-"""
-
-[post-switch]
-tmux = "[ -n \"$TMUX\" ] && tmux rename-window {{ branch | sanitize }}"
-
-[post-start]
-copy = "wt step copy-ignored"
-server = "npm run dev -- --port {{ branch | hash_port }}"
-
-[post-commit]
-notify = "curl -s https://ci.example.com/trigger?branch={{ branch }}"
-
-[pre-remove]
-archive = "tar -czf ~/.wt-logs/{{ branch }}.tar.gz test-results/ logs/ 2>/dev/null || true"
-
-[post-remove]
-kill-server = "lsof -ti :{{ branch | hash_port }} -sTCP:LISTEN | xargs kill 2>/dev/null || true"
-remove-db = "docker stop {{ repo }}-{{ branch | sanitize }}-postgres 2>/dev/null || true"
-```
-
 ## More recipes
 
 - Copy gitignored files between worktrees: `wt step copy-ignored` in `post-start` shares build caches and dependencies; use a `[[post-start]]` pipeline when a later hook depends on the copy — https://worktrunk.dev/tips-patterns/#eliminate-cold-starts

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -318,16 +318,6 @@ Git worktrees share the repository but not untracked files. [`wt step copy-ignor
 copy = "wt step copy-ignored"
 ```
 
-Use `pre-start` instead if subsequent hooks need the copied files — for example, copying `node_modules/` before `pnpm install` so the install reuses cached packages:
-
-```toml
-[[pre-start]]
-copy = "wt step copy-ignored"
-
-[[pre-start]]
-install = "pnpm install"
-```
-
 ## Progressive validation
 
 Quick checks before commit, thorough validation before merge:
@@ -355,17 +345,6 @@ elif [ {{ target }} = staging ]; then
 fi
 """
 ```
-
-## Python virtual environments
-
-Use `uv sync` to recreate virtual environments, or `python -m venv .venv && .venv/bin/pip install -r requirements.txt` for pip-based projects:
-
-```toml
-[pre-start]
-install = "uv sync"
-```
-
-For copying dependencies and caches between worktrees, see [`wt step copy-ignored`](https://worktrunk.dev/step/#language-specific-notes).
 
 ## Hook type examples
 
@@ -412,6 +391,7 @@ remove-db = "docker stop {{ repo }}-{{ branch | sanitize }}-postgres 2>/dev/null
 
 ## More recipes
 
+- Copy gitignored files between worktrees: `wt step copy-ignored` in `post-start` shares build caches and dependencies; use a `[[post-start]]` pipeline when a later hook depends on the copy — https://worktrunk.dev/tips-patterns/#eliminate-cold-starts
 - Dev server per worktree: `hash_port` in `post-start` for launch and `post-remove` for cleanup, with optional subdomain routing — https://worktrunk.dev/tips-patterns/#dev-server-per-worktree
 - Database per worktree: a `post-start` pipeline stores container name, port, and connection string as [per-branch vars](https://worktrunk.dev/config/#wt-config-state-vars) that later hooks reference — https://worktrunk.dev/tips-patterns/#database-per-worktree
 

--- a/skills/worktrunk/reference/tips-patterns.md
+++ b/skills/worktrunk/reference/tips-patterns.md
@@ -115,7 +115,17 @@ Use [`wt step copy-ignored`](https://worktrunk.dev/step/#wt-step-copy-ignored) t
 copy = "wt step copy-ignored"
 ```
 
-Use `pre-start` instead if subsequent hooks or `--execute` command need the copied files immediately.
+When another hook depends on the copy — for example, copying `node_modules/` before `pnpm install` so the install reuses cached packages — sequence them with a `[[post-start]]` pipeline:
+
+```toml
+[[post-start]]
+copy = "wt step copy-ignored"
+
+[[post-start]]
+install = "pnpm install"
+```
+
+Use `pre-start` instead when an `--execute` command needs the copied files immediately.
 
 All gitignored files are copied by default. To limit what gets copied, create `.worktreeinclude` with patterns — files must be both gitignored and listed. See [`wt step copy-ignored`](https://worktrunk.dev/step/#wt-step-copy-ignored) for details.
 

--- a/skills/worktrunk/reference/tips-patterns.md
+++ b/skills/worktrunk/reference/tips-patterns.md
@@ -129,18 +129,6 @@ Use `pre-start` instead when an `--execute` command needs the copied files immed
 
 All gitignored files are copied by default. To limit what gets copied, create `.worktreeinclude` with patterns — files must be both gitignored and listed. See [`wt step copy-ignored`](https://worktrunk.dev/step/#wt-step-copy-ignored) for details.
 
-## Local CI gate
-
-`pre-merge` hooks run before merging. Failures abort the merge:
-
-```toml
-[[pre-merge]]
-lint = "uv run ruff check"
-test = "uv run pytest"
-```
-
-This catches issues locally before pushing — like running CI locally.
-
 ## Manual commit messages
 
 The `commit.generation.command` receives the rendered prompt on stdin and returns the commit message on stdout. To write commit messages by hand instead of using an LLM, point it at `$EDITOR`:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1459,16 +1459,6 @@ Git worktrees share the repository but not untracked files. [`wt step copy-ignor
 copy = "wt step copy-ignored"
 ```
 
-Use `pre-start` instead if subsequent hooks need the copied files — for example, copying `node_modules/` before `pnpm install` so the install reuses cached packages:
-
-```toml
-[[pre-start]]
-copy = "wt step copy-ignored"
-
-[[pre-start]]
-install = "pnpm install"
-```
-
 ## Progressive validation
 
 Quick checks before commit, thorough validation before merge:
@@ -1496,17 +1486,6 @@ elif [ {{ target }} = staging ]; then
 fi
 """
 ```
-
-## Python virtual environments
-
-Use `uv sync` to recreate virtual environments, or `python -m venv .venv && .venv/bin/pip install -r requirements.txt` for pip-based projects:
-
-```toml
-[pre-start]
-install = "uv sync"
-```
-
-For copying dependencies and caches between worktrees, see [`wt step copy-ignored`](@/step.md#language-specific-notes).
 
 ## Hook type examples
 
@@ -1553,6 +1532,7 @@ remove-db = "docker stop {{ repo }}-{{ branch | sanitize }}-postgres 2>/dev/null
 
 ## More recipes
 
+- Copy gitignored files between worktrees: `wt step copy-ignored` in `post-start` shares build caches and dependencies; use a `[[post-start]]` pipeline when a later hook depends on the copy — https://worktrunk.dev/tips-patterns/#eliminate-cold-starts
 - Dev server per worktree: `hash_port` in `post-start` for launch and `post-remove` for cleanup, with optional subdomain routing — https://worktrunk.dev/tips-patterns/#dev-server-per-worktree
 - Database per worktree: a `post-start` pipeline stores container name, port, and connection string as [per-branch vars](@/config.md#wt-config-state-vars) that later hooks reference — https://worktrunk.dev/tips-patterns/#database-per-worktree
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1487,49 +1487,6 @@ fi
 """
 ```
 
-## Hook type examples
-
-```toml
-post-merge = "cargo install --path ."
-
-[[pre-start]]
-install = "npm ci"
-env = "echo 'PORT={{ branch | hash_port }}' > .env.local"
-
-[[pre-commit]]
-format = "cargo fmt -- --check"
-lint = "cargo clippy -- -D warnings"
-
-[[pre-merge]]
-test = "cargo test"
-build = "cargo build --release"
-
-[pre-switch]
-pull = """
-FETCH_HEAD="$(git rev-parse --git-common-dir)/FETCH_HEAD"
-if [ "$(find "$FETCH_HEAD" -mmin +360 2>/dev/null)" ] || [ ! -f "$FETCH_HEAD" ]; then
-    git pull
-fi
-"""
-
-[post-switch]
-tmux = "[ -n \"$TMUX\" ] && tmux rename-window {{ branch | sanitize }}"
-
-[post-start]
-copy = "wt step copy-ignored"
-server = "npm run dev -- --port {{ branch | hash_port }}"
-
-[post-commit]
-notify = "curl -s https://ci.example.com/trigger?branch={{ branch }}"
-
-[pre-remove]
-archive = "tar -czf ~/.wt-logs/{{ branch }}.tar.gz test-results/ logs/ 2>/dev/null || true"
-
-[post-remove]
-kill-server = "lsof -ti :{{ branch | hash_port }} -sTCP:LISTEN | xargs kill 2>/dev/null || true"
-remove-db = "docker stop {{ repo }}-{{ branch | sanitize }}-postgres 2>/dev/null || true"
-```
-
 ## More recipes
 
 - Copy gitignored files between worktrees: `wt step copy-ignored` in `post-start` shares build caches and dependencies; use a `[[post-start]]` pipeline when a later hook depends on the copy — https://worktrunk.dev/tips-patterns/#eliminate-cold-starts

--- a/src/help.rs
+++ b/src/help.rs
@@ -536,6 +536,10 @@ fn post_process_for_html(text: &str) -> String {
             "hooks reference — https://worktrunk.dev/tips-patterns/#database-per-worktree",
             "hooks reference — see [Tips & Patterns](@/tips-patterns.md#database-per-worktree)",
         )
+        .replace(
+            "depends on the copy — https://worktrunk.dev/tips-patterns/#eliminate-cold-starts",
+            "depends on the copy — see [Tips & Patterns](@/tips-patterns.md#eliminate-cold-starts)",
+        )
         // Approval prompt: plain code block → terminal shortcode with colored symbols
         // and gutter. CLI shows a plain ``` block; web shows styled terminal output
         // matching the actual CLI appearance (yellow ▲, dim ○, cyan ❯, gutter bar).


### PR DESCRIPTION
Docs consolidation sweep, same pattern as #2319.

**Copy-ignored recipe** — collapses hook.md's "Copying untracked files" overlap with tips-patterns.md into a "More recipes" bullet pointing at the canonical recipe. Keeps a one-paragraph intro in hook.md (worktrees don't share untracked files → use `wt step copy-ignored`) since it's a fundamental worktree concept. Moves the concrete pnpm pipeline example into tips-patterns.md's canonical recipe, and switches it from `[[pre-start]]` to `[[post-start]]` — the pipeline form handles ordering without blocking worktree creation. `pre-start` is now called out only as the exception for when `--execute` needs the files immediately.

**Trims**
- Dropped hook.md's "Hook type examples" dump: most of its 10 entries duplicate existing recipes (dev server, database, cold starts) or the Progressive validation section.
- Dropped tips-patterns.md's "Local CI gate": four-line recipe that duplicated hook.md's Progressive validation and merge.md's Local CI narrative.
- Dropped hook.md's "Python virtual environments" snippet: step.md already owns language-specific notes.

> _This was written by Claude Code on behalf of Maximilian Roos_