### PR TITLE
Extend `-v` variable dump to aliases + help-table drift test

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -494,9 +494,8 @@ Usage: <b><span class=c>wt config</span></b> <span class=c>[OPTIONS]</span> <spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -556,9 +555,8 @@ Usage: <b><span class=c>wt config show</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -608,9 +606,8 @@ Usage: <b><span class=c>wt config approvals</span></b> <span class=c>[OPTIONS]</
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -653,9 +650,8 @@ Usage: <b><span class=c>wt config alias</span></b> <span class=c>[OPTIONS]</span
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -729,9 +725,8 @@ Usage: <b><span class=c>wt config state</span></b> <span class=c>[OPTIONS]</span
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -788,9 +783,8 @@ Usage: <b><span class=c>wt config state default-branch</span></b> <span class=c>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -894,9 +888,8 @@ Usage: <b><span class=c>wt config state logs</span></b> <span class=c>[OPTIONS]<
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -956,9 +949,8 @@ Usage: <b><span class=c>wt config state ci-status</span></b> <span class=c>[OPTI
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -1030,9 +1022,8 @@ Usage: <b><span class=c>wt config state marker</span></b> <span class=c>[OPTIONS
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -1106,9 +1097,8 @@ Usage: <b><span class=c>wt config state vars</span></b> <span class=c>[OPTIONS]<
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -160,7 +160,7 @@ Some variables are conditional: `upstream` requires remote tracking; `base` only
 sync = "{% if upstream %}git fetch && git rebase {{ upstream }}{% endif %}"
 ```
 
-Run any hook-firing command with `-v` to see the resolved variables for the actual invocation — each hook prints a `template variables:` block showing every in-scope variable and its value (`(unset)` for conditional vars that didn't populate, like `target_worktree_path` during `wt switch -`).
+Run any hook-firing command with `-v` to see the resolved variables for the actual invocation — each hook prints a `template variables:` block showing every in-scope variable and its value (`(unset)` for conditional vars that didn't populate, like `target_worktree_path` during `wt switch -`). Aliases do the same under `-v`: `wt -v <alias>` prints the alias's in-scope variables before the pipeline runs.
 
 Variables use dot access and the `default` filter for missing keys. JSON object/array values are parsed automatically, so `{{ vars.config.port }}` works when the value is `{"port": 3000}`:
 
@@ -509,9 +509,8 @@ Usage: <b><span class=c>wt hook</span></b> <span class=c>[OPTIONS]</span> <span 
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts

--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -281,9 +281,8 @@ Usage: <b><span class=c>wt list</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts

--- a/docs/content/merge.md
+++ b/docs/content/merge.md
@@ -146,9 +146,8 @@ Usage: <b><span class=c>wt merge</span></b> <span class=c>[OPTIONS]</span> <span
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts

--- a/docs/content/remove.md
+++ b/docs/content/remove.md
@@ -133,9 +133,8 @@ Usage: <b><span class=c>wt remove</span></b> <span class=c>[OPTIONS]</span> <spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts

--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -76,9 +76,8 @@ Usage: <b><span class=c>wt step</span></b> <span class=c>[OPTIONS]</span> <span 
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -157,9 +156,8 @@ Usage: <b><span class=c>wt step commit</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -241,9 +239,8 @@ Usage: <b><span class=c>wt step squash</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -303,9 +300,8 @@ Usage: <b><span class=c>wt step diff</span></b> <span class=c>[OPTIONS]</span> <
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -439,9 +435,8 @@ Usage: <b><span class=c>wt step copy-ignored</span></b> <span class=c>[OPTIONS]<
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -518,9 +513,8 @@ Usage: <b><span class=c>wt step eval</span></b> <span class=c>[OPTIONS]</span> <
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -592,9 +586,8 @@ Usage: <b><span class=c>wt step for-each</span></b> <span class=c>[OPTIONS]</spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -670,9 +663,8 @@ Usage: <b><span class=c>wt step promote</span></b> <span class=c>[OPTIONS]</span
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -745,9 +737,8 @@ Usage: <b><span class=c>wt step prune</span></b> <span class=c>[OPTIONS]</span>
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts
@@ -839,9 +830,8 @@ Usage: <b><span class=c>wt step relocate</span></b> <span class=c>[OPTIONS]</spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts

--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -217,9 +217,8 @@ Usage: <b><span class=c>wt switch</span></b> <span class=c>[OPTIONS]</span> <spa
           User config file path
 
   <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable &amp; output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
           Skip approval prompts

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -497,9 +497,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -561,9 +560,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -619,9 +617,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -669,9 +666,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -759,9 +755,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -820,9 +815,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -936,9 +930,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -998,9 +991,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -1071,9 +1063,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -1158,9 +1149,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -151,7 +151,7 @@ Some variables are conditional: `upstream` requires remote tracking; `base` only
 sync = "{% if upstream %}git fetch && git rebase {{ upstream }}{% endif %}"
 ```
 
-Run any hook-firing command with `-v` to see the resolved variables for the actual invocation — each hook prints a `template variables:` block showing every in-scope variable and its value (`(unset)` for conditional vars that didn't populate, like `target_worktree_path` during `wt switch -`).
+Run any hook-firing command with `-v` to see the resolved variables for the actual invocation — each hook prints a `template variables:` block showing every in-scope variable and its value (`(unset)` for conditional vars that didn't populate, like `target_worktree_path` during `wt switch -`). Aliases do the same under `-v`: `wt -v <alias>` prints the alias's in-scope variables before the pipeline runs.
 
 Variables use dot access and the `default` filter for missing keys. JSON object/array values are parsed automatically, so `{{ vars.config.port }}` works when the value is `{"port": 3000}`:
 
@@ -503,9 +503,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -311,9 +311,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts

--- a/skills/worktrunk/reference/merge.md
+++ b/skills/worktrunk/reference/merge.md
@@ -136,9 +136,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts

--- a/skills/worktrunk/reference/remove.md
+++ b/skills/worktrunk/reference/remove.md
@@ -132,9 +132,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -68,9 +68,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -157,9 +156,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -245,9 +243,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -317,9 +314,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -453,9 +449,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -538,9 +533,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -620,9 +614,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -701,9 +694,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -783,9 +775,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts
@@ -885,9 +876,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts

--- a/skills/worktrunk/reference/switch.md
+++ b/skills/worktrunk/reference/switch.md
@@ -209,9 +209,8 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for
-          each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under
-          .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs +
+          diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -241,7 +241,7 @@ pub(crate) struct Cli {
     )]
     pub config: Option<std::path::PathBuf>,
 
-    /// Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+    /// Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
     #[arg(
         long,
         short = 'v',
@@ -1292,7 +1292,7 @@ Some variables are conditional: `upstream` requires remote tracking; `base` only
 sync = "{% if upstream %}git fetch && git rebase {{ upstream }}{% endif %}"
 ```
 
-Run any hook-firing command with `-v` to see the resolved variables for the actual invocation — each hook prints a `template variables:` block showing every in-scope variable and its value (`(unset)` for conditional vars that didn't populate, like `target_worktree_path` during `wt switch -`).
+Run any hook-firing command with `-v` to see the resolved variables for the actual invocation — each hook prints a `template variables:` block showing every in-scope variable and its value (`(unset)` for conditional vars that didn't populate, like `target_worktree_path` during `wt switch -`). Aliases do the same under `-v`: `wt -v <alias>` prints the alias's in-scope variables before the pipeline runs.
 
 Variables use dot access and the `default` filter for missing keys. JSON object/array values are parsed automatically, so `{{ vars.config.port }}` works when the value is `{"port": 3000}`:
 

--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -35,11 +35,14 @@ use std::collections::{BTreeMap, BTreeSet};
 use anyhow::{Context, bail};
 use color_print::cformat;
 use worktrunk::config::{
-    ALIAS_ARGS_KEY, CommandConfig, HookStep, ProjectConfig, UserConfig, append_aliases,
-    referenced_vars_for_config,
+    ALIAS_ARGS_KEY, CommandConfig, HookStep, ProjectConfig, UserConfig, ValidationScope,
+    append_aliases, format_scope_variables, referenced_vars_for_config,
 };
 use worktrunk::git::Repository;
-use worktrunk::styling::{eprintln, println, progress_message, warning_message};
+use worktrunk::styling::{
+    eprintln, format_with_gutter, info_message, println, progress_message, verbosity,
+    warning_message,
+};
 
 use crate::commands::command_approval::approve_alias_commands;
 use crate::commands::command_executor::{
@@ -511,6 +514,12 @@ fn run_alias(
     // Build JSON context for stdin
     let context_json = serde_json::to_string(&context_map)
         .expect("HashMap<String, String> serialization should never fail");
+
+    if verbosity() >= 1 {
+        let vars = format_scope_variables(ValidationScope::Alias, &context_map);
+        eprintln!("{}", info_message("template variables:"));
+        eprintln!("{}", format_with_gutter(&vars, None));
+    }
 
     eprintln!(
         "{}",

--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -35,8 +35,8 @@ use std::collections::{BTreeMap, BTreeSet};
 use anyhow::{Context, bail};
 use color_print::cformat;
 use worktrunk::config::{
-    ALIAS_ARGS_KEY, CommandConfig, HookStep, ProjectConfig, UserConfig, ValidationScope,
-    append_aliases, format_scope_variables, referenced_vars_for_config,
+    ALIAS_ARGS_KEY, CommandConfig, HookStep, ProjectConfig, UserConfig, append_aliases,
+    format_alias_variables, referenced_vars_for_config,
 };
 use worktrunk::git::Repository;
 use worktrunk::styling::{
@@ -516,7 +516,7 @@ fn run_alias(
         .expect("HashMap<String, String> serialization should never fail");
 
     if verbosity() >= 1 {
-        let vars = format_scope_variables(ValidationScope::Alias, &context_map);
+        let vars = format_alias_variables(&context_map);
         eprintln!("{}", info_message("template variables:"));
         eprintln!("{}", format_with_gutter(&vars, None));
     }

--- a/src/commands/command_executor.rs
+++ b/src/commands/command_executor.rs
@@ -5,8 +5,8 @@ use anyhow::{Context, Result, bail};
 use color_print::cformat;
 use worktrunk::HookType;
 use worktrunk::config::{
-    Command, CommandConfig, HookStep, UserConfig, expand_template, format_hook_variables,
-    template_references_var, validate_template_syntax,
+    Command, CommandConfig, HookStep, UserConfig, ValidationScope, expand_template,
+    format_scope_variables, template_references_var, validate_template_syntax,
 };
 use worktrunk::git::{Repository, WorktrunkError, interrupt_exit_code};
 use worktrunk::path::{format_path_for_display, to_posix_path};
@@ -488,7 +488,7 @@ fn announce_command(cmd: &PreparedCommand, origin: &CommandOrigin) {
             if verbosity() >= 1 {
                 let ctx: HashMap<String, String> = serde_json::from_str(&cmd.context_json)
                     .expect("context_json is always serialized from a HashMap<String, String>");
-                let vars = format_hook_variables(*hook_type, &ctx);
+                let vars = format_scope_variables(ValidationScope::Hook(*hook_type), &ctx);
                 eprintln!("{}", info_message("template variables:"));
                 eprintln!("{}", format_with_gutter(&vars, None));
             }

--- a/src/commands/command_executor.rs
+++ b/src/commands/command_executor.rs
@@ -5,8 +5,8 @@ use anyhow::{Context, Result, bail};
 use color_print::cformat;
 use worktrunk::HookType;
 use worktrunk::config::{
-    Command, CommandConfig, HookStep, UserConfig, ValidationScope, expand_template,
-    format_scope_variables, template_references_var, validate_template_syntax,
+    Command, CommandConfig, HookStep, UserConfig, expand_template, format_hook_variables,
+    template_references_var, validate_template_syntax,
 };
 use worktrunk::git::{Repository, WorktrunkError, interrupt_exit_code};
 use worktrunk::path::{format_path_for_display, to_posix_path};
@@ -488,7 +488,7 @@ fn announce_command(cmd: &PreparedCommand, origin: &CommandOrigin) {
             if verbosity() >= 1 {
                 let ctx: HashMap<String, String> = serde_json::from_str(&cmd.context_json)
                     .expect("context_json is always serialized from a HashMap<String, String>");
-                let vars = format_scope_variables(ValidationScope::Hook(*hook_type), &ctx);
+                let vars = format_hook_variables(*hook_type, &ctx);
                 eprintln!("{}", info_message("template variables:"));
                 eprintln!("{}", format_with_gutter(&vars, None));
             }

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Context;
 use color_print::cformat;
 use worktrunk::HookType;
-use worktrunk::config::{CommandConfig, ValidationScope, format_scope_variables};
+use worktrunk::config::{CommandConfig, format_hook_variables};
 use worktrunk::path::format_path_for_display;
 use worktrunk::styling::{
     eprintln, format_with_gutter, info_message, progress_message, verbosity, warning_message,
@@ -371,10 +371,7 @@ fn print_background_variable_tables(pipelines: &[(CommandContext<'_>, Vec<Source
             eprintln!("{}", info_message("template variables:"));
             eprintln!(
                 "{}",
-                format_with_gutter(
-                    &format_scope_variables(ValidationScope::Hook(sourced.hook_type), &ctx),
-                    None
-                )
+                format_with_gutter(&format_hook_variables(sourced.hook_type, &ctx), None)
             );
             seen.push(sourced.hook_type);
         }

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -4,7 +4,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Context;
 use color_print::cformat;
 use worktrunk::HookType;
-use worktrunk::config::{CommandConfig, format_hook_variables};
+use worktrunk::config::{CommandConfig, ValidationScope, format_scope_variables};
 use worktrunk::path::format_path_for_display;
 use worktrunk::styling::{
     eprintln, format_with_gutter, info_message, progress_message, verbosity, warning_message,
@@ -371,7 +371,10 @@ fn print_background_variable_tables(pipelines: &[(CommandContext<'_>, Vec<Source
             eprintln!("{}", info_message("template variables:"));
             eprintln!(
                 "{}",
-                format_with_gutter(&format_hook_variables(sourced.hook_type, &ctx), None)
+                format_with_gutter(
+                    &format_scope_variables(ValidationScope::Hook(sourced.hook_type), &ctx),
+                    None
+                )
             );
             seen.push(sourced.hook_type);
         }

--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -189,13 +189,13 @@ pub fn vars_available_in(scope: ValidationScope) -> Vec<&'static str> {
     vars
 }
 
-/// Format the resolved template variables for a hook invocation as an
-/// aligned `name = value` block — no heading, no indent, caller wraps.
+/// Format the resolved template variables for a hook or alias invocation
+/// as an aligned `name = value` block — no heading, no indent, caller wraps.
 ///
 /// Ordered per the `## Template variables` help table in `src/cli/mod.rs`:
 /// active, operation, repo, exec. A variable appears if it's in scope for
-/// `hook_type` per [`vars_available_in`]. Values come from `ctx`; vars that
-/// are in-scope but absent from `ctx` render as `(unset)` — this surfaces
+/// `scope` per [`vars_available_in`]. Values come from `ctx`; vars that are
+/// in-scope but absent from `ctx` render as `(unset)` — this surfaces
 /// operation-specific gaps (e.g., `target_worktree_path` during
 /// `wt switch -`, `upstream` when the branch doesn't track a remote).
 ///
@@ -205,16 +205,33 @@ pub fn vars_available_in(scope: ValidationScope) -> Vec<&'static str> {
 /// distinction here.
 ///
 /// Deprecated aliases and `vars.*` (user state) are intentionally omitted.
-pub fn format_hook_variables(hook_type: HookType, ctx: &HashMap<String, String>) -> String {
-    // Flat list in the canonical docs order: active, operation, repo, exec.
-    let vars: Vec<&'static str> = ACTIVE_VARS
-        .iter()
-        .chain(hook_extras(hook_type))
-        .chain(REPO_VARS)
-        .chain(EXEC_BASE_VARS)
-        .chain(HOOK_INFRASTRUCTURE_VARS)
-        .copied()
-        .collect();
+pub fn format_scope_variables(scope: ValidationScope, ctx: &HashMap<String, String>) -> String {
+    // Flat list in the canonical docs order: active, operation, repo, exec,
+    // infrastructure.
+    let vars: Vec<&'static str> = match scope {
+        ValidationScope::Hook(hook_type) => ACTIVE_VARS
+            .iter()
+            .chain(hook_extras(hook_type))
+            .chain(REPO_VARS)
+            .chain(EXEC_BASE_VARS)
+            .chain(HOOK_INFRASTRUCTURE_VARS)
+            .copied()
+            .collect(),
+        ValidationScope::Alias => ACTIVE_VARS
+            .iter()
+            .copied()
+            .chain(std::iter::once(ALIAS_ARGS_KEY))
+            .chain(REPO_VARS.iter().copied())
+            .chain(EXEC_BASE_VARS.iter().copied())
+            .collect(),
+        ValidationScope::SwitchExecute => ACTIVE_VARS
+            .iter()
+            .copied()
+            .chain(["base", "base_worktree_path"])
+            .chain(REPO_VARS.iter().copied())
+            .chain(EXEC_BASE_VARS.iter().copied())
+            .collect(),
+    };
 
     let max_name = vars.iter().map(|v| v.len()).max().unwrap_or(0);
 
@@ -1888,7 +1905,7 @@ mod tests {
     }
 
     #[test]
-    fn test_format_hook_variables_groups_and_unset() {
+    fn test_format_scope_variables_hook_groups_and_unset() {
         let mut ctx: HashMap<String, String> = HashMap::new();
         ctx.insert("branch".into(), "feature".into());
         ctx.insert("worktree_path".into(), "/tmp/feature".into());
@@ -1903,7 +1920,9 @@ mod tests {
         ctx.insert("hook_type".into(), "pre-switch".into());
         ctx.insert("hook_name".into(), "show-variables".into());
 
-        assert_snapshot!(format_hook_variables(HookType::PreSwitch, &ctx), @r"
+        assert_snapshot!(
+            format_scope_variables(ValidationScope::Hook(HookType::PreSwitch), &ctx),
+            @r"
         branch                = feature
         worktree_path         = /tmp/feature
         worktree_name         = feature
@@ -1926,15 +1945,16 @@ mod tests {
         cwd                   = /tmp/feature
         hook_type             = pre-switch
         hook_name             = show-variables
-        ");
+        "
+        );
     }
 
     #[test]
-    fn test_format_hook_variables_scope_filters_operation() {
+    fn test_format_scope_variables_hook_filters_operation() {
         // pre-commit only has `target` in operation scope — no base*, pr_*, etc.
         let mut ctx: HashMap<String, String> = HashMap::new();
         ctx.insert("target".into(), "main".into());
-        let out = format_hook_variables(HookType::PreCommit, &ctx);
+        let out = format_scope_variables(ValidationScope::Hook(HookType::PreCommit), &ctx);
         assert!(out.contains("target                = main"), "got: {out}");
         assert!(
             !out.contains("base "),
@@ -1944,5 +1964,28 @@ mod tests {
             !out.contains("pr_number"),
             "pre-commit has no `pr_number`; got: {out}"
         );
+    }
+
+    #[test]
+    fn test_format_scope_variables_alias_includes_args_no_hook_keys() {
+        let mut ctx: HashMap<String, String> = HashMap::new();
+        ctx.insert("branch".into(), "feature".into());
+        ctx.insert("worktree_path".into(), "/tmp/feature".into());
+        ctx.insert("worktree_name".into(), "feature".into());
+        ctx.insert("repo".into(), "demo".into());
+        ctx.insert("repo_path".into(), "/tmp/demo".into());
+        ctx.insert("cwd".into(), "/tmp/feature".into());
+        // args is JSON-encoded per `ALIAS_ARGS_KEY` contract.
+        ctx.insert(ALIAS_ARGS_KEY.into(), r#"["a","b c"]"#.into());
+
+        let out = format_scope_variables(ValidationScope::Alias, &ctx);
+        assert!(
+            out.contains(r#"args                  = ["a","b c"]"#),
+            "got: {out}"
+        );
+        // No hook-only keys appear in alias scope.
+        assert!(!out.contains("hook_type"), "got: {out}");
+        assert!(!out.contains("target"), "got: {out}");
+        assert!(!out.contains("base "), "got: {out}");
     }
 }

--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -189,52 +189,19 @@ pub fn vars_available_in(scope: ValidationScope) -> Vec<&'static str> {
     vars
 }
 
-/// Format the resolved template variables for a hook or alias invocation
-/// as an aligned `name = value` block — no heading, no indent, caller wraps.
+/// Shared formatter for [`format_hook_variables`] and [`format_alias_variables`].
 ///
-/// Ordered per the `## Template variables` help table in `src/cli/mod.rs`:
-/// active, operation, repo, exec. A variable appears if it's in scope for
-/// `scope` per [`vars_available_in`]. Values come from `ctx`; vars that are
-/// in-scope but absent from `ctx` render as `(unset)` — this surfaces
-/// operation-specific gaps (e.g., `target_worktree_path` during
-/// `wt switch -`, `upstream` when the branch doesn't track a remote).
+/// Renders `vars` as an aligned `name = value` block — no heading, no indent,
+/// caller wraps. Values come from `ctx`; vars absent from `ctx` render as
+/// `(unset)`, surfacing operation-specific gaps (e.g., `target_worktree_path`
+/// during `wt switch -`, `upstream` when the branch doesn't track a remote).
 ///
 /// `(unset)` relies on an invariant in `build_hook_context`: optional vars
 /// are omitted from the map rather than inserted as empty strings. If a
 /// future caller starts inserting `""`, revisit the empty-vs-absent
 /// distinction here.
-///
-/// Deprecated aliases and `vars.*` (user state) are intentionally omitted.
-pub fn format_scope_variables(scope: ValidationScope, ctx: &HashMap<String, String>) -> String {
-    // Flat list in the canonical docs order: active, operation, repo, exec,
-    // infrastructure.
-    let vars: Vec<&'static str> = match scope {
-        ValidationScope::Hook(hook_type) => ACTIVE_VARS
-            .iter()
-            .chain(hook_extras(hook_type))
-            .chain(REPO_VARS)
-            .chain(EXEC_BASE_VARS)
-            .chain(HOOK_INFRASTRUCTURE_VARS)
-            .copied()
-            .collect(),
-        ValidationScope::Alias => ACTIVE_VARS
-            .iter()
-            .copied()
-            .chain(std::iter::once(ALIAS_ARGS_KEY))
-            .chain(REPO_VARS.iter().copied())
-            .chain(EXEC_BASE_VARS.iter().copied())
-            .collect(),
-        ValidationScope::SwitchExecute => ACTIVE_VARS
-            .iter()
-            .copied()
-            .chain(["base", "base_worktree_path"])
-            .chain(REPO_VARS.iter().copied())
-            .chain(EXEC_BASE_VARS.iter().copied())
-            .collect(),
-    };
-
+fn format_variables_table(vars: &[&'static str], ctx: &HashMap<String, String>) -> String {
     let max_name = vars.iter().map(|v| v.len()).max().unwrap_or(0);
-
     vars.iter()
         .map(|var| {
             let value = match ctx.get(*var) {
@@ -245,6 +212,40 @@ pub fn format_scope_variables(scope: ValidationScope, ctx: &HashMap<String, Stri
         })
         .collect::<Vec<_>>()
         .join("\n")
+}
+
+/// Format the resolved template variables for a hook invocation.
+///
+/// Ordered per the `## Template variables` help table in `src/cli/mod.rs`:
+/// active, operation, repo, exec, infrastructure.
+///
+/// Deprecated aliases and `vars.*` (user state) are intentionally omitted.
+pub fn format_hook_variables(hook_type: HookType, ctx: &HashMap<String, String>) -> String {
+    let vars: Vec<&'static str> = ACTIVE_VARS
+        .iter()
+        .chain(hook_extras(hook_type))
+        .chain(REPO_VARS)
+        .chain(EXEC_BASE_VARS)
+        .chain(HOOK_INFRASTRUCTURE_VARS)
+        .copied()
+        .collect();
+    format_variables_table(&vars, ctx)
+}
+
+/// Format the resolved template variables for an alias invocation.
+///
+/// Ordering mirrors [`format_hook_variables`]; alias scope has no operation
+/// or infrastructure vars, and `args` sits between active and repo (it's the
+/// alias analogue of hook-operation context).
+pub fn format_alias_variables(ctx: &HashMap<String, String>) -> String {
+    let vars: Vec<&'static str> = ACTIVE_VARS
+        .iter()
+        .copied()
+        .chain(std::iter::once(ALIAS_ARGS_KEY))
+        .chain(REPO_VARS.iter().copied())
+        .chain(EXEC_BASE_VARS.iter().copied())
+        .collect();
+    format_variables_table(&vars, ctx)
 }
 
 /// Positional CLI args forwarded from `wt <alias> a b c` into the alias's
@@ -1905,7 +1906,7 @@ mod tests {
     }
 
     #[test]
-    fn test_format_scope_variables_hook_groups_and_unset() {
+    fn test_format_hook_variables_groups_and_unset() {
         let mut ctx: HashMap<String, String> = HashMap::new();
         ctx.insert("branch".into(), "feature".into());
         ctx.insert("worktree_path".into(), "/tmp/feature".into());
@@ -1920,9 +1921,7 @@ mod tests {
         ctx.insert("hook_type".into(), "pre-switch".into());
         ctx.insert("hook_name".into(), "show-variables".into());
 
-        assert_snapshot!(
-            format_scope_variables(ValidationScope::Hook(HookType::PreSwitch), &ctx),
-            @r"
+        assert_snapshot!(format_hook_variables(HookType::PreSwitch, &ctx), @r"
         branch                = feature
         worktree_path         = /tmp/feature
         worktree_name         = feature
@@ -1945,16 +1944,15 @@ mod tests {
         cwd                   = /tmp/feature
         hook_type             = pre-switch
         hook_name             = show-variables
-        "
-        );
+        ");
     }
 
     #[test]
-    fn test_format_scope_variables_hook_filters_operation() {
+    fn test_format_hook_variables_filters_operation() {
         // pre-commit only has `target` in operation scope — no base*, pr_*, etc.
         let mut ctx: HashMap<String, String> = HashMap::new();
         ctx.insert("target".into(), "main".into());
-        let out = format_scope_variables(ValidationScope::Hook(HookType::PreCommit), &ctx);
+        let out = format_hook_variables(HookType::PreCommit, &ctx);
         assert!(out.contains("target                = main"), "got: {out}");
         assert!(
             !out.contains("base "),
@@ -1967,7 +1965,7 @@ mod tests {
     }
 
     #[test]
-    fn test_format_scope_variables_alias_includes_args_no_hook_keys() {
+    fn test_format_alias_variables_includes_args_no_hook_keys() {
         let mut ctx: HashMap<String, String> = HashMap::new();
         ctx.insert("branch".into(), "feature".into());
         ctx.insert("worktree_path".into(), "/tmp/feature".into());
@@ -1978,7 +1976,7 @@ mod tests {
         // args is JSON-encoded per `ALIAS_ARGS_KEY` contract.
         ctx.insert(ALIAS_ARGS_KEY.into(), r#"["a","b c"]"#.into());
 
-        let out = format_scope_variables(ValidationScope::Alias, &ctx);
+        let out = format_alias_variables(&ctx);
         assert!(
             out.contains(r#"args                  = ["a","b c"]"#),
             "got: {out}"

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -122,7 +122,7 @@ pub use deprecation::{
 };
 pub use expansion::{
     ACTIVE_VARS, ALIAS_ARGS_KEY, DEPRECATED_TEMPLATE_VARS, EXEC_BASE_VARS, REPO_VARS,
-    TemplateExpandError, ValidationScope, base_vars, expand_template, format_hook_variables,
+    TemplateExpandError, ValidationScope, base_vars, expand_template, format_scope_variables,
     redact_credentials, referenced_vars_for_config, sanitize_branch_name, sanitize_db, short_hash,
     template_references_var, validate_template, validate_template_syntax, vars_available_in,
 };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -122,9 +122,10 @@ pub use deprecation::{
 };
 pub use expansion::{
     ACTIVE_VARS, ALIAS_ARGS_KEY, DEPRECATED_TEMPLATE_VARS, EXEC_BASE_VARS, REPO_VARS,
-    TemplateExpandError, ValidationScope, base_vars, expand_template, format_scope_variables,
-    redact_credentials, referenced_vars_for_config, sanitize_branch_name, sanitize_db, short_hash,
-    template_references_var, validate_template, validate_template_syntax, vars_available_in,
+    TemplateExpandError, ValidationScope, base_vars, expand_template, format_alias_variables,
+    format_hook_variables, redact_credentials, referenced_vars_for_config, sanitize_branch_name,
+    sanitize_db, short_hash, template_references_var, validate_template, validate_template_syntax,
+    vars_available_in,
 };
 pub use hooks::HooksConfig;
 pub use project::{ProjectCiConfig, ProjectConfig, ProjectListConfig, valid_project_config_keys};

--- a/tests/integration_tests/readme_sync.rs
+++ b/tests/integration_tests/readme_sync.rs
@@ -2318,6 +2318,116 @@ fn test_command_pages_and_skill_files_are_in_sync() {
     }
 }
 
+/// The hand-authored `## Template variables` table in `src/cli/mod.rs` must
+/// match the variable constants in `src/config/expansion.rs`. Drift means the
+/// help docs lie about which vars hooks and aliases can reference.
+///
+/// Checks presence and group placement; descriptions stay free-form prose.
+#[test]
+fn test_template_variables_table_matches_constants() {
+    use std::collections::{BTreeMap, BTreeSet};
+    use strum::IntoEnumIterator;
+    use worktrunk::config::{
+        ACTIVE_VARS, ALIAS_ARGS_KEY, DEPRECATED_TEMPLATE_VARS, EXEC_BASE_VARS, REPO_VARS,
+        ValidationScope, vars_available_in,
+    };
+    use worktrunk::git::HookType;
+
+    let cli_path = Path::new(env!("CARGO_MANIFEST_DIR")).join("src/cli/mod.rs");
+    let content = fs::read_to_string(&cli_path).unwrap();
+
+    // Carve out the `## Template variables` section: from its heading to the
+    // next `\n## ` (next level-2 heading). Anchored on the exact heading so an
+    // unrelated `## Template …` elsewhere can't be mistaken for it.
+    let heading = "\n## Template variables\n";
+    let start = content
+        .find(heading)
+        .expect("`## Template variables` heading missing in src/cli/mod.rs");
+    let rest = &content[start + heading.len()..];
+    let end = rest.find("\n## ").unwrap_or(rest.len());
+    let section = &rest[..end];
+
+    // Parse table rows: `| kind | `{{ name }}` | description |`. The kind
+    // column only appears on the first row of each group — subsequent rows
+    // leave it blank, inheriting the last-seen value.
+    let var_re = Regex::new(r"\{\{\s*([a-zA-Z_][a-zA-Z0-9_.<>]*)\s*\}\}").unwrap();
+    let mut actual: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    let mut current_kind: Option<String> = None;
+    for line in section.lines() {
+        if !line.starts_with("| ") || line.starts_with("|---") {
+            continue;
+        }
+        let cells: Vec<&str> = line.split('|').map(str::trim).collect();
+        // cells[0] and cells[last] are empty (leading/trailing `|`).
+        if cells.len() < 4 {
+            continue;
+        }
+        let kind_cell = cells[1];
+        let var_cell = cells[2];
+        // Skip the header row.
+        if kind_cell == "Kind" {
+            continue;
+        }
+        if !kind_cell.is_empty() {
+            current_kind = Some(kind_cell.to_string());
+        }
+        let Some(kind) = current_kind.as_ref() else {
+            continue;
+        };
+        if let Some(cap) = var_re.captures(var_cell) {
+            let name = cap[1].to_string();
+            actual.entry(kind.clone()).or_default().insert(name);
+        }
+    }
+
+    // Build expected groups from constants.
+    let mut expected: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+    expected.insert(
+        "active".into(),
+        ACTIVE_VARS.iter().map(|s| s.to_string()).collect(),
+    );
+    expected.insert(
+        "repo".into(),
+        REPO_VARS.iter().map(|s| s.to_string()).collect(),
+    );
+    // `exec` in the docs = runtime infra vars plus `args` (hook+alias body
+    // forwarding). The `hook_type`/`hook_name` names aren't exported as a
+    // constant, so they're inlined here — anchoring them to the table row
+    // they appear in.
+    let mut exec: BTreeSet<String> = EXEC_BASE_VARS.iter().map(|s| s.to_string()).collect();
+    exec.insert("hook_type".into());
+    exec.insert("hook_name".into());
+    exec.insert(ALIAS_ARGS_KEY.to_string());
+    expected.insert("exec".into(), exec);
+    // `user` row has a single entry — the `{{ vars.<key> }}` placeholder.
+    expected.insert("user".into(), BTreeSet::from(["vars.<key>".to_string()]));
+    // `operation` = union of hook-type-specific extras. Derived through the
+    // public `vars_available_in` so this test doesn't depend on the private
+    // `hook_extras` helper.
+    let base: BTreeSet<&&str> = ACTIVE_VARS
+        .iter()
+        .chain(REPO_VARS.iter())
+        .chain(EXEC_BASE_VARS.iter())
+        .chain(DEPRECATED_TEMPLATE_VARS.iter())
+        .collect();
+    let infra_and_args: BTreeSet<&str> = ["hook_type", "hook_name", ALIAS_ARGS_KEY].into();
+    let mut operation: BTreeSet<String> = BTreeSet::new();
+    for ht in HookType::iter() {
+        for v in vars_available_in(ValidationScope::Hook(ht)) {
+            if !base.contains(&v) && !infra_and_args.contains(v) {
+                operation.insert(v.to_string());
+            }
+        }
+    }
+    expected.insert("operation".into(), operation);
+
+    assert_eq!(
+        actual, expected,
+        "`## Template variables` table in src/cli/mod.rs drifted from \
+         constants in src/config/expansion.rs. Update the table or the constants."
+    );
+}
+
 /// Verify that post_process_for_html() transforms the approval prompt code block
 /// into a styled terminal shortcode. If the source text in cli/mod.rs changes
 /// without updating the replacement in help.rs, the .replace() silently stops

--- a/tests/integration_tests/step_alias.rs
+++ b/tests/integration_tests/step_alias.rs
@@ -1851,3 +1851,29 @@ deploy = "echo deploying"
         Some(&feature_path),
     );
 }
+
+/// Under `-v`, aliases print a table of resolved template variables before
+/// the announcement — symmetric with the hook-invocation verbose block, but
+/// with alias-scoped vars (`args` included, no `hook_*` keys).
+#[rstest]
+fn test_alias_verbose_prints_variable_table(mut repo: TestRepo) {
+    repo.write_test_config(
+        r#"
+[aliases]
+greet = "echo hello {{ args }}"
+"#,
+    );
+    let feature_path = repo.add_worktree("feature");
+
+    let settings = setup_snapshot_settings(&repo);
+    settings.bind(|| {
+        let mut cmd = make_snapshot_cmd_with_global_flags(
+            &repo,
+            "greet",
+            &["world"],
+            Some(&feature_path),
+            &["-v"],
+        );
+        assert_cmd_snapshot!("alias_verbose_variable_table", cmd);
+    });
+}

--- a/tests/snapshots/integration__integration_tests__help__help_config_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_approvals.snap
@@ -51,7 +51,7 @@ Usage: [1m[36mwt config approvals[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_approvals_add.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_approvals_add.snap
@@ -51,7 +51,7 @@ Usage: [1m[36mwt config approvals add[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_approvals_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_approvals_clear.snap
@@ -51,7 +51,7 @@ Usage: [1m[36mwt config approvals clear[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -50,7 +50,7 @@ Usage: [1m[36mwt config create[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -58,7 +58,7 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_shell.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_shell.snap
@@ -47,7 +47,7 @@ Usage: [1m[36mwt config shell[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_short.snap
@@ -50,7 +50,7 @@ Usage: [1m[36mwt config[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_show.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_show.snap
@@ -60,7 +60,7 @@ Usage: [1m[36mwt config show[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_state.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state.snap
@@ -58,7 +58,7 @@ Usage: [1m[36mwt config state[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_ci_status.snap
@@ -56,7 +56,7 @@ Usage: [1m[36mwt config state ci-status[0m [36m[OPTIONS][0m [36m[COMMAND]
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_clear.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_clear.snap
@@ -48,7 +48,7 @@ Usage: [1m[36mwt config state clear[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
@@ -53,7 +53,7 @@ Usage: [1m[36mwt config state default-branch[0m [36m[OPTIONS][0m [36m[COMM
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_get.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_get.snap
@@ -53,7 +53,7 @@ Usage: [1m[36mwt config state get[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
@@ -56,7 +56,7 @@ Usage: [1m[36mwt config state logs[0m [36m[OPTIONS][0m [36m[COMMAND][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_marker.snap
@@ -57,7 +57,7 @@ Usage: [1m[36mwt config state marker[0m [36m[OPTIONS][0m [36m[COMMAND][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_previous_branch.snap
@@ -53,7 +53,7 @@ Usage: [1m[36mwt config state previous-branch[0m [36m[OPTIONS][0m [36m[COM
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -69,7 +69,7 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -71,9 +71,9 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved 
-          template variables for each hook invocation; -vv: debug logs + 
-          diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output;
+           -vv: debug logs + diagnostic report + trace.log/output.log under 
+          .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_list_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_short.snap
@@ -49,7 +49,7 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
@@ -92,7 +92,7 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_md_root.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_root.snap
@@ -57,7 +57,7 @@ Global Options:
           User config file path
 
   -v, --verbose...
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   -y, --yes
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
@@ -92,7 +92,7 @@ Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_merge_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_short.snap
@@ -53,7 +53,7 @@ Usage: [1m[36mwt merge[0m [36m[OPTIONS][0m [36m[TARGET][0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_no_args.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_no_args.snap
@@ -48,7 +48,7 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
@@ -81,7 +81,7 @@ Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...[0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_remove_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_short.snap
@@ -51,7 +51,7 @@ Usage: [1m[36mwt remove[0m [36m[OPTIONS][0m [36m[BRANCHES]...[0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_root_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root_long.snap
@@ -57,7 +57,7 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_root_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_root_short.snap
@@ -49,7 +49,7 @@ Usage: [1m[36mwt[0m [36m[OPTIONS][0m [36m[COMMAND][0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_step_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_long.snap
@@ -61,7 +61,7 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_step_promote.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_promote.snap
@@ -55,7 +55,7 @@ Usage: [1m[36mwt step promote[0m [36m[OPTIONS][0m [36m[BRANCH][0m
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_step_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_short.snap
@@ -53,7 +53,7 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>[0m
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -113,7 +113,7 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
           User config file path
 
   [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
-          Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+          Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
 
   [1m[36m-y[0m, [1m[36m--yes[0m
           Skip approval prompts

--- a/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
@@ -57,7 +57,7 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
 [1m[32mGlobal Options:[0m
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_verbose_variable_table.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_verbose_variable_table.snap
@@ -1,0 +1,69 @@
+---
+source: tests/integration_tests/step_alias.rs
+info:
+  program: wt
+  args:
+    - "-v"
+    - greet
+    - world
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_EDITOR: ""
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[2m○[22m template variables:
+[107m [0m branch                = feature
+[107m [0m worktree_path         = _REPO_.feature
+[107m [0m worktree_name         = repo.feature
+[107m [0m commit                = 05a4a45d0b981dad5c27db59dca482836d59f89e
+[107m [0m short_commit          = 05a4a45
+[107m [0m upstream              = (unset)
+[107m [0m args                  = ["world"]
+[107m [0m repo                  = repo
+[107m [0m repo_path             = _REPO_
+[107m [0m owner                 = (unset)
+[107m [0m primary_worktree_path = _REPO_
+[107m [0m default_branch        = main
+[107m [0m remote                = origin
+[107m [0m remote_url            = ../origin.git
+[107m [0m cwd                   = _REPO_.feature
+[36m◎[39m [36mRunning alias [1mgreet[22m[39m
+[2m○[22m Expanding [1mgreet[22m
+[107m [0m [2m[0m[2m[34mecho[0m[2m hello [0m[2m[32m{{[0m[2m args [0m[2m[32m}}[0m[2m
+[107m [0m [2m→[22m
+[107m [0m [2m[0m[2m[34mecho[0m[2m hello world
+[0mhello world

--- a/tests/snapshots/integration__integration_tests__step_alias__step_help_includes_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_help_includes_aliases.snap
@@ -68,7 +68,7 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
 [1m[32mGlobal Options:
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_alias__step_list_no_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_list_no_aliases.snap
@@ -64,7 +64,7 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
 [1m[32mGlobal Options:
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_alias__step_list_with_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_list_with_aliases.snap
@@ -69,7 +69,7 @@ Usage: [1m[36mwt step[0m [36m[OPTIONS][0m [36m<COMMAND>
 [1m[32mGlobal Options:
   [1m[36m-C[0m[36m [0m[36m<path>[0m            Working directory for this command
       [1m[36m--config[0m[36m [0m[36m<path>[0m  User config file path
-  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/template output + resolved template variables for each hook invocation; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m     Verbose output (-v: info logs + hook/alias template variable & output; -vv: debug logs + diagnostic report + trace.log/output.log under .git/wt/logs/)
   [1m[36m-y[0m, [1m[36m--yes[0m            Skip approval prompts
 
 ----- stderr -----


### PR DESCRIPTION
Follow-ups from #2316.

## What's in here

1. **Alias `-v` variable dump.** Added `format_alias_variables(ctx)` alongside the existing `format_hook_variables(hook_type, ctx)`, with a private `format_variables_table` helper sharing the alignment + `(unset)` logic. Wired into `run_alias` before the announcement, symmetric with the foreground hook path.

2. **Help-table drift test.** `test_template_variables_table_matches_constants` parses the `## Template variables` table out of `src/cli/mod.rs`, extracts `(kind, var_name)` pairs, and asserts presence + group placement against `ACTIVE_VARS` / `REPO_VARS` / `EXEC_BASE_VARS` / `ALIAS_ARGS_KEY` / union of `vars_available_in(Hook(*))`. Uses public API only — no leak of the private `hook_extras` helper. Adding a var to the constants without updating the table (or vice versa) fails the test. Descriptions stay free-form.

3. **Shorter `-v` help text.** `Verbose output (-v: info logs + hook/alias template variable & output; ...)`.

## Example

```
\$ wt -v greet world
○ template variables:
  branch                = feature
  worktree_path         = _REPO_.feature
  worktree_name         = repo.feature
  …
  args                  = ["world"]
  repo                  = repo
  …
  cwd                   = _REPO_.feature
◎ Running alias greet
○ Expanding greet
  echo hello {{ args }}
  →
  echo hello world
hello world
```

> _This was written by Claude Code on behalf of @max-sixty_