### PR TITLE
fix(docs): style tables nested in `<details>` blocks

### DIFF
--- a/docs/sass/custom.scss
+++ b/docs/sass/custom.scss
@@ -599,7 +599,7 @@ main {
 // Tables use display: block + overflow-x: auto for horizontal scrolling within
 // the content area. This prevents tables from breaking out of the container.
 // border-collapse: separate + overflow: clip on inner tbody handles border-radius.
-.content > table {
+.content table {
     display: block;
     overflow-x: auto;
     width: fit-content;
@@ -1486,7 +1486,7 @@ header .logo:hover img {
     }
 
     // Tables
-    .content > table {
+    .content table {
         page-break-inside: avoid;
     }
 


### PR DESCRIPTION
The table CSS used `.content > table`, which skipped tables inside `<details>` and any other wrapper — they fell back to browser defaults (no borders, 1px padding, mid-aligned cells). Most visibly, the "Interface differences" table on `/extending/` looked unstyled.

Switched to a descendant selector for both the main rule and the print rule so nested tables pick up the same styling.