### PR TITLE
docs(hook): drop pre-start vs post-start section

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ wt switch -x claude -c feature-b -- 'Fix the pagination bug'
 wt switch -x claude -c feature-c -- 'Write tests for the API'
 ```
 
-The `-x` flag runs a command after switching; arguments after `--` are passed to it. Configure [post-start hooks](https://worktrunk.dev/hook/#pre-start-vs-post-start) to automate setup (install deps, start dev servers).
+The `-x` flag runs a command after switching; arguments after `--` are passed to it. Configure [post-start hooks](https://worktrunk.dev/hook/#hook-types) to automate setup (install deps, start dev servers).
 
 ## Next steps
 

--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -25,7 +25,7 @@ Hooks are shell commands that run at key points in the worktree lifecycle — au
 
 `pre-*` hooks block — failure aborts the operation. `post-*` hooks run in the background with output logged (use [`wt config state logs`](@/config.md#wt-config-state-logs) to find and manage log files). Use `-v` to see expanded command details for background hooks.
 
-The most common starting point is `post-start` — it runs background tasks (dev servers, file copying, builds) when creating a worktree.
+The most common starting point is `post-start` — it runs background tasks (dev servers, file copying, builds) without blocking worktree creation. Prefer `post-start` over `pre-start` unless a later step needs the work completed first.
 
 | Hook | Purpose |
 |------|---------|
@@ -298,17 +298,6 @@ copy = "wt step copy-ignored"
 Pipelines matter when there's a dependency chain — typically setup steps that must complete before other tasks can start. Common pattern: install dependencies, then run build + dev server concurrently.
 
 # Designing Effective Hooks
-
-## pre-start vs post-start
-
-Both run when creating a worktree. The difference:
-
-| Hook | Execution | Best for |
-|------|-----------|----------|
-| `pre-start` | Blocks until complete | Tasks the developer needs before working (dependency install) |
-| `post-start` | Background, parallel | Long-running tasks that don't block worktree creation |
-
-Many tasks work well in `post-start` — they'll likely be ready by the time they're needed, especially when the fallback is recompiling. If unsure, prefer `post-start` for faster worktree creation. For finer control over execution order within `post-start`, see [Pipeline ordering](#pipeline-ordering).
 
 ## Copying untracked files
 

--- a/docs/content/worktrunk.md
+++ b/docs/content/worktrunk.md
@@ -192,7 +192,7 @@ For parallel agents, create multiple worktrees and launch an agent in each:
 
 {{ terminal(cmd="wt switch -x claude -c feature-a -- 'Add user authentication'|||wt switch -x claude -c feature-b -- 'Fix the pagination bug'|||wt switch -x claude -c feature-c -- 'Write tests for the API'") }}
 
-The `-x` flag runs a command after switching; arguments after `--` are passed to it. Configure [post-start hooks](@/hook.md#pre-start-vs-post-start) to automate setup (install deps, start dev servers).
+The `-x` flag runs a command after switching; arguments after `--` are passed to it. Configure [post-start hooks](@/hook.md#hook-types) to automate setup (install deps, start dev servers).
 
 ## Next steps
 

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -16,7 +16,7 @@ Hooks are shell commands that run at key points in the worktree lifecycle — au
 
 `pre-*` hooks block — failure aborts the operation. `post-*` hooks run in the background with output logged (use [`wt config state logs`](https://worktrunk.dev/config/#wt-config-state-logs) to find and manage log files). Use `-v` to see expanded command details for background hooks.
 
-The most common starting point is `post-start` — it runs background tasks (dev servers, file copying, builds) when creating a worktree.
+The most common starting point is `post-start` — it runs background tasks (dev servers, file copying, builds) without blocking worktree creation. Prefer `post-start` over `pre-start` unless a later step needs the work completed first.
 
 | Hook | Purpose |
 |------|---------|
@@ -297,17 +297,6 @@ copy = "wt step copy-ignored"
 Pipelines matter when there's a dependency chain — typically setup steps that must complete before other tasks can start. Common pattern: install dependencies, then run build + dev server concurrently.
 
 # Designing Effective Hooks
-
-## pre-start vs post-start
-
-Both run when creating a worktree. The difference:
-
-| Hook | Execution | Best for |
-|------|-----------|----------|
-| `pre-start` | Blocks until complete | Tasks the developer needs before working (dependency install) |
-| `post-start` | Background, parallel | Long-running tasks that don't block worktree creation |
-
-Many tasks work well in `post-start` — they'll likely be ready by the time they're needed, especially when the fallback is recompiling. If unsure, prefer `post-start` for faster worktree creation. For finer control over execution order within `post-start`, see [Pipeline ordering](#pipeline-ordering).
 
 ## Copying untracked files
 

--- a/skills/worktrunk/reference/worktrunk.md
+++ b/skills/worktrunk/reference/worktrunk.md
@@ -174,7 +174,7 @@ wt switch -x claude -c feature-b -- 'Fix the pagination bug'
 wt switch -x claude -c feature-c -- 'Write tests for the API'
 ```
 
-The `-x` flag runs a command after switching; arguments after `--` are passed to it. Configure [post-start hooks](https://worktrunk.dev/hook/#pre-start-vs-post-start) to automate setup (install deps, start dev servers).
+The `-x` flag runs a command after switching; arguments after `--` are passed to it. Configure [post-start hooks](https://worktrunk.dev/hook/#hook-types) to automate setup (install deps, start dev servers).
 
 ## Next steps
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1157,7 +1157,7 @@ $ wt step push
 
 `pre-*` hooks block — failure aborts the operation. `post-*` hooks run in the background with output logged (use [`wt config state logs`](@/config.md#wt-config-state-logs) to find and manage log files). Use `-v` to see expanded command details for background hooks.
 
-The most common starting point is `post-start` — it runs background tasks (dev servers, file copying, builds) when creating a worktree.
+The most common starting point is `post-start` — it runs background tasks (dev servers, file copying, builds) without blocking worktree creation. Prefer `post-start` over `pre-start` unless a later step needs the work completed first.
 
 | Hook | Purpose |
 |------|---------|
@@ -1438,17 +1438,6 @@ copy = "wt step copy-ignored"
 Pipelines matter when there's a dependency chain — typically setup steps that must complete before other tasks can start. Common pattern: install dependencies, then run build + dev server concurrently.
 
 # Designing Effective Hooks
-
-## pre-start vs post-start
-
-Both run when creating a worktree. The difference:
-
-| Hook | Execution | Best for |
-|------|-----------|----------|
-| `pre-start` | Blocks until complete | Tasks the developer needs before working (dependency install) |
-| `post-start` | Background, parallel | Long-running tasks that don't block worktree creation |
-
-Many tasks work well in `post-start` — they'll likely be ready by the time they're needed, especially when the fallback is recompiling. If unsure, prefer `post-start` for faster worktree creation. For finer control over execution order within `post-start`, see [Pipeline ordering](#pipeline-ordering).
 
 ## Copying untracked files
 


### PR DESCRIPTION
The section mostly restated content already covered by the "Hook Types" table and the hook purpose table above it. Removing it and folding the load-bearing guidance ("prefer `post-start` unless a later step needs the work completed first") into the existing "most common starting point" sentence near the top.

> _This was written by Claude Code on behalf of Maximilian_