### PR TITLE
Render alias `args` in -v table as shell-escaped `{{ args }}`

### DIFF
--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -10,7 +10,7 @@
 
 use std::borrow::Cow;
 use std::collections::{BTreeSet, HashMap};
-use std::fmt::{self, Write};
+use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::sync::Arc;
 
@@ -235,17 +235,27 @@ pub fn format_hook_variables(hook_type: HookType, ctx: &HashMap<String, String>)
 /// Format the resolved template variables for an alias invocation.
 ///
 /// Ordering mirrors [`format_hook_variables`]; alias scope has no operation
-/// or infrastructure vars, and `args` sits between active and repo (it's the
-/// alias analogue of hook-operation context).
+/// or infrastructure vars, and `args` lives in the exec group per the help
+/// table in `src/cli/mod.rs` (alongside `cwd`).
+///
+/// `args` is stored as a JSON-encoded `Vec<String>` per the [`ALIAS_ARGS_KEY`]
+/// contract; the table displays it space-joined and shell-escaped via
+/// [`shell_join`] — matching what `{{ args }}` substitutes in templates.
 pub fn format_alias_variables(ctx: &HashMap<String, String>) -> String {
     let vars: Vec<&'static str> = ACTIVE_VARS
         .iter()
         .copied()
-        .chain(std::iter::once(ALIAS_ARGS_KEY))
         .chain(REPO_VARS.iter().copied())
         .chain(EXEC_BASE_VARS.iter().copied())
+        .chain(std::iter::once(ALIAS_ARGS_KEY))
         .collect();
-    format_variables_table(&vars, ctx)
+    let mut display_ctx = ctx.clone();
+    if let Some(json) = ctx.get(ALIAS_ARGS_KEY) {
+        let args: Vec<String> = serde_json::from_str(json)
+            .expect("ALIAS_ARGS_KEY is always serialized from a Vec<String>");
+        display_ctx.insert(ALIAS_ARGS_KEY.into(), shell_join(&args));
+    }
+    format_variables_table(&vars, &display_ctx)
 }
 
 /// Positional CLI args forwarded from `wt <alias> a b c` into the alias's
@@ -284,16 +294,18 @@ impl Object for ShellArgs {
     }
 
     fn render(self: &Arc<Self>, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let mut first = true;
-        for arg in &self.0 {
-            if !first {
-                f.write_char(' ')?;
-            }
-            first = false;
-            f.write_str(&escape(Cow::Borrowed(arg)))?;
-        }
-        Ok(())
+        f.write_str(&shell_join(&self.0))
     }
+}
+
+/// Space-join shell-escaped args — the canonical rendering of `{{ args }}`
+/// used by both `ShellArgs::render` (template expansion) and the alias
+/// `-v` variable table.
+fn shell_join(args: &[String]) -> String {
+    args.iter()
+        .map(|a| escape(Cow::Borrowed(a)).into_owned())
+        .collect::<Vec<_>>()
+        .join(" ")
 }
 
 /// Hash a string to a port in range 10000-19999.
@@ -1973,17 +1985,29 @@ mod tests {
         ctx.insert("repo".into(), "demo".into());
         ctx.insert("repo_path".into(), "/tmp/demo".into());
         ctx.insert("cwd".into(), "/tmp/feature".into());
-        // args is JSON-encoded per `ALIAS_ARGS_KEY` contract.
+        // args is JSON-encoded per `ALIAS_ARGS_KEY` contract; the table
+        // decodes and shell-renders it to match `{{ args }}` substitution.
         ctx.insert(ALIAS_ARGS_KEY.into(), r#"["a","b c"]"#.into());
 
         let out = format_alias_variables(&ctx);
         assert!(
-            out.contains(r#"args                  = ["a","b c"]"#),
+            out.contains("args                  = a 'b c'"),
             "got: {out}"
         );
         // No hook-only keys appear in alias scope.
         assert!(!out.contains("hook_type"), "got: {out}");
         assert!(!out.contains("target"), "got: {out}");
         assert!(!out.contains("base "), "got: {out}");
+    }
+
+    #[test]
+    fn test_format_alias_variables_args_empty() {
+        let mut ctx: HashMap<String, String> = HashMap::new();
+        ctx.insert(ALIAS_ARGS_KEY.into(), "[]".into());
+        let out = format_alias_variables(&ctx);
+        // Empty args render as an empty string after the `=` — distinct from
+        // `(unset)`, which means the key was absent entirely. `args` sits last
+        // in alias ordering, so the output ends with it.
+        assert!(out.ends_with("args                  = "), "got: {out:?}");
     }
 }

--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -239,8 +239,8 @@ pub fn format_hook_variables(hook_type: HookType, ctx: &HashMap<String, String>)
 /// table in `src/cli/mod.rs` (alongside `cwd`).
 ///
 /// `args` is stored as a JSON-encoded `Vec<String>` per the [`ALIAS_ARGS_KEY`]
-/// contract; the table displays it space-joined and shell-escaped via
-/// [`shell_join`] — matching what `{{ args }}` substitutes in templates.
+/// contract; the table displays it space-joined and shell-escaped so it
+/// matches what `{{ args }}` substitutes in templates.
 pub fn format_alias_variables(ctx: &HashMap<String, String>) -> String {
     let vars: Vec<&'static str> = ACTIVE_VARS
         .iter()

--- a/tests/integration_tests/step_alias.rs
+++ b/tests/integration_tests/step_alias.rs
@@ -1877,3 +1877,28 @@ greet = "echo hello {{ args }}"
         assert_cmd_snapshot!("alias_verbose_variable_table", cmd);
     });
 }
+
+/// Multi-token args with whitespace render shell-escaped in the `-v` table,
+/// matching what `{{ args }}` actually expands to on the line below.
+#[rstest]
+fn test_alias_verbose_renders_args_shell_escaped(mut repo: TestRepo) {
+    repo.write_test_config(
+        r#"
+[aliases]
+greet = "echo hello {{ args }}"
+"#,
+    );
+    let feature_path = repo.add_worktree("feature");
+
+    let settings = setup_snapshot_settings(&repo);
+    settings.bind(|| {
+        let mut cmd = make_snapshot_cmd_with_global_flags(
+            &repo,
+            "greet",
+            &["foo", "bar baz"],
+            Some(&feature_path),
+            &["-v"],
+        );
+        assert_cmd_snapshot!("alias_verbose_args_shell_escaped", cmd);
+    });
+}

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_verbose_args_shell_escaped.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_verbose_args_shell_escaped.snap
@@ -5,7 +5,8 @@ info:
   args:
     - "-v"
     - greet
-    - world
+    - foo
+    - bar baz
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -60,10 +61,10 @@ exit_code: 0
 [107m [0m remote                = origin
 [107m [0m remote_url            = ../origin.git
 [107m [0m cwd                   = _REPO_.feature
-[107m [0m args                  = world
+[107m [0m args                  = foo 'bar baz'
 [36m◎[39m [36mRunning alias [1mgreet[22m[39m
 [2m○[22m Expanding [1mgreet[22m
 [107m [0m [2m[0m[2m[34mecho[0m[2m hello [0m[2m[32m{{[0m[2m args [0m[2m[32m}}[0m[2m
 [107m [0m [2m→[22m
-[107m [0m [2m[0m[2m[34mecho[0m[2m hello world
-[0mhello world
+[107m [0m [2m[0m[2m[34mecho[0m[2m hello foo [0m[2m[32m'bar baz'[0m[2m
+[0mhello foo bar baz


### PR DESCRIPTION
Follow-up to #2324.

The alias `-v` table previously showed `args` as its raw JSON wire format (`["foo","bar baz"]`) — the internal `HashMap<String, String>` storage. Templates rehydrate that JSON into a `ShellArgs` object whose `render` impl produces a space-joined, shell-escaped string; the table now does the same so its value matches what `{{ args }}` substitutes one line below.

Factored the space-join-and-escape into a `shell_join` helper used by both `ShellArgs::render` and the alias table — one canonical rendering.

Also moved `args` into the **exec** group next to `cwd`, matching the `## Template variables` help table (previously it sat between active and repo, implying "operation context").

## Before/after

| Input | Before | After |
|---|---|---|
| `wt -v greet world` | `args = ["world"]` | `args = world` |
| `wt -v greet foo "bar baz"` | `args = ["foo","bar baz"]` | `args = foo 'bar baz'` |

> _This was written by Claude Code on behalf of @max-sixty_