### PR TITLE
docs(help): rename '[Aliases]' link to 'Extending Worktrunk guide'

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,8 @@ Help text renders in three contexts — check all three when editing:
 
 Because web docs concatenate everything, the `after_long_help` opener must not restate the `about`/`subtitle`. Start with new information — examples, context, or details not already in the definition. See `docs/CLAUDE.md` → "Command documentation structure" for detailed content principles and good/bad opener patterns.
 
+Link text must stand alone when the URL is stripped (terminal help drops the URL and keeps only the text). Use `` [`wt foo`](...) `` for commands — the backticks signal a `--help` lookup — or a descriptive phrase (`[hook template variables]`, `[Extending Worktrunk guide]`) for doc sections. Avoid bare labels that match the destination's heading (e.g., `See [Aliases](@/extending.md#aliases)` reads as a self-reference in terminal).
+
 After any doc changes, run tests to sync:
 
 ```bash

--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -127,7 +127,7 @@
 #
 # ### Aliases
 #
-# Command templates that run as `wt <name>`. See Aliases (https://worktrunk.dev/extending/#aliases) for usage and flags.
+# Command templates that run as `wt <name>`. See the Extending Worktrunk guide (https://worktrunk.dev/extending/#aliases) for usage and flags.
 #
 # [aliases]
 # greet = "echo Hello from {{ branch }}"

--- a/dev/wt.example.toml
+++ b/dev/wt.example.toml
@@ -38,7 +38,7 @@
 #
 # ## Aliases
 #
-# Command templates that run as `wt <name>`. See Aliases (https://worktrunk.dev/extending/#aliases) for usage and flags.
+# Command templates that run as `wt <name>`. See the Extending Worktrunk guide (https://worktrunk.dev/extending/#aliases) for usage and flags.
 #
 # [aliases]
 # deploy = "make deploy BRANCH={{ branch }}"

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -219,7 +219,7 @@ Built-in excludes always apply: VCS metadata directories (`.bzr/`, `.hg/`, `.jj/
 
 ### Aliases
 
-Command templates that run as `wt <name>`. See [Aliases](@/extending.md#aliases) for usage and flags.
+Command templates that run as `wt <name>`. See the [Extending Worktrunk guide](@/extending.md#aliases) for usage and flags.
 
 ```toml
 [aliases]
@@ -396,7 +396,7 @@ Built-in excludes always apply: VCS metadata directories (`.bzr/`, `.hg/`, `.jj/
 
 ## Aliases
 
-Command templates that run as `wt <name>`. See [Aliases](@/extending.md#aliases) for usage and flags.
+Command templates that run as `wt <name>`. See the [Extending Worktrunk guide](@/extending.md#aliases) for usage and flags.
 
 ```toml
 [aliases]
@@ -617,7 +617,7 @@ Usage: <b><span class=c>wt config approvals</span></b> <span class=c>[OPTIONS]</
 
 Inspect and preview aliases.
 
-Aliases are command templates configured in user (`~/.config/worktrunk/config.toml`) or project (`.config/wt.toml`) config and run as `wt <name>`. See [Aliases](@/extending.md#aliases) for the configuration format.
+Aliases are command templates configured in user (`~/.config/worktrunk/config.toml`) or project (`.config/wt.toml`) config and run as `wt <name>`. See the [Extending Worktrunk guide](@/extending.md#aliases) for the configuration format.
 
 ### Examples
 

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -218,7 +218,7 @@ Built-in excludes always apply: VCS metadata directories (`.bzr/`, `.hg/`, `.jj/
 
 ### Aliases
 
-Command templates that run as `wt <name>`. See [Aliases](https://worktrunk.dev/extending/#aliases) for usage and flags.
+Command templates that run as `wt <name>`. See the [Extending Worktrunk guide](https://worktrunk.dev/extending/#aliases) for usage and flags.
 
 ```toml
 [aliases]
@@ -395,7 +395,7 @@ Built-in excludes always apply: VCS metadata directories (`.bzr/`, `.hg/`, `.jj/
 
 ## Aliases
 
-Command templates that run as `wt <name>`. See [Aliases](https://worktrunk.dev/extending/#aliases) for usage and flags.
+Command templates that run as `wt <name>`. See the [Extending Worktrunk guide](https://worktrunk.dev/extending/#aliases) for usage and flags.
 
 ```toml
 [aliases]
@@ -628,7 +628,7 @@ Global Options:
 
 Inspect and preview aliases.
 
-Aliases are command templates configured in user (`~/.config/worktrunk/config.toml`) or project (`.config/wt.toml`) config and run as `wt <name>`. See [Aliases](https://worktrunk.dev/extending/#aliases) for the configuration format.
+Aliases are command templates configured in user (`~/.config/worktrunk/config.toml`) or project (`.config/wt.toml`) config and run as `wt <name>`. See the [Extending Worktrunk guide](https://worktrunk.dev/extending/#aliases) for the configuration format.
 
 ### Examples
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -487,7 +487,7 @@ Approved commands are saved to `~/.config/worktrunk/approvals.toml`. Re-approval
 
     /// Inspect and preview aliases
     #[command(
-        after_long_help = r#"Aliases are command templates configured in user (`~/.config/worktrunk/config.toml`) or project (`.config/wt.toml`) config and run as `wt <name>`. See [Aliases](@/extending.md#aliases) for the configuration format.
+        after_long_help = r#"Aliases are command templates configured in user (`~/.config/worktrunk/config.toml`) or project (`.config/wt.toml`) config and run as `wt <name>`. See the [Extending Worktrunk guide](@/extending.md#aliases) for the configuration format.
 
 ## Examples
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1714,7 +1714,7 @@ Built-in excludes always apply: VCS metadata directories (`.bzr/`, `.hg/`, `.jj/
 
 ### Aliases
 
-Command templates that run as `wt <name>`. See [Aliases](@/extending.md#aliases) for usage and flags.
+Command templates that run as `wt <name>`. See the [Extending Worktrunk guide](@/extending.md#aliases) for usage and flags.
 
 ```toml
 [aliases]
@@ -1891,7 +1891,7 @@ Built-in excludes always apply: VCS metadata directories (`.bzr/`, `.hg/`, `.jj/
 
 ## Aliases
 
-Command templates that run as `wt <name>`. See [Aliases](@/extending.md#aliases) for usage and flags.
+Command templates that run as `wt <name>`. See the [Extending Worktrunk guide](@/extending.md#aliases) for usage and flags.
 
 ```toml
 [aliases]

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -188,7 +188,7 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m#[0m
 [107m [0m [2m# ### Aliases[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# Command templates that run as `wt <name>`. See Aliases (https://worktrunk.dev/extending/#aliases) for usage and flags.[0m
+[107m [0m [2m# Command templates that run as `wt <name>`. See the Extending Worktrunk guide (https://worktrunk.dev/extending/#aliases) for usage and flags.[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# [aliases][0m
 [107m [0m [2m# greet = "echo Hello from {{ branch }}"[0m
@@ -352,7 +352,7 @@ With [2m--project[0m, creates [2m.config/wt.toml[0m in the current repositor
 [107m [0m [2m#[0m
 [107m [0m [2m# ## Aliases[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# Command templates that run as `wt <name>`. See Aliases (https://worktrunk.dev/extending/#aliases) for usage and flags.[0m
+[107m [0m [2m# Command templates that run as `wt <name>`. See the Extending Worktrunk guide (https://worktrunk.dev/extending/#aliases) for usage and flags.[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# [aliases][0m
 [107m [0m [2m# deploy = "make deploy BRANCH={{ branch }}"[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -236,7 +236,7 @@ Built-in excludes always apply: VCS metadata directories ([2m.bzr/[0m, [2m.hg
 
 [32mAliases[0m
 
-Command templates that run as [2mwt <name>[0m. See Aliases for usage and flags.
+Command templates that run as [2mwt <name>[0m. See the Extending Worktrunk guide for usage and flags.
 
 [107m [0m [2m[36m[aliases][0m
 [107m [0m [2mgreet = [0m[2m[32m"echo Hello from {{ branch }}"[0m
@@ -391,7 +391,7 @@ Built-in excludes always apply: VCS metadata directories ([2m.bzr/[0m, [2m.hg
 
 [1m[32mAliases[0m
 
-Command templates that run as [2mwt <name>[0m. See Aliases for usage and flags.
+Command templates that run as [2mwt <name>[0m. See the Extending Worktrunk guide for usage and flags.
 
 [107m [0m [2m[36m[aliases][0m
 [107m [0m [2mdeploy = [0m[2m[32m"make deploy BRANCH={{ branch }}"[0m


### PR DESCRIPTION
The bare `[Aliases](@/extending.md#aliases)` link text rendered in terminal help as "See Aliases for ..." — a self-reference when sitting inside a section already titled "Aliases" (`wt config user/project --help`), and a generic label elsewhere (`wt config alias --help`). Renamed to `[Extending Worktrunk guide]` in all three call sites.

Also adds a short guideline under "Help text authoring" in CLAUDE.md: link text must stand alone when the URL is stripped (since terminal help strips URLs and keeps only the text).

> _This was written by Claude Code on behalf of Maximilian_