### PR TITLE
perf(alias): O(1) upstream lookup in template context

### DIFF
--- a/src/commands/command_executor.rs
+++ b/src/commands/command_executor.rs
@@ -202,7 +202,7 @@ pub fn build_hook_context(
             map.insert("remote_url".into(), url);
         }
         if let Some(branch) = ctx.branch
-            && let Ok(Some(upstream)) = ctx.repo.branch(branch).upstream()
+            && let Ok(Some(upstream)) = ctx.repo.branch(branch).upstream_single()
         {
             map.insert("upstream".into(), upstream);
         }

--- a/src/git/repository/branch.rs
+++ b/src/git/repository/branch.rs
@@ -92,9 +92,15 @@ impl<'a> Branch<'a> {
 
     /// Get the upstream tracking branch for this branch.
     ///
-    /// Uses [`@{upstream}` syntax][1] to resolve the tracking branch.
+    /// First call in a process triggers `fetch_all_upstreams` — one
+    /// `git for-each-ref` over every local branch, cached for subsequent
+    /// calls. Amortizes well when callers query many branches
+    /// (`wt list`, integration target resolution). Prefer
+    /// [`upstream_single`] on hot paths that look up exactly one branch
+    /// (e.g. alias/hook template expansion), where the bulk scan becomes
+    /// O(branches) overhead the single call can't amortize.
     ///
-    /// [1]: https://git-scm.com/docs/gitrevisions#Documentation/gitrevisions.txt-emltaboranchgtemuaboranchgtupaboranchgtupstream
+    /// [`upstream_single`]: Self::upstream_single
     pub fn upstream(&self) -> anyhow::Result<Option<String>> {
         let upstreams = self
             .repo
@@ -102,6 +108,33 @@ impl<'a> Branch<'a> {
             .upstreams
             .get_or_try_init(|| self.repo.fetch_all_upstreams())?;
         Ok(upstreams.get(&self.name).cloned().unwrap_or(None))
+    }
+
+    /// Get this branch's upstream without the bulk scan used by
+    /// [`upstream`]. Runs one `git for-each-ref` scoped to this branch's
+    /// ref — O(1) in local branch count.
+    ///
+    /// Handles the `[gone]` track state the same way as the bulk path:
+    /// a configured-but-missing upstream reads as `None`.
+    ///
+    /// [`upstream`]: Self::upstream
+    pub fn upstream_single(&self) -> anyhow::Result<Option<String>> {
+        let output = self.repo.run_command(&[
+            "for-each-ref",
+            "--format=%(upstream:short)\t%(upstream:track)",
+            &format!("refs/heads/{}", self.name),
+        ])?;
+        let Some(line) = output.lines().next() else {
+            return Ok(None);
+        };
+        let (upstream, track) = line
+            .split_once('\t')
+            .expect("for-each-ref emits a tab between the two format fields");
+        if upstream.is_empty() || track == "[gone]" {
+            Ok(None)
+        } else {
+            Ok(Some(upstream.to_string()))
+        }
     }
 
     /// Unset the upstream tracking branch for this branch.


### PR DESCRIPTION
`Branch::upstream()` triggers `fetch_all_upstreams` — one `for-each-ref` over every local branch, cached for later callers. That amortizes well for bulk consumers (`wt list`, integration target resolution), but for alias/hook template expansion we only ever need the current branch's upstream, and there's nothing to amortize against.

On machines with slow fork cost (macOS Gatekeeper, AV, slow FS), the parent-side alias dispatch runs 12 git commands to build the template context before spawning the child. Tracing the reported case (#2322) shows 11 are O(1); only this `for-each-ref` scales with branch count. Swapping it for a single-branch lookup makes the parent alias-dispatch path fully O(1) in branches.

Adds `Branch::upstream_single()` — scoped `for-each-ref refs/heads/<branch>` with the same `[gone]`/empty-upstream handling as the bulk path. `build_hook_context` now calls that variant. `upstream()` itself is unchanged; docs point bulk vs. single-use callers at the right method.

Ref #2322

> _This was written by Claude Code on behalf of @max-sixty_