### PR TITLE
perf(git): use upstream_single() for single-branch lookups

### DIFF
--- a/src/commands/worktree/switch.rs
+++ b/src/commands/worktree/switch.rs
@@ -833,7 +833,7 @@ pub fn execute_switch(
 
                     // Report tracking info when the branch was auto-created from a remote
                     let from_remote = if !create_branch && !local_branch_existed {
-                        branch_handle.upstream()?
+                        branch_handle.upstream_single()?
                     } else {
                         None
                     };

--- a/src/git/repository/branch.rs
+++ b/src/git/repository/branch.rs
@@ -90,15 +90,17 @@ impl<'a> Branch<'a> {
         Ok(remotes)
     }
 
-    /// Get the upstream tracking branch for this branch.
+    /// Get the upstream tracking branch for this branch. Use this when the
+    /// caller (or its caller) will query many branches; use
+    /// [`upstream_single`] when exactly one branch is looked up.
     ///
     /// First call in a process triggers `fetch_all_upstreams` — one
     /// `git for-each-ref` over every local branch, cached for subsequent
-    /// calls. Amortizes well when callers query many branches
-    /// (`wt list`, integration target resolution). Prefer
-    /// [`upstream_single`] on hot paths that look up exactly one branch
-    /// (e.g. alias/hook template expansion), where the bulk scan becomes
-    /// O(branches) overhead the single call can't amortize.
+    /// calls. That bulk scan amortizes well across the per-worktree tasks
+    /// in `wt list`, where every row needs an upstream. On a single-branch
+    /// path (alias/hook template expansion, one-shot lookups during
+    /// switch/merge) the scan is O(branches) overhead with nothing to
+    /// amortize against — reach for [`upstream_single`] instead.
     ///
     /// [`upstream_single`]: Self::upstream_single
     pub fn upstream(&self) -> anyhow::Result<Option<String>> {
@@ -111,7 +113,9 @@ impl<'a> Branch<'a> {
     }
 
     /// Get this branch's upstream without the bulk scan used by
-    /// [`upstream`]. Runs one `git for-each-ref` scoped to this branch's
+    /// [`upstream`]. Prefer this when exactly one branch is being looked
+    /// up; prefer [`upstream`] when the caller (or its caller) will query
+    /// many branches. Runs one `git for-each-ref` scoped to this branch's
     /// ref — O(1) in local branch count.
     ///
     /// Handles the `[gone]` track state the same way as the bulk path:

--- a/src/git/repository/integration.rs
+++ b/src/git/repository/integration.rs
@@ -433,8 +433,10 @@ impl Repository {
             .effective_integration_targets
             .entry(local_target.to_string())
             .or_insert_with(|| {
-                // Get the upstream ref for the local target (e.g., origin/main for main)
-                let upstream = match self.branch(local_target).upstream() {
+                // Get the upstream ref for the local target (e.g., origin/main for main).
+                // Single-branch lookup — cached per-target in `effective_integration_targets`,
+                // so the bulk scan `upstream()` would run is pure overhead here.
+                let upstream = match self.branch(local_target).upstream_single() {
                     Ok(Some(upstream)) => upstream,
                     _ => return local_target.to_string(),
                 };


### PR DESCRIPTION
Follow-up to #2337. `Branch::upstream()` triggers a bulk `git for-each-ref` over every local branch (cached for later calls). That amortizes across the per-worktree tasks in `wt list`, but is wasted work on paths that only look up one branch.

Switched to `upstream_single()` at:

- `effective_integration_target` — caches per-target in its own DashMap, so the inner upstream call resolves exactly one branch (typically just the default branch).
- `switch.rs` tracking-info report — one-shot lookup during `wt switch`.

Left on `upstream()` the two `wt list` callers (`UpstreamTask` and `has_upstream()` via `CiStatusTask`), which run once per row and are exactly what the bulk cache is for.

Also rewrote both doc comments so the "bulk callers use `upstream()`, single-item callers use `upstream_single()`" rule is the first thing a reader sees — no more reasoning about amortization from scratch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)