### PR TITLE
Silence alias banner when there is no pipeline summary to show

### DIFF
--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -289,26 +289,28 @@ fn unknown_step_command_error(name: &str, alias_names: &[String]) -> anyhow::Err
     crate::enhance_clap_error(build_invalid_subcommand_error(step_cmd, name, suggestions))
 }
 
-/// Format the "Running alias …" announcement.
+/// Format the informative "Running alias …" announcement, or `None` when
+/// there is nothing beyond the alias name to announce.
 ///
-/// For pipelines or concurrent groups with named commands, includes a summary
-/// of the structure (e.g., `Running alias deploy: install; build, lint`).
-/// When all commands are unnamed, falls back to the bare form
-/// (`Running alias deploy`) — aliases have no natural fallback label for
-/// unnamed steps the way hooks use `user`/`project`.
+/// Returns `Some(…)` only when the alias has at least one named step, so the
+/// banner can carry a pipeline summary (e.g., `Running alias deploy: install;
+/// build, lint`). Single unnamed aliases (`ls = "wt list"`) and all-anonymous
+/// pipelines (`foo = ["a", "b"]`) return `None` — the banner would only echo
+/// the name the user just typed. Callers that still want a confirmation line
+/// (e.g. under `-v`) emit a bare `Running alias <name>` themselves.
 ///
 /// Sibling of `format_command_label` in `commands/mod.rs`, which builds the
 /// non-pipeline `Running {type} {name}` form for hooks. Both apply bold
 /// styling to the alias/command name — keep them in sync if styling evolves.
-fn format_alias_announcement(name: &str, cmd_config: &CommandConfig) -> String {
+fn format_alias_announcement(name: &str, cmd_config: &CommandConfig) -> Option<String> {
     let step_names = step_names_from_config(cmd_config);
     let summary =
         format_pipeline_summary_from_names(&step_names, |n| cformat!("<bold>{n}</>"), |_| None);
 
     if summary.is_empty() {
-        cformat!("Running alias <bold>{name}</>")
+        None
     } else {
-        cformat!("Running alias <bold>{name}</>: {summary}")
+        Some(cformat!("Running alias <bold>{name}</>: {summary}"))
     }
 }
 
@@ -521,10 +523,14 @@ fn run_alias(
         eprintln!("{}", format_with_gutter(&vars, None));
     }
 
-    eprintln!(
-        "{}",
-        progress_message(format_alias_announcement(&opts.name, cmd_config))
-    );
+    if let Some(msg) = format_alias_announcement(&opts.name, cmd_config) {
+        eprintln!("{}", progress_message(msg));
+    } else if verbosity() >= 1 {
+        eprintln!(
+            "{}",
+            progress_message(cformat!("Running alias <bold>{}</>", opts.name))
+        );
+    }
 
     // CD passed through, EXEC scrubbed (see `output::global` for rationale).
     let directives = DirectivePassthrough::inherit_from_env();
@@ -847,17 +853,16 @@ mod tests {
 
     #[test]
     fn test_format_alias_announcement_single_unnamed() {
+        // Single unnamed alias — banner would only echo the name, so suppress.
         let cfg = cfg_from_toml(r#"cmd = "echo hi""#);
-        let msg = format_alias_announcement("deploy", &cfg);
-        insta::assert_snapshot!(msg.ansi_strip(), @"Running alias deploy");
+        assert!(format_alias_announcement("deploy", &cfg).is_none());
     }
 
     #[test]
     fn test_format_alias_announcement_pipeline_all_unnamed() {
-        // Pipeline of unnamed strings → no summary suffix.
+        // Pipeline of unnamed strings — still no summary content to show.
         let cfg = cfg_from_toml(r#"cmd = ["echo a", "echo b"]"#);
-        let msg = format_alias_announcement("deploy", &cfg);
-        insta::assert_snapshot!(msg.ansi_strip(), @"Running alias deploy");
+        assert!(format_alias_announcement("deploy", &cfg).is_none());
     }
 
     #[test]
@@ -870,7 +875,7 @@ build = "cargo build"
 test = "cargo test"
 "#,
         );
-        let msg = format_alias_announcement("check", &cfg);
+        let msg = format_alias_announcement("check", &cfg).expect("summary expected");
         insta::assert_snapshot!(msg.ansi_strip(), @"Running alias check: build, test");
     }
 
@@ -885,7 +890,7 @@ cmd = [
 ]
 "#,
         );
-        let msg = format_alias_announcement("deploy", &cfg);
+        let msg = format_alias_announcement("deploy", &cfg).expect("summary expected");
         insta::assert_snapshot!(msg.ansi_strip(), @"Running alias deploy: install; build, lint");
     }
 
@@ -901,7 +906,7 @@ cmd = [
 ]
 "#,
         );
-        let msg = format_alias_announcement("ci", &cfg);
+        let msg = format_alias_announcement("ci", &cfg).expect("summary expected");
         insta::assert_snapshot!(msg.ansi_strip(), @"Running alias ci: build, test");
     }
 

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_append_executes_both.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_append_executes_both.snap
@@ -3,9 +3,9 @@ source: tests/integration_tests/step_alias.rs
 info:
   program: wt
   args:
+    - "-y"
     - step
     - greet
-    - "--yes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -45,6 +45,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRunning alias [1mgreet[22m[39m
 [0mUSER
 [0mPROJECT

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_approval_already_approved.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_approval_already_approved.snap
@@ -44,5 +44,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRunning alias [1mdeploy[22m[39m
 [0mdeploying feature

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_approval_user_and_project_both_need_approval.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_approval_user_and_project_both_need_approval.snap
@@ -3,9 +3,9 @@ source: tests/integration_tests/step_alias.rs
 info:
   program: wt
   args:
+    - "-y"
     - step
     - deploy
-    - "--yes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -45,6 +45,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRunning alias [1mdeploy[22m[39m
 [0muser deploy
 [0mproject deploy

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_approval_user_config_skips.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_approval_user_config_skips.snap
@@ -44,5 +44,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRunning alias [1mdeploy[22m[39m
 [0mdeploying from user config

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_approval_yes_first_run.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_approval_yes_first_run.snap
@@ -3,9 +3,9 @@ source: tests/integration_tests/step_alias.rs
 info:
   program: wt
   args:
+    - "-y"
     - step
     - deploy
-    - "--yes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -45,5 +45,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRunning alias [1mdeploy[22m[39m
 [0mdeploying

--- a/tests/snapshots/integration__integration_tests__step_alias__step_alias_args_sequence_access.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_alias_args_sequence_access.snap
@@ -3,10 +3,10 @@ source: tests/integration_tests/step_alias.rs
 info:
   program: wt
   args:
+    - "-y"
     - show
     - alpha
     - beta gamma
-    - "--yes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -46,7 +46,6 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRunning alias [1mshow[22m[39m
 [0mfirst=alpha
 count=2
 each= alpha beta gamma

--- a/tests/snapshots/integration__integration_tests__step_alias__step_alias_double_dash_escape.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_alias_double_dash_escape.snap
@@ -3,8 +3,8 @@ source: tests/integration_tests/step_alias.rs
 info:
   program: wt
   args:
+    - "-y"
     - run
-    - "--yes"
     - "--"
     - "--env=staging"
     - literal
@@ -47,5 +47,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRunning alias [1mrun[22m[39m
 [0mgot --env=staging literal

--- a/tests/snapshots/integration__integration_tests__step_alias__step_alias_empty_args_renders_empty.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_alias_empty_args_renders_empty.snap
@@ -3,8 +3,8 @@ source: tests/integration_tests/step_alias.rs
 info:
   program: wt
   args:
+    - "-y"
     - run
-    - "--yes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -44,5 +44,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRunning alias [1mrun[22m[39m
 [0m[]

--- a/tests/snapshots/integration__integration_tests__step_alias__step_alias_exit_code.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_alias_exit_code.snap
@@ -3,9 +3,9 @@ source: tests/integration_tests/step_alias.rs
 info:
   program: wt
   args:
+    - "-y"
     - step
     - fail
-    - "--yes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -45,4 +45,3 @@ exit_code: 42
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRunning alias [1mfail[22m[39m

--- a/tests/snapshots/integration__integration_tests__step_alias__step_alias_forwards_positional_args.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_alias_forwards_positional_args.snap
@@ -3,11 +3,11 @@ source: tests/integration_tests/step_alias.rs
 info:
   program: wt
   args:
+    - "-y"
     - run
     - one
     - two three
     - four
-    - "--yes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -47,5 +47,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRunning alias [1mrun[22m[39m
 [0mgot one two three four

--- a/tests/snapshots/integration__integration_tests__step_alias__step_alias_from_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_alias_from_project_config.snap
@@ -3,9 +3,9 @@ source: tests/integration_tests/step_alias.rs
 info:
   program: wt
   args:
+    - "-y"
     - step
     - hello
-    - "--yes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -45,5 +45,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRunning alias [1mhello[22m[39m
 [0mHello from feature

--- a/tests/snapshots/integration__integration_tests__step_alias__step_alias_from_user_config.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_alias_from_user_config.snap
@@ -44,5 +44,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRunning alias [1mgreet[22m[39m
 [0mGreetings from feature

--- a/tests/snapshots/integration__integration_tests__step_alias__step_alias_unreferenced_key_forwards_to_args.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_alias_unreferenced_key_forwards_to_args.snap
@@ -3,10 +3,10 @@ source: tests/integration_tests/step_alias.rs
 info:
   program: wt
   args:
+    - "-y"
     - run
     - "--env=staging"
     - foo
-    - "--yes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -46,5 +46,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRunning alias [1mrun[22m[39m
 [0mgot --env=staging foo

--- a/tests/snapshots/integration__integration_tests__step_alias__step_alias_user_var_overshadows_builtin.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__step_alias_user_var_overshadows_builtin.snap
@@ -3,9 +3,9 @@ source: tests/integration_tests/step_alias.rs
 info:
   program: wt
   args:
+    - "-y"
     - show
     - "--branch=override"
-    - "--yes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -45,5 +45,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRunning alias [1mshow[22m[39m
 [0mbranch=override

--- a/tests/snapshots/integration__integration_tests__step_alias__top_level_alias_dispatch.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__top_level_alias_dispatch.snap
@@ -3,8 +3,8 @@ source: tests/integration_tests/step_alias.rs
 info:
   program: wt
   args:
+    - "-y"
     - hello
-    - "--yes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -44,5 +44,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRunning alias [1mhello[22m[39m
 [0mHello from feature

--- a/tests/snapshots/integration__integration_tests__step_alias__top_level_alias_with_step_builtin_name.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__top_level_alias_with_step_builtin_name.snap
@@ -3,8 +3,8 @@ source: tests/integration_tests/step_alias.rs
 info:
   program: wt
   args:
+    - "-y"
     - commit
-    - "--yes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLICOLOR_FORCE: "1"
@@ -44,5 +44,4 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mRunning alias [1mcommit[22m[39m
 [0mcustom-commit


### PR DESCRIPTION
## Summary

Alias announcement banner (`◎ Running alias <name>`) now only prints when the alias has at least one named step to summarize. Single unnamed aliases (`ls = "wt list"`) and all-anonymous pipelines return no announcement — the banner was just echoing the user's typed name. Pipelines with named steps keep their informative summary (`Running alias deploy: install; build, lint`). `-v` still prints the bare form as a confirmation line.

Addresses half of #2322 (the other half — perf — landed in 4f9bd575a).

## Rule

- `[aliases] ls = "wt list"` → silent
- `[aliases] foo = ["a", "b"]` (anonymous pipeline) → silent
- `[aliases.check] build = "…", test = "…"` (concurrent named) → announce
- `[[aliases.deploy]] install = "…"` (named pipeline) → announce
- Any of the above under `-v` → announce (bare form if no summary)

Implementation: `format_alias_announcement` returns `Option<String>` — `None` when the summary would be empty. Caller falls back to the bare form only under `-v`.

## Alternatives considered

- **A. Auto-detect `wt <builtin>` passthrough.** Parse the template and silence only when it resolves to a trivial `wt <subcommand>` / `wt <subcommand> {{ args }}`. Narrower than the chosen approach — would still announce `deploy = "cd {{ worktree_path }} && make"`. Rejected: if the banner carries no summary, announcing it adds nothing regardless of what the template does; a token parser and `TOP_LEVEL_BUILTINS` coupling are extra machinery for no gain.
- **B. Explicit per-alias `quiet = true`.** Requires extending the schema: the current `[aliases.foo] k = "v"` form means "concurrent step named k", so reserving keys collides with real step names. Either a breaking reserved-key convention or a sibling `[alias-options.foo]` section. Rejected: extra user-visible knob for a default the data already implies.
- **C. Verbosity-gated (banner only at `-v`).** Silences pipelines too, even ones whose step summary is useful. Rejected: loses real signal for named pipelines.
- **D. Always silent (delete the banner).** Loses the informative summary case entirely. Rejected as baseline.
- **E. Global opt-out at top of user config.** Blunt — the reporter's case mixed trivial keystroke-savers with real pipelines, and a single global switch can't distinguish them. Rejected.

## Test plan

- [x] Unit tests: `test_format_alias_announcement_*` updated to assert `None` for single/anonymous cases, `Some(summary)` for named cases.
- [x] Integration snapshots: 16 single-step alias snapshots lose the banner line; `alias_pipeline_announcement`, `step_alias_multi_step_binds_across_pipeline` keep their summary; `alias_verbose_*` (both use `-v`) keep the bare banner via the verbosity branch.
- [x] `cargo run -- hook pre-merge --yes` — all 3296 tests pass, all lints pass.

> _This was written by Claude Code on behalf of @max-sixty_