### PR TITLE
bench: invalidate wt caches per iteration in remove/TTFO benches

### DIFF
--- a/benches/CLAUDE.md
+++ b/benches/CLAUDE.md
@@ -47,6 +47,44 @@ startup latency without output rendering or post-output work (mismatch warnings,
 
 Supported commands: `switch`, `remove`, `list`.
 
+## Cache Handling
+
+Worktrunk maintains a persistent SHA-keyed cache at `.git/wt/cache/` plus a git-config
+cache of the default branch at `worktrunk.default-branch`. Both survive process exits,
+so bench iterations read from prior iterations unless invalidated.
+
+**Rule:** if a benchmark runs a `wt` subcommand that populates these caches, every
+iteration must start cold — otherwise iter 1 measures the real cost and iter 2+ measure
+a cache hit. Invalidate via `criterion::Bencher::iter_batched` with
+`wt_perf::invalidate_caches_auto` as the setup closure (see the cold-cache variants in
+`benches/list.rs` and `benches/remove.rs` for the pattern).
+
+`invalidate_caches_auto` clears:
+
+- `.git/index` (main and linked worktrees)
+- `.git/objects/info/commit-graph*`
+- `.git/packed-refs`
+- `.git/wt/cache/` (all sha_cache kinds + ci-status + summaries)
+- `worktrunk.default-branch` (git config)
+
+User state — `worktrunk.history`, `worktrunk.hints.*`, `worktrunk.state.<branch>.*`,
+`.git/wt/logs/`, `.git/wt/trash/` — is intentionally preserved. It doesn't affect
+read-path performance and benches may depend on it (e.g., branch markers set during
+setup).
+
+**Which commands populate `.git/wt/cache/`:**
+
+| Command | Populates? | Notes |
+|---------|------------|-------|
+| `wt list` | Yes | Post-skeleton tasks. Exits early under `WORKTRUNK_SKELETON_ONLY=1` / `WORKTRUNK_FIRST_OUTPUT=1` — those skip the writing phase. |
+| `wt remove` | Yes | `prepare_worktree_removal` → `compute_integration_lazy` writes `is-ancestor` / `has-added-changes` / `merge-add-probe` whenever `BranchDeletionMode` is not `ForceDelete` (CLI `--force` is `force_worktree`, not `--force-delete`). |
+| `wt switch` | No | No sha_cache writers on the switch path. |
+| `wt` (completion via `COMPLETE=$SHELL`) | No | Only `for-each-ref` + worktree list. |
+
+Default-branch cache contribution is ~17ms per iteration on a typical-8 synthetic repo
+(measured: 166ms with default-branch cached → 183ms fully cold). Small enough that
+always clearing it is simpler than introducing a "warm default-branch" bench mode.
+
 ## Expected Performance
 
 **Modest repos** (500 commits, 100 files):

--- a/benches/remove.rs
+++ b/benches/remove.rs
@@ -15,7 +15,9 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use std::path::{Path, PathBuf};
 use std::process::Command;
-use wt_perf::{RepoConfig, isolate_cmd, run_git, run_git_ok, setup_fake_remote};
+use wt_perf::{
+    RepoConfig, invalidate_caches_auto, isolate_cmd, run_git, run_git_ok, setup_fake_remote,
+};
 
 /// Create a benchmark repo at a specific path with optional hooks.
 fn create_bench_repo(base_path: &Path, with_hooks: bool) -> PathBuf {
@@ -108,21 +110,30 @@ fn bench_remove_e2e(c: &mut Criterion) {
         ))
     };
 
-    // Baseline: first_output (exits before output rendering)
+    // Baseline: first_output (exits before output rendering).
+    //
+    // Invalidates caches per iteration so the timing reflects first-invocation
+    // TTFO — `prepare_worktree_removal` writes to `.git/wt/cache/` via
+    // `compute_integration_lazy`, and reusing it across iterations would
+    // measure warm-cache cost instead.
     group.bench_function("first_output", |b| {
-        b.iter(|| {
-            let mut cmd = Command::new(binary);
-            cmd.args(["remove", "--yes", "--no-hooks", "--force", "feature-wt-1"]);
-            cmd.current_dir(&repo_no_hooks);
-            isolate_cmd(&mut cmd, Some(&user_config_no_hooks));
-            cmd.env("WORKTRUNK_FIRST_OUTPUT", "1");
-            let output = cmd.output().unwrap();
-            assert!(
-                output.status.success(),
-                "first_output failed: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-        });
+        b.iter_batched(
+            || invalidate_caches_auto(&repo_no_hooks),
+            |_| {
+                let mut cmd = Command::new(binary);
+                cmd.args(["remove", "--yes", "--no-hooks", "--force", "feature-wt-1"]);
+                cmd.current_dir(&repo_no_hooks);
+                isolate_cmd(&mut cmd, Some(&user_config_no_hooks));
+                cmd.env("WORKTRUNK_FIRST_OUTPUT", "1");
+                let output = cmd.output().unwrap();
+                assert!(
+                    output.status.success(),
+                    "first_output failed: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            },
+            criterion::BatchSize::SmallInput,
+        );
     });
 
     // No hooks: --no-hooks (skip hook loading), run from feature worktree

--- a/benches/time_to_first_output.rs
+++ b/benches/time_to_first_output.rs
@@ -16,7 +16,7 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use std::path::Path;
 use std::process::Command;
-use wt_perf::{RepoConfig, create_repo, isolate_cmd, setup_fake_remote};
+use wt_perf::{RepoConfig, create_repo, invalidate_caches_auto, isolate_cmd, setup_fake_remote};
 
 fn bench_first_output(c: &mut Criterion) {
     let mut group = c.benchmark_group("first_output");
@@ -35,18 +35,30 @@ fn bench_first_output(c: &mut Criterion) {
         cmd
     };
 
-    // remove: exits after validation, before approval/output
+    // remove: exits after validation, before approval/output.
+    //
+    // `prepare_worktree_removal` calls `compute_integration_lazy`, which
+    // populates `.git/wt/cache/{is-ancestor,has-added-changes,merge-add-probe}`
+    // on the first invocation. Without invalidation between iterations, iter 1
+    // is cold and iter 2+ read from cache — the reported timing would be warm
+    // cache, which doesn't reflect the first-invocation TTFO a user sees.
+    // Invalidate via `iter_batched` so every iteration starts cold.
     group.bench_function("remove", |b| {
-        b.iter(|| {
-            let output = make_cmd(&["remove", "--yes", "--no-hooks", "--force", "feature-wt-1"])
-                .output()
-                .unwrap();
-            assert!(
-                output.status.success(),
-                "Benchmark command failed:\nstderr: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
-        });
+        b.iter_batched(
+            || invalidate_caches_auto(&repo_path),
+            |_| {
+                let output =
+                    make_cmd(&["remove", "--yes", "--no-hooks", "--force", "feature-wt-1"])
+                        .output()
+                        .unwrap();
+                assert!(
+                    output.status.success(),
+                    "Benchmark command failed:\nstderr: {}",
+                    String::from_utf8_lossy(&output.stderr)
+                );
+            },
+            criterion::BatchSize::SmallInput,
+        );
     });
 
     // switch: exits after execute_switch, before mismatch computation and output

--- a/tests/helpers/wt-perf/src/lib.rs
+++ b/tests/helpers/wt-perf/src/lib.rs
@@ -322,6 +322,22 @@ pub fn setup_fake_remote(repo_path: &Path) {
 }
 
 /// Invalidate caches for any repo (auto-detects worktrees).
+///
+/// Clears:
+/// - Git's index (main + linked worktrees) — fsmonitor/stat warmup
+/// - Commit graph (`objects/info/commit-graph*`)
+/// - `packed-refs`
+/// - All of `.git/wt/cache/` — worktrunk's persistent SHA-keyed caches
+///   (merge-tree-conflicts, merge-add-probe, is-ancestor, has-added-changes,
+///   diff-stats) plus sibling caches (ci-status, summaries)
+/// - `worktrunk.default-branch` in git config — worktrunk's cache of the
+///   default branch name (repopulated on next `wt` invocation via
+///   `origin/HEAD` or `git ls-remote`)
+///
+/// Does NOT clear user-modifiable state: `worktrunk.history`,
+/// `worktrunk.hints.*`, `worktrunk.state.<branch>.*`, `.git/wt/logs/`,
+/// `.git/wt/trash/`. These don't affect read-path performance, and benches
+/// may rely on them (e.g., branch markers set during setup).
 pub fn invalidate_caches_auto(repo_path: &Path) {
     let git_dir = repo_path.join(".git");
 
@@ -348,6 +364,17 @@ pub fn invalidate_caches_auto(repo_path: &Path) {
 
     // Remove worktrunk's persistent SHA-keyed caches (diff-stats, is-ancestor, etc.)
     let _ = std::fs::remove_dir_all(git_dir.join("wt/cache"));
+
+    // Unset worktrunk's default-branch cache (git config). Uses `Cmd` to stay
+    // consistent with how `Repository::clear_default_branch_cache` clears it.
+    // Exit code 5 = key didn't exist (harmless); any other failure is ignored
+    // because invalidation is best-effort.
+    let _ = Cmd::new("git")
+        .args(["config", "--unset", "worktrunk.default-branch"])
+        .current_dir(repo_path)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .run();
 }
 
 /// Get or clone the rust-lang/rust repository for real-world benchmarks.


### PR DESCRIPTION
## Summary

`wt remove` populates `.git/wt/cache/` via `compute_integration_lazy` whenever `BranchDeletionMode` isn't force-delete (the CLI's `--force` is `force_worktree`, not `--force-delete`). The `remove_e2e/first_output` and `first_output/remove` benches used `b.iter` with no invalidation, so iter 1 was cold and iter 2+ hit the cache — reported timings reflected warm-cache cost, not the first-invocation TTFO users see.

## Changes

- `benches/remove.rs::first_output` and `benches/time_to_first_output.rs::remove` switch to `iter_batched` + `invalidate_caches_auto`.
- `wt_perf::invalidate_caches_auto` now also unsets `worktrunk.default-branch` (git config). That cache contributes ~17ms per iteration on a typical-8 repo (166ms with default-branch cached vs 183ms fully cold) — measurable but small enough that always clearing it is simpler than introducing a second mode.
- `benches/CLAUDE.md` documents the rule, the full list of what `invalidate_caches_auto` clears (including what it deliberately preserves — `worktrunk.history`, `worktrunk.hints.*`, `worktrunk.state.*`, `.git/wt/logs/`, `.git/wt/trash/`), and which commands populate `.git/wt/cache/`.

Audit found no other benches affected: `completion.rs` and `cow_copy.rs` don't touch the cache; `list.rs` already wires warm/cold via `BenchConfig`; `wt switch` and `wt list` under `WORKTRUNK_FIRST_OUTPUT=1` exit before the writers run; `remove.rs::no_hooks`/`with_hooks` short-circuit at `same_commit` because `recreate_worktree` rebuilds the branch at main's HEAD.

> _This was written by Claude Code on behalf of Maximilian Roos_