### PR TITLE
perf(config): route fsmonitor and pager reads through bulk cache

### DIFF
--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -818,12 +818,16 @@ impl Repository {
 
     /// Check if git's builtin fsmonitor daemon is enabled.
     ///
-    /// Returns true only for `core.fsmonitor=true` (the builtin daemon).
-    /// Returns false for Watchman hooks, disabled, or unset.
+    /// Returns true for any git-bool truthy value (`true/1/yes/on`), which
+    /// matches how git itself routes the bool-or-string `core.fsmonitor`
+    /// config to the builtin daemon. Returns false for Watchman hook paths,
+    /// disabled, or unset.
     pub fn is_builtin_fsmonitor_enabled(&self) -> bool {
-        self.run_command(&["config", "--get", "core.fsmonitor"])
+        self.config_last("core.fsmonitor")
             .ok()
-            .map(|s| s.trim() == "true")
+            .flatten()
+            .as_deref()
+            .map(parse_git_bool)
             .unwrap_or(false)
     }
 

--- a/src/git/repository/tests.rs
+++ b/src/git/repository/tests.rs
@@ -527,3 +527,48 @@ fn extract_failed_command_from_other_error() {
     assert_eq!(output, "some other error");
     assert!(cmd.is_none());
 }
+
+#[test]
+fn is_builtin_fsmonitor_enabled_variants() {
+    use super::RepoCache;
+    use indexmap::IndexMap;
+    use std::sync::{Arc, RwLock};
+
+    fn repo_with_fsmonitor(value: Option<&str>) -> super::Repository {
+        let cache = RepoCache::default();
+        let mut map: IndexMap<String, Vec<String>> = IndexMap::new();
+        if let Some(v) = value {
+            map.insert("core.fsmonitor".to_string(), vec![v.to_string()]);
+        }
+        cache.all_config.set(RwLock::new(map)).unwrap();
+        super::Repository {
+            discovery_path: PathBuf::from("/nonexistent/repo"),
+            git_common_dir: PathBuf::from("/nonexistent/.git"),
+            cache: Arc::new(cache),
+        }
+    }
+
+    // Builtin daemon: any git-bool truthy value enables it.
+    for truthy in ["true", "1", "yes", "on", "TRUE"] {
+        assert!(
+            repo_with_fsmonitor(Some(truthy)).is_builtin_fsmonitor_enabled(),
+            "{truthy} should enable builtin fsmonitor"
+        );
+    }
+
+    // Watchman hook path is NOT the builtin daemon — must return false even
+    // though the value is non-empty and truthy in the colloquial sense.
+    assert!(
+        !repo_with_fsmonitor(Some("/usr/local/bin/git-fsmonitor-watchman.sh"))
+            .is_builtin_fsmonitor_enabled()
+    );
+
+    // Explicitly disabled and unset both report false.
+    for falsy in ["false", "0", "no", "off"] {
+        assert!(
+            !repo_with_fsmonitor(Some(falsy)).is_builtin_fsmonitor_enabled(),
+            "{falsy} should disable builtin fsmonitor"
+        );
+    }
+    assert!(!repo_with_fsmonitor(None).is_builtin_fsmonitor_enabled());
+}

--- a/src/pager.rs
+++ b/src/pager.rs
@@ -9,7 +9,8 @@ pub(crate) fn parse_pager_value(value: &str) -> Option<String> {
 /// Read `core.pager` from git config, returning None if unset or invalid.
 pub(crate) fn git_config_pager() -> Option<String> {
     let repo = Repository::current().ok()?;
-    repo.run_command(&["config", "--get", "core.pager"])
+    repo.config_value("core.pager")
         .ok()
+        .flatten()
         .and_then(|output| parse_pager_value(&output))
 }


### PR DESCRIPTION
Follow-up to #2344: the two `git config` subprocess call sites outside `RepoCache` that were intentionally left behind now consult the bulk `all_config` map.

`is_builtin_fsmonitor_enabled` reads `core.fsmonitor` via `config_last` and parses with `parse_git_bool`, matching how git itself routes the bool-or-string value — the builtin daemon is enabled for any git-bool truthy value, and anything else (including Watchman hook paths) counts as a hook/disabled. The practical widening over the previous `s.trim() == "true"` check is that `1`/`yes`/`on` now count as enabled; Watchman hook paths still correctly return false. A direct unit test seeds `all_config` on a fresh `RepoCache` and pins both the bool widening and the Watchman-stays-false invariant — the function's only production caller is macOS-gated, so the Linux coverage runner would otherwise see the body as dead code.

`git_config_pager` already built a `Repository::current()`, so the swap to `config_value` was one line.

Not migrated: `effective_remote_url` still calls `git remote get-url` because it needs `url.insteadOf` URL rewrites, which aren't a plain config lookup. It stays cached separately in `RepoCache.effective_remote_urls`.

> _This was written by Claude Code on behalf of Maximilian_