### PR TITLE
fix(relocate): surface failed git checkout/move instead of silent success

### DIFF
--- a/src/commands/relocate.rs
+++ b/src/commands/relocate.rs
@@ -23,7 +23,7 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use anyhow::Context;
+use anyhow::{Context, bail};
 use color_print::cformat;
 use worktrunk::config::UserConfig;
 use worktrunk::git::{Repository, WorktreeInfo};
@@ -96,6 +96,22 @@ pub struct RelocationExecutor {
     /// Counters for summary
     pub skipped: usize,
     pub relocated: usize,
+}
+
+/// Run a `Cmd` and bail with the trimmed stderr if it exits non-zero.
+///
+/// `Cmd::run()` returns `Ok(Output { status: non-zero, .. })` on failed
+/// commands — only spawn errors travel through `?`. Every raw-`Cmd` call
+/// site in this module must promote non-zero exits into errors, or a failed
+/// `git worktree move` / `git checkout` would print a false "Relocated ..."
+/// success message.
+fn run_checked(cmd: Cmd) -> anyhow::Result<std::process::Output> {
+    let output = cmd.run()?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).replace('\r', "\n");
+        bail!("{}", stderr.trim());
+    }
+    Ok(output)
 }
 
 // ============================================================================
@@ -477,13 +493,14 @@ impl RelocationExecutor {
         if is_main {
             self.move_main_worktree(idx, repo_path, default_branch)?;
         } else {
-            Cmd::new("git")
-                .args(["worktree", "move"])
-                .arg(src_path.to_string_lossy())
-                .arg(dest_path.to_string_lossy())
-                .context(&branch)
-                .run()
-                .context("Failed to move worktree")?;
+            run_checked(
+                Cmd::new("git")
+                    .args(["worktree", "move"])
+                    .arg(src_path.to_string_lossy())
+                    .arg(dest_path.to_string_lossy())
+                    .context(&branch),
+            )
+            .context("Failed to move worktree")?;
         }
 
         let msg = cformat!("Relocated <bold>{branch}</>: {src_display} → {dest_display}");
@@ -515,20 +532,22 @@ impl RelocationExecutor {
         let msg = cformat!("Switching main worktree to <bold>{default_branch}</>...");
         eprintln!("{}", progress_message(msg));
 
-        Cmd::new("git")
-            .args(["checkout", default_branch])
-            .current_dir(repo_path)
-            .context("main")
-            .run()
-            .context("Failed to checkout default branch")?;
+        run_checked(
+            Cmd::new("git")
+                .args(["checkout", default_branch])
+                .current_dir(repo_path)
+                .context("main"),
+        )
+        .with_context(|| format!("Failed to checkout default branch '{default_branch}'"))?;
 
-        // Try to create worktree; if it fails, rollback to original branch
-        let add_result = Cmd::new("git")
-            .args(["worktree", "add"])
-            .arg(candidate.expected_path.to_string_lossy())
-            .arg(branch)
-            .context(branch)
-            .run();
+        // Try to create worktree; if it fails, rollback to original branch.
+        let add_result = run_checked(
+            Cmd::new("git")
+                .args(["worktree", "add"])
+                .arg(candidate.expected_path.to_string_lossy())
+                .arg(branch)
+                .context(branch),
+        );
 
         if let Err(e) = add_result {
             // Rollback: checkout the original branch to restore user context
@@ -579,13 +598,14 @@ impl RelocationExecutor {
         let msg = cformat!("Moving <bold>{branch}</> to temporary location...");
         eprintln!("{}", progress_message(msg));
 
-        Cmd::new("git")
-            .args(["worktree", "move"])
-            .arg(candidate.wt.path.to_string_lossy())
-            .arg(temp_path.to_string_lossy())
-            .context(branch)
-            .run()
-            .context("Failed to move worktree to temp")?;
+        run_checked(
+            Cmd::new("git")
+                .args(["worktree", "move"])
+                .arg(candidate.wt.path.to_string_lossy())
+                .arg(temp_path.to_string_lossy())
+                .context(branch),
+        )
+        .context("Failed to move worktree to temp")?;
 
         // Update current_locations to reflect the move
         let old_canonical = candidate
@@ -614,13 +634,14 @@ impl RelocationExecutor {
             let src_display = format_path_for_display(&temp.original_path);
             let dest_display = format_path_for_display(&candidate.expected_path);
 
-            Cmd::new("git")
-                .args(["worktree", "move"])
-                .arg(temp.temp_path.to_string_lossy())
-                .arg(candidate.expected_path.to_string_lossy())
-                .context(branch)
-                .run()
-                .context("Failed to move worktree from temp to final location")?;
+            run_checked(
+                Cmd::new("git")
+                    .args(["worktree", "move"])
+                    .arg(temp.temp_path.to_string_lossy())
+                    .arg(candidate.expected_path.to_string_lossy())
+                    .context(branch),
+            )
+            .context("Failed to move worktree from temp to final location")?;
 
             let msg = cformat!("Relocated <bold>{branch}</>: {src_display} → {dest_display}");
             eprintln!("{}", success_message(msg));

--- a/src/commands/relocate.rs
+++ b/src/commands/relocate.rs
@@ -23,12 +23,11 @@
 use std::collections::{HashMap, HashSet};
 use std::path::{Path, PathBuf};
 
-use anyhow::{Context, bail};
+use anyhow::Context;
 use color_print::cformat;
 use worktrunk::config::UserConfig;
 use worktrunk::git::{Repository, WorktreeInfo};
 use worktrunk::path::format_path_for_display;
-use worktrunk::shell_exec::Cmd;
 use worktrunk::styling::{
     eprintln, format_with_gutter, hint_message, info_message, progress_message, success_message,
     warning_message,
@@ -81,7 +80,14 @@ struct TempRelocation {
 }
 
 /// Executes relocations in dependency order, handling cycles via temp moves.
-pub struct RelocationExecutor {
+///
+/// Git commands route through `repo.worktree_at(path).run_command(...)` rather
+/// than raw `Cmd::new("git").run()`. `Cmd::run()` returns `Ok(Output)` on
+/// non-zero exit — only spawn errors travel through `?` — so raw `.run()`
+/// would silently swallow a failed `git worktree move` / `git checkout` and
+/// let the caller print a false "Relocated ..." success message.
+pub struct RelocationExecutor<'a> {
+    repo: &'a Repository,
     pending: Vec<ValidatedCandidate>,
     /// Maps canonical current path → index in pending (for cycle detection)
     current_locations: HashMap<PathBuf, usize>,
@@ -96,22 +102,6 @@ pub struct RelocationExecutor {
     /// Counters for summary
     pub skipped: usize,
     pub relocated: usize,
-}
-
-/// Run a `Cmd` and bail with the trimmed stderr if it exits non-zero.
-///
-/// `Cmd::run()` returns `Ok(Output { status: non-zero, .. })` on failed
-/// commands — only spawn errors travel through `?`. Every raw-`Cmd` call
-/// site in this module must promote non-zero exits into errors, or a failed
-/// `git worktree move` / `git checkout` would print a false "Relocated ..."
-/// success message.
-fn run_checked(cmd: Cmd) -> anyhow::Result<std::process::Output> {
-    let output = cmd.run()?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).replace('\r', "\n");
-        bail!("{}", stderr.trim());
-    }
-    Ok(output)
 }
 
 // ============================================================================
@@ -283,10 +273,10 @@ pub fn validate_candidates(
 // Phase 3 & 4: Execute relocations
 // ============================================================================
 
-impl RelocationExecutor {
+impl<'a> RelocationExecutor<'a> {
     /// Create executor and classify targets (handling blockers with optional clobber).
     pub fn new(
-        repo: &Repository,
+        repo: &'a Repository,
         validated: Vec<ValidatedCandidate>,
         clobber: bool,
     ) -> anyhow::Result<Self> {
@@ -381,6 +371,7 @@ impl RelocationExecutor {
         }
 
         Ok(Self {
+            repo,
             pending: validated,
             current_locations,
             blocked,
@@ -393,12 +384,7 @@ impl RelocationExecutor {
     }
 
     /// Execute all relocations in dependency order.
-    pub fn execute(
-        &mut self,
-        repo_path: &Path,
-        default_branch: &str,
-        cwd: Option<&Path>,
-    ) -> anyhow::Result<()> {
+    pub fn execute(&mut self, default_branch: &str, cwd: Option<&Path>) -> anyhow::Result<()> {
         // Process until all pending are moved or in temp
         loop {
             let mut made_progress = false;
@@ -411,7 +397,7 @@ impl RelocationExecutor {
 
                 match self.is_target_empty(i) {
                     Some(true) => {
-                        self.move_worktree(i, repo_path, default_branch, cwd)?;
+                        self.move_worktree(i, default_branch, cwd)?;
                         made_progress = true;
                     }
                     Some(false) => {
@@ -477,7 +463,6 @@ impl RelocationExecutor {
     fn move_worktree(
         &mut self,
         idx: usize,
-        repo_path: &Path,
         default_branch: &str,
         cwd: Option<&Path>,
     ) -> anyhow::Result<()> {
@@ -491,16 +476,14 @@ impl RelocationExecutor {
         let dest_display = format_path_for_display(&dest_path);
 
         if is_main {
-            self.move_main_worktree(idx, repo_path, default_branch)?;
+            self.move_main_worktree(idx, default_branch)?;
         } else {
-            run_checked(
-                Cmd::new("git")
-                    .args(["worktree", "move"])
-                    .arg(src_path.to_string_lossy())
-                    .arg(dest_path.to_string_lossy())
-                    .context(&branch),
-            )
-            .context("Failed to move worktree")?;
+            let src = src_path.to_string_lossy();
+            let dest = dest_path.to_string_lossy();
+            self.repo
+                .worktree_at(self.repo.repo_path()?)
+                .run_command(&["worktree", "move", &src, &dest])
+                .context("Failed to move worktree")?;
         }
 
         let msg = cformat!("Relocated <bold>{branch}</>: {src_display} → {dest_display}");
@@ -520,45 +503,32 @@ impl RelocationExecutor {
     }
 
     /// Main worktree can't use `git worktree move`; must create new + switch.
-    fn move_main_worktree(
-        &mut self,
-        idx: usize,
-        repo_path: &Path,
-        default_branch: &str,
-    ) -> anyhow::Result<()> {
+    fn move_main_worktree(&mut self, idx: usize, default_branch: &str) -> anyhow::Result<()> {
         let candidate = &self.pending[idx];
         let branch = candidate.branch();
 
         let msg = cformat!("Switching main worktree to <bold>{default_branch}</>...");
         eprintln!("{}", progress_message(msg));
 
-        run_checked(
-            Cmd::new("git")
-                .args(["checkout", default_branch])
-                .current_dir(repo_path)
-                .context("main"),
-        )
-        .with_context(|| format!("Failed to checkout default branch '{default_branch}'"))?;
+        // Bind the main worktree up front so the rollback path can reuse it
+        // without threading another `?` through a best-effort cleanup.
+        let main_wt = self.repo.worktree_at(self.repo.repo_path()?);
+
+        main_wt
+            .run_command(&["checkout", default_branch])
+            .with_context(|| format!("Failed to checkout default branch '{default_branch}'"))?;
 
         // Try to create worktree; if it fails, rollback to original branch.
-        let add_result = run_checked(
-            Cmd::new("git")
-                .args(["worktree", "add"])
-                .arg(candidate.expected_path.to_string_lossy())
-                .arg(branch)
-                .context(branch),
-        );
+        let dest = candidate.expected_path.to_string_lossy();
+        let add_result = main_wt.run_command(&["worktree", "add", &dest, branch]);
 
         if let Err(e) = add_result {
             // Rollback: checkout the original branch to restore user context
             let rollback_msg = cformat!("Worktree creation failed, restoring <bold>{branch}</>...");
             eprintln!("{}", warning_message(rollback_msg));
 
-            let _ = Cmd::new("git")
-                .args(["checkout", branch])
-                .current_dir(repo_path)
-                .context("main")
-                .run(); // Best-effort rollback
+            // Best-effort rollback: log failures but don't mask the original error.
+            let _ = main_wt.run_command(&["checkout", branch]);
 
             return Err(e).context("Failed to create worktree for main relocation");
         }
@@ -598,14 +568,12 @@ impl RelocationExecutor {
         let msg = cformat!("Moving <bold>{branch}</> to temporary location...");
         eprintln!("{}", progress_message(msg));
 
-        run_checked(
-            Cmd::new("git")
-                .args(["worktree", "move"])
-                .arg(candidate.wt.path.to_string_lossy())
-                .arg(temp_path.to_string_lossy())
-                .context(branch),
-        )
-        .context("Failed to move worktree to temp")?;
+        let src = candidate.wt.path.to_string_lossy();
+        let dest = temp_path.to_string_lossy();
+        self.repo
+            .worktree_at(self.repo.repo_path()?)
+            .run_command(&["worktree", "move", &src, &dest])
+            .context("Failed to move worktree to temp")?;
 
         // Update current_locations to reflect the move
         let old_canonical = candidate
@@ -634,14 +602,12 @@ impl RelocationExecutor {
             let src_display = format_path_for_display(&temp.original_path);
             let dest_display = format_path_for_display(&candidate.expected_path);
 
-            run_checked(
-                Cmd::new("git")
-                    .args(["worktree", "move"])
-                    .arg(temp.temp_path.to_string_lossy())
-                    .arg(candidate.expected_path.to_string_lossy())
-                    .context(branch),
-            )
-            .context("Failed to move worktree from temp to final location")?;
+            let src = temp.temp_path.to_string_lossy();
+            let dest = candidate.expected_path.to_string_lossy();
+            self.repo
+                .worktree_at(self.repo.repo_path()?)
+                .run_command(&["worktree", "move", &src, &dest])
+                .context("Failed to move worktree from temp to final location")?;
 
             let msg = cformat!("Relocated <bold>{branch}</>: {src_display} → {dest_display}");
             eprintln!("{}", success_message(msg));

--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -1830,7 +1830,7 @@ pub fn step_relocate(
     // Phase 3 & 4: Create executor (classifies targets) and execute relocations
     let mut executor = RelocationExecutor::new(&repo, validated, clobber)?;
     let cwd = std::env::current_dir().ok();
-    executor.execute(&repo_path, &default_branch, cwd.as_deref())?;
+    executor.execute(&default_branch, cwd.as_deref())?;
 
     // Show summary
     let total_skipped = skipped + executor.skipped;

--- a/tests/integration_tests/step_relocate.rs
+++ b/tests/integration_tests/step_relocate.rs
@@ -598,6 +598,84 @@ worktree-path = "{{ nonexistent_variable }}"
     );
 }
 
+/// Regression test: main worktree relocation must surface a failed
+/// `git checkout <default_branch>` rather than silently claiming success.
+///
+/// Setup engineers a state where `worktrunk.default-branch` is set to a
+/// branch that does not exist locally. `Repository::default_branch()`
+/// trusts the persisted value (validation happens downstream), so
+/// `wt step relocate` proceeds into `move_main_worktree`, which tries
+/// `git checkout <nonexistent-branch>`. Before the fix, `Cmd::run()`
+/// returned `Ok(Output { status: non-zero, .. })` and the `?` operator
+/// didn't propagate it, so relocate printed "Relocated main ..." even
+/// though nothing happened.
+///
+/// After the fix: non-zero exit bails with the git stderr, exit code is
+/// non-zero, and the main worktree stays at its original path.
+#[rstest]
+fn test_relocate_main_worktree_checkout_failure_surfaces(repo: TestRepo) {
+    let parent = worktree_parent(&repo);
+    let repo_path = repo.root_path().to_path_buf();
+
+    // Switch main worktree to a non-default branch so it becomes a
+    // relocation candidate (expected path = repo.feature, not repo).
+    repo.run_git(&["checkout", "-b", "feature"]);
+
+    // Point worktrunk's default-branch cache at a branch that doesn't
+    // resolve locally. `default_branch()` now returns this value without
+    // validating it, so relocate's preflight does NOT bail and the main
+    // worktree code path runs `git checkout nonexistent-branch-xyz`.
+    repo.run_git(&[
+        "config",
+        "worktrunk.default-branch",
+        "nonexistent-branch-xyz",
+    ]);
+
+    let output = repo
+        .wt_command()
+        .args(["step", "relocate"])
+        .output()
+        .unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(
+        !output.status.success(),
+        "relocate must fail when checkout of default branch fails; \
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Relocated"),
+        "relocate must not claim success after a failed checkout; \
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+
+    // Main worktree is untouched - still at repo_path, still on feature.
+    assert!(
+        repo_path.exists(),
+        "main worktree path should still exist: {}",
+        repo_path.display()
+    );
+    let expected_path = parent.join("repo.feature");
+    assert!(
+        !expected_path.exists(),
+        "relocate must not create the new worktree path after checkout \
+         failure: {}",
+        expected_path.display()
+    );
+
+    let branch_output = repo
+        .git_command()
+        .args(["branch", "--show-current"])
+        .run()
+        .unwrap();
+    assert_eq!(
+        String::from_utf8_lossy(&branch_output.stdout).trim(),
+        "feature",
+        "main worktree branch should be unchanged after failed checkout"
+    );
+}
+
 /// Test that empty default branch is detected early with actionable error.
 ///
 /// Engineers a state where detection genuinely fails (no remote, no


### PR DESCRIPTION
## Summary

- `Cmd::run()` returns `Ok(Output { status: non-zero, .. })` on failed git commands — only spawn errors travel through `?`. `relocate.rs` used raw `Cmd::new(\"git\")...run()?` at four sites, so a failed \`git checkout\` / \`git worktree move\` silently returned \`Ok\` and the caller printed a false \"Relocated …\" success message.
- Reproducer test (\`test_relocate_main_worktree_checkout_failure_surfaces\`): points \`worktrunk.default-branch\` at a branch that doesn't resolve locally. Before the fix this exits 0 with \"Relocated 1 worktree\" on stderr; after the fix it bails with the git stderr and the main worktree is untouched.
- Follow-up refactor routes all four git call sites through \`repo.worktree_at(path).run_command(...)\` — the canonical project pattern for fail-fast git that \`validate_candidates\` already uses. \`RelocationExecutor\` now holds \`&'a Repository\`, so \`execute\`/\`move_worktree\`/\`move_main_worktree\` drop the \`repo_path: &Path\` parameter.

## Context

PR #2344 made \`Repository::default_branch()\` trust the persisted \`worktrunk.default-branch\` value without validating that the branch resolved locally. When a user has a stale cached value, \`wt step relocate\` now proceeds into \`move_main_worktree\`, which runs \`git checkout <cached_branch>\`. That checkout fails, but the \`.run()?\` swallowed the non-zero exit — and the caller then reported success.

## Test plan

- [x] New test reproduces the silent-success bug on unfixed code and passes after the fix
- [x] All 18 \`step_relocate\` tests pass
- [x] Full pre-merge (\`cargo run -- hook pre-merge --yes\`): 3318 tests, all lints, doctests, docs clean