### PR TITLE
perf(repo): skip submodule rev-parse probe via core.worktree in bulk config

### DIFF
--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -80,6 +80,7 @@ use wait_timeout::ChildExt;
 use anyhow::{Context, bail};
 
 use dunce::canonicalize;
+use normalize_path::NormalizePath;
 
 use crate::config::{LoadError, ProjectConfig, ResolvedConfig, UserConfig};
 
@@ -666,58 +667,58 @@ impl Repository {
     ///
     /// Result is cached in the repository's shared cache (same for all clones).
     ///
-    /// # Why we run from `git_common_dir`
+    /// # Why we anchor on `git_common_dir`
     ///
-    /// We need to return the *main* worktree regardless of which worktree we were discovered
-    /// from. For linked worktrees, `git_common_dir` is the stable reference that's shared
-    /// across all worktrees (e.g., `/myapp/.git` whether you're in `/myapp` or `/myapp.feature`).
+    /// We need to return the *main* worktree regardless of which worktree we
+    /// were discovered from. For linked worktrees, `git_common_dir` is the
+    /// stable reference shared across all worktrees (e.g., `/myapp/.git`
+    /// whether you're in `/myapp` or `/myapp.feature`), so we resolve every
+    /// case below relative to it.
     ///
-    /// # Why the try-fallback approach
+    /// # How we resolve the path
     ///
-    /// `--show-toplevel` behavior depends on whether git has explicit worktree metadata:
+    /// Everything we need is already in the bulk config map (`git config --list -z`,
+    /// populated once per command):
     ///
-    /// | git_common_dir location    | Has `core.worktree`? | `--show-toplevel` works? |
-    /// |----------------------------|----------------------|--------------------------|
-    /// | Normal `.git`              | No (implicit)        | No — "not a work tree"   |
-    /// | Submodule `.git/modules/X` | Yes (explicit)       | Yes — reads config       |
+    /// | git_common_dir location    | Signal                       | Resolution                           |
+    /// |----------------------------|------------------------------|--------------------------------------|
+    /// | Bare `.git`                | `core.bare = true`           | `git_common_dir` is the repo         |
+    /// | Submodule `.git/modules/X` | `core.worktree` set by git   | join + normalize against common dir  |
+    /// | Normal `.git`              | neither set                  | `parent(git_common_dir)`             |
     ///
-    /// Normal repos don't need `core.worktree` because the worktree is implicitly `parent(.git)`.
-    /// Submodules need it because their git data lives in the parent's `.git/modules/`.
-    ///
-    /// So we try `--show-toplevel` first (handles submodules), fall back to `parent()` (handles
-    /// normal repos). This avoids fragile path-based detection of submodules.
+    /// Submodules need `core.worktree` because their git data lives in the
+    /// parent's `.git/modules/`, so the implicit `parent(.git)` rule that
+    /// works for normal repos would point at `.git/modules` — wrong. Git
+    /// writes `core.worktree` explicitly to compensate. Reading it from the
+    /// bulk map matches git's own authority for the working tree and avoids
+    /// a `rev-parse --show-toplevel` subprocess on every call.
     ///
     /// # Errors
     ///
-    /// Returns an error if `is_bare()` fails (e.g., git timeout). This surfaces
-    /// the failure early rather than caching a potentially wrong path.
+    /// Returns an error if the bulk config read fails (e.g., git timeout). This
+    /// surfaces the failure early rather than caching a potentially wrong path.
     pub fn repo_path(&self) -> anyhow::Result<&Path> {
         self.cache
             .repo_path
             .get_or_try_init(|| {
-                // Submodules: --show-toplevel succeeds (git has explicit core.worktree config)
-                if let Ok(out) = Cmd::new("git")
-                    .args(["rev-parse", "--show-toplevel"])
-                    .current_dir(&self.git_common_dir)
-                    .context(path_to_logging_context(&self.git_common_dir))
-                    .run()
-                    && out.status.success()
-                {
-                    return Ok(PathBuf::from(String::from_utf8_lossy(&out.stdout).trim()));
+                if self.is_bare()? {
+                    return Ok(self.git_common_dir.clone());
                 }
 
-                // --show-toplevel failed:
-                // 1. Bare repos (no working tree) → git_common_dir IS the repo
-                // 2. Normal repos from inside .git → parent is the repo
-                if self.is_bare()? {
-                    Ok(self.git_common_dir.clone())
-                } else {
-                    Ok(self
-                        .git_common_dir
-                        .parent()
-                        .expect("Git directory has no parent")
-                        .to_path_buf())
+                if let Some(worktree) = self.config_last("core.worktree")? {
+                    let path = PathBuf::from(&worktree);
+                    return Ok(if path.is_absolute() {
+                        path
+                    } else {
+                        self.git_common_dir.join(path).normalize()
+                    });
                 }
+
+                Ok(self
+                    .git_common_dir
+                    .parent()
+                    .expect("Git directory has no parent")
+                    .to_path_buf())
             })
             .map(|p| p.as_path())
     }

--- a/src/git/repository/tests.rs
+++ b/src/git/repository/tests.rs
@@ -384,9 +384,7 @@ fn repo_path_error_when_is_bare_fails() {
     use std::sync::Arc;
 
     // Create a Repository with a non-existent git_common_dir.
-    // This makes --show-toplevel fail (reaching the is_bare branch),
-    // and then is_bare() also fails because the bulk config read
-    // can't run in a missing dir.
+    // is_bare() fails because the bulk config read can't run in a missing dir.
     let repo = super::Repository {
         discovery_path: PathBuf::from("/nonexistent/repo"),
         git_common_dir: PathBuf::from("/nonexistent/.git"),

--- a/src/git/repository/tests.rs
+++ b/src/git/repository/tests.rs
@@ -402,6 +402,37 @@ fn repo_path_error_when_is_bare_fails() {
 }
 
 #[test]
+fn repo_path_absolute_core_worktree() {
+    use super::RepoCache;
+    use indexmap::IndexMap;
+    use std::sync::{Arc, RwLock};
+
+    // Git writes `core.worktree` as a relative path for submodules
+    // (`../../../sub`), which the integration test `test_repo_path_in_submodule`
+    // covers. This unit test exercises the absolute-path branch — also legal
+    // per git-config(1) — without needing a filesystem fixture.
+    let cache = RepoCache::default();
+    let mut map: IndexMap<String, Vec<String>> = IndexMap::new();
+    map.insert("core.bare".to_string(), vec!["false".to_string()]);
+    map.insert(
+        "core.worktree".to_string(),
+        vec!["/absolute/worktree".to_string()],
+    );
+    cache.all_config.set(RwLock::new(map)).unwrap();
+
+    let repo = super::Repository {
+        discovery_path: PathBuf::from("/nonexistent/repo"),
+        git_common_dir: PathBuf::from("/nonexistent/.git/modules/sub"),
+        cache: Arc::new(cache),
+    };
+
+    assert_eq!(
+        repo.repo_path().unwrap(),
+        std::path::Path::new("/absolute/worktree")
+    );
+}
+
+#[test]
 fn parse_config_list_z_basic() {
     let input = b"core.bare\nfalse\0remote.origin.url\nhttps://example.com/a.git\0";
     let map = super::parse_config_list_z(input);

--- a/src/git/repository/worktrees.rs
+++ b/src/git/repository/worktrees.rs
@@ -35,8 +35,7 @@ impl Repository {
         // We detect this by checking whether the first worktree's path equals
         // git_common_dir (which never holds for normal repos, where git_common_dir
         // is `.git` inside the worktree). When matched, we correct it using
-        // repo_path(), which resolves the actual working directory via
-        // `git rev-parse --show-toplevel` (which does read core.worktree).
+        // repo_path(), which reads `core.worktree` from the bulk config map.
         //
         // We fix this here rather than at each call site because list_worktrees()
         // is the single point where worktree paths enter the system — all consumers


### PR DESCRIPTION
## Summary

Replaces the failing `git rev-parse --show-toplevel` probe in `Repository::repo_path()` with a direct read of `core.worktree` from the bulk config map. On non-submodule repos the probe fails unconditionally, costing roughly 5ms per call on healthy macOS — or ~200ms on systems with expensive `execve` like the one reported in #2322. `repo_path()` fires ~2× during parent-side alias dispatch, so the win compounds.

The new control flow matches git's own rules for locating the working tree:

| `git_common_dir` layout     | Signal                     | Resolution                       |
|-----------------------------|----------------------------|----------------------------------|
| Bare `.git`                 | `core.bare = true`         | `git_common_dir` is the repo     |
| Submodule `.git/modules/X`  | `core.worktree` set by git | join + normalize vs common dir   |
| Normal `.git`               | neither set                | `parent(git_common_dir)`         |

Submodules need `core.worktree` because their data lives in the parent's `.git/modules/`, so the implicit `parent(.git)` rule normal repos rely on would point at the wrong directory. Reading `core.worktree` from the bulk map is git's own signal for this — no `rev-parse` subprocess required.

## Correctness

The #762 → #1070 → #1280 chain of submodule fixes established two invariants: `repo_path()` must return the submodule working directory (not `.git/modules/sub`), and `list_worktrees()` depends on that to correct git's own mis-report for submodule main worktrees. Both still hold:

- `test_repo_path_in_submodule` (integration) passes — exercises `repo_path()`, `list_worktrees()`, and `worktree_for_branch()` in a real parent/submodule setup.
- `wt list` from inside a real submodule at `/tmp/subm-test/parent/sub` reports the submodule working directory, not the git data path.
- All 4 submodule-adjacent tests (`test_repo_path_in_submodule`, `test_push_{no_ff_,}with_submodule_recurse_config`, `test_remove_foreground_with_submodules`) pass.
- Bare repos still hit the `is_bare()` short-circuit; linked worktrees still fall through to `parent()` because the shared `.git` common dir has no `core.worktree`.

Errors still propagate via `Result` (from `all_config()` instead of the removed subprocess), preserving the #1280 invariant.

## Performance

hyperfine A/B on a healthy macOS system (200 runs each, `-N` bypasses shell):

| Context                  | Before          | After           | Speedup |
|--------------------------|-----------------|-----------------|---------|
| `wt noop` in normal repo | 53.2 ± 5.3 ms   | 48.8 ± 6.1 ms   | 1.09×   |
| `wt noop` in submodule   | 62.1 ± 12.6 ms  | 55.5 ± 11.7 ms  | 1.12×   |

Trace confirmation: `git rev-parse --show-toplevel [.git]` no longer appears in `RUST_LOG=debug` output for alias dispatch. The unrelated `rev-parse --show-toplevel [parent]` from `WorkingTree::root()` (legitimately successful) remains and is out of scope.

`benches/alias` results were too noisy to cite confidently on my machine during this session (`wt_version` — which this change doesn't touch — varied ±60% between runs), but the hyperfine measurement is clean.

Ref #2322

> _This was written by Claude Code on behalf of @max-sixty_