### PR TITLE
docs(hook): promote Recipes to top-level H1

### DIFF
--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -259,7 +259,7 @@ Any `--KEY=VALUE` whose key isn't referenced by a hook template forwards into `{
 
 The long form `--var KEY=VALUE` is deprecated but still supported. It force-binds regardless of whether any hook template references `KEY` — useful when a template only references the key conditionally (e.g. `{% if override %}…{% endif %}`).
 
-## Recipes
+# Recipes
 
 - [Eliminate cold starts](@/tips-patterns.md#eliminate-cold-starts): `wt step copy-ignored` in `post-start` shares build caches and dependencies; use a `[[post-start]]` pipeline when a later hook depends on the copy
 - [Dev server per worktree](@/tips-patterns.md#dev-server-per-worktree): `hash_port` in `post-start` for launch and `post-remove` for cleanup, with optional subdomain routing

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -260,7 +260,7 @@ Any `--KEY=VALUE` whose key isn't referenced by a hook template forwards into `{
 
 The long form `--var KEY=VALUE` is deprecated but still supported. It force-binds regardless of whether any hook template references `KEY` — useful when a template only references the key conditionally (e.g. `{% if override %}…{% endif %}`).
 
-## Recipes
+# Recipes
 
 - [Eliminate cold starts](https://worktrunk.dev/tips-patterns/#eliminate-cold-starts): `wt step copy-ignored` in `post-start` shares build caches and dependencies; use a `[[post-start]]` pipeline when a later hook depends on the copy
 - [Dev server per worktree](https://worktrunk.dev/tips-patterns/#dev-server-per-worktree): `hash_port` in `post-start` for launch and `post-remove` for cleanup, with optional subdomain routing

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1401,7 +1401,7 @@ Any `--KEY=VALUE` whose key isn't referenced by a hook template forwards into `{
 
 The long form `--var KEY=VALUE` is deprecated but still supported. It force-binds regardless of whether any hook template references `KEY` — useful when a template only references the key conditionally (e.g. `{% if override %}…{% endif %}`).
 
-## Recipes
+# Recipes
 
 - [Eliminate cold starts](@/tips-patterns.md#eliminate-cold-starts): `wt step copy-ignored` in `post-start` shares build caches and dependencies; use a `[[post-start]]` pipeline when a later hook depends on the copy
 - [Dev server per worktree](@/tips-patterns.md#dev-server-per-worktree): `hash_port` in `post-start` for launch and `post-remove` for cleanup, with optional subdomain routing


### PR DESCRIPTION
Follow-up to #2349. With the old "Designing Effective Hooks" umbrella heading removed, `## Recipes` was landing at H2 under `# Running Hooks Manually`, reading as a sub-topic of manual invocation — which it isn't. Promoting to `# Recipes` makes it a peer of the other top-level sections (`# Hook Types`, `# Security`, `# Configuration`, `# Running Hooks Manually`).

Trailing `## See also` stays at H2 — consistent with how other command docs handle their "See also" footers.

> _This was written by Claude Code on behalf of Maximilian_