### PR TITLE
perf(alias): batch rev-parse calls in alias dispatch

### DIFF
--- a/src/git/repository/config.rs
+++ b/src/git/repository/config.rs
@@ -494,11 +494,10 @@ impl Repository {
             return Ok(Some(PathBuf::from(path)));
         }
 
-        let in_worktree = self
-            .current_worktree()
-            .run_command(&["rev-parse", "--is-inside-work-tree"])
-            .map(|s| s.trim() == "true")
-            .unwrap_or(false);
+        // Batched rev-parse: asks `--is-inside-work-tree` and also pre-warms
+        // the worktree root / git-dir / branch caches, sparing three later
+        // forks on the typical alias path.
+        let in_worktree = self.current_worktree().prewarm_info().unwrap_or(false);
 
         if in_worktree {
             // Inside a worktree — use it (normal repo or linked worktree in bare repo)

--- a/src/git/repository/working_tree.rs
+++ b/src/git/repository/working_tree.rs
@@ -119,6 +119,83 @@ impl<'a> WorkingTree<'a> {
     // Worktree-specific methods
     // =========================================================================
 
+    /// Populate the `root`/`git_dir`/`branch` caches with a single batched
+    /// `git rev-parse` invocation and return whether this path is inside a
+    /// work tree.
+    ///
+    /// Folds four rev-parse selectors that would otherwise fire as separate
+    /// forks during alias/hook dispatch (`--is-inside-work-tree` from
+    /// [`Repository::project_config_path`], plus one each for [`Self::root`],
+    /// [`Self::git_dir`], and [`Self::branch`]) into one. `HEAD` is last in
+    /// the argument list because `rev-parse` aborts processing once it hits
+    /// an unresolvable ref — on an unborn branch the preceding selectors'
+    /// stdout still lands, so we can cache `root`/`git_dir` even though the
+    /// command exits non-zero. The `branch` cache is only populated when
+    /// the whole batch succeeded so [`Self::branch`]'s `symbolic-ref`
+    /// fallback still runs for genuine unborn-HEAD paths.
+    pub fn prewarm_info(&self) -> anyhow::Result<bool> {
+        let output = self.run_command_output(&[
+            "rev-parse",
+            "--is-inside-work-tree",
+            "--show-toplevel",
+            "--git-dir",
+            "--symbolic-full-name",
+            "HEAD",
+        ])?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let mut lines = stdout.lines();
+
+        let is_inside = lines.next().is_some_and(|s| s.trim() == "true");
+
+        // `root` and `git_dir` are safe to cache whenever their lines landed,
+        // because any failure in the batch is from `HEAD` — which is last.
+        if is_inside && let Some(root_raw) = lines.next() {
+            let root = PathBuf::from(root_raw.trim());
+            let root = canonicalize(&root).unwrap_or_else(|_| self.path.clone());
+            self.repo
+                .cache
+                .worktree_roots
+                .entry(self.path.clone())
+                .or_insert(root);
+
+            if let Some(git_dir_raw) = lines.next() {
+                let path = PathBuf::from(git_dir_raw.trim());
+                let absolute = if path.is_relative() {
+                    self.path.join(&path)
+                } else {
+                    path
+                };
+                if let Ok(resolved) = canonicalize(&absolute) {
+                    self.repo
+                        .cache
+                        .git_dirs
+                        .entry(self.path.clone())
+                        .or_insert(resolved);
+                }
+
+                // Only trust the `HEAD` line when the batch as a whole
+                // succeeded. On unborn branches it reads "HEAD" as a fallback
+                // literal, which would be indistinguishable from detached
+                // HEAD without the exit status.
+                if output.status.success()
+                    && let Some(head_raw) = lines.next()
+                {
+                    let branch = head_raw
+                        .trim()
+                        .strip_prefix("refs/heads/")
+                        .map(str::to_owned);
+                    self.repo
+                        .cache
+                        .current_branches
+                        .entry(self.path.clone())
+                        .or_insert(branch);
+                }
+            }
+        }
+
+        Ok(is_inside)
+    }
+
     /// Get the branch checked out in this worktree, or None if in detached HEAD state.
     ///
     /// Result is cached in the repository's shared cache (keyed by worktree path).


### PR DESCRIPTION
## Summary

Alias dispatch was firing four separate `git rev-parse` forks on the worktree path — `--is-inside-work-tree` from `project_config_path`, `--show-toplevel` from `WorkingTree::root`, `--git-dir` from `WorkingTree::git_dir`, and `--symbolic-full-name HEAD` from `WorkingTree::branch`. A user with ~200ms fork cost (#2322) pays ~800ms just for these four probes.

Folds all four selectors into one invocation via a new `WorkingTree::prewarm_info`, which also populates the `worktree_roots`, `git_dirs`, and `current_branches` caches so the later accessors hit cache. `project_config_path` calls `prewarm_info` in place of the solo `--is-inside-work-tree` probe.

## What's batched (and what isn't)

Batched (same `current_dir` = worktree path, all called by the alias fast path):

- `--is-inside-work-tree` — answers `project_config_path`
- `--show-toplevel` — pre-warms `root()`
- `--git-dir` — pre-warms `git_dir()`
- `--symbolic-full-name HEAD` — pre-warms `branch()`

Not batched — different `current_dir` or conditional on earlier results:

- `rev-parse --show-toplevel` run from `.git` (the `repo_path()` submodule probe — being evaluated separately in a sibling PR for #2322)
- `rev-parse --verify refs/heads/<default>` for default-branch resolution
- `rev-parse <ref>` for the `{{ commit }}` template variable

## Fallback behavior

`HEAD` is placed **last** in the argument list. On an unborn branch `rev-parse` aborts processing once it hits the unresolvable ref, but the preceding selectors' stdout still lands — so `root` and `git_dir` are cached even though the command exits 128. The `branch` cache is only populated when `output.status.success()`, preserving `branch()`'s existing `symbolic-ref --short HEAD` fallback for unborn HEAD. Detached HEAD (exit 0, stdout line = `"HEAD"`) caches `None`, matching today's semantics.

## Benchmark

`benches/alias` (healthy system, ~5-6ms/fork). Back-to-back comparison against clean main:

| variant    | before  | after   | delta  |
|------------|---------|---------|--------|
| wt_version |  5.00ms |  4.71ms | noise  |
| warm/1     | 53.3ms  | 43.5ms  | -19.6% |
| warm/100   | 53.4ms  | 43.0ms  | -17.2% |
| cold/1     | 58.7ms  | 48.6ms  | -15.9% |
| cold/100   | 62.1ms  | 49.7ms  | -18.2% |

`wt_version` is unaffected (no repo discovery). On an afflicted ~200ms/fork system, the same 3 saved forks should translate to ~600ms per `wt <alias>`.

Closes part of #2322.

## Test plan

- [x] `cargo run -- hook pre-merge --yes` (3317 tests, lints)
- [x] Manual trace on normal, detached, unborn repos — confirms fallback paths

> _This was written by Claude Code on behalf of max-sixty_