### PR TITLE
fix(repo): honor git's scope rules for core.worktree in repo_path()

### DIFF
--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -80,7 +80,6 @@ use wait_timeout::ChildExt;
 use anyhow::{Context, bail};
 
 use dunce::canonicalize;
-use normalize_path::NormalizePath;
 
 use crate::config::{LoadError, ProjectConfig, ResolvedConfig, UserConfig};
 
@@ -685,15 +684,23 @@ impl Repository {
     /// | git_common_dir location    | Signal                       | Resolution                           |
     /// |----------------------------|------------------------------|--------------------------------------|
     /// | Bare `.git`                | `core.bare = true`           | `git_common_dir` is the repo         |
-    /// | Submodule `.git/modules/X` | `core.worktree` set by git   | join + normalize against common dir  |
+    /// | Submodule `.git/modules/X` | `core.worktree` set by git   | `rev-parse --show-toplevel`          |
     /// | Normal `.git`              | neither set                  | `parent(git_common_dir)`             |
     ///
     /// Submodules need `core.worktree` because their git data lives in the
     /// parent's `.git/modules/`, so the implicit `parent(.git)` rule that
     /// works for normal repos would point at `.git/modules` — wrong. Git
-    /// writes `core.worktree` explicitly to compensate. Reading it from the
-    /// bulk map matches git's own authority for the working tree and avoids
-    /// a `rev-parse --show-toplevel` subprocess on every call.
+    /// writes `core.worktree` explicitly to compensate.
+    ///
+    /// The bulk `git config --list -z` map merges system + global + local
+    /// scope, but git only honors `core.worktree` from **local** (or
+    /// `[includeIf]`-imported) config for worktree discovery — a global
+    /// `core.worktree` would be read into the bulk map yet ignored by
+    /// git itself. So when the bulk map reports `core.worktree`, we delegate
+    /// to `rev-parse --show-toplevel` to let git apply its own scope rules;
+    /// if that fails (non-local value git ignored), we fall through to the
+    /// normal-repo path. The common case — no `core.worktree` anywhere —
+    /// still skips the subprocess, which is the whole point of this path.
     ///
     /// # Errors
     ///
@@ -707,13 +714,19 @@ impl Repository {
                     return Ok(self.git_common_dir.clone());
                 }
 
-                if let Some(worktree) = self.config_last("core.worktree")? {
-                    let path = PathBuf::from(&worktree);
-                    return Ok(if path.is_absolute() {
-                        path
-                    } else {
-                        self.git_common_dir.join(path).normalize()
-                    });
+                // `core.worktree` in the bulk map could come from any scope,
+                // but git only honors the local one. Let git resolve scope
+                // via `rev-parse --show-toplevel` rather than trusting the
+                // merged value ourselves.
+                if self.config_last("core.worktree")?.is_some()
+                    && let Ok(out) = Cmd::new("git")
+                        .args(["rev-parse", "--show-toplevel"])
+                        .current_dir(&self.git_common_dir)
+                        .context(path_to_logging_context(&self.git_common_dir))
+                        .run()
+                    && out.status.success()
+                {
+                    return Ok(PathBuf::from(String::from_utf8_lossy(&out.stdout).trim()));
                 }
 
                 Ok(self

--- a/src/git/repository/tests.rs
+++ b/src/git/repository/tests.rs
@@ -402,34 +402,39 @@ fn repo_path_error_when_is_bare_fails() {
 }
 
 #[test]
-fn repo_path_absolute_core_worktree() {
+fn repo_path_ignores_non_local_core_worktree() {
     use super::RepoCache;
     use indexmap::IndexMap;
     use std::sync::{Arc, RwLock};
 
-    // Git writes `core.worktree` as a relative path for submodules
-    // (`../../../sub`), which the integration test `test_repo_path_in_submodule`
-    // covers. This unit test exercises the absolute-path branch — also legal
-    // per git-config(1) — without needing a filesystem fixture.
+    // Regression test: `git config --list -z` merges system + global + local
+    // scope, but git only honors `core.worktree` from local config. A user
+    // with a stray global `core.worktree` in a normal repo should still see
+    // `parent(.git)` as the repo root — `rev-parse --show-toplevel` fails
+    // from inside `.git` in that case and we fall through.
+    let tmp = tempfile::tempdir().unwrap();
+    let git_dir = tmp.path().join(".git");
+    std::fs::create_dir(&git_dir).unwrap();
+
     let cache = RepoCache::default();
     let mut map: IndexMap<String, Vec<String>> = IndexMap::new();
     map.insert("core.bare".to_string(), vec!["false".to_string()]);
+    // Simulate a `core.worktree` picked up from global config. The path
+    // doesn't have to exist — it only has to be present in the bulk map.
     map.insert(
         "core.worktree".to_string(),
-        vec!["/absolute/worktree".to_string()],
+        vec!["/nonexistent/global/worktree".to_string()],
     );
     cache.all_config.set(RwLock::new(map)).unwrap();
 
     let repo = super::Repository {
-        discovery_path: PathBuf::from("/nonexistent/repo"),
-        git_common_dir: PathBuf::from("/nonexistent/.git/modules/sub"),
+        discovery_path: tmp.path().to_path_buf(),
+        git_common_dir: git_dir.clone(),
         cache: Arc::new(cache),
     };
 
-    assert_eq!(
-        repo.repo_path().unwrap(),
-        std::path::Path::new("/absolute/worktree")
-    );
+    // Should fall through to parent(git_common_dir), ignoring the bulk value.
+    assert_eq!(repo.repo_path().unwrap(), tmp.path());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

#2350 introduced a divergence for a narrow case: normal non-bare repos where a user has set `core.worktree` in global/system config. `git config --list -z` merges scopes into the bulk map, but git itself only honors `core.worktree` from **local** config for worktree discovery — so we'd return (e.g.) a stray global path as the repo root while git would return the actual worktree.

Fix: when the bulk map reports `core.worktree`, delegate to `git rev-parse --show-toplevel` so git applies its own scope rules. The common case (no `core.worktree` anywhere — the vast majority of repos) still skips the subprocess entirely; that was the whole point of #2350. Submodules pay one fork back, matching pre-#2350 behavior for that minority case.

Caught by Codex review of the merged #2350.

## Correctness

Verified against git (all from inside `.git`):

| `core.worktree` scope | `git rev-parse --show-toplevel` | Pre-fix (`#2350`) | Post-fix |
|-----------------------|---------------------------------|-------------------|----------|
| Not set anywhere      | fails → fall through            | `parent(.git)` ✓ | `parent(.git)` ✓ |
| Local (submodule / user-set)  | returns resolved path           | wrong for global; ok for local | matches git ✓ |
| Global only           | fails → git ignores it          | returned global value ❌ | matches git ✓ |

## Tests

- New unit test `repo_path_ignores_non_local_core_worktree` — pre-populates the bulk config cache with a `core.worktree` value but leaves the on-disk `.git/config` empty, so `rev-parse --show-toplevel` fails and we fall through to `parent(.git)`. Simulates the global-only scope case.
- Existing `test_repo_path_in_submodule` integration test still passes (local `core.worktree` in a real submodule).
- All 1023 lib tests and the 4 submodule integration tests pass.

## Performance

No regression for the common case (no `core.worktree` anywhere): still skips the subprocess. Submodules pay one fork — same as pre-#2350.

Ref #2322

> _This was written by Claude Code on behalf of @max-sixty_