### PR TITLE
perf(list): drop unused HashMap allocation in batch_ahead_behind

### DIFF
--- a/src/git/repository/diff.rs
+++ b/src/git/repository/diff.rs
@@ -254,15 +254,15 @@ impl Repository {
         Ok((ahead, behind))
     }
 
-    /// Batch-fetch ahead/behind counts for all local branches vs a base ref.
+    /// Prime `cache.ahead_behind` for all local branches vs a base ref.
     ///
     /// Uses `git for-each-ref --format='%(ahead-behind:BASE)'` (git 2.36+) to
-    /// get all counts in a single command, priming `cache.ahead_behind` so
-    /// subsequent `ahead_behind()` calls hit the cache.
+    /// compute all counts in a single command, so subsequent `ahead_behind()`
+    /// calls hit the cache.
     ///
-    /// On git < 2.36 or if the command fails, returns an empty map (and
-    /// `ahead_behind()` falls back to per-branch computation).
-    pub fn batch_ahead_behind(&self, base: &str) -> HashMap<String, (usize, usize)> {
+    /// On git < 2.36 or if the command fails, this is a no-op and
+    /// `ahead_behind()` falls back to per-branch computation.
+    pub fn batch_ahead_behind(&self, base: &str) {
         let format = format!("%(refname:lstrip=2) %(ahead-behind:{})", base);
         let output = match self.run_command(&[
             "for-each-ref",
@@ -273,27 +273,25 @@ impl Repository {
             Err(e) => {
                 // Fails on git < 2.36 (no %(ahead-behind:) support), invalid base ref, etc.
                 log::debug!("batch_ahead_behind({base}): git for-each-ref failed: {e}");
-                return HashMap::new();
+                return;
             }
         };
 
-        let results: HashMap<String, (usize, usize)> = output
+        output
             .lines()
             .filter_map(|line| {
                 // Format: "branch-name ahead behind"
                 let mut parts = line.rsplitn(3, ' ');
                 let behind: usize = parts.next()?.parse().ok()?;
                 let ahead: usize = parts.next()?.parse().ok()?;
-                let branch = parts.next()?.to_string();
-                // Cache each result for later lookup
+                let branch = parts.next()?;
+                Some((branch, ahead, behind))
+            })
+            .for_each(|(branch, ahead, behind)| {
                 self.cache
                     .ahead_behind
-                    .insert((base.to_string(), branch.clone()), (ahead, behind));
-                Some((branch, (ahead, behind)))
-            })
-            .collect();
-
-        results
+                    .insert((base.to_string(), branch.to_string()), (ahead, behind));
+            });
     }
 
     /// Get line diff statistics between two refs.

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -234,7 +234,7 @@ pub(super) struct RepoCache {
     /// Ahead/behind cache: (base_ref, head) -> (ahead, behind).
     /// Primed in bulk by `batch_ahead_behind()`; populated on demand by
     /// `ahead_behind()` for keys the batch didn't cover (e.g., HEAD SHAs
-    /// during rebase/merge, or git < 2.36 where the batch returns empty).
+    /// during rebase/merge, or git < 2.36 where the batch is a no-op).
     pub(super) ahead_behind: DashMap<(String, String), (usize, usize)>,
     /// Effective remote URLs: remote_name -> effective URL (with `url.insteadOf` applied).
     /// Separate from `all_config` because `git remote get-url` applies


### PR DESCRIPTION
#2347 (v0.43.0) collapsed `cached_ahead_behind` into `ahead_behind()`, leaving `batch_ahead_behind()` with a single caller in `src/commands/list/collect/mod.rs` that discards the return value. The function's real job is priming `cache.ahead_behind`; the returned `HashMap<String, (usize, usize)>` was dead work.

Returning `()` and dropping the `.collect::<HashMap<_, _>>()` saves an O(branches) allocation on every `wt list`, which is on the skeleton-first hot path (target: <60ms to skeleton). Doc comments updated to make the cache-priming contract explicit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)