### PR TITLE
refactor(repo): filter Branch::remotes() over the shared remote-branch inventory

### DIFF
--- a/src/git/repository/branch.rs
+++ b/src/git/repository/branch.rs
@@ -66,28 +66,20 @@ impl<'a> Branch<'a> {
     ///
     /// Returns a list of remote names that have this branch (e.g., `["origin"]`).
     /// Returns an empty list if no remotes have this branch.
+    ///
+    /// Filters the repository's remote-branch inventory (see
+    /// [`Repository::remote_branches`]); the first call within a command
+    /// triggers the `refs/remotes/` scan that populates the inventory.
+    ///
+    /// [`Repository::remote_branches`]: super::Repository::remote_branches
     pub fn remotes(&self) -> anyhow::Result<Vec<String>> {
-        // Get all remote tracking branches matching this name
-        // Format: refs/remotes/<remote>/<branch>
-        let output = self.repo.run_command(&[
-            "for-each-ref",
-            "--format=%(refname:strip=2)",
-            &format!("refs/remotes/*/{}", self.name),
-        ])?;
-
-        // Parse output: each line is "<remote>/<branch>"
-        // Extract the remote name (everything before the last /<branch>)
-        let suffix = format!("/{}", self.name);
-        let remotes: Vec<String> = output
-            .lines()
-            .filter_map(|line| {
-                let line = line.trim();
-                // Strip the branch suffix to get the remote name
-                line.strip_suffix(&suffix).map(String::from)
-            })
-            .collect();
-
-        Ok(remotes)
+        Ok(self
+            .repo
+            .remote_branches()?
+            .iter()
+            .filter(|r| r.local_name == self.name)
+            .map(|r| r.remote_name.clone())
+            .collect())
     }
 
     /// Get the upstream tracking branch for this branch.


### PR DESCRIPTION
Drops the per-call `git for-each-ref refs/remotes/*/<name>` subprocess in `Branch::remotes()` and replaces it with an in-memory filter over `Repository::remote_branches()`. The inventory was introduced in #2368; this is follow-up #1 — the one accessor left outside the consolidation.

On `wt switch <branch>` for a remote-only branch, the old code spawned a duplicate `refs/remotes/` scan after the inventory scan had already run. After this change there is one canonical `for-each-ref refs/remotes/` per Repository, shared by every caller.

### Behavioral note

When multiple remotes have the same branch, `remotes()[0]` now reflects the inventory's committer-timestamp-desc order rather than git's alphabetical default. The only affected sites are informational — the remote name shown in a warning at `switch.rs:417` and the `RemoteOnlyBranch` error at `repository_ext.rs:156`. No correctness impact, and nearly all users have a single remote.