### PR TITLE
perf(switch): strip remote prefix via inventory instead of two subprocesses

### DIFF
--- a/src/git/repository/remotes.rs
+++ b/src/git/repository/remotes.rs
@@ -332,27 +332,12 @@ impl Repository {
     /// if it's a valid remote-tracking ref. Returns `None` if the name isn't a remote ref
     /// or the remote can't be identified.
     ///
-    /// This handles remote names that don't contain `/` (the common case). It lists
-    /// all configured remotes and finds the one that matches the prefix.
-    ///
-    /// TODO: A cleaner approach would be to strip the prefix upstream — either have
-    /// `list_remote_branches()` return `(remote, local_branch, sha)` tuples, or track
-    /// `is_remote` on `ListItem` so the picker outputs just the local branch name.
-    /// Either would eliminate this runtime `git remote` call. See #1260.
+    /// Resolved from the remote-branch inventory — no subprocess calls once it's populated.
     pub fn strip_remote_prefix(&self, ref_name: &str) -> Option<String> {
-        // Quick check: is this actually a remote-tracking ref?
-        if !self.is_remote_tracking_branch(ref_name) {
-            return None;
-        }
-
-        // List all remotes and find the one that is a prefix of ref_name
-        let output = self.run_command(&["remote"]).ok()?;
-        output.lines().find_map(|remote| {
-            let prefix = format!("{}/", remote.trim());
-            ref_name
-                .strip_prefix(&prefix)
-                .filter(|branch| !branch.is_empty())
-                .map(|branch| branch.to_string())
-        })
+        self.remote_branches()
+            .ok()?
+            .iter()
+            .find(|r| r.short_name == ref_name)
+            .map(|r| r.local_name.clone())
     }
 }


### PR DESCRIPTION
`Repository::strip_remote_prefix` ran `git rev-parse --verify refs/remotes/<ref>` followed by `git remote` every call — two subprocesses to satisfy `wt switch origin/<branch>` in the picker path. The remote-branch inventory from #2368 already splits each ref into `short_name`/`remote_name`/`local_name`, so the lookup collapses to a direct search in the cached slice. The adjacent TODO that was explicitly waiting on this inventory shape is satisfied and removed.

Behavioral equivalence holds on every realistic input: local branch names and SHAs still return `None` (not in the inventory), and non-existent refs under an existing remote prefix still return `None`. The one subtle change is that `origin/HEAD` now returns `None` instead of `Some("HEAD")` — `parse_remote_branch_line` drops the symref. The switch call site would have mishandled `"HEAD"` as a branch name anyway, so this is a correctness improvement.