### PR TITLE
test(pty): raise prompt-marker timeout to 30s for parallel-load headroom

### DIFF
--- a/tests/common/pty.rs
+++ b/tests/common/pty.rs
@@ -301,7 +301,7 @@ fn prompted_pty_interaction(
 
     let mut accumulated = Vec::new();
     let mut writer = writer;
-    let timeout = Duration::from_secs(10);
+    let timeout = Duration::from_secs(30);
     let poll = Duration::from_millis(10);
     let marker = prompt_marker.as_bytes();
 


### PR DESCRIPTION
The 10s ceiling in `prompted_pty_interaction` tripped ~10 `approval_pty::*` tests under full-suite nextest parallelism (3325 tests). The tests pass instantly in isolation — they were racing the scheduler, not broken.

30s matches the `tests/CLAUDE.md` "long timeouts with fast polling" convention used by the `wait_for_file` helpers. Polling stays at 10ms, so isolated runs are unchanged; only the pathological slow case waits longer before panicking.

Verified with `cargo run -- hook pre-merge --yes` — 3325 tests pass.

> _This was written by Claude Code on behalf of Maximilian Roos_