### PR TITLE
perf(repo): resolve is_remote_tracking_branch via cached inventory

### DIFF
--- a/src/git/repository/remotes.rs
+++ b/src/git/repository/remotes.rs
@@ -315,15 +315,17 @@ impl Repository {
 
     /// Check if a ref is a remote tracking branch.
     ///
-    /// Returns true if the ref exists under `refs/remotes/` (e.g., `origin/main`).
-    /// Returns false for local branches, tags, SHAs, and non-existent refs.
+    /// Returns true if the ref appears in the remote-branch inventory
+    /// (e.g., `origin/main`). Returns false for local branches, tags, SHAs,
+    /// non-existent refs, and `<remote>/HEAD` symrefs (which the inventory
+    /// excludes).
+    ///
+    /// Resolved from the remote-branch inventory — no subprocess calls once
+    /// it's populated.
     pub fn is_remote_tracking_branch(&self, ref_name: &str) -> bool {
-        self.run_command(&[
-            "rev-parse",
-            "--verify",
-            &format!("refs/remotes/{}", ref_name),
-        ])
-        .is_ok()
+        self.remote_branches()
+            .ok()
+            .is_some_and(|branches| branches.iter().any(|r| r.short_name == ref_name))
     }
 
     /// Strip the remote prefix from a remote-tracking branch name.


### PR DESCRIPTION
Drops the `git rev-parse --verify refs/remotes/<ref>` subprocess in favor of a lookup against the `Repository::remote_branches()` inventory already populated by a single `for-each-ref` scan per Repository lifetime.

Mirrors the cutover #2372 did for `strip_remote_prefix`. Sole caller is `wt switch --create feature <base>`'s safety check that decides whether to unset the auto-assigned upstream on the new branch (so `git push` doesn't push to `main`).

Minor behavioural divergence: `<remote>/HEAD` symrefs now return `false` because the inventory excludes them. The call site receives user-supplied base branches (e.g. `origin/main`), not `origin/HEAD`, so this is benign in practice.

> _This was written by Claude Code on behalf of Maximilian_