### PR TITLE
refactor(git): store full refs in BranchRef, not short name + is_remote

### DIFF
--- a/src/commands/list/ci_status/mod.rs
+++ b/src/commands/list/ci_status/mod.rs
@@ -41,7 +41,7 @@ impl CiBranchName {
     /// For local branches, the name is already bare.
     ///
     /// The `is_remote` flag should come from an authoritative source:
-    /// - `BranchRef::is_remote` (from collection phase)
+    /// - `BranchRef::is_remote()` (from collection phase)
     /// - `git show-ref --verify refs/remotes/<branch>` (for CLI input)
     pub fn from_branch_ref(branch: &str, is_remote: bool) -> Self {
         if is_remote {

--- a/src/commands/list/collect/tasks.rs
+++ b/src/commands/list/collect/tasks.rs
@@ -68,7 +68,7 @@ impl TaskContext {
             let kind_str: &'static str = kind.into();
             let sha = &self.branch_ref.commit_sha;
             let short_sha = &sha[..sha.len().min(8)];
-            let branch = self.branch_ref.branch.as_deref().unwrap_or(short_sha);
+            let branch = self.branch_ref.short_name().unwrap_or(short_sha);
             log::debug!("Task {} timed out for {}", kind_str, branch);
             ErrorCause::Timeout
         } else {
@@ -181,10 +181,10 @@ impl Task for AheadBehindTask {
         // keeps both paths consistent.
         let head = ctx
             .branch_ref
-            .integration_ref()
-            .unwrap_or_else(|| ctx.branch_ref.commit_sha.clone());
+            .full_ref()
+            .unwrap_or(&ctx.branch_ref.commit_sha);
         let (ahead, behind) = repo
-            .ahead_behind(&base, &head)
+            .ahead_behind(&base, head)
             .map_err(|e| ctx.error(Self::KIND, &e))?;
 
         Ok(TaskResult::AheadBehind {
@@ -218,10 +218,10 @@ impl Task for CommittedTreesMatchTask {
         // equivalent; for detached HEAD, commit_sha is the only option.
         let ref_to_check = ctx
             .branch_ref
-            .integration_ref()
-            .unwrap_or_else(|| ctx.branch_ref.commit_sha.clone());
+            .full_ref()
+            .unwrap_or(&ctx.branch_ref.commit_sha);
         let committed_trees_match = repo
-            .trees_match(&ref_to_check, &base)
+            .trees_match(ref_to_check, &base)
             .map_err(|e| ctx.error(Self::KIND, &e))?;
         Ok(TaskResult::CommittedTreesMatch {
             item_idx: ctx.item_idx,
@@ -248,7 +248,7 @@ impl Task for HasFileChangesTask {
 
     fn compute(ctx: TaskContext) -> Result<TaskResult, TaskError> {
         // No branch name (detached HEAD) - return conservative default (assume has changes)
-        let Some(branch) = ctx.branch_ref.integration_ref() else {
+        let Some(branch) = ctx.branch_ref.full_ref() else {
             return Ok(TaskResult::HasFileChanges {
                 item_idx: ctx.item_idx,
                 has_file_changes: true,
@@ -263,7 +263,7 @@ impl Task for HasFileChangesTask {
         };
         let repo = &ctx.repo;
         let has_file_changes = repo
-            .has_added_changes(&branch, &target)
+            .has_added_changes(branch, &target)
             .map_err(|e| ctx.error(Self::KIND, &e))?;
 
         Ok(TaskResult::HasFileChanges {
@@ -295,7 +295,7 @@ impl Task for WouldMergeAddTask {
 
     fn compute(ctx: TaskContext) -> Result<TaskResult, TaskError> {
         // No branch name (detached HEAD) - return conservative default (assume would add)
-        let Some(branch) = ctx.branch_ref.integration_ref() else {
+        let Some(branch) = ctx.branch_ref.full_ref() else {
             return Ok(TaskResult::WouldMergeAdd {
                 item_idx: ctx.item_idx,
                 would_merge_add: true,
@@ -312,7 +312,7 @@ impl Task for WouldMergeAddTask {
         };
         let probe = ctx
             .repo
-            .merge_integration_probe(&branch, &base)
+            .merge_integration_probe(branch, &base)
             .map_err(|e| ctx.error(Self::KIND, &e))?;
         Ok(TaskResult::WouldMergeAdd {
             item_idx: ctx.item_idx,
@@ -348,10 +348,10 @@ impl Task for IsAncestorTask {
         // for rationale (rebase-in-progress transient HEAD).
         let ref_to_check = ctx
             .branch_ref
-            .integration_ref()
-            .unwrap_or_else(|| ctx.branch_ref.commit_sha.clone());
+            .full_ref()
+            .unwrap_or(&ctx.branch_ref.commit_sha);
         let is_ancestor = repo
-            .is_ancestor(&ref_to_check, &base)
+            .is_ancestor(ref_to_check, &base)
             .map_err(|e| ctx.error(Self::KIND, &e))?;
 
         Ok(TaskResult::IsAncestor {
@@ -380,10 +380,10 @@ impl Task for BranchDiffTask {
         // for rationale (rebase-in-progress transient HEAD).
         let ref_to_check = ctx
             .branch_ref
-            .integration_ref()
-            .unwrap_or_else(|| ctx.branch_ref.commit_sha.clone());
+            .full_ref()
+            .unwrap_or(&ctx.branch_ref.commit_sha);
         let diff = repo
-            .branch_diff_stats(&base, &ref_to_check)
+            .branch_diff_stats(&base, ref_to_check)
             .map_err(|e| ctx.error(Self::KIND, &e))?;
 
         Ok(TaskResult::BranchDiff {
@@ -456,10 +456,10 @@ impl Task for MergeTreeConflictsTask {
         // for rationale (rebase-in-progress transient HEAD).
         let ref_to_check = ctx
             .branch_ref
-            .integration_ref()
-            .unwrap_or_else(|| ctx.branch_ref.commit_sha.clone());
+            .full_ref()
+            .unwrap_or(&ctx.branch_ref.commit_sha);
         let has_merge_tree_conflicts = repo
-            .has_merge_conflicts(&base, &ref_to_check)
+            .has_merge_conflicts(&base, ref_to_check)
             .map_err(|e| ctx.error(Self::KIND, &e))?;
         Ok(TaskResult::MergeTreeConflicts {
             item_idx: ctx.item_idx,
@@ -627,7 +627,7 @@ impl Task for UserMarkerTask {
 
     fn compute(ctx: TaskContext) -> Result<TaskResult, TaskError> {
         let repo = &ctx.repo;
-        let user_marker = repo.user_marker(ctx.branch_ref.branch.as_deref());
+        let user_marker = repo.user_marker(ctx.branch_ref.short_name());
         Ok(TaskResult::UserMarker {
             item_idx: ctx.item_idx,
             user_marker,
@@ -645,7 +645,7 @@ impl Task for UpstreamTask {
         let repo = &ctx.repo;
 
         // No branch means no upstream
-        let Some(branch) = ctx.branch_ref.branch.as_deref() else {
+        let Some(branch) = ctx.branch_ref.short_name() else {
             return Ok(TaskResult::Upstream {
                 item_idx: ctx.item_idx,
                 upstream: UpstreamStatus::default(),
@@ -696,10 +696,10 @@ impl Task for CiStatusTask {
 
     fn compute(ctx: TaskContext) -> Result<TaskResult, TaskError> {
         let repo = &ctx.repo;
-        let pr_status = ctx.branch_ref.branch.as_deref().and_then(|branch| {
+        let pr_status = ctx.branch_ref.short_name().and_then(|branch| {
             // Use from_branch_ref with the authoritative is_remote flag
             // rather than guessing from the branch name
-            let ci_branch = CiBranchName::from_branch_ref(branch, ctx.branch_ref.is_remote);
+            let ci_branch = CiBranchName::from_branch_ref(branch, ctx.branch_ref.is_remote());
             PrStatus::detect(repo, &ci_branch, &ctx.branch_ref.commit_sha)
         });
 
@@ -765,7 +765,7 @@ impl Task for SummaryGenerateTask {
             ));
         };
 
-        let branch = ctx.branch_ref.branch.as_deref().unwrap_or("(detached)");
+        let branch = ctx.branch_ref.short_name().unwrap_or("(detached)");
         let worktree_path = ctx.branch_ref.worktree_path.as_deref();
 
         let summary = crate::summary::generate_summary_core(

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -414,43 +414,42 @@ pub enum HookType {
 /// which returns `Some(WorkingTree)` only when this ref has a worktree path.
 #[derive(Debug, Clone)]
 pub struct BranchRef {
-    /// Branch name (e.g., "main", "feature/auth", "origin/feature").
-    /// None for detached HEAD.
-    pub branch: Option<String>,
+    /// Full git ref (e.g., `refs/heads/feature`, `refs/remotes/origin/feature`).
+    /// `None` for detached HEAD.
+    ///
+    /// Storing the full ref — rather than a short name plus a remote/local
+    /// flag — makes the ref unambiguous: git lets users create a local branch
+    /// literally named `origin/foo`, and `git rev-parse origin/foo` then picks
+    /// `refs/heads/origin/foo` over `refs/remotes/origin/foo`. With the full
+    /// ref there is nothing to disambiguate.
+    pub full_ref: Option<String>,
     /// Commit SHA this branch/worktree points to.
     pub commit_sha: String,
     /// Path to worktree, if this branch has one.
     /// None for branch-only items (remote branches, local branches without worktrees).
     pub worktree_path: Option<PathBuf>,
-    /// True if this is a remote-tracking ref (e.g., "origin/feature").
-    /// Remote branches inherently exist on the remote and don't need push config.
-    // TODO(full-refs): Consider refactoring to store full refs (e.g., "refs/remotes/origin/feature"
-    // or "refs/heads/feature") instead of short names + is_remote flag. Full refs are self-describing
-    // and unambiguous, but would require changes throughout the codebase and user input resolution.
-    pub is_remote: bool,
 }
 
 impl BranchRef {
     /// Create a BranchRef for a local branch without a worktree.
     pub fn local_branch(branch: &str, commit_sha: &str) -> Self {
         Self {
-            branch: Some(branch.to_string()),
+            full_ref: Some(format!("refs/heads/{branch}")),
             commit_sha: commit_sha.to_string(),
             worktree_path: None,
-            is_remote: false,
         }
     }
 
     /// Create a BranchRef for a remote-tracking branch.
     ///
-    /// Remote branches (e.g., "origin/feature") are refs under refs/remotes/.
-    /// They inherently exist on the remote and don't need upstream tracking config.
+    /// `branch` is the short remote-qualified name (e.g., `"origin/feature"`),
+    /// as produced by `%(refname:lstrip=2)` in `list_remote_branches`. It is
+    /// stored as `refs/remotes/<branch>`.
     pub fn remote_branch(branch: &str, commit_sha: &str) -> Self {
         Self {
-            branch: Some(branch.to_string()),
+            full_ref: Some(format!("refs/remotes/{branch}")),
             commit_sha: commit_sha.to_string(),
             worktree_path: None,
-            is_remote: true,
         }
     }
 
@@ -469,37 +468,58 @@ impl BranchRef {
         self.worktree_path.is_some()
     }
 
-    /// Git ref string suitable for passing to integration helpers.
+    /// Full git ref (e.g., `refs/heads/feature`, `refs/remotes/origin/feature`),
+    /// suitable for passing to integration helpers that go through `git rev-parse`.
     ///
-    /// Remote branches are stored as short names like `origin/foo` (from
-    /// `%(refname:lstrip=2)` in `list_remote_branches`). Git allows local
-    /// branches literally named `origin/foo`, so passing the short form to
-    /// `git rev-parse` resolves to `refs/heads/origin/foo` — the local — and
-    /// the remote row silently computes stats against the wrong ref.
+    /// Returns `None` for detached HEAD.
+    pub fn full_ref(&self) -> Option<&str> {
+        self.full_ref.as_deref()
+    }
+
+    /// Short display name (e.g., `feature`, `origin/feature`) with the
+    /// `refs/heads/` or `refs/remotes/` prefix stripped. Use for user-facing
+    /// output and APIs that expect short names (`git config branch.<name>.*`,
+    /// `gh pr view <branch>`).
     ///
-    /// Qualifying the remote case to `refs/remotes/<name>` makes the ref
-    /// unambiguous; local branches keep the short form so
-    /// `resolve_preferring_branch` can still promote them over same-named
-    /// tags.
+    /// Returns `None` for detached HEAD.
     ///
-    /// Returns `None` for detached HEAD (no branch name).
-    pub fn integration_ref(&self) -> Option<String> {
-        let name = self.branch.as_deref()?;
-        Some(if self.is_remote {
-            format!("refs/remotes/{name}")
-        } else {
-            name.to_string()
-        })
+    /// # Panics
+    ///
+    /// Every constructor on this type produces a `full_ref` starting with
+    /// `refs/heads/` or `refs/remotes/`; this panics if that invariant is
+    /// ever violated (e.g., by a future struct-literal caller). The panic
+    /// is the intended behavior — silently returning an unqualified ref
+    /// would re-open the shadowing class of bug this type exists to rule out.
+    pub fn short_name(&self) -> Option<&str> {
+        let r = self.full_ref.as_deref()?;
+        Some(
+            r.strip_prefix("refs/heads/")
+                .or_else(|| r.strip_prefix("refs/remotes/"))
+                .expect("BranchRef.full_ref must start with refs/heads/ or refs/remotes/"),
+        )
+    }
+
+    /// True if this is a remote-tracking ref (under `refs/remotes/`).
+    pub fn is_remote(&self) -> bool {
+        self.full_ref
+            .as_deref()
+            .is_some_and(|r| r.starts_with("refs/remotes/"))
     }
 }
 
 impl From<&WorktreeInfo> for BranchRef {
     fn from(wt: &WorktreeInfo) -> Self {
+        // `WorktreeInfo.branch` is the short form produced by
+        // `parse_porcelain_list` (one `refs/heads/` prefix stripped). Worktrees
+        // always point at local branches, so re-qualifying with `refs/heads/`
+        // gives the full ref. Note: git permits a branch literally named
+        // `refs/heads/foo`; in that case `wt.branch == "refs/heads/foo"` and
+        // this produces `refs/heads/refs/heads/foo` — which is the correct full
+        // ref for that pathological branch, so we don't special-case it.
         Self {
-            branch: wt.branch.clone(),
+            full_ref: wt.branch.as_deref().map(|b| format!("refs/heads/{b}")),
             commit_sha: wt.head.clone(),
             worktree_path: Some(wt.path.clone()),
-            is_remote: false, // Worktrees are always local
         }
     }
 }
@@ -794,61 +814,72 @@ mod tests {
 
         let branch_ref = BranchRef::from(&wt);
 
-        assert_eq!(branch_ref.branch, Some("feature".to_string()));
+        assert_eq!(branch_ref.full_ref(), Some("refs/heads/feature"));
+        assert_eq!(branch_ref.short_name(), Some("feature"));
         assert_eq!(branch_ref.commit_sha, "abc123");
         assert_eq!(
             branch_ref.worktree_path,
             Some(PathBuf::from("/repo.feature"))
         );
         assert!(branch_ref.has_worktree());
-        assert!(!branch_ref.is_remote); // Worktrees are always local
+        assert!(!branch_ref.is_remote()); // Worktrees are always local
     }
 
     #[test]
     fn test_branch_ref_local_branch() {
         let branch_ref = BranchRef::local_branch("feature", "abc123");
 
-        assert_eq!(branch_ref.branch, Some("feature".to_string()));
+        assert_eq!(branch_ref.full_ref(), Some("refs/heads/feature"));
+        assert_eq!(branch_ref.short_name(), Some("feature"));
         assert_eq!(branch_ref.commit_sha, "abc123");
         assert_eq!(branch_ref.worktree_path, None);
         assert!(!branch_ref.has_worktree());
-        assert!(!branch_ref.is_remote);
+        assert!(!branch_ref.is_remote());
     }
 
     #[test]
     fn test_branch_ref_remote_branch() {
         let branch_ref = BranchRef::remote_branch("origin/feature", "abc123");
 
-        assert_eq!(branch_ref.branch, Some("origin/feature".to_string()));
+        assert_eq!(branch_ref.full_ref(), Some("refs/remotes/origin/feature"));
+        assert_eq!(branch_ref.short_name(), Some("origin/feature"));
         assert_eq!(branch_ref.commit_sha, "abc123");
         assert_eq!(branch_ref.worktree_path, None);
         assert!(!branch_ref.has_worktree());
-        assert!(branch_ref.is_remote);
+        assert!(branch_ref.is_remote());
     }
 
     #[test]
-    fn test_branch_ref_integration_ref() {
-        // Remote branches qualify to refs/remotes/ so they don't get shadowed
-        // by a same-named local branch (git allows local branches literally
-        // named `origin/foo`).
-        assert_eq!(
-            BranchRef::remote_branch("origin/foo", "abc").integration_ref(),
-            Some("refs/remotes/origin/foo".to_string())
-        );
-        // Local branches keep the short form so `resolve_preferring_branch`
-        // can still promote them over same-named tags.
-        assert_eq!(
-            BranchRef::local_branch("feature", "abc").integration_ref(),
-            Some("feature".to_string())
-        );
-        // Detached HEAD has no branch name — caller falls back to commit_sha.
+    fn test_branch_ref_full_ref_disambiguates_remote_from_local() {
+        // Git allows local branches literally named `origin/foo`. Full refs
+        // make the two distinguishable even though they share a short name.
+        //
+        // This pins the type-level contract; the end-to-end guardrail against
+        // `git rev-parse` picking the wrong ref lives at
+        // `test_list_remote_row_not_shadowed_by_same_named_local_branch` in
+        // `tests/integration_tests/list.rs`.
+        let remote = BranchRef::remote_branch("origin/foo", "abc");
+        let local = BranchRef::local_branch("origin/foo", "def");
+
+        assert_eq!(remote.full_ref(), Some("refs/remotes/origin/foo"));
+        assert_eq!(local.full_ref(), Some("refs/heads/origin/foo"));
+        assert_eq!(remote.short_name(), Some("origin/foo"));
+        assert_eq!(local.short_name(), Some("origin/foo"));
+        assert!(remote.is_remote());
+        assert!(!local.is_remote());
+    }
+
+    #[test]
+    fn test_branch_ref_detached_has_no_ref() {
+        // Detached HEAD has no branch name — callers fall back to commit_sha.
         let detached = BranchRef {
-            branch: None,
+            full_ref: None,
             commit_sha: "abc".into(),
             worktree_path: None,
-            is_remote: false,
         };
-        assert_eq!(detached.integration_ref(), None);
+        assert_eq!(detached.full_ref(), None);
+        assert_eq!(detached.short_name(), None);
+        assert!(!detached.is_remote());
     }
 
     #[test]
@@ -1029,7 +1060,8 @@ mod tests {
 
         let branch_ref = BranchRef::from(&wt);
 
-        assert_eq!(branch_ref.branch, None);
+        assert_eq!(branch_ref.full_ref(), None);
+        assert_eq!(branch_ref.short_name(), None);
         assert_eq!(branch_ref.commit_sha, "def456");
         assert!(branch_ref.has_worktree());
     }

--- a/src/git/repository/diff.rs
+++ b/src/git/repository/diff.rs
@@ -263,7 +263,12 @@ impl Repository {
     /// On git < 2.36 or if the command fails, this is a no-op and
     /// `ahead_behind()` falls back to per-branch computation.
     pub fn batch_ahead_behind(&self, base: &str) {
-        let format = format!("%(refname:lstrip=2) %(ahead-behind:{})", base);
+        // Uses `%(refname)` (full ref) rather than `%(refname:lstrip=2)` so the
+        // cache key matches what `AheadBehindTask` queries — that task passes
+        // `BranchRef::full_ref()` (e.g., `refs/heads/feature`). Keying by short
+        // names would force every row to miss the batch cache and fall back to
+        // per-branch `rev-list --count`.
+        let format = format!("%(refname) %(ahead-behind:{})", base);
         let output = match self.run_command(&[
             "for-each-ref",
             &format!("--format={}", format),
@@ -280,17 +285,17 @@ impl Repository {
         output
             .lines()
             .filter_map(|line| {
-                // Format: "branch-name ahead behind"
+                // Format: "refs/heads/branch-name ahead behind"
                 let mut parts = line.rsplitn(3, ' ');
                 let behind: usize = parts.next()?.parse().ok()?;
                 let ahead: usize = parts.next()?.parse().ok()?;
-                let branch = parts.next()?;
-                Some((branch, ahead, behind))
+                let full_ref = parts.next()?;
+                Some((full_ref, ahead, behind))
             })
-            .for_each(|(branch, ahead, behind)| {
+            .for_each(|(full_ref, ahead, behind)| {
                 self.cache
                     .ahead_behind
-                    .insert((base.to_string(), branch.to_string()), (ahead, behind));
+                    .insert((base.to_string(), full_ref.to_string()), (ahead, behind));
             });
     }
 
@@ -384,5 +389,46 @@ impl Repository {
             .ok()
             .map(|output| DiffStats::from_shortstat(&output).format_summary())
             .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::git::Repository;
+    use crate::testing::TestRepo;
+
+    #[test]
+    fn batch_ahead_behind_keys_cache_by_full_ref() {
+        // Callers in `wt list` pass `BranchRef::full_ref()` (`refs/heads/<name>`)
+        // into `ahead_behind`. This test pins the batch cache to the same key
+        // shape — short-name keys would force every row to miss the batch and
+        // fall back to per-branch `rev-list --count`.
+        let test = TestRepo::with_initial_commit();
+        let repo = Repository::at(test.path()).unwrap();
+
+        test.create_branch("feature");
+        test.run_git(&["checkout", "feature"]);
+        std::fs::write(test.path().join("f.txt"), "x").unwrap();
+        test.run_git(&["add", "."]);
+        test.run_git(&["commit", "-m", "feature"]);
+        test.run_git(&["checkout", "main"]);
+
+        repo.batch_ahead_behind("main");
+
+        assert_eq!(
+            repo.cache
+                .ahead_behind
+                .get(&("main".to_string(), "refs/heads/feature".to_string()))
+                .map(|v| *v),
+            Some((1, 0)),
+            "batch must prime cache under the full ref key"
+        );
+        assert!(
+            repo.cache
+                .ahead_behind
+                .get(&("main".to_string(), "feature".to_string()))
+                .is_none(),
+            "short-name key must not be used",
+        );
     }
 }

--- a/src/git/repository/integration.rs
+++ b/src/git/repository/integration.rs
@@ -50,14 +50,34 @@ impl Repository {
             .clone()
     }
 
+    /// Resolve a ref for integration helpers — passthrough for already-qualified
+    /// refs, branch-preferring resolution for short names.
+    ///
+    /// Inputs starting with `refs/` (e.g., from `BranchRef::full_ref()`) are
+    /// returned unchanged: they're already unambiguous, and re-qualifying would
+    /// either (a) waste a `rev-parse` in the common case, or (b) pick the wrong
+    /// ref when a branch literally named e.g. `refs/heads/foo` exists — the
+    /// caller gave us `refs/heads/foo` meaning the branch `foo`, not the
+    /// pathological branch at `refs/heads/refs/heads/foo`.
+    ///
+    /// Short names go through `resolve_preferring_branch` so its
+    /// branch-over-tag disambiguation still applies to user/CLI input.
+    fn resolve_ref(&self, r: &str) -> String {
+        if r.starts_with("refs/") {
+            r.to_string()
+        } else {
+            self.resolve_preferring_branch(r)
+        }
+    }
+
     /// Check if base is an ancestor of head (i.e., would be a fast-forward).
     ///
     /// See [`--is-ancestor`][1] for details.
     ///
     /// [1]: https://git-scm.com/docs/git-merge-base#Documentation/git-merge-base.txt---is-ancestor
     pub fn is_ancestor(&self, base: &str, head: &str) -> anyhow::Result<bool> {
-        let base = self.resolve_preferring_branch(base);
-        let head = self.resolve_preferring_branch(head);
+        let base = self.resolve_ref(base);
+        let head = self.resolve_ref(head);
 
         let base_sha = self.rev_parse_commit(&base)?;
         let head_sha = self.rev_parse_commit(&head)?;
@@ -74,8 +94,8 @@ impl Repository {
 
     /// Check if two refs point to the same commit.
     pub fn same_commit(&self, ref1: &str, ref2: &str) -> anyhow::Result<bool> {
-        let ref1 = self.resolve_preferring_branch(ref1);
-        let ref2 = self.resolve_preferring_branch(ref2);
+        let ref1 = self.resolve_ref(ref1);
+        let ref2 = self.resolve_ref(ref2);
         // Parse both refs in a single git command
         let output = self.run_command(&["rev-parse", &ref1, &ref2])?;
         let mut lines = output.lines();
@@ -95,8 +115,8 @@ impl Repository {
     /// For orphan branches (no common ancestor with target), returns true since all
     /// their changes are unique.
     pub fn has_added_changes(&self, branch: &str, target: &str) -> anyhow::Result<bool> {
-        let branch = self.resolve_preferring_branch(branch);
-        let target = self.resolve_preferring_branch(target);
+        let branch = self.resolve_ref(branch);
+        let target = self.resolve_ref(target);
 
         let branch_sha = self.rev_parse_commit(&branch)?;
         let target_sha = self.rev_parse_commit(&target)?;
@@ -124,8 +144,8 @@ impl Repository {
     /// Useful for detecting squash merges or rebases where the content has been
     /// integrated but commit ancestry doesn't show the relationship.
     pub fn trees_match(&self, ref1: &str, ref2: &str) -> anyhow::Result<bool> {
-        let ref1 = self.resolve_preferring_branch(ref1);
-        let ref2 = self.resolve_preferring_branch(ref2);
+        let ref1 = self.resolve_ref(ref1);
+        let ref2 = self.resolve_ref(ref2);
         // Parse both tree refs in a single git command
         let output = self.run_command(&[
             "rev-parse",
@@ -161,8 +181,8 @@ impl Repository {
     /// # Ok::<(), anyhow::Error>(())
     /// ```
     pub fn has_merge_conflicts(&self, base: &str, head: &str) -> anyhow::Result<bool> {
-        let base = self.resolve_preferring_branch(base);
-        let head = self.resolve_preferring_branch(head);
+        let base = self.resolve_ref(base);
+        let head = self.resolve_ref(head);
 
         let base_sha = self.rev_parse_commit(&base)?;
         let head_sha = self.rev_parse_commit(&head)?;
@@ -192,7 +212,7 @@ impl Repository {
         branch_head_sha: &str,
         tree_sha: &str,
     ) -> anyhow::Result<bool> {
-        let base = self.resolve_preferring_branch(base);
+        let base = self.resolve_ref(base);
         let base_sha = self.rev_parse_commit(&base)?;
 
         let cache_head = format!("{branch_head_sha}+{tree_sha}");
@@ -248,7 +268,7 @@ impl Repository {
 
     /// Check if merging a branch into target would add anything (not already integrated).
     ///
-    /// Caller must pass resolved refs (via `resolve_preferring_branch`).
+    /// Caller must pass resolved refs (via `resolve_ref`).
     ///
     /// Returns:
     /// - `Ok(Some(true))` if merging would change the target
@@ -364,8 +384,8 @@ impl Repository {
         branch: &str,
         target: &str,
     ) -> anyhow::Result<MergeProbeResult> {
-        let branch = self.resolve_preferring_branch(branch);
-        let target = self.resolve_preferring_branch(target);
+        let branch = self.resolve_ref(branch);
+        let target = self.resolve_ref(target);
 
         // Resolve refs to commit SHAs for the persistent cache key.
         // The probe result depends only on the two committed trees (the


### PR DESCRIPTION
`BranchRef` used to hold `{ branch: Option<String>, is_remote: bool }`. The bool discriminator plus a short name meant any caller passing `branch` to an integration helper was one `resolve_preferring_branch` call away from picking `refs/heads/origin/foo` when it wanted `refs/remotes/origin/foo` — the shadowing class of bug #2365 patched at seven task call sites with `BranchRef::integration_ref()`. This replaces that patch by making the disambiguation unrepresentable at the type level: `BranchRef` now stores the full ref (`refs/heads/<name>` or `refs/remotes/<name>`), and `integration_ref()` is gone. The regression test from #2365 stays as the structural guardrail.

## Key files

- `src/git/mod.rs` — `BranchRef` struct, constructors, and `full_ref()`/`short_name()`/`is_remote()` accessors. `short_name()` enforces the `refs/heads/`-or-`refs/remotes/` invariant via `.expect()` — silently returning an unqualified ref would reopen the bug class the type exists to rule out.
- `src/commands/list/collect/tasks.rs` — migrates seven task call sites to `full_ref()` for integration helpers and `short_name()` for display/CI lookup.
- `src/git/repository/diff.rs` — `batch_ahead_behind` now primes the cache under `refs/heads/<name>` (via `%(refname)` instead of `%(refname:lstrip=2)`). Without this the batch's one-shot `for-each-ref` missed every row against tasks querying via `full_ref()`, and `wt list` would degrade to per-branch `rev-list --count`.
- `src/git/repository/integration.rs` — introduces `Repository::resolve_ref` alongside the untouched `resolve_preferring_branch`. `resolve_ref` passthroughs `refs/`-prefixed inputs and delegates short names. All integration helpers (`is_ancestor`, `same_commit`, `has_added_changes`, `trees_match`, `has_merge_conflicts`, `has_merge_conflicts_by_tree`, `merge_integration_probe`) now resolve through it, so a branch literally named `refs/heads/foo` can't silently override the normal `foo` row when its full ref flows into integration checks.

## Tests

New unit tests pin the `BranchRef` invariants (full/short/is_remote across local, remote, detached) and the batch cache-key contract. The #2365 integration regression test (`test_list_remote_row_not_shadowed_by_same_named_local_branch`) still passes — that's the end-to-end guardrail against git's resolution behavior. Full pre-merge (3329 tests) green, lints pass, docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)