### PR TITLE
fix(hook-context): resolve `{{ commit }}` from ctx.worktree_path on detached HEAD

### DIFF
--- a/src/commands/command_executor.rs
+++ b/src/commands/command_executor.rs
@@ -189,18 +189,25 @@ pub fn build_hook_context(
     // When `ctx.branch` matches the running worktree's current branch — the
     // alias / hook hot path — reuse the HEAD SHA already cached by
     // `WorkingTree::prewarm_info` instead of firing a fresh `rev-parse`.
-    // The same cache read covers detached HEAD (`ctx.branch == None` and the
-    // running worktree is also detached). Cross-worktree contexts, where
-    // `ctx.branch` names a different branch than the running worktree, fall
-    // through to `rev-parse <branch>` in the discovery path.
-    let wt = ctx.repo.current_worktree();
+    // Detached HEAD (`ctx.branch == None`) must read HEAD from
+    // `ctx.worktree_path`, not the running worktree: `wt step for-each`
+    // iterates over sibling worktrees, and a sibling on detached HEAD has a
+    // different HEAD than the worktree `wt` runs in. Cross-worktree contexts
+    // on a branch fall through to `rev-parse <branch>`, which is repo-wide.
+    let running_wt = ctx.repo.current_worktree();
     let commit = match ctx.branch {
-        Some(branch) if wt.branch().ok().flatten().as_deref() != Some(branch) => ctx
+        Some(branch) if running_wt.branch().ok().flatten().as_deref() != Some(branch) => ctx
             .repo
             .run_command(&["rev-parse", branch])
             .ok()
             .map(|s| s.trim().to_owned()),
-        _ => wt.head_sha().ok().flatten(),
+        Some(_) => running_wt.head_sha().ok().flatten(),
+        None => ctx
+            .repo
+            .worktree_at(ctx.worktree_path)
+            .head_sha()
+            .ok()
+            .flatten(),
     };
     if let Some(commit) = commit {
         if commit.len() >= 7 {

--- a/tests/integration_tests/for_each.rs
+++ b/tests/integration_tests/for_each.rs
@@ -344,6 +344,64 @@ fn test_for_each_commit_matches_per_worktree_head(repo: TestRepo) {
     }
 }
 
+/// `{{ commit }}` for a sibling worktree on detached HEAD must resolve to that
+/// worktree's HEAD — not the running worktree's HEAD. The cache key for
+/// `WorkingTree::head_sha` is the worktree path, and HEAD is per-worktree, so
+/// reading via `repo.current_worktree()` in a detached sibling would return
+/// the main worktree's SHA. Build a divergence: advance `feature-b` past the
+/// shared tip, then detach it at that new SHA so its HEAD differs from main.
+#[rstest]
+fn test_for_each_commit_detached_sibling_matches_per_worktree_head(repo: TestRepo) {
+    let feature_b_path = repo.worktree_path("feature-b").to_path_buf();
+    repo.run_git_in(
+        &feature_b_path,
+        &["commit", "--allow-empty", "-m", "feature-b tip"],
+    );
+    repo.detach_head_in_worktree("feature-b");
+
+    let main_sha = repo.git_output(&["rev-parse", "HEAD"]);
+    let feature_b_sha = repo.head_sha_in(&feature_b_path);
+    assert_ne!(
+        main_sha, feature_b_sha,
+        "detached sibling must have a distinct HEAD so a buggy fallback to the running worktree's SHA is visible",
+    );
+
+    let output = repo
+        .wt_command()
+        .args([
+            "step",
+            "for-each",
+            "--",
+            "echo",
+            "{{ branch }} {{ commit }}",
+        ])
+        .output()
+        .expect("run wt step for-each");
+
+    assert!(
+        output.status.success(),
+        "for-each failed: stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    // Detached HEAD surfaces as `{{ branch }} == "HEAD"`. The sibling's commit
+    // must be its own HEAD, not the running worktree's.
+    let needle = format!("HEAD {feature_b_sha}");
+    assert!(
+        combined.contains(&needle),
+        "expected detached sibling's {{{{ commit }}}} = {feature_b_sha} in output\noutput={combined}",
+    );
+    assert!(
+        !combined.contains(&format!("HEAD {main_sha}")),
+        "detached sibling's {{{{ commit }}}} must not resolve to main's SHA {main_sha}\noutput={combined}",
+    );
+}
+
 #[rstest]
 fn test_for_each_json_with_failure(repo: TestRepo) {
     repo.commit("initial");


### PR DESCRIPTION
## Summary

`build_hook_context` read HEAD via `ctx.repo.current_worktree()` on the `ctx.branch == None` arm. `current_worktree()` is keyed by canonicalized `base_path()` (process CWD / `-C`), not `ctx.worktree_path` — so when the context points at a different worktree than where `wt` runs, the cached HEAD comes from the wrong handle.

The cross-worktree caller is `wt step for-each`: iterating over sibling worktrees where one is on detached HEAD, `{{ commit }}` resolved to the running worktree's SHA instead of the sibling's. The on-branch case is unaffected because `rev-parse <branch>` is repo-wide; HEAD is per-worktree.

The fix splits the match into three arms and reads `head_sha` from `ctx.repo.worktree_at(ctx.worktree_path)` when `ctx.branch == None`. `worktree_at` canonicalizes its input, so on the alias hot path (where `ctx.worktree_path = wt.root()` and CWD is the worktree root) the new arm still hits the cache primed by `WorkingTree::prewarm_info` — 4 git subprocesses on-branch, 2 detached, both unchanged from #2374. The on-branch cache-reuse logic is kept untouched on the second arm.

## Tests

- `test_for_each_commit_detached_sibling_matches_per_worktree_head` — advances `feature-b` past the shared tip, detaches it, and asserts `for-each` reports the sibling's own HEAD. Without the fix the test fails with `HEAD <main_sha>` for the detached row, matching the bug pattern.

> _This was written by Claude Code on behalf of @max-sixty_