### PR TITLE
perf(ci-status): resolve remote-ref check via cached inventory

### DIFF
--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -660,24 +660,17 @@ pub fn handle_state_get(
                 None => repo.require_current_branch("get ci-status for current branch")?,
             };
 
-            // Determine if this is a remote ref by checking git refs directly.
-            // This is authoritative - we check actual refs, not guessing from name.
             let is_remote = repo.is_remote_tracking_branch(&branch_name);
 
-            // Get the HEAD commit for this branch
             let head = repo
                 .run_command(&["rev-parse", &branch_name])
-                .map(|s| s.trim().to_string())
-                .unwrap_or_default();
-
-            if head.is_empty() {
-                return Err(worktrunk::git::GitError::BranchNotFound {
-                    branch: branch_name,
+                .map_err(|_| worktrunk::git::GitError::BranchNotFound {
+                    branch: branch_name.clone(),
                     show_create_hint: true,
                     last_fetch_ago: None,
-                }
-                .into());
-            }
+                })?
+                .trim()
+                .to_string();
 
             let ci_branch = CiBranchName::from_branch_ref(&branch_name, is_remote);
             let pr_status = PrStatus::detect(&repo, &ci_branch, &head);

--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -662,14 +662,7 @@ pub fn handle_state_get(
 
             // Determine if this is a remote ref by checking git refs directly.
             // This is authoritative - we check actual refs, not guessing from name.
-            let is_remote = repo
-                .run_command(&[
-                    "show-ref",
-                    "--verify",
-                    "--quiet",
-                    &format!("refs/remotes/{}", branch_name),
-                ])
-                .is_ok();
+            let is_remote = repo.is_remote_tracking_branch(&branch_name);
 
             // Get the HEAD commit for this branch
             let head = repo


### PR DESCRIPTION
`wt config state ci-status` spawned `git show-ref --verify --quiet refs/remotes/<branch>` on every invocation to decide whether the argument was a remote ref. Swap it for `Repository::is_remote_tracking_branch`, which reads the already-cached `remote_branches()` inventory populated by one `for-each-ref` scan. Same cleanup #2377 did for the sole other caller.

While there, collapse the surrounding `rev-parse` → `.unwrap_or_default()` → `if head.is_empty()` dance into a direct `.map_err(|_| BranchNotFound { ... })? .trim().to_string()` chain. The prior shape routed every git error through an empty-string sentinel; the new shape lets the error flow through directly.

> _This was written by Claude Code on behalf of Maximilian_