### PR TITLE
refactor(list, for-each): thread &[WorktreeInfo] through sort and for-each

### DIFF
--- a/src/commands/for_each.rs
+++ b/src/commands/for_each.rs
@@ -23,7 +23,7 @@
 
 use color_print::cformat;
 use worktrunk::config::UserConfig;
-use worktrunk::git::{Repository, WorktrunkError, interrupt_exit_code};
+use worktrunk::git::{Repository, WorktreeInfo, WorktrunkError, interrupt_exit_code};
 use worktrunk::styling::{
     eprintln, error_message, format_with_gutter, progress_message, success_message, warning_message,
 };
@@ -44,11 +44,10 @@ pub fn step_for_each(args: Vec<String>, format: crate::cli::SwitchFormat) -> any
     let json_mode = format == crate::cli::SwitchFormat::Json;
     let repo = Repository::current()?;
     // Filter out prunable worktrees (directory deleted) - can't run commands there
-    let worktrees: Vec<_> = repo
+    let worktrees: Vec<&WorktreeInfo> = repo
         .list_worktrees()?
         .iter()
         .filter(|wt| !wt.is_prunable())
-        .cloned()
         .collect();
     let config = UserConfig::load()?;
 
@@ -63,7 +62,7 @@ pub fn step_for_each(args: Vec<String>, format: crate::cli::SwitchFormat) -> any
     // Join args into a template string (will be expanded per-worktree)
     let command_template = args.join(" ");
 
-    for wt in &worktrees {
+    for &wt in &worktrees {
         let display_name = worktree_display_name(wt, &repo, &config);
         eprintln!(
             "{}",

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -762,7 +762,7 @@ pub fn collect(
 
     // Sort worktrees: current first, main second, then by timestamp descending
     let sorted_worktrees = sort_worktrees_with_cache(
-        worktrees.to_vec(),
+        worktrees,
         &main_worktree,
         current_worktree_path.as_ref(),
         &timestamps,
@@ -1488,14 +1488,14 @@ where
 /// Sort worktrees: current first, main second, then by timestamp descending.
 /// Uses pre-fetched timestamps for efficiency.
 fn sort_worktrees_with_cache(
-    worktrees: Vec<WorktreeInfo>,
+    worktrees: &[WorktreeInfo],
     main_worktree: &WorktreeInfo,
     current_path: Option<&std::path::PathBuf>,
     timestamps: &std::collections::HashMap<String, i64>,
 ) -> Vec<WorktreeInfo> {
     // Embed timestamp and priority in tuple to avoid parallel Vec and index lookups
     let mut with_sort_key: Vec<_> = worktrees
-        .into_iter()
+        .iter()
         .map(|wt| {
             let priority = if current_path.is_some_and(|cp| &wt.path == cp) {
                 0 // Current first
@@ -1510,7 +1510,10 @@ fn sort_worktrees_with_cache(
         .collect();
 
     with_sort_key.sort_by_key(|(_, priority, ts)| (*priority, std::cmp::Reverse(*ts)));
-    with_sort_key.into_iter().map(|(wt, _, _)| wt).collect()
+    with_sort_key
+        .into_iter()
+        .map(|(wt, _, _)| wt.clone())
+        .collect()
 }
 
 // ============================================================================


### PR DESCRIPTION
Two small follow-ups to #2383.

`sort_worktrees_with_cache` takes `&[WorktreeInfo]` instead of an owned `Vec<WorktreeInfo>`, cloning once when materializing the sorted output. The call site in `collect::collect` drops its `.to_vec()` — one fewer `Vec<WorktreeInfo>` allocation on the `wt list` hot path.

`step_for_each` holds `Vec<&WorktreeInfo>` rather than cloning each entry into a `Vec<WorktreeInfo>` — the loop only borrows (`worktree_display_name(wt, ...)`, `execute_shell_command(&wt.path, ...)`), so the clone was unnecessary.

No behavior change.

> _This was written by Claude Code on behalf of @max-sixty_