### PR TITLE
refactor(ci-status): take &BranchRef in CiBranchName::from_branch_ref

### DIFF
--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -699,11 +699,8 @@ pub fn handle_state_get(
                 }
             };
 
-            let short_name = branch_ref
-                .short_name()
-                .expect("local/remote BranchRef always has short_name");
-            let ci_branch = CiBranchName::from_branch_ref(short_name, branch_ref.is_remote());
-            let pr_status = PrStatus::detect(&repo, &ci_branch, &branch_ref.commit_sha);
+            let pr_status = CiBranchName::from_branch_ref(&branch_ref)
+                .and_then(|ci_branch| PrStatus::detect(&repo, &ci_branch, &branch_ref.commit_sha));
 
             if format == SwitchFormat::Json {
                 let output = pr_status

--- a/src/commands/list/ci_status/mod.rs
+++ b/src/commands/list/ci_status/mod.rs
@@ -11,7 +11,7 @@ mod platform;
 use anstyle::{AnsiColor, Color, Style};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use worktrunk::git::Repository;
+use worktrunk::git::{BranchRef, Repository};
 use worktrunk::shell_exec::Cmd;
 use worktrunk::utils::epoch_now;
 
@@ -34,32 +34,31 @@ pub struct CiBranchName {
 }
 
 impl CiBranchName {
-    /// Create from a branch name with authoritative `is_remote` flag.
+    /// Create from a [`BranchRef`], using its short name and remote/local kind.
     ///
     /// For remote branches (e.g., "origin/feature"), splits at the first `/`
     /// to extract the remote name and bare branch name.
     /// For local branches, the name is already bare.
     ///
-    /// The `is_remote` flag should come from an authoritative source:
-    /// - `BranchRef::is_remote()` (from collection phase)
-    /// - `git show-ref --verify refs/remotes/<branch>` (for CLI input)
-    pub fn from_branch_ref(branch: &str, is_remote: bool) -> Self {
-        if is_remote {
+    /// Returns `None` for detached HEAD (no short name).
+    pub fn from_branch_ref(branch_ref: &BranchRef) -> Option<Self> {
+        let short = branch_ref.short_name()?;
+        if branch_ref.is_remote() {
             // Remote branch — split "origin/feature" into remote + bare name.
-            if let Some((remote, name)) = branch.split_once('/') {
-                return Self {
-                    full_name: branch.to_string(),
+            if let Some((remote, name)) = short.split_once('/') {
+                return Some(Self {
+                    full_name: short.to_string(),
                     remote: Some(remote.to_string()),
                     name: name.to_string(),
-                };
+                });
             }
         }
         // Local branch — name is already bare
-        Self {
-            full_name: branch.to_string(),
+        Some(Self {
+            full_name: short.to_string(),
             remote: None,
-            name: branch.to_string(),
-        }
+            name: short.to_string(),
+        })
     }
 
     /// Returns true if this is a remote branch reference.
@@ -492,6 +491,36 @@ mod tests {
         assert_eq!(error.source, CiSource::Branch);
         assert!(!error.is_stale);
         assert!(error.url.is_none());
+    }
+
+    #[test]
+    fn test_ci_branch_name_from_local_branch_ref() {
+        let branch_ref = BranchRef::local_branch("feature", "abc123");
+        let ci = CiBranchName::from_branch_ref(&branch_ref).expect("local has short_name");
+        assert_eq!(ci.full_name, "feature");
+        assert_eq!(ci.name, "feature");
+        assert_eq!(ci.remote, None);
+        assert!(!ci.is_remote());
+    }
+
+    #[test]
+    fn test_ci_branch_name_from_remote_branch_ref() {
+        let branch_ref = BranchRef::remote_branch("origin/feature", "abc123");
+        let ci = CiBranchName::from_branch_ref(&branch_ref).expect("remote has short_name");
+        assert_eq!(ci.full_name, "origin/feature");
+        assert_eq!(ci.name, "feature");
+        assert_eq!(ci.remote.as_deref(), Some("origin"));
+        assert!(ci.is_remote());
+    }
+
+    #[test]
+    fn test_ci_branch_name_from_detached_head() {
+        let detached = BranchRef {
+            full_ref: None,
+            commit_sha: "abc123".to_string(),
+            worktree_path: None,
+        };
+        assert!(CiBranchName::from_branch_ref(&detached).is_none());
     }
 
     #[test]

--- a/src/commands/list/collect/tasks.rs
+++ b/src/commands/list/collect/tasks.rs
@@ -674,12 +674,8 @@ impl Task for CiStatusTask {
 
     fn compute(ctx: TaskContext) -> Result<TaskResult, TaskError> {
         let repo = &ctx.repo;
-        let pr_status = ctx.branch_ref.short_name().and_then(|branch| {
-            // Use from_branch_ref with the authoritative is_remote flag
-            // rather than guessing from the branch name
-            let ci_branch = CiBranchName::from_branch_ref(branch, ctx.branch_ref.is_remote());
-            PrStatus::detect(repo, &ci_branch, &ctx.branch_ref.commit_sha)
-        });
+        let pr_status = CiBranchName::from_branch_ref(&ctx.branch_ref)
+            .and_then(|ci_branch| PrStatus::detect(repo, &ci_branch, &ctx.branch_ref.commit_sha));
 
         Ok(TaskResult::CiStatus {
             item_idx: ctx.item_idx,


### PR DESCRIPTION
Both callers of `CiBranchName::from_branch_ref` held a `BranchRef` and were unpacking it into `(branch: &str, is_remote: bool)` just to repack it. The string/bool signature was a historical artifact — flagged as a "broader improvement" deferred from #2388. Now there's one canonical caller shape, the type makes the original "string from one source, bool from another" bug class unrepresentable, and the `short_name().and_then(...)` dance at each call site collapses into a single chain on `Option<Self>` (None for detached HEAD).

Also drops the `expect("local/remote BranchRef always has short_name")` in `wt config state get ci-status` — the `(None, None)` arm above already early-returns `BranchNotFound`, and the propagated `None` folds benignly into the existing `pr_status: Option<PrStatus>`.

Adds three unit tests for `from_branch_ref` covering the local / remote / detached-HEAD shapes — pre-existing gap, locks in the contract.

> _This was written by Claude Code on behalf of @max-sixty_