### PR TITLE
fix(config): clear single-branch ci-status cache from file storage

### DIFF
--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -825,8 +825,7 @@ pub fn handle_state_clear(key: &str, branch: Option<String>, all: bool) -> anyho
                     Some(b) => b,
                     None => repo.require_current_branch("clear ci-status for current branch")?,
                 };
-                let config_key = format!("worktrunk.state.{branch_name}.ci-status");
-                if repo.unset_config(&config_key).unwrap_or(false) {
+                if CachedCiStatus::clear_one(&repo, &branch_name) {
                     eprintln!(
                         "{}",
                         success_message(cformat!("Cleared CI cache for <bold>{branch_name}</>"))

--- a/src/commands/list/ci_status/cache.rs
+++ b/src/commands/list/ci_status/cache.rs
@@ -150,6 +150,17 @@ impl CachedCiStatus {
             .collect()
     }
 
+    /// Clear the cached CI status for a single branch.
+    ///
+    /// Returns `true` if a cache file was removed, `false` otherwise (no file
+    /// existed, or the removal failed). Mirrors `clear_all`'s best-effort
+    /// swallowing so the caller's success vs info message stays a simple
+    /// boolean.
+    pub(crate) fn clear_one(repo: &Repository, branch: &str) -> bool {
+        let path = Self::cache_file(repo, branch);
+        fs::remove_file(&path).is_ok()
+    }
+
     /// Clear all cached CI statuses, returns count cleared.
     pub(crate) fn clear_all(repo: &Repository) -> usize {
         let cache_dir = Self::cache_dir(repo);

--- a/tests/integration_tests/config_state.rs
+++ b/tests/integration_tests/config_state.rs
@@ -51,14 +51,18 @@ fn state_get_settings() -> insta::Settings {
     settings
 }
 
-/// Write CI status to the file-based cache at .git/wt/cache/ci-status/<branch>.json
-fn write_ci_cache(repo: &TestRepo, branch: &str, json: &str) {
-    let git_dir = repo.root_path().join(".git");
-    let cache_dir = git_dir.join("wt").join("cache").join("ci-status");
-    std::fs::create_dir_all(&cache_dir).unwrap();
-
+/// Path to the file-based CI cache entry at `.git/wt/cache/ci-status/<branch>.json`.
+fn ci_cache_file(repo: &TestRepo, branch: &str) -> PathBuf {
     let safe_branch = sanitize_for_filename(branch);
-    let cache_file = cache_dir.join(format!("{safe_branch}.json"));
+    repo.root_path()
+        .join(".git/wt/cache/ci-status")
+        .join(format!("{safe_branch}.json"))
+}
+
+/// Write CI status to the file-based cache.
+fn write_ci_cache(repo: &TestRepo, branch: &str, json: &str) {
+    let cache_file = ci_cache_file(repo, branch);
+    std::fs::create_dir_all(cache_file.parent().unwrap()).unwrap();
     std::fs::write(&cache_file, json).unwrap();
 }
 
@@ -443,29 +447,39 @@ fn test_state_clear_ci_status_all_empty(repo: TestRepo) {
 
 #[rstest]
 fn test_state_clear_ci_status_branch(repo: TestRepo) {
-    // Add CI cache entry
-    repo.git_command().args([
-        "config",
-        "worktrunk.state.main.ci-status",
-        &format!(r#"{{"status":{{"ci_status":"passed","source":"pull-request","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"abc12345"}}"#),
-    ])
-    .run()
-    .unwrap();
+    let head = repo.head_sha();
+    write_ci_cache(
+        &repo,
+        "main",
+        &format!(
+            r#"{{"status":{{"ci_status":"passed","source":"pr","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"{head}","branch":"main"}}"#
+        ),
+    );
+    let cache_file = ci_cache_file(&repo, "main");
+    assert!(cache_file.exists(), "cache file should exist before clear");
 
     let output = wt_state_cmd(&repo, "ci-status", "clear", &[])
         .output()
         .unwrap();
     assert!(output.status.success());
     assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"[32m✓[39m [32mCleared CI cache for [1mmain[22m[39m");
+    assert!(
+        !cache_file.exists(),
+        "cache file should be gone after clear"
+    );
 }
 
 #[rstest]
 fn test_state_clear_ci_status_branch_not_cached(repo: TestRepo) {
+    let cache_file = ci_cache_file(&repo, "main");
+    assert!(!cache_file.exists(), "cache file should not exist");
+
     let output = wt_state_cmd(&repo, "ci-status", "clear", &[])
         .output()
         .unwrap();
     assert!(output.status.success());
     assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"[2m○[22m No CI cache for [1mmain[22m");
+    assert!(!cache_file.exists(), "cache file should still not exist");
 }
 
 // ============================================================================
@@ -1385,20 +1399,26 @@ fn test_state_clear_ci_status_specific_branch(repo: TestRepo) {
         .run()
         .unwrap();
 
-    // Add CI cache via git config for the specific branch
-    repo.git_command().args([
-        "config",
-        "worktrunk.state.feature.ci-status",
-        &format!(r#"{{"status":{{"ci_status":"passed","source":"pull-request","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"abc12345"}}"#),
-    ])
-    .run()
-    .unwrap();
+    let head = repo.head_sha();
+    write_ci_cache(
+        &repo,
+        "feature",
+        &format!(
+            r#"{{"status":{{"ci_status":"passed","source":"pr","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"{head}","branch":"feature"}}"#
+        ),
+    );
+    let cache_file = ci_cache_file(&repo, "feature");
+    assert!(cache_file.exists(), "cache file should exist before clear");
 
     let output = wt_state_cmd(&repo, "ci-status", "clear", &["--branch", "feature"])
         .output()
         .unwrap();
     assert!(output.status.success());
     assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"[32m✓[39m [32mCleared CI cache for [1mfeature[22m[39m");
+    assert!(
+        !cache_file.exists(),
+        "cache file should be gone after clear"
+    );
 }
 
 #[rstest]
@@ -1408,12 +1428,15 @@ fn test_state_clear_ci_status_specific_branch_not_cached(repo: TestRepo) {
         .args(["branch", "feature"])
         .run()
         .unwrap();
+    let cache_file = ci_cache_file(&repo, "feature");
+    assert!(!cache_file.exists(), "cache file should not exist");
 
     let output = wt_state_cmd(&repo, "ci-status", "clear", &["--branch", "feature"])
         .output()
         .unwrap();
     assert!(output.status.success());
     assert_snapshot!(String::from_utf8_lossy(&output.stderr), @"[2m○[22m No CI cache for [1mfeature[22m");
+    assert!(!cache_file.exists(), "cache file should still not exist");
 }
 
 #[rstest]


### PR DESCRIPTION
The single-branch path in `wt config state ci-status clear` still called `unset_config("worktrunk.state.<branch>.ci-status")` — a leftover from when CI status lived in git config. The cache moved to `.git/wt/cache/ci-status/<branch>.json` (see the module docstring in `src/commands/list/ci_status/cache.rs`), so that config key never existed. The command always took the info branch, reported "No CI cache for <branch>", and never touched the real cache file. `--all` was already correct via `CachedCiStatus::clear_all`.

Adds `CachedCiStatus::clear_one(repo, branch) -> bool` mirroring `clear_all`'s best-effort `fs::remove_file`, and swaps the config-key call for it. User-facing messages are unchanged.

The two tests covering this path (`test_state_clear_ci_status_branch`, `test_state_clear_ci_status_specific_branch`) wrote a `worktrunk.state.*` git config key — a no-op against the real file cache — then asserted "Cleared CI cache". They passed by writing-then-clearing a config key nothing reads (and were missing the required `branch` field in the cached JSON that would have failed deserialization anyway). Rewritten to write via the file-based `write_ci_cache` helper with a valid `PrStatus` shape and real `head_sha()`, and to assert the cache file is gone after the clear. Also factored a `ci_cache_file(repo, branch)` helper so the path convention lives in one place, and added file-existence guards to the two `_not_cached` variants so they check a real precondition.