### PR TITLE
chore(plugin): drop static version, let Claude Code use commit SHA

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,8 +5,7 @@
     "email": "m@maxroos.com"
   },
   "metadata": {
-    "description": "Claude Code plugin for Worktrunk, a CLI for Git worktree management",
-    "version": "1.0.0"
+    "description": "Claude Code plugin for Worktrunk, a CLI for Git worktree management"
   },
   "plugins": [
     {

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,6 @@
 {
   "name": "worktrunk",
   "description": "Worktrunk is a CLI for Git worktree management, designed for parallel AI agent workflows. This plugin provides configuration guidance (LLM commit messages, project hooks, worktree paths) and automatic activity tracking (🤖/💬 indicators in `wt list` showing active Claude sessions).",
-  "version": "1.0.0",
   "author": {
     "name": "Worktrunk"
   },


### PR DESCRIPTION
The plugin manifest carried `version: 1.0.0` that hadn't moved despite ongoing changes to skills and hooks — it was misleading. Per the [plugin spec](https://code.claude.com/docs/en/plugins), omitting `version` makes Claude Code use the commit SHA, so every commit becomes an update for installed users automatically.

Removed `version` from `.claude-plugin/plugin.json` and from the `metadata` block in `.claude-plugin/marketplace.json`.

Trade-off: every commit to `main` is now an "update" for installed users, which could feel noisy if we iterate frequently. If that bites, we can add `version` back and bump deliberately.

> _This was written by Claude Code on behalf of @max-sixty_