### PR TITLE
chore: use full name on LICENSE copyright lines

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -5,7 +5,7 @@ You may choose either license at your option.
 MIT License
 ================================================================================
 
-Copyright (c) 2025 Max Sixty
+Copyright (c) 2025 Maximilian Roos
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -206,7 +206,7 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
 END OF TERMS AND CONDITIONS
 
-Copyright 2025 Max Sixty
+Copyright 2025 Maximilian Roos
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updates both copyright lines in `LICENSE` (MIT and Apache-2.0) from "Max Sixty" to "Maximilian Roos". No other occurrences of the spaced form exist in the repo; `max-sixty` (the GitHub handle) is left unchanged in URLs and references.

> _This was written by Claude Code on behalf of Maximilian Roos_