### PR TITLE
fix(deprecate): warn on `--claude-code` flag and `wt hook post-create` alias

### DIFF
--- a/src/cli/hook.rs
+++ b/src/cli/hook.rs
@@ -129,9 +129,10 @@ pub struct HookOptions {
 /// hint on typos (same `did_you_mean` helper used for unknown subcommands).
 ///
 /// `post-create` is the deprecated alias for `pre-start` — accepted here so
-/// scripted invocations keep working. The deprecation warning is emitted by
-/// the config loader when `[post-create]` appears in config; CLI invocations
-/// map silently to `pre-start`.
+/// scripted invocations keep working. The deprecation warning for the config
+/// section `[post-create]` is emitted by the config loader; the warning for
+/// the CLI invocation `wt hook post-create` is emitted by the dispatcher in
+/// `main.rs` before `HookOptions::parse` runs.
 pub fn parse_hook_type(name: &str) -> anyhow::Result<HookType> {
     match name {
         "pre-switch" => Ok(HookType::PreSwitch),

--- a/src/main.rs
+++ b/src/main.rs
@@ -178,6 +178,14 @@ fn handle_hook_command(action: HookCommand, yes: bool) -> anyhow::Result<()> {
             // which parses against a clap tree augmented with hook-type
             // subcommand stubs and renders their help directly. Execution flow
             // only reaches here for non-help invocations.
+            if args.first().and_then(|s| s.to_str()) == Some("post-create") {
+                eprintln!(
+                    "{}",
+                    warning_message(
+                        "wt hook post-create is deprecated; use wt hook pre-start instead"
+                    )
+                );
+            }
             let opts = HookOptions::parse(&args)?;
             run_hook(
                 opts.hook_type,
@@ -478,6 +486,14 @@ fn handle_list_command(args: ListArgs) -> anyhow::Result<()> {
             format,
             claude_code,
         }) => {
+            if claude_code {
+                eprintln!(
+                    "{}",
+                    warning_message(
+                        "--claude-code is deprecated; use --format=claude-code instead"
+                    )
+                );
+            }
             // Hidden --claude-code flag only applies when format is default (Table)
             // Explicit --format=json takes precedence over --claude-code
             let effective_format = if claude_code && matches!(format, OutputFormat::Table) {

--- a/tests/integration_tests/statusline.rs
+++ b/tests/integration_tests/statusline.rs
@@ -496,6 +496,44 @@ fn test_statusline_json_ignores_claude_code(repo: TestRepo) {
     assert_eq!(item["branch"], "main");
 }
 
+// --- Deprecated flags ---
+
+#[rstest]
+fn test_statusline_claude_code_flag_deprecated(repo: TestRepo) {
+    // The hidden `--claude-code` flag still maps to `--format=claude-code`,
+    // but emits a deprecation warning per invocation.
+    let escaped_path = escape_path_for_json(repo.root_path());
+    let json = format!(r#"{{"workspace": {{"current_dir": "{escaped_path}"}}}}"#);
+
+    let mut cmd = wt_command();
+    cmd.current_dir(repo.root_path());
+    cmd.args(["list", "statusline", "--claude-code"]);
+    repo.configure_wt_cmd(&mut cmd);
+    cmd.stdin(Stdio::piped());
+    cmd.stdout(Stdio::piped());
+    cmd.stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().expect("spawn");
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(json.as_bytes())
+        .unwrap();
+    let output = child.wait_with_output().expect("wait");
+
+    assert!(output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--claude-code is deprecated"),
+        "expected deprecation warning in stderr, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("--format=claude-code"),
+        "expected migration hint in stderr, got: {stderr}"
+    );
+}
+
 /// Tests that statusline correctly identifies nested worktrees.
 ///
 /// When worktrees are placed inside other worktrees (e.g., `.worktrees/` layout),

--- a/tests/integration_tests/user_hooks.rs
+++ b/tests/integration_tests/user_hooks.rs
@@ -1380,6 +1380,39 @@ fn test_standalone_hook_post_create(repo: TestRepo) {
 }
 
 #[rstest]
+fn test_standalone_hook_post_create_alias_deprecated(repo: TestRepo) {
+    // `wt hook post-create` still maps to `pre-start` for scripted callers,
+    // but emits a deprecation warning per invocation.
+    repo.write_project_config(r#"pre-start = "echo 'POST_CREATE_ALIAS' > hook_ran.txt""#);
+
+    let mut cmd = crate::common::wt_command();
+    cmd.current_dir(repo.root_path());
+    cmd.env("WORKTRUNK_CONFIG_PATH", repo.test_config_path());
+    cmd.args(["hook", "post-create", "--yes"]);
+
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "wt hook post-create should still succeed (alias for pre-start)"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("wt hook post-create is deprecated"),
+        "expected deprecation warning in stderr, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("wt hook pre-start"),
+        "expected migration hint in stderr, got: {stderr}"
+    );
+
+    // Verify the aliased hook actually ran.
+    let marker = repo.root_path().join("hook_ran.txt");
+    crate::common::wait_for_file_content(&marker);
+    let content = fs::read_to_string(&marker).unwrap();
+    assert!(content.contains("POST_CREATE_ALIAS"));
+}
+
+#[rstest]
 fn test_standalone_hook_pre_start_fails_on_failure(repo: TestRepo) {
     // pre-start hooks use FailFast like all other pre-* hooks — consistent with
     // the symmetric pre (blocking, fail-fast) / post (background, warn) pattern.


### PR DESCRIPTION
Both surfaces previously mapped silently to their canonical replacements, so users had no signal to migrate before eventual removal. Emit per-invocation warnings to stderr matching the existing pattern used by `wt select`, `--no-verify`, and `wt hook approvals`.

The config-section `[hooks.post-create]` warning path is unchanged — that already errors at config load (#2361). This only adds a warning for the bare CLI alias `wt hook post-create`, which still maps to `pre-start` after warning.

One UX consideration: `--claude-code` is read on every Claude Code statusline redraw, so users with the deprecated form in their statusline integration will see the warning each redraw until they migrate. That's the intent (surface the deprecation), but worth noting.

Co-Authored-By: Claude <noreply@anthropic.com>