### PR TITLE
ci: add nightly feature-powerset check

### DIFF
--- a/.github/nightly-failure.md
+++ b/.github/nightly-failure.md
@@ -1,0 +1,6 @@
+---
+title: Nightly tests failed
+labels: ci
+---
+
+Nightly tests [failed on {{ date | date('YYYY-MM-DD') }}]({{ env.LINK }})

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,6 +1,6 @@
 name: nightly
 # Catches feature-flag breakage that workspace feature unification can mask;
-# see issue/PR ...
+# see #2442 for the v0.45.0 incident that motivated this.
 #
 # Runs daily and can be triggered manually. Not wired to push or pull_request —
 # this is a slow check that addresses a class of bug that only matters at

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,0 +1,73 @@
+name: nightly
+# Catches feature-flag breakage that workspace feature unification can mask;
+# see issue/PR ...
+#
+# Runs daily and can be triggered manually. Not wired to push or pull_request —
+# this is a slow check that addresses a class of bug that only matters at
+# integration time, not per-commit.
+#
+# Runner versions pinned; see ci.yaml header comment for rationale.
+
+on:
+  schedule:
+    # Run at 5:37 UTC every day. Off-peak minute (avoid :00 to be a good
+    # citizen w.r.t. GitHub's cron scheduler), and offset from
+    # nightly-benchmark.yaml (4:17 UTC) so they don't contend for runners.
+    - cron: '37 5 * * *'
+  workflow_dispatch:
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: -C debuginfo=0
+
+jobs:
+  feature-powerset:
+    # Every combination of cli/syntax-highlighting/shell-integration-tests/
+    # git-wt should compile. Catches regressions in feature gating — including
+    # the v0.45.0 case where lib code used a `cli`-gated dependency
+    # unconditionally.
+    #
+    # Workspace members must use `default-features = false` when depending on
+    # worktrunk, or feature unification will mask gating bugs by silently
+    # enabling `cli` in the lib build (see tests/helpers/wt-perf/Cargo.toml).
+    runs-on: ubuntu-24.04
+    steps:
+    - name: 📂 Checkout code
+      uses: actions/checkout@v6
+
+    - name: 💰 Cache
+      uses: Swatinem/rust-cache@v2
+
+    - name: Install cargo-hack
+      uses: taiki-e/install-action@v2.75.22
+      with:
+        tool: cargo-hack
+
+    - name: cargo hack check --feature-powerset --no-dev-deps
+      run: cargo hack check --feature-powerset --no-dev-deps
+
+  create-issue-on-nightly-failure:
+    needs:
+      - feature-powerset
+    if: always() && contains(needs.*.result, 'failure') && github.repository_owner == 'max-sixty' && github.event_name == 'schedule'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      issues: write
+    steps:
+    - name: 📂 Checkout code
+      uses: actions/checkout@v6
+
+    - uses: JasonEtco/create-an-issue@v2
+      env:
+        # Use WORKTRUNK_BOT_TOKEN for a consistent bot identity (per
+        # .github/CLAUDE.md) and so any future issue-triage automation can
+        # cascade off issue creation — events from the default GITHUB_TOKEN
+        # don't trigger other workflows.
+        GITHUB_TOKEN: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
+        LINK: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+      with:
+        filename: .github/nightly-failure.md
+        update_existing: true
+        search_existing: open

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -11,179 +11,262 @@
 //!
 //! The progress line is cleared on [`Progress::finish`] or on drop, so the
 //! caller can print a summary message immediately afterward without overlap.
-
-#[cfg(feature = "cli")]
-use std::io::{IsTerminal, Write};
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-#[cfg(feature = "cli")]
-use std::thread;
-use std::thread::JoinHandle;
-#[cfg(feature = "cli")]
-use std::time::{Duration, Instant};
+//!
+//! The full spinner machinery (crossterm, the ticker thread, the render loop)
+//! lives in the `cli`-gated [`imp`] submodule. Without the `cli` feature,
+//! [`Progress`] is a zero-cost stub: `start` always returns a no-op reporter
+//! and `record` does nothing. Pure formatting helpers ([`format_bytes`],
+//! [`format_stats_paren`]) are always available since callers in both modes
+//! want them.
 
 use color_print::cformat;
-#[cfg(feature = "cli")]
-use crossterm::{
-    QueueableCommand,
-    cursor::MoveToColumn,
-    terminal::{Clear, ClearType},
-};
+
+pub use imp::Progress;
 
 #[cfg(feature = "cli")]
-const SPINNER_FRAMES: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
-#[cfg(feature = "cli")]
-const TICK_INTERVAL: Duration = Duration::from_millis(100);
-/// Delay before the first frame renders, so sub-second operations stay silent.
-#[cfg(feature = "cli")]
-const STARTUP_DELAY: Duration = Duration::from_millis(300);
+mod imp {
+    use std::io::{IsTerminal, Write};
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
+    use std::thread::{self, JoinHandle};
+    use std::time::{Duration, Instant};
 
-struct Shared {
-    files: AtomicUsize,
-    bytes: AtomicU64,
-    done: AtomicBool,
-    #[cfg(feature = "cli")]
-    verb: &'static str,
-}
+    use color_print::cformat;
+    use crossterm::{
+        QueueableCommand,
+        cursor::MoveToColumn,
+        terminal::{Clear, ClearType},
+    };
 
-struct Inner {
-    shared: Arc<Shared>,
-    ticker: JoinHandle<()>,
-}
+    use super::{format_bytes, format_count};
 
-/// Live spinner displaying file and byte counters for a single operation.
-///
-/// See [module docs](crate::progress) for the output format and lifecycle.
-pub struct Progress(Option<Inner>);
+    const SPINNER_FRAMES: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+    const TICK_INTERVAL: Duration = Duration::from_millis(100);
+    /// Delay before the first frame renders, so sub-second operations stay silent.
+    const STARTUP_DELAY: Duration = Duration::from_millis(300);
 
-impl Progress {
-    /// Start a progress reporter, enabling the spinner iff stderr is a TTY.
+    struct Shared {
+        files: AtomicUsize,
+        bytes: AtomicU64,
+        done: AtomicBool,
+        verb: &'static str,
+    }
+
+    struct Inner {
+        shared: Arc<Shared>,
+        ticker: JoinHandle<()>,
+    }
+
+    /// Live spinner displaying file and byte counters for a single operation.
     ///
-    /// `verb` is the present-participle label shown to the user (e.g.
-    /// `"Copying"`, `"Removing"`). Spawns a background ticker thread when a
-    /// TTY is detected. When stderr is not a TTY, returns a disabled reporter
-    /// and does no work.
-    ///
-    /// Without the `cli` feature, the spinner is unavailable (it depends on
-    /// `crossterm` for cursor control), so this always returns a disabled
-    /// reporter. Counters still record but nothing renders.
-    pub fn start(_verb: &'static str) -> Self {
-        #[cfg(feature = "cli")]
-        {
+    /// See [module docs](super) for the output format and lifecycle.
+    pub struct Progress(Option<Inner>);
+
+    impl Progress {
+        /// Start a progress reporter, enabling the spinner iff stderr is a TTY.
+        ///
+        /// `verb` is the present-participle label shown to the user (e.g.
+        /// `"Copying"`, `"Removing"`). Spawns a background ticker thread when a
+        /// TTY is detected. When stderr is not a TTY, returns a disabled reporter
+        /// and does no work.
+        pub fn start(verb: &'static str) -> Self {
             if std::io::stderr().is_terminal() {
-                return Self::enabled(_verb);
+                Self::enabled(verb)
+            } else {
+                Self::disabled()
             }
         }
-        Self::disabled()
-    }
 
-    /// A reporter that does nothing — for benchmarks, tests, and internal moves.
-    pub fn disabled() -> Self {
-        Self(None)
-    }
+        /// A reporter that does nothing — for benchmarks, tests, and internal moves.
+        pub fn disabled() -> Self {
+            Self(None)
+        }
 
-    /// Constructor for the enabled state, separated so the TTY-gated branch in
-    /// [`Self::start`] and the test-only "force enabled" path share one
-    /// implementation. Spawns the ticker thread; safe to call from any
-    /// context that genuinely wants live output.
-    #[cfg(feature = "cli")]
-    fn enabled(verb: &'static str) -> Self {
-        let shared = Arc::new(Shared {
-            files: AtomicUsize::new(0),
-            bytes: AtomicU64::new(0),
-            done: AtomicBool::new(false),
-            verb,
-        });
-        let ticker = {
-            let shared = Arc::clone(&shared);
-            thread::spawn(move || ticker_loop(&shared))
-        };
-        Self(Some(Inner { shared, ticker }))
-    }
+        /// Constructor for the enabled state, separated so the TTY-gated branch in
+        /// [`Self::start`] and the test-only "force enabled" path share one
+        /// implementation. Spawns the ticker thread; safe to call from any
+        /// context that genuinely wants live output.
+        fn enabled(verb: &'static str) -> Self {
+            let shared = Arc::new(Shared {
+                files: AtomicUsize::new(0),
+                bytes: AtomicU64::new(0),
+                done: AtomicBool::new(false),
+                verb,
+            });
+            let ticker = {
+                let shared = Arc::clone(&shared);
+                thread::spawn(move || ticker_loop(&shared))
+            };
+            Self(Some(Inner { shared, ticker }))
+        }
 
-    /// Record that a file (or symlink) was processed. Safe to call from any thread.
-    pub fn record(&self, bytes: u64) {
-        if let Some(inner) = &self.0 {
-            inner.shared.files.fetch_add(1, Ordering::Relaxed);
-            inner.shared.bytes.fetch_add(bytes, Ordering::Relaxed);
+        /// Record that a file (or symlink) was processed. Safe to call from any thread.
+        pub fn record(&self, bytes: u64) {
+            if let Some(inner) = &self.0 {
+                inner.shared.files.fetch_add(1, Ordering::Relaxed);
+                inner.shared.bytes.fetch_add(bytes, Ordering::Relaxed);
+            }
+        }
+
+        /// Stop the spinner and clear the progress line.
+        pub fn finish(self) {
+            // Drop runs the same shutdown logic — no need to duplicate it here.
+            drop(self);
         }
     }
 
-    /// Stop the spinner and clear the progress line.
-    pub fn finish(self) {
-        // Drop runs the same shutdown logic — no need to duplicate it here.
-        drop(self);
+    impl Drop for Progress {
+        fn drop(&mut self) {
+            // `Inner` is Drop-free, so we can take ownership of its fields and
+            // run shutdown without partial-move conflicts.
+            if let Some(inner) = self.0.take() {
+                inner.shared.done.store(true, Ordering::Relaxed);
+                inner.ticker.thread().unpark();
+                let _ = inner.ticker.join();
+                let _ = clear_line(&mut std::io::stderr().lock());
+            }
+        }
     }
-}
 
-impl Drop for Progress {
-    fn drop(&mut self) {
-        // `Inner` is Drop-free, so we can take ownership of its fields and
-        // run shutdown without partial-move conflicts. Without `cli`, an
-        // `Inner` is never constructed (see `start`/`enabled`), so this block
-        // is statically unreachable — the `cli`-gated `clear_line` call is
-        // therefore safe to elide.
-        if let Some(inner) = self.0.take() {
-            inner.shared.done.store(true, Ordering::Relaxed);
-            inner.ticker.thread().unpark();
-            let _ = inner.ticker.join();
-            #[cfg(feature = "cli")]
-            let _ = clear_line(&mut std::io::stderr().lock());
+    fn ticker_loop(shared: &Shared) {
+        let start = Instant::now();
+        // Sub-300ms operations render nothing — the line never gets drawn.
+        // park_timeout returns immediately on `unpark` from drop, so short
+        // operations don't block shutdown either.
+        while start.elapsed() < STARTUP_DELAY {
+            if shared.done.load(Ordering::Relaxed) {
+                return;
+            }
+            thread::park_timeout(STARTUP_DELAY - start.elapsed());
+        }
+        while !shared.done.load(Ordering::Relaxed) {
+            let frame_idx = (start.elapsed().as_millis() / TICK_INTERVAL.as_millis()) as usize
+                % SPINNER_FRAMES.len();
+            let files = shared.files.load(Ordering::Relaxed);
+            let bytes = shared.bytes.load(Ordering::Relaxed);
+            let line = format_line(shared.verb, files, bytes, SPINNER_FRAMES[frame_idx]);
+            let _ = render_line(&mut std::io::stderr().lock(), &line);
+            thread::park_timeout(TICK_INTERVAL);
+        }
+    }
+
+    fn format_line(verb: &str, files: usize, bytes: u64, spinner: char) -> String {
+        if files == 0 {
+            cformat!("<cyan>{spinner}</> {verb}...")
+        } else {
+            let word = if files == 1 { "file" } else { "files" };
+            cformat!(
+                "<cyan>{spinner}</> {verb} {} {} · {}",
+                format_count(files),
+                word,
+                format_bytes(bytes),
+            )
+        }
+    }
+
+    fn render_line<W: Write>(w: &mut W, line: &str) -> std::io::Result<()> {
+        w.queue(MoveToColumn(0))?;
+        w.queue(Clear(ClearType::CurrentLine))?;
+        write!(w, "{line}")?;
+        w.flush()
+    }
+
+    fn clear_line<W: Write>(w: &mut W) -> std::io::Result<()> {
+        w.queue(MoveToColumn(0))?;
+        w.queue(Clear(ClearType::CurrentLine))?;
+        w.flush()
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+
+        #[test]
+        fn test_format_line_empty() {
+            let line = format_line("Copying", 0, 0, '⠋');
+            assert!(line.contains("Copying..."));
+            assert!(line.contains('⠋'));
+        }
+
+        #[test]
+        fn test_format_line_singular() {
+            let line = format_line("Copying", 1, 42, '⠙');
+            assert!(line.contains("1 file "));
+            assert!(line.contains("42 B"));
+        }
+
+        #[test]
+        fn test_format_line_plural() {
+            let line = format_line("Removing", 2_500, 5 * 1024 * 1024, '⠹');
+            assert!(line.contains("Removing"));
+            assert!(line.contains("2,500 files"));
+            assert!(line.contains("5.0 MiB"));
+        }
+
+        #[test]
+        fn test_render_line_writes_text_with_prefix_control_bytes() {
+            let mut buf = Vec::new();
+            render_line(&mut buf, "hello").unwrap();
+            assert!(buf.ends_with(b"hello"));
+            assert!(buf.len() > b"hello".len());
+        }
+
+        #[test]
+        fn test_clear_line_writes_control_bytes() {
+            let mut buf = Vec::new();
+            clear_line(&mut buf).unwrap();
+            assert!(!buf.is_empty());
+        }
+
+        #[test]
+        fn test_start_in_non_tty_is_disabled() {
+            assert!(Progress::start("Copying").0.is_none());
+        }
+
+        #[test]
+        fn test_enabled_lifecycle_counters_propagate() {
+            let p = Progress::enabled("Copying");
+            p.record(1024);
+            p.record(2048);
+            let inner = p.0.as_ref().expect("expected enabled");
+            assert_eq!(inner.shared.files.load(Ordering::Relaxed), 2);
+            assert_eq!(inner.shared.bytes.load(Ordering::Relaxed), 3072);
+            p.finish();
+        }
+
+        #[test]
+        fn test_enabled_renders_after_startup_delay() {
+            let p = Progress::enabled("Removing");
+            p.record(100);
+            // Wait past the startup delay + one tick so ticker_loop reaches the
+            // render branch — the part that's hardest to cover otherwise.
+            std::thread::sleep(STARTUP_DELAY + TICK_INTERVAL + Duration::from_millis(50));
+            p.finish();
         }
     }
 }
 
-#[cfg(feature = "cli")]
-fn ticker_loop(shared: &Shared) {
-    let start = Instant::now();
-    // Sub-300ms operations render nothing — the line never gets drawn.
-    // park_timeout returns immediately on `unpark` from drop, so short
-    // operations don't block shutdown either.
-    while start.elapsed() < STARTUP_DELAY {
-        if shared.done.load(Ordering::Relaxed) {
-            return;
+#[cfg(not(feature = "cli"))]
+mod imp {
+    /// Zero-cost stub when the `cli` feature is off. The spinner depends on
+    /// `crossterm`, which is only pulled in by `cli`; library consumers that
+    /// disable default features get this no-op type instead. Counters are
+    /// dropped on the floor — no allocation, no thread, no rendering.
+    pub struct Progress;
+
+    impl Progress {
+        pub fn start(_verb: &'static str) -> Self {
+            Self
         }
-        thread::park_timeout(STARTUP_DELAY - start.elapsed());
-    }
-    while !shared.done.load(Ordering::Relaxed) {
-        let frame_idx = (start.elapsed().as_millis() / TICK_INTERVAL.as_millis()) as usize
-            % SPINNER_FRAMES.len();
-        let files = shared.files.load(Ordering::Relaxed);
-        let bytes = shared.bytes.load(Ordering::Relaxed);
-        let line = format_line(shared.verb, files, bytes, SPINNER_FRAMES[frame_idx]);
-        let _ = render_line(&mut std::io::stderr().lock(), &line);
-        thread::park_timeout(TICK_INTERVAL);
-    }
-}
 
-#[cfg(feature = "cli")]
-fn format_line(verb: &str, files: usize, bytes: u64, spinner: char) -> String {
-    if files == 0 {
-        cformat!("<cyan>{spinner}</> {verb}...")
-    } else {
-        let word = if files == 1 { "file" } else { "files" };
-        cformat!(
-            "<cyan>{spinner}</> {verb} {} {} · {}",
-            format_count(files),
-            word,
-            format_bytes(bytes),
-        )
+        pub fn disabled() -> Self {
+            Self
+        }
+
+        pub fn record(&self, _bytes: u64) {}
+
+        pub fn finish(self) {}
     }
-}
-
-#[cfg(feature = "cli")]
-fn render_line<W: Write>(w: &mut W, line: &str) -> std::io::Result<()> {
-    w.queue(MoveToColumn(0))?;
-    w.queue(Clear(ClearType::CurrentLine))?;
-    write!(w, "{line}")?;
-    w.flush()
-}
-
-#[cfg(feature = "cli")]
-fn clear_line<W: Write>(w: &mut W) -> std::io::Result<()> {
-    w.queue(MoveToColumn(0))?;
-    w.queue(Clear(ClearType::CurrentLine))?;
-    w.flush()
 }
 
 fn format_count(n: usize) -> String {
@@ -264,31 +347,6 @@ mod tests {
         assert_eq!(format_bytes(1_610_612_736), "1.5 GiB");
     }
 
-    #[cfg(feature = "cli")]
-    #[test]
-    fn test_format_line_empty() {
-        let line = format_line("Copying", 0, 0, '⠋');
-        assert!(line.contains("Copying..."));
-        assert!(line.contains('⠋'));
-    }
-
-    #[cfg(feature = "cli")]
-    #[test]
-    fn test_format_line_singular() {
-        let line = format_line("Copying", 1, 42, '⠙');
-        assert!(line.contains("1 file "));
-        assert!(line.contains("42 B"));
-    }
-
-    #[cfg(feature = "cli")]
-    #[test]
-    fn test_format_line_plural() {
-        let line = format_line("Removing", 2_500, 5 * 1024 * 1024, '⠹');
-        assert!(line.contains("Removing"));
-        assert!(line.contains("2,500 files"));
-        assert!(line.contains("5.0 MiB"));
-    }
-
     #[test]
     fn test_format_stats_paren_empty_is_blank() {
         assert_eq!(format_stats_paren(0, 0), "");
@@ -308,23 +366,6 @@ mod tests {
         assert!(s.contains("5.0 MiB"));
     }
 
-    #[cfg(feature = "cli")]
-    #[test]
-    fn test_render_line_writes_text_with_prefix_control_bytes() {
-        let mut buf = Vec::new();
-        render_line(&mut buf, "hello").unwrap();
-        assert!(buf.ends_with(b"hello"));
-        assert!(buf.len() > b"hello".len());
-    }
-
-    #[cfg(feature = "cli")]
-    #[test]
-    fn test_clear_line_writes_control_bytes() {
-        let mut buf = Vec::new();
-        clear_line(&mut buf).unwrap();
-        assert!(!buf.is_empty());
-    }
-
     #[test]
     fn test_disabled_record_is_noop() {
         let p = Progress::disabled();
@@ -332,34 +373,6 @@ mod tests {
         p.record(2_000_000);
         // No counters to inspect — Disabled has no fields. The assertion is
         // simply that the call doesn't panic and finish() returns cleanly.
-        p.finish();
-    }
-
-    #[test]
-    fn test_start_in_non_tty_is_disabled() {
-        assert!(Progress::start("Copying").0.is_none());
-    }
-
-    #[cfg(feature = "cli")]
-    #[test]
-    fn test_enabled_lifecycle_counters_propagate() {
-        let p = Progress::enabled("Copying");
-        p.record(1024);
-        p.record(2048);
-        let inner = p.0.as_ref().expect("expected enabled");
-        assert_eq!(inner.shared.files.load(Ordering::Relaxed), 2);
-        assert_eq!(inner.shared.bytes.load(Ordering::Relaxed), 3072);
-        p.finish();
-    }
-
-    #[cfg(feature = "cli")]
-    #[test]
-    fn test_enabled_renders_after_startup_delay() {
-        let p = Progress::enabled("Removing");
-        p.record(100);
-        // Wait past the startup delay + one tick so ticker_loop reaches the
-        // render branch — the part that's hardest to cover otherwise.
-        std::thread::sleep(STARTUP_DELAY + TICK_INTERVAL + Duration::from_millis(50));
         p.finish();
     }
 }

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -13,11 +13,10 @@
 //! caller can print a summary message immediately afterward without overlap.
 //!
 //! The full spinner machinery (crossterm, the ticker thread, the render loop)
-//! lives in the `cli`-gated [`imp`] submodule. Without the `cli` feature,
-//! [`Progress`] is a zero-cost stub: `start` always returns a no-op reporter
-//! and `record` does nothing. Pure formatting helpers ([`format_bytes`],
-//! [`format_stats_paren`]) are always available since callers in both modes
-//! want them.
+//! is gated on the `cli` feature. Without `cli`, [`Progress`] is a zero-cost
+//! stub: `start` always returns a no-op reporter and `record` does nothing.
+//! Pure formatting helpers ([`format_bytes`], [`format_stats_paren`]) are
+//! always available since callers in both modes want them.
 
 use color_print::cformat;
 

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -12,28 +12,37 @@
 //! The progress line is cleared on [`Progress::finish`] or on drop, so the
 //! caller can print a summary message immediately afterward without overlap.
 
+#[cfg(feature = "cli")]
 use std::io::{IsTerminal, Write};
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
-use std::thread::{self, JoinHandle};
+#[cfg(feature = "cli")]
+use std::thread;
+use std::thread::JoinHandle;
+#[cfg(feature = "cli")]
 use std::time::{Duration, Instant};
 
 use color_print::cformat;
+#[cfg(feature = "cli")]
 use crossterm::{
     QueueableCommand,
     cursor::MoveToColumn,
     terminal::{Clear, ClearType},
 };
 
+#[cfg(feature = "cli")]
 const SPINNER_FRAMES: &[char] = &['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+#[cfg(feature = "cli")]
 const TICK_INTERVAL: Duration = Duration::from_millis(100);
 /// Delay before the first frame renders, so sub-second operations stay silent.
+#[cfg(feature = "cli")]
 const STARTUP_DELAY: Duration = Duration::from_millis(300);
 
 struct Shared {
     files: AtomicUsize,
     bytes: AtomicU64,
     done: AtomicBool,
+    #[cfg(feature = "cli")]
     verb: &'static str,
 }
 
@@ -54,12 +63,18 @@ impl Progress {
     /// `"Copying"`, `"Removing"`). Spawns a background ticker thread when a
     /// TTY is detected. When stderr is not a TTY, returns a disabled reporter
     /// and does no work.
-    pub fn start(verb: &'static str) -> Self {
-        if std::io::stderr().is_terminal() {
-            Self::enabled(verb)
-        } else {
-            Self::disabled()
+    ///
+    /// Without the `cli` feature, the spinner is unavailable (it depends on
+    /// `crossterm` for cursor control), so this always returns a disabled
+    /// reporter. Counters still record but nothing renders.
+    pub fn start(_verb: &'static str) -> Self {
+        #[cfg(feature = "cli")]
+        {
+            if std::io::stderr().is_terminal() {
+                return Self::enabled(_verb);
+            }
         }
+        Self::disabled()
     }
 
     /// A reporter that does nothing — for benchmarks, tests, and internal moves.
@@ -71,6 +86,7 @@ impl Progress {
     /// [`Self::start`] and the test-only "force enabled" path share one
     /// implementation. Spawns the ticker thread; safe to call from any
     /// context that genuinely wants live output.
+    #[cfg(feature = "cli")]
     fn enabled(verb: &'static str) -> Self {
         let shared = Arc::new(Shared {
             files: AtomicUsize::new(0),
@@ -103,16 +119,21 @@ impl Progress {
 impl Drop for Progress {
     fn drop(&mut self) {
         // `Inner` is Drop-free, so we can take ownership of its fields and
-        // run shutdown without partial-move conflicts.
+        // run shutdown without partial-move conflicts. Without `cli`, an
+        // `Inner` is never constructed (see `start`/`enabled`), so this block
+        // is statically unreachable — the `cli`-gated `clear_line` call is
+        // therefore safe to elide.
         if let Some(inner) = self.0.take() {
             inner.shared.done.store(true, Ordering::Relaxed);
             inner.ticker.thread().unpark();
             let _ = inner.ticker.join();
+            #[cfg(feature = "cli")]
             let _ = clear_line(&mut std::io::stderr().lock());
         }
     }
 }
 
+#[cfg(feature = "cli")]
 fn ticker_loop(shared: &Shared) {
     let start = Instant::now();
     // Sub-300ms operations render nothing — the line never gets drawn.
@@ -135,6 +156,7 @@ fn ticker_loop(shared: &Shared) {
     }
 }
 
+#[cfg(feature = "cli")]
 fn format_line(verb: &str, files: usize, bytes: u64, spinner: char) -> String {
     if files == 0 {
         cformat!("<cyan>{spinner}</> {verb}...")
@@ -149,6 +171,7 @@ fn format_line(verb: &str, files: usize, bytes: u64, spinner: char) -> String {
     }
 }
 
+#[cfg(feature = "cli")]
 fn render_line<W: Write>(w: &mut W, line: &str) -> std::io::Result<()> {
     w.queue(MoveToColumn(0))?;
     w.queue(Clear(ClearType::CurrentLine))?;
@@ -156,6 +179,7 @@ fn render_line<W: Write>(w: &mut W, line: &str) -> std::io::Result<()> {
     w.flush()
 }
 
+#[cfg(feature = "cli")]
 fn clear_line<W: Write>(w: &mut W) -> std::io::Result<()> {
     w.queue(MoveToColumn(0))?;
     w.queue(Clear(ClearType::CurrentLine))?;
@@ -240,6 +264,7 @@ mod tests {
         assert_eq!(format_bytes(1_610_612_736), "1.5 GiB");
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn test_format_line_empty() {
         let line = format_line("Copying", 0, 0, '⠋');
@@ -247,6 +272,7 @@ mod tests {
         assert!(line.contains('⠋'));
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn test_format_line_singular() {
         let line = format_line("Copying", 1, 42, '⠙');
@@ -254,6 +280,7 @@ mod tests {
         assert!(line.contains("42 B"));
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn test_format_line_plural() {
         let line = format_line("Removing", 2_500, 5 * 1024 * 1024, '⠹');
@@ -281,6 +308,7 @@ mod tests {
         assert!(s.contains("5.0 MiB"));
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn test_render_line_writes_text_with_prefix_control_bytes() {
         let mut buf = Vec::new();
@@ -289,6 +317,7 @@ mod tests {
         assert!(buf.len() > b"hello".len());
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn test_clear_line_writes_control_bytes() {
         let mut buf = Vec::new();
@@ -311,6 +340,7 @@ mod tests {
         assert!(Progress::start("Copying").0.is_none());
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn test_enabled_lifecycle_counters_propagate() {
         let p = Progress::enabled("Copying");
@@ -322,6 +352,7 @@ mod tests {
         p.finish();
     }
 
+    #[cfg(feature = "cli")]
     #[test]
     fn test_enabled_renders_after_startup_delay() {
         let p = Progress::enabled("Removing");

--- a/tests/helpers/wt-perf/Cargo.toml
+++ b/tests/helpers/wt-perf/Cargo.toml
@@ -21,8 +21,12 @@ clap = { version = "4", features = ["derive"] }
 # For JSON output
 serde_json = "1"
 
-# For trace parsing (reuse worktrunk's trace module)
-worktrunk = { path = "../../.." }
+# For trace parsing (reuse worktrunk's trace module).
+# `default-features = false` avoids leaking the `cli` feature into the
+# workspace-unified resolution of worktrunk; without it, `cargo check
+# --no-default-features` on the worktrunk lib silently inherits `cli`,
+# masking gating bugs in lib code that uses `cli`-gated dependencies.
+worktrunk = { path = "../../..", default-features = false }
 
 [lib]
 name = "wt_perf"


### PR DESCRIPTION
Adds a nightly workflow for feature-flag breakage, fixes the wt-perf manifest leak that was masking the bug, and merges in the `features` branch with the actual `src/progress.rs` fix that the new check exposes.

## Why

worktrunk v0.45.0 fails to build with `cargo install --locked --no-default-features` because `src/progress.rs` used `crossterm` unconditionally despite `crossterm` being gated behind the `cli` feature. The lib code was broken on main but in-workspace `cargo check --no-default-features --lib` passed silently.

The mask: `tests/helpers/wt-perf/Cargo.toml` had `worktrunk = { path = "../../.." }` (default features on). Cargo's workspace resolver unifies features across all members, so even when checking worktrunk with `--no-default-features`, wt-perf's dep silently re-enabled `cli` in the lib build, pulling `crossterm` back in. Setting `default-features = false` plugs the leak — and with that change the existing `feature-check` job in `ci.yaml` already catches this bug class on every PR, before it can ship.

## What's added

- **`tests/helpers/wt-perf/Cargo.toml`** — `default-features = false` on the worktrunk path dep, with a comment explaining the leak.
- **`.github/workflows/nightly.yaml`** — nightly `feature-powerset` job (cargo-hack) plus `create-issue-on-nightly-failure`. Triggers: `schedule: '37 5 * * *'` + `workflow_dispatch` only — no push/PR. Issue creation is gated on `failure ∧ repo_owner == 'max-sixty' ∧ event_name == 'schedule'` and uses `JasonEtco/create-an-issue@v2` with `update_existing: true` for auto-dedup. Auth via `WORKTRUNK_BOT_TOKEN` for consistent bot identity (per `.github/CLAUDE.md`) and so future issue-triage automation can cascade. Coverage is partly redundant with what `feature-check` in `ci.yaml` now catches, but the powerset is broader (covers `git-wt` and `shell-integration-tests` combinations that ci.yaml doesn't enumerate).
- **`.github/nightly-failure.md`** — minimal issue template (title, `ci` label, link to failed run).
- **Merge of `origin/features`** — the `src/progress.rs` fix that this PR's check would otherwise have flagged. Without it CI on this PR would (correctly) fail.

## Verified locally

- `cargo check --lib --no-default-features` — passes
- `cargo hack check --feature-powerset --no-dev-deps` — all 20 subsets pass
- `cargo test --lib --bins` — 1056 + 603 passing, no regressions

## Trade-off

The wt-perf fix relies on a convention — workspace members depending on worktrunk must use `default-features = false` — that nothing enforces. A future workspace member added without that flag would silently re-introduce the leak. An out-of-workspace check (build a throwaway crate that depends on the checkout) would be more defense-in-depth but the brief opted for the simpler in-workspace job. A separate dispatched investigation is looking at whether the helpers should be workspace members at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)