### PR TITLE
docs(release-skill): sync index.json digest after cargo-release

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -19,7 +19,13 @@ metadata:
    ```bash
    cargo release X.Y.Z -p worktrunk -x --no-publish --no-push --no-tag --no-verify --no-confirm && cargo check
    ```
-   This bumps `Cargo.toml`, `Cargo.lock`, and applies `pre-release-replacements` (e.g., SKILL.md), then auto-commits. We'll reset this commit in step 9 to fold in the CHANGELOG.
+   This bumps `Cargo.toml`, `Cargo.lock`, and applies `pre-release-replacements` (e.g., `SKILL.md`'s `version:` line), then auto-commits. We'll reset this commit in step 9 to fold in the CHANGELOG.
+
+   Then sync the SHA-256 digest of `SKILL.md` in `docs/static/.well-known/agent-skills/index.json` — `cargo-release` doesn't know that file derives from `SKILL.md`, so it stays stale until the docs-sync test rewrites it:
+   ```bash
+   cargo test --test integration test_docs_are_in_sync || cargo test --test integration test_docs_are_in_sync
+   ```
+   The first run rewrites the digest and exits non-zero; the second confirms sync. The regenerated `index.json` is then picked up by `git add -A` in step 9.
 8. **Update CHANGELOG**: Add `## X.Y.Z` section at top with changes (see MANDATORY verification below)
 9. **Commit**: Reset the auto-commit from step 7, stage everything, and create the final release commit:
    ```bash


### PR DESCRIPTION
## Summary

`cargo-release`'s `pre-release-replacements` rewrites `skills/worktrunk/SKILL.md`'s `version:` line, but `docs/static/.well-known/agent-skills/index.json` stores a SHA-256 digest of `SKILL.md` that only the `test_docs_are_in_sync` integration test regenerates. Without an explicit step, the stale digest gets caught mid-merge by the pre-merge hook and forces an extra amend cycle (as just happened on v0.45.1).

This adds a docs-sync invocation to step 7 of the release skill so the regenerated `index.json` is folded into the final release commit by the existing `git add -A` in step 9. The first invocation rewrites the digest and exits non-zero; the second confirms sync.

> _This was written by Claude Code on behalf of @max-sixty_