### PR TITLE
fix(alias): align alias --help guidance with output guidelines

### DIFF
--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -40,7 +40,7 @@ use worktrunk::config::{
 };
 use worktrunk::git::Repository;
 use worktrunk::styling::{
-    eprintln, format_with_gutter, info_message, println, progress_message, verbosity,
+    eprintln, format_with_gutter, hint_message, info_message, progress_message, verbosity,
     warning_message,
 };
 
@@ -99,11 +99,12 @@ fn help_flag_requested(args: &[String]) -> bool {
 /// inspection path and documents the `--` escape for forwarding `--help` into
 /// the alias body.
 fn emit_alias_help_hint(name: &str) {
-    println!(
-        "`{name}` is an alias. Inspect with:
-  wt config alias show {name}
-  wt config alias dry-run {name}
-Forward `--help` to the alias body with `wt {name} -- --help`."
+    eprintln!("{}", info_message(cformat!("<bold>{name}</> is an alias")));
+    eprintln!(
+        "{}",
+        hint_message(cformat!(
+            "To view config, run <underline>wt config alias show {name}</>; to preview expansion, run <underline>wt config alias dry-run {name}</>; to forward --help to the alias body, run <underline>wt {name} -- --help</>"
+        ))
     );
 }
 

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_help_flag_prints_hint.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_help_flag_prints_hint.snap
@@ -42,9 +42,7 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-`deploy` is an alias. Inspect with:
-  wt config alias show deploy
-  wt config alias dry-run deploy
-Forward `--help` to the alias body with `wt deploy -- --help`.
 
 ----- stderr -----
+[2m○[22m [1mdeploy[22m is an alias
+[2m↳[22m [2mTo view config, run [4mwt config alias show deploy[24m; to preview expansion, run [4mwt config alias dry-run deploy[24m; to forward --help to the alias body, run [4mwt deploy -- --help[24m[22m


### PR DESCRIPTION
The hint emitted on `wt <alias> --help` violated several user-output conventions: it printed to stdout without a symbol or gutter, used backticks around commands and the alias name, and stacked three indented commands as bullets.

Replaced with a state-acknowledging info line for the alias name plus a single hint joining the three suggestions via "to X, run Y" semicolons. Commands and the alias name are styled with `<underline>` (dim-safe in hints), and output now goes to stderr where status messages belong.

Before:

```
$ wt sw --help
\`sw\` is an alias. Inspect with:
  wt config alias show sw
  wt config alias dry-run sw
Forward \`--help\` to the alias body with \`wt sw -- --help\`.
```

After:

```
$ wt sw --help
○ sw is an alias
↳ To view config, run wt config alias show sw; to preview expansion, run wt config alias dry-run sw; to forward --help to the alias body, run wt sw -- --help
```

> _This was written by Claude Code on behalf of [@max-sixty](https://github.com/max-sixty)._