### PR TITLE
docs(shell-exec): note PID forwarding in forward_signals doc

### DIFF
--- a/src/shell_exec.rs
+++ b/src/shell_exec.rs
@@ -866,8 +866,11 @@ impl Cmd {
     ///
     /// When combined with [`Cmd::inherit_stdin()`], the new-pgroup isolation
     /// is skipped (the child shares the parent's pgroup so it can drive the
-    /// controlling terminal). The signal listener still runs so signal-derived
-    /// child exits surface as `WorktrunkError::ChildProcessExited { signal: .. }`.
+    /// controlling terminal); the listener then forwards by PID single-shot
+    /// rather than `killpg`-with-escalation, so externally-delivered signals
+    /// (e.g. `kill -TERM <wt-pid>`) still reach the child. Either way,
+    /// signal-derived child exits surface as
+    /// `WorktrunkError::ChildProcessExited { signal: .. }`.
     ///
     /// Only affects `.stream()` on Unix. No-op on Windows.
     pub fn forward_signals(mut self) -> Self {


### PR DESCRIPTION
## Summary

Follow-up to #2444. The `forward_signals` docstring mentioned that the listener "still runs" in the shared-pgroup case but didn't say what it does — leaving readers to infer that signal-derived child exits surface but no explicit forwarding happens. With #2444's PID forwarding for externally-delivered signals, the doc lagged the implementation.

Two extra lines spelling out the actual behavior. No code change.

## Test plan

- [x] `cargo check` clean.
- [x] No code paths affected; doc-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)