### PR TITLE
fix(nushell): switch wrapper to @complete attribute on untyped rest

### DIFF
--- a/src/shell/snapshots/worktrunk__shell__tests__init_nu.snap
+++ b/src/shell/snapshots/worktrunk__shell__tests__init_nu.snap
@@ -8,7 +8,7 @@ expression: output
 # Note: nushell's completion engine bypasses custom completers when the current
 # token starts with `-`, so flag completions (e.g. `wt switch --<TAB>`) don't
 # appear. Subcommand and value completions work. (nushell/nushell#14504)
-export def "nu-complete wt" [context: string] {
+export def "nu-complete wt" [spans: list<string>] {
     let worktrunk_bin = if ($env.WORKTRUNK_BIN? | is-not-empty) {
         $env.WORKTRUNK_BIN
     } else {
@@ -17,15 +17,8 @@ export def "nu-complete wt" [context: string] {
         ($external | get 0.path)
     }
 
-    let tokens = ($context | split row " " | where {|t| $t != "" })
-    let tokens = if ($context | str ends-with " ") {
-        $tokens | append ""
-    } else {
-        $tokens
-    }
-
     let result = (do {
-        with-env { COMPLETE: nu } { ^$worktrunk_bin -- ...$tokens }
+        with-env { COMPLETE: nu } { ^$worktrunk_bin -- ...$spans }
     } | complete)
     if $result.exit_code != 0 { return [] }
 
@@ -66,7 +59,15 @@ export def "nu-complete wt" [context: string] {
 #   Stderr flows to the terminal in real-time. The binary sees non-TTY stdout
 #   and uses buffered mode, but commands other than `list` don't benefit from
 #   progressive rendering anyway.
-export def --env --wrapped wt [...args: string@"nu-complete wt"] {
+#
+# Completer wired via `@complete` attribute on an untyped `[...args]` rest.
+# The parameter-level `string@"completer"` form keeps tokens literal, which
+# blocks nushell's normal argument handling for `--flag="value"` (quote
+# stripping) and `~` (path expansion). Untyped rest gets that handling once
+# nushell/nushell#18131 ships in stable nu; until then `--flag="value"` still
+# arrives quoted. See nushell/nushell#18128 for upstream tracking.
+@complete "nu-complete wt"
+export def --env --wrapped wt [...args] {
     let worktrunk_bin = if ($env.WORKTRUNK_BIN? | is-not-empty) {
         $env.WORKTRUNK_BIN
     } else {

--- a/templates/nushell.nu
+++ b/templates/nushell.nu
@@ -4,7 +4,7 @@
 # Note: nushell's completion engine bypasses custom completers when the current
 # token starts with `-`, so flag completions (e.g. `wt switch --<TAB>`) don't
 # appear. Subcommand and value completions work. (nushell/nushell#14504)
-export def "nu-complete {{ cmd }}" [context: string] {
+export def "nu-complete {{ cmd }}" [spans: list<string>] {
     let worktrunk_bin = if ($env.WORKTRUNK_BIN? | is-not-empty) {
         $env.WORKTRUNK_BIN
     } else {
@@ -13,15 +13,8 @@ export def "nu-complete {{ cmd }}" [context: string] {
         ($external | get 0.path)
     }
 
-    let tokens = ($context | split row " " | where {|t| $t != "" })
-    let tokens = if ($context | str ends-with " ") {
-        $tokens | append ""
-    } else {
-        $tokens
-    }
-
     let result = (do {
-        with-env { COMPLETE: nu } { ^$worktrunk_bin -- ...$tokens }
+        with-env { COMPLETE: nu } { ^$worktrunk_bin -- ...$spans }
     } | complete)
     if $result.exit_code != 0 { return [] }
 
@@ -62,7 +55,15 @@ export def "nu-complete {{ cmd }}" [context: string] {
 #   Stderr flows to the terminal in real-time. The binary sees non-TTY stdout
 #   and uses buffered mode, but commands other than `list` don't benefit from
 #   progressive rendering anyway.
-export def --env --wrapped {{ cmd }} [...args: string@"nu-complete {{ cmd }}"] {
+#
+# Completer wired via `@complete` attribute on an untyped `[...args]` rest.
+# The parameter-level `string@"completer"` form keeps tokens literal, which
+# blocks nushell's normal argument handling for `--flag="value"` (quote
+# stripping) and `~` (path expansion). Untyped rest gets that handling once
+# nushell/nushell#18131 ships in stable nu; until then `--flag="value"` still
+# arrives quoted. See nushell/nushell#18128 for upstream tracking.
+@complete "nu-complete {{ cmd }}"
+export def --env --wrapped {{ cmd }} [...args] {
     let worktrunk_bin = if ($env.WORKTRUNK_BIN? | is-not-empty) {
         $env.WORKTRUNK_BIN
     } else {


### PR DESCRIPTION
Per fdncred's recommendation in nushell/nushell#18128, replaces the parameter-level `[...args: string@\"nu-complete wt\"]` with a function-level `@complete` attribute on an untyped `[...args]` rest. The completer signature moves from `[context: string]` (with manual `split row \" \"` reconstruction) to `[spans: list<string>]`, which nushell pre-tokenizes — net deletion of seven lines of fragile token reassembly.

Untyped rest is the form nushell routes through its normal external-argument handling, so once nushell/nushell#18131 ships in stable nu the wrapper will automatically benefit from `--flag=\"value\"` quote stripping and `~` expansion without further changes. Until then `--flag=\"value\"` still arrives at the binary with literal quotes — a pre-existing bug, not a regression introduced here. Supersedes #2437 (the body-level regex strip workaround).

## Test plan

- [x] `cargo test --test integration --features shell-integration-tests` — 1717 passed (including all four nu wrapper cases)
- [x] `pre-commit run --all-files` — clean
- [x] Smoke-tested the rendered template parses cleanly under nu 0.112.1
- [ ] Hand-verify subcommand completion at trailing space (e.g. `wt switch <TAB>`) in an interactive nu session — couldn't drive reedline via PTY in test, but fdncred's example in nushell/nushell#18128 implies `spans` is populated at the cursor position

Ref nushell/nushell#18128, nushell/nushell#18131