### PR TITLE
refactor(push): replace verb-string sniffing with PushKind enum

### DIFF
--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -15,7 +15,7 @@ use super::repository_ext::{
     RepositoryCliExt, check_not_default_branch, compute_integration_reason, is_primary_worktree,
 };
 use super::worktree::{
-    MergeOperations, RemoveResult, handle_no_ff_merge, handle_push, path_mismatch,
+    MergeOperations, PushKind, RemoveResult, handle_no_ff_merge, handle_push, path_mismatch,
 };
 use worktrunk::git::BranchDeletionMode;
 
@@ -255,7 +255,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
         handle_no_ff_merge(Some(&target_branch), operations, &current_branch)?;
     } else {
         // Fast-forward push to target branch
-        handle_push(Some(&target_branch), "Merged to", operations)?;
+        handle_push(Some(&target_branch), PushKind::MergeFastForward, operations)?;
     }
 
     // Destination: prefer the target branch's worktree; fall back to home path.

--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -501,10 +501,6 @@ pub fn handle_rebase(target: Option<&str>) -> anyhow::Result<RebaseResult> {
 /// and untracked files in a single diff. Copies the real index to preserve git's stat
 /// cache (avoiding re-reads of unchanged files), then registers untracked files with
 /// `git add -N` so they appear in the diff.
-///
-/// TODO: consider adding `--stage` flag (all/tracked/none) like `step commit` to
-/// control which change types are included. `tracked` would skip the temp index,
-/// `none` would diff only committed changes.
 pub fn step_diff(target: Option<&str>, extra_args: &[String]) -> anyhow::Result<()> {
     let repo = Repository::current()?;
     let wt = repo.current_worktree();

--- a/src/commands/worktree/mod.rs
+++ b/src/commands/worktree/mod.rs
@@ -88,7 +88,7 @@ mod switch;
 mod types;
 
 // Re-export public types and functions
-pub use push::{handle_no_ff_merge, handle_push};
+pub use push::{PushKind, handle_no_ff_merge, handle_push};
 pub(crate) use resolve::paths_match;
 pub use resolve::{
     compute_worktree_path, is_worktree_at_expected_path, offer_bare_repo_worktree_path_fix,

--- a/src/commands/worktree/push.rs
+++ b/src/commands/worktree/push.rs
@@ -16,6 +16,34 @@ use worktrunk::styling::{
 use super::types::MergeOperations;
 use crate::commands::repository_ext::{RepositoryCliExt, TargetWorktreeStash};
 
+/// Distinguishes a standalone push from a fast-forward push driven by `wt merge`.
+///
+/// Carried into [`handle_push`] so progress/success messages use the right verb
+/// without sniffing a passed-in string.
+#[derive(Debug, Clone, Copy)]
+pub enum PushKind {
+    /// `wt push` — no merge operations precede the push.
+    Standalone,
+    /// `wt merge` resolved to a fast-forward.
+    MergeFastForward,
+}
+
+impl PushKind {
+    fn verb_past(self) -> &'static str {
+        match self {
+            PushKind::Standalone => "Pushed to",
+            PushKind::MergeFastForward => "Merged to",
+        }
+    }
+
+    fn verb_progressive(self) -> &'static str {
+        match self {
+            PushKind::Standalone => "Pushing",
+            PushKind::MergeFastForward => "Merging",
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Shared scaffolding
 // ---------------------------------------------------------------------------
@@ -98,11 +126,12 @@ impl MergeContext {
 
     /// Print progress message, commit graph, and diff statistics.
     ///
-    /// `verb_ing` is the gerund shown in the progress line (e.g. "Merging", "Pushing").
-    /// `extra_note` is appended after the SHA (e.g. " (--no-ff)").
+    /// `verb_progressive` is the present participle shown in the progress line
+    /// (e.g. "Merging", "Pushing"). `extra_note` is appended after the SHA
+    /// (e.g. " (--no-ff)").
     fn show_progress(
         &self,
-        verb_ing: &str,
+        verb_progressive: &str,
         extra_note: &str,
         operations: Option<MergeOperations>,
     ) -> anyhow::Result<()> {
@@ -123,7 +152,7 @@ impl MergeContext {
         eprintln!(
             "{}",
             progress_message(cformat!(
-                "{verb_ing} {} {commit_text} to <bold>{}</> @ <dim>{head_sha}</>{extra_note}{operations_note}",
+                "{verb_progressive} {} {commit_text} to <bold>{}</> @ <dim>{head_sha}</>{extra_note}{operations_note}",
                 self.commit_count,
                 self.target_branch,
             ))
@@ -248,17 +277,12 @@ fn format_up_to_date_context(operations: Option<MergeOperations>) -> String {
 /// overlaps with the push range.
 pub fn handle_push(
     target: Option<&str>,
-    verb: &str,
+    kind: PushKind,
     operations: Option<MergeOperations>,
 ) -> anyhow::Result<()> {
     let mut ctx = MergeContext::prepare(target, operations)?;
 
-    let verb_ing = if verb.starts_with("Merged") {
-        "Merging"
-    } else {
-        "Pushing"
-    };
-    ctx.show_progress(verb_ing, "", operations)?;
+    ctx.show_progress(kind.verb_progressive(), "", operations)?;
 
     // Perform the push via --receive-pack (atomically updates ref + working tree)
     let git_common_dir = ctx.repo.git_common_dir();
@@ -281,7 +305,7 @@ pub fn handle_push(
     ctx.restore_stash();
 
     if ctx.commit_count > 0 {
-        ctx.show_success(verb, "", "");
+        ctx.show_success(kind.verb_past(), "", "");
     } else {
         ctx.show_up_to_date_if_needed(operations);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,7 +45,7 @@ pub(crate) use crate::cli::OutputFormat;
 #[cfg(unix)]
 use commands::handle_picker;
 use commands::repository_ext::RepositoryCliExt;
-use commands::worktree::{handle_no_ff_merge, handle_push};
+use commands::worktree::{PushKind, handle_no_ff_merge, handle_push};
 use commands::{
     HookCliArgs, MergeOptions, OperationMode, RebaseResult, RemoveTarget, SquashResult,
     SwitchOptions, add_approvals, clear_approvals, handle_alias_dry_run, handle_alias_show,
@@ -243,7 +243,7 @@ fn handle_step_command(action: StepCommand, yes: bool) -> anyhow::Result<()> {
                 let current_branch = repo.require_current_branch("step push --no-ff")?;
                 handle_no_ff_merge(target.as_deref(), None, &current_branch)
             } else {
-                handle_push(target.as_deref(), "Pushed to", None)
+                handle_push(target.as_deref(), PushKind::Standalone, None)
             }
         }
         StepCommand::Rebase { target } => {


### PR DESCRIPTION
\`handle_push\` previously took \`verb: &str\` and guessed the present participle from a \`starts_with(\"Merged\")\` prefix check. Replace with an explicit \`PushKind { Standalone, MergeFastForward }\` carrying both verb forms; the doc comment is also corrected from \"gerund\" to \"present participle.\"

Also drops a stale YAGNI TODO from \`step_diff\` proposing a \`--stage\` flag.

Two callers updated: \`main.rs\` (standalone push) and \`merge.rs\` (fast-forward merge path).