### PR TITLE
refactor(alias): dedup help-intercept between try_alias and step_alias

### DIFF
--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -95,10 +95,18 @@ fn help_flag_requested(args: &[String]) -> bool {
     false
 }
 
-/// Print guidance when `wt <alias> --help` is invoked. Points at the canonical
-/// inspection path and documents the `--` escape for forwarding `--help` into
-/// the alias body.
-fn emit_alias_help_hint(name: &str) {
+/// If `args` requests `--help` for an alias, emit the help hint and return
+/// `true`. Aliases have no clap-style help page — the template *is* the help —
+/// so dispatchers redirect the user to `wt config alias show / dry-run`.
+///
+/// Aliases can bind a `help` variable; only intercept when the template
+/// doesn't reference it. `-h` is never a binding, so it's always safe to
+/// intercept. Conservatively: intercept if any help flag appears and no
+/// binding is claimed on `help`.
+fn try_intercept_alias_help(name: &str, args: &[String], referenced: &BTreeSet<String>) -> bool {
+    if referenced.contains("help") || !help_flag_requested(args) {
+        return false;
+    }
     eprintln!("{}", info_message(cformat!("<bold>{name}</> is an alias")));
     eprintln!(
         "{}",
@@ -106,6 +114,7 @@ fn emit_alias_help_hint(name: &str) {
             "To view config, run <underline>wt config alias show {name}</>; to preview expansion, run <underline>wt config alias dry-run {name}</>; to forward --help to the alias body, run <underline>wt {name} -- --help</>"
         ))
     );
+    true
 }
 
 /// Options parsed from alias-dispatch args (`wt step <alias>` or `wt <alias>`).
@@ -355,12 +364,7 @@ pub fn try_alias(name: String, rest: Vec<String>, global_yes: bool) -> anyhow::R
         return Ok(None);
     };
     let referenced = referenced_vars_for_config(cmd_config)?;
-    // Aliases can bind a `help` variable; only intercept `--help` when the
-    // template doesn't reference it. `-h` is never a binding, so it's always
-    // safe to intercept. Conservatively: intercept if any help flag appears
-    // and no binding is claimed on `help`.
-    if !referenced.contains("help") && help_flag_requested(&rest) {
-        emit_alias_help_hint(&name);
+    if try_intercept_alias_help(&name, &rest, &referenced) {
         return Ok(Some(()));
     }
     let mut alias_args = Vec::with_capacity(1 + rest.len());
@@ -417,8 +421,7 @@ pub fn step_alias(args: Vec<String>, global_yes: bool) -> anyhow::Result<()> {
         return Err(unknown_step_command_error(&name, &alias_names));
     };
     let referenced = referenced_vars_for_config(cmd_config)?;
-    if !referenced.contains("help") && help_flag_requested(&args[1..]) {
-        emit_alias_help_hint(&name);
+    if try_intercept_alias_help(&name, &args[1..], &referenced) {
         return Ok(());
     }
     let (opts, warnings) = AliasOptions::parse(args, &referenced)?;

--- a/src/completion.rs
+++ b/src/completion.rs
@@ -512,7 +512,7 @@ fn build_hook_completion_command(name: &'static str) -> Command {
 /// completion but would misrepresent alias semantics on a `--help` page. The
 /// help-path counterparts are `augment_help` (text-splices the `Aliases:`
 /// section into `wt --help` / `wt step --help`, preserving source markers and
-/// shadowed-by-builtin annotations) and `emit_alias_help_hint` (redirects
+/// shadowed-by-builtin annotations) and `try_intercept_alias_help` (redirects
 /// `wt <alias> --help` to `wt config alias show` / `dry-run`).
 fn inject_alias_subcommands(cmd: Command) -> Command {
     let aliases = load_aliases_for_completion();


### PR DESCRIPTION
Both dispatchers (`try_alias` for `wt <alias>` and `step_alias` for `wt step <alias>`) ran the same `!referenced.contains(\"help\") && help_flag_requested(...)` + `emit_alias_help_hint` pair. Collapse to a single `try_intercept_alias_help` helper that returns whether the help hint was emitted; the comment about `help` binding moves into the helper's doc.

> _This was written by Claude Code on behalf of @max-sixty_