### PR TITLE
refactor(list): skip per-result render in JSON mode and drop dead `is_tty`

### DIFF
--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -1216,12 +1216,19 @@ pub fn collect(
 
             match event {
                 results::DrainEvent::Result { item_idx, item } => {
+                    has_data[item_idx] = true;
+
+                    // JSON and buffered-table modes render once at the end,
+                    // not per-result.
+                    if progressive_state.is_none() && progressive_handler.is_none() {
+                        return;
+                    }
+
                     // `update_row` and the picker handler both write through
                     // an idempotent slot (terminal line / `Mutex<String>`),
                     // so forwarding every result without dedup is safe; the
                     // table dedups internally against its previous render.
                     let rendered = layout.format_list_item_line(item);
-                    has_data[item_idx] = true;
 
                     if let Some(state_cell) = progressive_state.as_ref() {
                         let mut s = state_cell.borrow_mut();

--- a/src/commands/list/progressive_table.rs
+++ b/src/commands/list/progressive_table.rs
@@ -37,11 +37,10 @@ pub struct ProgressiveTable {
     row_count: usize,
     /// Total number of data rows (including those not shown in skeleton)
     total_row_count: usize,
-    /// Whether output is going to a TTY
-    is_tty: bool,
     /// Lines that have been modified since last flush
     dirty: Vec<usize>,
-    /// Whether the skeleton was printed (only true in TTY mode after render_skeleton)
+    /// Whether the skeleton was printed. Tests skip `render_skeleton` to keep
+    /// this false and suppress stdout output.
     rendered: bool,
 }
 
@@ -78,7 +77,6 @@ impl ProgressiveTable {
         max_width: usize,
         terminal_height: Option<usize>,
     ) -> Self {
-        let is_tty = stdout().is_terminal();
         let total_row_count = skeletons.len();
 
         // Limit visible rows to fit in terminal: header + rows + spacer + footer = rows + 3
@@ -107,17 +105,16 @@ impl ProgressiveTable {
             max_width,
             row_count: visible_row_count,
             total_row_count,
-            is_tty,
             dirty: Vec::new(),
             rendered: false,
         }
     }
 
-    /// Print the skeleton table to stdout (TTY only).
+    /// Print the skeleton table to stdout.
     ///
     /// Idempotent: calling multiple times has no effect after the first render.
     pub fn render_skeleton(&mut self) -> std::io::Result<()> {
-        if self.is_tty && !self.rendered {
+        if !self.rendered {
             self.print_all()?;
             self.rendered = true;
         }
@@ -200,11 +197,10 @@ impl ProgressiveTable {
             return Ok(());
         }
 
-        // Defense-in-depth: dirty should only be non-empty if we're in TTY mode and rendered.
-        // The update_* methods gate on `self.rendered`, which is only set when is_tty is true.
+        // Defense-in-depth: dirty is only populated after render_skeleton has run.
         debug_assert!(
-            self.is_tty && self.rendered,
-            "dirty list should only be non-empty after render_skeleton in TTY mode"
+            self.rendered,
+            "dirty list should only be non-empty after render_skeleton"
         );
 
         // Take ownership of dirty indices to avoid borrow conflict with redraw_line
@@ -445,9 +441,7 @@ mod tests {
             80,
         );
 
-        // Simulate TTY render state (in tests, is_tty is false so render_skeleton is a no-op,
-        // but we can manually set both flags to test dirty tracking while maintaining invariant)
-        table.is_tty = true;
+        // Simulate post-render state without actually printing the skeleton.
         table.rendered = true;
 
         // After render, updates mark lines as dirty


### PR DESCRIPTION
Two follow-ups from the `RenderTarget` refactor (#2469), both in `src/commands/list/`.

**Skip per-result render when no consumer needs it.** In `drain_results`'s `DrainEvent::Result` arm, `format_list_item_line` ran on every result and was discarded in `RenderTarget::Json` and the buffered-table path (both have `progressive_state` and `progressive_handler` as `None`). Those modes build their final output later — JSON via `handle_list`, buffered table via `TableRenderPlan::render`. The arm now sets `has_data[item_idx]` first (still needed by reveal) and returns early when neither consumer is present.

**Drop `ProgressiveTable.is_tty`.** After `RenderTarget` resolved progressive mode only on a TTY, the field was always `true` in production. Tests drive the silent path by skipping `render_skeleton`, which keeps `rendered` false — that's the only condition the production code needs. Field, the `stdout().is_terminal()` call in `new_with_height`, the `self.is_tty &&` conjuncts in `render_skeleton` and `flush`'s debug_assert, and the `table.is_tty = true;` setup in `test_dirty_tracking_after_render` are all gone.

Net diff: +16 / −15. The runtime benefit (no wasted `format_list_item_line` per result in JSON / buffered modes) doesn't show up in LOC because the gating block is roughly the same size as the work it skips.

Verified with `cargo run -- hook pre-merge --yes` (3393 tests pass, lints clean, no snapshot drift).

> _This was written by Claude Code on behalf of @max-sixty_