### PR TITLE
ci: add cargo-affected jobs (advisory)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -389,38 +389,30 @@ jobs:
         echo "merge-base with origin/main: $sha"
 
     - name: 💾 Restore coverage DB
-      id: db
       uses: actions/cache/restore@v4
       with:
         path: target/affected
         # Exact match: collect ran on the PR's merge-base → tight diff.
         key: cargo-affected-db-v1-${{ runner.os }}-${{ steps.mb.outputs.sha }}
         # Fallback: most recent main DB. cargo-affected runs all tests when
-        # collect_sha isn't an ancestor of HEAD (instead of bailing), so this
-        # path is correct, just broader.
+        # collect_sha isn't an ancestor of HEAD; with no DB at all it does
+        # the same. Either way the run produces a useful signal.
         restore-keys: |
           cargo-affected-db-v1-${{ runner.os }}-
 
-    - name: 🛑 Skip if no DB cached
-      if: steps.db.outputs.cache-matched-key == ''
-      run: echo "::notice::No cargo-affected DB cached yet — the collect-affected job on main bootstraps it. Skipping."
-
     - name: Install cargo-insta
-      if: steps.db.outputs.cache-matched-key != ''
       uses: baptiste0928/cargo-install@v3
       with:
         crate: cargo-insta
         version: "=1.46.3"
 
     - name: Install cargo-nextest
-      if: steps.db.outputs.cache-matched-key != ''
       uses: baptiste0928/cargo-install@v3
       with:
         crate: cargo-nextest
         version: "=0.9.132"
 
     - name: Install cargo-affected
-      if: steps.db.outputs.cache-matched-key != ''
       uses: baptiste0928/cargo-install@v3
       with:
         crate: cargo-affected
@@ -428,28 +420,23 @@ jobs:
         # No rev/branch/tag → action resolves to latest default-branch sha.
 
     - name: Install llvm-tools
-      if: steps.db.outputs.cache-matched-key != ''
       run: rustup component add llvm-tools
 
     - name: 💰 Cache
-      if: steps.db.outputs.cache-matched-key != ''
       uses: Swatinem/rust-cache@v2
 
     - name: Install shells (zsh, fish)
-      if: steps.db.outputs.cache-matched-key != ''
       uses: awalsh128/cache-apt-pkgs-action@latest
       with:
         packages: zsh fish
         version: 1.0
 
     - name: Install nushell
-      if: steps.db.outputs.cache-matched-key != ''
       uses: hustcer/setup-nu@v3
       with:
         version: '0.112.2'
 
     - name: 🎯 Run affected tests
-      if: steps.db.outputs.cache-matched-key != ''
       env:
         NEXTEST_NO_INPUT_HANDLER: 1
       run: cargo affected run --features shell-integration-tests --verbose

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -276,6 +276,198 @@ jobs:
     - name: 📊 Run benchmarks
       run: cargo bench
 
+  # cargo-affected: runs only the tests whose recorded coverage overlaps the
+  # diff. Advisory at this stage — `test (linux/macos/windows)` still runs the
+  # full suite. The signal is the runtime delta on the exact-match path and
+  # whether selection misses any failures the full suite catches.
+  #
+  # TODO: once cargo-affected is trusted on this repo, gate the full test
+  # matrix to run only on pushes to main and on PRs with a `full-tests` label
+  # (or similar). PR pushes would default to affected-only. The full suite
+  # could fold into the existing `nightly` workflow, which already hosts
+  # slower integration-time checks. Periodic full runs remain essential —
+  # cargo-affected misses non-Rust inputs (`include_str!`, templates, SQL),
+  # build-time inputs not in its fingerprint (build.rs, rust-toolchain.toml,
+  # .cargo/config.toml), and proc-macro source edits.
+  #
+  # Cache strategy:
+  # - `collect-affected` (push to main) saves `target/affected/` to
+  #   actions/cache keyed on the main commit sha.
+  # - `affected-tests` (PRs) restores the cache. Primary key is the
+  #   PR/main merge-base — when collect ran on that exact commit, we get a
+  #   tight diff (`PR changes only`) and the smallest possible selection.
+  # - Restore-keys fall back to the most recent main DB. Its `collect_sha`
+  #   may be ahead of the merge-base; cargo-affected handles that by running
+  #   all tests with a notice (no `Diverged` bail), so the fallback always
+  #   produces a useful run, just with broader selection.
+  # - Cache keys include `runner.os` (fingerprint embeds `rustc -vV`) and
+  #   the cargo-affected commit sha resolved at runtime, so schema-affecting
+  #   upstream changes invalidate stale DBs automatically.
+  collect-affected:
+    name: collect affected coverage
+    if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
+    runs-on: ubuntu-24.04
+    steps:
+    - name: 📂 Checkout code
+      uses: actions/checkout@v6
+      with:
+        # `cargo affected run` later diffs PR HEAD against the sha that was
+        # HEAD when collect ran. That sha must be reachable.
+        fetch-depth: 0
+
+    - name: Resolve cargo-affected latest sha
+      id: ca
+      run: |
+        sha=$(git ls-remote --exit-code https://github.com/max-sixty/cargo-affected HEAD | cut -f1)
+        echo "rev=$sha" >> "$GITHUB_OUTPUT"
+        echo "Using cargo-affected $sha"
+
+    - name: Install cargo-insta
+      uses: baptiste0928/cargo-install@v3
+      with:
+        crate: cargo-insta
+        version: "=1.46.3"
+
+    - name: Install cargo-nextest
+      uses: baptiste0928/cargo-install@v3
+      with:
+        crate: cargo-nextest
+        version: "=0.9.132"
+
+    - name: Install cargo-affected
+      uses: baptiste0928/cargo-install@v3
+      with:
+        crate: cargo-affected
+        git: https://github.com/max-sixty/cargo-affected
+        rev: ${{ steps.ca.outputs.rev }}
+
+    - name: Install llvm-tools
+      run: rustup component add llvm-tools
+
+    - name: 💰 Cache
+      uses: Swatinem/rust-cache@v2
+
+    - name: Install shells (zsh, fish)
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: zsh fish
+        version: 1.0
+
+    - name: Install nushell
+      uses: hustcer/setup-nu@v3
+      with:
+        version: '0.112.2'
+
+    - name: 📊 Collect coverage data
+      env:
+        NEXTEST_NO_INPUT_HANDLER: 1
+      run: cargo affected collect --features shell-integration-tests
+
+    - name: 💾 Save coverage DB
+      uses: actions/cache/save@v4
+      with:
+        path: target/affected
+        key: cargo-affected-db-${{ runner.os }}-${{ steps.ca.outputs.rev }}-${{ github.sha }}
+
+  affected-tests:
+    name: affected tests (linux, advisory)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-24.04
+    # Advisory while we calibrate selection accuracy against the full suite.
+    # The full matrix (`test (linux/macos/windows)`) is still required for
+    # merge.
+    continue-on-error: true
+    steps:
+    - name: 📂 Checkout code
+      uses: actions/checkout@v6
+      with:
+        # Need the cached `collect_sha` reachable from HEAD for the diff;
+        # see collect-affected above.
+        fetch-depth: 0
+
+    - name: Resolve cargo-affected latest sha
+      id: ca
+      run: |
+        sha=$(git ls-remote --exit-code https://github.com/max-sixty/cargo-affected HEAD | cut -f1)
+        echo "rev=$sha" >> "$GITHUB_OUTPUT"
+        echo "Using cargo-affected $sha"
+
+    - name: Compute merge-base for cache key
+      id: mb
+      env:
+        PR_HEAD: ${{ github.event.pull_request.head.sha }}
+      run: |
+        git fetch --no-tags --depth=200 origin main
+        sha=$(git merge-base origin/main "$PR_HEAD")
+        echo "sha=$sha" >> "$GITHUB_OUTPUT"
+        echo "merge-base with origin/main: $sha"
+
+    - name: 💾 Restore coverage DB
+      id: db
+      uses: actions/cache/restore@v4
+      with:
+        path: target/affected
+        # Exact match: collect ran on the PR's merge-base → tight diff.
+        key: cargo-affected-db-${{ runner.os }}-${{ steps.ca.outputs.rev }}-${{ steps.mb.outputs.sha }}
+        # Fallback: most recent main DB. cargo-affected runs all tests when
+        # collect_sha isn't an ancestor of HEAD (instead of bailing), so this
+        # path is correct, just broader.
+        restore-keys: |
+          cargo-affected-db-${{ runner.os }}-${{ steps.ca.outputs.rev }}-
+
+    - name: 🛑 Skip if no DB cached
+      if: steps.db.outputs.cache-matched-key == ''
+      run: echo "::notice::No cargo-affected DB cached yet — the collect-affected job on main bootstraps it. Skipping."
+
+    - name: Install cargo-insta
+      if: steps.db.outputs.cache-matched-key != ''
+      uses: baptiste0928/cargo-install@v3
+      with:
+        crate: cargo-insta
+        version: "=1.46.3"
+
+    - name: Install cargo-nextest
+      if: steps.db.outputs.cache-matched-key != ''
+      uses: baptiste0928/cargo-install@v3
+      with:
+        crate: cargo-nextest
+        version: "=0.9.132"
+
+    - name: Install cargo-affected
+      if: steps.db.outputs.cache-matched-key != ''
+      uses: baptiste0928/cargo-install@v3
+      with:
+        crate: cargo-affected
+        git: https://github.com/max-sixty/cargo-affected
+        rev: ${{ steps.ca.outputs.rev }}
+
+    - name: Install llvm-tools
+      if: steps.db.outputs.cache-matched-key != ''
+      run: rustup component add llvm-tools
+
+    - name: 💰 Cache
+      if: steps.db.outputs.cache-matched-key != ''
+      uses: Swatinem/rust-cache@v2
+
+    - name: Install shells (zsh, fish)
+      if: steps.db.outputs.cache-matched-key != ''
+      uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: zsh fish
+        version: 1.0
+
+    - name: Install nushell
+      if: steps.db.outputs.cache-matched-key != ''
+      uses: hustcer/setup-nu@v3
+      with:
+        version: '0.112.2'
+
+    - name: 🎯 Run affected tests
+      if: steps.db.outputs.cache-matched-key != ''
+      env:
+        NEXTEST_NO_INPUT_HANDLER: 1
+      run: cargo affected run --features shell-integration-tests --verbose
+
   code-coverage:
     runs-on: ubuntu-24.04
     steps:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -300,9 +300,9 @@ jobs:
   #   may be ahead of the merge-base; cargo-affected handles that by running
   #   all tests with a notice (no `Diverged` bail), so the fallback always
   #   produces a useful run, just with broader selection.
-  # - Cache keys include `runner.os` (fingerprint embeds `rustc -vV`) and
-  #   the cargo-affected commit sha resolved at runtime, so schema-affecting
-  #   upstream changes invalidate stale DBs automatically.
+  # - Cache keys include `runner.os` (fingerprint embeds `rustc -vV`) and a
+  #   manual `db-v{N}` marker. Bump the marker if cargo-affected ships an
+  #   on-disk schema change; the cache is otherwise version-agnostic.
   collect-affected:
     name: collect affected coverage
     if: ${{ (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch' }}
@@ -314,13 +314,6 @@ jobs:
         # `cargo affected run` later diffs PR HEAD against the sha that was
         # HEAD when collect ran. That sha must be reachable.
         fetch-depth: 0
-
-    - name: Resolve cargo-affected latest sha
-      id: ca
-      run: |
-        sha=$(git ls-remote --exit-code https://github.com/max-sixty/cargo-affected HEAD | cut -f1)
-        echo "rev=$sha" >> "$GITHUB_OUTPUT"
-        echo "Using cargo-affected $sha"
 
     - name: Install cargo-insta
       uses: baptiste0928/cargo-install@v3
@@ -339,7 +332,7 @@ jobs:
       with:
         crate: cargo-affected
         git: https://github.com/max-sixty/cargo-affected
-        rev: ${{ steps.ca.outputs.rev }}
+        # No rev/branch/tag → action resolves to latest default-branch sha.
 
     - name: Install llvm-tools
       run: rustup component add llvm-tools
@@ -367,7 +360,7 @@ jobs:
       uses: actions/cache/save@v4
       with:
         path: target/affected
-        key: cargo-affected-db-${{ runner.os }}-${{ steps.ca.outputs.rev }}-${{ github.sha }}
+        key: cargo-affected-db-v1-${{ runner.os }}-${{ github.sha }}
 
   affected-tests:
     name: affected tests (linux, advisory)
@@ -385,13 +378,6 @@ jobs:
         # see collect-affected above.
         fetch-depth: 0
 
-    - name: Resolve cargo-affected latest sha
-      id: ca
-      run: |
-        sha=$(git ls-remote --exit-code https://github.com/max-sixty/cargo-affected HEAD | cut -f1)
-        echo "rev=$sha" >> "$GITHUB_OUTPUT"
-        echo "Using cargo-affected $sha"
-
     - name: Compute merge-base for cache key
       id: mb
       env:
@@ -408,12 +394,12 @@ jobs:
       with:
         path: target/affected
         # Exact match: collect ran on the PR's merge-base → tight diff.
-        key: cargo-affected-db-${{ runner.os }}-${{ steps.ca.outputs.rev }}-${{ steps.mb.outputs.sha }}
+        key: cargo-affected-db-v1-${{ runner.os }}-${{ steps.mb.outputs.sha }}
         # Fallback: most recent main DB. cargo-affected runs all tests when
         # collect_sha isn't an ancestor of HEAD (instead of bailing), so this
         # path is correct, just broader.
         restore-keys: |
-          cargo-affected-db-${{ runner.os }}-${{ steps.ca.outputs.rev }}-
+          cargo-affected-db-v1-${{ runner.os }}-
 
     - name: 🛑 Skip if no DB cached
       if: steps.db.outputs.cache-matched-key == ''
@@ -439,7 +425,7 @@ jobs:
       with:
         crate: cargo-affected
         git: https://github.com/max-sixty/cargo-affected
-        rev: ${{ steps.ca.outputs.rev }}
+        # No rev/branch/tag → action resolves to latest default-branch sha.
 
     - name: Install llvm-tools
       if: steps.db.outputs.cache-matched-key != ''


### PR DESCRIPTION
## Summary

Adds two CI jobs that exercise `cargo affected` against this repo as an advisory signal alongside the existing full test matrix.

- **`collect-affected`** runs on push to `main` and on `workflow_dispatch`. It builds with coverage instrumentation, runs every test, and writes `target/affected/coverage.db` to `actions/cache`.
- **`affected-tests`** runs on PRs as `continue-on-error: true`. It restores the cached DB and runs `cargo affected run --features shell-integration-tests`. Failures don't block merges.

## Cache strategy

- Cargo-affected installs from `https://github.com/max-sixty/cargo-affected` with no rev/branch/tag pin — `baptiste0928/cargo-install` resolves the latest default-branch sha at install time and caches the binary per-resolved-rev.
- The PR job's primary cache key is the PR/main merge-base. Exact match → tight diff (PR changes only) → minimal selection.
- Restore-keys fall back to the most recent main DB. With [Fall back to all tests when selection can't be precise](https://github.com/max-sixty/cargo-affected/commit/9afb870), `cargo affected run` runs all tests with a notice whenever it can't compute a precise selection — Cargo.lock change, divergent `collect_sha`, or no DB at all. So `affected-tests` always produces a useful run, even before the cache is seeded.
- Cache key has a manual `db-v1-` marker. Bump it if cargo-affected ships an on-disk schema change; the cache is otherwise version-agnostic.

## TODO

Once selection accuracy is calibrated against the full suite, gate the full `test (linux/macos/windows)` matrix to run only on pushes to main and on PRs with a `full-tests` label (or similar). PR pushes would default to affected-only. The full suite could fold into the existing `nightly` workflow.

Periodic full runs remain essential — cargo-affected misses non-Rust inputs (`include_str!`, templates, SQL), build-time inputs not in its fingerprint (`build.rs`, `rust-toolchain.toml`, `.cargo/config.toml`), and proc-macro source edits.

## Test plan

- [x] Bootstrap PR (no DB cached): `affected-tests` runs `cargo affected run` which falls back to all tests via the upstream fix. ~6m28s on this PR vs. 5m31s for `test (linux)` — the ~1m delta is install + cargo-affected setup.
- [ ] On merge to main: `collect-affected` runs and seeds the cache.
- [ ] On a follow-up PR: `affected-tests` restores the cache, exact-match merge-base works, selection is non-empty.
- [ ] Stale-PR scenario: open a PR, push more commits to main, confirm restore-keys fallback hits and `cargo affected run` runs all tests via the fallback path.
- [ ] Cargo.lock change: confirm env-fingerprint mismatch path runs all tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)