### PR TITLE
refactor(merge): collapse Option<bool> tri-state into one resolution path

### DIFF
--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -1,6 +1,6 @@
 use anyhow::Context;
 use worktrunk::HookType;
-use worktrunk::config::{Approvals, UserConfig};
+use worktrunk::config::{Approvals, MergeConfig, UserConfig};
 use worktrunk::git::Repository;
 use worktrunk::styling::{eprintln, info_message};
 
@@ -20,28 +20,58 @@ use super::worktree::{
 };
 use worktrunk::git::BranchDeletionMode;
 
-/// Options for the merge command
-///
-/// All boolean fields are optional CLI overrides. If None, the effective config
-/// (project-specific merged with global) is used. If that's also None, defaults apply.
+/// Tri-state CLI overrides for the six `wt merge` boolean flags. `None` =
+/// fall through to effective config; `Some(b)` = user explicitly chose.
+pub struct MergeFlagOverrides {
+    pub squash: Option<bool>,
+    pub commit: Option<bool>,
+    pub rebase: Option<bool>,
+    pub remove: Option<bool>,
+    pub ff: Option<bool>,
+    pub verify: Option<bool>,
+}
+
+impl MergeFlagOverrides {
+    pub fn from_cli(args: &crate::cli::MergeArgs) -> Self {
+        Self {
+            squash: crate::flag_pair(args.squash, args.no_squash),
+            commit: crate::flag_pair(args.commit, args.no_commit),
+            rebase: crate::flag_pair(args.rebase, args.no_rebase),
+            remove: crate::flag_pair(args.remove, args.no_remove),
+            ff: crate::flag_pair(args.ff, args.no_ff),
+            verify: crate::flag_pair(args.verify, args.no_hooks || args.no_verify),
+        }
+    }
+
+    /// Apply the override → effective-config → default-true chain.
+    pub fn resolve(&self, config: &MergeConfig) -> ResolvedMergeFlags {
+        ResolvedMergeFlags {
+            squash: self.squash.unwrap_or(config.squash()),
+            commit: self.commit.unwrap_or(config.commit()),
+            rebase: self.rebase.unwrap_or(config.rebase()),
+            remove: self.remove.unwrap_or(config.remove()),
+            ff: self.ff.unwrap_or(config.ff()),
+            verify: self.verify.unwrap_or(config.verify()),
+        }
+    }
+}
+
+pub struct ResolvedMergeFlags {
+    pub squash: bool,
+    pub commit: bool,
+    pub rebase: bool,
+    pub remove: bool,
+    pub ff: bool,
+    pub verify: bool,
+}
+
+/// Options for the merge command. `flags` carries tri-state CLI overrides for
+/// the six boolean flags; `stage` is the same shape but for stage mode.
 pub struct MergeOptions<'a> {
     pub target: Option<&'a str>,
-    /// CLI override for squash. None = use effective config default.
-    pub squash: Option<bool>,
-    /// CLI override for commit. None = use effective config default.
-    pub commit: Option<bool>,
-    /// CLI override for rebase. None = use effective config default.
-    pub rebase: Option<bool>,
-    /// CLI override for remove. None = use effective config default.
-    pub remove: Option<bool>,
-    /// CLI override for ff. None = use effective config default.
-    pub ff: Option<bool>,
-    /// CLI override for verify. None = use effective config default.
-    pub verify: Option<bool>,
+    pub flags: MergeFlagOverrides,
     pub yes: bool,
-    /// CLI override for stage mode. None = use effective config default.
     pub stage: Option<super::commit::StageMode>,
-    /// Output format (text or json).
     pub format: crate::cli::SwitchFormat,
 }
 
@@ -90,12 +120,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
     let json_mode = opts.format == crate::cli::SwitchFormat::Json;
     let MergeOptions {
         target,
-        squash: squash_opt,
-        commit: commit_opt,
-        rebase: rebase_opt,
-        remove: remove_opt,
-        ff: ff_opt,
-        verify: verify_opt,
+        flags,
         yes,
         stage,
         ..
@@ -103,7 +128,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
 
     // Load config once, run LLM setup prompt if committing, then reuse config
     let mut config = UserConfig::load().context("Failed to load config")?;
-    if commit_opt.unwrap_or(true) {
+    if flags.commit.unwrap_or(true) {
         // One-time LLM setup prompt (errors logged internally; don't block merge)
         let _ = crate::output::prompt_commit_generation(&mut config);
     }
@@ -117,13 +142,14 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
     // Get effective settings (project-specific merged with global, defaults applied)
     let resolved = env.resolved();
 
-    // CLI flags override config values
-    let squash = squash_opt.unwrap_or(resolved.merge.squash());
-    let commit = commit_opt.unwrap_or(resolved.merge.commit());
-    let rebase = rebase_opt.unwrap_or(resolved.merge.rebase());
-    let remove = remove_opt.unwrap_or(resolved.merge.remove());
-    let ff = ff_opt.unwrap_or(resolved.merge.ff());
-    let verify = verify_opt.unwrap_or(resolved.merge.verify());
+    let ResolvedMergeFlags {
+        squash,
+        commit,
+        rebase,
+        remove,
+        ff,
+        verify,
+    } = flags.resolve(&resolved.merge);
     let stage_mode = stage.unwrap_or(resolved.commit.stage());
 
     // Cache current worktree for multiple queries

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -49,7 +49,7 @@ pub(crate) use handle_switch::{SwitchOptions, handle_switch};
 pub(crate) use hook_commands::{HookCliArgs, handle_hook_show, run_hook};
 pub(crate) use init::{handle_completions, handle_init};
 pub(crate) use list::handle_list;
-pub(crate) use merge::{MergeOptions, handle_merge};
+pub(crate) use merge::{MergeFlagOverrides, MergeOptions, handle_merge};
 #[cfg(unix)]
 pub(crate) use picker::handle_picker;
 pub(crate) use repository_ext::RemoveTarget;

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,12 +46,12 @@ use commands::handle_picker;
 use commands::repository_ext::RepositoryCliExt;
 use commands::worktree::{PushKind, handle_no_ff_merge, handle_push};
 use commands::{
-    HookCliArgs, MergeOptions, OperationMode, RebaseResult, RemoveTarget, SquashResult,
-    SwitchOptions, add_approvals, clear_approvals, handle_alias_dry_run, handle_alias_show,
-    handle_claude_install, handle_claude_install_statusline, handle_claude_uninstall,
-    handle_completions, handle_config_create, handle_config_show, handle_config_update,
-    handle_configure_shell, handle_custom_command, handle_hints_clear, handle_hints_get,
-    handle_hook_show, handle_init, handle_list, handle_logs_list, handle_merge,
+    HookCliArgs, MergeFlagOverrides, MergeOptions, OperationMode, RebaseResult, RemoveTarget,
+    SquashResult, SwitchOptions, add_approvals, clear_approvals, handle_alias_dry_run,
+    handle_alias_show, handle_claude_install, handle_claude_install_statusline,
+    handle_claude_uninstall, handle_completions, handle_config_create, handle_config_show,
+    handle_config_update, handle_configure_shell, handle_custom_command, handle_hints_clear,
+    handle_hints_get, handle_hook_show, handle_init, handle_list, handle_logs_list, handle_merge,
     handle_opencode_install, handle_opencode_uninstall, handle_promote, handle_rebase,
     handle_show_theme, handle_squash, handle_state_clear, handle_state_clear_all, handle_state_get,
     handle_state_set, handle_state_show, handle_switch, handle_unconfigure_shell,
@@ -126,7 +126,7 @@ fn print_windows_picker_unavailable() {
     );
 }
 
-fn flag_pair(positive: bool, negative: bool) -> Option<bool> {
+pub(crate) fn flag_pair(positive: bool, negative: bool) -> Option<bool> {
     match (positive, negative) {
         (true, _) => Some(true),
         (_, true) => Some(false),
@@ -1113,12 +1113,7 @@ fn handle_merge_command(args: MergeArgs, yes: bool) -> anyhow::Result<()> {
     }
     handle_merge(MergeOptions {
         target: args.target.as_deref(),
-        squash: flag_pair(args.squash, args.no_squash),
-        commit: flag_pair(args.commit, args.no_commit),
-        rebase: flag_pair(args.rebase, args.no_rebase),
-        remove: flag_pair(args.remove, args.no_remove),
-        ff: flag_pair(args.ff, args.no_ff),
-        verify: flag_pair(args.verify, args.no_hooks || args.no_verify),
+        flags: MergeFlagOverrides::from_cli(&args),
         yes,
         stage: args.stage,
         format: args.format,


### PR DESCRIPTION
The six tri-state merge flags (squash/commit/rebase/remove/ff/verify) threaded through three layers with mechanical 6× repetition: the clap pairs in `MergeArgs`, the six `flag_pair` calls in `handle_merge_command`, and the six `_opt.unwrap_or(resolved.merge.X())` calls in `handle_merge`.

This introduces `MergeFlagOverrides` (six `Option<bool>`) with `from_cli` to absorb the `flag_pair` calls and `resolve(&MergeConfig)` to absorb the `unwrap_or` block, returning a `ResolvedMergeFlags` struct of plain `bool`s. `handle_merge` now reads:

```rust
let ResolvedMergeFlags { squash, commit, rebase, remove, ff, verify } =
    flags.resolve(&resolved.merge);
```

Out of scope: the `--FLAG`/`--no-FLAG` clap pairs in `MergeArgs` (would need proc macros); `MergeConfig` itself (load-bearing for TOML and the `Merge` trait); other commands' `Option<bool>` use (different semantics). The CLI surface and the LLM commit-prompt timing are byte-identical.

`flag_pair` stays — `switch` and `list` still call it.

> _This was written by Claude Code on behalf of @max-sixty_