### PR TITLE
fix(commit): suppress spurious "(--no-hooks)" line after declined approval

### DIFF
--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -15,11 +15,43 @@ use super::template_vars::TemplateVars;
 // Re-export StageMode from config for use by CLI
 pub use worktrunk::config::StageMode;
 
+/// Whether pre/post-commit hooks run, and — if not — whether to print the skip message.
+/// Two distinct paths disable hooks: `--no-hooks` (we own the skip message) and declined
+/// approval (the caller already printed its own message).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum HookGate {
+    /// Run pre-commit and post-commit hooks normally.
+    Run,
+    /// Skip hooks because the user passed `--no-hooks`. `commit()` prints the skip message.
+    NoHooksFlag,
+    /// Skip hooks silently — caller has already explained why.
+    Silent,
+}
+
+impl HookGate {
+    /// Whether pre/post-commit hooks should execute.
+    pub(crate) fn run(self) -> bool {
+        matches!(self, Self::Run)
+    }
+
+    /// Build from an entry-point `verify` flag plus an approval-prompt result.
+    /// `verify=false` → `NoHooksFlag`; declined → `Silent`; approved → `Run`.
+    pub(crate) fn from_approval(verify: bool, approved: bool) -> Self {
+        if !verify {
+            Self::NoHooksFlag
+        } else if approved {
+            Self::Run
+        } else {
+            Self::Silent
+        }
+    }
+}
+
 /// Options for committing current changes.
 pub struct CommitOptions<'a> {
     pub ctx: &'a CommandContext<'a>,
     pub target_branch: Option<&'a str>,
-    pub verify: bool,
+    pub hooks: HookGate,
     pub stage_mode: StageMode,
     pub warn_about_untracked: bool,
     pub show_no_squash_note: bool,
@@ -31,7 +63,7 @@ impl<'a> CommitOptions<'a> {
         Self {
             ctx,
             target_branch: None,
-            verify: true,
+            hooks: HookGate::Run,
             stage_mode: StageMode::All,
             warn_about_untracked: true,
             show_no_squash_note: false,
@@ -166,8 +198,10 @@ impl CommitOptions<'_> {
         );
         let any_hooks_exist = user_cfg.is_some() || proj_cfg.is_some();
 
-        // Show skip message
-        if !self.verify && any_hooks_exist {
+        // Only print "Skipping pre-commit hooks (--no-hooks)" when --no-hooks was actually
+        // passed. If hooks are disabled because the caller declined an approval prompt
+        // (HookGate::Silent), the caller has already printed its own message.
+        if self.hooks == HookGate::NoHooksFlag && any_hooks_exist {
             eprintln!("{}", info_message("Skipping pre-commit hooks (--no-hooks)"));
         }
 
@@ -175,7 +209,7 @@ impl CommitOptions<'_> {
             .target_branch
             .map_or_else(TemplateVars::new, |t| TemplateVars::new().with_target(t));
 
-        if self.verify {
+        if self.hooks.run() {
             // Run pre-commit hooks (user first, then project).
             execute_hook(
                 self.ctx,
@@ -223,7 +257,7 @@ impl CommitOptions<'_> {
         )?;
 
         // Spawn post-commit hooks in background (respects --no-hooks)
-        if self.verify {
+        if self.hooks.run() {
             let extra_vars = template_vars.as_extra_vars();
             spawn_background_hooks(self.ctx, HookType::PostCommit, &extra_vars, None)?;
         }

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -7,7 +7,7 @@ use worktrunk::styling::{eprintln, info_message};
 use super::command_approval::approve_command_batch;
 use super::command_executor::CommandContext;
 use super::command_executor::FailureStrategy;
-use super::commit::CommitOptions;
+use super::commit::{CommitOptions, HookGate};
 use super::context::CommandEnv;
 use super::hooks::{HookAnnouncer, execute_hook};
 use super::project_config::{ApprovableCommand, collect_commands_for_hooks};
@@ -188,8 +188,14 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
     let approvals = Approvals::load().context("Failed to load approvals")?;
     let approved = approve_command_batch(&all_commands, &project_id, &approvals, yes, false)?;
 
-    // If commands were declined, skip hooks but continue with merge
-    // Shadow verify to gate all subsequent hook execution on approval
+    // Commit-phase gate uses the original `verify` (before the shadow below) so it can
+    // distinguish --no-hooks from declined-approval; CommitOptions and handle_squash
+    // need that distinction to suppress a duplicate "(--no-hooks)" line.
+    let commit_hooks = HookGate::from_approval(verify, approved);
+
+    // If commands were declined, skip hooks but continue with merge.
+    // Shadow verify to gate all subsequent hook execution (pre-merge, post-merge,
+    // pre-remove, post-switch) on approval.
     let verify = if approved {
         verify
     } else {
@@ -205,7 +211,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
             let ctx = env.context(yes);
             let mut options = CommitOptions::new(&ctx);
             options.target_branch = Some(&target_branch);
-            options.verify = verify;
+            options.hooks = commit_hooks;
             options.stage_mode = stage_mode;
             options.warn_about_untracked = stage_mode == super::commit::StageMode::All;
             options.show_no_squash_note = true;
@@ -217,13 +223,15 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
         false // No dirty changes or --no-commit
     };
 
-    // Squash commits if enabled - track whether squashing occurred
+    // Squash commits if enabled - track whether squashing occurred.
+    // Pass `commit_hooks` (not the shadowed `verify`) so handle_squash gets the
+    // --no-hooks vs declined-approval distinction.
     let squashed = if squash_enabled {
         matches!(
             super::step_commands::handle_squash(
                 Some(&target_branch),
                 yes,
-                verify,
+                commit_hooks,
                 Some(stage_mode)
             )?,
             super::step_commands::SquashResult::Squashed

--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -37,7 +37,7 @@ use worktrunk::styling::{
 
 use super::command_approval::approve_or_skip;
 use super::command_executor::FailureStrategy;
-use super::commit::{CommitGenerator, CommitOptions, StageMode};
+use super::commit::{CommitGenerator, CommitOptions, HookGate, StageMode};
 use super::context::CommandEnv;
 use super::hooks::{execute_hook, spawn_background_hooks};
 use super::repository_ext::{RemoveTarget, RepositoryCliExt};
@@ -80,17 +80,18 @@ pub fn step_commit(
     // CLI flag overrides config value
     let stage_mode = stage.unwrap_or(env.resolved().commit.stage());
 
-    // "Approve at the Gate": approve commit hooks upfront (unless --no-hooks)
-    // Shadow verify: if user declines approval, skip hooks but continue commit
-    let verify = verify
+    // "Approve at the Gate": prompt for approval upfront (when hooks are enabled) so
+    // hook execution downstream is fully gated.
+    let approved = verify
         && approve_or_skip(
             &ctx,
             &[HookType::PreCommit, HookType::PostCommit],
             "Commands declined, committing without hooks",
         )?;
+    let hooks = HookGate::from_approval(verify, approved);
 
     let mut options = CommitOptions::new(&ctx);
-    options.verify = verify;
+    options.hooks = hooks;
     options.stage_mode = stage_mode;
     options.show_no_squash_note = false;
     // Only warn about untracked if we're staging all
@@ -115,12 +116,14 @@ pub enum SquashResult {
 /// Handle shared squash workflow (used by `wt step squash` and `wt merge`)
 ///
 /// # Arguments
-/// * `verify` - If true, run pre-commit hooks (false when --no-hooks flag is passed)
+/// * `hooks` - Whether to run pre-commit hooks. `Run` triggers an internal approval
+///   prompt; `NoHooksFlag` skips with a "(--no-hooks)" message; `Silent` skips silently
+///   (used when the caller already declined approval upstream and announced it).
 /// * `stage` - CLI-provided stage mode. If None, uses the effective config default.
 pub fn handle_squash(
     target: Option<&str>,
     yes: bool,
-    verify: bool,
+    hooks: HookGate,
     stage: Option<StageMode>,
 ) -> anyhow::Result<SquashResult> {
     // Load config once, run LLM setup prompt, then reuse config
@@ -149,20 +152,29 @@ pub fn handle_squash(
     );
     let any_hooks_exist = user_cfg.is_some() || proj_cfg.is_some();
 
-    // "Approve at the Gate": approve commit hooks upfront (unless --no-hooks)
-    // Shadow verify: if user declines approval, skip hooks but continue squash
-    let verify = if verify {
-        approve_or_skip(
-            &ctx,
-            &[HookType::PreCommit, HookType::PostCommit],
-            "Commands declined, squashing without hooks",
-        )?
-    } else {
-        // Show skip message when --no-hooks was passed and hooks exist
-        if any_hooks_exist {
-            eprintln!("{}", info_message("Skipping pre-commit hooks (--no-hooks)"));
+    // Resolve the hook gate: Run triggers an approval prompt and downgrades to Silent
+    // on decline (approve_or_skip prints its own message). NoHooksFlag prints the skip
+    // message itself; Silent stays quiet so the upstream caller's decline message isn't
+    // followed by a spurious "(--no-hooks)" line.
+    let hooks = match hooks {
+        HookGate::Run => {
+            if approve_or_skip(
+                &ctx,
+                &[HookType::PreCommit, HookType::PostCommit],
+                "Commands declined, squashing without hooks",
+            )? {
+                HookGate::Run
+            } else {
+                HookGate::Silent
+            }
         }
-        false // --no-hooks was passed
+        HookGate::NoHooksFlag => {
+            if any_hooks_exist {
+                eprintln!("{}", info_message("Skipping pre-commit hooks (--no-hooks)"));
+            }
+            HookGate::NoHooksFlag
+        }
+        HookGate::Silent => HookGate::Silent,
     };
 
     // Get and validate target ref (any commit-ish for merge-base calculation)
@@ -186,7 +198,7 @@ pub fn handle_squash(
     }
 
     // Run pre-commit hooks (user first, then project).
-    if verify {
+    if hooks.run() {
         execute_hook(
             &ctx,
             HookType::PreCommit,
@@ -342,7 +354,7 @@ pub fn handle_squash(
     );
 
     // Spawn post-commit hooks in background (respects --no-hooks)
-    if verify {
+    if hooks.run() {
         let extra_vars = template_vars.as_extra_vars();
         spawn_background_hooks(&ctx, HookType::PostCommit, &extra_vars, None)?;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ pub(crate) use invocation::{
 
 pub(crate) use crate::cli::OutputFormat;
 
+use commands::commit::HookGate;
 #[cfg(unix)]
 use commands::handle_picker;
 use commands::repository_ext::RepositoryCliExt;
@@ -215,7 +216,12 @@ fn handle_step_command(action: StepCommand, yes: bool) -> anyhow::Result<()> {
                 commands::step_show_squash_prompt(args.target.as_deref())
             } else {
                 // Approval is handled inside handle_squash (like step_commit)
-                handle_squash(args.target.as_deref(), yes, verify, args.stage).map(|result| {
+                let hooks = if verify {
+                    HookGate::Run
+                } else {
+                    HookGate::NoHooksFlag
+                };
+                handle_squash(args.target.as_deref(), yes, hooks, args.stage).map(|result| {
                     match result {
                         SquashResult::Squashed | SquashResult::NoNetChanges => {}
                         SquashResult::NoCommitsAhead(branch) => {

--- a/tests/integration_tests/approval_pty.rs
+++ b/tests/integration_tests/approval_pty.rs
@@ -53,6 +53,16 @@ fn approval_pty_settings(repo: &TestRepo) -> insta::Settings {
     settings
 }
 
+/// Decline-path regression: a declined approval prompt prints its own "Commands declined,
+/// …" line; the downstream commit/squash phase must not also print
+/// "Skipping pre-commit hooks (--no-hooks)" — the user didn't pass that flag.
+fn assert_no_spurious_no_hooks(output: &str) {
+    assert!(
+        !output.contains("--no-hooks"),
+        "Declined approval should not produce a spurious '(--no-hooks)' line. Output:\n{output}"
+    );
+}
+
 /// Get test env vars with shell integration configured.
 ///
 /// This adds SHELL=/bin/zsh to the env vars, which is needed because:
@@ -459,6 +469,7 @@ command = "cat >/dev/null && echo 'feat: test commit message'"
         output.contains("committing without hooks"),
         "Should indicate commit proceeds without hooks. Output:\n{output}"
     );
+    assert_no_spurious_no_hooks(&output);
 }
 
 #[rstest]
@@ -501,6 +512,47 @@ command = "cat >/dev/null && echo 'feat: squashed commit message'"
         output.contains("squashing without hooks"),
         "Should indicate squash proceeds without hooks. Output:\n{output}"
     );
+    assert_no_spurious_no_hooks(&output);
+}
+
+/// `wt merge` with a pre-commit hook + dirty worktree: declining the approval
+/// prompt should print only "Commands declined, continuing merge", not also
+/// "Skipping pre-commit hooks (--no-hooks)" from the commit phase.
+#[rstest]
+fn test_approval_prompt_merge_decline_no_spurious_skip(mut repo: TestRepo) {
+    // Remove origin so worktrunk uses directory name as project identifier
+    repo.run_git(&["remote", "remove", "origin"]);
+
+    // Add pre-commit hook to project config and commit it
+    repo.write_project_config(r#"pre-commit = "echo 'pre-commit hook'""#);
+    repo.commit("Add pre-commit config");
+
+    // Create a feature worktree with a dirty change so the merge runs the commit phase
+    let feature_wt = repo.add_worktree("feature-merge-decline");
+    std::fs::write(feature_wt.join("new-file.txt"), "new content").unwrap();
+
+    // Configure LLM commit generation so the commit phase has a message to use
+    repo.write_test_config(
+        r#"
+[commit.generation]
+command = "cat >/dev/null && echo 'feat: test commit message'"
+"#,
+    );
+
+    let env_vars = test_env_vars_with_shell(&repo);
+
+    // Decline the approval prompt
+    let (output, exit_code) = exec_wt_in_pty_cwd(&feature_wt, &["merge"], &env_vars, "n\n");
+
+    assert_eq!(
+        exit_code, 0,
+        "Merge should succeed even when hooks declined. Output:\n{output}"
+    );
+    assert!(
+        output.contains("Commands declined, continuing merge"),
+        "Should show merge-specific decline message. Output:\n{output}"
+    );
+    assert_no_spurious_no_hooks(&output);
 }
 
 /// `wt config approvals add` accepts the prompt — covers the success branch of


### PR DESCRIPTION
## Summary

`CommitOptions::commit` and `handle_squash` collapsed two distinct reasons for skipping pre-commit hooks into a single `verify: bool` — the user passing `--no-hooks` and the user declining an approval prompt. With hooks configured, declining produced both messages back-to-back:

```
○ Commands declined, committing without hooks
○ Skipping pre-commit hooks (--no-hooks)   ← wrong, the user didn't pass --no-hooks
```

Replace `verify: bool` with a `HookGate` enum (`Run` / `NoHooksFlag` / `Silent`) so the caller's intent is preserved through the call chain. `CommitOptions::commit` only prints the "(--no-hooks)" line for `NoHooksFlag`; `Silent` skips hooks without a message.

## Scope

The same wart existed in `handle_squash` when called from `wt merge` (declined approval shadowed `verify` to `false`, which `handle_squash` then read as `--no-hooks`). Both paths fixed:

- `wt step commit` and the auto-commit phase of `wt merge` flow through `CommitOptions::commit`
- `wt step squash` and the squash phase of `wt merge` flow through `handle_squash`
- Standalone `wt step squash --no-hooks` still prints the skip message
- `wt merge --no-hooks` still prints the skip message once

## Tests

- `tests/integration_tests/approval_pty.rs` — added regression assertions to the existing `test_approval_prompt_step_commit_decline` and `test_approval_prompt_step_squash_decline`, plus a new `test_approval_prompt_merge_decline_no_spurious_skip` for the `wt merge` path
- Existing `test_step_commit_with_no_hooks_flag`, `test_step_squash_with_no_hooks_flag`, `test_merge_pre_merge_command_no_hooks`, and `test_merge_post_merge_command_skipped_with_no_hooks` snapshots unchanged — the `--no-hooks` path still produces the message exactly once

🤖 Generated with [Claude Code](https://claude.com/claude-code)