### PR TITLE
ci: generalise composite action and use it from test matrix

### DIFF
--- a/.github/actions/test-setup/action.yaml
+++ b/.github/actions/test-setup/action.yaml
@@ -1,5 +1,8 @@
-name: cargo-affected setup
-description: Tools and caches shared by collect-affected and affected-tests
+name: test setup
+description: |
+  Cargo test tooling, rust-cache, and the shells our PTY tests exercise.
+  Used by the test matrix and the cargo-affected jobs (which add their own
+  cargo-affected + llvm-tools steps after this).
 
 runs:
   using: composite
@@ -16,27 +19,25 @@ runs:
         crate: cargo-nextest
         version: "=0.9.132"
 
-    - name: Install cargo-affected
-      uses: baptiste0928/cargo-install@v3
-      with:
-        crate: cargo-affected
-        git: https://github.com/max-sixty/cargo-affected
-        # No rev/branch/tag → action resolves to latest default-branch sha.
-
-    - name: Install llvm-tools
-      shell: bash
-      run: rustup component add llvm-tools
-
     - name: 💰 Cache
       uses: Swatinem/rust-cache@v2
 
-    - name: Install shells (zsh, fish)
+    - name: Install shells (zsh, fish) - Ubuntu
+      if: runner.os == 'Linux'
       uses: awalsh128/cache-apt-pkgs-action@latest
       with:
         packages: zsh fish
         version: 1.0
 
+    - name: Install shells (fish) - macOS
+      if: runner.os == 'macOS'
+      shell: bash
+      run: |
+        brew install fish
+        # bash and zsh are pre-installed on macOS
+
     - name: Install nushell
+      if: runner.os != 'Windows'
       uses: hustcer/setup-nu@v3
       with:
         version: '0.112.2'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -344,9 +344,6 @@ jobs:
         git: https://github.com/max-sixty/cargo-affected
         # No rev/branch/tag → action resolves to latest default-branch sha.
 
-    - name: Install llvm-tools
-      run: rustup component add llvm-tools
-
     - name: 🎯 Run affected tests
       env:
         NEXTEST_NO_INPUT_HANDLER: 1

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -85,48 +85,7 @@ jobs:
     - name: 📂 Checkout code
       uses: actions/checkout@v6
 
-    - name: Install cargo-insta
-      uses: baptiste0928/cargo-install@v3
-      with:
-        crate: cargo-insta
-        version: "=1.46.3"
-
-    - name: Install cargo-nextest
-      uses: baptiste0928/cargo-install@v3
-      with:
-        crate: cargo-nextest
-        version: "=0.9.132"
-
-    - name: 💰 Cache
-      uses: Swatinem/rust-cache@v2
-
-    - name: Install shells (zsh, fish) - Ubuntu
-      if: runner.os == 'Linux'
-      uses: awalsh128/cache-apt-pkgs-action@latest
-      with:
-        packages: zsh fish
-        version: 1.0
-
-    - name: Install shells (fish) - macOS
-      if: runner.os == 'macOS'
-      run: |
-        brew install fish
-        # bash and zsh are pre-installed on macOS
-
-    - name: Install nushell
-      if: runner.os != 'Windows'
-      uses: hustcer/setup-nu@v3
-      with:
-        version: '0.112.2'
-
-    - name: Install shells - Windows
-      if: runner.os == 'Windows'
-      run: |
-        # Git Bash is pre-installed on GitHub Actions Windows runners
-        # Fish, zsh, and nushell are not commonly available on native Windows (require WSL/MSYS2)
-        # CI will test with bash only on Windows (tests skip unavailable shells)
-        echo "Using Git Bash for Windows tests"
-      shell: pwsh
+    - uses: ./.github/actions/test-setup
 
     - name: Install wt
       uses: baptiste0928/cargo-install@v3
@@ -315,7 +274,17 @@ jobs:
         # HEAD when collect ran. That sha must be reachable.
         fetch-depth: 0
 
-    - uses: ./.github/actions/affected-setup
+    - uses: ./.github/actions/test-setup
+
+    - name: Install cargo-affected
+      uses: baptiste0928/cargo-install@v3
+      with:
+        crate: cargo-affected
+        git: https://github.com/max-sixty/cargo-affected
+        # No rev/branch/tag → action resolves to latest default-branch sha.
+
+    - name: Install llvm-tools
+      run: rustup component add llvm-tools
 
     - name: 📊 Collect coverage data
       env:
@@ -366,7 +335,17 @@ jobs:
         restore-keys: |
           cargo-affected-db-v1-${{ runner.os }}-
 
-    - uses: ./.github/actions/affected-setup
+    - uses: ./.github/actions/test-setup
+
+    - name: Install cargo-affected
+      uses: baptiste0928/cargo-install@v3
+      with:
+        crate: cargo-affected
+        git: https://github.com/max-sixty/cargo-affected
+        # No rev/branch/tag → action resolves to latest default-branch sha.
+
+    - name: Install llvm-tools
+      run: rustup component add llvm-tools
 
     - name: 🎯 Run affected tests
       env:


### PR DESCRIPTION
## Summary

Follow-up to #2483. The composite action installed `cargo-affected` and `llvm-tools`, which the regular `test (linux/macos/windows)` matrix doesn't need. Lift only the always-shared subset (cargo-insta, cargo-nextest, rust-cache, OS-conditional shells, nushell) into `test-setup`, and have the affected-* jobs add `cargo-affected` + `llvm-tools` inline.

The test matrix now uses the action too: ~50 lines of inline setup collapse to one `uses:` line. Pinned tool versions (cargo-insta, cargo-nextest, nushell) serve all four callers from one place.

OS branching that was already inline in test-matrix moves into the action — same `runner.os` conditionals, just relocated.

Drops the Windows-only informational `echo "Using Git Bash for Windows tests"` step (was a no-op).

## Test plan
- [x] `pre-commit run` passes on changed files
- [ ] `test (linux/macos/windows)` still install the same toolchain
- [ ] `affected tests (linux, advisory)` still installs cargo-affected + llvm-tools
- [ ] `collect affected coverage` (gated to push-to-main) still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)