### PR TITLE
refactor(hooks): retire Option<&mut HookAnnouncer> plumbing

### DIFF
--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -8,9 +8,7 @@ use worktrunk::styling::{
 
 use super::command_executor::CommandContext;
 use super::command_executor::FailureStrategy;
-use super::hooks::{
-    HookAnnouncer, execute_hook, prepare_background_pipelines, run_hooks_background,
-};
+use super::hooks::{HookAnnouncer, execute_hook, prepare_background_pipelines};
 use super::repository_ext::warn_about_untracked_files;
 use super::template_vars::TemplateVars;
 
@@ -191,11 +189,11 @@ impl<'a> CommitGenerator<'a> {
 impl CommitOptions<'_> {
     /// Commit uncommitted changes with the shared commit pipeline.
     ///
-    /// `announcer`: when `Some`, post-commit pipelines are extended onto the
-    /// caller's announcer so they share an announce line with later phases
-    /// (e.g. `wt merge --squash` batching post-commit + post-remove +
-    /// post-switch + post-merge). When `None`, post-commit self-announces.
-    pub fn commit(self, announcer: Option<&mut HookAnnouncer<'_>>) -> anyhow::Result<()> {
+    /// Post-commit pipelines are registered on `announcer` so they share an
+    /// announce line with later phases (e.g. `wt merge --squash` batching
+    /// post-commit + post-remove + post-switch + post-merge). Standalone
+    /// callers pass an announcer-of-one and `flush()` it after this returns.
+    pub fn commit(self, announcer: &mut HookAnnouncer<'_>) -> anyhow::Result<()> {
         let project_config = self.ctx.repo.load_project_config()?;
         let user_hooks = self.ctx.config.hooks(self.ctx.project_id().as_deref());
         let (user_cfg, proj_cfg) = super::hooks::lookup_hook_configs(
@@ -263,16 +261,12 @@ impl CommitOptions<'_> {
             self.stage_mode,
         )?;
 
-        // Spawn post-commit hooks in background (respects --no-hooks).
+        // Register post-commit hooks on the caller's announcer (respects --no-hooks).
         if self.hooks.run() {
             let extra_vars = template_vars.as_extra_vars();
             let pipelines =
                 prepare_background_pipelines(self.ctx, HookType::PostCommit, &extra_vars, None)?;
-            if let Some(announcer) = announcer {
-                announcer.extend(pipelines);
-            } else {
-                run_hooks_background(pipelines, false)?;
-            }
+            announcer.extend(pipelines);
         }
 
         Ok(())

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -222,7 +222,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
             options.warn_about_untracked = stage_mode == super::commit::StageMode::All;
             options.show_no_squash_note = true;
 
-            options.commit(Some(&mut announcer))?;
+            options.commit(&mut announcer)?;
             true // Committed directly
         }
     } else {
@@ -355,14 +355,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
             expected_path,
             removed_commit: feature_commit.clone(),
         };
-        crate::output::handle_remove_output(
-            &remove_result,
-            false,
-            verify,
-            false,
-            false,
-            Some(&mut announcer),
-        )?;
+        crate::output::handle_remove_output(&remove_result, false, verify, false, &mut announcer)?;
         true
     };
 

--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -39,9 +39,7 @@ use super::command_approval::approve_or_skip;
 use super::command_executor::FailureStrategy;
 use super::commit::{CommitGenerator, CommitOptions, HookGate, StageMode};
 use super::context::CommandEnv;
-use super::hooks::{
-    HookAnnouncer, execute_hook, prepare_background_pipelines, run_hooks_background,
-};
+use super::hooks::{HookAnnouncer, execute_hook, prepare_background_pipelines};
 use super::repository_ext::{RemoveTarget, RepositoryCliExt};
 use super::template_vars::TemplateVars;
 use crate::output::handle_remove_output;
@@ -99,7 +97,9 @@ pub fn step_commit(
     // Only warn about untracked if we're staging all
     options.warn_about_untracked = stage_mode == StageMode::All;
 
-    options.commit(None)
+    let mut announcer = HookAnnouncer::new(&env.repo, &env.config, false);
+    options.commit(&mut announcer)?;
+    announcer.flush()
 }
 
 /// Result of a squash operation
@@ -122,16 +122,17 @@ pub enum SquashResult {
 ///   prompt; `NoHooksFlag` skips with a "(--no-hooks)" message; `Silent` skips silently
 ///   (used when the caller already declined approval upstream and announced it).
 /// * `stage` - CLI-provided stage mode. If None, uses the effective config default.
-/// * `parent_announcer` - When `Some`, post-commit hooks register on the
-///   caller's announcer so they share an announce line with later phases
-///   (e.g. `wt merge --squash` combining post-commit + post-remove +
-///   post-switch + post-merge). When `None`, post-commit self-announces.
+/// * `announcer` - When `Some`, post-commit hooks register on the caller's
+///   announcer so they share an announce line with later phases (e.g.
+///   `wt merge --squash` combining post-commit + post-remove + post-switch +
+///   post-merge). When `None`, post-commit self-announces with a local
+///   announcer constructed from this function's loaded config.
 pub fn handle_squash(
     target: Option<&str>,
     yes: bool,
     hooks: HookGate,
     stage: Option<StageMode>,
-    parent_announcer: Option<&mut HookAnnouncer<'_>>,
+    announcer: Option<&mut HookAnnouncer<'_>>,
 ) -> anyhow::Result<SquashResult> {
     // Load config once, run LLM setup prompt, then reuse config
     let mut config = UserConfig::load().context("Failed to load config")?;
@@ -365,10 +366,12 @@ pub fn handle_squash(
         let extra_vars = template_vars.as_extra_vars();
         let pipelines =
             prepare_background_pipelines(&ctx, HookType::PostCommit, &extra_vars, None)?;
-        if let Some(announcer) = parent_announcer {
+        if let Some(announcer) = announcer {
             announcer.extend(pipelines);
         } else {
-            run_hooks_background(pipelines, false)?;
+            let mut local = HookAnnouncer::new(repo, ctx.config, false);
+            local.extend(pipelines);
+            local.flush()?;
         }
     }
 
@@ -1451,7 +1454,9 @@ pub fn step_prune(
                 return Ok(false);
             }
         };
-        handle_remove_output(&plan, foreground, run_hooks, true, true, None)?;
+        let mut announcer = HookAnnouncer::new(repo, config, true);
+        handle_remove_output(&plan, foreground, run_hooks, true, &mut announcer)?;
+        announcer.flush()?;
         Ok(true)
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use worktrunk::styling::{
 
 use commands::command_approval::approve_or_skip;
 use commands::command_executor::CommandContext;
+use commands::hooks::HookAnnouncer;
 use commands::worktree::RemoveResult;
 
 mod cli;
@@ -808,7 +809,9 @@ fn handle_remove_command(args: RemoveArgs, yes: bool) -> anyhow::Result<()> {
                 // "Approve at the Gate": approval happens AFTER validation passes
                 let run_hooks = verify && approve_remove(yes)?;
 
-                handle_remove_output(&result, args.foreground, run_hooks, false, false, None)?;
+                let mut announcer = HookAnnouncer::new(&repo, &config, false);
+                handle_remove_output(&result, args.foreground, run_hooks, false, &mut announcer)?;
+                announcer.flush()?;
                 if json_mode {
                     let json = serde_json::json!([result.to_json()]);
                     println!("{}", serde_json::to_string_pretty(&json)?);
@@ -847,34 +850,37 @@ fn handle_remove_command(args: RemoveArgs, yes: bool) -> anyhow::Result<()> {
                 let show_branch =
                     plans.others.len() + plans.branch_only.len() + plans.current.iter().len() > 1;
                 for result in &plans.others {
+                    let mut announcer = HookAnnouncer::new(&repo, &config, show_branch);
                     handle_remove_output(
                         result,
                         args.foreground,
                         run_hooks,
                         false,
-                        show_branch,
-                        None,
+                        &mut announcer,
                     )?;
+                    announcer.flush()?;
                 }
                 for result in &plans.branch_only {
+                    let mut announcer = HookAnnouncer::new(&repo, &config, show_branch);
                     handle_remove_output(
                         result,
                         args.foreground,
                         run_hooks,
                         false,
-                        show_branch,
-                        None,
+                        &mut announcer,
                     )?;
+                    announcer.flush()?;
                 }
                 if let Some(ref result) = plans.current {
+                    let mut announcer = HookAnnouncer::new(&repo, &config, show_branch);
                     handle_remove_output(
                         result,
                         args.foreground,
                         run_hooks,
                         false,
-                        show_branch,
-                        None,
+                        &mut announcer,
                     )?;
+                    announcer.flush()?;
                 }
 
                 if json_mode {

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -733,8 +733,7 @@ pub fn handle_remove_output(
     foreground: bool,
     verify: bool,
     quiet: bool,
-    show_branch_in_hooks: bool,
-    announcer: Option<&mut HookAnnouncer<'_>>,
+    announcer: &mut HookAnnouncer<'_>,
 ) -> anyhow::Result<()> {
     match result {
         RemoveResult::RemovedWorktree {
@@ -762,7 +761,6 @@ pub fn handle_remove_output(
                 removed_commit: removed_commit.as_deref(),
                 foreground,
                 verify,
-                show_branch_in_hooks,
             },
             announcer,
         ),
@@ -891,7 +889,7 @@ fn spawn_hooks_after_remove(
     repo: &Repository,
     ctx: &RemovedWorktreeOutputContext<'_>,
     removed_branch: &str,
-    announcer: Option<&mut HookAnnouncer<'_>>,
+    announcer: &mut HookAnnouncer<'_>,
 ) -> anyhow::Result<()> {
     if !ctx.verify {
         return Ok(());
@@ -946,14 +944,7 @@ fn spawn_hooks_after_remove(
         )?);
     }
 
-    if let Some(announcer) = announcer {
-        announcer.extend(pipelines);
-    } else {
-        let mut local = HookAnnouncer::new(repo, &config, ctx.show_branch_in_hooks);
-        local.extend(pipelines);
-        local.flush()?;
-    }
-
+    announcer.extend(pipelines);
     Ok(())
 }
 
@@ -1181,8 +1172,6 @@ struct RemovedWorktreeOutputContext<'a> {
     removed_commit: Option<&'a str>,
     foreground: bool,
     verify: bool,
-    /// Show branch name in hook announcements for disambiguation in batch contexts.
-    show_branch_in_hooks: bool,
 }
 
 fn execute_pre_remove_hooks_if_needed(
@@ -1248,7 +1237,7 @@ fn prepare_remove_directory_change(
 fn handle_detached_removed_worktree_output(
     repo: &Repository,
     ctx: &RemovedWorktreeOutputContext<'_>,
-    announcer: Option<&mut HookAnnouncer<'_>>,
+    announcer: &mut HookAnnouncer<'_>,
 ) -> anyhow::Result<()> {
     if ctx.foreground {
         eprintln!(
@@ -1318,7 +1307,7 @@ fn handle_named_removed_worktree_foreground(
     repo: &Repository,
     ctx: &RemovedWorktreeOutputContext<'_>,
     branch_name: &str,
-    announcer: Option<&mut HookAnnouncer<'_>>,
+    announcer: &mut HookAnnouncer<'_>,
 ) -> anyhow::Result<()> {
     eprintln!(
         "{}",
@@ -1375,7 +1364,7 @@ fn handle_named_removed_worktree_background(
     repo: &Repository,
     ctx: &RemovedWorktreeOutputContext<'_>,
     branch_name: &str,
-    announcer: Option<&mut HookAnnouncer<'_>>,
+    announcer: &mut HookAnnouncer<'_>,
 ) -> anyhow::Result<()> {
     if let Some(expected) = ctx.expected_path {
         eprintln!(
@@ -1413,7 +1402,7 @@ fn handle_named_removed_worktree_background(
 /// Handle output for RemovedWorktree removal
 fn handle_removed_worktree_output(
     ctx: RemovedWorktreeOutputContext<'_>,
-    announcer: Option<&mut HookAnnouncer<'_>>,
+    announcer: &mut HookAnnouncer<'_>,
 ) -> anyhow::Result<()> {
     // Use main_path for discovery - the worktree being removed might be cwd,
     // and git operations after removal need a valid working directory.


### PR DESCRIPTION
## Summary

Now that all callers (merge, remove single + multi, prune, step commit) construct an announcer, the receiving sites take it by mutable reference rather than `Option`. `handle_remove_output` and the four internal handlers lose the `Option` wrapper, and `spawn_hooks_after_remove` collapses to a single `announcer.extend(...)` call. `CommitOptions::commit` likewise; the standalone `step_commit` path now constructs a local announcer and flushes it after `commit()` returns.

`RemovedWorktreeOutputContext` no longer carries `show_branch_in_hooks` — the announcer already knows — and `handle_remove_output` drops the matching parameter.

`handle_squash` keeps `Option<&mut HookAnnouncer<'_>>`: it loads its own config inside, so the standalone path builds a local announcer from that owned config rather than relying on a caller-owned one.

## Test plan
- [x] `pre-commit run --all-files`
- [x] `cargo test --test integration --features shell-integration-tests` (1725 passed)

> _This was written by Claude Code on behalf of max-sixty_