### PR TITLE
docs(release): merge step uses /gpk to land via PR

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -31,7 +31,7 @@ metadata:
    ```bash
    git reset --soft HEAD~1 && git add -A && git commit -m "Release vX.Y.Z"
    ```
-10. **Merge to main**: `wt merge --no-remove` (rebases onto main, pushes, keeps worktree)
+10. **Merge to main**: `/gpk` — opens a PR, waits for CI, merges via PR (preserves worktree)
 11. **Tag and push**: `git tag vX.Y.Z && git push origin vX.Y.Z`
 12. **Wait for release workflow**: Poll with `gh pr checks --required` or `gh run view <run-id>` every 60 seconds until complete (avoid `gh run watch` — it can hang). Non-required checks are ignored
 


### PR DESCRIPTION
The release workflow's merge step previously ran `wt merge --no-remove`, which rebases locally and pushes via a hook. When the post-merge push lost a non-fast-forward race, `wt merge` still returned success (the merge itself succeeded — the push is a hook), so the next steps tagged a commit that wasn't on remote main. The release workflow then failed at `gh release create` because the GITHUB_TOKEN integration cannot create a release pointing at an orphan commit.

Switching to `/gpk` routes the merge through a PR. GitHub requires the branch to be mergeable into current main, runs CI first, and the resulting commit is on main by definition — so the tag and release steps always have something valid to point at.

> _This was written by Claude Code on behalf of @max-sixty_