### PR TITLE
Fix copy-ignored symlink destination boundary

### DIFF
--- a/benches/cow_copy.rs
+++ b/benches/cow_copy.rs
@@ -148,7 +148,7 @@ fn bench_helper(
             b.iter(|| {
                 let dest = temp.path().join(format!("copy_p_{}", iter));
                 iter += 1;
-                copy_dir_recursive(src, &dest, false, &Progress::disabled()).unwrap();
+                copy_dir_recursive(src, &dest, None, false, &Progress::disabled()).unwrap();
                 std::fs::remove_dir_all(&dest).ok();
             });
         },

--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -25,9 +25,7 @@ use path_slash::PathExt as _;
 use rayon::prelude::*;
 use worktrunk::HookType;
 use worktrunk::config::{CopyIgnoredConfig, UserConfig};
-use worktrunk::copy::{
-    copy_dir_recursive, copy_dir_recursive_within_root, copy_leaf, copy_leaf_within_root,
-};
+use worktrunk::copy::{copy_dir_recursive, copy_leaf};
 use worktrunk::git::{Repository, WorktreeInfo};
 use worktrunk::path::format_path_for_display;
 use worktrunk::progress::{Progress, format_bytes};
@@ -822,14 +820,11 @@ pub fn step_copy_ignored(
         let dest_entry = dest_path.join(relative);
 
         if *is_dir {
-            let (n, b) = copy_dir_recursive_within_root(
-                src_entry,
-                &dest_entry,
-                &dest_path,
-                force,
-                &progress,
-            )
-            .with_context(|| format!("copying directory {}", format_path_for_display(relative)))?;
+            let (n, b) =
+                copy_dir_recursive(src_entry, &dest_entry, Some(&dest_path), force, &progress)
+                    .with_context(|| {
+                        format!("copying directory {}", format_path_for_display(relative))
+                    })?;
             copied_count += n;
             copied_bytes += b;
         } else {
@@ -841,7 +836,7 @@ pub fn step_copy_ignored(
                     )
                 })?;
             }
-            if let Some(bytes) = copy_leaf_within_root(src_entry, &dest_entry, &dest_path, force)? {
+            if let Some(bytes) = copy_leaf(src_entry, &dest_entry, Some(&dest_path), force)? {
                 copied_count += 1;
                 copied_bytes += bytes;
                 progress.record(bytes);
@@ -925,10 +920,10 @@ fn move_entry(src: &Path, dest: &Path, is_dir: bool) -> anyhow::Result<()> {
 /// Copy then delete — fallback when `rename` fails with EXDEV (cross-device).
 fn copy_and_remove(src: &Path, dest: &Path, is_dir: bool) -> anyhow::Result<()> {
     if is_dir {
-        copy_dir_recursive(src, dest, true, &Progress::disabled())?;
+        copy_dir_recursive(src, dest, None, true, &Progress::disabled())?;
         fs::remove_dir_all(src).context(format!("removing source directory {}", src.display()))?;
     } else {
-        copy_leaf(src, dest, true)?;
+        copy_leaf(src, dest, None, true)?;
 
         fs::remove_file(src).context(format!("removing source file {}", src.display()))?;
     }

--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -25,7 +25,9 @@ use path_slash::PathExt as _;
 use rayon::prelude::*;
 use worktrunk::HookType;
 use worktrunk::config::{CopyIgnoredConfig, UserConfig};
-use worktrunk::copy::{copy_dir_recursive, copy_leaf};
+use worktrunk::copy::{
+    copy_dir_recursive, copy_dir_recursive_within_root, copy_leaf, copy_leaf_within_root,
+};
 use worktrunk::git::{Repository, WorktreeInfo};
 use worktrunk::path::format_path_for_display;
 use worktrunk::progress::{Progress, format_bytes};
@@ -820,10 +822,14 @@ pub fn step_copy_ignored(
         let dest_entry = dest_path.join(relative);
 
         if *is_dir {
-            let (n, b) = copy_dir_recursive(src_entry, &dest_entry, force, &progress)
-                .with_context(|| {
-                    format!("copying directory {}", format_path_for_display(relative))
-                })?;
+            let (n, b) = copy_dir_recursive_within_root(
+                src_entry,
+                &dest_entry,
+                &dest_path,
+                force,
+                &progress,
+            )
+            .with_context(|| format!("copying directory {}", format_path_for_display(relative)))?;
             copied_count += n;
             copied_bytes += b;
         } else {
@@ -835,7 +841,7 @@ pub fn step_copy_ignored(
                     )
                 })?;
             }
-            if let Some(bytes) = copy_leaf(src_entry, &dest_entry, force)? {
+            if let Some(bytes) = copy_leaf_within_root(src_entry, &dest_entry, &dest_path, force)? {
                 copied_count += 1;
                 copied_bytes += bytes;
                 progress.record(bytes);

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -148,13 +148,41 @@ pub fn copy_dir_recursive(
     force: bool,
     progress: &Progress,
 ) -> anyhow::Result<(usize, u64)> {
+    copy_dir_recursive_inner(src, dest, None, force, progress)
+}
+
+/// Copy a directory tree, refusing destination directory ancestry that resolves
+/// outside `root`.
+pub fn copy_dir_recursive_within_root(
+    src: &Path,
+    dest: &Path,
+    root: &Path,
+    force: bool,
+    progress: &Progress,
+) -> anyhow::Result<(usize, u64)> {
+    copy_dir_recursive_inner(src, dest, Some(root), force, progress)
+}
+
+fn copy_dir_recursive_inner(
+    src: &Path,
+    dest: &Path,
+    root: Option<&Path>,
+    force: bool,
+    progress: &Progress,
+) -> anyhow::Result<(usize, u64)> {
     // Phase 1: Walk directories iteratively, creating dest dirs and collecting leaves.
+    // When `root` is set, every directory we descend into is checked against the
+    // boundary; leaves inherit that guarantee because `entry.file_name()` is a
+    // single basename and cannot escape the validated `dest_dir`.
     let mut leaves = Vec::new();
     let mut dir_stack = vec![(src.to_path_buf(), dest.to_path_buf())];
     #[cfg(unix)]
     let mut dirs_for_perms: Vec<(PathBuf, PathBuf)> = Vec::new();
 
     while let Some((src_dir, dest_dir)) = dir_stack.pop() {
+        if let Some(root) = root {
+            ensure_path_within_root(&dest_dir, root)?;
+        }
         fs::create_dir_all(&dest_dir)
             .with_context(|| format!("creating directory {}", dest_dir.display()))?;
         #[cfg(unix)]
@@ -198,77 +226,6 @@ pub fn copy_dir_recursive(
     // Phase 3: Preserve source directory permissions AFTER copying contents.
     // Must be done after copying — if the source lacks write permission (e.g., 0o555),
     // setting it before copying would make the destination read-only and fail the copies.
-    #[cfg(unix)]
-    for (src_dir, dest_dir) in &dirs_for_perms {
-        let src_perms = fs::metadata(src_dir)
-            .with_context(|| format!("reading permissions for {}", src_dir.display()))?
-            .permissions();
-        fs::set_permissions(dest_dir, src_perms)
-            .with_context(|| format!("setting permissions on {}", dest_dir.display()))?;
-    }
-
-    Ok((copied_files.into_inner(), copied_bytes.into_inner()))
-}
-
-/// Copy a directory tree, refusing destination directory ancestry that resolves
-/// outside `root`.
-pub fn copy_dir_recursive_within_root(
-    src: &Path,
-    dest: &Path,
-    root: &Path,
-    force: bool,
-    progress: &Progress,
-) -> anyhow::Result<(usize, u64)> {
-    // Phase 1: Walk directories iteratively, creating dest dirs and collecting leaves.
-    let mut leaves = Vec::new();
-    let mut dir_stack = vec![(src.to_path_buf(), dest.to_path_buf())];
-    #[cfg(unix)]
-    let mut dirs_for_perms: Vec<(PathBuf, PathBuf)> = Vec::new();
-
-    while let Some((src_dir, dest_dir)) = dir_stack.pop() {
-        ensure_path_within_root(&dest_dir, root)?;
-        fs::create_dir_all(&dest_dir)
-            .with_context(|| format!("creating directory {}", dest_dir.display()))?;
-        #[cfg(unix)]
-        dirs_for_perms.push((src_dir.clone(), dest_dir.clone()));
-
-        let entries: Vec<_> = fs::read_dir(&src_dir)?.collect::<Result<Vec<_>, _>>()?;
-        for entry in entries {
-            let file_type = entry.file_type()?;
-            let src_path = entry.path();
-            let dest_path = dest_dir.join(entry.file_name());
-
-            if file_type.is_dir() {
-                dir_stack.push((src_path, dest_path));
-            } else if file_type.is_file() || file_type.is_symlink() {
-                ensure_parent_within_root(&dest_path, root)?;
-                leaves.push(CopyLeaf {
-                    src: src_path,
-                    dest: dest_path,
-                });
-            } else {
-                log::debug!("skipping non-regular file: {}", src_path.display());
-            }
-        }
-    }
-
-    // Phase 2: Copy all leaves in parallel.
-    let copied_files = AtomicUsize::new(0);
-    let copied_bytes = AtomicU64::new(0);
-    COPY_POOL.install(|| {
-        leaves
-            .par_iter()
-            .try_for_each(|leaf| -> anyhow::Result<()> {
-                if let Some(bytes) = copy_leaf(&leaf.src, &leaf.dest, force)? {
-                    copied_files.fetch_add(1, Ordering::Relaxed);
-                    copied_bytes.fetch_add(bytes, Ordering::Relaxed);
-                    progress.record(bytes);
-                }
-                Ok(())
-            })
-    })?;
-
-    // Phase 3: Preserve source directory permissions AFTER copying contents.
     #[cfg(unix)]
     for (src_dir, dest_dir) in &dirs_for_perms {
         let src_perms = fs::metadata(src_dir)

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -43,7 +43,20 @@ static COPY_POOL: LazyLock<rayon::ThreadPool> = LazyLock::new(|| {
 /// when the entry was copied (reporting the source's logical byte size), or
 /// `None` if skipped because the destination already exists. When `force` is
 /// true, existing entries are removed before copying.
-pub fn copy_leaf(src: &Path, dest: &Path, force: bool) -> anyhow::Result<Option<u64>> {
+///
+/// When `root` is `Some`, refuses destination paths whose parent resolves
+/// outside `root`. The check guards the parent chain, not the final leaf, so
+/// leaf-symlink behavior is preserved (without `force` the symlink is skipped;
+/// with `force` the symlink itself is replaced).
+pub fn copy_leaf(
+    src: &Path,
+    dest: &Path,
+    root: Option<&Path>,
+    force: bool,
+) -> anyhow::Result<Option<u64>> {
+    if let Some(root) = root {
+        ensure_path_within_root(dest.parent().unwrap_or(dest), root)?;
+    }
     if force {
         remove_if_exists(dest)?;
     }
@@ -89,22 +102,6 @@ pub fn copy_leaf(src: &Path, dest: &Path, force: bool) -> anyhow::Result<Option<
     Ok(Some(bytes))
 }
 
-/// Copy a single file or symlink, refusing destination paths whose parent
-/// resolves outside `root`.
-///
-/// The check intentionally guards the parent chain, not the final leaf. Existing
-/// leaf symlinks remain idempotent: without `force` they are skipped, and with
-/// `force` the symlink itself is removed before copying.
-pub fn copy_leaf_within_root(
-    src: &Path,
-    dest: &Path,
-    root: &Path,
-    force: bool,
-) -> anyhow::Result<Option<u64>> {
-    ensure_parent_within_root(dest, root)?;
-    copy_leaf(src, dest, force)
-}
-
 fn ensure_path_within_root(path: &Path, root: &Path) -> anyhow::Result<()> {
     let canonical_root = canonicalize_with_parents(root);
     let canonical_path = canonicalize_with_parents(path);
@@ -117,11 +114,6 @@ fn ensure_path_within_root(path: &Path, root: &Path) -> anyhow::Result<()> {
     );
 
     Ok(())
-}
-
-fn ensure_parent_within_root(path: &Path, root: &Path) -> anyhow::Result<()> {
-    let parent = path.parent().unwrap_or(path);
-    ensure_path_within_root(parent, root)
 }
 
 /// A leaf item (file or symlink) collected during the directory walk.
@@ -141,29 +133,12 @@ struct CopyLeaf {
 /// removed before copying. `progress` receives per-file callbacks; pass
 /// [`Progress::disabled`] for a zero-overhead no-op.
 ///
+/// When `root` is `Some`, refuses destination directory ancestry that resolves
+/// outside `root`. Leaves inherit the guarantee because `entry.file_name()` is
+/// a single basename and cannot escape the validated parent directory.
+///
 /// Returns `(files_copied, bytes_copied)` — counts exclude skipped entries.
 pub fn copy_dir_recursive(
-    src: &Path,
-    dest: &Path,
-    force: bool,
-    progress: &Progress,
-) -> anyhow::Result<(usize, u64)> {
-    copy_dir_recursive_inner(src, dest, None, force, progress)
-}
-
-/// Copy a directory tree, refusing destination directory ancestry that resolves
-/// outside `root`.
-pub fn copy_dir_recursive_within_root(
-    src: &Path,
-    dest: &Path,
-    root: &Path,
-    force: bool,
-    progress: &Progress,
-) -> anyhow::Result<(usize, u64)> {
-    copy_dir_recursive_inner(src, dest, Some(root), force, progress)
-}
-
-fn copy_dir_recursive_inner(
     src: &Path,
     dest: &Path,
     root: Option<&Path>,
@@ -171,9 +146,6 @@ fn copy_dir_recursive_inner(
     progress: &Progress,
 ) -> anyhow::Result<(usize, u64)> {
     // Phase 1: Walk directories iteratively, creating dest dirs and collecting leaves.
-    // When `root` is set, every directory we descend into is checked against the
-    // boundary; leaves inherit that guarantee because `entry.file_name()` is a
-    // single basename and cannot escape the validated `dest_dir`.
     let mut leaves = Vec::new();
     let mut dir_stack = vec![(src.to_path_buf(), dest.to_path_buf())];
     #[cfg(unix)]
@@ -214,7 +186,7 @@ fn copy_dir_recursive_inner(
         leaves
             .par_iter()
             .try_for_each(|leaf| -> anyhow::Result<()> {
-                if let Some(bytes) = copy_leaf(&leaf.src, &leaf.dest, force)? {
+                if let Some(bytes) = copy_leaf(&leaf.src, &leaf.dest, None, force)? {
                     copied_files.fetch_add(1, Ordering::Relaxed);
                     copied_bytes.fetch_add(bytes, Ordering::Relaxed);
                     progress.record(bytes);

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -25,6 +25,7 @@ use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 use anyhow::Context;
 use rayon::prelude::*;
 
+use crate::path::{canonicalize_with_parents, format_path_for_display};
 use crate::progress::Progress;
 
 /// Capped at 4 threads to avoid saturating the CPU — the global rayon pool is
@@ -86,6 +87,41 @@ pub fn copy_leaf(src: &Path, dest: &Path, force: bool) -> anyhow::Result<Option<
         }
     }
     Ok(Some(bytes))
+}
+
+/// Copy a single file or symlink, refusing destination paths whose parent
+/// resolves outside `root`.
+///
+/// The check intentionally guards the parent chain, not the final leaf. Existing
+/// leaf symlinks remain idempotent: without `force` they are skipped, and with
+/// `force` the symlink itself is removed before copying.
+pub fn copy_leaf_within_root(
+    src: &Path,
+    dest: &Path,
+    root: &Path,
+    force: bool,
+) -> anyhow::Result<Option<u64>> {
+    ensure_parent_within_root(dest, root)?;
+    copy_leaf(src, dest, force)
+}
+
+fn ensure_path_within_root(path: &Path, root: &Path) -> anyhow::Result<()> {
+    let canonical_root = canonicalize_with_parents(root);
+    let canonical_path = canonicalize_with_parents(path);
+
+    anyhow::ensure!(
+        canonical_path.starts_with(&canonical_root),
+        "refusing to copy outside destination worktree: {} resolves outside {}",
+        format_path_for_display(path),
+        format_path_for_display(root)
+    );
+
+    Ok(())
+}
+
+fn ensure_parent_within_root(path: &Path, root: &Path) -> anyhow::Result<()> {
+    let parent = path.parent().unwrap_or(path);
+    ensure_path_within_root(parent, root)
 }
 
 /// A leaf item (file or symlink) collected during the directory walk.
@@ -162,6 +198,77 @@ pub fn copy_dir_recursive(
     // Phase 3: Preserve source directory permissions AFTER copying contents.
     // Must be done after copying — if the source lacks write permission (e.g., 0o555),
     // setting it before copying would make the destination read-only and fail the copies.
+    #[cfg(unix)]
+    for (src_dir, dest_dir) in &dirs_for_perms {
+        let src_perms = fs::metadata(src_dir)
+            .with_context(|| format!("reading permissions for {}", src_dir.display()))?
+            .permissions();
+        fs::set_permissions(dest_dir, src_perms)
+            .with_context(|| format!("setting permissions on {}", dest_dir.display()))?;
+    }
+
+    Ok((copied_files.into_inner(), copied_bytes.into_inner()))
+}
+
+/// Copy a directory tree, refusing destination directory ancestry that resolves
+/// outside `root`.
+pub fn copy_dir_recursive_within_root(
+    src: &Path,
+    dest: &Path,
+    root: &Path,
+    force: bool,
+    progress: &Progress,
+) -> anyhow::Result<(usize, u64)> {
+    // Phase 1: Walk directories iteratively, creating dest dirs and collecting leaves.
+    let mut leaves = Vec::new();
+    let mut dir_stack = vec![(src.to_path_buf(), dest.to_path_buf())];
+    #[cfg(unix)]
+    let mut dirs_for_perms: Vec<(PathBuf, PathBuf)> = Vec::new();
+
+    while let Some((src_dir, dest_dir)) = dir_stack.pop() {
+        ensure_path_within_root(&dest_dir, root)?;
+        fs::create_dir_all(&dest_dir)
+            .with_context(|| format!("creating directory {}", dest_dir.display()))?;
+        #[cfg(unix)]
+        dirs_for_perms.push((src_dir.clone(), dest_dir.clone()));
+
+        let entries: Vec<_> = fs::read_dir(&src_dir)?.collect::<Result<Vec<_>, _>>()?;
+        for entry in entries {
+            let file_type = entry.file_type()?;
+            let src_path = entry.path();
+            let dest_path = dest_dir.join(entry.file_name());
+
+            if file_type.is_dir() {
+                dir_stack.push((src_path, dest_path));
+            } else if file_type.is_file() || file_type.is_symlink() {
+                ensure_parent_within_root(&dest_path, root)?;
+                leaves.push(CopyLeaf {
+                    src: src_path,
+                    dest: dest_path,
+                });
+            } else {
+                log::debug!("skipping non-regular file: {}", src_path.display());
+            }
+        }
+    }
+
+    // Phase 2: Copy all leaves in parallel.
+    let copied_files = AtomicUsize::new(0);
+    let copied_bytes = AtomicU64::new(0);
+    COPY_POOL.install(|| {
+        leaves
+            .par_iter()
+            .try_for_each(|leaf| -> anyhow::Result<()> {
+                if let Some(bytes) = copy_leaf(&leaf.src, &leaf.dest, force)? {
+                    copied_files.fetch_add(1, Ordering::Relaxed);
+                    copied_bytes.fetch_add(bytes, Ordering::Relaxed);
+                    progress.record(bytes);
+                }
+                Ok(())
+            })
+    })?;
+
+    // Phase 3: Preserve source directory permissions AFTER copying contents.
     #[cfg(unix)]
     for (src_dir, dest_dir) in &dirs_for_perms {
         let src_perms = fs::metadata(src_dir)

--- a/tests/integration_tests/step_copy_ignored.rs
+++ b/tests/integration_tests/step_copy_ignored.rs
@@ -778,6 +778,88 @@ fn test_copy_ignored_force_directory(mut repo: TestRepo) {
     );
 }
 
+#[cfg(unix)]
+fn setup_copy_ignored_symlinked_dest_dir(repo: &mut TestRepo) -> (PathBuf, tempfile::TempDir) {
+    let feature_path = repo.add_worktree("feature");
+
+    let target_dir = repo.root_path().join("target");
+    fs::create_dir_all(target_dir.join("debug")).unwrap();
+    fs::write(target_dir.join("debug").join("output"), "copied content").unwrap();
+    fs::write(repo.root_path().join(".gitignore"), "target/\n").unwrap();
+    fs::write(repo.root_path().join(".worktreeinclude"), "target/\n").unwrap();
+
+    let outside = tempfile::tempdir().unwrap();
+    let outside_target = outside.path().join("target");
+    fs::create_dir_all(&outside_target).unwrap();
+    fs::write(outside_target.join("sentinel"), "keep me").unwrap();
+    std::os::unix::fs::symlink(&outside_target, feature_path.join("target")).unwrap();
+
+    (feature_path, outside)
+}
+
+#[cfg(unix)]
+fn assert_copy_ignored_rejects_symlinked_dest_dir(repo: &TestRepo, feature_path: &Path) {
+    let output = repo
+        .wt_command()
+        .args(["step", "copy-ignored"])
+        .current_dir(feature_path)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "copy-ignored should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("refusing to copy outside destination worktree"),
+        "expected outside-destination error, got: {stderr}",
+    );
+}
+
+#[cfg(unix)]
+fn assert_symlinked_dest_outside_unchanged(outside: &tempfile::TempDir) {
+    let outside_target = outside.path().join("target");
+    assert_eq!(
+        fs::read_to_string(outside_target.join("sentinel")).unwrap(),
+        "keep me",
+        "sentinel outside destination worktree should remain unchanged",
+    );
+    assert!(
+        !outside_target.join("debug").join("output").exists(),
+        "copy-ignored should not write through destination directory symlink",
+    );
+}
+
+/// Refuse to copy through destination directory symlinks.
+#[cfg(unix)]
+#[rstest]
+fn test_copy_ignored_rejects_symlinked_destination_directory(mut repo: TestRepo) {
+    let (feature_path, outside) = setup_copy_ignored_symlinked_dest_dir(&mut repo);
+
+    assert_copy_ignored_rejects_symlinked_dest_dir(&repo, &feature_path);
+    assert_symlinked_dest_outside_unchanged(&outside);
+}
+
+/// --force must not overwrite files through destination directory symlinks.
+#[cfg(unix)]
+#[rstest]
+fn test_copy_ignored_force_rejects_symlinked_destination_directory(mut repo: TestRepo) {
+    let (feature_path, outside) = setup_copy_ignored_symlinked_dest_dir(&mut repo);
+
+    let output = repo
+        .wt_command()
+        .args(["step", "copy-ignored", "--force"])
+        .current_dir(&feature_path)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "copy-ignored --force should fail");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("refusing to copy outside destination worktree"),
+        "expected outside-destination error, got: {stderr}",
+    );
+    assert_symlinked_dest_outside_unchanged(&outside);
+}
+
 /// Test --verbose shows entries being copied (GitHub issue #1084)
 #[rstest]
 fn test_copy_ignored_verbose(mut repo: TestRepo) {


### PR DESCRIPTION
## Summary

Fixes a destination-boundary issue in `wt step copy-ignored`.

Previously, a linked worktree could contain a symlinked destination directory
such as `target -> /tmp/outside`. When `copy-ignored` copied ignored files from
another worktree, it would create nested directories and files through that
symlink, writing outside the destination worktree. `--force` made the same
boundary issue more risky because it could overwrite outside files.

This PR adds guarded copy entry points for `copy-ignored` that resolve the
destination ancestry with `canonicalize_with_parents` and reject paths whose
resolved parent chain escapes the destination worktree root. The guard checks
parent ancestry rather than the final leaf so existing leaf-symlink behavior
stays intact: without `--force` leaf symlinks are skipped, and with `--force`
the symlink itself is replaced.

## Changes

- Add `copy_leaf_within_root` and `copy_dir_recursive_within_root`.
- Route `wt step copy-ignored` through the guarded copy functions.
- Add Unix regression tests for symlinked destination directories, including
  the `--force` case.

## Tests

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --lib copy`
- `cargo test --test integration step_copy_ignored`
