### PR TITLE
Scrub legacy directive file from child commands

### DIFF
--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -28,7 +28,9 @@
 //! first, then project. The CD directive file is passed through to child
 //! processes so inner `wt` invocations can redirect the parent shell's cwd;
 //! the EXEC directive file is scrubbed so alias bodies cannot inject
-//! arbitrary shell into the interactive session.
+//! arbitrary shell into the interactive session. The legacy single-file
+//! directive is handled only by top-level legacy output mode, not by alias
+//! child execution.
 
 use std::collections::{BTreeMap, BTreeSet};
 

--- a/src/output/concurrent.rs
+++ b/src/output/concurrent.rs
@@ -43,9 +43,7 @@ use anyhow::Context;
 
 use worktrunk::command_log::log_command;
 use worktrunk::git::WorktrunkError;
-use worktrunk::shell_exec::{
-    DIRECTIVE_CD_FILE_ENV_VAR, DIRECTIVE_FILE_ENV_VAR, ShellConfig, scrub_directive_env_vars,
-};
+use worktrunk::shell_exec::{DIRECTIVE_CD_FILE_ENV_VAR, ShellConfig, scrub_directive_env_vars};
 use worktrunk::styling::stderr;
 
 use super::handlers::DirectivePassthrough;
@@ -64,7 +62,8 @@ pub struct ConcurrentCommand<'a> {
     /// Optional label for `commands.jsonl` tracing.
     pub log_label: Option<&'a str>,
     /// Directive file env vars to pass through to the child. See
-    /// `DirectivePassthrough` for the trust model (CD passthrough, EXEC scrub).
+    /// `DirectivePassthrough` for the trust model (CD passthrough, EXEC and
+    /// legacy scrub).
     pub directives: &'a DirectivePassthrough,
 }
 
@@ -248,9 +247,6 @@ fn spawn_child(
     scrub_directive_env_vars(&mut command);
     if let Some(path) = &cmd.directives.cd_file {
         command.env(DIRECTIVE_CD_FILE_ENV_VAR, path);
-    }
-    if let Some(path) = &cmd.directives.legacy_file {
-        command.env(DIRECTIVE_FILE_ENV_VAR, path);
     }
 
     #[cfg(unix)]
@@ -457,7 +453,7 @@ mod tests {
     //! Unit tests that exercise the executor's option-bearing code paths which
     //! aren't reachable through the alias integration tests today: every child
     //! currently has `log_label=None` (aliases skip per-child logging) and the
-    //! CD/legacy directive env vars are usually unset. Driving these branches
+    //! CD directive env var is usually unset. Driving these branches
     //! with a direct call proves they behave correctly when a future caller
     //! (concurrent foreground hooks, once their deprecation completes) uses them.
     use super::*;
@@ -497,9 +493,9 @@ mod tests {
         // passing a log_label doesn't panic and the command still runs.
     }
 
-    /// `DirectivePassthrough` with both `cd_file` and `legacy_file` set must
-    /// propagate both env vars to the child. The child script echoes each env
-    /// var; we assert both values are delivered.
+    /// `DirectivePassthrough` only passes `cd_file` through to the child. The
+    /// child script appends to a file named by the env var; we assert the CD
+    /// path is delivered while the legacy file stays untouched.
     ///
     /// Unix-only: the script uses POSIX `sh` redirect syntax and relies on
     /// native temp paths that don't need escaping. Git Bash on Windows would
@@ -512,22 +508,16 @@ mod tests {
         let legacy = NamedTempFile::new().unwrap();
         let directives = DirectivePassthrough {
             cd_file: Some(cd.path().to_path_buf()),
-            legacy_file: Some(legacy.path().to_path_buf()),
         };
-        // Write each env var's value to its matching temp file. If the child
-        // didn't receive the env var, the redirect would fail or write an
-        // empty file.
-        let script = format!(
-            "printf CD > {} && printf LEGACY > {}",
-            cd.path().display(),
-            legacy.path().display(),
-        );
+        // The child can write to the CD path if it receives the env var.
+        // The legacy file is only a sentinel here and should stay empty.
+        let script = format!("printf CD > {}", cd.path().display());
         let outcomes = run_one_with_directives("job", &script, None, &directives);
         assert!(outcomes[0].is_ok(), "child should exit 0");
         let cd_contents = std::fs::read_to_string(cd.path()).unwrap();
         let legacy_contents = std::fs::read_to_string(legacy.path()).unwrap();
         assert_eq!(cd_contents, "CD");
-        assert_eq!(legacy_contents, "LEGACY");
+        assert!(legacy_contents.is_empty());
     }
 
     /// An empty `cmds` slice must return an empty outcomes vec without

--- a/src/output/global.rs
+++ b/src/output/global.rs
@@ -36,12 +36,13 @@
 //!
 //! Users who upgrade wt without restarting their shell still run the previous
 //! release's shell wrapper, which only sets `WORKTRUNK_DIRECTIVE_FILE`. When
-//! only that variable is set, wt falls back to the pre-split protocol (shell
-//! commands written to the single file) silently. For bash, zsh, fish, and
-//! PowerShell a shell restart picks up the new wrapper automatically; nushell
-//! is the only shell where users have to rerun `wt config shell install`
-//! because its wrapper is a static file. Remove the legacy path in the next
-//! breaking release.
+//! only that variable is set, top-level wt falls back to the pre-split
+//! protocol (shell commands written to the single file) silently. Child alias,
+//! foreground-hook, and concurrent command execution do not pass this legacy
+//! env var through. For bash, zsh, fish, and PowerShell a shell restart picks
+//! up the new wrapper automatically; nushell is the only shell where users
+//! have to rerun `wt config shell install` because its wrapper is a static
+//! file. Remove the legacy path in the next breaking release.
 
 use std::fs::OpenOptions;
 use std::io::{self, Write};

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -1448,9 +1448,9 @@ fn handle_removed_worktree_output(
 ///   (outlive the parent shell).
 /// - `DirectivePassthrough::inherit_from_env()` — re-adds whichever directive
 ///   env vars are currently set in this process. Used by aliases and
-///   foreground hooks, which may emit `cd` directives. In new-protocol mode
-///   only the CD file passes through; in legacy compat mode the single
-///   legacy file passes through to preserve pre-split behavior.
+///   foreground hooks, which may emit `cd` directives. Only the CD file
+///   passes through; the legacy single-file directive is handled exclusively
+///   by top-level legacy output mode.
 ///
 /// ## Stdout routing
 ///
@@ -1514,9 +1514,6 @@ pub fn execute_shell_command(
     if let Some(path) = directives.cd_file {
         cmd = cmd.directive_cd_file(path);
     }
-    if let Some(path) = directives.legacy_file {
-        cmd = cmd.directive_legacy_file(path);
-    }
 
     cmd.stream()?;
 
@@ -1531,11 +1528,12 @@ pub fn execute_shell_command(
 /// Constructed by callers via [`DirectivePassthrough::none`] or
 /// [`DirectivePassthrough::inherit_from_env`]. The EXEC file is intentionally
 /// never included — alias/hook shell bodies must not inject arbitrary shell
-/// into the parent session.
+/// into the parent session. The legacy single-file `WORKTRUNK_DIRECTIVE_FILE`
+/// is also excluded; it is only honored by top-level legacy output handling in
+/// `output::global`.
 #[derive(Debug, Default, Clone)]
 pub struct DirectivePassthrough {
     pub cd_file: Option<std::path::PathBuf>,
-    pub legacy_file: Option<std::path::PathBuf>,
 }
 
 impl DirectivePassthrough {
@@ -1544,20 +1542,23 @@ impl DirectivePassthrough {
         Self::default()
     }
 
-    /// Pass CD and legacy directive files through to the child, reading the
-    /// current process environment. Used by trusted contexts (aliases,
-    /// foreground hooks) that may legitimately emit a `cd` directive. The
-    /// EXEC file is deliberately omitted.
+    /// Pass the CD directive file through to the child, reading the current
+    /// process environment. Used by trusted contexts (aliases, foreground
+    /// hooks) that may legitimately emit a `cd` directive. The EXEC file and
+    /// legacy single-file directive are deliberately omitted.
     pub fn inherit_from_env() -> Self {
-        use worktrunk::shell_exec::{DIRECTIVE_CD_FILE_ENV_VAR, DIRECTIVE_FILE_ENV_VAR};
+        Self::inherit_from_reader(|var| std::env::var_os(var))
+    }
+
+    fn inherit_from_reader(read_env: impl Fn(&str) -> Option<std::ffi::OsString>) -> Self {
+        use worktrunk::shell_exec::DIRECTIVE_CD_FILE_ENV_VAR;
         let read = |var: &str| {
-            std::env::var_os(var)
+            read_env(var)
                 .map(std::path::PathBuf::from)
                 .filter(|p| !p.as_os_str().is_empty())
         };
         Self {
             cd_file: read(DIRECTIVE_CD_FILE_ENV_VAR),
-            legacy_file: read(DIRECTIVE_FILE_ENV_VAR),
         }
     }
 }
@@ -1664,6 +1665,23 @@ mod tests {
                 reason
             );
         }
+    }
+
+    #[test]
+    fn test_inherit_from_env_ignores_legacy_directive_file() {
+        use std::collections::HashMap;
+
+        let legacy_file = std::path::PathBuf::from("/tmp/directive-legacy");
+        let env = HashMap::from([(
+            worktrunk::shell_exec::DIRECTIVE_FILE_ENV_VAR.to_string(),
+            legacy_file.display().to_string(),
+        )]);
+
+        let directives = DirectivePassthrough::inherit_from_reader(|var| {
+            env.get(var).map(std::ffi::OsString::from)
+        });
+
+        assert!(directives.cd_file.is_none());
     }
 
     #[test]

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -23,8 +23,10 @@
 //! - `WORKTRUNK_DIRECTIVE_EXEC_FILE` — arbitrary shell; the wrapper sources it.
 //!
 //! The legacy single-file `WORKTRUNK_DIRECTIVE_FILE` env var is still honored
-//! for one release to bridge users who upgraded `wt` without restarting
-//! their shell. See `global` for the `DirectiveMode` selection logic.
+//! by top-level legacy output handling for one release to bridge users who
+//! upgraded `wt` without restarting their shell. Child aliases, foreground
+//! hooks, and concurrent commands only receive `WORKTRUNK_DIRECTIVE_CD_FILE`.
+//! See `global` for the `DirectiveMode` selection logic.
 //!
 //! When no directive env vars are set (direct binary call):
 //! - Commands execute directly.

--- a/src/shell_exec.rs
+++ b/src/shell_exec.rs
@@ -623,10 +623,6 @@ pub struct Cmd {
     /// injection surface). `WORKTRUNK_DIRECTIVE_EXEC_FILE` is NEVER re-added,
     /// so alias/hook bodies cannot inject arbitrary shell into the parent.
     directive_cd_file: Option<std::path::PathBuf>,
-    /// When set, re-adds the legacy `WORKTRUNK_DIRECTIVE_FILE` env var. Used in
-    /// legacy-wrapper compat mode to preserve pre-split behavior for alias/hook
-    /// bodies running under an old shell wrapper.
-    directive_legacy_file: Option<std::path::PathBuf>,
 }
 
 struct ExternalCommandLog {
@@ -671,7 +667,6 @@ impl Cmd {
             forward_signals: false,
             external_label: None,
             directive_cd_file: None,
-            directive_legacy_file: None,
         }
     }
 
@@ -729,9 +724,9 @@ impl Cmd {
 
         // Prevent subprocesses from writing shell directives (security).
         // Applied last so it can't be re-added by user-provided envs.
-        // `stream()` selectively re-adds `WORKTRUNK_DIRECTIVE_CD_FILE` (and
-        // the legacy var, in compat mode) for trusted contexts — but never
-        // `WORKTRUNK_DIRECTIVE_EXEC_FILE`, which carries arbitrary shell.
+        // `stream()` selectively re-adds `WORKTRUNK_DIRECTIVE_CD_FILE` for
+        // trusted contexts — but never `WORKTRUNK_DIRECTIVE_EXEC_FILE`, which
+        // carries arbitrary shell.
         scrub_directive_env_vars(cmd);
     }
 
@@ -903,17 +898,6 @@ impl Cmd {
         self
     }
 
-    /// Pass the legacy (pre-split) directive file through to the child process.
-    ///
-    /// Used only in legacy-wrapper compat mode. Preserves pre-split behavior
-    /// for alias/hook bodies running under an old shell wrapper that still
-    /// sets `WORKTRUNK_DIRECTIVE_FILE`. Remove together with the legacy env
-    /// var in the next breaking release.
-    pub fn directive_legacy_file(mut self, path: impl Into<std::path::PathBuf>) -> Self {
-        self.directive_legacy_file = Some(path.into());
-        self
-    }
-
     /// Execute the command and return its output.
     ///
     /// Captures stdout/stderr and returns them in `Output`. For interactive
@@ -930,7 +914,7 @@ impl Cmd {
             "Cmd::shell() commands must use .stream(), not .run()"
         );
         debug_assert!(
-            self.directive_cd_file.is_none() && self.directive_legacy_file.is_none(),
+            self.directive_cd_file.is_none(),
             "directive_*_file is only applied by .stream(), not .run()"
         );
 
@@ -1035,10 +1019,7 @@ impl Cmd {
             "pipe_into does not support external() logging"
         );
         debug_assert!(
-            self.directive_cd_file.is_none()
-                && self.directive_legacy_file.is_none()
-                && next.directive_cd_file.is_none()
-                && next.directive_legacy_file.is_none(),
+            self.directive_cd_file.is_none() && next.directive_cd_file.is_none(),
             "directive_*_file is only applied by .stream(), not pipe_into"
         );
 
@@ -1186,14 +1167,11 @@ impl Cmd {
         self.log_stream_start(&cmd_str, &exec_mode);
         self.apply_common_settings(&mut cmd);
 
-        // Re-add directive files after security scrub for trusted contexts.
-        // CD file is always safe to pass through (raw path, no shell). EXEC
-        // file is never re-added — alias/hook bodies must not inject shell.
+        // Re-add the CD file after security scrub for trusted contexts. It is
+        // always safe to pass through (raw path, no shell). EXEC file is never
+        // re-added — alias/hook bodies must not inject shell.
         if let Some(ref path) = self.directive_cd_file {
             cmd.env(DIRECTIVE_CD_FILE_ENV_VAR, path);
-        }
-        if let Some(ref path) = self.directive_legacy_file {
-            cmd.env(DIRECTIVE_FILE_ENV_VAR, path);
         }
 
         #[cfg(not(unix))]

--- a/tests/integration_tests/step_alias.rs
+++ b/tests/integration_tests/step_alias.rs
@@ -1,8 +1,9 @@
 //! Integration tests for `wt step <alias>`
 
 use crate::common::{
-    TestRepo, configure_directive_files, directive_files, make_snapshot_cmd,
-    make_snapshot_cmd_with_global_flags, repo, setup_snapshot_settings, wt_bin,
+    TestRepo, configure_directive_files, configure_legacy_directive_file, directive_files,
+    legacy_directive_file, make_snapshot_cmd, make_snapshot_cmd_with_global_flags, repo,
+    setup_snapshot_settings, wt_bin,
 };
 use insta_cmd::assert_cmd_snapshot;
 use rstest::rstest;
@@ -799,6 +800,40 @@ new-branch = "'{wt_toml}' switch --create alias-created"
     assert!(
         !stderr.contains("shell integration"),
         "inner wt should not warn about shell integration being uninstalled, got: {stderr}",
+    );
+}
+
+/// `wt step <alias>` does not pass the legacy `WORKTRUNK_DIRECTIVE_FILE`
+/// through to the alias subprocess. The child shell body would append to the
+/// file if it could see the env var; the file must remain empty.
+#[rstest]
+#[cfg(unix)]
+fn test_alias_does_not_pass_legacy_directive_file(repo: TestRepo) {
+    repo.write_test_config(
+        r#"
+[aliases]
+probe = "if [ -n \"${WORKTRUNK_DIRECTIVE_FILE:-}\" ]; then printf CHILD >> \"$WORKTRUNK_DIRECTIVE_FILE\"; fi"
+"#,
+    );
+    repo.commit("Add alias config");
+
+    let (directive_path, _guard) = legacy_directive_file();
+
+    let mut cmd = repo.wt_command();
+    configure_legacy_directive_file(&mut cmd, &directive_path);
+    cmd.args(["step", "probe"]);
+
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "alias should succeed even when the legacy directive file is set: stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let directives = std::fs::read_to_string(&directive_path).unwrap_or_default();
+    assert!(
+        directives.trim().is_empty(),
+        "alias child should not be able to append to WORKTRUNK_DIRECTIVE_FILE, got: {directives:?}"
     );
 }
 

--- a/tests/integration_tests/user_hooks.rs
+++ b/tests/integration_tests/user_hooks.rs
@@ -7,8 +7,9 @@
 //! - Skipped together with project hooks via --no-hooks
 
 use crate::common::{
-    TestRepo, make_snapshot_cmd, make_snapshot_cmd_with_global_flags, repo, resolve_git_common_dir,
-    setup_snapshot_settings, wait_for_file, wait_for_file_content, wait_for_file_count,
+    TestRepo, configure_legacy_directive_file, legacy_directive_file, make_snapshot_cmd,
+    make_snapshot_cmd_with_global_flags, repo, resolve_git_common_dir, setup_snapshot_settings,
+    wait_for_file, wait_for_file_content, wait_for_file_count,
 };
 use insta_cmd::assert_cmd_snapshot;
 use path_slash::PathExt as _;
@@ -3571,6 +3572,39 @@ setup = "'{wt_toml}' switch --create hook-created --no-hooks"
     assert!(
         !stderr.contains("shell integration"),
         "inner wt should not warn about shell integration being uninstalled, got: {stderr}",
+    );
+}
+
+/// Foreground hooks do not pass the legacy `WORKTRUNK_DIRECTIVE_FILE` through
+/// to child shell commands. If the child could see the env var, it would
+/// append to the file; the file must remain empty.
+#[rstest]
+#[cfg(unix)]
+fn test_foreground_hook_does_not_pass_legacy_directive_file(repo: TestRepo) {
+    repo.write_test_config(
+        r#"
+[pre-start]
+setup = "if [ -n \"${WORKTRUNK_DIRECTIVE_FILE:-}\" ]; then printf CHILD >> \"$WORKTRUNK_DIRECTIVE_FILE\"; fi"
+"#,
+    );
+
+    let (directive_path, _guard) = legacy_directive_file();
+
+    let mut cmd = repo.wt_command();
+    configure_legacy_directive_file(&mut cmd, &directive_path);
+    cmd.args(["hook", "pre-start", "setup"]);
+
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "foreground hook should succeed even when the legacy directive file is set: stderr={}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let directives = std::fs::read_to_string(&directive_path).unwrap_or_default();
+    assert!(
+        directives.trim().is_empty(),
+        "foreground hook child should not be able to append to WORKTRUNK_DIRECTIVE_FILE, got: {directives:?}"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes legacy directive-file passthrough into child commands.

The split directive protocol already prevents alias and hook child processes
from writing arbitrary shell into the parent session: children may receive
`WORKTRUNK_DIRECTIVE_CD_FILE`, but not `WORKTRUNK_DIRECTIVE_EXEC_FILE`.
However, the compatibility variable `WORKTRUNK_DIRECTIVE_FILE` still combined
CD and shell execution directives for old shell wrappers. Passing that legacy
file through to aliases, foreground hooks, or concurrent child commands let
those children append shell that the parent wrapper could later source.

This PR keeps top-level legacy wrapper compatibility intact, but stops passing
`WORKTRUNK_DIRECTIVE_FILE` into child command execution. Child aliases, hooks,
and concurrent commands now only receive the safe CD directive file.

## Changes

- Remove legacy directive passthrough from `DirectivePassthrough`.
- Remove `shell_exec::Cmd::directive_legacy_file`.
- Stop concurrent command spawning from re-adding `WORKTRUNK_DIRECTIVE_FILE`.
- Update comments documenting the new trust boundary.
- Add regression coverage for aliases and foreground hooks under legacy env
  setup, plus unit coverage for legacy env filtering.

## Tests

- `cargo fmt --all --check`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --bin wt test_inherit_from_env_ignores_legacy_directive_file --features shell-integration-tests`
- `cargo test --test integration legacy_directive_file --features shell-integration-tests`
