### PR TITLE
docs(release): point step 12 at release.yaml directly

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -37,9 +37,12 @@ metadata:
     MERGE_SHA=$(gh pr view --json mergeCommit --jq '.mergeCommit.oid')
     git tag vX.Y.Z "$MERGE_SHA" && git push origin vX.Y.Z
     ```
-12. **Wait for release workflow**: Poll with `gh pr checks --required` or `gh run view <run-id>` every 60 seconds until complete (avoid `gh run watch` — it can hang). Non-required checks are ignored
+12. **Wait for the release workflow**: The tag push triggers `release.yaml`. Launch a ci-reporter agent to monitor the run through to completion (avoid `gh run watch` — it can hang); the run ID comes from:
+    ```bash
+    gh run list --workflow=release.yaml --event=push --branch=vX.Y.Z --limit 1 --json databaseId --jq '.[0].databaseId'
+    ```
 
-The tag push triggers the release workflow which builds binaries and publishes to crates.io, Homebrew, and winget automatically.
+`release.yaml` builds binaries and publishes to crates.io, Homebrew, and winget automatically.
 
 ## CHANGELOG Review
 
@@ -244,18 +247,3 @@ Interpreting results:
 - **Tool fails to run** (e.g., missing baseline): likely the crate hasn't been published yet or the registry cache is stale. Try `cargo semver-checks check-release -p worktrunk --baseline-version <last-published>`.
 
 This check validates the chosen bump — it doesn't distinguish patch vs. minor when no breakage exists. Continue using the commit review to decide between patch (fixes only) and minor (new features).
-
-## Troubleshooting
-
-### Release workflow fails after tag push
-
-If the workflow fails (e.g., cargo publish error), fix the issue, then recreate the tag:
-
-```bash
-gh release delete vX.Y.Z --yes           # Delete GitHub release
-git push origin :refs/tags/vX.Y.Z        # Delete remote tag
-git tag -d vX.Y.Z                        # Delete local tag
-git tag vX.Y.Z && git push origin vX.Y.Z # Recreate and push
-```
-
-The new tag will trigger a fresh workflow run with the fixed code.


### PR DESCRIPTION
Step 12's polling instructions assumed the post-tag workflow was a PR check (`gh pr checks --required`), which it isn't — the tag push runs `release.yaml` as a tag-triggered workflow. Update step 12 to name the workflow file, give a working `gh run list` query for the run ID, and recommend the ci-reporter agent for the actual wait.

Drop the `## Troubleshooting` subsection in the same pass — its retag recipe (`git tag vX.Y.Z && git push`) re-tagged the local HEAD, which after `/gpk` is no longer the released commit, and the recovery scenario is uncommon enough that inline guidance was earning its keep.

> _This was written by Claude Code on behalf of @max-sixty_