### PR TITLE
fix(deps): update vulnerable advisory crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,9 +1738,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -2455,9 +2455,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -2478,9 +2478,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",


### PR DESCRIPTION
## Problem We Are Solving

`cargo audit` reports `RUSTSEC-2026-0009` against the locked `time` 0.3.46 dependency. Even though Worktrunk does not call the vulnerable parser directly, the project is still shipping a lockfile with a known RustSec advisory, so every developer and CI run inherits that vulnerable dependency graph.

The lockfile also includes `rand` 0.9.2, which currently emits an informational unsoundness warning. Leaving that warning in place would make the follow-up dependency-policy PR noisy and make it harder to distinguish new dependency problems from known pre-existing ones.

## Why This Matters

Worktrunk is a developer tool that runs on contributor machines and inside CI. Keeping the locked dependency graph clear of current advisories reduces the chance that a transitive vulnerability becomes reachable later and gives future automated dependency gates a clean baseline.

This PR is intentionally small because dependency updates are easiest to review when the blast radius is limited to lockfile resolution.

## What Changed

- Updated `time` from 0.3.46 to 0.3.47 in `Cargo.lock`.
- Updated `time-macros` from 0.2.26 to 0.2.27 as part of the `time` patch update.
- Updated `rand` from 0.9.2 to 0.9.3.
- Left `Cargo.toml` unchanged because the existing dependency requirements already resolve to the patched versions.

## How This Solves It

The patch moves the lockfile to versions that clear the current RustSec advisory and informational warning. It keeps the dependency requirements stable and only changes resolved package versions/checksums, so downstream behavior should remain unchanged except for the dependency graph being safer.

## Validation

- `cargo audit` passes.
- `cargo test --locked --lib --bins` currently fails on the existing unrelated `testing::mock_commands::tests::test_mock_config_write` test. This branch is lockfile-only and does not touch that code.

## Reviewer Notes

- This is the base PR for #2509, which adds dependency gates. Review this one first so the dependency-policy PR can be rebased or merged without carrying the lockfile update in its diff.
