### PR TITLE
ci: add dependency security gates

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -12,6 +12,7 @@ sync = 'if [ "{{ target }}" = "main" ]; then git pull && git push; fi'
 
 [[pre-merge]]
 pre-commit = 'if [ -n "$MSYSTEM" ]; then SKIP=lychee-system pre-commit run --all-files; else pre-commit run --all-files; fi'
+dependency-policy = "cargo deny check advisories sources"
 insta = """RUSTFLAGS='-D warnings' NEXTEST_NO_INPUT_HANDLER=1 cargo insta test --test-runner nextest --dnd --check $([ "$(uname)" = 'Linux' ] && echo '--unreferenced reject') --features shell-integration-tests"""
 doctest = "RUSTDOCFLAGS='-Dwarnings' cargo test --doc"
 doc = "RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps --document-private-items"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -67,6 +67,26 @@ jobs:
     - name: Binary builds without syntax-highlighting
       run: cargo check --bin wt --no-default-features --features cli
 
+  dependency-policy:
+    runs-on: ubuntu-24.04
+    needs: changes
+    if: needs.changes.outputs.cargo == 'true' || github.event_name == 'workflow_dispatch'
+    steps:
+    - name: 📂 Checkout code
+      uses: actions/checkout@v6
+
+    - name: 💰 Cache
+      uses: Swatinem/rust-cache@v2
+
+    - name: Install cargo-deny
+      uses: baptiste0928/cargo-install@v3
+      with:
+        crate: cargo-deny
+        version: "=0.19.0"
+
+    - name: Check dependency policy
+      run: cargo deny check advisories sources
+
   test:
     strategy:
       fail-fast: false
@@ -139,6 +159,8 @@ jobs:
             - 'Cargo.toml'
             - 'Cargo.lock'
             - 'rust-toolchain.toml'
+            - 'deny.toml'
+            - '.config/wt.toml'
             - '.github/workflows/ci.yaml'
           docs:
             - 'docs/**'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -369,7 +369,7 @@ jobs:
     - name: 🎯 Run affected tests
       env:
         NEXTEST_NO_INPUT_HANDLER: 1
-      run: cargo affected run --features shell-integration-tests --verbose
+      run: cargo affected run --verbose -- --features shell-integration-tests
 
   code-coverage:
     runs-on: ubuntu-24.04

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1738,9 +1738,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -2455,9 +2455,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -2478,9 +2478,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,9 @@
+[advisories]
+ignore = []
+unsound = "all"
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Problem We Are Solving

Dependency security checks are currently manual. A vulnerable crate can enter or remain in `Cargo.lock` unless someone remembers to run `cargo audit` locally and interpret the output before merging.

The project also has no source-policy gate. That means an unexpected registry or git dependency source would not be caught automatically during review, even though dependency source changes are high-signal from a supply-chain perspective.

## Why This Matters

Worktrunk is installed and executed on developer machines. Dependency advisories and unexpected dependency sources are two of the clearest supply-chain risks for a Rust CLI, so they should be checked by both CI and the local pre-merge path.

This first policy phase deliberately avoids licenses and bans. Those need a project dependency-policy decision, while advisories and sources are immediately actionable.

## What Changed

- Added `deny.toml` with first-phase `cargo-deny` configuration for:
  - advisories
  - unsound advisories
  - dependency sources
- Kept `ignore = []` so the gate starts from a clean baseline.
- Denied unknown registries and unknown git sources.
- Allowed crates.io as the only registry source.
- Added `dependency-policy = "cargo deny check advisories sources"` to `.config/wt.toml`.
- Added a Linux CI `dependency-policy` job pinned to `cargo-deny` 0.19.0.
- Included `deny.toml` and `.config/wt.toml` in the existing Cargo/CI path filter.
- Fixed the `affected-tests` workflow invocation so current `cargo-affected` receives nextest args after `--`.

## How This Solves It

`cargo deny check advisories sources` now runs in the same places maintainers already trust for release readiness:

- locally through `wt hook pre-merge --yes dependency-policy`
- in CI through the new `dependency-policy` job

The advisory check blocks known vulnerable or unsound dependencies from being introduced silently. The source check blocks dependency graph changes that pull from unapproved registries or git sources. Keeping the config limited to advisories and sources makes the gate useful now without forcing license or ban decisions in this PR.

## Validation

- `cargo deny check advisories sources` passes.
- `cargo run -- hook pre-merge --yes dependency-policy` passes.
- `ruby -rpsych -e 'Psych.load_file(".github/workflows/ci.yaml")'` passes after the CI argument fix.
- `git diff --check` passes.
- `pre-commit run --all-files` was not available locally because `pre-commit` is not installed.

## Reviewer Notes

- This PR is stacked on #2508. Until #2508 merges, the diff also includes the lockfile-only dependency update from that PR.
- The license and bans sections are intentionally omitted. They should be added in a later PR after the dependency policy is agreed.
- The branch includes a follow-up fix for the advisory `affected-tests` job: current `cargo-affected` expects nextest arguments after `--`, so the workflow now runs `cargo affected run --verbose -- --features shell-integration-tests`.
