### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   # CI does clean builds, so incremental compilation tracking adds I/O overhead

--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -1,0 +1,40 @@
+name: codeql
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '23 3 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  analyze:
+    runs-on: ubuntu-24.04
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, rust]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          queries: +security-extended
+
+      - name: Autobuild
+        if: matrix.language == 'rust'
+        uses: github/codeql-action/autobuild@v4
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v4

--- a/.github/workflows/nightly-benchmark.yaml
+++ b/.github/workflows/nightly-benchmark.yaml
@@ -7,6 +7,9 @@ on:
     - cron: '17 4 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -16,6 +16,9 @@ on:
     - cron: '37 5 * * *'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/publish-docs.yaml
+++ b/.github/workflows/publish-docs.yaml
@@ -14,6 +14,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-docs:
     runs-on: ubuntu-24.04

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,8 +19,7 @@
 # (via upload-artifact/download-artifact) is fine since it's scoped to the
 # current run.
 
-permissions:
-  "contents": "write"
+permissions: {}
 
 # This task will run whenever you push a git tag that looks like a version
 # like "1.0.0", "v0.1.0-prerelease.1", "my-app/0.1.0", "releases/v1.0.0", etc.
@@ -55,6 +54,8 @@ jobs:
   # Run 'dist plan' (or host) to determine what tasks we need to do
   plan:
     runs-on: "ubuntu-24.04"
+    permissions:
+      contents: read
     outputs:
       val: ${{ steps.plan.outputs.manifest }}
       tag: ${{ !github.event.pull_request && github.ref_name || '' }}
@@ -114,6 +115,8 @@ jobs:
       # - N "local" tasks that build each platform's binaries and platform-specific installers
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
     container: ${{ matrix.container && matrix.container.image || null }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -177,6 +180,8 @@ jobs:
       - plan
       - build-local-artifacts
     runs-on: "ubuntu-24.04"
+    permissions:
+      contents: read
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/global-dist-manifest.json
@@ -228,6 +233,8 @@ jobs:
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     runs-on: "ubuntu-24.04"
+    permissions:
+      contents: write
     outputs:
       val: ${{ steps.host.outputs.manifest }}
     steps:
@@ -302,6 +309,8 @@ jobs:
     runs-on: ubuntu-24.04
     environment: release
     if: ${{ needs.plan.outputs.publishing == 'true' }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - name: Publish to crates.io
@@ -317,6 +326,7 @@ jobs:
     if: ${{ needs.plan.outputs.publishing == 'true' }}
     env:
       GH_TOKEN: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
+    permissions: {}
     steps:
       - name: Sync winget-pkgs fork with upstream
         run: |
@@ -340,6 +350,7 @@ jobs:
       GITHUB_USER: "worktrunk-bot"
       GITHUB_EMAIL: "worktrunk-bot@users.noreply.github.com"
     if: ${{ needs.plan.outputs.publishing == 'true' && (!fromJson(needs.plan.outputs.val).announcement_is_prerelease || fromJson(needs.plan.outputs.val).publish_prereleases) }}
+    permissions: {}
     steps:
       - uses: actions/checkout@v6
         with:
@@ -368,6 +379,8 @@ jobs:
     runs-on: ubuntu-24.04
     environment: release
     if: ${{ needs.plan.outputs.publishing == 'true' }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - name: Update PKGBUILD version
@@ -402,6 +415,8 @@ jobs:
     runs-on: "ubuntu-24.04"
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/tend-ci-fix.yaml
+++ b/.github/workflows/tend-ci-fix.yaml
@@ -13,6 +13,8 @@ on:
     types: [completed]
     branches: ["main"]
 
+permissions: {}
+
 jobs:
   fix-ci:
     if: github.event.workflow_run.conclusion == 'failure'

--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -30,6 +30,8 @@ on:
   pull_request_review_comment:
     types: [edited]
 
+permissions: {}
+
 jobs:
   verify:
     # Filter out fork PRs for review events — secrets are unavailable there

--- a/.github/workflows/tend-nightly.yaml
+++ b/.github/workflows/tend-nightly.yaml
@@ -12,6 +12,8 @@ on:
     - cron: "17 6 * * *"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   nightly:
     runs-on: ubuntu-24.04

--- a/.github/workflows/tend-notifications.yaml
+++ b/.github/workflows/tend-notifications.yaml
@@ -12,6 +12,8 @@ on:
     - cron: "*/15 * * * *"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   notifications:
     runs-on: ubuntu-24.04

--- a/.github/workflows/tend-review-runs.yaml
+++ b/.github/workflows/tend-review-runs.yaml
@@ -12,6 +12,8 @@ on:
     - cron: "47 7 * * *"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   review-runs:
     runs-on: ubuntu-24.04

--- a/.github/workflows/tend-review.yaml
+++ b/.github/workflows/tend-review.yaml
@@ -11,6 +11,8 @@ on:
   pull_request_target:
     types: [opened, synchronize, ready_for_review, reopened]
 
+permissions: {}
+
 jobs:
   review:
     if: >-
@@ -26,12 +28,19 @@ jobs:
       actions: read
       issues: write
     steps:
+      - name: Skip privileged review on fork PRs
+        if: github.event.pull_request.head.repo.full_name != github.repository
+        run: >-
+          echo "::notice::Skipping tend-review for fork PR #${{ github.event.pull_request.number }} from
+          ${{ github.event.pull_request.head.repo.full_name }}. Privileged review automation only runs for same-repo pull requests."
+
       # GitHub only materializes refs/pull/N/merge for mergeable PRs — on
       # conflicting PRs it 404s and every downstream step cascades as skipped.
       # Probe first and fall back to /head so review always runs; on fallback
       # the review sees the PR branch in isolation rather than the post-merge
       # tree.
       - name: Resolve PR checkout ref
+        if: github.event.pull_request.head.repo.full_name == github.repository
         id: pr_ref
         env:
           GH_TOKEN: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
@@ -44,6 +53,7 @@ jobs:
             echo "::notice::refs/pull/$PR/merge unavailable (likely merge conflict); falling back to /head"
           fi
       - uses: actions/checkout@v6
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           ref: ${{ steps.pr_ref.outputs.ref }}
           fetch-depth: 0
@@ -51,8 +61,10 @@ jobs:
           token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
 
       - uses: ./.github/actions/claude-setup
+        if: github.event.pull_request.head.repo.full_name == github.repository
 
       - uses: max-sixty/tend@v1
+        if: github.event.pull_request.head.repo.full_name == github.repository
         with:
           github_token: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-triage.yaml
+++ b/.github/workflows/tend-triage.yaml
@@ -15,6 +15,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.issue.number }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   triage:
     runs-on: ubuntu-24.04

--- a/.github/workflows/tend-weekly.yaml
+++ b/.github/workflows/tend-weekly.yaml
@@ -12,6 +12,8 @@ on:
     - cron: "17 9 * * 0"
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   weekly:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Problem We Are Solving

The GitHub Actions workflows had broader default token permissions than many jobs need. Broad permissions increase the blast radius if a job, action, or workflow step is compromised.

The riskiest workflow shape is `pull_request_target` combined with privileged tokens and PR-related checkout logic. That event can access secrets and write-scoped tokens, so it must not check out or execute untrusted fork PR code.

The repository also did not have a dedicated CodeQL workflow for Rust and GitHub Actions security patterns, so risky workflow changes depended primarily on manual review.

## Why This Matters

CI is part of the developer-machine safety boundary for this project. If a privileged workflow executes untrusted code, an attacker can potentially exfiltrate tokens, modify PRs, or affect the repository. Least-privilege permissions and explicit fork quarantine reduce that risk without disabling useful automation for trusted same-repo PRs.

## What Changed

- Added restrictive workflow-level permissions across GitHub Actions workflows.
- Kept write permissions only on jobs that need them.
- Hardened `tend-review` so fork PRs do not run the privileged checkout/setup/Tend execution path.
- Added a fork notice step so skipped fork reviews are visible and intentional.
- Added a CodeQL workflow for Rust and GitHub Actions with `security-extended` queries.

## How This Solves It

The permission changes make read-only the default and force write scopes to be explicit per job. That narrows the token permissions available to unrelated workflow steps.

The `tend-review` quarantine keeps same-repo automation working, but fork PRs now stop before the privileged workflow checks out or executes PR code. This preserves the useful bot review path where it is lower risk and avoids the dangerous `pull_request_target` plus untrusted-code combination for forks.

CodeQL adds automated scanning for Rust code and GitHub Actions workflow security issues, giving maintainers another line of review for future workflow changes.

## Validation

- YAML sanity check passed with `ruby -rpsych` over all workflow files.
- `git diff --check` passed.
- `pre-commit run --all-files` could not run because `pre-commit` is not installed locally.
- `actionlint` is not installed locally.

## Reviewer Notes

- Same-repo Tend review automation remains enabled.
- Fork PRs now receive a notice and skip privileged checkout/setup/Tend execution.
- The generated Tend workflow headers are preserved; this PR makes a minimal security hardening edit directly in the generated workflow files.
