### PR TITLE
feat(switch): suggest pr:N or mr:N for numeric branch names

### DIFF
--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -710,6 +710,7 @@ pub fn handle_state_get(
                         branch: branch_name,
                         show_create_hint: true,
                         last_fetch_ago: None,
+                        pr_mr_platform: repo.detect_ref_type(),
                     }
                     .into());
                 }

--- a/src/commands/repository_ext.rs
+++ b/src/commands/repository_ext.rs
@@ -157,6 +157,7 @@ impl RepositoryCliExt for Repository {
                                 branch: branch.into(),
                                 show_create_hint: false,
                                 last_fetch_ago: None,
+                                pr_mr_platform: None,
                             }
                             .into());
                         }

--- a/src/commands/worktree/switch.rs
+++ b/src/commands/worktree/switch.rs
@@ -518,6 +518,7 @@ fn validate_worktree_creation(
             branch: branch.to_string(),
             show_create_hint: true,
             last_fetch_ago: format_last_fetch_ago(repo),
+            pr_mr_platform: repo.detect_ref_type(),
         }
         .into());
     }

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -435,8 +435,8 @@ impl GitError {
                     }
                     let create_hint =
                         cformat!("to create a new branch, run <underline>{create_cmd}</>");
-                    if branch.parse::<u32>().is_ok() {
-                        let pr_mr_hint = pr_mr_switch_hint(branch, *pr_mr_platform, ctx);
+                    if let Ok(number) = branch.parse::<u32>() {
+                        let pr_mr_hint = pr_mr_switch_hint(number, *pr_mr_platform, ctx);
                         cformat!("{pr_mr_hint}; {create_hint}; {list_hint}")
                     } else {
                         // Existing format: capitalize the leading "to".
@@ -1142,16 +1142,17 @@ impl std::error::Error for HookErrorWithHint {
 /// chain it with `; …` follow-ups. Capitalization matches the existing hint
 /// style ("To switch …", "to create …").
 ///
-/// `branch` must already be validated as numeric (parses as `u32`); combined
-/// with the literal `pr:` / `mr:` prefix the result is shell-safe, so the
-/// command is formatted directly to avoid `shell_escape` quoting (`'pr:42'`).
+/// `number` is the same digits as the branch (the caller has already parsed
+/// the branch as `u32`); combined with the literal `pr:` / `mr:` prefix the
+/// result is shell-safe, so the command is formatted directly to avoid
+/// `shell_escape` quoting (`'pr:42'`).
 fn pr_mr_switch_hint(
-    branch: &str,
+    number: u32,
     platform: Option<RefType>,
     ctx: Option<&SwitchSuggestionCtx>,
 ) -> String {
     let make_cmd = |ref_type: RefType| {
-        let cmd = format!("wt switch {}{branch}", ref_type.syntax());
+        let cmd = format!("wt switch {}{number}", ref_type.syntax());
         match ctx {
             Some(ctx) => ctx.apply(cmd),
             None => cmd,
@@ -1159,9 +1160,6 @@ fn pr_mr_switch_hint(
     };
     match platform {
         Some(ref_type) => {
-            let number = branch
-                .parse()
-                .expect("pr_mr_switch_hint requires a numeric branch name");
             let label = ref_type.display(number);
             let cmd = make_cmd(ref_type);
             cformat!("To switch to {label}, run <underline>{cmd}</>")
@@ -1170,7 +1168,7 @@ fn pr_mr_switch_hint(
             let pr_cmd = make_cmd(RefType::Pr);
             let mr_cmd = make_cmd(RefType::Mr);
             cformat!(
-                "To switch to PR #{branch} or MR !{branch}, run <underline>{pr_cmd}</> or <underline>{mr_cmd}</>"
+                "To switch to PR #{number} or MR !{number}, run <underline>{pr_cmd}</> or <underline>{mr_cmd}</>"
             )
         }
     }

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -183,6 +183,10 @@ pub enum GitError {
         /// Pre-formatted label for the last fetch time (e.g., "3h ago", "never").
         /// When present, the list-branches hint includes the fetch age as a parenthetical.
         last_fetch_ago: Option<String>,
+        /// Platform's reference type for the PR/MR hint when the branch name is
+        /// purely numeric. `None` means the platform is unknown — fall back to
+        /// suggesting both `pr:N` and `mr:N`.
+        pr_mr_platform: Option<RefType>,
     },
     /// Reference (branch, tag, commit) not found - used when any commit-ish is accepted
     ReferenceNotFound {
@@ -415,18 +419,31 @@ impl GitError {
                 branch,
                 show_create_hint,
                 last_fetch_ago,
+                pr_mr_platform,
             } => {
                 let list_cmd = suggest_command("list", &[], &["--branches", "--remotes"]);
+                let fetch_note = last_fetch_ago
+                    .as_ref()
+                    .map(|ago| cformat!(" ({ago})"))
+                    .unwrap_or_default();
+                let list_hint =
+                    cformat!("to list branches, run <underline>{list_cmd}</>{fetch_note}");
                 let hint = if *show_create_hint {
                     let mut create_cmd = suggest_command("switch", &[branch], &["--create"]);
                     if let Some(ctx) = ctx {
                         create_cmd = ctx.apply(create_cmd);
                     }
-                    let fetch_note = last_fetch_ago.as_ref().map(|ago| cformat!(" ({ago})"));
-                    cformat!(
-                        "To create a new branch, run <underline>{create_cmd}</>; to list branches, run <underline>{list_cmd}</>{note}",
-                        note = fetch_note.as_deref().unwrap_or("")
-                    )
+                    let create_hint =
+                        cformat!("to create a new branch, run <underline>{create_cmd}</>");
+                    if branch.parse::<u32>().is_ok() {
+                        let pr_mr_hint = pr_mr_switch_hint(branch, *pr_mr_platform, ctx);
+                        cformat!("{pr_mr_hint}; {create_hint}; {list_hint}")
+                    } else {
+                        // Existing format: capitalize the leading "to".
+                        cformat!(
+                            "To create a new branch, run <underline>{create_cmd}</>; {list_hint}"
+                        )
+                    }
                 } else {
                     cformat!("To list branches, run <underline>{list_cmd}</>")
                 };
@@ -1118,6 +1135,44 @@ impl std::error::Error for HookErrorWithHint {
     }
 }
 
+/// Build the leading "To switch to PR/MR …" hint shown when a numeric branch
+/// name doesn't exist locally.
+///
+/// Returns a sentence-cased clause without trailing punctuation so callers can
+/// chain it with `; …` follow-ups. Capitalization matches the existing hint
+/// style ("To switch …", "to create …").
+///
+/// `branch` must already be validated as numeric (parses as `u32`); combined
+/// with the literal `pr:` / `mr:` prefix the result is shell-safe, so the
+/// command is formatted directly to avoid `shell_escape` quoting (`'pr:42'`).
+fn pr_mr_switch_hint(
+    branch: &str,
+    platform: Option<RefType>,
+    ctx: Option<&SwitchSuggestionCtx>,
+) -> String {
+    let make_cmd = |ref_type: RefType| {
+        let cmd = format!("wt switch {}{branch}", ref_type.syntax());
+        match ctx {
+            Some(ctx) => ctx.apply(cmd),
+            None => cmd,
+        }
+    };
+    match platform {
+        Some(ref_type) => {
+            let label = ref_type.display(branch.parse().unwrap_or(0));
+            let cmd = make_cmd(ref_type);
+            cformat!("To switch to {label}, run <underline>{cmd}</>")
+        }
+        None => {
+            let pr_cmd = make_cmd(RefType::Pr);
+            let mr_cmd = make_cmd(RefType::Mr);
+            cformat!(
+                "To switch to PR #{branch} or MR !{branch}, run <underline>{pr_cmd}</> or <underline>{mr_cmd}</>"
+            )
+        }
+    }
+}
+
 /// Format an error with header and gutter content
 fn format_error_block(header: impl Into<String>, error: &str) -> String {
     let header = header.into();
@@ -1746,6 +1801,7 @@ mod tests {
                 branch: "emails".into(),
                 show_create_hint: true,
                 last_fetch_ago: None,
+                pr_mr_platform: None,
             }),
             ctx: SwitchSuggestionCtx {
                 extra_flags: vec!["--execute=claude".into()],

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -1159,7 +1159,10 @@ fn pr_mr_switch_hint(
     };
     match platform {
         Some(ref_type) => {
-            let label = ref_type.display(branch.parse().unwrap_or(0));
+            let number = branch
+                .parse()
+                .expect("pr_mr_switch_hint requires a numeric branch name");
+            let label = ref_type.display(number);
             let cmd = make_cmd(ref_type);
             cformat!("To switch to {label}, run <underline>{cmd}</>")
         }

--- a/src/git/repository/config.rs
+++ b/src/git/repository/config.rs
@@ -380,6 +380,7 @@ impl Repository {
                 branch,
                 show_create_hint: true,
                 last_fetch_ago: None,
+                pr_mr_platform: self.detect_ref_type(),
             }
             .into());
         }

--- a/src/git/repository/remotes.rs
+++ b/src/git/repository/remotes.rs
@@ -268,27 +268,15 @@ impl Repository {
 
     /// Detect the platform's reference type (PR for GitHub, MR for GitLab).
     ///
-    /// Honors the `forge.platform` config override first, then falls back to
-    /// hostname matching on the primary remote's effective URL (so `url.insteadOf`
+    /// Hostname-matches the primary remote's effective URL (so `url.insteadOf`
     /// rewrites are respected). Returns `None` when the platform can't be
-    /// determined (no remote, opaque host, unknown override).
+    /// determined (no remote, opaque host).
     ///
-    /// Mirrors the detection rules used by `platform_for_repo` (case-sensitive
-    /// `forge.platform` match, effective URL hostname check) so a hint here and
-    /// a CI-status decision elsewhere agree on the same repo.
+    /// Drives the numeric-branch hint in `BranchNotFound` only — `forge.platform`
+    /// is intentionally not consulted here. Honoring it would duplicate
+    /// `platform_for_repo`'s precedence rules; users with that override and an
+    /// opaque remote host fall through to the both-platforms hint.
     pub fn detect_ref_type(&self) -> Option<RefType> {
-        if let Some(platform) = self
-            .load_project_config()
-            .ok()
-            .flatten()
-            .and_then(|c| c.forge_platform().map(str::to_string))
-        {
-            match platform.as_str() {
-                "github" => return Some(RefType::Pr),
-                "gitlab" => return Some(RefType::Mr),
-                _ => {}
-            }
-        }
         let url = self
             .primary_remote()
             .ok()

--- a/src/git/repository/remotes.rs
+++ b/src/git/repository/remotes.rs
@@ -92,6 +92,7 @@
 use anyhow::Context;
 
 use super::{GitRemoteUrl, Repository};
+use crate::git::error::RefType;
 
 impl Repository {
     /// Get the primary remote name for this repository.
@@ -263,6 +264,34 @@ impl Repository {
         self.primary_remote_url()
             .as_deref()
             .and_then(GitRemoteUrl::parse)
+    }
+
+    /// Detect the platform's reference type (PR for GitHub, MR for GitLab).
+    ///
+    /// Honors the `forge.platform` config override first, then falls back to
+    /// hostname matching on the primary remote URL. Returns `None` when the
+    /// platform can't be determined (no remote, opaque host, unknown override).
+    pub fn detect_ref_type(&self) -> Option<RefType> {
+        if let Some(platform) = self
+            .load_project_config()
+            .ok()
+            .flatten()
+            .and_then(|c| c.forge_platform().map(str::to_ascii_lowercase))
+        {
+            match platform.as_str() {
+                "github" => return Some(RefType::Pr),
+                "gitlab" => return Some(RefType::Mr),
+                _ => {}
+            }
+        }
+        let parsed = self.primary_remote_parsed_url()?;
+        if parsed.is_github() {
+            Some(RefType::Pr)
+        } else if parsed.is_gitlab() {
+            Some(RefType::Mr)
+        } else {
+            None
+        }
     }
 
     /// Get a project identifier for approval tracking.

--- a/src/git/repository/remotes.rs
+++ b/src/git/repository/remotes.rs
@@ -269,14 +269,19 @@ impl Repository {
     /// Detect the platform's reference type (PR for GitHub, MR for GitLab).
     ///
     /// Honors the `forge.platform` config override first, then falls back to
-    /// hostname matching on the primary remote URL. Returns `None` when the
-    /// platform can't be determined (no remote, opaque host, unknown override).
+    /// hostname matching on the primary remote's effective URL (so `url.insteadOf`
+    /// rewrites are respected). Returns `None` when the platform can't be
+    /// determined (no remote, opaque host, unknown override).
+    ///
+    /// Mirrors the detection rules used by `platform_for_repo` (case-sensitive
+    /// `forge.platform` match, effective URL hostname check) so a hint here and
+    /// a CI-status decision elsewhere agree on the same repo.
     pub fn detect_ref_type(&self) -> Option<RefType> {
         if let Some(platform) = self
             .load_project_config()
             .ok()
             .flatten()
-            .and_then(|c| c.forge_platform().map(str::to_ascii_lowercase))
+            .and_then(|c| c.forge_platform().map(str::to_string))
         {
             match platform.as_str() {
                 "github" => return Some(RefType::Pr),
@@ -284,7 +289,11 @@ impl Repository {
                 _ => {}
             }
         }
-        let parsed = self.primary_remote_parsed_url()?;
+        let url = self
+            .primary_remote()
+            .ok()
+            .and_then(|remote| self.effective_remote_url(&remote))?;
+        let parsed = GitRemoteUrl::parse(&url)?;
         if parsed.is_github() {
             Some(RefType::Pr)
         } else if parsed.is_gitlab() {

--- a/tests/integration_tests/git_error_display.rs
+++ b/tests/integration_tests/git_error_display.rs
@@ -110,6 +110,7 @@ fn branch_not_found() {
         branch: "nonexistent".into(),
         show_create_hint: true,
         last_fetch_ago: None,
+        pr_mr_platform: None,
     };
 
     assert_snapshot!("branch_not_found", err.to_string());
@@ -121,6 +122,7 @@ fn branch_not_found_with_fetch_time() {
         branch: "nonexistent".into(),
         show_create_hint: true,
         last_fetch_ago: Some("last fetched 3h ago".into()),
+        pr_mr_platform: None,
     };
 
     assert_snapshot!("branch_not_found_with_fetch_time", err.to_string());
@@ -132,9 +134,49 @@ fn branch_not_found_no_create_hint() {
         branch: "nonexistent".into(),
         show_create_hint: false,
         last_fetch_ago: None,
+        pr_mr_platform: None,
     };
 
     assert_snapshot!("branch_not_found_no_create_hint", err.to_string());
+}
+
+#[test]
+fn branch_not_found_numeric_unknown_platform() {
+    // Purely numeric name with unknown platform: hint suggests both `pr:N` and `mr:N`.
+    let err = GitError::BranchNotFound {
+        branch: "2474".into(),
+        show_create_hint: true,
+        last_fetch_ago: None,
+        pr_mr_platform: None,
+    };
+
+    assert_snapshot!("branch_not_found_numeric_unknown_platform", err.to_string());
+}
+
+#[test]
+fn branch_not_found_numeric_github() {
+    use worktrunk::git::RefType;
+    let err = GitError::BranchNotFound {
+        branch: "2474".into(),
+        show_create_hint: true,
+        last_fetch_ago: Some("last fetched 9h ago".into()),
+        pr_mr_platform: Some(RefType::Pr),
+    };
+
+    assert_snapshot!("branch_not_found_numeric_github", err.to_string());
+}
+
+#[test]
+fn branch_not_found_numeric_gitlab() {
+    use worktrunk::git::RefType;
+    let err = GitError::BranchNotFound {
+        branch: "2474".into(),
+        show_create_hint: true,
+        last_fetch_ago: None,
+        pr_mr_platform: Some(RefType::Mr),
+    };
+
+    assert_snapshot!("branch_not_found_numeric_gitlab", err.to_string());
 }
 
 #[test]

--- a/tests/integration_tests/repository.rs
+++ b/tests/integration_tests/repository.rs
@@ -603,13 +603,23 @@ fn test_detect_ref_type() {
 
     // GitLab remote → MR
     let gitlab = TestRepo::new();
-    gitlab.run_git(&["remote", "add", "origin", "https://gitlab.com/owner/repo.git"]);
+    gitlab.run_git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://gitlab.com/owner/repo.git",
+    ]);
     let r = Repository::at(gitlab.root_path().to_path_buf()).unwrap();
     assert_eq!(r.detect_ref_type(), Some(RefType::Mr));
 
     // Unknown host → None
     let other = TestRepo::new();
-    other.run_git(&["remote", "add", "origin", "https://example.com/owner/repo.git"]);
+    other.run_git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://example.com/owner/repo.git",
+    ]);
     let r = Repository::at(other.root_path().to_path_buf()).unwrap();
     assert_eq!(r.detect_ref_type(), None);
 

--- a/tests/integration_tests/repository.rs
+++ b/tests/integration_tests/repository.rs
@@ -2,7 +2,7 @@
 
 use std::fs;
 
-use worktrunk::git::Repository;
+use worktrunk::git::{RefType, Repository};
 
 use crate::common::{BareRepoTest, TestRepo};
 
@@ -582,6 +582,41 @@ fn test_primary_remote_url_composition() {
     let r2 = Repository::at(bare.root_path().to_path_buf()).unwrap();
     assert_eq!(r2.primary_remote_url(), None);
     assert!(r2.primary_remote_parsed_url().is_none());
+}
+
+/// `detect_ref_type` resolves the platform's PR/MR reference type from the
+/// primary remote URL. Drives the numeric branch hint in `BranchNotFound`
+/// ("To switch to PR #N, run wt switch pr:N"). The `forge.platform` override
+/// branch is exercised end-to-end via the `platform_for_repo` paths.
+#[test]
+fn test_detect_ref_type() {
+    // GitHub remote → PR
+    let github = TestRepo::new();
+    github.run_git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://github.com/max-sixty/worktrunk.git",
+    ]);
+    let r = Repository::at(github.root_path().to_path_buf()).unwrap();
+    assert_eq!(r.detect_ref_type(), Some(RefType::Pr));
+
+    // GitLab remote → MR
+    let gitlab = TestRepo::new();
+    gitlab.run_git(&["remote", "add", "origin", "https://gitlab.com/owner/repo.git"]);
+    let r = Repository::at(gitlab.root_path().to_path_buf()).unwrap();
+    assert_eq!(r.detect_ref_type(), Some(RefType::Mr));
+
+    // Unknown host → None
+    let other = TestRepo::new();
+    other.run_git(&["remote", "add", "origin", "https://example.com/owner/repo.git"]);
+    let r = Repository::at(other.root_path().to_path_buf()).unwrap();
+    assert_eq!(r.detect_ref_type(), None);
+
+    // No remote → None
+    let empty = TestRepo::new();
+    let r = Repository::at(empty.root_path().to_path_buf()).unwrap();
+    assert_eq!(r.detect_ref_type(), None);
 }
 
 /// `remote_url` for a configured remote round-trips; unknown remotes

--- a/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__branch_not_found_numeric_github.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__branch_not_found_numeric_github.snap
@@ -1,0 +1,6 @@
+---
+source: tests/integration_tests/git_error_display.rs
+expression: err.to_string()
+---
+[31m✗[39m [31mNo branch named [1m2474[22m[39m
+[2m↳[22m [2mTo switch to PR #2474, run [4mwt switch pr:2474[24m; to create a new branch, run [4mwt switch --create 2474[24m; to list branches, run [4mwt list --branches --remotes[24m (last fetched 9h ago)[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__branch_not_found_numeric_gitlab.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__branch_not_found_numeric_gitlab.snap
@@ -1,0 +1,6 @@
+---
+source: tests/integration_tests/git_error_display.rs
+expression: err.to_string()
+---
+[31m✗[39m [31mNo branch named [1m2474[22m[39m
+[2m↳[22m [2mTo switch to MR !2474, run [4mwt switch mr:2474[24m; to create a new branch, run [4mwt switch --create 2474[24m; to list branches, run [4mwt list --branches --remotes[24m[22m

--- a/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__branch_not_found_numeric_unknown_platform.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__branch_not_found_numeric_unknown_platform.snap
@@ -1,0 +1,6 @@
+---
+source: tests/integration_tests/git_error_display.rs
+expression: err.to_string()
+---
+[31m✗[39m [31mNo branch named [1m2474[22m[39m
+[2m↳[22m [2mTo switch to PR #2474 or MR !2474, run [4mwt switch pr:2474[24m or [4mwt switch mr:2474[24m; to create a new branch, run [4mwt switch --create 2474[24m; to list branches, run [4mwt list --branches --remotes[24m[22m


### PR DESCRIPTION
## Summary

When `wt switch <number>` fails because no branch by that name exists, the hint now leads with how to switch to the matching PR/MR before mentioning `--create`.

Platform is detected by hostname-matching the primary remote's effective URL (so `url.insteadOf` rewrites are respected):
- **GitHub** → `wt switch pr:N`
- **GitLab** → `wt switch mr:N`
- **Unknown / opaque host** → both suggestions

Non-numeric branch names keep the original hint unchanged.

### Before

```
✗ No branch named 2474
↳ To create a new branch, run wt switch --create 2474; to list branches, run wt list --branches --remotes
```

### After (GitHub)

```
✗ No branch named 2474
↳ To switch to PR #2474, run wt switch pr:2474; to create a new branch, run wt switch --create 2474; to list branches, run wt list --branches --remotes
```

## Test plan

- [x] Snapshot tests cover GitHub, GitLab, and unknown-platform variants
- [x] Direct test for `Repository::detect_ref_type` covers all URL branches
- [x] Existing `branch_not_found` snapshots unchanged (non-numeric names)
- [x] `cargo run -- hook pre-merge --yes` passes (3412 tests, all lints)
- [x] Manual smoke test in temp repo: GitHub remote → `pr:N`, GitLab remote → `mr:N`, no remote → both