### PR TITLE
ci(affected): cache only coverage.db, not full target/affected

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -294,7 +294,11 @@ jobs:
     - name: 💾 Save coverage DB
       uses: actions/cache/save@v5
       with:
-        path: target/affected
+        # Only the SQLite DB. `target/affected/profraw-<PID>/` holds raw
+        # profile bundles (~5 GB on this repo) that aren't needed past the
+        # current collect — caching them blows past the 10 GB repo cache
+        # cap and forces eviction of every prior cache.
+        path: target/affected/coverage.db
         key: cargo-affected-db-v1-${{ runner.os }}-${{ github.sha }}
 
   affected-tests:
@@ -326,7 +330,7 @@ jobs:
     - name: 💾 Restore coverage DB
       uses: actions/cache/restore@v5
       with:
-        path: target/affected
+        path: target/affected/coverage.db
         # Exact match: collect ran on the PR's merge-base → tight diff.
         key: cargo-affected-db-v1-${{ runner.os }}-${{ steps.mb.outputs.sha }}
         # Fallback: most recent main DB. cargo-affected runs all tests when


### PR DESCRIPTION
## Summary

cargo-affected leaves per-collect profraw bundles (~5 GB on this repo) in `target/affected/profraw-<PID>/`. The CI cache was saving the parent dir, so a single collect saturates the 10 GB repo cache cap and evicts every other cache — which is why PRs were missing both the exact-match and prefix-fallback keys and falling back to the full suite.

Narrow save/restore to `target/affected/coverage.db` (~225 MB). With this, multiple main-collect caches can coexist and PRs are far more likely to hit the prefix-fallback.

Cleaning up the profraw bundles inside cargo-affected itself is a separate follow-up (also benefits local devs whose `target/affected/` currently grows by 13 GB per `cargo affected collect` until they `cargo clean`).

## Test plan

- [ ] CI green on this PR (the affected-tests job will still cache-miss until a main-collect runs against the new path; that's expected)
- [ ] After merge, next push to main saves a small (~225 MB) cache
- [ ] Subsequent PR runs hit the prefix-fallback and benefit from selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)