### PR TITLE
ci(bench): append nightly results to worktrunk-bot gist

### DIFF
--- a/.github/scripts/criterion-to-jsonl.py
+++ b/.github/scripts/criterion-to-jsonl.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+"""Convert Criterion estimates into JSONL rows for time-series benchmark tracking.
+
+Walks `target/criterion/**/new/estimates.json` and prints one JSON line per
+benchmark group with timestamp, commit SHA, group name, and key statistics.
+"""
+
+import argparse
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--sha", required=True, help="commit SHA to record")
+    parser.add_argument(
+        "--root",
+        type=Path,
+        default=Path("target/criterion"),
+        help="Criterion output root (default: target/criterion)",
+    )
+    args = parser.parse_args()
+
+    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    estimates = sorted(args.root.glob("**/new/estimates.json"))
+    if not estimates:
+        raise SystemExit(f"No criterion estimates found under {args.root}")
+    for est in estimates:
+        bench = est.relative_to(args.root).parent.parent.as_posix()
+        data = json.loads(est.read_text())
+        row = {
+            "ts": ts,
+            "sha": args.sha,
+            "bench": bench,
+            "mean_ns": data["mean"]["point_estimate"],
+            "stddev_ns": data["std_dev"]["point_estimate"],
+        }
+        print(json.dumps(row))
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/nightly-benchmark.yaml
+++ b/.github/workflows/nightly-benchmark.yaml
@@ -36,3 +36,21 @@ jobs:
       with:
         name: benchmark-results-${{ github.run_id }}
         path: target/criterion
+
+    # Time-series benchmark store, owned by worktrunk-bot:
+    # https://gist.github.com/worktrunk-bot/19bb23cb9658722abfe69479d0a4f9bf
+    - name: 💾 Append results to gist
+      env:
+        # Bot identity for consistent attribution (per .github/CLAUDE.md).
+        GITHUB_TOKEN: ${{ secrets.WORKTRUNK_BOT_TOKEN }}
+        GIST_ID: 19bb23cb9658722abfe69479d0a4f9bf
+      run: |
+        set -euo pipefail
+        python3 .github/scripts/criterion-to-jsonl.py --sha "$GITHUB_SHA" > new-rows.jsonl
+        git clone "https://x-access-token:${GITHUB_TOKEN}@gist.github.com/${GIST_ID}.git" /tmp/gist
+        cat new-rows.jsonl >> /tmp/gist/results.jsonl
+        git -C /tmp/gist \
+          -c user.name=worktrunk-bot \
+          -c user.email=worktrunk-bot@users.noreply.github.com \
+          commit -am "benchmarks: ${GITHUB_SHA::7}"
+        git -C /tmp/gist push


### PR DESCRIPTION
## Summary

Today the nightly benchmark job uploads `target/criterion` as a 90-day artifact and nothing else; results aren't queryable across runs. This adds a JSONL append to a public gist so we can track regressions and trends over time.

## Changes

`.github/scripts/criterion-to-jsonl.py` — walks `target/criterion/**/new/estimates.json` and emits one JSON line per benchmark group (timestamp, commit SHA, mean_ns, stddev_ns). Errors out if no estimates are found, so a broken bench step fails the workflow instead of silently skipping.

`.github/workflows/nightly-benchmark.yaml` — new step clones the gist using the existing `WORKTRUNK_BOT_TOKEN` (already has `gist` scope), appends new rows to `results.jsonl`, commits, and pushes. The 90-day artifact upload is unchanged — it remains the per-run raw data; the gist becomes the long-term time series.

## Gist

https://gist.github.com/worktrunk-bot/19bb23cb9658722abfe69479d0a4f9bf

Created locally as `worktrunk-bot`, contains a placeholder line that will sit alongside real rows once the next nightly fires (or `workflow_dispatch` triggers it manually).

## Test plan

- [ ] `actionlint` and `pre-commit` clean (verified locally)
- [ ] Smoke-tested the Python script against synthetic Criterion data — produces correct JSONL, errors on empty tree
- [ ] Trigger `workflow_dispatch` post-merge to verify the first real append lands in the gist

> _This was written by Claude Code on behalf of @max-sixty_