### PR TITLE
ci(bench): skip gist append on forks

### DIFF
--- a/.github/workflows/nightly-benchmark.yaml
+++ b/.github/workflows/nightly-benchmark.yaml
@@ -39,7 +39,13 @@ jobs:
 
     # Time-series benchmark store, owned by worktrunk-bot:
     # https://gist.github.com/worktrunk-bot/19bb23cb9658722abfe69479d0a4f9bf
+    #
+    # Skipped on forks: `WORKTRUNK_BOT_TOKEN` is not exposed to forks. This is
+    # the canonical fork guard for any step or job that references repository
+    # secrets — see also `code-coverage` (ci.yaml) and `deploy-docs`
+    # (publish-docs.yaml).
     - name: 💾 Append results to gist
+      if: github.repository_owner == 'max-sixty'
       env:
         # Bot identity for consistent attribution (per .github/CLAUDE.md).
         GITHUB_TOKEN: ${{ secrets.WORKTRUNK_BOT_TOKEN }}


### PR DESCRIPTION
Audited the GitHub Actions setup for fork-PR compatibility. Most secret-touching jobs are already correctly gated: codecov uploads in `ci.yaml`, `deploy-docs` in `publish-docs.yaml`, the failure-issue creator in `nightly.yaml`, and the publish jobs in `release.yaml` (gated on `publishing == 'true'`, false on PRs). `tend-mention.yaml` filters fork PRs at the trigger; `tend-review.yaml` uses `pull_request_target` so it only runs on the base repo.

The one gap was the new "💾 Append results to gist" step in `nightly-benchmark.yaml`, which references `secrets.WORKTRUNK_BOT_TOKEN` with no guard. Scheduled triggers are auto-disabled on forks, so the cron itself isn't the risk — but a fork user who runs the workflow via `workflow_dispatch` would hit a failure on that step. Added `if: github.repository_owner == 'max-sixty'` to skip it on forks, with a short comment pointing to the two other places using the same pattern so future additions can follow it.

Out of scope: the `tend-{ci-fix,nightly,notifications,review-runs,triage,weekly}.yaml` workflows have no fork guards either, but they're autogenerated by `tend` and noted not to edit locally — better fixed upstream in the `tend` plugin.

> _This was written by Claude Code on behalf of @max-sixty_