### PR TITLE
perf(bench): add with_vars alias variant to dispatch group

### DIFF
--- a/benches/alias.rs
+++ b/benches/alias.rs
@@ -6,7 +6,7 @@
 // dramatically slower than the equivalent subcommand; these benchmarks give
 // that cost a regression-free measurement harness.
 //
-// One group (`dispatch`), five variants:
+// One group (`dispatch`), nine variants:
 //   - wt_version:  `wt --version` startup floor (no repo discovery)
 //   - warm/1, warm/100, cold/1, cold/100: stub alias at 1 and 100 worktrees,
 //     warm and cold caches. Each worktree has its own branch, so 100
@@ -14,10 +14,18 @@
 //     the O(1) upstream lookup from 4f9bd575a. The cold/100 variant is
 //     where a regression to the pre-fix bulk `for-each-ref` would hurt
 //     most (packed-refs scan dominates).
+//   - with_vars/{warm,cold}/{1,100}: same axes, but the alias body
+//     references several template vars that drive expensive paths inside
+//     `build_hook_context` (rev-parse for `commit`, `default_branch`
+//     detection, `primary_worktree` lookup, upstream lookup). Pairs with
+//     stub to bracket the dispatch curve once a future filter scopes
+//     context build to referenced vars only — until then with_vars tracks
+//     stub within noise, since context build is unconditional.
 //
 // Run examples:
 //   cargo bench --bench alias                          # All variants
 //   cargo bench --bench alias -- --skip cold           # Warm only, faster
+//   cargo bench --bench alias -- --skip with_vars      # Stub only
 //   cargo bench --bench alias -- --sample-size 10      # Fast iteration
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
@@ -28,6 +36,17 @@ use wt_perf::{RepoConfig, create_repo, invalidate_caches_auto, isolate_cmd};
 /// Alias body is a shell builtin so the wall-clock is dominated by the
 /// parent's dispatch — not by running a real subcommand.
 const STUB_CONFIG: &str = "[aliases]\nstub = \"echo hello\"\n";
+
+/// Alias body references vars that drive the expensive paths in
+/// `build_hook_context`: `commit` / `short_commit` (`rev-parse <branch>`
+/// fork), `default_branch` (cold detection), `primary_worktree_path`
+/// (lookup). `branch` and `worktree_path` are nearly free but kept so a
+/// future filter sees them as "referenced". `upstream` is omitted because
+/// the bench repo has no remote — adding `setup_fake_remote` would change
+/// what the stub variant measures and break label continuity.
+const WITH_VARS_CONFIG: &str = r#"[aliases]
+with_vars = "echo {{ branch }} {{ default_branch }} {{ commit }} {{ short_commit }} {{ primary_worktree_path }} {{ worktree_path }}"
+"#;
 
 /// Lean repo config for the scaling rows — alias dispatch doesn't care
 /// about commit history depth, so minimal everything keeps setup under
@@ -81,29 +100,43 @@ fn bench_dispatch(c: &mut Criterion) {
     for worktrees in [1usize, 100] {
         let temp = create_repo(&lean_worktrees(worktrees));
         let repo_path = temp.path().join("repo");
-        let user_config = temp.path().join("user-config.toml");
-        std::fs::write(&user_config, STUB_CONFIG).unwrap();
+        let stub_config = temp.path().join("stub-config.toml");
+        let vars_config = temp.path().join("with-vars-config.toml");
+        std::fs::write(&stub_config, STUB_CONFIG).unwrap();
+        std::fs::write(&vars_config, WITH_VARS_CONFIG).unwrap();
 
-        for cold in [false, true] {
-            let label = if cold { "cold" } else { "warm" };
-
-            group.bench_with_input(BenchmarkId::new(label, worktrees), &worktrees, |b, _| {
-                let run = || {
-                    run_and_check(
-                        wt_cmd(binary, &repo_path, &user_config, &["stub"]),
-                        "dispatch",
-                    );
+        // Stub variants keep their label structure (`dispatch/{warm,cold}/{1,100}`)
+        // so nightly bench history stays continuous. with_vars sits under a
+        // `with_vars/` prefix as new siblings.
+        for (id_prefix, alias_name, user_config) in [
+            (None, "stub", &stub_config),
+            (Some("with_vars"), "with_vars", &vars_config),
+        ] {
+            for cold in [false, true] {
+                let cache_label = if cold { "cold" } else { "warm" };
+                let id = match id_prefix {
+                    Some(prefix) => format!("{prefix}/{cache_label}"),
+                    None => cache_label.to_string(),
                 };
-                if cold {
-                    b.iter_batched(
-                        || invalidate_caches_auto(&repo_path),
-                        |_| run(),
-                        criterion::BatchSize::SmallInput,
-                    );
-                } else {
-                    b.iter(run);
-                }
-            });
+
+                group.bench_with_input(BenchmarkId::new(id, worktrees), &worktrees, |b, _| {
+                    let run = || {
+                        run_and_check(
+                            wt_cmd(binary, &repo_path, user_config, &[alias_name]),
+                            "dispatch",
+                        );
+                    };
+                    if cold {
+                        b.iter_batched(
+                            || invalidate_caches_auto(&repo_path),
+                            |_| run(),
+                            criterion::BatchSize::SmallInput,
+                        );
+                    } else {
+                        b.iter(run);
+                    }
+                });
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

- Pairs with the existing stub variant to bracket the dispatch curve. Body references vars that drive the expensive paths in `build_hook_context` — `commit` / `short_commit` (rev-parse fork), `default_branch` (cold detection), `primary_worktree_path` (lookup).
- On main today, `build_hook_context` computes every var unconditionally — so with_vars tracks stub within noise. The variant becomes informative once a filter scopes context build to referenced vars only, at which point stub drops to a post-filter floor and with_vars holds near today's uniform cost, making the filter's delta visible.
- Existing stub labels (`dispatch/{warm,cold}/{1,100}`) are unchanged — nightly bench gist stays continuous. New variants land under `dispatch/with_vars/{warm,cold}/{1,100}`.
- `upstream` is omitted because the bench repo has no remote; adding `setup_fake_remote` would change what the stub variant measures and break label continuity.

## Test plan

- [x] `cargo run -- hook pre-merge --yes` — green (3425 tests)
- [x] Quick run of with_vars/warm/{1,100}: ~33–35ms (in line with stub measurements)

🤖 Generated with [Claude Code](https://claude.com/claude-code)