### PR TITLE
ci(codecov): enable tokenless coverage uploads on fork PRs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -112,7 +112,7 @@ jobs:
         path: target/nextest/default/junit.xml
 
     - name: 📊 Upload test results to Codecov
-      if: ${{ !cancelled() && github.repository_owner == 'max-sixty' }}
+      if: ${{ !cancelled() }}
       uses: codecov/codecov-action@v6.0.0
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
@@ -409,10 +409,10 @@ jobs:
         path: cobertura.xml
 
     - name: Upload to codecov.io
-      # Codecov action raises errors on forks; allow running on PRs to main repo
-      if: github.repository_owner == 'max-sixty'
       uses: codecov/codecov-action@v6.0.0
       with:
         files: cobertura.xml
-        fail_ci_if_error: true
+        # Soft-fail on fork PRs: secrets aren't available there, so we rely on
+        # tokenless upload, which can hiccup. Keep hard-fail on the main repo.
+        fail_ci_if_error: ${{ github.repository_owner == 'max-sixty' }}
         token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Summary

Drop the `github.repository_owner == 'max-sixty'` guards on both Codecov upload steps in `ci.yaml` (test-results upload in the `test` job, coverage upload in the `code-coverage` job). The action falls back to tokenless when `secrets.CODECOV_TOKEN` is empty (which is the case on fork PRs), and the major fork-tokenless bug ([codecov-action#1842](https://github.com/codecov/codecov-action/issues/1842)) was fixed in late October 2025.

`fail_ci_if_error` on the coverage upload is now tied to the main repo so a Codecov flake on a fork PR doesn't red-X the build; the test-results upload doesn't set `fail_ci_if_error`, so it's already soft-fail.

## Caveat — Codecov org setting

Tokenless uploads on forks require the org-level setting **"Token authentication for public repositories" = Not required** at https://app.codecov.io/account/gh/max-sixty/org-upload-token. If that isn't set, every fork-PR upload will fail (silently in the test job, soft-fail in the coverage job). Worth confirming before this lands. See [codecov-action#1845](https://github.com/codecov/codecov-action/issues/1845) for context.

## Why now

Sibling project `prql` gated codecov on forks in 2024-06 due to rate limits and upload flakes. The codecov-action fork code path got real attention in 2025 (`fix: OIDC on forks` in v5.4.3, the Codecov backend sync fix that closed #1842 in October 2025). v6.0.0 is just a Node 24 bump on top of that work — no fork regressions.

> _This was written by Claude Code on behalf of @max-sixty_