### PR TITLE
test(nextest): build helper bins via setup-script for filtered runs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -46,5 +46,8 @@ command = [
 ]
 
 [[profile.default.scripts]]
-filter = "all()"
+# Only the `integration` test binary calls `workspace_bin()` (via MockConfig
+# and analyze_trace.rs), so don't pay the helper-build cost on `--lib`,
+# `--bin wt`, doctest, or bench runs.
+filter = "binary(integration)"
 setup = "build-bins"

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -38,6 +38,20 @@ path = "junit.xml"
 # LLVM_PROFILE_FILE (cargo-llvm-cov sets it to a path inside its target dir)
 # and pass it through with --target-dir. Worktrunk already requires bash for
 # shell-integration tests on every platform, so bash here is fine.
+#
+# TODO: collapse this whole layer once cargo-dist supports per-binary
+# exclusion. The chain — separate `tests/helpers/{mock-stub,wt-perf}`
+# packages, the dummy `tests/builds.rs` trick that makes `default-members`
+# build them, this setup-script, and `workspace_bin()` in src/testing/mod.rs
+# — exists only because cargo-dist (≤ 0.30.x at time of writing) ships every
+# `[[bin]]` in the main crate and offers no per-binary opt-out. PR #127
+# (commit d21925692) documented the failure modes: `required-features` on
+# `[[bin]]` still trips cargo-dist's "bin not found", and
+# `[package.metadata.dist] dist = false` excludes the entire package, not
+# individual binaries. When cargo-dist gains per-binary exclusion (or we
+# move off cargo-dist), pull mock-stub and wt-perf back into the worktrunk
+# crate as `[[bin]]` targets, use `CARGO_BIN_EXE_<name>`, and delete this
+# script along with `workspace_bin()` and the helper packages.
 [scripts.setup.build-bins]
 command = [
     "bash",

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -11,6 +11,10 @@
 #
 #   cargo test --test integration --features shell-integration-tests
 
+# Enable setup-scripts (still experimental in nextest) so the build-bins script
+# below can run before any test starts.
+experimental = ["setup-scripts"]
+
 [profile.default]
 slow-timeout = { period = "180s", terminate-after = 1 }
 status-level = "fail"
@@ -18,3 +22,29 @@ success-output = "never"
 
 [profile.default.junit]
 path = "junit.xml"
+
+# Build the helper binaries (`mock-stub`, `wt-perf`) before any test runs.
+#
+# These live in separate workspace packages so cargo-dist doesn't ship them
+# (see tests/helpers/mock-stub/Cargo.toml for the rationale). The
+# `default-members` setting builds them under unfiltered `cargo nextest run`,
+# but a target filter like `--test integration` overrides default-members and
+# the helpers are skipped — so tests that spawn them fail.
+#
+# Under `cargo llvm-cov nextest`, nextest doesn't propagate the outer
+# --target-dir as a CARGO_TARGET_DIR env var, so a plain `cargo build` would
+# write to target/ rather than target/llvm-cov-target/ and the test binary
+# would still find no helpers. Derive the right target-dir from
+# LLVM_PROFILE_FILE (cargo-llvm-cov sets it to a path inside its target dir)
+# and pass it through with --target-dir. Worktrunk already requires bash for
+# shell-integration tests on every platform, so bash here is fine.
+[scripts.setup.build-bins]
+command = [
+    "bash",
+    "-c",
+    'if [ -n "${LLVM_PROFILE_FILE:-}" ]; then cargo build --bin mock-stub --bin wt-perf --target-dir "$(dirname "$LLVM_PROFILE_FILE")"; else cargo build --bin mock-stub --bin wt-perf; fi',
+]
+
+[[profile.default.scripts]]
+filter = "all()"
+setup = "build-bins"


### PR DESCRIPTION
## Summary

`cargo nextest run --test integration ...` (and the `cargo llvm-cov nextest --test integration ...` flow used for coverage debugging) restrict the build to the integration test binary and skip the `default-members` build that produces `mock-stub` and `wt-perf`. The binaries don't exist where `workspace_bin()` expects them, and tests that spawn them fail at runtime — most visibly the `wt merge` snapshot tests and the `gh`/`glab` CI-status snapshots.

Wire a nextest setup-script that runs `cargo build --bin mock-stub --bin wt-perf` before any test in the `integration` binary. Under coverage, derive the right target-dir from `LLVM_PROFILE_FILE` since nextest doesn't propagate the outer `--target-dir` as a `CARGO_TARGET_DIR` env var.

The setup-script is filtered to `binary(integration)` so unrelated runs (`--lib`, `--bin wt`, doctests, benches) skip the helper build.

A TODO comment captures the upstream blocker: cargo-dist (≤ 0.30.x) ships every `[[bin]]` in the main crate and offers no per-binary opt-out, so the whole helper-package + setup-script chain only exists because we can't put the binaries directly in the worktrunk crate. PR #127 (commit d21925692) documented the failure modes that ruled out the simpler options.

## Test plan

- [x] Originally-failing 9 tests under \`cargo llvm-cov nextest --test integration ...\` (18/18 cases including rstest variants)
- [x] \`cargo nextest run --test integration test_quickstart_merge\` — passes, SETUP fires
- [x] \`cargo nextest run --lib\` — 1075/1075 pass, no SETUP
- [x] Full \`cargo nextest run --features shell-integration-tests\` — 3428/3428
- [x] \`task coverage\` — 1744 integration + 1075 + 607 unit tests pass
- [x] \`pre-commit run --all-files\` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)