### PR TITLE
docs(cache): list head_sha() in the not-cached set

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -460,6 +460,7 @@ Most data is stable for the duration of a command. `Repository` caches read-only
 
 **Not cached (changes during command execution):**
 - `is_dirty()` — changes as we stage/commit
+- `head_sha()` — HEAD moves on commit/rebase/merge; a stale SHA would surface in `{{ commit }}` for hooks that fire after the move
 
 `list_worktrees()` *is* cached, even though `wt switch --create` / `wt remove` mutate the underlying list. The invariant is that mutating paths must not read the list through the same `Repository` after their own mutation: either read once up front and thread the slice through, or call `Repository::at(...)` again to get a fresh cache before any post-mutation probe.
 

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -48,6 +48,8 @@
 //! **What is NOT cached.** Values that change during command execution are intentionally
 //! excluded:
 //! - `WorkingTree::is_dirty()` — changes as we stage and commit
+//! - `WorkingTree::head_sha()` — HEAD moves on commit, rebase, or merge; a stale SHA
+//!   would surface in template variables (`{{ commit }}`) for hooks that fire after the move
 //!
 //! [`Repository::list_worktrees`] is cached despite mutating commands adding or
 //! removing worktrees. The cache is safe because no caller reads the list


### PR DESCRIPTION
The "What is NOT cached" bullet list in `src/git/repository/mod.rs` only mentioned `WorkingTree::is_dirty()`, but `WorkingTree::head_sha()` is intentionally uncached for the same kind of reason — HEAD moves on commit/rebase/merge and a stale SHA would surface in `{{ commit }}` for hooks that fire after the move. Adds the missing bullet so the module-level caching doc matches the rationale already spelled out on `WorkingTree::head_sha`, and mirrors it into the parallel "Repository Caching" section in `CLAUDE.md` so both spots stay in sync.

Docs-only; no code changes.

> _This was written by Claude Code on behalf of Maximilian_