### PR TITLE
ci: fix cargo-affected invocations (drop --verbose, use `--` for nextest args)

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -365,7 +365,7 @@ jobs:
     - name: 🎯 Run affected tests
       env:
         NEXTEST_NO_INPUT_HANDLER: 1
-      run: cargo affected run --features shell-integration-tests --verbose
+      run: cargo affected run --features shell-integration-tests
 
   code-coverage:
     runs-on: ubuntu-24.04

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -296,7 +296,7 @@ jobs:
     - name: 📊 Collect coverage data
       env:
         NEXTEST_NO_INPUT_HANDLER: 1
-      run: cargo affected collect --features shell-integration-tests
+      run: cargo affected collect -- --features shell-integration-tests
 
     - name: 💾 Save coverage DB
       uses: actions/cache/save@v5
@@ -365,7 +365,7 @@ jobs:
     - name: 🎯 Run affected tests
       env:
         NEXTEST_NO_INPUT_HANDLER: 1
-      run: cargo affected run --features shell-integration-tests
+      run: cargo affected run -- --features shell-integration-tests
 
   code-coverage:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
## Summary

Two fixes to the `cargo affected` invocations in `.github/workflows/ci.yaml`.

### 1. Drop `--verbose` from `affected tests` (commit 1)

The `affected tests (linux, advisory)` job was running:

```
cargo affected run --features shell-integration-tests --verbose
```

cargo-affected's `run` subcommand currently uses `trailing_var_arg = true`, so once clap sees an unknown flag (`--features`), it sweeps everything after it — including `--verbose` — into the trailing args sink and forwards it verbatim to `cargo nextest run`. nextest's `--verbose`:

- bumps status level to `all` (per-test `START [progress]` lines), and
- prints the spawned command for each test (`command: /path/to/binary --exact <test> --nocapture`).

With ~3400 tests, that's two extra lines per test — the CI log becomes unreadable. See the reference run around test 2684/3429 (e.g., `test_switch_remote_prefix_stripped`):
https://github.com/max-sixty/worktrunk/actions/runs/25270305877/job/74091452305?pr=2541

cargo-affected already prints its own pipeline progress, so we don't want nextest's verbose mode layered on top.

### 2. Use `--` before `--features` in both call sites (commit 2)

cargo-affected PR https://github.com/max-sixty/cargo-affected/pull/11 makes both `run` and `collect` parsers strict (`last = true`), so unknown flags will error unless preceded by `--`. The workflow pulls cargo-affected from the latest default-branch sha (no rev pin), so once that PR merges:

- `cargo affected collect --features shell-integration-tests` → `UnknownArgument`
- `cargo affected run --features shell-integration-tests` → `UnknownArgument`

Both call sites move to `cargo affected {run,collect} -- --features shell-integration-tests`. The new form is also accepted by the current (loose) parser, so this is safe to merge before PR #11 lands.

## Test plan

- [ ] CI on this PR runs `cargo affected run` without the verbose nextest output (no `START` / `command:` lines per test).
- [ ] Once cargo-affected#11 merges, both `collect` and `run` steps continue to work without `UnknownArgument`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)