### PR TITLE
docs(homepage): replace "Scaling agents becomes trivial" intro line

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Worktrunk is a CLI for git worktree management, designed for running AI agents i
 
 Worktrunk's three core commands make worktrees as easy as branches. Plus, Worktrunk has a bunch of quality-of-life features to simplify working with many parallel changes, including hooks to automate local workflows.
 
-Scaling agents becomes trivial. A quick demo:
+A quick demo:
 
 ![Worktrunk Demo](https://cdn.jsdelivr.net/gh/max-sixty/worktrunk-assets@main/assets/docs/light/wt-core.gif)
 
@@ -94,7 +94,7 @@ git branch -d feat</pre></td>
 - **[Aliases](https://worktrunk.dev/extending/#aliases) & [per-branch variables](https://worktrunk.dev/config/#wt-config-state-vars)** — custom `wt <name>` commands and branch-scoped state for hook templates
 - ...and **[lots more](#next-steps)**
 
-A demo with some advanced features:
+Multiple parallel agents, same simple commands:
 
 ![Worktrunk omnibus demo: multiple Claude agents in Zellij tabs with hooks, LLM commits, and merge workflow](https://raw.githubusercontent.com/max-sixty/worktrunk-assets/main/assets/docs/light/wt-zellij-omnibus.gif)
 

--- a/docs/content/worktrunk.md
+++ b/docs/content/worktrunk.md
@@ -14,7 +14,7 @@ Worktrunk's three core commands make worktrees as easy as branches.
 Plus, Worktrunk has a bunch of quality-of-life features to simplify working
 with many parallel changes, including hooks to automate local workflows.
 
-Scaling agents becomes trivial. A quick demo:
+A quick demo:
 
 <figure class="demo">
 <picture>
@@ -94,7 +94,7 @@ git branch -d feat{% end %}</td>
 - **[Aliases](@/extending.md#aliases) & [per-branch variables](@/config.md#wt-config-state-vars)** — custom `wt <name>` commands and branch-scoped state for hook templates
 - ...and **[lots more](#next-steps)**
 
-A demo with some advanced features:
+Multiple parallel agents, same simple commands:
 
 <figure class="demo">
 <picture>

--- a/skills/worktrunk/reference/worktrunk.md
+++ b/skills/worktrunk/reference/worktrunk.md
@@ -7,7 +7,7 @@ Worktrunk's three core commands make worktrees as easy as branches.
 Plus, Worktrunk has a bunch of quality-of-life features to simplify working
 with many parallel changes, including hooks to automate local workflows.
 
-Scaling agents becomes trivial. A quick demo:
+A quick demo:
 
 ## Context: git worktrees
 
@@ -79,7 +79,7 @@ git branch -d feat</td>
 - **[Aliases](https://worktrunk.dev/extending/#aliases) & [per-branch variables](https://worktrunk.dev/config/#wt-config-state-vars)** — custom `wt <name>` commands and branch-scoped state for hook templates
 - ...and **[lots more](#next-steps)**
 
-A demo with some advanced features:
+Multiple parallel agents, same simple commands:
 
 ## Install
 


### PR DESCRIPTION
The line was a generic LLM-flavored flourish ("scaling," "becomes trivial") that also overclaimed: it sat above the core-commands GIF, whose own caption honestly says "Listing worktrees, switching, cleaning up." The parallel-agents demo lives further down the page.

Drop the slop sentence above the basics demo, and move the zoom-out claim down to the second demo's lead-in, where the GIF actually substantiates it: `"Multiple parallel agents, same simple commands:"` — ties back to the "as easy as branches" framing in the intro.