### PR TITLE
fix(prune): wrap multi-line git errors with context to silence debug_assert

### DIFF
--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -1543,7 +1543,7 @@ pub fn step_prune(
 
     // Capture once at command entry. Reused for every per-branch
     // `integration_reason` probe later in this function.
-    let snapshot = repo.capture_refs()?;
+    let snapshot = repo.capture_refs().context("capturing repository refs")?;
 
     // Pass the local default branch (e.g. "main") directly — `integration_reason`
     // ORs over local + upstream internally, so a branch merged into either side
@@ -1552,8 +1552,12 @@ pub fn step_prune(
         .default_branch()
         .context("cannot determine default branch")?;
 
-    let worktrees = repo.list_worktrees()?;
-    let current_root = repo.current_worktree().root()?.to_path_buf();
+    let worktrees = repo.list_worktrees().context("listing worktrees")?;
+    let current_root = repo
+        .current_worktree()
+        .root()
+        .context("resolving current worktree root")?
+        .to_path_buf();
     let current_root = dunce::canonicalize(&current_root).unwrap_or(current_root);
     let now_secs = worktrunk::utils::epoch_now();
 
@@ -1756,7 +1760,10 @@ pub fn step_prune(
         // Skip main worktree (non-linked); in bare repos all are linked,
         // so the default-branch check above is the primary guard.
         let wt_tree = repo.worktree_at(&wt.path);
-        if !wt_tree.is_linked()? {
+        if !wt_tree
+            .is_linked()
+            .context("checking whether worktree is linked")?
+        {
             continue;
         }
 
@@ -1771,7 +1778,7 @@ pub fn step_prune(
         });
     }
 
-    for branch in repo.all_branches()? {
+    for branch in repo.all_branches().context("listing branches")? {
         if seen_branches.contains(&branch) {
             continue;
         }
@@ -1829,7 +1836,7 @@ pub fn step_prune(
 
     // Process results as they arrive from the channel.
     for (idx, result) in rx {
-        let (effective_target, reason) = result?;
+        let (effective_target, reason) = result.context("checking branch integration")?;
         let Some(reason) = reason else {
             continue;
         };
@@ -1849,7 +1856,7 @@ pub fn step_prune(
             // they were just created from the default branch
             if min_age_duration > Duration::ZERO {
                 let wt_tree = repo.worktree_at(&wt.path);
-                let git_dir = wt_tree.git_dir()?;
+                let git_dir = wt_tree.git_dir().context("resolving worktree git dir")?;
                 let metadata = fs::metadata(&git_dir).context("Failed to read worktree git dir")?;
                 let created = metadata.created().or_else(|_| {
                     fs::metadata(git_dir.join("commondir")).and_then(|m| m.modified())
@@ -1901,7 +1908,9 @@ pub fn step_prune(
                 run_hooks,
                 worktrees,
                 &snapshot_arc,
-            )? {
+            )
+            .with_context(|| format!("removing worktree for {}", candidate.label))?
+            {
                 removed.push(candidate);
             }
             continue;
@@ -1960,7 +1969,9 @@ pub fn step_prune(
             run_hooks,
             worktrees,
             &snapshot_arc,
-        )? {
+        )
+        .with_context(|| format!("removing worktree for {}", candidate.label))?
+        {
             removed.push(candidate);
         }
     }
@@ -2039,7 +2050,8 @@ pub fn step_prune(
             run_hooks,
             worktrees,
             &snapshot_arc,
-        )?
+        )
+        .with_context(|| format!("removing worktree for {}", current.label))?
     {
         removed.push(current);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1418,3 +1418,26 @@ fn main() {
         Err(error) => handle_command_failure(error, verbose, &command_line),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Regression: an anyhow error whose top-level message has the multi-line
+    /// stderr from a failing git command — but a non-empty chain — must take
+    /// the chain branch, not the `debug_assert!` branch. Real-world example:
+    /// step_prune callers wrap `repo.run_command(...)` failures with
+    /// `.context("listing worktrees")?`, so the multi-line git stderr ends up
+    /// in the chain rather than as the top-level message.
+    #[test]
+    fn print_command_error_handles_multiline_with_context() {
+        let inner = anyhow::anyhow!(
+            "warning: unable to access '.git/config': Permission denied\nfatal: unknown error occurred while reading the configuration files"
+        );
+        let err: anyhow::Error = Err::<(), _>(inner)
+            .context("listing worktrees")
+            .unwrap_err();
+        // Must not panic the debug_assert. The chain branch handles this.
+        print_command_error(&err);
+    }
+}


### PR DESCRIPTION
The Windows flake of \`test_prune_skips_unmerged\` (#2564) revealed a latent reporting bug: when git failed to read \`.git/config\` mid-prune, the multi-line stderr propagated up as a top-level anyhow message with an empty chain — exactly the case \`print_command_error\`'s \`debug_assert!(false, \"Multiline error without context\")\` is designed to nag on. Debug builds (including \`cargo test\`) exited 101 instead of rendering the error.

The offending call sites are in \`step_prune\`'s foreground path: \`capture_refs()\`, \`list_worktrees()\`, \`all_branches()\`, \`integration_reason\` channel results, the \`is_linked\`/\`git_dir\`/\`root\` probes, and \`try_remove\`. Each used \`?\` without a \`.context(...)\` wrapper, so any failing git subprocess inside them surfaced as a bare multi-line bail.

Wrapping at the helper (\`Repository::run_command\` itself) would silence the assert globally but breaks callers that read \`e.to_string()\` to extract raw git stderr — e.g. \`step_commands.rs:610\` embeds the rebase output in \`GitError::RebaseConflict { git_output }\`. That change regressed \`merge::test_merge_rebase_conflict\` and the \`list::test_list_*\` snapshots when I tried it. Targeted call-site context keeps the structured paths intact while routing prune errors through \`print_command_error\`'s chain branch — context as header, git stderr in the gutter.

The Windows ACL race (#2564) is left to that issue — this PR is just the reporting fix.

### Test plan

- New unit test \`print_command_error_handles_multiline_with_context\` in \`main.rs\` builds the post-context anyhow shape and asserts \`print_command_error\` doesn't panic.
- Full \`cargo run -- hook pre-merge --yes\` passes (3465 tests).

> _This was written by Claude Code on behalf of @max-sixty_