### PR TITLE
fix(config): distinguish "not configured" from "not active" in shell status

### DIFF
--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -756,13 +756,10 @@ fn render_shell_status(out: &mut String) -> anyhow::Result<()> {
         };
         writeln!(out, "{}", warning_message(warning_text))?;
         if hint_under_warning {
-            writeln!(
-                out,
-                "{}",
-                hint_message(cformat!(
-                    "To configure, run <underline>{cmd} config shell install</>"
-                ))
-            )?;
+            let hint = hint_message(cformat!(
+                "To configure, run <underline>{cmd} config shell install</>"
+            ));
+            writeln!(out, "{hint}")?;
         }
         // Show invocation details to help diagnose
         let invocation = crate::invocation_path();

--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -702,12 +702,68 @@ fn render_project_config(out: &mut String) -> anyhow::Result<()> {
 fn render_shell_status(out: &mut String) -> anyhow::Result<()> {
     writeln!(out, "{}", format_heading("SHELL INTEGRATION", None))?;
 
+    // Use the same detection logic as `wt config shell install`. Hoisted above the
+    // active/inactive warning so the warning text can distinguish "installed but
+    // not loaded" (▲ not active) from "never installed" (▲ not configured).
+    let cmd = crate::binary_name();
+    let scan_result = match scan_shell_configs(None, true, &cmd) {
+        Ok(r) => r,
+        Err(e) => {
+            writeln!(
+                out,
+                "{}",
+                hint_message(format!("Could not determine shell status: {e}"))
+            )?;
+            return Ok(());
+        }
+    };
+
+    // Get detection details to show matched lines inline
+    let detection_results = scan_for_detection_details(&cmd).unwrap_or_default();
+
+    // Check for legacy fish conf.d path (deprecated location from before #566)
+    // We need this early to handle the case where fish shows "Not configured" at the
+    // new location but has valid integration at the legacy location.
+    let legacy_fish_conf_d = Shell::legacy_fish_conf_d_path(&cmd).ok();
+    let legacy_fish_has_integration = legacy_fish_conf_d.as_ref().is_some_and(|legacy_path| {
+        detection_results
+            .iter()
+            .any(|d| d.path == *legacy_path && !d.matched_lines.is_empty())
+    });
+
+    // "Configured somewhere" means any rc file already has the init line, any
+    // wrapper-based shell has its wrapper file (WouldAdd on a wrapper means
+    // the file exists but content differs — i.e. outdated, still installed),
+    // or fish has integration at the legacy conf.d path.
+    let any_configured_somewhere = scan_result.configured.iter().any(|r| {
+        matches!(r.action, ConfigAction::AlreadyExists)
+            || (r.shell.is_wrapper_based() && matches!(r.action, ConfigAction::WouldAdd))
+    }) || legacy_fish_has_integration;
+
     // Shell integration runtime status (moved from RUNTIME section)
     let shell_active = output::is_shell_integration_active();
+    // When the user has no working integration anywhere, the install hint goes
+    // directly under the warning so cause and remedy stay together. The trailing
+    // hint at the bottom of the section is suppressed in this case.
+    let hint_under_warning = !shell_active && !any_configured_somewhere;
     if shell_active {
         writeln!(out, "{}", info_message("Shell integration active"))?;
     } else {
-        writeln!(out, "{}", warning_message("Shell integration not active"))?;
+        let warning_text = if any_configured_somewhere {
+            "Shell integration not active"
+        } else {
+            "Shell integration not configured"
+        };
+        writeln!(out, "{}", warning_message(warning_text))?;
+        if hint_under_warning {
+            writeln!(
+                out,
+                "{}",
+                hint_message(cformat!(
+                    "To configure, run <underline>{cmd} config shell install</>"
+                ))
+            )?;
+        }
         // Show invocation details to help diagnose
         let invocation = crate::invocation_path();
         let is_git_subcommand = crate::is_git_subcommand();
@@ -740,33 +796,6 @@ fn render_shell_status(out: &mut String) -> anyhow::Result<()> {
         writeln!(out, "{}", format_with_gutter(&debug_lines.join("\n"), None))?;
     }
     writeln!(out)?;
-
-    // Use the same detection logic as `wt config shell install`
-    let cmd = crate::binary_name();
-    let scan_result = match scan_shell_configs(None, true, &cmd) {
-        Ok(r) => r,
-        Err(e) => {
-            writeln!(
-                out,
-                "{}",
-                hint_message(format!("Could not determine shell status: {e}"))
-            )?;
-            return Ok(());
-        }
-    };
-
-    // Get detection details to show matched lines inline
-    let detection_results = scan_for_detection_details(&cmd).unwrap_or_default();
-
-    // Check for legacy fish conf.d path (deprecated location from before #566)
-    // We need this early to handle the case where fish shows "Not configured" at the
-    // new location but has valid integration at the legacy location.
-    let legacy_fish_conf_d = Shell::legacy_fish_conf_d_path(&cmd).ok();
-    let legacy_fish_has_integration = legacy_fish_conf_d.as_ref().is_some_and(|legacy_path| {
-        detection_results
-            .iter()
-            .any(|d| d.path == *legacy_path && !d.matched_lines.is_empty())
-    });
 
     let mut any_not_configured = false;
     let mut has_any_unmatched = false;
@@ -992,15 +1021,14 @@ fn render_shell_status(out: &mut String) -> anyhow::Result<()> {
         )?;
     }
 
-    // Summary hint when the user has no working integration and could install some.
-    // Fires when any shell is in the plain "Not configured" state (rc file present,
-    // no init line) AND in the fresh-user case where every shell falls into `skipped`
-    // because no rc file exists. Without this second arm, a brand-new user runs
-    // `wt config show` and sees only "▲ not active" + four "Skipped" lines with no
-    // next step. The `!shell_active` gate avoids firing for the dotfile-manager
-    // case (wrapper sourced from a non-standard path so no rc file has the init line).
+    // Summary hint pointing at `wt config shell install`. The fresh-user and
+    // nothing-configured-anywhere cases are already covered by the hint emitted
+    // directly under the warning, so this trailing emit is suppressed when
+    // `hint_under_warning` fired. It still fires for the partial-config case
+    // (some shells configured, some not) and for fish-legacy (working
+    // integration via the legacy path, other shells unconfigured).
     let nothing_configured_yet = !shell_active && scan_result.configured.is_empty();
-    if any_not_configured || nothing_configured_yet {
+    if !hint_under_warning && (any_not_configured || nothing_configured_yet) {
         writeln!(
             out,
             "{}",

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_claude_available_plugin_not_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_claude_available_plugin_not_installed.snap
@@ -55,14 +55,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mCLAUDE CODE[39m
 [2m↳[22m [2mPlugin not installed. To install, run [4mwt config plugins claude install[24m[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
@@ -67,14 +67,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_no_cd_deprecation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_no_cd_deprecation.snap
@@ -65,14 +65,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_no_ff_deprecation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_no_ff_deprecation.snap
@@ -65,14 +65,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_pre_hook_table_form_deprecation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_pre_hook_table_form_deprecation.snap
@@ -74,14 +74,14 @@ exit_code: 0
 [107m [0m  env = "cp .env.example .env"[m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
@@ -67,14 +67,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_select_section_deprecation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_select_section_deprecation.snap
@@ -65,14 +65,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_empty_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_empty_project_config.snap
@@ -55,14 +55,14 @@ exit_code: 0
 [2m↳[22m [2mEmpty file[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_empty_system_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_empty_system_config.snap
@@ -57,14 +57,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
@@ -55,14 +55,14 @@ exit_code: 0
 [2m↳[22m [2mTo apply: [4mwt -C _REPO_ config update[24m[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_command_not_found.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_command_not_found.snap
@@ -60,14 +60,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mDIAGNOSTICS[39m
 [2m↳[22m [2mCI status requires GitHub or GitLab remote[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_not_configured.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_not_configured.snap
@@ -57,14 +57,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mDIAGNOSTICS[39m
 [2m↳[22m [2mCI status requires GitHub or GitLab remote[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_update_available.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_update_available.snap
@@ -57,14 +57,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mDIAGNOSTICS[39m
 [2m↳[22m [2mCI status requires GitHub or GitLab remote[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_version_check_unavailable.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_version_check_unavailable.snap
@@ -57,14 +57,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mDIAGNOSTICS[39m
 [2m↳[22m [2mCI status requires GitHub or GitLab remote[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_github_remote.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_github_remote.snap
@@ -55,14 +55,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_gitlab_remote.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_gitlab_remote.snap
@@ -55,14 +55,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_project_toml.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_project_toml.snap
@@ -61,14 +61,14 @@ exit_code: 0
 [107m [0m [2minvalid = [unclosed bracket
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_system_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_system_config.snap
@@ -63,14 +63,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_user_toml.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_user_toml.snap
@@ -61,14 +61,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_no_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_no_project_config.snap
@@ -55,14 +55,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_no_user_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_no_user_config.snap
@@ -54,14 +54,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_opencode_available_plugin_not_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_opencode_available_plugin_not_installed.snap
@@ -55,14 +55,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOPENCODE[39m
 [2m↳[22m [2mPlugin not installed. To install, run [4mwt config plugins opencode install[24m[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_opencode_plugin_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_opencode_plugin_installed.snap
@@ -55,14 +55,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOPENCODE[39m
 [32m✓[39m [32mPlugin installed[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_opencode_plugin_outdated.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_opencode_plugin_outdated.snap
@@ -55,14 +55,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOPENCODE[39m
 [2m↳[22m [2mPlugin outdated. To update, run [4mwt config plugins opencode install[24m[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_outside_git_repo.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_outside_git_repo.snap
@@ -44,14 +44,14 @@ exit_code: 0
 [2m[36mPROJECT CONFIG[39m Not in a git repository[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_plugin_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_plugin_installed.snap
@@ -55,14 +55,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mCLAUDE CODE[39m
 [32m✓[39m [32mPlugin installed[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_statusline_configured.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_statusline_configured.snap
@@ -55,14 +55,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mCLAUDE CODE[39m
 [32m✓[39m [32mPlugin installed[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_project_config_for_ci.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_project_config_for_ci.snap
@@ -70,14 +70,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
@@ -68,14 +68,14 @@ exit_code: 0
 [33m▲[39m [33mKey [1mcommit-generation[22m belongs in user config as [commit.generation][39m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_warning.snap
@@ -55,14 +55,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [1mbash[22m: Not configured shell extension & completions
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [33m▲[39m [33mFound [1mwt[22m in [1m~/.bashrc:3[22m but not detected as integration:[39m
 [107m [0m [2m[0m[2m[34malias[0m[2m wt=[0m[2m[32m"git worktree"[0m[2m
 [2m↳[22m [2mIf `alias wt="git worktree"` is meant to load Worktrunk shell integration, report a false negative: https://github.com/max-sixty/worktrunk/issues/new?title=Shell%20integration%20detection%20false%20negative&body=Shell%20integration%20not%20detected%20despite%20config%20containing%20%60wt%60.%0A%0A%2A%2AUnmatched%20lines%3A%2A%2A%0A%60%60%60%0Aalias%20wt%3D%22git%20worktree%22%0A%60%60%60%0A%0A%2A%2AExpected%20behavior%3A%2A%2A%20These%20lines%20should%20be%20detected%20as%20shell%20integration.[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_project_keys.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_project_keys.snap
@@ -57,14 +57,14 @@ exit_code: 0
 [107m [0m [2mdeploy = [0m[2m[32m"task deploy"
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_user_keys.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_user_keys.snap
@@ -59,14 +59,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_whitespace_only_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_whitespace_only_project_config.snap
@@ -55,14 +55,14 @@ exit_code: 0
 [2m↳[22m [2mEmpty file[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_with_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_with_project_config.snap
@@ -58,14 +58,14 @@ exit_code: 0
 [107m [0m [2mserver = [0m[2m[32m"npm run dev"
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_with_system_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_with_system_config.snap
@@ -62,14 +62,14 @@ exit_code: 0
 [2m↳[22m [2mNot found[22m
 
 [36mSHELL INTEGRATION[39m
-[33m▲[39m [33mShell integration not active[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 [107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
 
 [2m○[22m [2mbash: Skipped; ~/.bashrc not found[22m
 [2m○[22m [2mzsh: Skipped; ~/.zshrc not found[22m
 [2m○[22m [2mfish: Skipped; ~/.config/fish/functions not found[22m
 [2m○[22m [2mnu: Skipped; ~/.config/nushell/vendor/autoload not found[22m
-[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m


### PR DESCRIPTION
Follow-up to #2562. `wt config show` now reads `▲ Shell integration not configured` when no working integration exists in any shell (fresh user, container, CI sandbox), and keeps `▲ Shell integration not active` for the case where it's installed but not loaded in this session. The install hint also moves directly under the warning when nothing is configured anywhere, so cause and remedy stay adjacent instead of being separated by four `Skipped` rows.

The "configured somewhere" signal accepts `AlreadyExists` rc-file matches, wrapper-based shells with their wrapper present (even if outdated content), and fish at the legacy `conf.d` path — anything less reads as "not configured." The trailing summary hint still fires for partial-config (e.g., zsh `AlreadyExists` + bash needs init line) and for fish-legacy.

Fresh-user output:

```
SHELL INTEGRATION
▲ Shell integration not configured
↳ To configure, run wt config shell install
  Invoked as: ...

○ bash: Skipped; ~/.bashrc not found
...
```

35 `config_show` snapshots updated for the warning text and hint position. Active, partial-config, fish-outdated/nushell-outdated, and fish-legacy snapshots are unchanged.

> _This was written by Claude Code on behalf of @max-sixty_