### PR TITLE
refactor: route every short-SHA display through git's abbreviation logic

### DIFF
--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -126,7 +126,7 @@ Hooks can use template variables that expand at runtime:
 |           | `{{ worktree_path }}`         | Worktree path |
 |           | `{{ worktree_name }}`         | Worktree directory name |
 |           | `{{ commit }}`                | Branch HEAD SHA |
-|           | `{{ short_commit }}`          | Branch HEAD SHA (7 chars) |
+|           | `{{ short_commit }}`          | Branch HEAD SHA, abbreviated per `core.abbrev` |
 |           | `{{ upstream }}`              | Branch upstream (if tracking a remote) |
 | operation | `{{ base }}`                  | Base branch name |
 |           | `{{ base_worktree_path }}`    | Base worktree path |

--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -191,7 +191,7 @@ Query structured data with `--format=json`:
 | Field | Type | Description |
 |-------|------|-------------|
 | `sha` | string | Full commit SHA (40 chars) |
-| `short_sha` | string | Short commit SHA (7 chars) |
+| `short_sha` | string | Short commit SHA, abbreviated per `core.abbrev` (auto-extends for ambiguous prefixes) |
 | `message` | string | Commit message (first line) |
 | `timestamp` | number | Unix timestamp |
 

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -117,7 +117,7 @@ Hooks can use template variables that expand at runtime:
 |           | `{{ worktree_path }}`         | Worktree path |
 |           | `{{ worktree_name }}`         | Worktree directory name |
 |           | `{{ commit }}`                | Branch HEAD SHA |
-|           | `{{ short_commit }}`          | Branch HEAD SHA (7 chars) |
+|           | `{{ short_commit }}`          | Branch HEAD SHA, abbreviated per `core.abbrev` |
 |           | `{{ upstream }}`              | Branch upstream (if tracking a remote) |
 | operation | `{{ base }}`                  | Base branch name |
 |           | `{{ base_worktree_path }}`    | Base worktree path |

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -202,7 +202,7 @@ $ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 | Field | Type | Description |
 |-------|------|-------------|
 | `sha` | string | Full commit SHA (40 chars) |
-| `short_sha` | string | Short commit SHA (7 chars) |
+| `short_sha` | string | Short commit SHA, abbreviated per `core.abbrev` (auto-extends for ambiguous prefixes) |
 | `message` | string | Commit message (first line) |
 | `timestamp` | number | Unix timestamp |
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -847,7 +847,7 @@ $ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 | Field | Type | Description |
 |-------|------|-------------|
 | `sha` | string | Full commit SHA (40 chars) |
-| `short_sha` | string | Short commit SHA (7 chars) |
+| `short_sha` | string | Short commit SHA, abbreviated per `core.abbrev` (auto-extends for ambiguous prefixes) |
 | `message` | string | Commit message (first line) |
 | `timestamp` | number | Unix timestamp |
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1303,7 +1303,7 @@ Hooks can use template variables that expand at runtime:
 |           | `{{ worktree_path }}`         | Worktree path |
 |           | `{{ worktree_name }}`         | Worktree directory name |
 |           | `{{ commit }}`                | Branch HEAD SHA |
-|           | `{{ short_commit }}`          | Branch HEAD SHA (7 chars) |
+|           | `{{ short_commit }}`          | Branch HEAD SHA, abbreviated per `core.abbrev` |
 |           | `{{ upstream }}`              | Branch upstream (if tracking a remote) |
 | operation | `{{ base }}`                  | Base branch name |
 |           | `{{ base_worktree_path }}`    | Base worktree path |

--- a/src/commands/command_executor.rs
+++ b/src/commands/command_executor.rs
@@ -296,8 +296,10 @@ pub fn build_hook_context(
                 .flatten(),
         };
         if let Some(commit) = commit {
-            if want("short_commit") && commit.len() >= 7 {
-                map.insert("short_commit".into(), commit[..7].into());
+            if want("short_commit")
+                && let Ok(short) = ctx.repo.short_sha(&commit)
+            {
+                map.insert("short_commit".into(), short);
             }
             if want("commit") {
                 map.insert("commit".into(), commit);

--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -184,10 +184,8 @@ impl<'a> CommitGenerator<'a> {
             .context("Failed to commit")?;
 
         let commit_sha = wt.run_command(&["rev-parse", "HEAD"])?.trim().to_string();
-        // Display uses `--short` to honor `core.abbrev` and auto-extend for
-        // ambiguous prefixes; the JSON payload carries the full SHA.
-        let commit_hash = wt.run_command(&["rev-parse", "--short", "HEAD"])?;
-        let commit_hash = commit_hash.trim();
+        // Display uses `Repository::short_sha`; the JSON payload carries the full SHA.
+        let commit_hash = wt.repo().short_sha(&commit_sha)?;
 
         eprintln!(
             "{}",

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -1091,8 +1091,9 @@ pub fn collect(
         if item.worktree_data().is_some_and(|d| d.is_prunable()) {
             continue;
         }
-        if let Some((timestamp, commit_message)) = commit_details_map.get(&item.head) {
+        if let Some((short_sha, timestamp, commit_message)) = commit_details_map.get(&item.head) {
             item.commit = Some(CommitDetails {
+                short_sha: short_sha.clone(),
                 timestamp: *timestamp,
                 commit_message: commit_message.clone(),
             });
@@ -1502,7 +1503,7 @@ pub fn collect(
 /// Sort items by timestamp descending using the pre-fetched commit-details map.
 fn sort_by_timestamp_desc_with_cache<T, F>(
     items: Vec<T>,
-    commit_details: &std::collections::HashMap<String, (i64, String)>,
+    commit_details: &std::collections::HashMap<String, (String, i64, String)>,
     get_sha: F,
 ) -> Vec<T>
 where
@@ -1512,7 +1513,9 @@ where
     let mut with_ts: Vec<_> = items
         .into_iter()
         .map(|item| {
-            let ts = commit_details.get(get_sha(&item)).map_or(0, |(ts, _)| *ts);
+            let ts = commit_details
+                .get(get_sha(&item))
+                .map_or(0, |(_, ts, _)| *ts);
             (item, ts)
         })
         .collect();
@@ -1526,7 +1529,7 @@ fn sort_worktrees_with_cache(
     worktrees: &[WorktreeInfo],
     main_worktree: &WorktreeInfo,
     current_path: Option<&std::path::PathBuf>,
-    commit_details: &std::collections::HashMap<String, (i64, String)>,
+    commit_details: &std::collections::HashMap<String, (String, i64, String)>,
 ) -> Vec<WorktreeInfo> {
     // Embed timestamp and priority in tuple to avoid parallel Vec and index lookups
     let mut with_sort_key: Vec<_> = worktrees
@@ -1539,7 +1542,7 @@ fn sort_worktrees_with_cache(
             } else {
                 2 // Rest by timestamp
             };
-            let ts = commit_details.get(&wt.head).map_or(0, |(ts, _)| *ts);
+            let ts = commit_details.get(&wt.head).map_or(0, |(_, ts, _)| *ts);
             (wt, priority, ts)
         })
         .collect();
@@ -1621,9 +1624,10 @@ pub fn populate_item(
     if item.head != worktrunk::git::NULL_OID
         && !is_prunable
         && let Ok(map) = repo.commit_details_many(&[&item.head])
-        && let Some((timestamp, commit_message)) = map.get(&item.head)
+        && let Some((short_sha, timestamp, commit_message)) = map.get(&item.head)
     {
         item.commit = Some(CommitDetails {
+            short_sha: short_sha.clone(),
             timestamp: *timestamp,
             commit_message: commit_message.clone(),
         });

--- a/src/commands/list/json_output.rs
+++ b/src/commands/list/json_output.rs
@@ -244,12 +244,19 @@ impl JsonItem {
         let is_current = worktree_data.is_some_and(|d| d.is_current);
         let is_previous = worktree_data.is_some_and(|d| d.is_previous);
 
-        // Commit info — empty strings for null OID (unborn branches)
+        // Commit info — empty strings for null OID (unborn branches). The
+        // short form is fetched in the same `git log --no-walk` batch as the
+        // subject and timestamp (see `commit_details_many`), so it honors
+        // `core.abbrev` and disambiguates without an extra subprocess.
         let (sha, short_sha) = if item.head == worktrunk::git::NULL_OID {
             (String::new(), String::new())
         } else {
             let sha = item.head.clone();
-            let short_sha = sha[..7.min(sha.len())].to_string();
+            let short_sha = item
+                .commit
+                .as_ref()
+                .map(|c| c.short_sha.clone())
+                .unwrap_or_else(|| sha.clone());
             (sha, short_sha)
         };
         let commit = JsonCommit {

--- a/src/commands/list/json_output.rs
+++ b/src/commands/list/json_output.rs
@@ -115,7 +115,8 @@ pub struct JsonCommit {
     /// Full commit SHA
     pub sha: String,
 
-    /// Short commit SHA (7 characters)
+    /// Short commit SHA, abbreviated per `core.abbrev` (auto-extends for
+    /// ambiguous prefixes).
     pub short_sha: String,
 
     /// Commit message (first line)
@@ -247,7 +248,10 @@ impl JsonItem {
         // Commit info — empty strings for null OID (unborn branches). The
         // short form is fetched in the same `git log --no-walk` batch as the
         // subject and timestamp (see `commit_details_many`), so it honors
-        // `core.abbrev` and disambiguates without an extra subprocess.
+        // `core.abbrev` and disambiguates without an extra subprocess. Prunable
+        // worktrees and rows whose batch failed have no `commit` populated;
+        // fall back to a 7-char prefix slice so the JSON field stays a "short"
+        // SHA rather than leaking the full 40 chars.
         let (sha, short_sha) = if item.head == worktrunk::git::NULL_OID {
             (String::new(), String::new())
         } else {
@@ -256,7 +260,7 @@ impl JsonItem {
                 .commit
                 .as_ref()
                 .map(|c| c.short_sha.clone())
-                .unwrap_or_else(|| sha.clone());
+                .unwrap_or_else(|| sha[..7.min(sha.len())].to_string());
             (sha, short_sha)
         };
         let commit = JsonCommit {

--- a/src/commands/list/layout.rs
+++ b/src/commands/list/layout.rs
@@ -1305,6 +1305,7 @@ mod tests {
             head: "abc12345".to_string(),
             branch: Some("feature".to_string()),
             commit: Some(CommitDetails {
+                short_sha: "abc1234".to_string(),
                 timestamp: 1234567890,
                 commit_message: "Test commit message".to_string(),
             }),
@@ -1414,6 +1415,7 @@ mod tests {
             head: "abc12345".to_string(),
             branch: Some("main".to_string()),
             commit: Some(CommitDetails {
+                short_sha: "abc1234".to_string(),
                 timestamp: 1234567890,
                 commit_message: "Test".to_string(),
             }),
@@ -1916,6 +1918,7 @@ mod tests {
                 head: "a620bcfe".to_string(),
                 branch: Some(branch.to_string()),
                 commit: Some(CommitDetails {
+                    short_sha: "a620bcf".to_string(),
                     timestamp: ts,
                     commit_message: "Some commit message".to_string(),
                 }),

--- a/src/commands/list/model/stats.rs
+++ b/src/commands/list/model/stats.rs
@@ -8,6 +8,10 @@ use worktrunk::git::LineDiff;
 /// Commit metadata for a branch or worktree HEAD.
 #[derive(serde::Serialize, Clone, Default, Debug)]
 pub struct CommitDetails {
+    /// Abbreviated form of the HEAD SHA, honoring `core.abbrev` and
+    /// auto-extending for ambiguous prefixes. Fetched in the same `git log`
+    /// batch as `timestamp` and `commit_message`.
+    pub short_sha: String,
     pub timestamp: i64,
     pub commit_message: String,
 }

--- a/src/commands/step_commands.rs
+++ b/src/commands/step_commands.rs
@@ -472,11 +472,9 @@ pub fn handle_squash(
     repo.run_command(&["commit", "-m", &commit_message])
         .context("Failed to create squash commit")?;
 
-    // Full SHA for the JSON payload, plus a `--short`-rendered hash for the
-    // success line (honors `core.abbrev` and auto-extends for ambiguous prefixes).
+    // Full SHA for the JSON payload, abbreviated form for the success line.
     let commit_sha = repo.run_command(&["rev-parse", "HEAD"])?.trim().to_string();
-    let commit_hash = repo.run_command(&["rev-parse", "--short", "HEAD"])?;
-    let commit_hash = commit_hash.trim();
+    let commit_hash = repo.short_sha(&commit_sha)?;
 
     // Show success immediately after completing the squash
     eprintln!(
@@ -1840,10 +1838,10 @@ pub fn step_prune(
         // metadata, current-worktree deferral, and path-based candidates.
         if let CheckSource::Linked { wt_idx } = &item.source {
             let wt = &worktrees[*wt_idx];
-            let label = wt
-                .branch
-                .clone()
-                .unwrap_or_else(|| format!("(detached {})", &wt.head[..7.min(wt.head.len())]));
+            let label = wt.branch.clone().unwrap_or_else(|| {
+                let short = repo.short_sha(&wt.head).unwrap_or_else(|_| wt.head.clone());
+                format!("(detached {short})")
+            });
 
             // Skip recently-created worktrees that look "merged" because
             // they were just created from the default branch

--- a/src/commands/template_vars.rs
+++ b/src/commands/template_vars.rs
@@ -87,10 +87,12 @@ impl TemplateVars {
         self
     }
 
-    /// Override `commit`. Also sets `short_commit` to the first 7 characters
-    /// when present (commit SHAs are ASCII hex, so the byte slice is safe).
-    pub fn with_active_commit(mut self, commit: &str) -> Self {
-        self.active_short_commit = commit.get(..7).map(str::to_owned);
+    /// Override `commit` and `short_commit`. Caller resolves the abbreviated
+    /// form via [`Repository::short_sha`](worktrunk::git::Repository::short_sha)
+    /// so we don't slice raw bytes here — 7-char prefixes regularly collide in
+    /// large repos and ignore the user's `core.abbrev` setting.
+    pub fn with_active_commit(mut self, commit: &str, short_commit: &str) -> Self {
+        self.active_short_commit = Some(short_commit.to_string());
         self.active_commit = Some(commit.to_string());
         self
     }
@@ -222,22 +224,11 @@ mod tests {
     }
 
     #[test]
-    fn active_commit_derives_short_commit() {
-        let vars = TemplateVars::new().with_active_commit("0123456789abcdef");
+    fn active_commit_emits_both_forms() {
+        let vars = TemplateVars::new().with_active_commit("0123456789abcdef", "0123456");
         let pairs = vars.as_extra_vars();
         assert!(pairs.contains(&("commit", "0123456789abcdef")));
         assert!(pairs.contains(&("short_commit", "0123456")));
-    }
-
-    #[test]
-    fn active_commit_skips_short_when_too_short() {
-        // SHAs are always >= 7 chars in practice, but `.get(..7)` returns None
-        // for shorter strings rather than panicking — preserves merge.rs's
-        // pre-refactor behavior.
-        let vars = TemplateVars::new().with_active_commit("abc");
-        let pairs = vars.as_extra_vars();
-        assert!(pairs.iter().any(|(k, _)| *k == "commit"));
-        assert!(!pairs.iter().any(|(k, _)| *k == "short_commit"));
     }
 
     #[test]

--- a/src/commands/worktree/finish.rs
+++ b/src/commands/worktree/finish.rs
@@ -94,7 +94,10 @@ pub fn finish_after_merge(
         None
     };
     if let Some(commit) = feature_commit.as_deref() {
-        feature_vars = feature_vars.with_active_commit(commit);
+        let short = repo
+            .short_sha(commit)
+            .unwrap_or_else(|_| commit.to_string());
+        feature_vars = feature_vars.with_active_commit(commit, &short);
     }
 
     // Finish worktree unless removal is disabled or blocked.

--- a/src/commands/worktree/hooks.rs
+++ b/src/commands/worktree/hooks.rs
@@ -62,10 +62,13 @@ impl PostRemoveContext {
             .to_string();
 
         let commit = removed_commit.unwrap_or("").to_string();
-        let short_commit = if commit.len() >= 7 {
-            commit[..7].to_string()
+        // Empty commit (no removal SHA recorded) skips the short form rather
+        // than asking git to abbreviate "". For a real SHA, fall back to the
+        // full string only if `rev-parse --short` errors (very rare).
+        let short_commit = if commit.is_empty() {
+            String::new()
         } else {
-            commit.clone()
+            repo.short_sha(&commit).unwrap_or_else(|_| commit.clone())
         };
 
         // Target vars: where the user ends up after removal (primary worktree).

--- a/src/commands/worktree/push.rs
+++ b/src/commands/worktree/push.rs
@@ -441,7 +441,8 @@ pub fn handle_no_ff_merge(
 
     ctx.restore_stash();
 
-    let merge_sha_short = &merge_sha[..merge_sha.len().min(7)];
+    // Display uses `Repository::short_sha`; the JSON payload carries the full SHA.
+    let merge_sha_short = ctx.repo.short_sha(&merge_sha)?;
     let sha_suffix = cformat!(" @ <dim>{merge_sha_short}</>");
     ctx.show_success("Merged to", &sha_suffix, ", --no-ff");
 

--- a/src/commands/worktree/push.rs
+++ b/src/commands/worktree/push.rs
@@ -160,8 +160,8 @@ impl MergeContext {
         } else {
             "commits"
         };
-        let head_sha = self.repo.run_command(&["rev-parse", "--short", "HEAD"])?;
-        let head_sha = head_sha.trim();
+        let full_sha = self.repo.run_command(&["rev-parse", "HEAD"])?;
+        let head_sha = self.repo.short_sha(full_sha.trim())?;
 
         let operations_note = format_operations_note(operations);
 

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -137,7 +137,7 @@ impl ProjectConfig {
 /// - `{{ primary_worktree_path }}` - Primary worktree path (main worktree for normal repos; default branch worktree for bare repos)
 /// - `{{ default_branch }}` - Default branch name (e.g., "main")
 /// - `{{ commit }}` - Current HEAD commit SHA (full 40-character hash)
-/// - `{{ short_commit }}` - Current HEAD commit SHA (short 7-character hash)
+/// - `{{ short_commit }}` - Current HEAD commit SHA, abbreviated per `core.abbrev` (auto-extends for ambiguous prefixes)
 /// - `{{ remote }}` - Primary remote name (e.g., "origin")
 /// - `{{ upstream }}` - Upstream tracking branch (e.g., "origin/feature"), if configured
 ///

--- a/src/git/repository/diff.rs
+++ b/src/git/repository/diff.rs
@@ -53,12 +53,15 @@ impl Repository {
         Ok(files)
     }
 
-    /// Get commit timestamp and subject for multiple commits in a single git command.
+    /// Get short SHA, commit timestamp and subject for multiple commits in a
+    /// single git command.
     ///
-    /// Returns a map from commit SHA to `(timestamp, subject)`. Uses NUL
-    /// separators between fields so subjects containing spaces or other
-    /// whitespace parse unambiguously. `%s` is the subject line only, so no
-    /// multi-line handling is needed.
+    /// Returns a map from full commit SHA to `(short_sha, timestamp, subject)`.
+    /// `%h` is the abbreviated SHA — same machinery as `git rev-parse --short`,
+    /// so it honors `core.abbrev` and auto-extends for ambiguous prefixes.
+    /// Uses NUL separators between fields so subjects containing spaces or
+    /// other whitespace parse unambiguously. `%s` is the subject line only, so
+    /// no multi-line handling is needed.
     ///
     /// Fails if any SHA is invalid — `git log --no-walk` refuses the whole
     /// batch on a single bad ref. Callers should surface the error rather
@@ -68,7 +71,7 @@ impl Repository {
     pub fn commit_details_many(
         &self,
         commits: &[&str],
-    ) -> anyhow::Result<HashMap<String, (i64, String)>> {
+    ) -> anyhow::Result<HashMap<String, (String, i64, String)>> {
         if commits.is_empty() {
             return Ok(HashMap::new());
         }
@@ -80,7 +83,7 @@ impl Repository {
             "log",
             "--no-walk",
             "--no-show-signature",
-            "--format=%H%x00%ct%x00%s",
+            "--format=%H%x00%h%x00%ct%x00%s",
         ];
         args.extend(commits);
 
@@ -88,18 +91,21 @@ impl Repository {
 
         let mut result = HashMap::with_capacity(commits.len());
         for line in stdout.lines() {
-            let mut parts = line.splitn(3, '\0');
-            let (Some(sha), Some(timestamp_str), Some(subject)) =
-                (parts.next(), parts.next(), parts.next())
+            let mut parts = line.splitn(4, '\0');
+            let (Some(sha), Some(short_sha), Some(timestamp_str), Some(subject)) =
+                (parts.next(), parts.next(), parts.next(), parts.next())
             else {
                 bail!(
-                    "Malformed git log output: expected '<sha>\\0<ts>\\0<subject>', got {line:?}"
+                    "Malformed git log output: expected '<sha>\\0<short>\\0<ts>\\0<subject>', got {line:?}"
                 );
             };
             let timestamp: i64 = timestamp_str
                 .parse()
                 .with_context(|| format!("Failed to parse timestamp {timestamp_str:?}"))?;
-            result.insert(sha.to_string(), (timestamp, subject.to_owned()));
+            result.insert(
+                sha.to_string(),
+                (short_sha.to_owned(), timestamp, subject.to_owned()),
+            );
         }
 
         Ok(result)

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -1183,6 +1183,24 @@ impl Repository {
         Ok(self.run_command_output(args)?.status.success())
     }
 
+    /// Abbreviate a commit SHA for display, honoring `core.abbrev` and
+    /// auto-extending for ambiguous prefixes.
+    ///
+    /// Wraps `git rev-parse --short <sha>`. Use this anywhere a short SHA is
+    /// shown to the user or passed to a hook template — never slice
+    /// `&sha[..7]` directly, since 7 chars regularly collides in large repos
+    /// and ignores the user's `core.abbrev` setting.
+    ///
+    /// For batches (e.g., abbreviating many worktree heads at once), prefer
+    /// folding `%h` into an existing `git log --format` call rather than
+    /// looping this helper. See [`commit_details_many`](Self::commit_details_many).
+    pub fn short_sha(&self, sha: &str) -> anyhow::Result<String> {
+        Ok(self
+            .run_command(&["rev-parse", "--short", sha])?
+            .trim()
+            .to_string())
+    }
+
     /// Delay before showing progress output for slow operations.
     /// See .claude/rules/cli-output-formatting.md: "Progress messages apply only to slow operations (>400ms)"
     pub const SLOW_OPERATION_DELAY_MS: i64 = 400;

--- a/src/git/repository/tests.rs
+++ b/src/git/repository/tests.rs
@@ -628,10 +628,16 @@ fn commit_details_many_returns_subject_with_spaces() {
         .unwrap();
 
     assert_eq!(result.len(), 2);
-    assert_eq!(result[&sha1].1, "first commit with spaces");
-    assert_eq!(result[&sha2].1, "second commit");
-    assert!(result[&sha1].0 > 0);
-    assert!(result[&sha2].0 > 0);
+    let (short1, ts1, subject1) = &result[&sha1];
+    let (short2, ts2, subject2) = &result[&sha2];
+    assert_eq!(subject1, "first commit with spaces");
+    assert_eq!(subject2, "second commit");
+    assert!(*ts1 > 0);
+    assert!(*ts2 > 0);
+    // Short SHAs are a prefix of the full SHA; default `core.abbrev` is 7,
+    // and a fresh test repo never needs more than that.
+    assert!(sha1.starts_with(short1.as_str()));
+    assert!(sha2.starts_with(short2.as_str()));
 }
 
 #[test]
@@ -680,7 +686,7 @@ fn commit_details_many_preserves_multibyte_utf8_subject() {
 
     let result = test.repo.commit_details_many(&[sha.as_str()]).unwrap();
 
-    assert_eq!(result[&sha].1, subject);
+    assert_eq!(result[&sha].2, subject);
 }
 
 #[test]
@@ -704,7 +710,7 @@ fn commit_details_many_deduplicates_repeated_sha() {
         .unwrap();
 
     assert_eq!(result.len(), 1);
-    assert_eq!(result[&sha].1, "only commit");
+    assert_eq!(result[&sha].2, "only commit");
 }
 
 #[test]

--- a/src/git/repository/working_tree.rs
+++ b/src/git/repository/working_tree.rs
@@ -531,7 +531,7 @@ impl<'a> WorkingTree<'a> {
         ])
         .context("Failed to create backup ref")?;
 
-        Ok(backup_sha[..7].to_string())
+        self.repo().short_sha(&backup_sha)
     }
 }
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -261,12 +261,12 @@ Query structured data with [2m--format=json[0m:
 
 [32mCommit object[0m
 
-   Field    Type          Description         
- ───────── ────── ─────────────────────────── 
- [2msha[0m       string Full commit SHA (40 chars)  
- [2mshort_sha[0m string Short commit SHA (7 chars)  
- [2mmessage[0m   string Commit message (first line) 
- [2mtimestamp[0m number Unix timestamp              
+   Field    Type                                      Description                                     
+ ───────── ────── ─────────────────────────────────────────────────────────────────────────────────── 
+ [2msha[0m       string Full commit SHA (40 chars)                                                          
+ [2mshort_sha[0m string Short commit SHA, abbreviated per [2mcore.abbrev[0m (auto-extends for ambiguous prefixes) 
+ [2mmessage[0m   string Commit message (first line)                                                         
+ [2mtimestamp[0m number Unix timestamp                                                                      
 
 [32mworking_tree object[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -311,12 +311,13 @@ Query structured data with [2m--format=json[0m:
 
 [32mCommit object[0m
 
-   Field    Type          Description         
- ───────── ────── ─────────────────────────── 
- [2msha[0m       string Full commit SHA (40 chars)  
- [2mshort_sha[0m string Short commit SHA (7 chars)  
- [2mmessage[0m   string Commit message (first line) 
- [2mtimestamp[0m number Unix timestamp              
+   Field    Type                           Description                          
+ ───────── ────── ───────────────────────────────────────────────────────────── 
+ [2msha[0m       string Full commit SHA (40 chars)                                    
+ [2mshort_sha[0m string Short commit SHA, abbreviated per [2mcore.abbrev[0m (auto-extends   
+                  for ambiguous prefixes)                                       
+ [2mmessage[0m   string Commit message (first line)                                   
+ [2mtimestamp[0m number Unix timestamp                                                
 
 [32mworking_tree object[0m
 


### PR DESCRIPTION
Every site that abbreviated a commit SHA was either slicing `&sha[..7]` or running its own ad-hoc `git rev-parse --short` call. 7-char prefixes regularly collide in repos with many commits, and none of the slicing sites honored `core.abbrev`. Cut over to a single canonical helper.

## Single helper, every display site

`Repository::short_sha(&str) -> Result<String>` wraps `git rev-parse --short`. Routes display through git's own abbreviation logic so `core.abbrev` is honored and prefixes auto-extend on collision. Used by:

- `step commit` / `step squash` success lines
- `step push --no-ff` `Merged to @ <hash>` line — the original bug. Flagged on #2560 as a pre-existing third instance of the same pattern fixed there in `commit.rs` and `step_commands.rs`.
- `{{ short_commit }}` template var in hook contexts (`command_executor.rs`, `template_vars.rs`)
- post-remove hook context for the removed worktree
- safety-backup ref display (`create_safety_backup`)
- `(detached <sha>)` label in the orphan-check loop

All seven sites previously sliced `commit[..7]` or called their own `rev-parse`. Now they route through one helper.

## Batched form for `wt list --format=json`

The JSON list path emits one `short_sha` per worktree row. Looping `short_sha` would fork a subprocess per row, so the short SHA is folded into the existing `commit_details_many` batch instead — `%h` is added to the `git log --no-walk --format=...` call that already fetches timestamp and subject. One subprocess for the whole list, same `core.abbrev` behavior as every other site.

`CommitDetails` gains a `short_sha: String` field with the same provenance as the timestamp and subject. The JSON schema is unchanged (`commit.short_sha` was already a field) — only its length now varies by `core.abbrev` instead of being hard-coded to 7.

## API change

`TemplateVars::with_active_commit(commit, short_commit)` now takes both forms. Previously it sliced `commit.get(..7)` internally. The sole caller (`worktree/finish.rs`) resolves the short form via `Repository::short_sha` and passes both.

## Docs

`{{ short_commit }}` is no longer documented as "(7 chars)" — `src/cli/mod.rs` and `src/config/project.rs` now describe `core.abbrev` behavior. Doc-sync regenerated `docs/content/hook.md` and the skill mirror.

## Tests

Full suite passes (3463/3463). `commit_details_many` tests updated for the new tuple shape; `CommitDetails` fixtures in `layout.rs` get a `short_sha` field; `template_vars` tests pass both forms explicitly. Two integration tests previously asserting `short_commit` was exactly 7 chars (`post_start_commands.rs`, `user_hooks.rs`) still pass — fresh test repos default to `core.abbrev = 7`.

> _This was written by Claude Code on behalf of @max-sixty_