### PR TITLE
refactor(list): hoist short_sha onto ListItem so every row has it

### DIFF
--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -808,6 +808,7 @@ pub fn collect(
             // URL expanded post-skeleton to minimize time-to-skeleton
             ListItem {
                 head: wt.head.clone(),
+                short_sha: String::new(),
                 branch: wt.branch.clone(),
                 commit: None,
                 counts: None,
@@ -1081,23 +1082,27 @@ pub fn collect(
         }
     }
 
-    // Populate commit details (timestamp + subject) on every item directly
-    // from the pre-skeleton batch map. No per-SHA recovery — if the batch
-    // failed, the warning printed above is the user-visible signal and
-    // Age/Message cells render their placeholder. Prunable worktrees are
-    // skipped because their directory is missing from disk; leaving these
-    // rows at the placeholder matches the old task-queue UX.
+    // Populate commit data on every item directly from the pre-skeleton batch
+    // map. No per-SHA recovery — if the batch failed, the warning printed above
+    // is the user-visible signal and Age/Message cells render their placeholder.
+    //
+    // `short_sha` is populated for every row (including prunable), since it's a
+    // pure SHA derivation that doesn't need the worktree directory. The
+    // timestamp/message bundle is skipped for prunable rows to match the old
+    // task-queue UX where probes against a missing worktree dir failed.
     for item in &mut all_items {
+        let Some((short_sha, timestamp, commit_message)) = commit_details_map.get(&item.head)
+        else {
+            continue;
+        };
+        item.short_sha = short_sha.clone();
         if item.worktree_data().is_some_and(|d| d.is_prunable()) {
             continue;
         }
-        if let Some((short_sha, timestamp, commit_message)) = commit_details_map.get(&item.head) {
-            item.commit = Some(CommitDetails {
-                short_sha: short_sha.clone(),
-                timestamp: *timestamp,
-                commit_message: commit_message.clone(),
-            });
-        }
+        item.commit = Some(CommitDetails {
+            timestamp: *timestamp,
+            commit_message: commit_message.clone(),
+        });
     }
 
     // No need to prime the ambient `cache.ahead_behind` here: the
@@ -1570,6 +1575,7 @@ pub fn build_worktree_item(
 ) -> ListItem {
     ListItem {
         head: wt.head.clone(),
+        short_sha: String::new(),
         branch: wt.branch.clone(),
         commit: None,
         counts: None,
@@ -1613,24 +1619,28 @@ pub fn populate_item(
     item: &mut ListItem,
     mut options: CollectOptions,
 ) -> anyhow::Result<()> {
-    // Populate commit details (timestamp + subject) directly. The main
-    // `collect()` path batches this across all items pre-skeleton; the
-    // single-item statusline path has no such batch, so fetch the one SHA
-    // here. Skip null OIDs (unborn branches) and prunable worktrees —
-    // matches the behavior in `collect()`. Silent on batch failure: the
-    // statusline is a compact prompt element with no room for warnings, and
-    // `commit.message` / `commit.timestamp` fall through to their defaults.
+    // Populate commit data directly. The main `collect()` path batches this
+    // across all items pre-skeleton; the single-item statusline path has no
+    // such batch, so fetch the one SHA here. Skip null OIDs (unborn branches).
+    // Silent on batch failure: the statusline is a compact prompt element with
+    // no room for warnings, and `commit.message` / `commit.timestamp` fall
+    // through to their defaults.
+    //
+    // `short_sha` populates for every row (including prunable). The
+    // timestamp/message bundle is skipped for prunable rows to match the old
+    // task-queue UX where probes against a missing worktree dir failed.
     let is_prunable = item.worktree_data().is_some_and(|d| d.is_prunable());
     if item.head != worktrunk::git::NULL_OID
-        && !is_prunable
         && let Ok(map) = repo.commit_details_many(&[&item.head])
         && let Some((short_sha, timestamp, commit_message)) = map.get(&item.head)
     {
-        item.commit = Some(CommitDetails {
-            short_sha: short_sha.clone(),
-            timestamp: *timestamp,
-            commit_message: commit_message.clone(),
-        });
+        item.short_sha = short_sha.clone();
+        if !is_prunable {
+            item.commit = Some(CommitDetails {
+                timestamp: *timestamp,
+                commit_message: commit_message.clone(),
+            });
+        }
     }
 
     // Extract worktree data (skip if not a worktree item)

--- a/src/commands/list/json_output.rs
+++ b/src/commands/list/json_output.rs
@@ -248,24 +248,17 @@ impl JsonItem {
         // Commit info — empty strings for null OID (unborn branches). The
         // short form is fetched in the same `git log --no-walk` batch as the
         // subject and timestamp (see `commit_details_many`), so it honors
-        // `core.abbrev` and disambiguates without an extra subprocess. Prunable
-        // worktrees and rows whose batch failed have no `commit` populated;
-        // fall back to a 7-char prefix slice so the JSON field stays a "short"
-        // SHA rather than leaking the full 40 chars.
-        let (sha, short_sha) = if item.head == worktrunk::git::NULL_OID {
-            (String::new(), String::new())
+        // `core.abbrev` and disambiguates without an extra subprocess. Lives on
+        // `ListItem` directly so prunable worktrees still carry it even though
+        // their `commit` (timestamp + message) is intentionally left empty.
+        let sha = if item.head == worktrunk::git::NULL_OID {
+            String::new()
         } else {
-            let sha = item.head.clone();
-            let short_sha = item
-                .commit
-                .as_ref()
-                .map(|c| c.short_sha.clone())
-                .unwrap_or_else(|| sha[..7.min(sha.len())].to_string());
-            (sha, short_sha)
+            item.head.clone()
         };
         let commit = JsonCommit {
             sha,
-            short_sha,
+            short_sha: item.short_sha.clone(),
             message: item
                 .commit
                 .as_ref()

--- a/src/commands/list/layout.rs
+++ b/src/commands/list/layout.rs
@@ -1303,9 +1303,9 @@ mod tests {
         // Create test data with specific widths to verify position calculation
         let item = ListItem {
             head: "abc12345".to_string(),
+            short_sha: "abc1234".to_string(),
             branch: Some("feature".to_string()),
             commit: Some(CommitDetails {
-                short_sha: "abc1234".to_string(),
                 timestamp: 1234567890,
                 commit_message: "Test commit message".to_string(),
             }),
@@ -1413,9 +1413,9 @@ mod tests {
         // Create minimal data - most columns will be empty
         let item = ListItem {
             head: "abc12345".to_string(),
+            short_sha: "abc1234".to_string(),
             branch: Some("main".to_string()),
             commit: Some(CommitDetails {
-                short_sha: "abc1234".to_string(),
                 timestamp: 1234567890,
                 commit_message: "Test".to_string(),
             }),
@@ -1541,6 +1541,7 @@ mod tests {
         };
         super::super::model::ListItem {
             head: "abc12345".to_string(),
+            short_sha: "abc1234".to_string(),
             branch: Some(branch.to_string()),
             commit: None,
             counts: None,
@@ -1788,6 +1789,7 @@ mod tests {
         };
         super::super::model::ListItem {
             head: "abc12345".to_string(),
+            short_sha: "abc1234".to_string(),
             branch: Some(branch.to_string()),
             commit: None,
             counts: None,
@@ -1916,9 +1918,9 @@ mod tests {
             });
             super::super::model::ListItem {
                 head: "a620bcfe".to_string(),
+                short_sha: "a620bcf".to_string(),
                 branch: Some(branch.to_string()),
                 commit: Some(CommitDetails {
-                    short_sha: "a620bcf".to_string(),
                     timestamp: ts,
                     commit_message: "Some commit message".to_string(),
                 }),

--- a/src/commands/list/model/item.rs
+++ b/src/commands/list/model/item.rs
@@ -196,6 +196,13 @@ pub struct ListItem {
     // Common fields (present for both worktrees and branches)
     #[serde(rename = "head_sha")]
     pub head: String,
+    /// Abbreviated form of `head`, honoring `core.abbrev` and auto-extending
+    /// for ambiguous prefixes. Always populated when there is a HEAD commit
+    /// to abbreviate (the `git log` batch in `collect()` emits `%h` for every
+    /// row, including prunable worktrees). Empty for null OIDs (unborn
+    /// branches) or when the batch failed for this row.
+    #[serde(skip)]
+    pub short_sha: String,
     /// Branch name - None for detached worktrees
     pub branch: Option<String>,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
@@ -296,6 +303,7 @@ impl ListItem {
     pub(crate) fn new_branch(head: String, branch: String) -> Self {
         Self {
             head,
+            short_sha: String::new(),
             branch: Some(branch),
             commit: None,
             counts: None,

--- a/src/commands/list/model/stats.rs
+++ b/src/commands/list/model/stats.rs
@@ -6,12 +6,13 @@
 use worktrunk::git::LineDiff;
 
 /// Commit metadata for a branch or worktree HEAD.
+///
+/// The abbreviated SHA lives on `ListItem::short_sha` so it stays available even
+/// when this struct isn't populated (prunable worktrees, items missing from the
+/// pre-skeleton batch); the fields here are the per-commit data fetched
+/// alongside it in the same `git log` batch.
 #[derive(serde::Serialize, Clone, Default, Debug)]
 pub struct CommitDetails {
-    /// Abbreviated form of the HEAD SHA, honoring `core.abbrev` and
-    /// auto-extending for ambiguous prefixes. Fetched in the same `git log`
-    /// batch as `timestamp` and `commit_message`.
-    pub short_sha: String,
     pub timestamp: i64,
     pub commit_message: String,
 }


### PR DESCRIPTION
Follow-up to #2576. The parent PR routed every short-SHA display through `git`'s abbreviation logic, but the JSON path kept a `sha[..7]` slice fallback for prunable worktrees and rows whose batch failed — those rows have no `CommitDetails` populated, so the field had nowhere to read from.

The pre-skeleton `commit_details_many` batch already returns `%h` for every row in the list, including prunable worktrees (the batch runs against the repo, not the worktree dir). Hoisting `short_sha` out of `CommitDetails` and onto `ListItem` directly lets the populate loops set it on every row before the prunable skip; `JsonItem::from_list_item` then reads `item.short_sha` without a fallback. `CommitDetails` keeps the prunable skip for the timestamp/message bundle, which is what actually preserves the old task-queue UX.

Net effect: every short-SHA emission in worktrunk now routes through `git`'s `%h`/`rev-parse --short` machinery — no manual slicing left in the user-facing path.

> _This was written by Claude Code on behalf of @max-sixty_