### PR TITLE
test: unify WORKTRUNK_TEST_POWERSHELL_ENV into STATIC_TEST_ENV_VARS

### DIFF
--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -263,6 +263,10 @@ pub const STATIC_TEST_ENV_VARS: &[(&str, &str)] = &[
     ("WORKTRUNK_TEST_FISH_INSTALLED", "0"),
     ("WORKTRUNK_TEST_NUSHELL_ENV", "0"),
     ("WORKTRUNK_TEST_POWERSHELL_INSTALLED", "0"),
+    // Disable PowerShell auto-detection (PSModulePath / SHELL signal). Orthogonal
+    // to _INSTALLED above: this gates whether PS is iterated at all in
+    // scan_shell_configs; _INSTALLED gates the Skipped path once it is iterated.
+    ("WORKTRUNK_TEST_POWERSHELL_ENV", "0"),
 ];
 
 // NOTE: TERM is intentionally NOT in STATIC_TEST_ENV_VARS because:
@@ -448,10 +452,6 @@ pub fn configure_cli_command(cmd: &mut Command) {
     // own test repo via the default lookup; host leakage is prevented
     // by the env-strip above.
     isolate_subprocess_env(cmd, None);
-    // Disable auto PowerShell detection (tests that need it should set to "1").
-    // Other shell-installed defaults live in STATIC_TEST_ENV_VARS so PTY tests
-    // (which use TestRepo::test_env_vars) inherit them too.
-    cmd.env("WORKTRUNK_TEST_POWERSHELL_ENV", "0");
     cmd.env("WORKTRUNK_TEST_EPOCH", TEST_EPOCH.to_string());
     // Enable warn-level logging so diagnostics show up in test failures
     cmd.env("RUST_LOG", "warn");


### PR DESCRIPTION
## Summary

- Moves `WORKTRUNK_TEST_POWERSHELL_ENV` from the inline body of `configure_cli_command` into `STATIC_TEST_ENV_VARS`, alongside the other shell-detection defaults
- Keeps `_POWERSHELL_ENV` and `_POWERSHELL_INSTALLED` as distinct vars — they encode orthogonal signals: `_ENV` gates whether PS is iterated in `scan_shell_configs`; `_INSTALLED` gates the Skipped path once iteration happens
- No snapshot churn: the rendered env block is alphabetically sorted and the value is identical

## Why

`_POWERSHELL_ENV` was the lone shell-detection default not in STATIC. PTY tests go through `TestRepo::test_env_vars`, which only inherits STATIC entries — so a future PTY test exercising PS auto-detection would silently pick up host `PSModulePath`/`SHELL`. This aligns the PowerShell case with bash/zsh/fish/nushell.

## Test plan

- [x] `cargo test --test integration -- config_show` (107 passed)
- [x] `cargo test --test integration -- configure_shell` (42 passed)
- [x] No snapshot diffs

🤖 Generated with [Claude Code](https://claude.com/claude-code)