### PR TITLE
refactor(config): drop project-config preload at picker / branchless entry

### DIFF
--- a/src/commands/context.rs
+++ b/src/commands/context.rs
@@ -76,10 +76,6 @@ impl CommandEnv {
         let branch = current_wt
             .branch()
             .context("Failed to determine current branch")?;
-        // Warm the project config so downstream hook code reads it from the
-        // cache and any deprecation warnings surface here, before hook output.
-        // Clone user out — `CommandEnv` owns its config.
-        repo.project_config().context("Failed to load config")?;
         let config = repo.user_config().clone();
 
         Ok(Self {

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -727,11 +727,9 @@ pub fn handle_picker(
         } else {
             Repository::current().context("Failed to switch worktree")?
         };
-        // Warm the project config so it sits in the cache for downstream
-        // `run_pre_switch_hooks` / `plan_switch` and any deprecation warnings
-        // surface before hook output. Clone user out so
-        // `offer_bare_repo_worktree_path_fix` can mutate locally.
-        repo.project_config().context("Failed to load config")?;
+        // Clone user out so `offer_bare_repo_worktree_path_fix` can mutate
+        // locally. Project config is loaded on demand by downstream
+        // `run_pre_switch_hooks` / `plan_switch`.
         let mut config = repo.user_config().clone();
         offer_bare_repo_worktree_path_fix(&repo, &mut config)?;
 

--- a/src/git/repository/config.rs
+++ b/src/git/repository/config.rs
@@ -561,11 +561,8 @@ impl Repository {
     /// Unlike `user_config`, this does **not** participate in
     /// [`Repository::prewarm`] — `.config/wt.toml` lives inside the
     /// worktree, so the read can't fire until git discovery finishes.
-    /// Callers pay a few-tens-of-µs sequential file read on first access.
-    /// Deprecation warnings emit on that first call, so handlers that
-    /// produce ordered output (hooks, picker) typically warm this from
-    /// the entry point rather than letting it interleave with their own
-    /// stderr later.
+    /// Callers pay a few-tens-of-µs sequential file read on first access,
+    /// and deprecation warnings (if any) emit on that first call.
     ///
     /// User and project configs are kept distinct rather than merged
     /// because downstream consumers (alias loading, hook resolution,


### PR DESCRIPTION
Follow-up to #2573. The `LoadedConfigs::load` inlining left two call sites with a bare `repo.project_config()?;` whose only effect was to warm the cache and emit any deprecation warnings before downstream hook output started. Reading the resulting code, the discarded `?` looks load-bearing without being so — the next reader has to trace the call chain to confirm nothing reads the value.

Both call sites — `CommandEnv::for_action_branchless` and the picker post-switch path — have downstream consumers (`run_pre_switch_hooks`, `plan_switch`, the rest of the hook pipeline) that load project config themselves on first use. Project-config deprecation warnings still surface; they just emerge from the first real read instead of from a bare statement at the entry point. User-config warnings continue to come from prewarm, so the user-visible ordering of warnings vs. command output is unchanged in the common path.

Drop both. The surrounding comments now name where project config is loaded, rather than implying the entry point pre-warms it.