### PR TITLE
refactor(list): route ListItem::display_name through short_sha

### DIFF
--- a/src/commands/list/model/item.rs
+++ b/src/commands/list/model/item.rs
@@ -332,13 +332,11 @@ impl ListItem {
     }
 
     /// Short display name for this item — the branch if present, otherwise
-    /// a truncated HEAD SHA. Use when reporting which item is pending,
-    /// stuck, or missing: `branch_name()`'s `"(detached)"` fallback collapses
-    /// distinct detached items into one label.
+    /// the short SHA. Use when reporting which item is pending, stuck, or
+    /// missing: `branch_name()`'s `"(detached)"` fallback collapses distinct
+    /// detached items into one label.
     pub fn display_name(&self) -> &str {
-        self.branch
-            .as_deref()
-            .unwrap_or_else(|| &self.head[..8.min(self.head.len())])
+        self.branch.as_deref().unwrap_or(&self.short_sha)
     }
 
     pub fn is_main(&self) -> bool {


### PR DESCRIPTION
The last manual `&self.head[..8]` slice in the list path. Routes through the canonical `short_sha` instead, completing the cutover started in #2576 (every short-SHA emission through git's `%h`/`rev-parse --short` machinery) and #2577 (hoisting `short_sha` onto `ListItem`).

When `short_sha` is empty the function returns `""`. The unborn-branch case is caught by the branch arm. The only path where this falls through to an empty string is "detached HEAD where the `commit_details_many` batch failed" — already a degraded state with placeholders in every other cell, so an empty diagnostic label is acceptable.

> _This was written by Claude Code on behalf of @max-sixty_