### PR TITLE
docs: refresh STATIC_TEST_ENV_VARS comment for WORKTRUNK_TEST_POWERSHELL_ENV

### DIFF
--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -263,9 +263,10 @@ pub const STATIC_TEST_ENV_VARS: &[(&str, &str)] = &[
     ("WORKTRUNK_TEST_FISH_INSTALLED", "0"),
     ("WORKTRUNK_TEST_NUSHELL_ENV", "0"),
     ("WORKTRUNK_TEST_POWERSHELL_INSTALLED", "0"),
-    // Disable PowerShell auto-detection (PSModulePath / SHELL signal). Orthogonal
-    // to _INSTALLED above: this gates whether PS is iterated at all in
-    // scan_shell_configs; _INSTALLED gates the Skipped path once it is iterated.
+    // Disable PowerShell auto-detection (PSModulePath / SHELL signal).
+    // Iteration is unconditional (matches the other shells); this var only
+    // controls `allow_create` via `should_auto_configure_powershell()` so we
+    // don't write a profile in tests that aren't asserting that path.
     ("WORKTRUNK_TEST_POWERSHELL_ENV", "0"),
 ];
 


### PR DESCRIPTION
## Summary

After #2581, PowerShell iterates unconditionally in `scan_shell_configs` alongside the other shells. The comment for `WORKTRUNK_TEST_POWERSHELL_ENV` in `src/testing/mod.rs` still claimed the var "gates whether PS is iterated at all" — that's now stale. Updated to reflect that the var only controls `allow_create` via `should_auto_configure_powershell()`.

Caught by the auto-reviewer on #2581.

## Test plan

- [x] No code changes; comment-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)