### PR TITLE
test: avoid same-size mtime race in step_commit_dry_run_stage_tracked

### DIFF
--- a/tests/integration_tests/merge.rs
+++ b/tests/integration_tests/merge.rs
@@ -2484,8 +2484,11 @@ fn test_step_commit_dry_run_stage_tracked(repo: TestRepo) {
         .run()
         .expect("git commit failed");
 
-    // Modify the tracked file (unstaged) and create a new untracked file
-    fs::write(repo.root_path().join("tracked.txt"), "modified").expect("Failed to write");
+    // Modify the tracked file (unstaged) and create a new untracked file. The new
+    // content must differ in size from "original" — otherwise `git add -u` against
+    // the dry-run temp index can race on mtime and treat the file as unchanged
+    // (same-size + same-second mtime → no DATA_CHANGED, no MTIME_CHANGED).
+    fs::write(repo.root_path().join("tracked.txt"), "modified content").expect("Failed to write");
     fs::write(repo.root_path().join("untracked.txt"), "new").expect("Failed to write");
 
     let worktrunk_config = r#"


### PR DESCRIPTION
The test wrote `tracked.txt` as `"original"` then `"modified"` — both 8 bytes. `wt step commit --dry-run --stage=tracked` runs `git add -u` against a copy of the index, so the only signal git has for the modification is mtime. On Linux/ext4 the recorded entry mtime and the post-modification mtime can be indistinguishable at the kernel's resolution; git treats the file as unchanged, the temp index keeps the old blob hash, and `git diff --staged` returns nothing. The rendered prompt then has empty `<diffstat>` / `<diff>` blocks and the assertion on `"tracked.txt"` / `"modified"` fires.

Reproduces 0/200 locally on macOS APFS and passes on `test (linux)`, but flaked on the `affected (linux, advisory)` job for PR #2581 ([logs](https://github.com/max-sixty/worktrunk/actions/runs/25306727293/job/74184225239)) — that PR only touched PowerShell shell config and has no plausible effect on this code path.

Switching the modification to `"modified content"` makes the new size differ from the committed blob, so git's DATA_CHANGED check fires unconditionally and the test no longer depends on mtime resolution. This mirrors the adjacent `test_step_commit_with_stage_tracked_flag` (`merge.rs:2113`) which uses `"initial"` → `"modified"` (different sizes) for the same reason. PR #2433 fixed an analogous mtime-tick collision in the picker/summary tests.

The `stdout.contains("modified")` assertion still passes since `"modified"` is a prefix of the new content.

> _This was written by Claude Code on behalf of @max-sixty_