### PR TITLE
fix(config): suppress redundant deprecation hint during `wt config update`

### DIFF
--- a/src/commands/config/update.rs
+++ b/src/commands/config/update.rs
@@ -10,7 +10,7 @@ use std::path::PathBuf;
 use anyhow::Context;
 use worktrunk::config::{
     DeprecationInfo, compute_migrated_content, config_path,
-    copy_approved_commands_to_approvals_file, format_migration_diff,
+    copy_approved_commands_to_approvals_file, format_deprecation_warnings, format_migration_diff,
 };
 use worktrunk::git::Repository;
 use worktrunk::styling::{
@@ -54,9 +54,8 @@ pub fn handle_config_update(yes: bool, print: bool) -> anyhow::Result<()> {
 
     if print {
         // Emit migrated content to stdout. Multiple configs → separate with a
-        // labeled header so the output is still parseable. Deprecation
-        // warnings already went to stderr from `Repository::prewarm`'s
-        // user-config preload, so we don't re-emit them here.
+        // labeled header so the output is still parseable. `--print` is for
+        // piping, so stderr stays empty.
         let multi = candidates.len() > 1;
         for (idx, candidate) in candidates.iter().enumerate() {
             if multi {
@@ -118,11 +117,13 @@ pub fn handle_config_update(yes: bool, print: bool) -> anyhow::Result<()> {
 
 /// Format update preview for display.
 ///
-/// Shows the diff. Deprecation warnings already went to stderr from
-/// `Repository::prewarm`'s user-config preload, so we don't re-emit them
-/// here.
+/// Renders the per-pattern deprecation warnings followed by the diff. The
+/// `wt config update` hint that normally accompanies prewarm-time warnings
+/// is dropped here — the prompt below the preview is the action.
 fn format_update_preview(candidate: &UpdateCandidate) -> String {
     let mut out = String::new();
+
+    out.push_str(&format_deprecation_warnings(&candidate.info));
 
     let label = candidate
         .config_path

--- a/src/main.rs
+++ b/src/main.rs
@@ -1248,9 +1248,15 @@ fn handle_merge_command(args: MergeArgs, yes: bool) -> anyhow::Result<()> {
     })
 }
 
-/// True when the parsed command renders a TUI or stderr-sensitive output
-/// (a picker, statusline-on-prompt) and would be visually broken by config
-/// deprecation warnings landing on stderr above it.
+/// True when the parsed command should silence prewarm-time deprecation
+/// warnings. Two reasons qualify:
+///
+/// - **TUI / stderr-sensitive output** (`select`, `switch` picker mode,
+///   `list statusline`) — warnings on stderr would land above the picker
+///   or shell prompt and visually break it.
+/// - **`config update`** — the handler renders the deprecations and a diff
+///   itself, so the prewarm-time warning + `wt config update` hint is
+///   redundant noise above its own UI.
 ///
 /// Read from `Cli::command` before `Repository::prewarm` so the suppress
 /// latch beats `prewarm_user_config`'s warning-emission path. The handler
@@ -1263,6 +1269,9 @@ fn command_suppresses_warnings(command: Option<&Commands>) -> bool {
         Some(Commands::List(args)) => {
             matches!(args.subcommand, Some(ListSubcommand::Statusline { .. }))
         }
+        Some(Commands::Config {
+            action: ConfigCommand::Update { .. },
+        }) => true,
         _ => false,
     }
 }

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -2841,6 +2841,11 @@ fn test_config_update_print_emits_migrated_without_writing(repo: TestRepo) {
         "config update --print should succeed: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+    assert!(
+        output.stderr.is_empty(),
+        "--print must keep stderr empty for pipe-friendliness, got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
         stdout.contains("{{ repo }}") && !stdout.contains("{{ main_worktree }}"),

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -2822,7 +2822,7 @@ fn test_config_update_print_on_clean_config_is_silent(repo: TestRepo) {
 }
 
 /// `wt config update --print` emits the migrated TOML to stdout without
-/// touching the config file. Warnings still go to stderr.
+/// touching the config file. Stderr stays empty so the output is pipeable.
 #[rstest]
 fn test_config_update_print_emits_migrated_without_writing(repo: TestRepo) {
     let config_path = repo.test_config_path();

--- a/tests/snapshots/integration__integration_tests__config_show__config_update_applies_approved_commands_migration.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_update_applies_approved_commands_migration.snap
@@ -36,13 +36,17 @@ info:
     WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
@@ -51,7 +55,6 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mUser config: [1mapproved-commands[22m under [1m[projects][22m is deprecated in favor of [1mapprovals.toml[22m[39m
-[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a/test-config.toml/current b/test-config.toml/migrated[m
 [107m [0m [1mindex 51f8ab1..a30ca31 100644[m

--- a/tests/snapshots/integration__integration_tests__config_show__config_update_applies_commit_generation_migration.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_update_applies_commit_generation_migration.snap
@@ -36,13 +36,17 @@ info:
     WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
@@ -51,7 +55,6 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33mUser config: [1m[commit-generation][22m is deprecated in favor of [1m[commit.generation][22m[39m
-[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a/test-config.toml/current b/test-config.toml/migrated[m
 [107m [0m [1mindex 40d0385..bc7273c 100644[m

--- a/tests/snapshots/integration__integration_tests__config_show__config_update_applies_template_var_migration.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_update_applies_template_var_migration.snap
@@ -36,13 +36,17 @@ info:
     WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
@@ -53,7 +57,6 @@ exit_code: 0
 [33m▲[39m [33mUser config: template variable [1mrepo_root[22m is deprecated in favor of [1mrepo_path[22m[39m
 [33m▲[39m [33mUser config: template variable [1mworktree[22m is deprecated in favor of [1mworktree_path[22m[39m
 [33m▲[39m [33mUser config: template variable [1mmain_worktree[22m is deprecated in favor of [1mrepo[22m[39m
-[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a/test-config.toml/current b/test-config.toml/migrated[m
 [107m [0m [1mindex 7cc556b..b3535c5 100644[m

--- a/tests/snapshots/integration__integration_tests__config_update_pty__config_update_prompt_accept.snap
+++ b/tests/snapshots/integration__integration_tests__config_update_pty__config_update_prompt_accept.snap
@@ -4,7 +4,6 @@ expression: "&output"
 ---
 [33m▲[39m [33mUser config: template variable [1mrepo_root[22m is deprecated in favor of [1mrepo_path[22m[39m
 [33m▲[39m [33mUser config: template variable [1mmain_worktree[22m is deprecated in favor of [1mrepo[22m[39m
-[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a/test-config.toml/current b/test-config.toml/migrated[m
 [107m [0m [1mindex dee4883..5eef8a6 100644[m

--- a/tests/snapshots/integration__integration_tests__config_update_pty__config_update_prompt_decline.snap
+++ b/tests/snapshots/integration__integration_tests__config_update_pty__config_update_prompt_decline.snap
@@ -4,7 +4,6 @@ expression: "&output"
 ---
 [33m▲[39m [33mUser config: template variable [1mrepo_root[22m is deprecated in favor of [1mrepo_path[22m[39m
 [33m▲[39m [33mUser config: template variable [1mmain_worktree[22m is deprecated in favor of [1mrepo[22m[39m
-[2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [2m○[22m Proposed diff:
 [107m [0m [1mdiff --git a/test-config.toml/current b/test-config.toml/migrated[m
 [107m [0m [1mindex dee4883..5eef8a6 100644[m


### PR DESCRIPTION
## Summary

Every `wt` invocation against a deprecated config emitted a deprecation warning followed by a `to apply updates, run wt config update` hint — silly when the user was already running `wt config update`.

`command_suppresses_warnings` in `src/main.rs` now latches warning suppression for `Config { Update }` before `Repository::prewarm`, same precedent the TUI/picker commands already use. The update handler renders the per-pattern warnings inline alongside its diff, so users still see what's being migrated — only the redundant `wt config update` self-suggestion vanishes.

`--print` is now fully silent on stderr, matching its pipe-friendly intent.

## Test plan

- [x] `cargo run -- hook pre-merge --yes` — 3472 tests pass, lints clean
- [x] Manual: `wt config update` against a deprecated config shows warnings + diff (no hint)
- [x] Manual: `wt config update --print` produces clean stdout, empty stderr
- [x] Manual: `wt list` against a deprecated config still shows warnings + hint (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)