### PR TITLE
feat(config): add parent and name path-traversal template filters

### DIFF
--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -186,12 +186,21 @@ Templates support Jinja2 filters for transforming values:
 | `sanitize_hash` | `{{ branch \| sanitize_hash }}` | Filesystem-safe name with hash suffix for uniqueness |
 | `hash` | `{{ branch \| hash }}` | 3-character base36 digest of the input |
 | `hash_port` | `{{ branch \| hash_port }}` | Hash to port 10000-19999 |
+| `parent` | `{{ repo_path \| parent }}` | Strip the last path component (`/a/b/c` → `/a/b`) |
+| `name` | `{{ repo_path \| name }}` | Keep only the last path component (`/a/b/c` → `c`) |
 
 The `sanitize` filter makes branch names safe for filesystem paths. The `sanitize_db` filter produces database-safe identifiers — lowercase alphanumeric and underscores, no leading digits, with a 3-character hash suffix to avoid collisions and reserved words. The `sanitize_hash` filter produces a filesystem-safe name and appends a 3-character hash suffix when sanitization changed the input, so distinct originals never collide — already-safe names pass through unchanged. The `hash` filter is the bare 3-character base36 digest, useful for composing your own truncate-with-collision-avoidance recipes when an output budget is tight (e.g., Unix socket paths capped at 107 bytes):
 
 ```toml
 # Truncated branch slug + hash: collisions remain disambiguated even when prefixes match
 worktree-path = "/tmp/{{ (branch | sanitize)[:20] }}_{{ branch | sanitize | hash }}"
+```
+
+The `parent` and `name` filters traverse paths. They're useful for bare repos in a hidden directory like `myproject/.git`, where `{{ repo }}` resolves to `.git`:
+
+```toml
+# Place worktrees as siblings of the bare repo, named `<wrapper>.<branch>`
+worktree-path = "{{ repo_path }}/../{{ repo_path | parent | name }}.{{ branch | sanitize }}"
 ```
 
 The `hash_port` filter is useful for running dev servers on unique ports per worktree:

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -177,12 +177,21 @@ Templates support Jinja2 filters for transforming values:
 | `sanitize_hash` | `{{ branch \| sanitize_hash }}` | Filesystem-safe name with hash suffix for uniqueness |
 | `hash` | `{{ branch \| hash }}` | 3-character base36 digest of the input |
 | `hash_port` | `{{ branch \| hash_port }}` | Hash to port 10000-19999 |
+| `parent` | `{{ repo_path \| parent }}` | Strip the last path component (`/a/b/c` → `/a/b`) |
+| `name` | `{{ repo_path \| name }}` | Keep only the last path component (`/a/b/c` → `c`) |
 
 The `sanitize` filter makes branch names safe for filesystem paths. The `sanitize_db` filter produces database-safe identifiers — lowercase alphanumeric and underscores, no leading digits, with a 3-character hash suffix to avoid collisions and reserved words. The `sanitize_hash` filter produces a filesystem-safe name and appends a 3-character hash suffix when sanitization changed the input, so distinct originals never collide — already-safe names pass through unchanged. The `hash` filter is the bare 3-character base36 digest, useful for composing your own truncate-with-collision-avoidance recipes when an output budget is tight (e.g., Unix socket paths capped at 107 bytes):
 
 ```toml
 # Truncated branch slug + hash: collisions remain disambiguated even when prefixes match
 worktree-path = "/tmp/{{ (branch | sanitize)[:20] }}_{{ branch | sanitize | hash }}"
+```
+
+The `parent` and `name` filters traverse paths. They're useful for bare repos in a hidden directory like `myproject/.git`, where `{{ repo }}` resolves to `.git`:
+
+```toml
+# Place worktrees as siblings of the bare repo, named `<wrapper>.<branch>`
+worktree-path = "{{ repo_path }}/../{{ repo_path | parent | name }}.{{ branch | sanitize }}"
 ```
 
 The `hash_port` filter is useful for running dev servers on unique ports per worktree:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1363,12 +1363,21 @@ Templates support Jinja2 filters for transforming values:
 | `sanitize_hash` | `{{ branch \| sanitize_hash }}` | Filesystem-safe name with hash suffix for uniqueness |
 | `hash` | `{{ branch \| hash }}` | 3-character base36 digest of the input |
 | `hash_port` | `{{ branch \| hash_port }}` | Hash to port 10000-19999 |
+| `parent` | `{{ repo_path \| parent }}` | Strip the last path component (`/a/b/c` → `/a/b`) |
+| `name` | `{{ repo_path \| name }}` | Keep only the last path component (`/a/b/c` → `c`) |
 
 The `sanitize` filter makes branch names safe for filesystem paths. The `sanitize_db` filter produces database-safe identifiers — lowercase alphanumeric and underscores, no leading digits, with a 3-character hash suffix to avoid collisions and reserved words. The `sanitize_hash` filter produces a filesystem-safe name and appends a 3-character hash suffix when sanitization changed the input, so distinct originals never collide — already-safe names pass through unchanged. The `hash` filter is the bare 3-character base36 digest, useful for composing your own truncate-with-collision-avoidance recipes when an output budget is tight (e.g., Unix socket paths capped at 107 bytes):
 
 ```toml
 # Truncated branch slug + hash: collisions remain disambiguated even when prefixes match
 worktree-path = "/tmp/{{ (branch | sanitize)[:20] }}_{{ branch | sanitize | hash }}"
+```
+
+The `parent` and `name` filters traverse paths. They're useful for bare repos in a hidden directory like `myproject/.git`, where `{{ repo }}` resolves to `.git`:
+
+```toml
+# Place worktrees as siblings of the bare repo, named `<wrapper>.<branch>`
+worktree-path = "{{ repo_path }}/../{{ repo_path | parent | name }}.{{ branch | sanitize }}"
 ```
 
 The `hash_port` filter is useful for running dev servers on unique ports per worktree:

--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -613,6 +613,18 @@ fn setup_template_env(repo: &Repository) -> Environment<'static> {
         short_hash(value.as_str().unwrap_or_default())
     });
     env.add_filter("hash_port", |value: String| string_to_port(&value));
+    env.add_filter("parent", |value: Value| -> String {
+        std::path::Path::new(value.as_str().unwrap_or_default())
+            .parent()
+            .map(|p| to_posix_path(&p.to_string_lossy()))
+            .unwrap_or_default()
+    });
+    env.add_filter("name", |value: Value| -> String {
+        std::path::Path::new(value.as_str().unwrap_or_default())
+            .file_name()
+            .map(|n| n.to_string_lossy().into_owned())
+            .unwrap_or_default()
+    });
 
     // Register worktree_path_of_branch function for looking up branch worktree paths.
     // Returns raw paths — shell escaping is applied by the formatter at output time.
@@ -751,6 +763,8 @@ pub fn validate_template(
 /// - `sanitize_hash` — Filesystem-safe name with hash suffix so distinct inputs never collide
 /// - `hash` — 3-character base36 hash digest of the input
 /// - `hash_port` — Hash to deterministic port number (10000-19999)
+/// - `parent` — Strip the last path component (e.g., `/a/b/c` → `/a/b`)
+/// - `name` — Keep only the last path component (e.g., `/a/b/c` → `c`)
 ///
 /// # Functions
 /// - `worktree_path_of_branch(branch)` — Look up the filesystem path of a branch's worktree
@@ -1483,6 +1497,59 @@ mod tests {
         assert!((10000..20000).contains(&r2_port));
 
         assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn test_path_parent_and_name_filters() {
+        let test = test_repo();
+        let mut vars = HashMap::new();
+
+        // Bare repo wrapped in a hidden dir: `parent | name` recovers the wrapper name
+        // (the case from #1279 — `{{ repo }}` resolves to `.git`, but the user wants `myrepo`)
+        vars.insert("repo_path", "/projects/myrepo/.git");
+        let result = expand_template(
+            "{{ repo_path | parent | name }}",
+            &vars,
+            false,
+            &test.repo,
+            "test",
+        )
+        .unwrap();
+        assert_eq!(result, "myrepo");
+
+        // Composing into a worktree-path template
+        vars.insert("branch", "feature-auth");
+        let result = expand_template(
+            "{{ repo_path }}/../{{ repo_path | parent | name }}.{{ branch | sanitize }}",
+            &vars,
+            false,
+            &test.repo,
+            "test",
+        )
+        .unwrap();
+        assert_eq!(result, "/projects/myrepo/.git/../myrepo.feature-auth");
+
+        // `parent` strips the last component
+        vars.insert("repo_path", "/a/b/c");
+        let parent =
+            expand_template("{{ repo_path | parent }}", &vars, false, &test.repo, "test").unwrap();
+        assert_eq!(parent, "/a/b");
+
+        // `name` keeps only the last component
+        let name =
+            expand_template("{{ repo_path | name }}", &vars, false, &test.repo, "test").unwrap();
+        assert_eq!(name, "c");
+
+        // No separator: parent is empty, name is the whole input
+        vars.insert("repo_path", "myrepo");
+        assert_eq!(
+            expand_template("{{ repo_path | parent }}", &vars, false, &test.repo, "test").unwrap(),
+            ""
+        );
+        assert_eq!(
+            expand_template("{{ repo_path | name }}", &vars, false, &test.repo, "test").unwrap(),
+            "myrepo"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Two new filters expose `Path::parent` and `Path::file_name` to templates, enabling path traversal that previous filters couldn't express. They unblock the bare-repo-in-hidden-directory layout (`myproject/.git`), where `{{ repo }}` resolves to `.git`: users who want a richer worktree-path naming scheme can now write `{{ repo_path | parent | name }}` to recover `myproject`.

The interactive bare-repo prompt still suggests the simpler `{{ repo_path }}/../{{ branch | sanitize }}` template, since the bare layout already nests worktrees inside a repo-specific wrapper directory — no prefix needed for disambiguation. The filters are there for users with different layout preferences (#1281 discussion).

Thanks to @seakayone for reporting #1279 and @Xilis for raising the `parent_dir` question that prompted this approach.

> _This was written by Claude Code on behalf of @max-sixty_