### PR TITLE
skills(running-tend): catch all CI cargo-install pins in weekly bumps

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -205,9 +205,16 @@ the full test suite (`cargo run -- hook pre-merge --yes`) and verify
 
 ## Weekly Maintenance: CI Pin Bumps
 
-Bump pinned third-party versions in `.github/workflows/ci.yaml` to track upstream:
+Pinned third-party versions in CI are invisible to Dependabot — it follows `Cargo.toml` deps and `uses: foo@vN` action refs, not inline `version:` strings. They drift unless this step bumps them.
 
-- **`hustcer/setup-nu@v3`** — set `version:` to the latest from `gh api repos/nushell/nushell/releases/latest --jq '.tag_name'` and update all three call sites (`test`, `benchmarks`, `code-coverage`).
+For each weekly run, check upstream and bump:
+
+- **`baptiste0928/cargo-install@v3` blocks** in `.github/workflows/ci.yaml` and `.github/actions/{test,claude}-setup/action.yaml` — every `version: "=X.Y.Z"` against `cargo info <crate>`. Today: `cargo-insta`, `cargo-nextest`, `cargo-llvm-cov`, `cargo-msrv`, `cargo-udeps`, `lychee`, `worktrunk`. The `cargo-affected` install has no version pin (follows default branch) — leave it alone. Verify each crate's `rust-version` against the pinned toolchain and note compatibility in the PR body (see PR #1657 for the format).
+- **`hustcer/setup-nu@v3`** `version:` input — latest from `gh api repos/nushell/nushell/releases/latest --jq '.tag_name'`. Three call sites: `ci.yaml` (`benchmarks`, `code-coverage`) and `actions/test-setup/action.yaml`.
+- **`taiki-e/install-action@v2.x`** `tool: zola@<ver>` in the `check-docs` job — latest from `gh api repos/getzola/zola/releases/latest --jq '.tag_name'`.
+- **Runner images** — `ubuntu-24.04`, `macos-15`, `windows-2022`. Keep `windows-2022` pinned (actions/runner-images#12677 — windows-2025 lacks the D: drive).
+
+Discovery shortcut: a recent green CI run on `main` flags cargo-install drift directly via workflow annotations. `gh run view <run-id> --json jobs --jq '.jobs[].databaseId' | xargs -I{} gh api repos/<owner>/<repo>/check-runs/{}/annotations` returns one warning per outdated pin.
 
 ## Weekly Maintenance: Statusline Cache-Check
 

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,8 @@
 name: ci
 
 # Runner versions are pinned to avoid surprise breaking changes from -latest migrations.
-# The tend-renovate workflow checks weekly for updates and creates PRs.
+# The tend-weekly workflow checks for updates and opens bump PRs (see
+# .claude/skills/running-tend/SKILL.md → "Weekly Maintenance: CI Pin Bumps").
 # - windows-2022: Pinned because windows-2025 lacks D: drive (actions/runner-images#12677)
 # - ubuntu-24.04, macos-15: Pinned to current -latest equivalents
 


### PR DESCRIPTION
## Summary

The "Weekly Maintenance: CI Pin Bumps" section in `running-tend` listed only `hustcer/setup-nu`, so the bot stopped touching the seven `baptiste0928/cargo-install` pins after PR #1657 (2026-03-22, the last comprehensive renovation). Recent CI runs (e.g. [run 25335746690](https://github.com/max-sixty/worktrunk/actions/runs/25335746690)) surface the drift via `cargo-install` annotations:

- `worktrunk` 0.35.2 → 0.47.0 (12 minor versions behind)
- `lychee` 0.23.0 → 0.24.2
- `cargo-insta` 1.46.3 → 1.47.2
- `cargo-nextest` 0.9.132 → 0.9.133

(plus three more pins not surfaced as annotations: `cargo-msrv`, `cargo-udeps`, `cargo-llvm-cov`.) Dependabot doesn't help here — it follows `Cargo.toml` deps and `uses: foo@vN` action refs, not inline `version: "=X.Y.Z"` strings inside `with:` blocks.

This PR expands the skill section to enumerate every `cargo-install` pin and its location, the Zola pin in `taiki-e/install-action`, and the runner images. Adds a discovery shortcut so the bot can walk a recent green run's annotations to find new pins it doesn't know about. Also fixes a stale comment in `ci.yaml` that referenced a non-existent `tend-renovate` workflow.

The version bumps themselves are intentionally **not** in this PR — the next `tend-weekly` run should pick them up and open a renovation PR with MSRV verification per #1657's format.

## Test plan

- [ ] Next `tend-weekly` run produces a renovation PR covering the seven cargo-install pins
- [ ] PR body lists MSRV compatibility per #1657's format