### PR TITLE
test(switch): cover GitLab fork remote lookup across ssh/https

### DIFF
--- a/src/commands/worktree/switch.rs
+++ b/src/commands/worktree/switch.rs
@@ -223,9 +223,8 @@ fn resolve_fork_ref(
                     ref_type.display(number)
                 )
             })?;
-            // TODO(gitlab-protocol): We only try the URL based on glab's git_protocol setting.
-            // If the user's remote uses the other protocol (ssh vs https), we'll fail to find it.
-            // Consider trying both ssh and https URLs before erroring.
+            // find_remote_by_url matches by (host, owner, repo); ssh vs https
+            // doesn't matter (test_find_remote_by_url_cross_protocol).
             let remote = repo.find_remote_by_url(&target_url).ok_or_else(|| {
                 anyhow::anyhow!(
                     "No remote found for target project; \

--- a/tests/integration_tests/default_branch.rs
+++ b/tests/integration_tests/default_branch.rs
@@ -487,6 +487,41 @@ fn test_find_remote_for_repo_insteadof_multiple_remotes(repo: TestRepo) {
     );
 }
 
+/// find_remote_by_url matches a remote regardless of which transport
+/// protocol (ssh vs https) the lookup URL uses, because both URLs are parsed
+/// into (host, owner, repo) before matching. This is what lets `wt switch`
+/// resolve a GitLab fork target whether the user's remote is configured with
+/// SSH and glab returns HTTPS, or vice versa.
+#[rstest]
+fn test_find_remote_by_url_cross_protocol(repo: TestRepo) {
+    // Remote configured with HTTPS
+    repo.run_git(&["remote", "remove", "origin"]);
+    repo.run_git(&[
+        "remote",
+        "add",
+        "origin",
+        "https://gitlab.com/group/subgroup/proj.git",
+    ]);
+
+    let git_repo = Repository::at(repo.root_path()).unwrap();
+
+    // Lookup with SSH form should still find it
+    let found = git_repo.find_remote_by_url("git@gitlab.com:group/subgroup/proj.git");
+    assert_eq!(found.as_deref(), Some("origin"));
+
+    // And vice versa: re-configure with SSH, look up with HTTPS
+    repo.run_git(&["remote", "remove", "origin"]);
+    repo.run_git(&[
+        "remote",
+        "add",
+        "origin",
+        "git@gitlab.com:group/subgroup/proj.git",
+    ]);
+    let git_repo = Repository::at(repo.root_path()).unwrap();
+    let found = git_repo.find_remote_by_url("https://gitlab.com/group/subgroup/proj.git");
+    assert_eq!(found.as_deref(), Some("origin"));
+}
+
 /// Test find_remote_by_url: resolves through insteadOf.
 #[rstest]
 fn test_find_remote_by_url_insteadof(repo: TestRepo) {


### PR DESCRIPTION
## Summary

The TODO at `src/commands/worktree/switch.rs:226-236` warned that `find_remote_by_url` could fail when glab's `git_protocol` setting (ssh vs https) disagreed with how the user's remote is configured, and suggested adding a fallback that converts ssh ↔ https and retries.

That concern is obsolete: `find_remote_by_url` parses **both** URLs (the lookup target and each configured remote) into `(host, owner, repo)` via `GitRemoteUrl::parse`, then matches on those components. Transport protocol is abstracted away before matching, so a remote configured with `git@gitlab.com:foo/bar.git` already matches a lookup with `https://gitlab.com/foo/bar.git` and vice versa.

Implementing the literal fallback would have been dead code (the first lookup already succeeds across protocols). Instead:

- Remove the obsolete TODO.
- Add `test_find_remote_by_url_cross_protocol` (no `insteadOf` involved) to lock in the cross-protocol behavior so future readers don't re-introduce the fallback.
- Leave a one-line comment at the call site pointing to the test.

## Test plan

- [x] `cargo run -- hook pre-merge --yes` (3485 tests pass, lints clean)
- [x] New unit test covers HTTPS remote / SSH lookup and SSH remote / HTTPS lookup, with a nested GitLab subgroup path
- [x] Existing `test_find_remote_by_url_insteadof` still passes

> _This was written by Claude Code on behalf of @max-sixty_