### PR TITLE
refactor(list): always emit main/remote JSON fields

### DIFF
--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -172,8 +172,8 @@ Query structured data with `--format=json`:
 | `main_state` | string | Relation to the default branch (see below) |
 | `integration_reason` | string | Why branch is integrated (see below) |
 | `operation_state` | string | `"conflicts"`, `"rebase"`, or `"merge"`; absent when clean |
-| `main` | object | Relationship to the default branch (see below); absent when is_main |
-| `remote` | object | Tracking branch info (see below); absent when no tracking |
+| `main` | object | Relationship to the default branch (see below); always present (inner fields are `null` for the main worktree) |
+| `remote` | object | Tracking branch info (see below); always present (inner fields are `null` when no tracking branch) |
 | `worktree` | object | Worktree metadata (see below) |
 | `is_main` | boolean | Is the main worktree |
 | `is_current` | boolean | Is the current worktree |
@@ -208,20 +208,24 @@ Query structured data with `--format=json`:
 
 ### main object
 
+Always emitted. Inner fields are `null` for the main worktree (which has nothing to compare to itself) and while counts haven't been computed yet.
+
 | Field | Type | Description |
 |-------|------|-------------|
-| `ahead` | number | Commits ahead of the default branch |
-| `behind` | number | Commits behind the default branch |
-| `diff` | object | Lines changed vs the default branch: `{added, deleted}` |
+| `ahead` | number/null | Commits ahead of the default branch |
+| `behind` | number/null | Commits behind the default branch |
+| `diff` | object/null | Lines changed vs the default branch: `{added, deleted}` |
 
 ### remote object
 
+Always emitted. Inner fields are `null` when no tracking branch is configured (and while upstream data hasn't loaded yet).
+
 | Field | Type | Description |
 |-------|------|-------------|
-| `name` | string | Remote name (e.g., `"origin"`) |
-| `branch` | string | Remote branch name |
-| `ahead` | number | Commits ahead of remote |
-| `behind` | number | Commits behind remote |
+| `name` | string/null | Remote name (e.g., `"origin"`) |
+| `branch` | string/null | Remote branch name |
+| `ahead` | number/null | Commits ahead of remote |
+| `behind` | number/null | Commits behind remote |
 
 ### worktree object
 

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -183,8 +183,8 @@ $ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 | `main_state` | string | Relation to the default branch (see below) |
 | `integration_reason` | string | Why branch is integrated (see below) |
 | `operation_state` | string | `"conflicts"`, `"rebase"`, or `"merge"`; absent when clean |
-| `main` | object | Relationship to the default branch (see below); absent when is_main |
-| `remote` | object | Tracking branch info (see below); absent when no tracking |
+| `main` | object | Relationship to the default branch (see below); always present (inner fields are `null` for the main worktree) |
+| `remote` | object | Tracking branch info (see below); always present (inner fields are `null` when no tracking branch) |
 | `worktree` | object | Worktree metadata (see below) |
 | `is_main` | boolean | Is the main worktree |
 | `is_current` | boolean | Is the current worktree |
@@ -219,20 +219,24 @@ $ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 
 ### main object
 
+Always emitted. Inner fields are `null` for the main worktree (which has nothing to compare to itself) and while counts haven't been computed yet.
+
 | Field | Type | Description |
 |-------|------|-------------|
-| `ahead` | number | Commits ahead of the default branch |
-| `behind` | number | Commits behind the default branch |
-| `diff` | object | Lines changed vs the default branch: `{added, deleted}` |
+| `ahead` | number/null | Commits ahead of the default branch |
+| `behind` | number/null | Commits behind the default branch |
+| `diff` | object/null | Lines changed vs the default branch: `{added, deleted}` |
 
 ### remote object
 
+Always emitted. Inner fields are `null` when no tracking branch is configured (and while upstream data hasn't loaded yet).
+
 | Field | Type | Description |
 |-------|------|-------------|
-| `name` | string | Remote name (e.g., `"origin"`) |
-| `branch` | string | Remote branch name |
-| `ahead` | number | Commits ahead of remote |
-| `behind` | number | Commits behind remote |
+| `name` | string/null | Remote name (e.g., `"origin"`) |
+| `branch` | string/null | Remote branch name |
+| `ahead` | number/null | Commits ahead of remote |
+| `behind` | number/null | Commits behind remote |
 
 ### worktree object
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -828,8 +828,8 @@ $ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 | `main_state` | string | Relation to the default branch (see below) |
 | `integration_reason` | string | Why branch is integrated (see below) |
 | `operation_state` | string | `"conflicts"`, `"rebase"`, or `"merge"`; absent when clean |
-| `main` | object | Relationship to the default branch (see below); absent when is_main |
-| `remote` | object | Tracking branch info (see below); absent when no tracking |
+| `main` | object | Relationship to the default branch (see below); always present (inner fields are `null` for the main worktree) |
+| `remote` | object | Tracking branch info (see below); always present (inner fields are `null` when no tracking branch) |
 | `worktree` | object | Worktree metadata (see below) |
 | `is_main` | boolean | Is the main worktree |
 | `is_current` | boolean | Is the current worktree |
@@ -864,20 +864,24 @@ $ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 
 ### main object
 
+Always emitted. Inner fields are `null` for the main worktree (which has nothing to compare to itself) and while counts haven't been computed yet.
+
 | Field | Type | Description |
 |-------|------|-------------|
-| `ahead` | number | Commits ahead of the default branch |
-| `behind` | number | Commits behind the default branch |
-| `diff` | object | Lines changed vs the default branch: `{added, deleted}` |
+| `ahead` | number/null | Commits ahead of the default branch |
+| `behind` | number/null | Commits behind the default branch |
+| `diff` | object/null | Lines changed vs the default branch: `{added, deleted}` |
 
 ### remote object
 
+Always emitted. Inner fields are `null` when no tracking branch is configured (and while upstream data hasn't loaded yet).
+
 | Field | Type | Description |
 |-------|------|-------------|
-| `name` | string | Remote name (e.g., `"origin"`) |
-| `branch` | string | Remote branch name |
-| `ahead` | number | Commits ahead of remote |
-| `behind` | number | Commits behind remote |
+| `name` | string/null | Remote name (e.g., `"origin"`) |
+| `branch` | string/null | Remote branch name |
+| `ahead` | number/null | Commits ahead of remote |
+| `behind` | number/null | Commits behind remote |
 
 ### worktree object
 

--- a/src/commands/list/json_output.rs
+++ b/src/commands/list/json_output.rs
@@ -59,13 +59,15 @@ pub struct JsonItem {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub operation_state: Option<&'static str>,
 
-    /// Relationship to default branch (absent when is_main == true)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub main: Option<JsonMain>,
+    /// Relationship to default branch. Always present; inner fields are
+    /// `null` when the data isn't applicable (the main worktree doesn't
+    /// compare to itself) or hasn't been computed yet.
+    pub main: JsonMain,
 
-    /// Relationship to remote tracking branch (absent when no tracking branch)
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub remote: Option<JsonRemote>,
+    /// Relationship to remote tracking branch. Always present; inner
+    /// fields are `null` when no tracking branch is configured or the
+    /// data hasn't been computed yet.
+    pub remote: JsonRemote,
 
     /// Worktree-specific state
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -165,34 +167,39 @@ impl From<LineDiff> for JsonDiff {
     }
 }
 
-/// Relationship to default branch
+/// Relationship to default branch.
+///
+/// Every field is `null` for the main worktree (which doesn't compare to
+/// itself) and while counts are still being computed.
 #[derive(Debug, Clone, Serialize, JsonSchema)]
 pub struct JsonMain {
     /// Commits ahead of default branch
-    pub ahead: usize,
+    pub ahead: Option<usize>,
 
     /// Commits behind default branch
-    pub behind: usize,
+    pub behind: Option<usize>,
 
     /// Lines added/deleted vs default branch
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub diff: Option<JsonDiff>,
 }
 
-/// Relationship to remote tracking branch
-#[derive(Debug, Clone, Serialize, JsonSchema)]
+/// Relationship to remote tracking branch.
+///
+/// Every field is `null` when no tracking branch is configured and while
+/// upstream data is still being fetched.
+#[derive(Debug, Clone, Default, Serialize, JsonSchema)]
 pub struct JsonRemote {
     /// Remote name (e.g., "origin")
-    pub name: String,
+    pub name: Option<String>,
 
     /// Remote branch name (e.g., "feature-login")
-    pub branch: String,
+    pub branch: Option<String>,
 
     /// Commits ahead of remote
-    pub ahead: usize,
+    pub ahead: Option<usize>,
 
     /// Commits behind remote
-    pub behind: usize,
+    pub behind: Option<usize>,
 }
 
 /// Worktree-specific state
@@ -301,22 +308,31 @@ impl JsonItem {
             .operation_state
             .and_then(|s| s.as_json_str());
 
-        // Main relationship (absent when is_main)
+        // Main relationship — always emit the field; inner values are
+        // `null` for the main worktree (which has nothing to compare to)
+        // and while counts haven't been computed yet.
         let main = if is_main {
-            None
+            JsonMain {
+                ahead: None,
+                behind: None,
+                diff: None,
+            }
         } else {
-            item.counts.map(|counts| JsonMain {
-                ahead: counts.ahead,
-                behind: counts.behind,
+            JsonMain {
+                ahead: item.counts.map(|c| c.ahead),
+                behind: item.counts.map(|c| c.behind),
                 diff: item.branch_diff.map(|bd| JsonDiff::from(bd.diff)),
-            })
+            }
         };
 
-        // Remote relationship
+        // Remote relationship — always emit the field; inner values are
+        // `null` when no tracking branch is configured (or upstream data
+        // hasn't loaded yet).
         let remote = item
             .upstream
             .as_ref()
-            .and_then(|u| upstream_to_json(u, &item.branch));
+            .map(|u| upstream_to_json(u, &item.branch))
+            .unwrap_or_default();
 
         // Worktree state
         let worktree = worktree_data.map(|data| {
@@ -378,18 +394,21 @@ impl JsonItem {
     }
 }
 
-/// Convert UpstreamStatus to JsonRemote
-fn upstream_to_json(upstream: &UpstreamStatus, branch: &Option<String>) -> Option<JsonRemote> {
-    upstream.active().map(|active| {
+/// Convert UpstreamStatus to JsonRemote. When no remote tracking branch is
+/// configured, returns a `JsonRemote` with all fields `None` so the field is
+/// always present in JSON output with consistent shape.
+fn upstream_to_json(upstream: &UpstreamStatus, branch: &Option<String>) -> JsonRemote {
+    match upstream.active() {
         // Use local branch name since UpstreamStatus only stores the remote name,
         // not the full tracking refspec. In most cases these match (e.g., feature -> origin/feature).
-        JsonRemote {
-            name: active.remote.to_string(),
-            branch: branch.clone().unwrap_or_default(),
-            ahead: active.ahead,
-            behind: active.behind,
-        }
-    })
+        Some(active) => JsonRemote {
+            name: Some(active.remote.to_string()),
+            branch: branch.clone(),
+            ahead: Some(active.ahead),
+            behind: Some(active.behind),
+        },
+        None => JsonRemote::default(),
+    }
 }
 
 /// Extract worktree state and reason from WorktreeData
@@ -597,12 +616,10 @@ mod tests {
         };
         let branch = Some("feature".to_string());
         let json = upstream_to_json(&upstream, &branch);
-        assert!(json.is_some());
-        let json = json.unwrap();
-        assert_eq!(json.name, "origin");
-        assert_eq!(json.branch, "feature");
-        assert_eq!(json.ahead, 3);
-        assert_eq!(json.behind, 2);
+        assert_eq!(json.name.as_deref(), Some("origin"));
+        assert_eq!(json.branch.as_deref(), Some("feature"));
+        assert_eq!(json.ahead, Some(3));
+        assert_eq!(json.behind, Some(2));
     }
 
     #[test]
@@ -614,7 +631,12 @@ mod tests {
         };
         let branch = Some("feature".to_string());
         let json = upstream_to_json(&upstream, &branch);
-        assert!(json.is_none());
+        // No tracking branch → all fields null, but the field itself is
+        // still emitted.
+        assert!(json.name.is_none());
+        assert!(json.branch.is_none());
+        assert!(json.ahead.is_none());
+        assert!(json.behind.is_none());
     }
 
     #[test]
@@ -626,9 +648,8 @@ mod tests {
         };
         let branch = None;
         let json = upstream_to_json(&upstream, &branch);
-        assert!(json.is_some());
-        let json = json.unwrap();
-        assert_eq!(json.branch, ""); // Empty string when branch is None
+        assert_eq!(json.name.as_deref(), Some("origin"));
+        assert!(json.branch.is_none()); // null when branch is None
     }
 
     // ============================================================================
@@ -849,8 +870,8 @@ mod tests {
         "#);
 
         let main = serde_json::to_string_pretty(&JsonMain {
-            ahead: 3,
-            behind: 1,
+            ahead: Some(3),
+            behind: Some(1),
             diff: Some(JsonDiff {
                 added: 50,
                 deleted: 20,
@@ -868,11 +889,27 @@ mod tests {
         }
         "#);
 
+        // Main worktree (or pre-load): inner fields are null, outer field
+        // is still emitted.
+        let main_null = serde_json::to_string_pretty(&JsonMain {
+            ahead: None,
+            behind: None,
+            diff: None,
+        })
+        .unwrap();
+        assert_snapshot!(main_null, @r#"
+        {
+          "ahead": null,
+          "behind": null,
+          "diff": null
+        }
+        "#);
+
         let remote = serde_json::to_string_pretty(&JsonRemote {
-            name: "origin".to_string(),
-            branch: "feature".to_string(),
-            ahead: 2,
-            behind: 0,
+            name: Some("origin".to_string()),
+            branch: Some("feature".to_string()),
+            ahead: Some(2),
+            behind: Some(0),
         })
         .unwrap();
         assert_snapshot!(remote, @r#"
@@ -881,6 +918,17 @@ mod tests {
           "branch": "feature",
           "ahead": 2,
           "behind": 0
+        }
+        "#);
+
+        // No tracking branch: all fields null, outer field is still emitted.
+        let remote_null = serde_json::to_string_pretty(&JsonRemote::default()).unwrap();
+        assert_snapshot!(remote_null, @r#"
+        {
+          "name": null,
+          "branch": null,
+          "ahead": null,
+          "behind": null
         }
         "#);
 

--- a/src/commands/list/model/item.rs
+++ b/src/commands/list/model/item.rs
@@ -208,10 +208,10 @@ pub struct ListItem {
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub commit: Option<CommitDetails>,
 
-    // TODO: Evaluate if skipping these fields in JSON when None is correct behavior.
-    // Currently, main worktree omits counts/branch_diff (since it doesn't compare to itself),
-    // but consumers may expect these fields to always be present (even if zero).
-    // Consider: always include with default values vs current "omit when not computed" approach.
+    // `counts` and `branch_diff` carry "not yet computed / not applicable"
+    // (the main worktree has nothing to compare to). The user-visible JSON
+    // shape lives in `JsonItem` (see `json_output.rs`), which always emits
+    // the `main` object with `null` inner values for these cases.
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub counts: Option<AheadBehind>,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
@@ -245,7 +245,9 @@ pub struct ListItem {
     #[serde(skip)]
     pub is_orphan: Option<bool>,
 
-    // TODO: Same concern as counts/branch_diff above - should upstream fields always be present?
+    // Same as `counts`/`branch_diff`: the user-visible JSON shape lives in
+    // `JsonItem`, which always emits the `remote` object with `null` inner
+    // values when no tracking branch is configured.
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub upstream: Option<UpstreamStatus>,
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -19,13 +19,17 @@ info:
     WORKTRUNK_APPROVALS_PATH: /nonexistent/wt/approvals.toml
     WORKTRUNK_CONFIG_PATH: /nonexistent/wt/config.toml
     WORKTRUNK_SYSTEM_CONFIG_PATH: /etc/xdg/worktrunk/config.toml
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
 ---
 success: true
 exit_code: 0
@@ -235,29 +239,29 @@ Query structured data with [2m--format=json[0m:
 
 [1mFields:[0m
 
-       Field           Type                                  Description                               
- ────────────────── ─────────── ────────────────────────────────────────────────────────────────────── 
- [2mbranch[0m             string/null Branch name (null for detached HEAD)                                   
- [2mpath[0m               string      Worktree path (absent for branches without worktrees)                  
- [2mkind[0m               string      [2m"worktree"[0m or [2m"branch"[0m                                                 
- [2mcommit[0m             object      Commit info (see below)                                                
- [2mworking_tree[0m       object      Working tree state (see below)                                         
- [2mmain_state[0m         string      Relation to the default branch (see below)                             
- [2mintegration_reason[0m string      Why branch is integrated (see below)                                   
- [2moperation_state[0m    string      [2m"conflicts"[0m, [2m"rebase"[0m, or [2m"merge"[0m; absent when clean                   
- [2mmain[0m               object      Relationship to the default branch (see below); absent when is_main    
- [2mremote[0m             object      Tracking branch info (see below); absent when no tracking              
- [2mworktree[0m           object      Worktree metadata (see below)                                          
- [2mis_main[0m            boolean     Is the main worktree                                                   
- [2mis_current[0m         boolean     Is the current worktree                                                
- [2mis_previous[0m        boolean     Previous worktree from wt switch                                       
- [2mci[0m                 object      CI status (see below); absent when no CI                               
- [2murl[0m                string      Dev server URL from project config; absent when not configured         
- [2murl_active[0m         boolean     Whether the URL's port is listening; absent when not configured        
- [2msummary[0m            string      LLM-generated branch summary; absent when not configured or no summary 
- [2mstatusline[0m         string      Pre-formatted status with ANSI colors                                  
- [2msymbols[0m            string      Raw status symbols without colors (e.g., [2m"!?↓"[0m)                        
- [2mvars[0m               object      Per-branch variables from [2mwt config state vars[0m (absent when empty)     
+       Field           Type                                                     Description                                                  
+ ────────────────── ─────────── ──────────────────────────────────────────────────────────────────────────────────────────────────────────── 
+ [2mbranch[0m             string/null Branch name (null for detached HEAD)                                                                         
+ [2mpath[0m               string      Worktree path (absent for branches without worktrees)                                                        
+ [2mkind[0m               string      [2m"worktree"[0m or [2m"branch"[0m                                                                                       
+ [2mcommit[0m             object      Commit info (see below)                                                                                      
+ [2mworking_tree[0m       object      Working tree state (see below)                                                                               
+ [2mmain_state[0m         string      Relation to the default branch (see below)                                                                   
+ [2mintegration_reason[0m string      Why branch is integrated (see below)                                                                         
+ [2moperation_state[0m    string      [2m"conflicts"[0m, [2m"rebase"[0m, or [2m"merge"[0m; absent when clean                                                         
+ [2mmain[0m               object      Relationship to the default branch (see below); always present (inner fields are [2mnull[0m for the main worktree) 
+ [2mremote[0m             object      Tracking branch info (see below); always present (inner fields are [2mnull[0m when no tracking branch)             
+ [2mworktree[0m           object      Worktree metadata (see below)                                                                                
+ [2mis_main[0m            boolean     Is the main worktree                                                                                         
+ [2mis_current[0m         boolean     Is the current worktree                                                                                      
+ [2mis_previous[0m        boolean     Previous worktree from wt switch                                                                             
+ [2mci[0m                 object      CI status (see below); absent when no CI                                                                     
+ [2murl[0m                string      Dev server URL from project config; absent when not configured                                               
+ [2murl_active[0m         boolean     Whether the URL's port is listening; absent when not configured                                              
+ [2msummary[0m            string      LLM-generated branch summary; absent when not configured or no summary                                       
+ [2mstatusline[0m         string      Pre-formatted status with ANSI colors                                                                        
+ [2msymbols[0m            string      Raw status symbols without colors (e.g., [2m"!?↓"[0m)                                                              
+ [2mvars[0m               object      Per-branch variables from [2mwt config state vars[0m (absent when empty)                                           
 
 [32mCommit object[0m
 
@@ -281,20 +285,24 @@ Query structured data with [2m--format=json[0m:
 
 [32mmain object[0m
 
- Field   Type                       Description                      
- ────── ────── ───────────────────────────────────────────────────── 
- [2mahead[0m  number Commits ahead of the default branch                   
- [2mbehind[0m number Commits behind the default branch                     
- [2mdiff[0m   object Lines changed vs the default branch: [2m{added, deleted}[0m 
+Always emitted. Inner fields are [2mnull[0m for the main worktree (which has nothing to compare to itself) and while counts haven't been computed yet.
+
+ Field     Type                          Description                      
+ ────── ─────────── ───────────────────────────────────────────────────── 
+ [2mahead[0m  number/null Commits ahead of the default branch                   
+ [2mbehind[0m number/null Commits behind the default branch                     
+ [2mdiff[0m   object/null Lines changed vs the default branch: [2m{added, deleted}[0m 
 
 [32mremote object[0m
 
- Field   Type          Description          
- ────── ────── ──────────────────────────── 
- [2mname[0m   string Remote name (e.g., [2m"origin"[0m) 
- [2mbranch[0m string Remote branch name           
- [2mahead[0m  number Commits ahead of remote      
- [2mbehind[0m number Commits behind remote        
+Always emitted. Inner fields are [2mnull[0m when no tracking branch is configured (and while upstream data hasn't loaded yet).
+
+ Field     Type             Description          
+ ────── ─────────── ──────────────────────────── 
+ [2mname[0m   string/null Remote name (e.g., [2m"origin"[0m) 
+ [2mbranch[0m string/null Remote branch name           
+ [2mahead[0m  number/null Commits ahead of remote      
+ [2mbehind[0m number/null Commits behind remote        
 
 [32mworktree object[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -19,13 +19,17 @@ info:
     WORKTRUNK_APPROVALS_PATH: /nonexistent/wt/approvals.toml
     WORKTRUNK_CONFIG_PATH: /nonexistent/wt/config.toml
     WORKTRUNK_SYSTEM_CONFIG_PATH: /etc/xdg/worktrunk/config.toml
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
 ---
 success: true
 exit_code: 0
@@ -290,9 +294,11 @@ Query structured data with [2m--format=json[0m:
  [2moperation_state[0m    string      [2m"conflicts"[0m, [2m"rebase"[0m, or [2m"merge"[0m; absent when  
                                 clean                                           
  [2mmain[0m               object      Relationship to the default branch (see below); 
-                                absent when is_main                             
- [2mremote[0m             object      Tracking branch info (see below); absent when   
-                                no tracking                                     
+                                always present (inner fields are [2mnull[0m for the   
+                                main worktree)                                  
+ [2mremote[0m             object      Tracking branch info (see below); always        
+                                present (inner fields are [2mnull[0m when no tracking 
+                                branch)                                         
  [2mworktree[0m           object      Worktree metadata (see below)                   
  [2mis_main[0m            boolean     Is the main worktree                            
  [2mis_current[0m         boolean     Is the current worktree                         
@@ -332,20 +338,26 @@ Query structured data with [2m--format=json[0m:
 
 [32mmain object[0m
 
- Field   Type                       Description                      
- ────── ────── ───────────────────────────────────────────────────── 
- [2mahead[0m  number Commits ahead of the default branch                   
- [2mbehind[0m number Commits behind the default branch                     
- [2mdiff[0m   object Lines changed vs the default branch: [2m{added, deleted}[0m 
+Always emitted. Inner fields are [2mnull[0m for the main worktree (which has nothing 
+to compare to itself) and while counts haven't been computed yet.
+
+ Field     Type                          Description                      
+ ────── ─────────── ───────────────────────────────────────────────────── 
+ [2mahead[0m  number/null Commits ahead of the default branch                   
+ [2mbehind[0m number/null Commits behind the default branch                     
+ [2mdiff[0m   object/null Lines changed vs the default branch: [2m{added, deleted}[0m 
 
 [32mremote object[0m
 
- Field   Type          Description          
- ────── ────── ──────────────────────────── 
- [2mname[0m   string Remote name (e.g., [2m"origin"[0m) 
- [2mbranch[0m string Remote branch name           
- [2mahead[0m  number Commits ahead of remote      
- [2mbehind[0m number Commits behind remote        
+Always emitted. Inner fields are [2mnull[0m when no tracking branch is configured (and
+ while upstream data hasn't loaded yet).
+
+ Field     Type             Description          
+ ────── ─────────── ──────────────────────────── 
+ [2mname[0m   string/null Remote name (e.g., [2m"origin"[0m) 
+ [2mbranch[0m string/null Remote branch name           
+ [2mahead[0m  number/null Commits ahead of remote      
+ [2mbehind[0m number/null Commits behind remote        
 
 [32mworktree object[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_json_tree_matches_main_after_merge.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_json_tree_matches_main_after_merge.snap
@@ -11,10 +11,15 @@ info:
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
     GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
     GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -30,13 +35,17 @@ info:
     WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
@@ -65,6 +74,11 @@ exit_code: 0
       }
     },
     "main_state": "is_main",
+    "main": {
+      "ahead": null,
+      "behind": null,
+      "diff": null
+    },
     "remote": {
       "name": "origin",
       "branch": "main",
@@ -104,7 +118,14 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 1
+      "behind": 1,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false
@@ -139,7 +160,14 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 1
+      "behind": 1,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false
@@ -174,7 +202,14 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 1
+      "behind": 1,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false
@@ -210,7 +245,14 @@ exit_code: 0
     "integration_reason": "no-added-changes",
     "main": {
       "ahead": 2,
-      "behind": 0
+      "behind": 0,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false

--- a/tests/snapshots/integration__integration_tests__list__list_json_with_display_fields.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_json_with_display_fields.snap
@@ -11,10 +11,15 @@ info:
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
     GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
     GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -30,13 +35,17 @@ info:
     WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
@@ -65,6 +74,11 @@ exit_code: 0
       }
     },
     "main_state": "is_main",
+    "main": {
+      "ahead": null,
+      "behind": null,
+      "diff": null
+    },
     "remote": {
       "name": "origin",
       "branch": "main",
@@ -104,7 +118,14 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 3
+      "behind": 3,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false
@@ -139,7 +160,14 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 3
+      "behind": 3,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false
@@ -174,7 +202,14 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 3
+      "behind": 3,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false
@@ -209,7 +244,14 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 2,
-      "behind": 2
+      "behind": 2,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false
@@ -245,7 +287,14 @@ exit_code: 0
     "integration_reason": "ancestor",
     "main": {
       "ahead": 0,
-      "behind": 2
+      "behind": 2,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false

--- a/tests/snapshots/integration__integration_tests__list__list_json_with_git_operation.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_json_with_git_operation.snap
@@ -11,10 +11,15 @@ info:
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
     GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
     GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -30,13 +35,17 @@ info:
     WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
@@ -65,6 +74,11 @@ exit_code: 0
       }
     },
     "main_state": "is_main",
+    "main": {
+      "ahead": null,
+      "behind": null,
+      "diff": null
+    },
     "remote": {
       "name": "origin",
       "branch": "main",
@@ -104,7 +118,14 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 2
+      "behind": 2,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false
@@ -139,7 +160,14 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 2
+      "behind": 2,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false
@@ -174,7 +202,14 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 2
+      "behind": 2,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false
@@ -210,7 +245,14 @@ exit_code: 0
     "operation_state": "conflicts",
     "main": {
       "ahead": 1,
-      "behind": 1
+      "behind": 1,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": true

--- a/tests/snapshots/integration__integration_tests__list__list_json_with_metadata.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_json_with_metadata.snap
@@ -11,10 +11,15 @@ info:
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
     GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
     GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -30,13 +35,17 @@ info:
     WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
@@ -65,6 +74,11 @@ exit_code: 0
       }
     },
     "main_state": "is_main",
+    "main": {
+      "ahead": null,
+      "behind": null,
+      "diff": null
+    },
     "remote": {
       "name": "origin",
       "branch": "main",
@@ -104,7 +118,14 @@ exit_code: 0
     "main_state": "ahead",
     "main": {
       "ahead": 1,
-      "behind": 0
+      "behind": 0,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false
@@ -139,7 +160,14 @@ exit_code: 0
     "main_state": "ahead",
     "main": {
       "ahead": 1,
-      "behind": 0
+      "behind": 0,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false
@@ -174,7 +202,14 @@ exit_code: 0
     "main_state": "ahead",
     "main": {
       "ahead": 1,
-      "behind": 0
+      "behind": 0,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false
@@ -209,7 +244,14 @@ exit_code: 0
     "main_state": "empty",
     "main": {
       "ahead": 0,
-      "behind": 0
+      "behind": 0,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false
@@ -244,7 +286,14 @@ exit_code: 0
     "main_state": "empty",
     "main": {
       "ahead": 0,
-      "behind": 0
+      "behind": 0,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "state": "locked",

--- a/tests/snapshots/integration__integration_tests__list__list_json_with_user_marker.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_json_with_user_marker.snap
@@ -11,10 +11,15 @@ info:
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
     GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
     GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -30,13 +35,17 @@ info:
     WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
@@ -65,6 +74,11 @@ exit_code: 0
       }
     },
     "main_state": "is_main",
+    "main": {
+      "ahead": null,
+      "behind": null,
+      "diff": null
+    },
     "remote": {
       "name": "origin",
       "branch": "main",
@@ -104,7 +118,14 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 1
+      "behind": 1,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false
@@ -139,7 +160,14 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 1
+      "behind": 1,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false
@@ -174,7 +202,14 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 1
+      "behind": 1,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false
@@ -209,7 +244,14 @@ exit_code: 0
     "main_state": "empty",
     "main": {
       "ahead": 0,
-      "behind": 0
+      "behind": 0,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false
@@ -244,7 +286,14 @@ exit_code: 0
     "main_state": "empty",
     "main": {
       "ahead": 0,
-      "behind": 0
+      "behind": 0,
+      "diff": null
+    },
+    "remote": {
+      "name": null,
+      "branch": null,
+      "ahead": null,
+      "behind": null
     },
     "worktree": {
       "detached": false


### PR DESCRIPTION
## Summary

`wt list --format=json` now always emits the `main` and `remote` objects;
inner values are explicit `null` when the data is not applicable or
has not been computed yet.

Before:
```json
// main worktree
{ "branch": "main", "main_state": "is_main", ... }
// branch with no upstream
{ "branch": "feature-a", "main": {"ahead": 1, "behind": 0}, ... }
```

After:
```json
// main worktree
{ "branch": "main", "main_state": "is_main",
  "main":   { "ahead": null, "behind": null, "diff": null },
  "remote": { "name": "origin", "branch": "main", "ahead": 0, "behind": 0 }, ... }
// branch with no upstream
{ "branch": "feature-a",
  "main":   { "ahead": 1, "behind": 0, "diff": null },
  "remote": { "name": null, "branch": null, "ahead": null, "behind": null }, ... }
```

## Why

This is a JSON output shape change (new behavior: explicit nulls
instead of omitted fields). The old shape required consumers to handle
both "field absent" and "field present-but-zero", because `main` was
absent for the main worktree and `remote` was absent for branches
without a tracking branch. The new shape gives consumers a single,
stable schema.

CLAUDE.md's "External interfaces to protect" lists config and CLI
flags but not JSON output, so this surface is flexible. The change is
also forward-compatible: existing jq queries like `.remote.ahead > 0`
keep working because `null > 0` is falsy.

## Notes on the model layer

The TODOs at `src/commands/list/model/item.rs:208-250` referenced JSON
shape, but the user-facing JSON travels through `JsonItem` in
`src/commands/list/json_output.rs` (constructed via
`JsonItem::from_list_item`), not through the flatten serialization on
`ListItem`. The fix lives at that real serialization boundary; the
model-side comments now point at it.

## Test plan

- [x] `cargo run -- hook pre-merge --yes` — 3484 tests, 0 failures
- [x] Manual: `wt list --format=json` shows new shape on a real repo
- [x] Snapshots regenerated (5 list_json + 2 help snapshots)
- [x] Docs synced (`docs/content/list.md`, `skills/worktrunk/reference/list.md`)

> _This was written by Claude Code on behalf of @max-sixty_