### PR TITLE
perf(list): skip redundant MergeTreeConflicts on dirty worktrees

### DIFF
--- a/src/commands/list/collect/execution.rs
+++ b/src/commands/list/collect/execution.rs
@@ -375,11 +375,9 @@ pub fn work_items_for_worktree(
         TaskKind::UserMarker,
         TaskKind::WorkingTreeConflicts,
         TaskKind::BranchDiff,
-        // TODO: For dirty worktrees, WorkingTreeConflicts already runs merge-tree
-        // (via stash-create + merge-tree). MergeTreeConflicts duplicates that call
-        // against HEAD. Could skip MergeTreeConflicts when WorkingTreeConflicts
-        // produces a non-None answer, but needs result-ordering changes since both
-        // tasks run in parallel today.
+        // MergeTreeConflictsTask peeks the shared porcelain cache and
+        // skips its own merge-tree call when WorkingTreeConflictsTask
+        // will produce an authoritative dirty-tree result.
         TaskKind::MergeTreeConflicts,
         TaskKind::CiStatus,
         TaskKind::WouldMergeAdd,

--- a/src/commands/list/collect/tasks.rs
+++ b/src/commands/list/collect/tasks.rs
@@ -542,6 +542,19 @@ impl Task for WorkingTreeDiffTask {
 ///
 /// Uses default_branch (local main) for consistency with other Main subcolumn symbols.
 /// Shows whether merging to your local main would conflict.
+///
+/// **Skip-when-dirty optimization:** for worktree items, peek at the shared
+/// porcelain cache. When the worktree is dirty (and has no unmerged
+/// entries), `WorkingTreeConflictsTask` will produce a `Some(Some(_))`
+/// dirty-tree result that is authoritative for tier 3 (`tier_would_conflict`
+/// short-circuits on `Some(Some(_))` and ignores the HEAD probe). Returning
+/// the redundant HEAD probe in that case would mean a second `git merge-tree`
+/// call against HEAD for the same row. Skip with a sentinel `false` —
+/// the value is ignored by the gate, and seeding `Some(false)` keeps the
+/// "loaded" invariant other gates expect.
+///
+/// Branch-only items have no working tree, so they fall through to the
+/// normal HEAD-vs-base merge-tree call.
 pub struct MergeTreeConflictsTask;
 
 impl Task for MergeTreeConflictsTask {
@@ -555,6 +568,21 @@ impl Task for MergeTreeConflictsTask {
                 has_merge_tree_conflicts: false,
             });
         };
+        // Skip-when-dirty: defer to WorkingTreeConflictsTask. Only when the
+        // worktree is dirty without unmerged entries — the unmerged path
+        // returns `Some(None)` from WorkingTreeConflictsTask, which falls
+        // back to this HEAD probe.
+        if let Some(wt) = ctx.branch_ref.working_tree(&ctx.repo) {
+            let porcelain = wt
+                .status_porcelain_cached()
+                .map_err(|e| ctx.error(Self::KIND, &e))?;
+            if !porcelain.trim().is_empty() && !has_unmerged_entries(&porcelain) {
+                return Ok(TaskResult::MergeTreeConflicts {
+                    item_idx: ctx.item_idx,
+                    has_merge_tree_conflicts: false,
+                });
+            }
+        }
         let repo = &ctx.repo;
         // Resolve via snapshot — see `branch_check_sha` for the
         // rebase-in-progress rationale.

--- a/src/commands/list/model/state.rs
+++ b/src/commands/list/model/state.rs
@@ -298,7 +298,8 @@ pub fn tier_orphan(is_orphan: Option<bool>) -> Tier<MainState> {
     }
 }
 
-/// Tier 3: `WouldConflict`. Requires *both* conflict probes to be loaded.
+/// Tier 3: `WouldConflict`. Authoritative source depends on which probe
+/// landed.
 ///
 /// `has_merge_tree_conflicts` is the committed-HEAD probe (from
 /// `MergeTreeConflicts`). `has_working_tree_conflicts` is the dirty-tree
@@ -307,36 +308,49 @@ pub fn tier_orphan(is_orphan: Option<bool>) -> Tier<MainState> {
 /// dirty-tree result, fall back to the HEAD probe), `Some(Some(b))` =
 /// dirty-tree result.
 ///
+/// **The working-tree probe is authoritative when present.** A dirty
+/// worktree's tree includes HEAD's content plus any uncommitted changes,
+/// so its merge-tree result reflects the user's current state better than
+/// the HEAD-only probe. When `has_working_tree_conflicts` is
+/// `Some(Some(b))`, fire/rule out on `b` and ignore the HEAD probe.
+/// `MergeTreeConflictsTask` skips its merge-tree call in that case to
+/// avoid a redundant subprocess (returning a sentinel `false` that this
+/// gate ignores).
+///
 /// Behavior:
-/// - If either probe reports `true`, fire `WouldConflict` — no need to
-///   wait for the other.
-/// - If the HEAD probe is `None`, wait (we can't rule out a conflict
-///   without it).
-/// - If the HEAD probe is `Some(false)` and the working-tree probe is
-///   `None`, wait — the working-tree result could still flip us to
-///   `WouldConflict`.
-/// - If both report "no conflict" (HEAD probe `Some(false)` and
-///   working-tree probe either `Some(None)` or `Some(Some(false))`), rule
-///   out.
+/// - `has_working_tree_conflicts == Some(Some(true))` → fire (dirty
+///   conflict, authoritative).
+/// - `has_working_tree_conflicts == Some(Some(false))` → rule out (dirty
+///   no-conflict, authoritative).
+/// - Otherwise consult the HEAD probe:
+///   - `Some(true)` → fire.
+///   - `Some(false)` and working-tree probe loaded (`Some(None)`, i.e.,
+///     clean or unmerged) → rule out.
+///   - `Some(false)` and working-tree probe still `None` → wait (the
+///     working-tree probe could still flip us).
+///   - `None` → wait.
 pub fn tier_would_conflict(
     has_merge_tree_conflicts: Option<bool>,
     has_working_tree_conflicts: Option<Option<bool>>,
 ) -> Tier<MainState> {
-    // Working-tree probe short-circuit: if it reports a dirty conflict,
-    // fire regardless of the HEAD probe.
-    if let Some(Some(true)) = has_working_tree_conflicts {
-        return Tier::Fired(MainState::WouldConflict);
+    // Working-tree probe is authoritative when it reports a dirty result.
+    match has_working_tree_conflicts {
+        Some(Some(true)) => return Tier::Fired(MainState::WouldConflict),
+        Some(Some(false)) => return Tier::RuledOut,
+        Some(None) | None => {}
     }
-    // HEAD probe short-circuit.
+    // HEAD probe.
     match has_merge_tree_conflicts {
         Some(true) => return Tier::Fired(MainState::WouldConflict),
         Some(false) => {}
         None => return Tier::Wait,
     }
     // HEAD probe says "no conflict" — still need the working-tree probe
-    // to complete (unless it's already reported a non-dirty result).
+    // to load (clean / unmerged path returns `Some(None)`).
     match has_working_tree_conflicts {
-        Some(_) => Tier::RuledOut,
+        Some(None) => Tier::RuledOut,
+        // Some(Some(_)) handled above.
+        Some(Some(_)) => unreachable!(),
         None => Tier::Wait,
     }
 }
@@ -781,11 +795,20 @@ mod tests {
         // Some(None) meaning "working tree is clean, no dirty-tree
         // result") → rule out.
         assert_eq!(tier_would_conflict(Some(false), Some(None)), Tier::RuledOut);
-        // HEAD probe says "no conflict" and WT probe reports a clean
-        // dirty-tree result (Some(Some(false))) → rule out.
+        // WT probe reports a clean dirty-tree result (Some(Some(false)))
+        // → rule out, regardless of HEAD probe.
         assert_eq!(
             tier_would_conflict(Some(false), Some(Some(false))),
             Tier::RuledOut
+        );
+        // WT probe is authoritative: rule out even when HEAD probe was
+        // skipped (None) because MergeTreeConflictsTask deferred to it.
+        assert_eq!(tier_would_conflict(None, Some(Some(false))), Tier::RuledOut);
+        // WT probe is authoritative: fire even when HEAD probe says no
+        // conflict (the dirty tree's merge result wins).
+        assert_eq!(
+            tier_would_conflict(Some(false), Some(Some(true))),
+            Tier::Fired(MainState::WouldConflict)
         );
         // HEAD probe hasn't reported → wait (could flip us to conflict).
         assert_eq!(tier_would_conflict(None, None), Tier::Wait);

--- a/src/commands/list/model/state.rs
+++ b/src/commands/list/model/state.rs
@@ -333,25 +333,17 @@ pub fn tier_would_conflict(
     has_merge_tree_conflicts: Option<bool>,
     has_working_tree_conflicts: Option<Option<bool>>,
 ) -> Tier<MainState> {
-    // Working-tree probe is authoritative when it reports a dirty result.
-    match has_working_tree_conflicts {
-        Some(Some(true)) => return Tier::Fired(MainState::WouldConflict),
-        Some(Some(false)) => return Tier::RuledOut,
-        Some(None) | None => {}
-    }
-    // HEAD probe.
-    match has_merge_tree_conflicts {
-        Some(true) => return Tier::Fired(MainState::WouldConflict),
-        Some(false) => {}
-        None => return Tier::Wait,
-    }
-    // HEAD probe says "no conflict" — still need the working-tree probe
-    // to load (clean / unmerged path returns `Some(None)`).
-    match has_working_tree_conflicts {
-        Some(None) => Tier::RuledOut,
-        // Some(Some(_)) handled above.
-        Some(Some(_)) => unreachable!(),
-        None => Tier::Wait,
+    use Tier::*;
+    match (has_merge_tree_conflicts, has_working_tree_conflicts) {
+        // Working-tree probe is authoritative when it reports a dirty result.
+        (_, Some(Some(true))) => Fired(MainState::WouldConflict),
+        (_, Some(Some(false))) => RuledOut,
+        // Otherwise consult HEAD probe.
+        (Some(true), _) => Fired(MainState::WouldConflict),
+        (Some(false), Some(None)) => RuledOut,
+        // HEAD says "no conflict" but WT hasn't reported — wait.
+        (Some(false), None) => Wait,
+        (None, _) => Wait,
     }
 }
 
@@ -809,6 +801,17 @@ mod tests {
         assert_eq!(
             tier_would_conflict(Some(false), Some(Some(true))),
             Tier::Fired(MainState::WouldConflict)
+        );
+        // WT probe is authoritative: rule out even when HEAD probe says
+        // "would conflict" (uncommitted changes resolve it). This
+        // combination shouldn't arise in production — the
+        // `MergeTreeConflictsTask` skip-when-dirty path keeps HEAD as a
+        // sentinel `false` whenever WT is `Some(Some(_))` — but pin the
+        // contract so a future refactor that reorders the matches
+        // doesn't silently regress.
+        assert_eq!(
+            tier_would_conflict(Some(true), Some(Some(false))),
+            Tier::RuledOut
         );
         // HEAD probe hasn't reported → wait (could flip us to conflict).
         assert_eq!(tier_would_conflict(None, None), Tier::Wait);

--- a/src/commands/list/model/status_symbols.rs
+++ b/src/commands/list/model/status_symbols.rs
@@ -106,8 +106,11 @@
 //! 1. `is_main == true` (metadata) → `^`. Always immediate for the main
 //!    worktree, regardless of any other field.
 //! 2. `is_orphan == Some(true)` → orphan display.
-//! 3. `has_merge_tree_conflicts == Some(true)` or
-//!    `has_working_tree_conflicts == Some(Some(true))` → `✗`.
+//! 3. `has_working_tree_conflicts == Some(Some(true))` (dirty-tree probe
+//!    is authoritative when present) or `has_merge_tree_conflicts == Some(true)`
+//!    → `✗`. When the dirty-tree probe says `Some(Some(false))` it rules
+//!    out tier 3 even if the HEAD probe was skipped (see
+//!    [`tier_would_conflict`](super::state::tier_would_conflict)).
 //! 4. Distinguish Empty / SameCommitDirty / Integrated — requires `counts`,
 //!    `is_clean` (from `working_tree_diff` + `working_tree_status` for
 //!    worktrees; trivially clean for branches), and the integration signals.

--- a/tests/snapshots/integration__integration_tests__list__list_warns_when_commit_details_batch_fails.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_warns_when_commit_details_batch_fails.snap
@@ -10,10 +10,15 @@ info:
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
     GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
     GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -29,13 +34,17 @@ info:
     WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
@@ -56,6 +65,6 @@ exit_code: 0
 [107m [0m [1m(detached)[22m: ahead-behind (git merge-base failed for 05a4a45d0b981dad5c27db59dca482836d59f89e 0000000000000000000000000000000000000001: fatal: Not a valid commit name 0000000000000000000000000000000000000001)
 [107m [0m [1m(detached)[22m: committed-trees-match (fatal: ambiguous argument '0000000000000000000000000000000000000001^{tree}': unknown revision or path not in the working tree.)
 [107m [0m [1m(detached)[22m: working-tree-diff (fatal: bad object HEAD)
-[107m [0m [1m(detached)[22m: merge-tree-conflicts (git merge-base failed for 05a4a45d0b981dad5c27db59dca482836d59f89e 0000000000000000000000000000000000000001: fatal: Not a valid commit name 0000000000000000000000000000000000000001)
+[107m [0m [1m(detached)[22m: merge-tree-conflicts (fatal: bad object HEAD)
 [107m [0m [1m(detached)[22m: working-tree-conflicts (fatal: bad object HEAD)[39m
 [2m↳[22m [2mTo create a diagnostic file, run with [4m-vv[24m[22m


### PR DESCRIPTION
## Summary

- For dirty worktrees, `WorkingTreeConflicts` already runs `git merge-tree` against a tree that includes HEAD + uncommitted changes; `MergeTreeConflicts` was duplicating that work against HEAD alone.
- `MergeTreeConflictsTask` now peeks the shared porcelain cache and short-circuits with a sentinel `false` when the worktree is dirty without unmerged entries.
- `tier_would_conflict` now treats `Some(Some(_))` as authoritative — the dirty-tree probe wins regardless of the HEAD probe. This is the answer most users want for "would this merge conflict?" anyway, since the dirty tree reflects the current working state.

## Implementation notes

- The optimization fires only for worktree items that are dirty AND have no unmerged entries. Branch-only items, clean worktrees, and unmerged-state worktrees still run the HEAD probe normally.
- One snapshot updated: `test_list_warns_when_commit_details_batch_fails` — the corrupt-HEAD repro now surfaces `merge-tree-conflicts (fatal: bad object HEAD)` from the early porcelain check instead of the deeper `merge-base failed` message. Same severity; same diagnostic value.
- Behavior change in one edge case: when HEAD would conflict but uncommitted changes resolve it, the dirty probe now wins (rules out the conflict). The TODO this PR resolves explicitly proposed this trade-off.

## Test plan

- [x] `cargo run -- hook pre-merge --yes` (full lints + 3484 tests) passes
- [x] Manually verified in a synthetic dirty-conflict repo via `RUST_LOG=worktrunk=debug` that exactly one merge-tree subprocess fires per dirty row (the `WorkingTreeConflicts` ephemeral-commit one), down from two
- [x] `test_list_working_tree_conflicts` and `test_list_full_clean_working_tree_uses_commit_conflicts` both pass — `✗` symbol still renders correctly for dirty conflicts; clean conflicts still detected via HEAD probe
- [x] Updated `tier_would_conflict` unit tests cover the new short-circuit and the "skipped HEAD probe" path

> _This was written by Claude Code on behalf of @max-sixty_