### PR TITLE
chore(list): drop obsolete TODOs about always-present JSON fields

### DIFF
--- a/src/commands/list/model/item.rs
+++ b/src/commands/list/model/item.rs
@@ -208,10 +208,6 @@ pub struct ListItem {
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub commit: Option<CommitDetails>,
 
-    // TODO: Evaluate if skipping these fields in JSON when None is correct behavior.
-    // Currently, main worktree omits counts/branch_diff (since it doesn't compare to itself),
-    // but consumers may expect these fields to always be present (even if zero).
-    // Consider: always include with default values vs current "omit when not computed" approach.
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub counts: Option<AheadBehind>,
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
@@ -245,7 +241,6 @@ pub struct ListItem {
     #[serde(skip)]
     pub is_orphan: Option<bool>,
 
-    // TODO: Same concern as counts/branch_diff above - should upstream fields always be present?
     #[serde(flatten, skip_serializing_if = "Option::is_none")]
     pub upstream: Option<UpstreamStatus>,
 


### PR DESCRIPTION
The two TODOs in `ListItem` (`src/commands/list/model/item.rs`) asked whether `wt list --json` should always emit `counts`, `branch_diff`, and `upstream` — even on the main worktree, with null/default values — instead of omitting them.

#2598 explored that direction and was closed: the absent-when-not-applicable convention is more self-documenting and lighter, the original concern ("consumers may expect these always present") never surfaced from a real consumer, and "always present" creates internal inconsistency with the other JSON fields that legitimately use `skip_serializing_if`.

Drop the TODOs so the question doesn't get re-litigated.

> _This was written by Claude Code on behalf of @max-sixty_