### PR TITLE
refactor(step): extract internal helpers in promote/prune

### DIFF
--- a/src/commands/step/promote.rs
+++ b/src/commands/step/promote.rs
@@ -160,6 +160,74 @@ pub enum PromoteResult {
     AlreadyInMain(String),
 }
 
+/// Resolve the branch to promote when no explicit argument was passed.
+///
+/// From the main worktree, restore the default branch. From a linked worktree,
+/// promote the current branch.
+fn resolve_target_branch(branch: Option<&str>, repo: &Repository) -> anyhow::Result<String> {
+    use worktrunk::git::GitError;
+
+    if let Some(b) = branch {
+        return Ok(b.to_string());
+    }
+
+    let current_wt = repo.current_worktree();
+    if !current_wt.is_linked()? {
+        // From main worktree with no args: restore default branch
+        repo.default_branch()
+            .ok_or_else(|| anyhow::anyhow!("Could not determine default branch"))
+    } else {
+        // From other worktree with no args: promote current branch
+        current_wt.branch()?.ok_or_else(|| {
+            GitError::DetachedHead {
+                action: Some("promote".into()),
+            }
+            .into()
+        })
+    }
+}
+
+/// Bail if a leftover staging dir exists from a previous interrupted promote —
+/// it may contain the user's only copy of files from the failed swap.
+/// Checked BEFORE `ensure_clean` so users see the recovery path first.
+fn check_leftover_staging(staging_path: &Path) -> anyhow::Result<()> {
+    if !staging_path.exists() {
+        return Ok(());
+    }
+    let display = staging_path.to_slash_lossy();
+    Err(anyhow::anyhow!(
+        "Files may need manual recovery from: {display}\n\
+         Remove it to retry: rm -rf \"{display}\""
+    )
+    .context("Found leftover staging directory from an interrupted promote"))
+}
+
+/// Print the user-facing announcement for the promote operation: either a
+/// "restoring main worktree" info line or a mismatch warning plus a hint
+/// for restoring canonical locations.
+fn print_promote_announcement(is_restoring: bool, default_branch: Option<&str>) {
+    if is_restoring {
+        // Restoring default branch to main worktree - no warning needed
+        eprintln!("{}", info_message("Restoring main worktree"));
+        return;
+    }
+
+    // Creating mismatch - show warning and how to restore
+    eprintln!(
+        "{}",
+        warning_message("Promoting creates mismatched worktree state (shown as ⚑ in wt list)",)
+    );
+    // Only show restore hint if we know the default branch
+    if let Some(default) = default_branch {
+        eprintln!(
+            "{}",
+            hint_message(cformat!(
+                "Run <underline>wt step promote {default}</> to restore canonical locations"
+            ))
+        );
+    }
+}
+
 /// Exchange branches between two worktrees.
 ///
 /// Steps: detach target → detach main → switch main → switch target.
@@ -233,22 +301,7 @@ pub fn handle_promote(branch: Option<&str>) -> anyhow::Result<PromoteResult> {
         })?;
 
     // Resolve the branch to promote (default_branch computed lazily, only when needed)
-    let target_branch = match branch {
-        Some(b) => b.to_string(),
-        None => {
-            let current_wt = repo.current_worktree();
-            if !current_wt.is_linked()? {
-                // From main worktree with no args: restore default branch
-                repo.default_branch()
-                    .ok_or_else(|| anyhow::anyhow!("Could not determine default branch"))?
-            } else {
-                // From other worktree with no args: promote current branch
-                current_wt.branch()?.ok_or_else(|| GitError::DetachedHead {
-                    action: Some("promote".into()),
-                })?
-            }
-        }
-    };
+    let target_branch = resolve_target_branch(branch, &repo)?;
 
     // Check if target is already in main worktree
     if target_branch == main_branch {
@@ -267,17 +320,9 @@ pub fn handle_promote(branch: Option<&str>) -> anyhow::Result<PromoteResult> {
     let target_path = &target_wt.path;
 
     // Bail early if a leftover staging dir exists from a previous interrupted promote —
-    // it may contain the user's only copy of files from the failed swap.
-    // Check BEFORE ensure_clean so users see the recovery path first.
+    // checked before `ensure_clean` so users see the recovery path first.
     let staging_path = repo.wt_dir().join(PROMOTE_STAGING_DIR);
-    if staging_path.exists() {
-        let display = staging_path.to_slash_lossy();
-        return Err(anyhow::anyhow!(
-            "Files may need manual recovery from: {display}\n\
-             Remove it to retry: rm -rf \"{display}\""
-        )
-        .context("Found leftover staging directory from an interrupted promote"));
-    }
+    check_leftover_staging(&staging_path)?;
 
     // Ensure both worktrees are clean
     let main_working_tree = repo.worktree_at(main_path);
@@ -290,26 +335,7 @@ pub fn handle_promote(branch: Option<&str>) -> anyhow::Result<PromoteResult> {
     // Only lookup default_branch if needed for messaging (already resolved if no-arg from main)
     let default_branch = repo.default_branch();
     let is_restoring = default_branch.as_ref() == Some(&target_branch);
-
-    if is_restoring {
-        // Restoring default branch to main worktree - no warning needed
-        eprintln!("{}", info_message("Restoring main worktree"));
-    } else {
-        // Creating mismatch - show warning and how to restore
-        eprintln!(
-            "{}",
-            warning_message("Promoting creates mismatched worktree state (shown as ⚑ in wt list)",)
-        );
-        // Only show restore hint if we know the default branch
-        if let Some(default) = &default_branch {
-            eprintln!(
-                "{}",
-                hint_message(cformat!(
-                    "Run <underline>wt step promote {default}</> to restore canonical locations"
-                ))
-            );
-        }
-    }
+    print_promote_announcement(is_restoring, default_branch.as_deref());
 
     // Discover gitignored entries BEFORE branch exchange — .gitignore rules belong
     // to the current branch and will change after `git switch`.

--- a/src/commands/step/prune.rs
+++ b/src/commands/step/prune.rs
@@ -1,5 +1,6 @@
 //! `wt step prune` — remove worktrees and branches integrated into the default branch.
 
+use std::collections::HashSet;
 use std::fs;
 use std::path::PathBuf;
 use std::time::Duration;
@@ -10,7 +11,7 @@ use crossbeam_channel as chan;
 use rayon::prelude::*;
 use worktrunk::HookType;
 use worktrunk::config::UserConfig;
-use worktrunk::git::{BranchDeletionMode, Repository, WorktreeInfo};
+use worktrunk::git::{BranchDeletionMode, RefSnapshot, Repository, WorktreeInfo};
 use worktrunk::styling::{eprintln, hint_message, info_message, println, success_message};
 
 use super::super::command_approval::approve_or_skip;
@@ -18,6 +19,351 @@ use super::super::context::CommandEnv;
 use super::super::hooks::HookAnnouncer;
 use super::super::repository_ext::{RemoveTarget, RepositoryCliExt};
 use crate::output::handle_remove_output;
+
+/// A candidate worktree or branch selected for removal.
+struct Candidate {
+    /// Original index in `check_items` (for deterministic output ordering)
+    check_idx: usize,
+    /// Branch name (None for detached HEAD worktrees)
+    branch: Option<String>,
+    /// Display label: branch name or abbreviated commit SHA
+    label: String,
+    /// Worktree path (for Path-based removal of detached worktrees)
+    path: Option<PathBuf>,
+    /// Current worktree, other worktree, or branch-only (no worktree)
+    kind: CandidateKind,
+}
+
+enum CandidateKind {
+    Current,
+    Other,
+    BranchOnly,
+}
+
+impl CandidateKind {
+    fn as_str(&self) -> &'static str {
+        match self {
+            CandidateKind::Current => "current",
+            CandidateKind::Other => "worktree",
+            CandidateKind::BranchOnly => "branch_only",
+        }
+    }
+}
+
+/// Where a candidate originated, used to drive integration checks and dry-run labels.
+enum CheckSource {
+    /// Worktree with directory gone (prunable)
+    Prunable { branch: String },
+    /// Linked worktree
+    Linked { wt_idx: usize },
+    /// Local branch without a worktree entry
+    Orphan,
+}
+
+struct CheckItem {
+    integration_ref: String,
+    source: CheckSource,
+}
+
+/// Per-candidate context displayed only in dry-run output.
+struct DryRunInfo {
+    reason_desc: String,
+    effective_target: String,
+    suffix: &'static str,
+}
+
+/// Build a human-readable count like "3 worktrees & branches".
+///
+/// Worktree + branch is the default pair (matching progress messages'
+/// "worktree & branch" pattern). Unpaired items listed separately.
+fn prune_summary(candidates: &[Candidate]) -> String {
+    let mut worktree_with_branch = 0usize;
+    let mut detached_worktree = 0usize;
+    let mut branch_only = 0usize;
+    for c in candidates {
+        match (&c.kind, &c.branch) {
+            (CandidateKind::BranchOnly, _) => branch_only += 1,
+            (CandidateKind::Current | CandidateKind::Other, Some(_)) => {
+                worktree_with_branch += 1;
+            }
+            (CandidateKind::Current | CandidateKind::Other, None) => {
+                detached_worktree += 1;
+            }
+        }
+    }
+    let mut parts = Vec::new();
+    if worktree_with_branch > 0 {
+        let noun = if worktree_with_branch == 1 {
+            "worktree & branch"
+        } else {
+            "worktrees & branches"
+        };
+        parts.push(format!("{worktree_with_branch} {noun}"));
+    }
+    if detached_worktree > 0 {
+        let noun = if detached_worktree == 1 {
+            "worktree"
+        } else {
+            "worktrees"
+        };
+        parts.push(format!("{detached_worktree} {noun}"));
+    }
+    if branch_only > 0 {
+        let noun = if branch_only == 1 {
+            "branch"
+        } else {
+            "branches"
+        };
+        parts.push(format!("{branch_only} {noun}"));
+    }
+    parts.join(", ")
+}
+
+/// Try to remove a candidate immediately. Returns Ok(true) if removed,
+/// Ok(false) if skipped (preparation error), Err on execution error.
+fn try_remove(
+    candidate: &Candidate,
+    repo: &Repository,
+    config: &UserConfig,
+    foreground: bool,
+    run_hooks: bool,
+    worktrees: &[WorktreeInfo],
+    snapshot: &RefSnapshot,
+) -> anyhow::Result<bool> {
+    let target = match candidate.kind {
+        CandidateKind::Current => RemoveTarget::Current,
+        CandidateKind::BranchOnly => RemoveTarget::Branch(
+            candidate
+                .branch
+                .as_ref()
+                .context("BranchOnly candidate missing branch")?,
+        ),
+        CandidateKind::Other => match &candidate.branch {
+            Some(branch) => RemoveTarget::Branch(branch),
+            None => RemoveTarget::Path(
+                candidate
+                    .path
+                    .as_ref()
+                    .context("detached candidate missing path")?,
+            ),
+        },
+    };
+    let plan = match repo.prepare_worktree_removal(
+        target,
+        BranchDeletionMode::SafeDelete,
+        false,
+        config,
+        None,
+        Some(worktrees),
+        Some(snapshot),
+    ) {
+        Ok(plan) => plan,
+        Err(_) => {
+            // prepare_worktree_removal is the gate: if the worktree can't
+            // be removed (dirty, locked, etc.), it's simply not selected.
+            return Ok(false);
+        }
+    };
+    let mut announcer = HookAnnouncer::new(repo, config, true);
+    handle_remove_output(&plan, foreground, run_hooks, true, &mut announcer)?;
+    announcer.flush()?;
+    Ok(true)
+}
+
+/// Walk the worktree list and the local branch list to build the set of
+/// candidates whose integration status needs checking.
+///
+/// Returns the items in a deterministic order: worktree entries first
+/// (preserving `worktrees` order), then orphan branches.
+fn gather_check_items(
+    repo: &Repository,
+    worktrees: &[WorktreeInfo],
+    default_branch: Option<&str>,
+) -> anyhow::Result<Vec<CheckItem>> {
+    let mut check_items: Vec<CheckItem> = Vec::new();
+    // Track branches seen via worktree entries so we don't double-count
+    // in the orphan branch scan below.
+    let mut seen_branches: HashSet<String> = HashSet::new();
+
+    for (idx, wt) in worktrees.iter().enumerate() {
+        if let Some(branch) = &wt.branch {
+            seen_branches.insert(branch.clone());
+        }
+
+        if wt.locked.is_some() {
+            continue;
+        }
+
+        if let Some(branch) = &wt.branch
+            && default_branch == Some(branch.as_str())
+        {
+            continue;
+        }
+
+        if wt.is_prunable() {
+            if let Some(branch) = &wt.branch {
+                check_items.push(CheckItem {
+                    integration_ref: branch.clone(),
+                    source: CheckSource::Prunable {
+                        branch: branch.clone(),
+                    },
+                });
+            }
+            continue;
+        }
+
+        // Skip main worktree (non-linked); in bare repos all are linked,
+        // so the default-branch check above is the primary guard.
+        let wt_tree = repo.worktree_at(&wt.path);
+        if !wt_tree
+            .is_linked()
+            .context("checking whether worktree is linked")?
+        {
+            continue;
+        }
+
+        let integration_ref = match &wt.branch {
+            Some(b) if !wt.detached => b.clone(),
+            _ => wt.head.clone(),
+        };
+
+        check_items.push(CheckItem {
+            integration_ref,
+            source: CheckSource::Linked { wt_idx: idx },
+        });
+    }
+
+    for branch in repo.all_branches().context("listing branches")? {
+        if seen_branches.contains(&branch) {
+            continue;
+        }
+        if default_branch == Some(branch.as_str()) {
+            continue;
+        }
+        check_items.push(CheckItem {
+            integration_ref: branch,
+            source: CheckSource::Orphan,
+        });
+    }
+
+    Ok(check_items)
+}
+
+/// Resolve the age of a linked worktree from filesystem metadata.
+///
+/// Tries `git_dir.created()` first; on filesystems that don't track creation
+/// time (e.g. older ext4) falls back to the `commondir` mtime, which git
+/// touches when the worktree is first created.
+fn worktree_age(
+    repo: &Repository,
+    wt: &WorktreeInfo,
+    now_secs: u64,
+) -> anyhow::Result<Option<Duration>> {
+    let wt_tree = repo.worktree_at(&wt.path);
+    let git_dir = wt_tree.git_dir().context("resolving worktree git dir")?;
+    let metadata = fs::metadata(&git_dir).context("Failed to read worktree git dir")?;
+    let created = metadata
+        .created()
+        .or_else(|_| fs::metadata(git_dir.join("commondir")).and_then(|m| m.modified()));
+
+    let Ok(created) = created else {
+        return Ok(None);
+    };
+    let Ok(created_epoch) = created.duration_since(std::time::UNIX_EPOCH) else {
+        return Ok(None);
+    };
+    Ok(Some(Duration::from_secs(
+        now_secs.saturating_sub(created_epoch.as_secs()),
+    )))
+}
+
+/// Resolve the age of an orphan branch via its reflog creation timestamp.
+///
+/// Returns `None` if the reflog is missing or unparsable — callers treat
+/// "unknown age" as "old enough", matching the previous inline behavior.
+fn orphan_branch_age(repo: &Repository, branch: &str, now_secs: u64) -> Option<Duration> {
+    let ref_name = format!("refs/heads/{branch}");
+    let stdout = repo
+        .run_command(&["reflog", "show", "--format=%ct", &ref_name])
+        .ok()?;
+    let created_epoch = stdout
+        .trim()
+        .lines()
+        .last()
+        .and_then(|s| s.parse::<u64>().ok())?;
+    Some(Duration::from_secs(now_secs.saturating_sub(created_epoch)))
+}
+
+/// Render dry-run output (text or JSON) and the `Skipped (younger than ...)`
+/// trailer. Returns once printing is complete; the caller exits early.
+fn render_dry_run(
+    mut dry_run_info: Vec<(Candidate, DryRunInfo)>,
+    mut skipped_young: Vec<String>,
+    min_age: &str,
+    format: crate::cli::SwitchFormat,
+) -> anyhow::Result<()> {
+    // Sort by original check order for deterministic output regardless of
+    // channel completion order.
+    dry_run_info.sort_by_key(|(c, _)| c.check_idx);
+
+    if format == crate::cli::SwitchFormat::Json {
+        let items: Vec<serde_json::Value> = dry_run_info
+            .iter()
+            .map(|(c, info)| {
+                serde_json::json!({
+                    "branch": c.branch,
+                    "path": c.path,
+                    "kind": c.kind.as_str(),
+                    "reason": info.reason_desc,
+                    "target": info.effective_target,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&items)?);
+        return Ok(());
+    }
+
+    let mut dry_candidates = Vec::new();
+    for (candidate, info) in dry_run_info {
+        eprintln!(
+            "{}",
+            info_message(cformat!(
+                "<bold>{}</>{} — {} {}",
+                candidate.label,
+                info.suffix,
+                info.reason_desc,
+                info.effective_target
+            ))
+        );
+        dry_candidates.push(candidate);
+    }
+
+    // Report skipped worktrees (after candidates, before summary).
+    // Sort for deterministic output regardless of channel completion order.
+    skipped_young.sort();
+    if !skipped_young.is_empty() {
+        let names = skipped_young.join(", ");
+        eprintln!(
+            "{}",
+            info_message(format!("Skipped {names} (younger than {min_age})"))
+        );
+    }
+
+    if dry_candidates.is_empty() {
+        if skipped_young.is_empty() {
+            eprintln!("{}", info_message("No merged worktrees to remove"));
+        }
+        return Ok(());
+    }
+    eprintln!(
+        "{}",
+        hint_message(format!(
+            "{} would be removed (dry run)",
+            prune_summary(&dry_candidates)
+        ))
+    );
+    Ok(())
+}
 
 /// Remove worktrees and branches integrated into the default branch.
 ///
@@ -61,82 +407,6 @@ pub fn step_prune(
 
     let default_branch = repo.default_branch();
 
-    // Gather candidates: integrated worktrees + integrated branch-only refs
-    struct Candidate {
-        /// Original index in check_items (for deterministic output ordering)
-        check_idx: usize,
-        /// Branch name (None for detached HEAD worktrees)
-        branch: Option<String>,
-        /// Display label: branch name or abbreviated commit SHA
-        label: String,
-        /// Worktree path (for Path-based removal of detached worktrees)
-        path: Option<PathBuf>,
-        /// Current worktree, other worktree, or branch-only (no worktree)
-        kind: CandidateKind,
-    }
-    enum CandidateKind {
-        Current,
-        Other,
-        BranchOnly,
-    }
-
-    impl CandidateKind {
-        fn as_str(&self) -> &'static str {
-            match self {
-                CandidateKind::Current => "current",
-                CandidateKind::Other => "worktree",
-                CandidateKind::BranchOnly => "branch_only",
-            }
-        }
-    }
-
-    /// Build a human-readable count like "3 worktrees & branches".
-    ///
-    /// Worktree + branch is the default pair (matching progress messages'
-    /// "worktree & branch" pattern). Unpaired items listed separately.
-    fn prune_summary(candidates: &[Candidate]) -> String {
-        let mut worktree_with_branch = 0usize;
-        let mut detached_worktree = 0usize;
-        let mut branch_only = 0usize;
-        for c in candidates {
-            match (&c.kind, &c.branch) {
-                (CandidateKind::BranchOnly, _) => branch_only += 1,
-                (CandidateKind::Current | CandidateKind::Other, Some(_)) => {
-                    worktree_with_branch += 1;
-                }
-                (CandidateKind::Current | CandidateKind::Other, None) => {
-                    detached_worktree += 1;
-                }
-            }
-        }
-        let mut parts = Vec::new();
-        if worktree_with_branch > 0 {
-            let noun = if worktree_with_branch == 1 {
-                "worktree & branch"
-            } else {
-                "worktrees & branches"
-            };
-            parts.push(format!("{worktree_with_branch} {noun}"));
-        }
-        if detached_worktree > 0 {
-            let noun = if detached_worktree == 1 {
-                "worktree"
-            } else {
-                "worktrees"
-            };
-            parts.push(format!("{detached_worktree} {noun}"));
-        }
-        if branch_only > 0 {
-            let noun = if branch_only == 1 {
-                "branch"
-            } else {
-                "branches"
-            };
-            parts.push(format!("{branch_only} {noun}"));
-        }
-        parts.join(", ")
-    }
-
     // For non-dry-run, approve hooks upfront so we can remove inline.
     let run_hooks = if dry_run {
         false // unused in dry-run path
@@ -157,137 +427,8 @@ pub fn step_prune(
     let mut removed: Vec<Candidate> = Vec::new();
     let mut deferred_current: Option<Candidate> = None;
     let mut skipped_young: Vec<String> = Vec::new();
-    // Track branches seen via worktree entries so we don't double-count
-    // in the orphan branch scan below.
-    let mut seen_branches: std::collections::HashSet<String> = std::collections::HashSet::new();
 
-    /// Try to remove a candidate immediately. Returns Ok(true) if removed,
-    /// Ok(false) if skipped (preparation error), Err on execution error.
-    fn try_remove(
-        candidate: &Candidate,
-        repo: &Repository,
-        config: &UserConfig,
-        foreground: bool,
-        run_hooks: bool,
-        worktrees: &[WorktreeInfo],
-        snapshot: &worktrunk::git::RefSnapshot,
-    ) -> anyhow::Result<bool> {
-        let target = match candidate.kind {
-            CandidateKind::Current => RemoveTarget::Current,
-            CandidateKind::BranchOnly => RemoveTarget::Branch(
-                candidate
-                    .branch
-                    .as_ref()
-                    .context("BranchOnly candidate missing branch")?,
-            ),
-            CandidateKind::Other => match &candidate.branch {
-                Some(branch) => RemoveTarget::Branch(branch),
-                None => RemoveTarget::Path(
-                    candidate
-                        .path
-                        .as_ref()
-                        .context("detached candidate missing path")?,
-                ),
-            },
-        };
-        let plan = match repo.prepare_worktree_removal(
-            target,
-            BranchDeletionMode::SafeDelete,
-            false,
-            config,
-            None,
-            Some(worktrees),
-            Some(snapshot),
-        ) {
-            Ok(plan) => plan,
-            Err(_) => {
-                // prepare_worktree_removal is the gate: if the worktree can't
-                // be removed (dirty, locked, etc.), it's simply not selected.
-                return Ok(false);
-            }
-        };
-        let mut announcer = HookAnnouncer::new(repo, config, true);
-        handle_remove_output(&plan, foreground, run_hooks, true, &mut announcer)?;
-        announcer.flush()?;
-        Ok(true)
-    }
-
-    enum CheckSource {
-        /// Worktree with directory gone (prunable)
-        Prunable { branch: String },
-        /// Linked worktree
-        Linked { wt_idx: usize },
-        /// Local branch without a worktree entry
-        Orphan,
-    }
-
-    struct CheckItem {
-        integration_ref: String,
-        source: CheckSource,
-    }
-
-    let mut check_items: Vec<CheckItem> = Vec::new();
-
-    for (idx, wt) in worktrees.iter().enumerate() {
-        if let Some(branch) = &wt.branch {
-            seen_branches.insert(branch.clone());
-        }
-
-        if wt.locked.is_some() {
-            continue;
-        }
-
-        if let Some(branch) = &wt.branch
-            && default_branch.as_deref() == Some(branch.as_str())
-        {
-            continue;
-        }
-
-        if wt.is_prunable() {
-            if let Some(branch) = &wt.branch {
-                check_items.push(CheckItem {
-                    integration_ref: branch.clone(),
-                    source: CheckSource::Prunable {
-                        branch: branch.clone(),
-                    },
-                });
-            }
-            continue;
-        }
-
-        // Skip main worktree (non-linked); in bare repos all are linked,
-        // so the default-branch check above is the primary guard.
-        let wt_tree = repo.worktree_at(&wt.path);
-        if !wt_tree
-            .is_linked()
-            .context("checking whether worktree is linked")?
-        {
-            continue;
-        }
-
-        let integration_ref = match &wt.branch {
-            Some(b) if !wt.detached => b.clone(),
-            _ => wt.head.clone(),
-        };
-
-        check_items.push(CheckItem {
-            integration_ref,
-            source: CheckSource::Linked { wt_idx: idx },
-        });
-    }
-
-    for branch in repo.all_branches().context("listing branches")? {
-        if seen_branches.contains(&branch) {
-            continue;
-        }
-        if default_branch.as_deref() == Some(branch.as_str()) {
-            continue;
-        }
-        check_items.push(CheckItem {
-            integration_ref: branch,
-            source: CheckSource::Orphan,
-        });
-    }
+    let check_items = gather_check_items(&repo, worktrees, default_branch.as_deref())?;
 
     // Parallel integration checks with inline removals.
     //
@@ -325,11 +466,6 @@ pub fn step_prune(
     });
 
     // Collect integration context alongside candidates for dry-run display.
-    struct DryRunInfo {
-        reason_desc: String,
-        effective_target: String,
-        suffix: &'static str,
-    }
     let mut dry_run_info: Vec<(Candidate, DryRunInfo)> = Vec::new();
 
     // Process results as they arrive from the channel.
@@ -352,28 +488,18 @@ pub fn step_prune(
 
             // Skip recently-created worktrees that look "merged" because
             // they were just created from the default branch
-            if min_age_duration > Duration::ZERO {
-                let wt_tree = repo.worktree_at(&wt.path);
-                let git_dir = wt_tree.git_dir().context("resolving worktree git dir")?;
-                let metadata = fs::metadata(&git_dir).context("Failed to read worktree git dir")?;
-                let created = metadata.created().or_else(|_| {
-                    fs::metadata(git_dir.join("commondir")).and_then(|m| m.modified())
-                });
-                if let Ok(created) = created
-                    && let Ok(created_epoch) = created.duration_since(std::time::UNIX_EPOCH)
-                {
-                    let age = Duration::from_secs(now_secs.saturating_sub(created_epoch.as_secs()));
-                    if age < min_age_duration {
-                        if !dry_run {
-                            eprintln!(
-                                "{}",
-                                info_message(format!("Skipped {label} (younger than {min_age})"))
-                            );
-                        }
-                        skipped_young.push(label);
-                        continue;
-                    }
+            if min_age_duration > Duration::ZERO
+                && let Some(age) = worktree_age(&repo, wt, now_secs)?
+                && age < min_age_duration
+            {
+                if !dry_run {
+                    eprintln!(
+                        "{}",
+                        info_message(format!("Skipped {label} (younger than {min_age})"))
+                    );
                 }
+                skipped_young.push(label);
+                continue;
             }
 
             let wt_path = dunce::canonicalize(&wt.path).unwrap_or(wt.path.clone());
@@ -422,27 +548,19 @@ pub fn step_prune(
         };
 
         // Age check for orphan branches via reflog creation timestamp
-        if matches!(&item.source, CheckSource::Orphan) && min_age_duration > Duration::ZERO {
-            let ref_name = format!("refs/heads/{branch}");
-            if let Ok(stdout) = repo.run_command(&["reflog", "show", "--format=%ct", &ref_name])
-                && let Some(created_epoch) = stdout
-                    .trim()
-                    .lines()
-                    .last()
-                    .and_then(|s| s.parse::<u64>().ok())
-            {
-                let age = Duration::from_secs(now_secs.saturating_sub(created_epoch));
-                if age < min_age_duration {
-                    if !dry_run {
-                        eprintln!(
-                            "{}",
-                            info_message(format!("Skipped {branch} (younger than {min_age})"))
-                        );
-                    }
-                    skipped_young.push(branch.clone());
-                    continue;
-                }
+        if matches!(&item.source, CheckSource::Orphan)
+            && min_age_duration > Duration::ZERO
+            && let Some(age) = orphan_branch_age(&repo, branch, now_secs)
+            && age < min_age_duration
+        {
+            if !dry_run {
+                eprintln!(
+                    "{}",
+                    info_message(format!("Skipped {branch} (younger than {min_age})"))
+                );
             }
+            skipped_young.push(branch.clone());
+            continue;
         }
 
         let candidate = Candidate {
@@ -475,67 +593,7 @@ pub fn step_prune(
     }
 
     if dry_run {
-        // Sort by original check order for deterministic output regardless of
-        // channel completion order.
-        dry_run_info.sort_by_key(|(c, _)| c.check_idx);
-
-        if format == crate::cli::SwitchFormat::Json {
-            let items: Vec<serde_json::Value> = dry_run_info
-                .iter()
-                .map(|(c, info)| {
-                    serde_json::json!({
-                        "branch": c.branch,
-                        "path": c.path,
-                        "kind": c.kind.as_str(),
-                        "reason": info.reason_desc,
-                        "target": info.effective_target,
-                    })
-                })
-                .collect();
-            println!("{}", serde_json::to_string_pretty(&items)?);
-            return Ok(());
-        }
-
-        let mut dry_candidates = Vec::new();
-        for (candidate, info) in dry_run_info {
-            eprintln!(
-                "{}",
-                info_message(cformat!(
-                    "<bold>{}</>{} — {} {}",
-                    candidate.label,
-                    info.suffix,
-                    info.reason_desc,
-                    info.effective_target
-                ))
-            );
-            dry_candidates.push(candidate);
-        }
-
-        // Report skipped worktrees (after candidates, before summary).
-        // Sort for deterministic output regardless of channel completion order.
-        skipped_young.sort();
-        if !skipped_young.is_empty() {
-            let names = skipped_young.join(", ");
-            eprintln!(
-                "{}",
-                info_message(format!("Skipped {names} (younger than {min_age})"))
-            );
-        }
-
-        if dry_candidates.is_empty() {
-            if skipped_young.is_empty() {
-                eprintln!("{}", info_message("No merged worktrees to remove"));
-            }
-            return Ok(());
-        }
-        eprintln!(
-            "{}",
-            hint_message(format!(
-                "{} would be removed (dry run)",
-                prune_summary(&dry_candidates)
-            ))
-        );
-        return Ok(());
+        return render_dry_run(dry_run_info, skipped_young, min_age, format);
     }
 
     // Remove deferred current worktree last (cd-to-primary happens here)


### PR DESCRIPTION
## Summary

Both `promote.rs` and `prune.rs` were left as single-file modules by the recent step_commands split (#2601). Each had natural seams that were keeping the orchestrators larger than they needed to be. Public API unchanged.

### `src/commands/step/promote.rs`
Extracted three setup-phase helpers from `handle_promote`:
- `resolve_target_branch` — resolves the optional branch arg (default branch from main worktree, current branch from a linked worktree).
- `check_leftover_staging` — guards against the `staging/promote/` recovery directory before any clean check (was inline with manual error construction).
- `print_promote_announcement` — emits the restoring vs. mismatch warning + restore hint.

### `src/commands/step/prune.rs`
Lifted all inline definitions out of `step_prune` (`Candidate`, `CandidateKind`, `CheckItem`, `CheckSource`, `DryRunInfo`, `prune_summary`, `try_remove`) to module level. Added three phase helpers:
- `gather_check_items` — walks worktrees and local branches into the check list (handles `seen_branches` dedup and the linked/prunable/orphan classification).
- `worktree_age` / `orphan_branch_age` — replace the two inline age probes (filesystem mtime with commondir fallback, and reflog `%ct`) with `Option<Duration>` returns. The caller pattern collapses to `if min_age > 0 && let Some(age) = ... && age < min_age`.
- `render_dry_run` — prints the dry-run text/JSON summary and the `Skipped (younger than ...)` trailer.

### Line shape

| Function | Before | After |
|---|---|---|
| `step_prune` body | 553 | 265 |
| `handle_promote` body | 178 | 136 |
| `promote.rs` total | 458 | 484 |
| `prune.rs` total | 581 | 639 |

Total module growth (~84 lines) is the doc comments on the new helpers and signature lines that get repeated when content is hoisted; the orchestrators themselves now read as a sequence of named phases.

## Test plan

- [x] `cargo run -- hook pre-merge --yes` passes (3492 tests, all lints, doctests, clippy).
- [x] `cargo test --test integration -- prune` (37 tests) passes unchanged.
- [x] `cargo test --test integration -- promote` (25 tests) passes unchanged.
- [x] Behavior preserved: the two age helpers preserve the original "unknown age = treat as old enough" semantics; `worktree_age` propagates the `fs::metadata` errors via `?` exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)