### PR TITLE
test(config): cover .exe alias hints in config show

### DIFF
--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -843,6 +843,60 @@ fn test_config_show_nushell_outdated_wrapper(mut repo: TestRepo, temp_home: Temp
     });
 }
 
+/// Cover the `.exe` alias hint inside `render_already_configured`. The hint
+/// fires when at least one matched integration line in the rc file uses
+/// `wt.exe` — common on Git Bash where the binary is `wt.exe` but POSIX
+/// aliases must still target `wt`. We pair the canonical line (so the row
+/// hits `AlreadyExists`) with an extra `wt.exe` line in the same file so
+/// `detection.matched_lines` carries the `.exe` content.
+#[rstest]
+fn test_config_show_bash_matched_exe_emits_alias_hint(mut repo: TestRepo, temp_home: TempDir) {
+    repo.setup_mock_ci_tools_unauthenticated();
+
+    let global_config_dir = temp_home.path().join(".config").join("worktrunk");
+    fs::create_dir_all(&global_config_dir).unwrap();
+    fs::write(global_config_dir.join("config.toml"), "").unwrap();
+
+    fs::write(
+        temp_home.path().join(".bashrc"),
+        r#"# Canonical line so the row reports AlreadyExists.
+if command -v wt >/dev/null 2>&1; then eval "$(command wt config shell init bash)"; fi
+# Stale wt.exe form left over from a Windows install — scan_for_detection_details
+# still recognizes it as a matched integration line.
+eval "$(wt.exe config shell init bash)"
+"#,
+    )
+    .unwrap();
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        repo.configure_mock_commands(&mut cmd);
+        cmd.arg("config").arg("show").current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+        set_xdg_config_path(&mut cmd, temp_home.path());
+        cmd.env("WORKTRUNK_TEST_COMPINIT_CONFIGURED", "1");
+        cmd.env("WORKTRUNK_TEST_BASH_INSTALLED", "1");
+        // SHELL=bash so current_shell() == Bash and the verify-wrapper hint
+        // appears under bash (not duplicated for other shells).
+        cmd.env("SHELL", "/bin/bash");
+
+        // Pre-snapshot guard: confirm the unredacted output really did emit
+        // the alias hint. The shared `wt\.exe` → `wt` redaction collapses
+        // both `<underline>wt</>` and `<underline>wt.exe</>` to the same
+        // visual `wt` in the snapshot, which would otherwise hide whether
+        // the .exe branch ran at all.
+        let raw = String::from_utf8_lossy(&cmd.output().unwrap().stdout).to_string();
+        assert!(
+            raw.contains("Creates shell function") && raw.contains("not ") && raw.contains(".exe"),
+            "Expected the .exe alias hint in unredacted output, got:\n{raw}"
+        );
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
 #[rstest]
 fn test_config_show_zsh_compinit_correct_order(mut repo: TestRepo, temp_home: TempDir) {
     // Setup mock gh/glab for deterministic BINARIES output
@@ -1533,6 +1587,56 @@ alias wt="git worktree"
         set_temp_home_env(&mut cmd, temp_home.path());
         set_xdg_config_path(&mut cmd, temp_home.path());
         cmd.env("WORKTRUNK_TEST_COMPINIT_CONFIGURED", "1");
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
+/// Cover the unmatched-candidate `.exe` hint in `render_shell_status`. When
+/// the detector finds a `wt`-mentioning line that doesn't look like a valid
+/// integration AND any of the unmatched candidates contains `.exe`, an
+/// extra hint explains the function-name vs alias-name distinction.
+#[rstest]
+fn test_config_show_unmatched_candidate_exe_emits_extra_hint(
+    mut repo: TestRepo,
+    temp_home: TempDir,
+) {
+    repo.setup_mock_ci_tools_unauthenticated();
+
+    let global_config_dir = temp_home.path().join(".config").join("worktrunk");
+    fs::create_dir_all(&global_config_dir).unwrap();
+    fs::write(global_config_dir.join("config.toml"), "").unwrap();
+
+    // `.bashrc` line containing `wt` at a word boundary but not in a
+    // shell-integration shape — the detector flags it as an unmatched
+    // candidate, and the `.exe` token triggers the extra alias hint.
+    // Use `export` rather than `alias` so the line doesn't get classified
+    // as a bypass alias (which would emit a separate warning instead).
+    fs::write(
+        temp_home.path().join(".bashrc"),
+        r#"# Custom shim path pointing at a Windows binary
+export WT_BIN="/c/Program Files/wt.exe"
+"#,
+    )
+    .unwrap();
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        repo.configure_mock_commands(&mut cmd);
+        cmd.arg("config").arg("show").current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+        set_xdg_config_path(&mut cmd, temp_home.path());
+        cmd.env("WORKTRUNK_TEST_COMPINIT_CONFIGURED", "1");
+
+        // Pre-snapshot guard: the shared `wt\.exe` → `wt` redaction would
+        // otherwise hide whether the unmatched-candidate `.exe` branch ran.
+        let raw = String::from_utf8_lossy(&cmd.output().unwrap().stdout).to_string();
+        assert!(
+            raw.contains("creates shell function") && raw.contains(".exe"),
+            "Expected the .exe alias hint in unredacted output, got:\n{raw}"
+        );
 
         assert_cmd_snapshot!(cmd);
     });

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_bash_matched_exe_emits_alias_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_bash_matched_exe_emits_alias_hint.snap
@@ -1,0 +1,78 @@
+---
+source: tests/integration_tests/config_show.rs
+assertion_line: 885
+info:
+  program: wt
+  args:
+    - config
+    - show
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
+    GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
+    GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: /bin/bash
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "1"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_COMPINIT_CONFIGURED: "1"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
+[2m↳[22m [2mEmpty file (using defaults)[22m
+
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
+[2m↳[22m [2mNot found[22m
+
+[36mSHELL INTEGRATION[39m
+[33m▲[39m [33mShell integration not active[39m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m $SHELL: [1m/bin/bash[22m
+
+[2m○[22m [1mbash[22m: Already configured shell extension & completions @ ~/.bashrc:2
+[107m [0m [2m[0m[2m[35mif[0m[2m [0m[2m[34mcommand[0m[2m [0m[2m[36m-v[0m[2m wt [0m[2m[36m>[0m[2m/dev/null [0m[2m[33m2[0m[2m>&1; [0m[2m[35mthen[0m[2m [0m[2m[34meval[0m[2m [0m[2m[32m"$([0m[2m[34mcommand[0m[2m wt config shell init bash)"[0m[2m; [0m[2m[35mfi[0m[2m
+[107m [0m [2m[0m[2m[34meval[0m[2m [0m[2m[32m"$([0m[2m[34mwt[0m[2m config shell init bash)"[0m[2m
+[2m↳[22m [2mCreates shell function [1mwt[22m. Aliases should use [4mwt[24m, not [4mwt[24m[22m
+[2m↳[22m [2mTo verify wrapper loaded: [4mtype wt[24m[22m
+
+[36mOTHER[39m
+[2m○[22m wt: [1m[VERSION][22m
+[2m○[22m git: [1m[VERSION][22m
+[2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_exe_emits_extra_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_exe_emits_extra_hint.snap
@@ -1,0 +1,78 @@
+---
+source: tests/integration_tests/config_show.rs
+assertion_line: 1622
+info:
+  program: wt
+  args:
+    - config
+    - show
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
+    GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
+    GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_COMPINIT_CONFIGURED: "1"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
+[2m↳[22m [2mEmpty file (using defaults)[22m
+
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
+[2m↳[22m [2mNot found[22m
+
+[36mSHELL INTEGRATION[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+
+[2m○[22m [1mbash[22m: Not configured shell extension & completions
+[33m▲[39m [33mFound [1mwt[22m in [1m~/.bashrc:2[22m but not detected as integration:[39m
+[107m [0m [2m[0m[2m[35mexport[0m[2m WT_BIN=[0m[2m[32m"/c/Program Files/wt"[0m[2m
+[2m↳[22m [2mNote: [1mwt[22m creates shell function [1mwt[22m. Aliases should use [4mwt[24m, not [4mwt[24m[22m
+[2m↳[22m [2mIf `export WT_BIN="/c/Program Files/wt"` is meant to load Worktrunk shell integration, report a false negative: https://github.com/max-sixty/worktrunk/issues/new?title=Shell%20integration%20detection%20false%20negative&body=Shell%20integration%20not%20detected%20despite%20config%20containing%20%60wt%60.%0A%0A%2A%2AUnmatched%20lines%3A%2A%2A%0A%60%60%60%0Aexport%20WT_BIN%3D%22%2Fc%2FProgram%20Files%2Fwt%22%0A%60%60%60%0A%0A%2A%2AExpected%20behavior%3A%2A%2A%20These%20lines%20should%20be%20detected%20as%20shell%20integration.[22m
+
+[36mOTHER[39m
+[2m○[22m wt: [1m[VERSION][22m
+[2m○[22m git: [1m[VERSION][22m
+[2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----


### PR DESCRIPTION
## Summary

Stacks on top of #2608 to close the two reachable codecov/patch gaps tend flagged. Coverage-only — no production changes.

- `render_already_configured` `.exe` alias hint (lines 854-857): new test pairs the canonical bash integration line with a stale `wt.exe` form so `detection.matched_lines` carries the `.exe` content.
- `render_shell_status` unmatched-candidate `.exe` hint (lines 1143-1149): new test uses `export WT_BIN="…/wt.exe"` so the line is flagged at word boundary but not classified as integration or as a bypass alias.

Both tests guard against the shared `wt\.exe` → `wt` snapshot redaction with a string assertion on the unredacted output — otherwise the redaction collapses `<underline>wt</>` and `<underline>wt.exe</>` to identical `wt` and the snapshot would not show whether the `.exe` branch ran.

The other two gaps from tend's analysis are intentionally not addressed:

- **`render_zsh_compinit_warning` body** (lines 753, 758): functionally exercised by the existing `test_config_show_zsh_compinit_warning` (the snapshot shows the warning text), but llvm-cov reports the `writeln!` macro-tail closes as missing. This is the macro-tail false-positive pattern documented in CLAUDE.md, not a real coverage gap.
- **`render_fish_completion_status`'s `completion_path` Err arm**: effectively unreachable. The only way `Shell::Fish.completion_path` errors is when `home_dir_required()` fails, but the same helper backs `config_paths` — which had to succeed earlier in `scan_shell_configs` to reach the `AlreadyExists` branch that calls `render_fish_completion_status`. The `let-else` is defensive code for an unreachable state.

## Test plan

- [x] `cargo test --test integration --features shell-integration-tests -- test_config_show_bash_matched_exe_emits_alias_hint test_config_show_unmatched_candidate_exe_emits_extra_hint`
- [x] `cargo run -- hook pre-merge --yes` (3494 tests pass)
- [x] Verified covered lines via `cargo llvm-cov report --show-missing-lines` — 854-857 and 1143-1149 are no longer in the missing list

🤖 Generated with [Claude Code](https://claude.com/claude-code)