### PR TITLE
ci(affected): restore prior coverage DB before collecting

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -257,6 +257,12 @@ jobs:
   #   at the end of every successful collect, but caching the path
   #   explicitly keeps the contract obvious and ~10 GB of profile bundles
   #   from leaking into the cache if that cleanup ever regresses.
+  # - `collect-affected` also restores the most recent prior main DB before
+  #   collecting, so the new DB accumulates rows for up to FINGERPRINT_KEEP
+  #   (=10) recent main-tip env_fingerprints (LRU-evicted in `Db::gc`).
+  #   PRs whose manifests match any of those fingerprints get exact-match
+  #   selection instead of the all-or-nothing single-fingerprint cache.
+  #   Don't "simplify" by removing the restore — it's load-bearing.
   # - `affected-tests` (PRs) restores the cache. Primary key is the
   #   PR/main merge-base — when collect ran on that exact commit, we get a
   #   tight diff (`PR changes only`) and the smallest possible selection.
@@ -293,6 +299,24 @@ jobs:
 
     - name: Install llvm-tools
       run: rustup component add llvm-tools
+
+    - name: 💾 Restore prior coverage DB
+      uses: actions/cache/restore@v5
+      with:
+        path: target/affected/coverage.db
+        # Primary key matches the current sha (no-op on first push of this
+        # commit; on re-runs of the same sha, lets us skip rebuilding from
+        # scratch).
+        key: cargo-affected-db-v1-${{ runner.os }}-${{ github.sha }}
+        # Fall back to any prior main DB. cargo-affected preserves rows for
+        # up to FINGERPRINT_KEEP (=10) distinct fingerprints in one DB,
+        # evicting LRU on each collect. By feeding a prior DB into the new
+        # collect, we accumulate fingerprint snapshots across main commits —
+        # PRs whose manifests match any of the last ~10 main fingerprints
+        # get exact-match selection, instead of the all-or-nothing
+        # single-fingerprint cache.
+        restore-keys: |
+          cargo-affected-db-v1-${{ runner.os }}-
 
     - name: 📊 Collect coverage data
       env:


### PR DESCRIPTION
Each main collect started from an empty `target/affected/`, so the cached DB always contained exactly one `env_fingerprint`. PRs whose merged tree's manifests byte-differed from that snapshot fingerprint-mismatched and ran the full suite — empirically, 3 of 5 sampled PRs hit this short-circuit because `tests/helpers/wt-perf/Cargo.toml` had churned on main between collect and the PR run.

Restoring the most recent prior main DB before collecting lets cargo-affected's existing `FINGERPRINT_KEEP=10` LRU accumulate rows for ~10 recent main-tip fingerprints in one cache entry, so PRs find an exact-match fingerprint most of the time. Restore-key falls through to any prior `cargo-affected-db-v1-${runner.os}-` entry; the primary key matches the current sha so re-runs of the same commit are no-ops.

No cache key bump (schema unchanged), no changes to `affected-tests`. Added a note in the existing "Cache strategy" comment block warning future maintainers not to remove the restore.