### PR TITLE
ci(affected): emit and upload cargo-affected report.json artifact

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -390,7 +390,19 @@ jobs:
     - name: 🎯 Run affected tests
       env:
         NEXTEST_NO_INPUT_HANDLER: 1
-      run: cargo affected run -- --features shell-integration-tests
+      run: cargo affected run --report-json target/affected/report.json -- --features shell-integration-tests
+
+    # Report writes BEFORE nextest runs, so it survives test failures —
+    # uploading on `!cancelled()` makes it the most useful diagnostic
+    # when tests fail (cache state, fingerprint divergence, selection
+    # reasons). Schema documented at:
+    # https://github.com/max-sixty/cargo-affected/blob/main/docs/report-json.md
+    - name: 📊 Upload cargo-affected report
+      if: ${{ !cancelled() }}
+      uses: actions/upload-artifact@v7
+      with:
+        name: cargo-affected-report
+        path: target/affected/report.json
 
   code-coverage:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
Pass `--report-json target/affected/report.json` to `cargo affected run` and upload the artifact on `!cancelled()`.

The report is the only diagnostic for cache hits/misses, fingerprint divergence, and selection reasons. Without it, CI logs can't tell us why a PR ran the full suite on a fingerprint miss vs. a tight exact-match selection — exactly the gap that motivated the prior worktrunk-CI investigation (3 of 5 sampled PRs falling back to the full suite, with no signal on which build input drifted).

The report writes before nextest, so it survives test failures — gating upload on `!cancelled()` keeps it available exactly when it's most useful. Default `--report-detail summary` is the right CI choice; `full` can be multi-MB on this suite and is easy to re-run locally.

Schema: https://github.com/max-sixty/cargo-affected/blob/main/docs/report-json.md

> _This was written by Claude Code on behalf of @max-sixty_