### PR TITLE
fix(picker): clear screen on exit in inline mode

### DIFF
--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -547,6 +547,23 @@ pub fn handle_picker(
         .no_info(true) // Hide info line (matched/total counter)
         .preview(Some("".to_string())) // Enable preview (empty string means use SkimItem::preview())
         .preview_window(preview_window_spec)
+        // Force the inline-mode clearing path on exit.
+        //
+        // tuikit only enters the alternate screen when the picker is full
+        // height; at `height: "90%"` we're inline, so `smcup` is never
+        // sent. But its `pause()` still emits `rmcup` whenever the option
+        // `disable_alternate_screen` is false — and unmatched `rmcup`
+        // varies by terminal: a no-op on most macOS terminals, but on some
+        // Linux setups it leaves the picker frame on screen because no
+        // explicit erase ran.
+        //
+        // skim plumbs `disable_alternate_screen = no_clear_start` (see
+        // `skim/src/lib.rs` `Skim::run_with`), so setting `no_clear_start`
+        // here forces pause() down the `cursor_goto + erase_down` branch,
+        // which actually erases the rows skim drew on. The other side
+        // effect, `clear_on_start = false`, is harmless for us — skim
+        // immediately overdraws the rows it allocates.
+        .no_clear_start(true)
         // Color scheme using fzf's --color=light values: dark text (237) on light gray bg (251)
         //
         // Terminal color compatibility is tricky:


### PR DESCRIPTION
## Summary

The interactive picker (`wt switch`) sometimes leaves its frame on screen after Enter — observed on at least one Linux setup, not on macOS. Root cause is in skim/tuikit's screen handling, not in our code; this patch works around it by toggling a skim option.

## Why

The picker uses `height: "90%"`, so tuikit never enters the alternate screen — `smcup` is never sent. But its `pause()` still emits `rmcup` whenever `disable_alternate_screen` is false (the default). Unmatched `rmcup`:
- macOS terminals (iTerm, default Terminal.app): no-op, terminal stays clean by other means
- Some Linux terminals: no-op too, but no explicit erase runs either, so the picker frame remains visible

skim plumbs `disable_alternate_screen = no_clear_start` ([`skim/src/lib.rs` `Skim::run_with`](https://docs.rs/skim/0.20.5/src/skim/lib.rs.html#317)). Setting `no_clear_start: true` forces `pause()` down the `cursor_goto + erase_down` branch, which actually erases the rows skim drew on.

Side effect: `clear_on_start = false`. Harmless here — skim immediately overdraws the rows it allocates.

## Risk

Low. The change is more deterministic than the default — explicit erase via cursor positioning is more portable than relying on terminal-specific behavior of unmatched `rmcup`. Easy to revert if it surprises someone.

Caveat: the affected user can't reliably reproduce on macOS, so this is a plausible fix shipped to gather telemetry from real Linux terminals. The mechanism is sound; verification will come from users.

## Test plan

- [x] `cargo run -- hook pre-merge --yes` (3499 tests pass)
- [x] Manual: post-load Enter on macOS — significantly cleaner clearing (2 stragglers vs full picker corruption)
- [ ] User to verify on the affected Linux box after release