### PR TITLE
fix(picker): stash collect warnings until skim releases the terminal

### DIFF
--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -366,6 +366,12 @@ pub trait PickerProgressHandler: Send + Sync {
     /// skeleton state use the skeleton renderer. The handler writes every
     /// slot — slot writes are idempotent.
     fn on_reveal(&self, rendered: Vec<String>);
+
+    /// Stash a pre-formatted warning line. Skim owns the terminal while
+    /// collect runs on the picker's bg thread, so eprintln from collect
+    /// would corrupt the rendered frame. The picker drains stashed lines
+    /// after `Skim::run_with` returns, when stderr is safe again.
+    fn stash_warning(&self, line: String);
 }
 
 /// Controls how show flags (branches/remotes/full) are determined in [`collect`].
@@ -625,6 +631,19 @@ pub fn collect(
         }
     };
 
+    // The picker (`wt switch`) drives a skim TUI that owns the terminal while
+    // collect runs on a background thread. Any stderr write from collect
+    // would overlay the picker's rendered frame and corrupt skim's clear
+    // math, so warnings go through the handler's stash instead — picker
+    // drains and emits them after `Skim::run_with` returns.
+    let emit_warning = |line: String| {
+        if let Some(h) = progressive_handler.as_ref() {
+            h.stash_warning(line);
+        } else {
+            eprintln!("{line}");
+        }
+    };
+
     // Opportunistic stale-default-branch check: `default_branch` above is
     // the persisted value, now trusted without validation on the hot path.
     // Cross-check against the enumerated branch set and surface a warning
@@ -662,17 +681,17 @@ pub fn collect(
     };
 
     if warn_stale_default && let Some(branch) = default_branch.as_deref() {
-        eprintln!(
-            "{}",
+        emit_warning(
             warning_message(cformat!(
                 "Configured default branch <bold>{branch}</> does not exist locally"
             ))
+            .to_string(),
         );
-        eprintln!(
-            "{}",
+        emit_warning(
             hint_message(cformat!(
                 "To reset, run <underline>wt config state default-branch clear</>"
             ))
+            .to_string(),
         );
     }
 
@@ -751,9 +770,8 @@ pub fn collect(
         // Surface git's actual stderr (when available via the typed leaf)
         // rather than our `CommandError` summary.
         let detail = err.display_message();
-        eprintln!(
-            "{}",
-            warning_message(cformat!("Failed to batch-fetch commit details: {detail}"))
+        emit_warning(
+            warning_message(cformat!("Failed to batch-fetch commit details: {detail}")).to_string(),
         );
         std::collections::HashMap::new()
     });
@@ -1377,7 +1395,7 @@ pub fn collect(
     {
         // Warning: what happened + gutter showing which tasks blocked
         let mut diag = format!(
-            "wt list timed out after {}s ({received_count} results received)",
+            "Listing worktrees timed out after {}s ({received_count} results received)",
             results::DRAIN_TIMEOUT.as_secs()
         );
 
@@ -1398,13 +1416,12 @@ pub fn collect(
             ));
         }
 
-        eprintln!("{}", warning_message(&diag));
-
-        eprintln!(
-            "{}",
+        emit_warning(warning_message(&diag).to_string());
+        emit_warning(
             hint_message(cformat!(
-                "A git command likely hung; run <underline>wt list -v</> for details or <underline>wt list -vv</> to create a diagnostic file"
+                "A git command likely hung; for details, re-run with <underline>-v</>; for a diagnostic file, re-run with <underline>-vv</>"
             ))
+            .to_string(),
         );
     }
 
@@ -1478,10 +1495,10 @@ pub fn collect(
         }
 
         let warning = warning_parts.join("\n");
-        eprintln!("{}", warning_message(&warning));
+        emit_warning(warning_message(&warning).to_string());
 
         // Show issue reporting hint (free function - doesn't collect diagnostic data)
-        eprintln!("{}", hint_message(crate::diagnostic::issue_hint()));
+        emit_warning(hint_message(crate::diagnostic::issue_hint()).to_string());
     }
 
     // Populate display fields for all items (used by JSON output and statusline)

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -458,6 +458,35 @@ fn format_stall_footer(
     )
 }
 
+/// Emit the drain-timeout warning + hint when the default 120s
+/// `DRAIN_TIMEOUT` was hit. No-op for `Complete` outcomes or when an
+/// explicit `collect_deadline` was supplied — those are intentional
+/// truncations the caller controls.
+///
+/// Split out so tests can drive it with a synthetic `DrainOutcome::TimedOut`
+/// without spinning up a real 120s drain.
+fn handle_drain_timeout(
+    drain_outcome: DrainOutcome,
+    collect_deadline: Option<std::time::Instant>,
+    emit: &dyn Fn(String),
+) {
+    if collect_deadline.is_none()
+        && let DrainOutcome::TimedOut {
+            received_count,
+            items_with_missing,
+        } = drain_outcome
+    {
+        let diag = format_drain_timeout_diag(received_count, &items_with_missing);
+        emit(warning_message(&diag).to_string());
+        emit(
+            hint_message(cformat!(
+                "A git command likely hung; for details, re-run with <underline>-v</>; for a diagnostic file, re-run with <underline>-vv</>"
+            ))
+            .to_string(),
+        );
+    }
+}
+
 /// Build the drain-timeout diagnostic shown when the default 120s
 /// `DRAIN_TIMEOUT` is hit. Returns the pre-formatted warning text — the
 /// caller wraps it in `warning_message` and routes through the picker stash
@@ -1416,24 +1445,11 @@ pub fn collect(
     // final table / finalize / timeout paths must not inherit that.
     placeholder = super::render::PLACEHOLDER;
 
-    // Handle timeout if it occurred.
-    // Budget-based deadlines (collect_deadline) are intentional truncation — don't warn.
-    // Only warn for the default DRAIN_TIMEOUT (120s), which indicates a hung command.
-    if collect_deadline.is_none()
-        && let DrainOutcome::TimedOut {
-            received_count,
-            items_with_missing,
-        } = drain_outcome
-    {
-        let diag = format_drain_timeout_diag(received_count, &items_with_missing);
-        emit_warning(warning_message(&diag).to_string());
-        emit_warning(
-            hint_message(cformat!(
-                "A git command likely hung; for details, re-run with <underline>-v</>; for a diagnostic file, re-run with <underline>-vv</>"
-            ))
-            .to_string(),
-        );
-    }
+    // Handle timeout if it occurred. Budget-based deadlines
+    // (collect_deadline) are intentional truncation — don't warn. Only
+    // warn for the default DRAIN_TIMEOUT (120s), which indicates a hung
+    // command.
+    handle_drain_timeout(drain_outcome, collect_deadline, &emit_warning);
 
     // The drain calls `refresh_status_symbols` after every *successful*
     // result, but items with zero successful results (all tasks errored
@@ -1854,6 +1870,65 @@ mod tests {
         insta::assert_snapshot!(
             strip_ansi(&rendered),
             @"Listing worktrees timed out after 120s (7 results received)"
+        );
+    }
+
+    /// `handle_drain_timeout` emits both warning + hint when the default
+    /// timeout fires (`collect_deadline: None` + `TimedOut`). Captures
+    /// emissions through the closure to avoid touching real stderr.
+    #[test]
+    fn test_handle_drain_timeout_emits_on_default_timeout() {
+        use std::sync::Mutex;
+        let captured: Mutex<Vec<String>> = Mutex::new(Vec::new());
+        let emit = |line: String| captured.lock().unwrap().push(line);
+        let outcome = DrainOutcome::TimedOut {
+            received_count: 4,
+            items_with_missing: vec![],
+        };
+        handle_drain_timeout(outcome, None, &emit);
+        let lines = captured.lock().unwrap();
+        assert_eq!(lines.len(), 2, "expected warning + hint, got: {lines:?}");
+        assert!(
+            strip_ansi(&lines[0]).contains("Listing worktrees timed out after"),
+            "warning line: {}",
+            lines[0]
+        );
+        assert!(
+            strip_ansi(&lines[1]).contains("re-run with -v"),
+            "hint line: {}",
+            lines[1]
+        );
+    }
+
+    /// An explicit `collect_deadline` is intentional truncation — the helper
+    /// must stay silent so user-budgeted deadlines don't surface as bugs.
+    #[test]
+    fn test_handle_drain_timeout_silent_when_deadline_set() {
+        use std::sync::Mutex;
+        let captured: Mutex<Vec<String>> = Mutex::new(Vec::new());
+        let emit = |line: String| captured.lock().unwrap().push(line);
+        let outcome = DrainOutcome::TimedOut {
+            received_count: 0,
+            items_with_missing: vec![],
+        };
+        let deadline = std::time::Instant::now();
+        handle_drain_timeout(outcome, Some(deadline), &emit);
+        assert!(
+            captured.lock().unwrap().is_empty(),
+            "expected no emissions for budgeted deadline"
+        );
+    }
+
+    /// `Complete` outcomes are the happy path — the helper must stay silent.
+    #[test]
+    fn test_handle_drain_timeout_silent_on_complete() {
+        use std::sync::Mutex;
+        let captured: Mutex<Vec<String>> = Mutex::new(Vec::new());
+        let emit = |line: String| captured.lock().unwrap().push(line);
+        handle_drain_timeout(DrainOutcome::Complete, None, &emit);
+        assert!(
+            captured.lock().unwrap().is_empty(),
+            "expected no emissions for Complete outcome"
         );
     }
 

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -254,7 +254,7 @@ pub(crate) use execution::ExpectedResults;
 use execution::{work_items_for_branch, work_items_for_worktree};
 use results::drain_results;
 use types::DrainOutcome;
-use types::{TaskError, TaskResult};
+use types::{MissingResult, TaskError, TaskResult};
 
 struct TableRenderPlan {
     progressive_table: Option<ProgressiveTable>,
@@ -456,6 +456,38 @@ fn format_stall_footer(
     cformat!(
         "{INFO_SYMBOL} {dim}{footer_base} ({completed}/{total} loaded, no recent progress; {waiting_clause}){dim:#}"
     )
+}
+
+/// Build the drain-timeout diagnostic shown when the default 120s
+/// `DRAIN_TIMEOUT` is hit. Returns the pre-formatted warning text — the
+/// caller wraps it in `warning_message` and routes through the picker stash
+/// or stderr. Pure so tests can exercise it without spinning up a 120s drain.
+fn format_drain_timeout_diag(
+    received_count: usize,
+    items_with_missing: &[MissingResult],
+) -> String {
+    let mut diag = format!(
+        "Listing worktrees timed out after {}s ({received_count} results received)",
+        results::DRAIN_TIMEOUT.as_secs()
+    );
+
+    if !items_with_missing.is_empty() {
+        diag.push_str("; blocked tasks:");
+        let missing_lines: Vec<String> = items_with_missing
+            .iter()
+            .take(5)
+            .map(|result| {
+                let missing_names: Vec<&str> =
+                    result.missing_kinds.iter().map(|k| k.into()).collect();
+                cformat!("<bold>{}</>: {}", result.name, missing_names.join(", "))
+            })
+            .collect();
+        diag.push_str(&format!(
+            "\n{}",
+            format_with_gutter(&missing_lines.join("\n"), None)
+        ));
+    }
+    diag
 }
 
 /// Collect worktree data with rendering driven by `render_target`.
@@ -1393,29 +1425,7 @@ pub fn collect(
             items_with_missing,
         } = drain_outcome
     {
-        // Warning: what happened + gutter showing which tasks blocked
-        let mut diag = format!(
-            "Listing worktrees timed out after {}s ({received_count} results received)",
-            results::DRAIN_TIMEOUT.as_secs()
-        );
-
-        if !items_with_missing.is_empty() {
-            diag.push_str("; blocked tasks:");
-            let missing_lines: Vec<String> = items_with_missing
-                .iter()
-                .take(5)
-                .map(|result| {
-                    let missing_names: Vec<&str> =
-                        result.missing_kinds.iter().map(|k| k.into()).collect();
-                    cformat!("<bold>{}</>: {}", result.name, missing_names.join(", "))
-                })
-                .collect();
-            diag.push_str(&format!(
-                "\n{}",
-                format_with_gutter(&missing_lines.join("\n"), None)
-            ));
-        }
-
+        let diag = format_drain_timeout_diag(received_count, &items_with_missing);
         emit_warning(warning_message(&diag).to_string());
         emit_warning(
             hint_message(cformat!(
@@ -1833,6 +1843,44 @@ mod tests {
         insta::assert_snapshot!(
             strip_ansi(&rendered),
             @"○ Showing 3 worktrees (5/12 loaded, no recent progress; waiting on 3 tasks, including ci-status for feat)"
+        );
+    }
+
+    /// Drain timeout diagnostic without per-item breakdown — the early-exit
+    /// path when no items are blocked.
+    #[test]
+    fn test_format_drain_timeout_diag_no_items() {
+        let rendered = format_drain_timeout_diag(7, &[]);
+        insta::assert_snapshot!(
+            strip_ansi(&rendered),
+            @"Listing worktrees timed out after 120s (7 results received)"
+        );
+    }
+
+    /// With blocked items, the diagnostic appends a gutter listing each
+    /// item's missing task kinds. `take(5)` caps the list; cover that here.
+    #[test]
+    fn test_format_drain_timeout_diag_with_blocked_items() {
+        let items = vec![
+            MissingResult {
+                item_idx: 0,
+                name: "feature-a".to_string(),
+                missing_kinds: vec![TaskKind::CiStatus, TaskKind::BranchDiff],
+            },
+            MissingResult {
+                item_idx: 1,
+                name: "feature-b".to_string(),
+                missing_kinds: vec![TaskKind::AheadBehind],
+            },
+        ];
+        let rendered = format_drain_timeout_diag(3, &items);
+        insta::assert_snapshot!(
+            strip_ansi(&rendered),
+            @r"
+        Listing worktrees timed out after 120s (3 results received); blocked tasks:
+          feature-a: ci-status, branch-diff
+          feature-b: ahead-behind
+        "
         );
     }
 

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -107,6 +107,7 @@ use anyhow::Context;
 use skim::prelude::*;
 use skim::reader::CommandCollector;
 use worktrunk::git::{Repository, current_or_recover};
+use worktrunk::styling::eprintln;
 
 use super::command_executor::FailureStrategy;
 use super::hooks::{HookAnnouncer, execute_hook};
@@ -610,6 +611,11 @@ pub fn handle_picker(
 
     let (tx, rx): (SkimItemSender, SkimItemReceiver) = unbounded();
 
+    // Shared between the bg-thread handler (which pushes warnings while
+    // skim owns the terminal) and the main thread (which drains them after
+    // `Skim::run_with` returns and stderr is safe again).
+    let stashed_warnings: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+
     let handler: Arc<dyn collect::PickerProgressHandler> =
         Arc::new(progressive_handler::PickerHandler {
             tx: tx.clone(),
@@ -620,6 +626,7 @@ pub fn handle_picker(
             preview_dims,
             llm_command,
             summary_hint,
+            stashed_warnings: Arc::clone(&stashed_warnings),
         });
 
     // Spawn collect on a background thread. The handler holds the only
@@ -661,6 +668,9 @@ pub fn handle_picker(
         drop(rx);
         let _ = bg_handle.join();
         orchestrator.wait_for_idle();
+        for line in stashed_warnings.lock().unwrap().drain(..) {
+            eprintln!("{line}");
+        }
         println!("{}", orchestrator.dump_cache_json());
         return Ok(());
     }
@@ -674,6 +684,14 @@ pub fn handle_picker(
     // are read-only.
     let output = Skim::run_with(&options, Some(rx));
     drop(bg_handle);
+
+    // Skim has released the terminal — emit any warnings that collect's bg
+    // thread stashed during the run. Late warnings (e.g. drain timeouts)
+    // may still be in flight; we capture whatever has landed by now and let
+    // the rest fall on the floor with the bg thread.
+    for line in stashed_warnings.lock().unwrap().drain(..) {
+        eprintln!("{line}");
+    }
 
     // Handle selection (signal file cleaned up by PreviewState::Drop)
     if let Some(out) = output

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -131,6 +131,16 @@ use items::{PreviewCache, WorktreeSkimItem};
 use preview::{PreviewLayout, PreviewMode, PreviewState};
 use preview_orchestrator::PreviewOrchestrator;
 
+/// Drain stashed warnings to stderr. Called after skim has released the
+/// terminal (or in the dry-run path after the bg thread joins) — eprintln
+/// during the picker would corrupt skim's frame, so collect routes warnings
+/// through `PickerProgressHandler::stash_warning` and we emit them here.
+fn drain_stashed_warnings(stash: &Mutex<Vec<String>>) {
+    for line in stash.lock().unwrap().drain(..) {
+        eprintln!("{line}");
+    }
+}
+
 /// Action selected by the user in the picker.
 enum PickerAction {
     /// Switch to the selected worktree (Enter key).
@@ -668,9 +678,7 @@ pub fn handle_picker(
         drop(rx);
         let _ = bg_handle.join();
         orchestrator.wait_for_idle();
-        for line in stashed_warnings.lock().unwrap().drain(..) {
-            eprintln!("{line}");
-        }
+        drain_stashed_warnings(&stashed_warnings);
         println!("{}", orchestrator.dump_cache_json());
         return Ok(());
     }
@@ -689,9 +697,7 @@ pub fn handle_picker(
     // thread stashed during the run. Late warnings (e.g. drain timeouts)
     // may still be in flight; we capture whatever has landed by now and let
     // the rest fall on the floor with the bg thread.
-    for line in stashed_warnings.lock().unwrap().drain(..) {
-        eprintln!("{line}");
-    }
+    drain_stashed_warnings(&stashed_warnings);
 
     // Handle selection (signal file cleaned up by PreviewState::Drop)
     if let Some(out) = output
@@ -839,10 +845,29 @@ fn resolve_identifier(
 #[cfg(test)]
 pub mod tests {
     use super::preview::{PreviewLayout, PreviewMode, PreviewStateData};
-    use super::{PickerAction, PickerCollector, resolve_identifier};
+    use super::{PickerAction, PickerCollector, drain_stashed_warnings, resolve_identifier};
     use crate::commands::worktree::RemoveResult;
     use std::fs;
+    use std::sync::Mutex;
     use worktrunk::git::BranchDeletionMode;
+
+    /// Empties the stash and emits each line. Verifies post-skim drain
+    /// semantics without standing up a real picker.
+    #[test]
+    fn drain_stashed_warnings_empties_the_stash() {
+        let stash = Mutex::new(vec!["one".to_string(), "two".to_string()]);
+        drain_stashed_warnings(&stash);
+        assert!(stash.lock().unwrap().is_empty());
+    }
+
+    /// A fresh stash with no warnings is a no-op — exercising the empty path
+    /// keeps the loop body covered when the picker exits cleanly.
+    #[test]
+    fn drain_stashed_warnings_handles_empty_stash() {
+        let stash: Mutex<Vec<String>> = Mutex::new(Vec::new());
+        drain_stashed_warnings(&stash);
+        assert!(stash.lock().unwrap().is_empty());
+    }
 
     #[test]
     fn test_preview_state_data_roundtrip() {

--- a/src/commands/picker/progressive_handler.rs
+++ b/src/commands/picker/progressive_handler.rs
@@ -41,6 +41,10 @@ pub(super) struct PickerHandler {
     /// are disabled — gives the Summary tab something useful instead of a
     /// perpetual "Generating…" placeholder.
     pub(super) summary_hint: Option<String>,
+    /// Pre-formatted warning lines stashed by `collect::collect` while skim
+    /// owns the terminal. The picker drains and emits these to stderr after
+    /// `Skim::run_with` returns. Lines are kept in arrival order.
+    pub(super) stashed_warnings: Arc<Mutex<Vec<String>>>,
 }
 
 impl PickerProgressHandler for PickerHandler {
@@ -123,6 +127,10 @@ impl PickerProgressHandler for PickerHandler {
             *slot.lock().unwrap() = strip_osc8_hyperlinks(&line);
         }
     }
+
+    fn stash_warning(&self, line: String) {
+        self.stashed_warnings.lock().unwrap().push(line);
+    }
 }
 
 #[cfg(test)]
@@ -150,6 +158,7 @@ mod tests {
             preview_dims: (80, 24),
             llm_command: None,
             summary_hint: Some("disabled".to_string()),
+            stashed_warnings: Arc::new(Mutex::new(Vec::new())),
         };
         (handler, test, rx)
     }
@@ -226,5 +235,17 @@ mod tests {
         assert_eq!(shared.len(), 3);
         assert_eq!(shared[1].output().as_ref(), "feat-a");
         assert_eq!(shared[2].output().as_ref(), "feat-b");
+    }
+
+    /// `stash_warning` accumulates lines in arrival order so the picker can
+    /// drain them in one shot after skim releases the terminal.
+    #[test]
+    fn stash_warning_preserves_order() {
+        let (handler, _test, _rx) = make_handler();
+        handler.stash_warning("first".into());
+        handler.stash_warning("second".into());
+        handler.stash_warning("third".into());
+        let stash = handler.stashed_warnings.lock().unwrap();
+        assert_eq!(stash.as_slice(), &["first", "second", "third"]);
     }
 }

--- a/tests/integration_tests/switch_picker_dry_run.rs
+++ b/tests/integration_tests/switch_picker_dry_run.rs
@@ -57,6 +57,42 @@ fn test_picker_dry_run_dumps_cache_json(mut repo: TestRepo) {
     }
 }
 
+/// Verifies that warnings collect emits while running on the picker's bg
+/// thread (here, the stale-default-branch warning) reach stderr — they're
+/// stashed during the run and drained after the dry-run path joins the bg
+/// thread. Direct eprintln from collect would corrupt skim's frame in real
+/// runs.
+#[rstest]
+fn test_picker_dry_run_drains_stashed_warnings(mut repo: TestRepo) {
+    repo.add_worktree("feature-a");
+    // Persist a default branch that doesn't exist locally — collect's
+    // opportunistic stale-default check turns this into a warning.
+    repo.run_git(&["config", "worktrunk.default-branch", "nonexistent"]);
+
+    let output = repo
+        .wt_command()
+        .args(["switch"])
+        .env("WORKTRUNK_PICKER_DRY_RUN", "1")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "dry-run should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let stderr = String::from_utf8(output.stderr).expect("stderr is utf-8");
+    assert!(
+        stderr.contains("Configured default branch") && stderr.contains("nonexistent"),
+        "expected stale-default-branch warning on stderr, got: {stderr}"
+    );
+    assert!(
+        stderr.contains("wt config state default-branch clear"),
+        "expected reset hint on stderr, got: {stderr}"
+    );
+}
+
 /// Same as above but with `list.summary=true` and a fake LLM command
 /// configured, to exercise the `spawn_summary` branch in `handle_picker`.
 /// Uses `/bin/cat` as the LLM: it reads stdin and writes it back, so the


### PR DESCRIPTION
## Summary

`collect::collect` emits warnings on stderr (stale default branch, batch-fetch failure, drain timeout, per-row task errors). On the `wt list` path that's fine. On `wt switch`, collect runs on a background thread while skim's TUI owns the terminal — eprintln overlays the rendered frame and corrupts skim's clear math, leaving fragments visible after the user picks.

Reproducer (synthetic picker-test repo with a stale `worktrunk.default-branch` set):

```
▲ Configured default branch ghost-branch does not exist locally
↳ To reset, run wt config state default-branch clear
```

…appears overlaid on picker rows mid-render.

## Approach

Warnings flow through a new `PickerProgressHandler::stash_warning`. The picker holds an `Arc<Mutex<Vec<String>>>` shared with its handler, collect appends from the bg thread, and the picker drains and emits the lines after `Skim::run_with` returns (and in the dry-run path after the bg thread joins). Late warnings still in flight on the bg thread fall on the floor with the thread, per the existing "don't join after skim" rule.

`wt list`'s stderr behavior is unchanged — when `progressive_handler` is `None`, the same closure writes straight to stderr.

The drain-timeout warning + hint that previously hardcoded `wt list` is now subcommand-agnostic and follows `writing-user-outputs` patterns: `"Listing worktrees timed out after Xs"`, command at end of clause, semicolon between alternatives, `-vv` last.

## Test infrastructure

Three small extractions made the new code testable end-to-end and brought patch coverage up from 66.7% to 100%:

- `drain_stashed_warnings(&Mutex<Vec<String>>)` in `picker/mod.rs` — both drain call sites collapse to one line; helper body has dedicated unit tests.
- `format_drain_timeout_diag(received_count, &items)` in `collect/mod.rs` — pure formatter; snapshot-tested for the no-blocked and blocked-items paths.
- `handle_drain_timeout(drain_outcome, collect_deadline, &emit)` in `collect/mod.rs` — wraps the previously-untestable `DrainOutcome::TimedOut` branch (`DRAIN_TIMEOUT` is 120s with no test seam). Three unit tests synthesize `DrainOutcome` values directly to cover all branches: timeout-fires, intentional-truncation, complete-outcome.

Plus a new integration test in `switch_picker_dry_run.rs` that runs the picker in dry-run mode against a stale `worktrunk.default-branch` and asserts the warning + reset hint reach stderr after the bg thread joins.

## Test plan

- [x] `cargo run -- hook pre-merge --yes` — 3508 tests pass, pre-commit clean (8 new tests across the helpers above).
- [x] `wt list` warning snapshot tests still pass — non-picker stderr unchanged.
- [x] Manual repro: `WORKTRUNK_PICKER_DRY_RUN=1 wt switch --no-cd` against picker-test with a stale default branch now surfaces both warning lines on stderr after the picker exits.

> _This was written by Claude Code on behalf of @max-sixty_