### PR TITLE
docs(skills): tighten CLAUDE.md skills list, sharpen writing-user-outputs description

### DIFF
--- a/.claude/skills/writing-user-outputs/SKILL.md
+++ b/.claude/skills/writing-user-outputs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: writing-user-outputs
-description: CLI output formatting standards for worktrunk. Use when writing user-facing messages, error handling, progress output, hints, warnings, or working with the output system.
+description: CLI output formatting standards for worktrunk. Load before editing any code that calls warning_message, hint_message, error_message, info_message, eprintln, or println, or that produces strings the user will see (CLI help, progress UI, snapshot text). Documents ANSI color nesting rules, message patterns, and output system architecture.
 metadata:
   internal: true
 ---

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,11 +36,13 @@ Use consistent terminology in documentation, help text, and code comments:
 
 ## Skills
 
-Check `.claude/skills/` for available skills and load those relevant to your task.
+**Load relevant skills before starting work, and reload when scope changes mid-session.**
 
-Key skills:
+Project-local skills in `.claude/skills/`:
 
-- **`writing-user-outputs`** — Required when modifying user-facing messages, hints, warnings, errors, or any terminal output formatting. Documents ANSI color nesting rules, message patterns, and output system architecture.
+- `writing-user-outputs` — load before editing any code that calls `warning_message`, `hint_message`, `error_message`, `info_message`, `eprintln`, or `println`, or that produces strings the user sees (CLI help, progress UI, snapshot text).
+- `running-tend` — operating in CI or writing tend workflows.
+- `release` — cutting a release.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

A skill-loading audit (session `db518a8b`) found a session that edited user-facing warnings (`warning_message`, `hint_message`, `eprintln`) without ever loading `writing-user-outputs` — despite the project `CLAUDE.md` flagging it as required. Two structural causes:

1. The `## Skills` section was three lines under "Key skills:" with no imperative. "Required when…" read as a recommendation.
2. The skill's frontmatter description used category words ("messages, errors, warnings") that don't pattern-match against literal symbols in a dispatch prompt.

This PR tightens both:

- `CLAUDE.md` `## Skills` now opens with "Load relevant skills before starting work" and lists only the project-local skills (`writing-user-outputs`, `running-tend`, `release`) with concrete symbol-level triggers for `writing-user-outputs`.
- `writing-user-outputs`'s description names the literal output functions (`warning_message`, `hint_message`, `error_message`, `info_message`, `eprintln`, `println`) so it pattern-matches earlier in the skill listing.

The full audit report (root causes, evidence, alternative proposals) is in `/tmp/skill-loading-audit-report.md` from the dispatching session.

## Test plan

- [x] `git diff main` reviewed
- [ ] Pre-commit hooks pass