### PR TITLE
ci(nightly): add nix flake check job

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -55,16 +55,17 @@ jobs:
     # extracted from a tarball without `.git`.
     #
     # Runs `nix flake check`, which exercises every check defined in
-    # flake.nix — in particular `worktrunk-tests` (cargo test --lib --bins).
-    # Cold builds take ~10-15 min without a binary cache; nightly cadence
-    # absorbs the latency.
+    # flake.nix — in particular `worktrunk-tests`, which runs `cargo test`
+    # with default features (lib + bins + integration + doctests; the
+    # `shell-integration-tests` feature is intentionally off). Cold builds
+    # take ~10-15 min without a binary cache; nightly cadence absorbs it.
     runs-on: ubuntu-24.04
     steps:
     - name: 📂 Checkout code
       uses: actions/checkout@v6
 
     - name: Install Nix
-      uses: cachix/install-nix-action@v30
+      uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: |
           experimental-features = nix-command flakes

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -47,9 +47,36 @@ jobs:
     - name: cargo hack check --feature-powerset --no-dev-deps
       run: cargo hack check --feature-powerset --no-dev-deps
 
+  nix-flake:
+    # Build and test under the nix sandbox so packaging-environment bugs
+    # surface before a release / nixpkgs maintainer hits them. See #2624 for
+    # the canonical example: a unit test that depends on the process CWD
+    # being inside a git repo, which fails in the sandbox where source is
+    # extracted from a tarball without `.git`.
+    #
+    # Runs `nix flake check`, which exercises every check defined in
+    # flake.nix — in particular `worktrunk-tests` (cargo test --lib --bins).
+    # Cold builds take ~10-15 min without a binary cache; nightly cadence
+    # absorbs the latency.
+    runs-on: ubuntu-24.04
+    steps:
+    - name: 📂 Checkout code
+      uses: actions/checkout@v6
+
+    - name: Install Nix
+      uses: cachix/install-nix-action@v30
+      with:
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+    - name: nix flake check
+      run: nix flake check --print-build-logs --keep-going
+
   create-issue-on-nightly-failure:
     needs:
       - feature-powerset
+      - nix-flake
     if: always() && contains(needs.*.result, 'failure') && github.repository_owner == 'max-sixty' && github.event_name == 'schedule'
     runs-on: ubuntu-24.04
     permissions:

--- a/flake.nix
+++ b/flake.nix
@@ -164,6 +164,24 @@
 
           # Check formatting
           worktrunk-fmt = craneLib.cargoFmt { inherit src; };
+
+          # Run tests inside the nix sandbox. Catches packaging-environment
+          # bugs (#2624 is the canonical example) before nixpkgs maintainers
+          # do — see .github/workflows/nightly.yaml.
+          #
+          # Wider src than the package build: tests need .snap files and
+          # tests/ fixtures (prebuilt _git/ trees, .sh scripts, no-extension
+          # git database files). Default features only — shell-integration-
+          # tests requires zsh/fish/nushell + PTY (see CLAUDE.md → "Shell/PTY
+          # Integration Tests").
+          worktrunk-tests = craneLib.cargoTest (
+            commonArgs
+            // {
+              inherit cargoArtifacts;
+              src = pkgs.lib.cleanSource ./.;
+              nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.git ];
+            }
+          );
         };
 
         packages = {


### PR DESCRIPTION
## Summary

- Adds a `nix-flake` job to `.github/workflows/nightly.yaml` that runs `nix flake check`.
- Adds a `worktrunk-tests` flake check that runs `cargo test` (default features) against `pkgs.lib.cleanSource ./.`, which keeps `tests/` fixtures and `src/` `.snap` files visible to the test build. The production package src filter stays narrow.
- Wires the new job into the existing `create-issue-on-nightly-failure` flow so failures open the standard nightly-failure issue.

## Why

Surfaces packaging-environment bugs before nixpkgs maintainers hit them. The canonical example is #2624 — a unit test that depends on the process CWD being inside a git repo, which fails in the nix build sandbox where source is extracted from a tarball without `.git`.

`shell-integration-tests` is intentionally not enabled — it requires zsh/fish/nushell + PTY, and nextest's InputHandler conflicts with interactive shells in CI sandboxes (see CLAUDE.md → "Shell/PTY Integration Tests"). Worth a follow-up if/when the basic check is stable.

Cold runs are slow (~10–15 min build + test). Nightly cadence absorbs the latency. If we want to cut that we can add a binary cache (cachix or FlakeHub) in a follow-up.

## Test plan

- [ ] First scheduled run (or `workflow_dispatch`) succeeds.
- [ ] If `worktrunk-tests` fails, the failure surfaces against the existing nightly-failure issue.
- [ ] Locally: `nix flake check` passes on a machine with nix installed (not validated — no nix on this dev host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)