### PR TITLE
fix(hooks): avoid panic on empty hook tables

### DIFF
--- a/src/commands/command_executor.rs
+++ b/src/commands/command_executor.rs
@@ -782,10 +782,13 @@ pub fn prepare_steps(
                 result.push(PreparedStep::Single(make_prepared(cmd, json, lazy)));
             }
             HookStep::Concurrent(_) => {
-                let prepared = chunk
+                let prepared: Vec<_> = chunk
                     .into_iter()
                     .map(|(cmd, json, lazy)| make_prepared(cmd, json, lazy))
                     .collect();
+                if prepared.is_empty() {
+                    continue;
+                }
                 result.push(PreparedStep::Concurrent(prepared));
             }
         }

--- a/tests/integration_tests/user_hooks.rs
+++ b/tests/integration_tests/user_hooks.rs
@@ -2073,6 +2073,40 @@ fn test_concurrent_hook_post_switch(repo: TestRepo) {
 }
 
 #[rstest]
+fn test_empty_post_switch_table_does_not_panic_with_post_start(repo: TestRepo) {
+    // Regression for #2634: a table with all commands commented out deserializes
+    // as an empty concurrent hook step. Background hook announcement/spawning
+    // must skip it instead of indexing into the empty command list.
+    repo.write_test_config(
+        r#"[post-switch]
+# Empty on purpose.
+
+[post-start]
+marker = "echo 'POST_START_RAN' > post_start_marker.txt"
+"#,
+    );
+
+    let mut cmd = repo.wt_command();
+    cmd.args(["switch", "--create", "feature", "--yes", "-v"]);
+    let output = cmd.output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "wt switch should not panic on an empty post-switch table; stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("panicked at"),
+        "stderr should not contain a Rust panic:\n{stderr}"
+    );
+
+    let worktree_path = repo.root_path().parent().unwrap().join("repo.feature");
+    let marker = worktree_path.join("post_start_marker.txt");
+    wait_for_file_content(&marker);
+    let content = fs::read_to_string(&marker).unwrap();
+    assert!(content.contains("POST_START_RAN"));
+}
+
+#[rstest]
 fn test_concurrent_hook_with_name_filter(repo: TestRepo) {
     // Write project config with multiple named hooks
     repo.write_project_config(


### PR DESCRIPTION
## Summary

Fixes an out-of-bounds panic when a hook table exists but contains no commands, for example:

```toml
[post-switch]
# all commands commented out
```

That config shape deserializes into an empty concurrent hook step. The background hook announcer/spawner later assumes concurrent steps contain at least one command and indexes `cmds[0]`.

This PR skips empty concurrent hook steps during hook preparation, so execution paths never receive `PreparedStep::Concurrent(vec![])`.

Fixes #2634.

## Changes

- Skip empty `HookStep::Concurrent` groups in `prepare_steps`.
- Add a regression integration test for an empty `[post-switch]` table combined with a real `[post-start]` hook under `wt switch --create -v`.

## Test plan

```bash
cargo fmt
cargo test --test integration test_empty_post_switch_table_does_not_panic_with_post_start -- --nocapture
cargo test --test integration concurrent_hook -- --nocapture
cargo test --test integration user_post_start_hook_executes -- --nocapture
cargo test --bins command_executor::tests
```
