### PR TITLE
test(recover): decouple current_or_recover test from inherited CWD

### DIFF
--- a/src/git/recover.rs
+++ b/src/git/recover.rs
@@ -21,9 +21,24 @@ use super::Repository;
 ///
 /// Prints an info message when recovery occurs.
 pub fn current_or_recover() -> anyhow::Result<(Repository, bool)> {
-    match Repository::current() {
+    or_recover(Repository::current(), recover_from_deleted_cwd)
+}
+
+/// Wiring between `Repository::current()` and `recover_from_deleted_cwd`.
+///
+/// Split out so tests can exercise each branch with explicit inputs rather
+/// than relying on the test binary's inherited CWD — which the Nix flake
+/// build sandbox strips of `.git`, breaking environment-coupled assertions.
+fn or_recover<F>(
+    current: anyhow::Result<Repository>,
+    recover: F,
+) -> anyhow::Result<(Repository, bool)>
+where
+    F: FnOnce() -> Option<Repository>,
+{
+    match current {
         Ok(repo) => Ok((repo, false)),
-        Err(err) => match recover_from_deleted_cwd() {
+        Err(err) => match recover() {
             Some(repo) => {
                 eprintln!(
                     "{}",
@@ -281,13 +296,32 @@ mod tests {
     }
 
     #[test]
-    fn test_current_or_recover_returns_repo_when_cwd_exists() {
-        // In a test environment, CWD exists, so current_or_recover should succeed
-        // via the normal Repository::current() path (not recovery).
-        // Tests run inside a git repo in CI, so Repository::current() succeeds.
-        let (repo, recovered) = current_or_recover().unwrap();
+    fn test_or_recover_uses_current_repo_without_recovering() {
+        let test = TestRepo::new();
+        let (repo, recovered) = or_recover(Ok(test.repo.clone()), || {
+            panic!("recovery should not run when current succeeds")
+        })
+        .unwrap();
         assert!(!recovered);
         assert!(repo.repo_path().unwrap().exists());
+    }
+
+    #[test]
+    fn test_or_recover_recovers_when_current_fails() {
+        let test = TestRepo::new();
+        let recovered_repo = test.repo.clone();
+        let (_, recovered) = or_recover(Err(anyhow::anyhow!("CWD missing")), move || {
+            Some(recovered_repo)
+        })
+        .unwrap();
+        assert!(recovered);
+    }
+
+    #[test]
+    fn test_or_recover_propagates_error_when_recovery_fails() {
+        let result = or_recover(Err(anyhow::anyhow!("CWD missing")), || None);
+        let err = result.unwrap_err();
+        assert!(err.to_string().contains("CWD missing"));
     }
 
     #[test]

--- a/src/git/recover.rs
+++ b/src/git/recover.rs
@@ -298,10 +298,7 @@ mod tests {
     #[test]
     fn test_or_recover_uses_current_repo_without_recovering() {
         let test = TestRepo::new();
-        let (repo, recovered) = or_recover(Ok(test.repo.clone()), || {
-            panic!("recovery should not run when current succeeds")
-        })
-        .unwrap();
+        let (repo, recovered) = or_recover(Ok(test.repo.clone()), || None).unwrap();
         assert!(!recovered);
         assert!(repo.repo_path().unwrap().exists());
     }

--- a/src/output/commit_generation.rs
+++ b/src/output/commit_generation.rs
@@ -327,11 +327,10 @@ mod tests {
         // Provide our own search path so the positive case doesn't depend
         // on which standard tools the inherited PATH happens to ship.
         let tmp = tempfile::tempdir().unwrap();
-        let bin_name = if cfg!(windows) {
-            "wt-fake-bin.exe"
-        } else {
-            "wt-fake-bin"
-        };
+        #[cfg(windows)]
+        let bin_name = "wt-fake-bin.exe";
+        #[cfg(not(windows))]
+        let bin_name = "wt-fake-bin";
         let bin_path = tmp.path().join(bin_name);
         std::fs::write(&bin_path, "").unwrap();
         #[cfg(unix)]

--- a/src/output/commit_generation.rs
+++ b/src/output/commit_generation.rs
@@ -5,7 +5,9 @@
 //! and offers to auto-configure the recommended settings.
 
 use std::collections::HashMap;
+use std::ffi::OsStr;
 use std::io::{self, IsTerminal};
+use std::path::PathBuf;
 use std::sync::LazyLock;
 
 use color_print::cformat;
@@ -99,19 +101,18 @@ fn parse_recommended_commands(config: &str) -> HashMap<String, String> {
 }
 
 /// Check if a command is available in PATH.
-///
-/// Uses platform-appropriate method: `where` on Windows, `which` on Unix.
 fn command_exists(cmd: &str) -> bool {
-    #[cfg(windows)]
-    let check_cmd = "where";
-    #[cfg(not(windows))]
-    let check_cmd = "which";
+    command_exists_in(cmd, std::env::var_os("PATH").as_deref())
+}
 
-    worktrunk::shell_exec::Cmd::new(check_cmd)
-        .arg(cmd)
-        .run()
-        .map(|output| output.status.success())
-        .unwrap_or(false)
+/// Inner implementation that takes an explicit PATH-style search list.
+///
+/// Split out so tests can verify the lookup against a controlled directory
+/// rather than the inherited PATH, which can omit even `which`/`where` in
+/// minimal sandboxes (e.g., the Nix flake build sandbox).
+fn command_exists_in(cmd: &str, paths: Option<&OsStr>) -> bool {
+    let cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+    which::which_in(cmd, paths, &cwd).is_ok()
 }
 
 /// Format a command string as TOML for display.
@@ -322,18 +323,39 @@ mod tests {
     }
 
     #[test]
-    fn test_command_exists_known_command() {
-        // 'which' (Unix) or 'where' (Windows) should always exist
-        #[cfg(not(windows))]
-        assert!(command_exists("which"));
-        #[cfg(windows)]
-        assert!(command_exists("where"));
+    fn test_command_exists_in_finds_binary_on_explicit_path() {
+        // Provide our own search path so the positive case doesn't depend
+        // on which standard tools the inherited PATH happens to ship.
+        let tmp = tempfile::tempdir().unwrap();
+        let bin_name = if cfg!(windows) {
+            "wt-fake-bin.exe"
+        } else {
+            "wt-fake-bin"
+        };
+        let bin_path = tmp.path().join(bin_name);
+        std::fs::write(&bin_path, "").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&bin_path, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+
+        assert!(command_exists_in(bin_name, Some(tmp.path().as_os_str())));
     }
 
     #[test]
     fn test_command_exists_nonexistent() {
         // A command that definitely doesn't exist
         assert!(!command_exists("__nonexistent_command_12345__"));
+    }
+
+    #[test]
+    fn test_command_exists_in_returns_false_when_paths_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(!command_exists_in(
+            "__nonexistent__",
+            Some(tmp.path().as_os_str()),
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fix two `nix-flake` nightly check regressions — both pre-existing failures in the build sandbox where `pkgs.lib.cleanSource` strips `.git` and minimal PATH lacks standard tools. Each fixes the current "first failure"; further nix-flake test failures remain (snapshot mismatches in integration tests with implicit CWD assumptions) and are a separate scope.

- **`git::recover::tests::test_current_or_recover_returns_repo_when_cwd_exists`** (#2632) — extracts `or_recover()` from `current_or_recover()` so the wiring can be tested with explicit `Repository::current()` and recovery-closure inputs. Replaces the single env-coupled assertion with three branch-coverage tests (success / recovers / propagates error).
- **`output::commit_generation::tests::test_command_exists_known_command`** — switches `command_exists` from shelling out to the `which`/`where` binary (absent in the Nix build sandbox) to the `which` crate (already a workspace dep). Splits out `command_exists_in` so the positive-case test asserts against a tempdir-controlled search path instead of inherited PATH.

## Why this is a fix, not a test skip

Following the rule established by the closure of #2633 and codified in [running-tend](skills/running-tend/SKILL.md): no `Repository::current().is_err() else return` guards. Each commit either fixes production code (`command_exists` no longer needs an external binary) or restructures the test so its setup doesn't depend on environment that isn't guaranteed.

## Test plan

- [x] `cargo run -- hook pre-merge --yes` — 3526 tests pass, all lints clean.
- [x] Reproduced both original failures by running the test binary from a non-git tempdir / minimal PATH; both now pass.
- [x] Required CI green (test linux/macos/windows, lint, code-coverage, codecov/patch).
- [x] `nix-flake` nightly run on the branch confirms both targeted tests now pass; remaining failures (e.g. `test_config_init_already_exists`, `test_config_show_*`) are pre-existing and unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)