### PR TITLE
ci(nightly): trigger from a `nightly` PR label

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -8,9 +8,11 @@ name: nightly
 #   - minimal-versions: cargo check against minimum-version dep resolution
 #   - nix-flake: nix flake check (packaging-environment bugs, motivated by #2624)
 #
-# Runs daily on cron, on demand via workflow_dispatch, and on pushes/PRs that
-# touch dependency or toolchain files — catching cargo-affecting changes at
-# PR time avoids a 24-hour bisect window. The cron run still catches drift
+# Runs daily on cron, on demand via workflow_dispatch, on pushes to main that
+# touch dependency or toolchain files, and on PRs labelled `nightly`. The
+# label is the iteration knob for fixes targeting nightly-only failures
+# (e.g. nix-flake's sandbox suite); without it, contributors had to wait for
+# the cron run or `gh workflow run` manually. The cron still catches drift
 # that's not commit-correlated (registry updates, transitive resolution).
 #
 # Runner versions pinned; see ci.yaml header comment for rationale.
@@ -30,11 +32,11 @@ on:
       - '.github/workflows/nightly.yaml'
   pull_request:
     branches: [main]
-    paths:
-      - 'Cargo.toml'
-      - 'Cargo.lock'
-      - 'rust-toolchain.toml'
-      - '.github/workflows/nightly.yaml'
+    # `labeled` fires when the `nightly` label is added; `synchronize`
+    # re-runs on subsequent pushes while the label is still attached. Each
+    # job below gates on the label so unlabelled PRs (and unrelated label
+    # additions) are no-ops.
+    types: [opened, synchronize, reopened, labeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -46,6 +48,18 @@ env:
   RUSTFLAGS: -C debuginfo=0
 
 jobs:
+  gate:
+    # Single point that filters PR events. Skipped → all downstream jobs
+    # skip via `needs: gate`, which is cheaper than repeating the
+    # conditional on every job. Schedule / workflow_dispatch / push events
+    # always pass through.
+    if: |
+      github.event_name != 'pull_request' ||
+      contains(github.event.pull_request.labels.*.name, 'nightly')
+    runs-on: ubuntu-24.04
+    steps:
+      - run: 'true'
+
   feature-powerset:
     # Every combination of cli/syntax-highlighting/shell-integration-tests/
     # git-wt should compile. Catches regressions in feature gating — including
@@ -55,6 +69,7 @@ jobs:
     # Workspace members must use `default-features = false` when depending on
     # worktrunk, or feature unification will mask gating bugs by silently
     # enabling `cli` in the lib build (see tests/helpers/wt-perf/Cargo.toml).
+    needs: gate
     runs-on: ubuntu-24.04
     steps:
     - name: 📂 Checkout code
@@ -85,6 +100,7 @@ jobs:
     # PTY tests are intentionally off because they read $SHELL from the
     # runner env, which resolves differently on `ubuntu-24.04-arm` and
     # masks musl/arm signal with environment noise.
+    needs: gate
     strategy:
       fail-fast: false
       matrix:
@@ -122,6 +138,7 @@ jobs:
     # already advisory non-required (CLAUDE.md: "Don't wait for CI
     # benchmarks before merging"). The cron run also appends results to the
     # time-series gist so we have daily perf history on main.
+    needs: gate
     runs-on: ubuntu-24.04
     steps:
     - name: 📂 Checkout code
@@ -181,6 +198,7 @@ jobs:
     # Moved from ci.yaml — `cargo udeps` requires nightly toolchain anyway,
     # so it's already in the "nightly concern" bucket; rarely flips between
     # PRs touching deps.
+    needs: gate
     runs-on: ubuntu-24.04
     steps:
     - name: 📂 Checkout code
@@ -208,6 +226,7 @@ jobs:
     # exists for the same downstream-protection reason) can resolve to a
     # lower compatible version that doesn't actually compile if our manifest
     # under-specifies.
+    needs: gate
     runs-on: ubuntu-24.04
     steps:
     - name: 📂 Checkout code
@@ -238,6 +257,7 @@ jobs:
     # with default features (lib + bins + integration + doctests; the
     # `shell-integration-tests` feature is intentionally off). Cold builds
     # take ~10-15 min without a binary cache; nightly cadence absorbs it.
+    needs: gate
     runs-on: ubuntu-24.04
     steps:
     - name: 📂 Checkout code

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -9,7 +9,8 @@ name: nightly
 #   - nix-flake: nix flake check (packaging-environment bugs, motivated by #2624)
 #
 # Runs daily on cron, on demand via workflow_dispatch, on pushes to main that
-# touch dependency or toolchain files, and on PRs labelled `nightly`. The
+# touch dependency or toolchain files, and on PRs that either (a) touch the
+# same dependency/toolchain files or (b) carry the `nightly` label. The
 # label is the iteration knob for fixes targeting nightly-only failures
 # (e.g. nix-flake's sandbox suite); without it, contributors had to wait for
 # the cron run or `gh workflow run` manually. The cron still catches drift
@@ -32,10 +33,10 @@ on:
       - '.github/workflows/nightly.yaml'
   pull_request:
     branches: [main]
-    # `labeled` fires when the `nightly` label is added; `synchronize`
-    # re-runs on subsequent pushes while the label is still attached. Each
-    # job below gates on the label so unlabelled PRs (and unrelated label
-    # additions) are no-ops.
+    # `labeled` fires when a label is added (so the `nightly` label can
+    # trigger a run mid-PR); `synchronize` re-runs on subsequent pushes.
+    # The `gate` job below decides whether to actually run, ORing the
+    # label against a Cargo-paths diff check.
     types: [opened, synchronize, reopened, labeled]
 
 concurrency:
@@ -49,16 +50,40 @@ env:
 
 jobs:
   gate:
-    # Single point that filters PR events. Skipped → all downstream jobs
-    # skip via `needs: gate`, which is cheaper than repeating the
-    # conditional on every job. Schedule / workflow_dispatch / push events
-    # always pass through.
-    if: |
-      github.event_name != 'pull_request' ||
-      contains(github.event.pull_request.labels.*.name, 'nightly')
+    # Single point that decides whether to run on PR events. Non-PR events
+    # (cron, workflow_dispatch, push) pass through unconditionally. PR
+    # events run if either the `nightly` label is attached OR the diff
+    # touches one of the listed dependency/toolchain files. The decision
+    # is exposed via `outputs.run`; downstream jobs gate on it.
     runs-on: ubuntu-24.04
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
     steps:
-      - run: 'true'
+      - id: decide
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'nightly') }}
+        run: |
+          set -euo pipefail
+          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [[ "$HAS_LABEL" == "true" ]]; then
+            echo "run=true (label)"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          files=$(gh pr view "$PR" --repo "$REPO" --json files --jq '.files[].path')
+          if echo "$files" | grep -qE '^(Cargo\.toml|Cargo\.lock|rust-toolchain\.toml|\.github/workflows/nightly\.yaml)$'; then
+            echo "run=true (cargo-affecting paths changed)"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false (no `nightly` label, no cargo-affecting paths)"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+          fi
 
   feature-powerset:
     # Every combination of cli/syntax-highlighting/shell-integration-tests/
@@ -70,6 +95,7 @@ jobs:
     # worktrunk, or feature unification will mask gating bugs by silently
     # enabling `cli` in the lib build (see tests/helpers/wt-perf/Cargo.toml).
     needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-24.04
     steps:
     - name: 📂 Checkout code
@@ -101,6 +127,7 @@ jobs:
     # runner env, which resolves differently on `ubuntu-24.04-arm` and
     # masks musl/arm signal with environment noise.
     needs: gate
+    if: needs.gate.outputs.run == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -139,6 +166,7 @@ jobs:
     # benchmarks before merging"). The cron run also appends results to the
     # time-series gist so we have daily perf history on main.
     needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-24.04
     steps:
     - name: 📂 Checkout code
@@ -199,6 +227,7 @@ jobs:
     # so it's already in the "nightly concern" bucket; rarely flips between
     # PRs touching deps.
     needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-24.04
     steps:
     - name: 📂 Checkout code
@@ -227,6 +256,7 @@ jobs:
     # lower compatible version that doesn't actually compile if our manifest
     # under-specifies.
     needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-24.04
     steps:
     - name: 📂 Checkout code
@@ -258,6 +288,7 @@ jobs:
     # `shell-integration-tests` feature is intentionally off). Cold builds
     # take ~10-15 min without a binary cache; nightly cadence absorbs it.
     needs: gate
+    if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-24.04
     steps:
     - name: 📂 Checkout code

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -81,7 +81,7 @@ jobs:
             echo "run=true (cargo-affecting paths changed)"
             echo "run=true" >> "$GITHUB_OUTPUT"
           else
-            echo "run=false (no `nightly` label, no cargo-affecting paths)"
+            echo 'run=false (no `nightly` label, no cargo-affecting paths)'
             echo "run=false" >> "$GITHUB_OUTPUT"
           fi
 

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -27,7 +27,7 @@ on:
   push:
     branches: [main]
     paths:
-      - 'Cargo.toml'
+      - '**/Cargo.toml'
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
       - '.github/workflows/nightly.yaml'
@@ -50,40 +50,35 @@ env:
 
 jobs:
   gate:
-    # Single point that decides whether to run on PR events. Non-PR events
-    # (cron, workflow_dispatch, push) pass through unconditionally. PR
-    # events run if either the `nightly` label is attached OR the diff
-    # touches one of the listed dependency/toolchain files. The decision
-    # is exposed via `outputs.run`; downstream jobs gate on it.
+    # Decides whether to run on PR events. Non-PR events (cron,
+    # workflow_dispatch, push) pass through unconditionally. PR events
+    # run when either the `nightly` label is attached OR the diff touches
+    # one of the dependency/toolchain files. The decision is exposed via
+    # `outputs.run`; downstream jobs gate on it.
+    #
+    # `dorny/paths-filter` works against the GitHub API for PR events, so
+    # no checkout step is needed.
     runs-on: ubuntu-24.04
+    permissions:
+      pull-requests: read
     outputs:
       run: ${{ steps.decide.outputs.run }}
     steps:
+      - uses: dorny/paths-filter@v3
+        if: github.event_name == 'pull_request'
+        id: changes
+        with:
+          filters: |
+            nightly:
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+              - 'rust-toolchain.toml'
+              - '.github/workflows/nightly.yaml'
       - id: decide
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-          HAS_LABEL: ${{ contains(github.event.pull_request.labels.*.name, 'nightly') }}
         run: |
-          set -euo pipefail
-          if [[ "${{ github.event_name }}" != "pull_request" ]]; then
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          if [[ "$HAS_LABEL" == "true" ]]; then
-            echo "run=true (label)"
-            echo "run=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          files=$(gh pr view "$PR" --repo "$REPO" --json files --jq '.files[].path')
-          if echo "$files" | grep -qE '^(Cargo\.toml|Cargo\.lock|rust-toolchain\.toml|\.github/workflows/nightly\.yaml)$'; then
-            echo "run=true (cargo-affecting paths changed)"
-            echo "run=true" >> "$GITHUB_OUTPUT"
-          else
-            echo 'run=false (no `nightly` label, no cargo-affecting paths)'
-            echo "run=false" >> "$GITHUB_OUTPUT"
-          fi
+          echo "run=${{ github.event_name != 'pull_request' ||
+            contains(github.event.pull_request.labels.*.name, 'nightly') ||
+            steps.changes.outputs.nightly == 'true' }}" >> "$GITHUB_OUTPUT"
 
   feature-powerset:
     # Every combination of cli/syntax-highlighting/shell-integration-tests/


### PR DESCRIPTION
## Summary

Add a `nightly` PR label as an iteration knob for nightly-only failures **on top of** the existing path-based auto-trigger — both work.

The nightly workflow now runs on PR events when either:
- the PR diff touches `**/Cargo.toml`, `Cargo.lock`, `rust-toolchain.toml`, or `.github/workflows/nightly.yaml` (existing behaviour, preserved), **or**
- the PR has the `nightly` label (new — for fixes that don't touch those paths, like the nix-flake sandbox suite).

A single `gate` job decides via `dorny/paths-filter@v3`; downstream jobs gate on `needs.gate.outputs.run == 'true'`. Cron, `workflow_dispatch`, and main-push paths-trigger pass through unchanged. The pattern mirrors prql's `tests.yaml` `rules` job.

The `nightly` label has been created on the repo.

## Test plan

- [x] YAML parses (`python -c 'import yaml; yaml.safe_load(...)'`).
- [ ] Unlabelled PR with no Cargo diff: `gate.outputs.run == 'false'`, downstream skipped (this PR exercises that path until labelled).
- [ ] Add `nightly` label: `gate` reruns, `outputs.run == 'true'`, downstream runs.
- [ ] PR touching `Cargo.toml` without label: `gate` detects path change, `outputs.run == 'true'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)