### PR TITLE
ci(nightly): re-enable nix-flake job & fix sandbox failures

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -270,39 +270,34 @@ jobs:
     - name: cargo check
       run: cargo check --workspace --all-targets
 
-  # nix-flake:
-  #   # Build and test under the nix sandbox so packaging-environment bugs
-  #   # surface before a release / nixpkgs maintainer hits them. See #2624 for
-  #   # the canonical example: a unit test that depends on the process CWD
-  #   # being inside a git repo, which fails in the sandbox where source is
-  #   # extracted from a tarball without `.git`.
-  #   #
-  #   # Runs `nix flake check`, which exercises every check defined in
-  #   # flake.nix — in particular `worktrunk-tests`, which runs `cargo test`
-  #   # with default features (lib + bins + integration + doctests; the
-  #   # `shell-integration-tests` feature is intentionally off). Cold builds
-  #   # take ~10-15 min without a binary cache; nightly cadence absorbs it.
-  #   #
-  #   # Temporarily disabled: many sandbox-specific test failures remain
-  #   # (e.g. bare wt_command() inheriting CWD, target/debug-vs-release
-  #   # snapshot hardcoding). Re-enable behind the `nightly` PR label so
-  #   # fixes can iterate without blocking the nightly cron run.
-  #   needs: gate
-  #   if: needs.gate.outputs.run == 'true'
-  #   runs-on: ubuntu-24.04
-  #   steps:
-  #   - name: 📂 Checkout code
-  #     uses: actions/checkout@v6
-  #
-  #   - name: Install Nix
-  #     uses: cachix/install-nix-action@v31
-  #     with:
-  #       extra_nix_config: |
-  #         experimental-features = nix-command flakes
-  #         access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
-  #
-  #   - name: nix flake check
-  #     run: nix flake check --print-build-logs --keep-going
+  nix-flake:
+    # Build and test under the nix sandbox so packaging-environment bugs
+    # surface before a release / nixpkgs maintainer hits them. See #2624 for
+    # the canonical example: a unit test that depends on the process CWD
+    # being inside a git repo, which fails in the sandbox where source is
+    # extracted from a tarball without `.git`.
+    #
+    # Runs `nix flake check`, which exercises every check defined in
+    # flake.nix — in particular `worktrunk-tests`, which runs `cargo test`
+    # with default features (lib + bins + integration + doctests; the
+    # `shell-integration-tests` feature is intentionally off). Cold builds
+    # take ~10-15 min without a binary cache; nightly cadence absorbs it.
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
+    runs-on: ubuntu-24.04
+    steps:
+    - name: 📂 Checkout code
+      uses: actions/checkout@v6
+
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: |
+          experimental-features = nix-command flakes
+          access-tokens = github.com=${{ secrets.GITHUB_TOKEN }}
+
+    - name: nix flake check
+      run: nix flake check --print-build-logs --keep-going
 
   create-issue-on-nightly-failure:
     needs:
@@ -311,6 +306,7 @@ jobs:
       - benchmarks
       - check-unused-dependencies
       - minimal-versions
+      - nix-flake
     if: always() && contains(needs.*.result, 'failure') && github.repository_owner == 'max-sixty' && github.event_name == 'schedule'
     runs-on: ubuntu-24.04
     permissions:

--- a/flake.nix
+++ b/flake.nix
@@ -179,7 +179,15 @@
             // {
               inherit cargoArtifacts;
               src = pkgs.lib.cleanSource ./.;
-              nativeBuildInputs = commonArgs.nativeBuildInputs ++ [ pkgs.git ];
+              # Tests shell out to a few host tools — `git` for the harness,
+              # `python3` for argv-quoting and post-start fixtures, `ps`
+              # (procps) for the pgid invariant test. Without these on PATH
+              # the sandbox surfaces them as `No such file or directory`.
+              nativeBuildInputs = commonArgs.nativeBuildInputs ++ [
+                pkgs.git
+                pkgs.python3
+                pkgs.procps
+              ];
             }
           );
         };

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -991,13 +991,12 @@ fn setup_snapshot_settings_for_paths_with_home(
         "${1}[VERSION]",
     );
 
-    // Normalize project root paths in "Binary invoked as:" debug output
-    // Tests run cargo which produces paths like /path/to/worktrunk/target/debug/wt
-    // Normalize to [PROJECT_ROOT]/target/debug/wt for deterministic snapshots
-    settings.add_filter(
-        r"(Binary invoked as: \x1b\[1m)[^\x1b]+/target/(debug|release)/wt(\x1b\[22m)",
-        "${1}[PROJECT_ROOT]/target/$2/wt$3",
-    );
+    // Collapse build-mode (debug|release) so snapshots survive both cargo's
+    // debug builds and crane/release builds (notably the nightly nix-flake
+    // sandbox). The pattern is anchored on `/target/.../wt` so it matches
+    // the bin path in "Invoked as:" / "Binary invoked as:" / diagnostic
+    // hint output without touching unrelated `target/` paths.
+    settings.add_filter(r"/target/(debug|release)/wt", "/target/[BUILD_MODE]/wt");
 
     // Normalize shell probe binary paths
     // Shell probe reports the actual binary location which varies by system

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -1208,7 +1208,14 @@ pub fn add_pty_binary_path_filters(settings: &mut insta::Settings) {
     // cargo-affected (`affected/build/`, max-sixty/cargo-affected#12), and
     // cross-target builds (e.g. `target/x86_64-unknown-linux-musl/debug/wt`
     // from the nightly `release-target` matrix).
-    settings.add_filter(r"[^\s]+/target/(?:[^/\s]+/)*(?:debug|release)/wt", "[BIN]");
+    //
+    // Include the literal `[BUILD_MODE]` placeholder so this filter still
+    // collapses to `[BIN]` when the prelude's `target/(debug|release)/wt`
+    // → `target/[BUILD_MODE]/wt` rewrite has already run.
+    settings.add_filter(
+        r"[^\s]+/target/(?:[^/\s]+/)*(?:debug|release|\[BUILD_MODE\])/wt",
+        "[BIN]",
+    );
 }
 
 // =============================================================================

--- a/tests/integration_tests/config_init.rs
+++ b/tests/integration_tests/config_init.rs
@@ -23,6 +23,10 @@ fn test_config_init_already_exists(temp_home: TempDir) {
     settings.bind(|| {
         let mut cmd = wt_command();
         cmd.arg("config").arg("create");
+        // Run from a directory with no project config so the hint is
+        // deterministic — bare wt_command() otherwise inherits the
+        // worktrunk repo's CWD and would pick up `.config/wt.toml`.
+        cmd.current_dir(temp_home.path());
         set_temp_home_env(&mut cmd, temp_home.path());
         set_xdg_config_path(&mut cmd, temp_home.path());
 
@@ -33,7 +37,7 @@ fn test_config_init_already_exists(temp_home: TempDir) {
 
         ----- stderr -----
         [2m○[22m User config already exists: [1m~/.config/worktrunk/config.toml[22m
-        [2m↳[22m [2mTo view both user and project configs, run [4mwt config show[24m[22m
+        [2m↳[22m [2mTo view, run [4mwt config show[24m. To create a project config, run [4mwt config create --project[24m[22m
         ");
     });
 }

--- a/tests/integration_tests/diagnostic.rs
+++ b/tests/integration_tests/diagnostic.rs
@@ -626,7 +626,7 @@ fn normalize_report(content: &str) -> String {
         .unwrap()
         .replace_all(
             &result,
-            "**Command:** `[PROJECT_ROOT]/target/debug/wt list -vv`",
+            "**Command:** `[PROJECT_ROOT]/target/[BUILD_MODE]/wt list -vv`",
         )
         .to_string();
 

--- a/tests/integration_tests/post_start_commands.rs
+++ b/tests/integration_tests/post_start_commands.rs
@@ -585,7 +585,12 @@ fn test_post_create_script_reads_json(repo: TestRepo) {
     let scripts_dir = repo.root_path().join("scripts");
     fs::create_dir_all(&scripts_dir).unwrap();
 
-    let script_content = r#"#!/usr/bin/env python3
+    // Resolve `python3` on PATH and bake the absolute path into the shebang.
+    // `#!/usr/bin/env python3` doesn't work in the nix sandbox where
+    // `/usr/bin/env` doesn't exist; the kernel runs the literal interpreter
+    // path, so shebang resolution can't piggyback on PATH directly.
+    let python = which::which("python3").expect("python3 in PATH for test");
+    let script_body = r#"
 import json
 import sys
 
@@ -596,6 +601,7 @@ with open('hook_output.txt', 'w') as f:
     f.write(f"hook_type={ctx['hook_type']}\n")
     f.write(f"hook_name={ctx.get('hook_name', 'unnamed')}\n")
 "#;
+    let script_content = format!("#!{}{}", python.display(), script_body);
     let script_path = scripts_dir.join("setup.py");
     fs::write(&script_path, script_content).unwrap();
     fs::set_permissions(&script_path, fs::Permissions::from_mode(0o755)).unwrap();

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_bash_matched_exe_emits_alias_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_bash_matched_exe_emits_alias_hint.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration_tests/config_show.rs
-assertion_line: 885
 info:
   program: wt
   args:
@@ -61,7 +60,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 [107m [0m $SHELL: [1m/bin/bash[22m
 
 [2m○[22m [1mbash[22m: Already configured shell extension & completions @ ~/.bashrc:2

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_claude_available_plugin_not_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_claude_available_plugin_not_installed.snap
@@ -61,7 +61,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mCLAUDE CODE[39m
 [2m↳[22m [2mPlugin not installed. To install, run [4mwt config plugins claude install[24m[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_deprecation_details.snap
@@ -73,7 +73,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_no_cd_deprecation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_no_cd_deprecation.snap
@@ -71,7 +71,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_no_ff_deprecation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_no_ff_deprecation.snap
@@ -71,7 +71,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_pre_hook_table_form_deprecation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_pre_hook_table_form_deprecation.snap
@@ -80,7 +80,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_project_commit_generation_deprecations.snap
@@ -73,7 +73,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_displays_select_section_deprecation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_displays_select_section_deprecation.snap
@@ -71,7 +71,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_empty_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_empty_project_config.snap
@@ -61,7 +61,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_empty_system_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_empty_system_config.snap
@@ -63,7 +63,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_fish_outdated_wrapper.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_fish_outdated_wrapper.snap
@@ -59,7 +59,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [33m▲[39m [33m[1mfish[22m: Outdated shell extension @ ~/.config/fish/functions/wt.fish[39m
 [2m↳[22m [2mTo update, run [4mwt config shell install fish[24m[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_fish_with_completions.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_fish_with_completions.snap
@@ -59,7 +59,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [2m○[22m [1mfish[22m: Already configured shell extension @ ~/.config/fish/functions/wt.fish:7
 [107m [0m [2m[0m[2m[34mcommand[0m[2m wt config shell init fish [0m[2m[36m|[0m[2m [0m[2m[34msource[0m[2m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_fish_without_completions.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_fish_without_completions.snap
@@ -59,7 +59,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [2m○[22m [1mfish[22m: Already configured shell extension @ ~/.config/fish/functions/wt.fish:7
 [107m [0m [2m[0m[2m[34mcommand[0m[2m wt config shell init fish [0m[2m[36m|[0m[2m [0m[2m[34msource[0m[2m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_from_linked_worktree_shows_main_worktree_hint.snap
@@ -61,7 +61,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_command_not_found.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_command_not_found.snap
@@ -41,7 +41,7 @@ info:
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
     WORKTRUNK_TEST_FISH_INSTALLED: "0"
-    WORKTRUNK_TEST_LATEST_VERSION: 0.47.0
+    WORKTRUNK_TEST_LATEST_VERSION: 0.48.0
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
@@ -66,7 +66,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mDIAGNOSTICS[39m
 [2m↳[22m [2mCI status requires GitHub or GitLab remote[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_not_configured.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_not_configured.snap
@@ -41,7 +41,7 @@ info:
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
     WORKTRUNK_TEST_FISH_INSTALLED: "0"
-    WORKTRUNK_TEST_LATEST_VERSION: 0.47.0
+    WORKTRUNK_TEST_LATEST_VERSION: 0.48.0
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
@@ -63,7 +63,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mDIAGNOSTICS[39m
 [2m↳[22m [2mCI status requires GitHub or GitLab remote[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_update_available.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_update_available.snap
@@ -63,7 +63,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mDIAGNOSTICS[39m
 [2m↳[22m [2mCI status requires GitHub or GitLab remote[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_version_check_unavailable.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_version_check_unavailable.snap
@@ -63,7 +63,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mDIAGNOSTICS[39m
 [2m↳[22m [2mCI status requires GitHub or GitLab remote[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_github_remote.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_github_remote.snap
@@ -61,7 +61,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_gitlab_remote.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_gitlab_remote.snap
@@ -61,7 +61,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_project_toml.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_project_toml.snap
@@ -67,7 +67,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_system_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_system_config.snap
@@ -69,7 +69,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_user_toml.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_user_toml.snap
@@ -67,7 +67,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_no_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_no_project_config.snap
@@ -61,7 +61,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_no_user_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_no_user_config.snap
@@ -60,7 +60,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_nushell_outdated_wrapper.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_nushell_outdated_wrapper.snap
@@ -59,7 +59,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [33m▲[39m [33m[1mnu[22m: Outdated shell extension @ ~/.config/nushell/vendor/autoload/wt.nu[39m
 [2m↳[22m [2mTo update, run [4mwt config shell install nu[24m[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_opencode_available_plugin_not_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_opencode_available_plugin_not_installed.snap
@@ -61,7 +61,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOPENCODE[39m
 [2m↳[22m [2mPlugin not installed. To install, run [4mwt config plugins opencode install[24m[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_opencode_plugin_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_opencode_plugin_installed.snap
@@ -61,7 +61,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOPENCODE[39m
 [32m✓[39m [32mPlugin installed[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_opencode_plugin_outdated.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_opencode_plugin_outdated.snap
@@ -61,7 +61,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOPENCODE[39m
 [2m↳[22m [2mPlugin outdated. To update, run [4mwt config plugins opencode install[24m[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_outside_git_repo.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_outside_git_repo.snap
@@ -50,7 +50,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_partial_shell_config_shows_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_partial_shell_config_shows_hint.snap
@@ -60,7 +60,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 [107m [0m $SHELL: [1m/bin/zsh[22m
 
 [2m○[22m [1mbash[22m: Not configured shell extension & completions

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_plugin_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_plugin_installed.snap
@@ -61,7 +61,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mCLAUDE CODE[39m
 [32m✓[39m [32mPlugin installed[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_powershell_detected_via_psmodulepath.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_powershell_detected_via_psmodulepath.snap
@@ -59,7 +59,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 [107m [0m Detected shell: [1mpowershell[22m (via PSModulePath)
 
 [2m○[22m [1mbash[22m: Already configured shell extension & completions @ ~/.bashrc:1

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_skipped_with_installed_binary.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_skipped_with_installed_binary.snap
@@ -60,7 +60,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 [107m [0m $SHELL: [1m/bin/zsh[22m
 
 [2m○[22m [1mbash[22m: [2mSkipped; ~/.bashrc not found[22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_statusline_configured.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_statusline_configured.snap
@@ -61,7 +61,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mCLAUDE CODE[39m
 [32m✓[39m [32mPlugin installed[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_project_config_for_ci.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_project_config_for_ci.snap
@@ -76,7 +76,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
@@ -74,7 +74,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_exe_emits_extra_hint.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_exe_emits_extra_hint.snap
@@ -1,6 +1,5 @@
 ---
 source: tests/integration_tests/config_show.rs
-assertion_line: 1622
 info:
   program: wt
   args:
@@ -62,7 +61,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [2m○[22m [1mbash[22m: Not configured shell extension & completions
 [33m▲[39m [33mFound [1mwt[22m in [1m~/.bashrc:2[22m but not detected as integration:[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_not_suppressed_by_wrapper.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_not_suppressed_by_wrapper.snap
@@ -60,7 +60,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [2m○[22m [1mbash[22m: Not configured shell extension & completions
 [33m▲[39m [33m[1mfish[22m: Outdated shell extension @ ~/.config/fish/functions/wt.fish[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_unmatched_candidate_warning.snap
@@ -61,7 +61,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [2m○[22m [1mbash[22m: Not configured shell extension & completions
 [33m▲[39m [33mFound [1mwt[22m in [1m~/.bashrc:3[22m but not detected as integration:[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_project_keys.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_project_keys.snap
@@ -63,7 +63,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_user_keys.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_warns_unknown_user_keys.snap
@@ -65,7 +65,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_whitespace_only_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_whitespace_only_project_config.snap
@@ -61,7 +61,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_with_project_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_with_project_config.snap
@@ -64,7 +64,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_with_system_config.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_with_system_config.snap
@@ -68,7 +68,7 @@ exit_code: 0
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [36mOTHER[39m
 [2m○[22m wt: [1m[VERSION][22m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_correct_order.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_correct_order.snap
@@ -60,7 +60,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [2m○[22m [1mzsh[22m: Already configured shell extension & completions @ ~/.zshrc:5
 [107m [0m [2m[0m[2m[35mif[0m[2m [0m[2m[34mcommand[0m[2m [0m[2m[36m-v[0m[2m wt [0m[2m[36m>[0m[2m/dev/null [0m[2m[33m2[0m[2m>&1; [0m[2m[35mthen[0m[2m [0m[2m[34meval[0m[2m [0m[2m[32m"$([0m[2m[34mcommand[0m[2m wt config shell init zsh)"[0m[2m; [0m[2m[35mfi[0m[2m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_zsh_compinit_warning.snap
@@ -60,7 +60,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 
 [2m○[22m [1mzsh[22m: Already configured shell extension & completions @ ~/.zshrc:2
 [107m [0m [2m[0m[2m[35mif[0m[2m [0m[2m[34mcommand[0m[2m [0m[2m[36m-v[0m[2m wt [0m[2m[36m>[0m[2m/dev/null [0m[2m[33m2[0m[2m>&1; [0m[2m[35mthen[0m[2m [0m[2m[34meval[0m[2m [0m[2m[32m"$([0m[2m[34mcommand[0m[2m wt config shell init zsh)"[0m[2m; [0m[2m[35mfi[0m[2m

--- a/tests/snapshots/integration__integration_tests__configure_shell__config_show_detects_fish_legacy_conf_d.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__config_show_detects_fish_legacy_conf_d.snap
@@ -59,7 +59,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 [107m [0m $SHELL: [1m/bin/fish[22m
 [2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
 

--- a/tests/snapshots/integration__integration_tests__configure_shell__config_show_fish_legacy_with_functions_dir.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__config_show_fish_legacy_with_functions_dir.snap
@@ -59,7 +59,7 @@ exit_code: 0
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not active[39m
-[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/debug/wt[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
 [107m [0m $SHELL: [1m/bin/fish[22m
 
 [2m○[22m Fish integration found in deprecated location @ [1m~/.config/fish/conf.d/wt.fish[22m

--- a/tests/snapshots/integration__integration_tests__diagnostic__diagnostic_file_format.snap
+++ b/tests/snapshots/integration__integration_tests__diagnostic__diagnostic_file_format.snap
@@ -5,7 +5,7 @@ expression: normalize_report(&content)
 ## Diagnostic Report
 
 **Generated:** [TIMESTAMP]
-**Command:** `[PROJECT_ROOT]/target/debug/wt list -vv`
+**Command:** `[PROJECT_ROOT]/target/[BUILD_MODE]/wt list -vv`
 **Result:** Command completed successfully
 
 <details>

--- a/tests/snapshots/integration__integration_tests__switch__switch_existing_with_shell_configured.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_existing_with_shell_configured.snap
@@ -11,10 +11,15 @@ info:
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
     GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
     GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -30,13 +35,17 @@ info:
     WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
@@ -44,5 +53,5 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33mWorktree for [1mshell-configured[22m @ [1m_REPO_.shell-configured[22m, but cannot change directory — ran [1m[PROJECT_ROOT]/target/debug/wt[22m; shell integration wraps [1mwt[22m[39m
+[33m▲[39m [33mWorktree for [1mshell-configured[22m @ [1m_REPO_.shell-configured[22m, but cannot change directory — ran [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m; shell integration wraps [1mwt[22m[39m
 [2m↳[22m [2mTo change directory, run [4mwt switch shell-configured[24m[22m


### PR DESCRIPTION
## Summary

Restore the `nix-flake` nightly job (disabled in #2647) and fix the
sandbox-specific test failures it surfaces. With this merged, the
nightly cron run is back to gating against packaging-environment bugs.

## What's in here

- **Build-mode snapshot redaction**: 49 snapshots hardcoded
  `target/debug/wt` in "Invoked as:" and diagnostic output, which broke
  under crane's release builds. Collapse both modes to
  `target/[BUILD_MODE]/wt` in the shared insta filter.
- **Nix sandbox env**: add `pkgs.python3` and `pkgs.procps` to
  `worktrunk-tests`' native build inputs (needed by argv-quoting,
  post-start, and pgid-invariant tests). Replace
  `#!/usr/bin/env python3` with the absolute python path resolved at
  script-write time, since `/usr/bin/env` doesn't exist on NixOS.
- **PTY filter ordering**: extend `add_pty_binary_path_filters`'
  alternation to match the `[BUILD_MODE]` placeholder so PTY snapshots
  still collapse to `[BIN]` after the prelude rewrite runs first
  (caught by worktrunk-bot review).
- **One inherited-CWD test fix**: `test_config_init_already_exists`
  branched on whether the inherited CWD had a project config — pin
  it to a no-config tempdir so the snapshot is deterministic across
  cargo and nix.

## Test plan

- [x] `nix-flake` job passes in CI (1633 / 1633, was 54 failing)
- [x] All required `ci` checks pass
- [x] Auto-reviewer approved

🤖 Generated with [Claude Code](https://claude.com/claude-code)