### PR TITLE
test(testing): default `wt_command()` CWD to an isolated tempdir

### DIFF
--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -361,16 +361,37 @@ pub fn scrub_git_path_vars(cmd: &mut Command) {
     }
 }
 
+/// A process-scoped empty directory used as the default `current_dir` for
+/// [`wt_command`]. Created lazily on first use and kept alive for the rest of
+/// the test process; the OS reaps it from the temp dir afterwards (statics
+/// aren't dropped at process exit, so `TempDir::drop` doesn't run).
+///
+/// The dir is guaranteed to be outside any git repository and to have no
+/// `.config/wt.toml`, so `wt` invocations spawned through [`wt_command`] don't
+/// pick up the test process's inherited CWD (which is typically the worktrunk
+/// repo root, with its own `.config/wt.toml` and git history).
+fn isolated_test_cwd() -> &'static Path {
+    static ISOLATED_CWD: std::sync::LazyLock<TempDir> =
+        std::sync::LazyLock::new(|| TempDir::new().expect("create isolated test cwd"));
+    ISOLATED_CWD.path()
+}
+
 /// Create a `wt` CLI command with standardized test environment settings.
 ///
 /// The command has the following guarantees:
 /// - All host `GIT_*` and `WORKTRUNK_*` variables are cleared
 /// - Color output is forced (`CLICOLOR_FORCE=1`) so ANSI styling appears in snapshots
 /// - Terminal width set to 150 columns (`COLUMNS=150`)
+/// - `current_dir` defaults to a process-scoped empty tempdir (not a git repo,
+///   no project config), so `wt` doesn't pick up worktrunk's own
+///   `.config/wt.toml` or detect a git repo from the test process's inherited
+///   CWD. Tests that need a specific CWD must override via
+///   `cmd.current_dir(...)`; `repo.wt_command()` does so automatically.
 #[must_use]
 pub fn wt_command() -> Command {
     let mut cmd = Command::new(wt_bin());
     configure_cli_command(&mut cmd);
+    cmd.current_dir(isolated_test_cwd());
     cmd
 }
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -47,6 +47,12 @@ let output = wt_command()
     .output()?;
 ```
 
+`wt_command()`'s default `current_dir` is a process-scoped empty tempdir
+(outside any git repo, no project config) — so a bare `wt_command()` won't
+pick up the test process's inherited CWD. Tests that need a specific CWD
+(e.g., the worktrunk repo root for `readme_sync` help-text capture) must
+call `.current_dir(...)` explicitly.
+
 ### Method reference
 
 | Method | Returns | Use when |

--- a/tests/integration_tests/config_init.rs
+++ b/tests/integration_tests/config_init.rs
@@ -23,10 +23,6 @@ fn test_config_init_already_exists(temp_home: TempDir) {
     settings.bind(|| {
         let mut cmd = wt_command();
         cmd.arg("config").arg("create");
-        // Run from a directory with no project config so the hint is
-        // deterministic — bare wt_command() otherwise inherits the
-        // worktrunk repo's CWD and would pick up `.config/wt.toml`.
-        cmd.current_dir(temp_home.path());
         set_temp_home_env(&mut cmd, temp_home.path());
         set_xdg_config_path(&mut cmd, temp_home.path());
 


### PR DESCRIPTION
## Summary

Bare `wt_command()` (free function in `src/testing/mod.rs`) previously didn't set `current_dir`, so spawned `wt` test subprocesses inherited the test process's CWD — which is the worktrunk repo root, with its own `.config/wt.toml` and git history. PR #2648 patched one such case (`test_config_init_already_exists`) per-test after the nix sandbox surfaced it.

This change sets a sane default at the constructor: a process-scoped empty `LazyLock<TempDir>` (outside any git repo, no project config). The inherited CWD is never the implicit answer.

## Why structural over per-test

I audited the 330 bare `wt_command()` callsites in `tests/integration_tests/`:

- **297 already set `current_dir(...)` later** in their chain — `Command::current_dir` overwrites, so the new default is a no-op for them.
- **33 SUSPECT** sites don't set `current_dir`. None deliberately rely on inherited CWD — they're all CWD-independent in practice today (`wt --help`, `wt --version`, `wt config plugins opencode install`, `wt config shell init <shell>`, clap routing of unknown subcommands, etc.) but precariously so. A future change to any of those code paths that starts reading project config would silently couple them to the worktrunk repo's `.config/wt.toml` again.

Setting the default once removes the latent surprise; patching 33 sites would not.

## What's in here

- `src/testing/mod.rs`: add `isolated_test_cwd()` helper backed by `LazyLock<TempDir>`; call `cmd.current_dir(...)` from `wt_command()`.
- `tests/CLAUDE.md`: document the new default contract.
- `tests/integration_tests/config_init.rs`: remove the now-redundant per-test override added in #2648.

## Test plan

- [x] `cargo check --tests` clean
- [x] All 64 SUSPECT-class tests pass with the new default (help, completion, custom subcommand routing, opencode plugin install/uninstall, config_init, config_show_theme)
- [x] Full integration suite has the same pre-existing flakes as `main` (test_quickstart_merge, test_docs_merge_pre_merge_hook, test_readme_example_complex, ci_status::* — verified by stashing and running on main)
- [x] All 1737 unit tests pass
- [x] `pre-commit run --all-files` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)