### PR TITLE
docs(picker): drop stale `dedupe git calls` TODO

### DIFF
--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -77,15 +77,6 @@
 //! # Open trace.json in Perfetto, or run the phase-duration SQL query
 //! # documented in benches/CLAUDE.md §"What's on the critical path?".
 //! ```
-//!
-//! # TODO(picker-perf): dedupe git calls
-//!
-//! `num_items_estimate` and `collect::collect` each call `list_worktrees`.
-//! Pre-seed collect's OnceCells from the main-thread fetch to save one
-//! `git worktree list` on the bg thread's critical path toward skeleton.
-//! (The branch inventory is already shared via `Repository::cache`, so
-//! calling `local_branches()` / `remote_branches()` from both the main
-//! and bg threads runs the scan at most once.)
 
 mod items;
 mod log_formatter;


### PR DESCRIPTION
## Summary

The TODO in `src/commands/picker/mod.rs` asking to "dedupe `list_worktrees` calls between `num_items_estimate` and `collect::collect`" has already been resolved.

`Repository::list_worktrees` has been cached on `RepoCache` since 2114fda101 (#2375), and the picker shares that cache across its main thread and the bg `picker-collect` thread via `Arc<RepoCache>` — `repo.clone()` shares the `OnceCell<Vec<WorktreeInfo>>`, so the second call is a memory hit.

The `RepoCache::worktrees` docstring already states the contract: *"The picker warms this on the main thread (for its preview-window sizing estimate) so the background `collect::collect` pass hits memory instead of respawning the subprocess on the critical path to skeleton."*

The TODO was originally added in #2250 and partially walked back in #2368 (the parenthetical noting the branch-inventory cache), but the body was never updated when #2375 closed the worktree half.

## Verification

`RUST_LOG=worktrunk=debug WORKTRUNK_PICKER_DRY_RUN=1 wt -C <picker-test> switch` against the `wt-perf setup picker-test` repo shows exactly one `git worktree list --porcelain` subprocess per invocation (1 `wt-trace` record, 1 spawn debug line).

No behavior change — pure doc-comment deletion (9 lines).

## Test plan

- [x] `pre-commit run --files src/commands/picker/mod.rs` — passes
- [x] `cargo check` — passes
- [x] Empirical: 1 `git worktree list --porcelain` subprocess per `wt switch`

> _This was written by Claude Code on behalf of Maximilian Roos_