### PR TITLE
docs(picker): warn off the cached merge-base path in compute_log_preview

### DIFF
--- a/src/commands/picker/items.rs
+++ b/src/commands/picker/items.rs
@@ -503,12 +503,20 @@ impl WorktreeSkimItem {
         // dim/bright split tracks main's current position. See the cache
         // entry docstring for why we keep this off the SHA-keyed disk cache.
         //
-        // Don't switch to `Repository::merge_base` / `default_branch_sha`
-        // here. Both cache against snapshotted SHAs; the dim/bright logic
-        // requires the merge-base call to *re-resolve* the default branch
-        // each render so the styling shifts when main advances. The
-        // `log_cache_dim_split_tracks_main_advance` test below pins this
-        // contract — switching to the cached path makes it fail.
+        // Don't pre-resolve `default_branch` to a SHA via
+        // `Repository::default_branch_sha` here. That accessor is a
+        // snapshot of the local-branch inventory at first scan (see its
+        // docstring) — feeding the snapshot into a merge-base call would
+        // freeze the dim/bright styling at the SHA main pointed at when
+        // the picker started, instead of the current SHA. The
+        // `log_cache_dim_split_tracks_main_advance` test pins this
+        // contract.
+        //
+        // (`Repository::merge_base` is correctness-safe — it re-resolves
+        // ref names through an uncached `git rev-parse` before hitting
+        // its SHA-keyed cache — but it'd cost an extra subprocess per
+        // render on cache miss, with no win since each item's head is
+        // unique.)
         //
         // Error handling note: this code runs in an interactive preview
         // pane. Silent fallbacks beat disruptive errors during navigation;

--- a/src/commands/picker/items.rs
+++ b/src/commands/picker/items.rs
@@ -503,6 +503,13 @@ impl WorktreeSkimItem {
         // dim/bright split tracks main's current position. See the cache
         // entry docstring for why we keep this off the SHA-keyed disk cache.
         //
+        // Don't switch to `Repository::merge_base` / `default_branch_sha`
+        // here. Both cache against snapshotted SHAs; the dim/bright logic
+        // requires the merge-base call to *re-resolve* the default branch
+        // each render so the styling shifts when main advances. The
+        // `log_cache_dim_split_tracks_main_advance` test below pins this
+        // contract — switching to the cached path makes it fail.
+        //
         // Error handling note: this code runs in an interactive preview
         // pane. Silent fallbacks beat disruptive errors during navigation;
         // the preview is supplementary, users can still select worktrees


### PR DESCRIPTION
The Log preview's `git merge-base` call (around `items.rs:510`) looks like a candidate for switching to a cached method, but it isn't always safe — `Repository::default_branch_sha` (the inventory-snapshot accessor added in #2658) would freeze the dim/bright styling at the SHA main pointed at when the picker started.

Adds a comment block at the call site spelling out which substitution is unsafe and why, and a brief note that `Repository::merge_base` (the broader cached method) would be correctness-safe — just slower than the current direct subprocess. No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)