### PR TITLE
test(filters): close cross-platform bold-around-placeholder trap

### DIFF
--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -92,6 +92,7 @@ use std::time::{Duration, Instant};
 
 use crate::shell_exec::Cmd;
 
+use color_print::cformat;
 use dashmap::DashMap;
 use once_cell::sync::OnceCell;
 use wait_timeout::ChildExt;
@@ -1582,8 +1583,8 @@ fn emit_user_config_warnings(warnings: &[LoadError]) {
                 let path_display = crate::path::format_path_for_display(path);
                 crate::styling::eprintln!(
                     "{}",
-                    crate::styling::warning_message(format!(
-                        "{label} @ {path_display} failed to parse, skipping"
+                    crate::styling::warning_message(cformat!(
+                        "{label} @ <bold>{path_display}</> failed to parse, skipping"
                     ))
                 );
                 crate::styling::eprintln!(

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -334,6 +334,33 @@ fn test_config_loading() {
 
 For environment-dependent tests, use `Command::new()` with `.env()` to set variables in a subprocess, or use the test isolation helpers (`repo.wt_command()`, `wt_command()`).
 
+## Snapshot Filters
+
+### Bold codes around redacted paths
+
+Source code may wrap a path in `<bold>` for terminal styling (e.g., `cformat!("{label} @ <bold>{path}</> failed")`). Setup-side path filters in `tests/common/mod.rs` substitute the path to a placeholder like `[TEST_CONFIG]` or `[PROJECT_ID]`, and a follow-up filter strips ANSI codes immediately wrapping those placeholders so the snapshot reads as a clean `[PLACEHOLDER]`.
+
+The strip filter only fires on placeholders established **before** it. It runs at the end of `setup_snapshot_settings*`, so any path-redaction filter the test adds *after* setup escapes it.
+
+If a test introduces its own placeholder for a path (e.g., `_REPO_/system-config.toml` → `[TEST_SYSTEM_CONFIG_FILE]`), use `add_path_placeholder_filter` so the filter consumes any styling wrappers around the path:
+
+```rust
+// ✅ GOOD: helper wraps the pattern with optional ANSI consumption
+common::add_path_placeholder_filter(
+    &mut settings,
+    r"_REPO_/system-config\.toml",
+    "[TEST_SYSTEM_CONFIG_FILE]",
+);
+
+// ❌ BAD: bare add_filter substitutes only the path, so a `<bold>{path}</>`
+// source leaves `\x1b[1m[TEST_SYSTEM_CONFIG_FILE]\x1b[22m` in the snapshot.
+settings.add_filter(r"_REPO_/system-config\.toml", "[TEST_SYSTEM_CONFIG_FILE]");
+```
+
+The helper wraps the pattern in `(?:\x1b\[\d+m)*` brackets, which eat only the bold open/close immediately adjacent to the path — surrounding color spans (yellow warning, etc.) are preserved.
+
+Setup-side path-redaction placeholders in the strip list (`add_placeholder_ansi_strip_filter` in `tests/common/mod.rs`): `[TEST_CONFIG]`, `[TEST_CONFIG_NEW]`, `[TEST_APPROVALS]`, `[TEST_GIT_CONFIG]`, `[PROJECT_ID]`, `[TEMP_HOME]`, `[TEMP]`. Placeholders that hold a real value (`[VERSION]`, `[HASH]`, `[BUILD_MODE]`, `[BINARY_PATH]`) keep their bold codes so the snapshot still asserts the user-visible styling. The strip pass is invoked at the end of every `setup_*_snapshot_settings` helper, so the contract holds uniformly across `setup_snapshot_settings*`, `setup_home_snapshot_settings`, and `setup_temp_snapshot_settings`.
+
 ## Test Style
 
 ### Snapshot env drift is cosmetic

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -708,26 +708,64 @@ fn add_placeholder_cleanup_filters(settings: &mut insta::Settings) {
     );
 }
 
+/// Match the parent path of a `test-*` config under the test tempdir, in
+/// either the absolute (`/var/folders/.../.tmp.../`) or tilde
+/// (`~/`, `~/.tmp.../`) form. `format_path_for_display` produces both shapes
+/// — macOS keeps the absolute form (canonicalized HOME `/private/var/...`
+/// doesn't prefix the uncanonicalized config path), Linux strips to a tilde
+/// (HOME == tempdir, prefix matches).
+const TEST_PATH_PREFIX: &str =
+    r"'?(?:~(?:/\.tmp[^/\\']+)?|(?:[A-Z]:)?[/\\][^\s']+[/\\]\.tmp[^/\\']+)[/\\]";
+
 fn add_temp_path_placeholder_filters(settings: &mut insta::Settings) {
     settings.add_filter(
-        r"'?(?:[A-Z]:)?[/\\][^\s']+[/\\]\.tmp[^/\\']+[/\\]test-config\.toml\.new'?",
+        &format!(r"{TEST_PATH_PREFIX}test-config\.toml\.new'?"),
         "[TEST_CONFIG_NEW]",
     );
     settings.add_filter(
-        r"'?(?:[A-Z]:)?[/\\][^\s']+[/\\]\.tmp[^/\\']+[/\\]test-config\.toml'?",
+        &format!(r"{TEST_PATH_PREFIX}test-config\.toml'?"),
         "[TEST_CONFIG]",
     );
     settings.add_filter(
-        r"'?(?:[A-Z]:)?[/\\][^\s']+[/\\]\.tmp[^/\\']+[/\\]test-approvals\.toml'?",
+        &format!(r"{TEST_PATH_PREFIX}test-approvals\.toml'?"),
         "[TEST_APPROVALS]",
-    );
-    settings.add_filter(
-        r"(?:\x1b\[\d+m)+(\[TEST_(?:CONFIG(?:_NEW)?|APPROVALS)\])(?:\x1b\[\d+m)+",
-        "$1",
     );
     settings.add_filter(
         r"(?:[A-Z]:)?/[^\s]+/\.tmp[^/]+/test-gitconfig",
         "[TEST_GIT_CONFIG]",
+    );
+}
+
+/// Strip ANSI codes immediately wrapping a path-redaction placeholder so a
+/// `<bold>{path}</>` source collapses to a clean `[PLACEHOLDER]` in snapshots.
+///
+/// Targeted: only placeholders that name a redacted path — not value
+/// placeholders (`[VERSION]`, `[HASH]`, `[BUILD_MODE]`, `[BINARY_PATH]`) where
+/// bold is meaningful styling we want to assert.
+///
+/// Insta filters apply in insertion order, so this must run *after* every
+/// in-setup substitution that establishes one of these placeholders. Filters
+/// added by tests on top of `setup_snapshot_settings*` are past this point —
+/// they must consume ANSI inline via [`add_path_placeholder_filter`].
+fn add_placeholder_ansi_strip_filter(settings: &mut insta::Settings) {
+    settings.add_filter(
+        r"(?:\x1b\[\d+m)+(\[(?:TEST_(?:CONFIG(?:_NEW)?|APPROVALS|GIT_CONFIG)|PROJECT_ID|TEMP(?:_HOME)?)\])(?:\x1b\[\d+m)+",
+        "$1",
+    );
+}
+
+/// Add a filter substituting `path_pattern` → `placeholder`, consuming any
+/// ANSI codes immediately wrapping the path. Use this for test-specific path
+/// redactions that need to survive a `<bold>` source — the late strip pass in
+/// `setup_snapshot_settings*` runs before test-level filters get a chance.
+pub fn add_path_placeholder_filter(
+    settings: &mut insta::Settings,
+    path_pattern: &str,
+    placeholder: &str,
+) {
+    settings.add_filter(
+        &format!(r"(?:\x1b\[\d+m)*{path_pattern}(?:\x1b\[\d+m)*"),
+        placeholder,
     );
 }
 
@@ -1046,6 +1084,11 @@ fn setup_snapshot_settings_for_paths_with_home(
     settings.add_filter(r#"    CARGO_LLVM_COV_TARGET_DIR: "[^"]+"\n"#, "");
     settings.add_filter(r#"    LLVM_PROFILE_FILE: "[^"]+"\n"#, "");
 
+    // Last so every placeholder established above (e.g. [TEST_CONFIG],
+    // [PROJECT_ID], [TEMP_HOME], [HASH]) is in place when we strip styling
+    // wrappers around it.
+    add_placeholder_ansi_strip_filter(&mut settings);
+
     settings
 }
 
@@ -1094,6 +1137,7 @@ pub fn setup_home_snapshot_settings(temp_home: &TempDir) -> insta::Settings {
     // Normalize thread IDs in panic messages (vary across runs)
     settings.add_filter(r"thread '([^']+)' \(\d+\)", "thread '$1'");
     add_standard_env_redactions(&mut settings);
+    add_placeholder_ansi_strip_filter(&mut settings);
 
     settings
 }
@@ -1137,6 +1181,7 @@ pub fn setup_temp_snapshot_settings(temp_path: &std::path::Path) -> insta::Setti
 
     add_standard_env_redactions(&mut settings);
     add_remove_stats_byte_filter(&mut settings);
+    add_placeholder_ansi_strip_filter(&mut settings);
 
     settings
 }
@@ -1225,6 +1270,7 @@ pub fn add_pty_binary_path_filters(settings: &mut insta::Settings) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use insta::assert_snapshot;
     use rstest::rstest;
 
     #[rstest]
@@ -1241,5 +1287,33 @@ mod tests {
         let output = repo.git_command().args(["log", "--oneline"]).run().unwrap();
         let log = String::from_utf8_lossy(&output.stdout);
         assert_eq!(log.lines().count(), 5);
+    }
+
+    /// Regression: a `<bold>{path}</>` warning has to land on the same snapshot
+    /// regardless of whether `format_path_for_display` returned the absolute
+    /// (macOS) or tilde (Linux) form. The path-substitution filter has to
+    /// catch both alternatives, and the late ANSI-strip pass has to remove the
+    /// styling wrappers around the resulting placeholder.
+    #[test]
+    fn placeholder_strip_collapses_styled_paths_cross_platform() {
+        let mut settings = insta::Settings::new();
+        add_temp_path_placeholder_filters(&mut settings);
+        add_placeholder_ansi_strip_filter(&mut settings);
+
+        // macOS: format_path_for_display falls through to the absolute form
+        // because HOME is canonicalized (/private/var) but the path isn't.
+        let macos = "▲ \x1b[1m/var/folders/abc/T/.tmpXYZ/test-config.toml\x1b[22m failed";
+        // Linux CI: HOME == tempdir, so the prefix strips to a clean tilde
+        // form with no `.tmp...` segment between `~` and the filename.
+        let linux_home_eq_tempdir = "▲ \x1b[1m~/test-config.toml\x1b[22m failed";
+        // Linux dev box: HOME != tempdir but tempdir lives under HOME, so the
+        // tilde form keeps the `.tmpXYZ/` segment.
+        let linux_home_above_tempdir = "▲ \x1b[1m~/.tmpXYZ/test-config.toml\x1b[22m failed";
+
+        settings.bind(|| {
+            assert_snapshot!(macos, @"▲ [TEST_CONFIG] failed");
+            assert_snapshot!(linux_home_eq_tempdir, @"▲ [TEST_CONFIG] failed");
+            assert_snapshot!(linux_home_above_tempdir, @"▲ [TEST_CONFIG] failed");
+        });
     }
 }

--- a/tests/integration_tests/list_config.rs
+++ b/tests/integration_tests/list_config.rs
@@ -400,14 +400,7 @@ branches = "not-a-bool"
     )
     .unwrap();
 
-    let mut settings = setup_snapshot_settings(&repo);
-    // `format_path_for_display` produces different strings depending on
-    // whether HOME contains the tempdir — macOS tempdir lives under
-    // /var/folders (absolute), Linux CI tempdir lives under HOME (tilde).
-    // The default `~/…` → `_PARENT_/…` filter only fires in the tilde case,
-    // so normalize the Linux form back to `[TEST_CONFIG]` for a stable
-    // snapshot across platforms.
-    settings.add_filter(r"_PARENT_/[^\s,]*test-config\.toml", "[TEST_CONFIG]");
+    let settings = setup_snapshot_settings(&repo);
     settings.bind(|| {
         let mut cmd = wt_command();
         repo.configure_wt_cmd(&mut cmd);
@@ -539,8 +532,7 @@ fn test_list_config_malformed_non_section_field_warns_on_stderr(repo: TestRepo) 
     )
     .unwrap();
 
-    let mut settings = setup_snapshot_settings(&repo);
-    settings.add_filter(r"_PARENT_/[^\s,]*test-config\.toml", "[TEST_CONFIG]");
+    let settings = setup_snapshot_settings(&repo);
     settings.bind(|| {
         let mut cmd = wt_command();
         repo.configure_wt_cmd(&mut cmd);
@@ -573,7 +565,11 @@ fn test_list_config_malformed_system_config_warns_on_stderr(repo: TestRepo) {
     fs::write(&system_config, "[list]\nbranches = \"not-a-bool\"\n").unwrap();
 
     let mut settings = setup_snapshot_settings(&repo);
-    settings.add_filter(r"_REPO_/system-config\.toml", "[TEST_SYSTEM_CONFIG_FILE]");
+    crate::common::add_path_placeholder_filter(
+        &mut settings,
+        r"_REPO_/system-config\.toml",
+        "[TEST_SYSTEM_CONFIG_FILE]",
+    );
     settings.bind(|| {
         let mut cmd = wt_command();
         repo.configure_wt_cmd(&mut cmd);
@@ -595,7 +591,11 @@ fn test_list_config_malformed_system_config_non_section_field(repo: TestRepo) {
     .unwrap();
 
     let mut settings = setup_snapshot_settings(&repo);
-    settings.add_filter(r"_REPO_/system-config\.toml", "[TEST_SYSTEM_CONFIG_FILE]");
+    crate::common::add_path_placeholder_filter(
+        &mut settings,
+        r"_REPO_/system-config\.toml",
+        "[TEST_SYSTEM_CONFIG_FILE]",
+    );
     settings.bind(|| {
         let mut cmd = wt_command();
         repo.configure_wt_cmd(&mut cmd);

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_user_toml.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_invalid_user_toml.snap
@@ -75,7 +75,7 @@ exit_code: 0
 [2m○[22m Hyperlinks: [1minactive[22m
 
 ----- stderr -----
-[33m▲[39m [33mUser config @ ~/.config/worktrunk/config.toml failed to parse, skipping[39m
+[33m▲[39m [33mUser config @ [1m~/.config/worktrunk/config.toml[22m failed to parse, skipping[39m
 [107m [0m TOML parse error at line 1, column 6
 [107m [0m   |
 [107m [0m 1 | this is not valid toml {{{


### PR DESCRIPTION
## Summary

`format_path_for_display` produces two shapes for the test-config path:

- macOS: `/var/folders/.../.tmp.../test-config.toml` (absolute — HOME canonicalizes to `/private/var/...` but the path doesn't, so `strip_prefix` falls through)
- Linux CI: `~/test-config.toml` (HOME == tempdir, prefix strips cleanly)

`add_temp_path_placeholder_filters` only matched the absolute form. The follow-up bold-strip pass only fires on already-substituted placeholders, so on Linux the `[TEST_CONFIG]` placeholder was established later (via the generic `~/` → `_PARENT_/` filter and a test-specific filter), and any `<bold>` wrapping the path leaked through into snapshots.

#2661 worked around this by reverting the `<bold>` styling on the user-config parse warning. The same trap was latent for any future code that bolded a redacted path; this PR closes it.

## Changes

- **`tests/common/mod.rs`** — extend the path-substitution filter to match the tilde forms (`~/test-config.toml` and `~/.tmp.../test-config.toml`) so the placeholder lands consistently across platforms. Invoke the ANSI-strip pass at the end of every `setup_*_snapshot_settings` helper — `setup_snapshot_settings*`, `setup_home_snapshot_settings`, and `setup_temp_snapshot_settings` — so it sees every in-setup placeholder including `[PROJECT_ID]`, `[TEMP_HOME]`, and `[TEMP]` (all latent gaps). Strip list is targeted to path-redaction placeholders, so value placeholders (`[VERSION]`, `[HASH]`, `[BUILD_MODE]`, `[BINARY_PATH]`) keep their bold styling.
- **`add_path_placeholder_filter` helper** — for test-specific path redactions added after setup (which the late strip pass can't reach). Used at the two `_REPO_/system-config.toml` callsites and documented as the canonical pattern.
- **`tests/integration_tests/list_config.rs`** — drop the now-redundant `_PARENT_/...test-config.toml` filters; route the two system-config substitutions through the helper.
- **`tests/CLAUDE.md`** — document the trap, the helper, and the contract that every `setup_*_snapshot_settings` ends with the strip pass.
- **`src/git/repository/mod.rs`** — re-add `<bold>{path_display}</>` to the user-config parse warning, matching the `writing-user-outputs` convention.
- **regression test** — exercises the macOS absolute form plus two Linux tilde forms (HOME == tempdir, HOME above tempdir) to assert they collapse to the same snapshot output.
- **snapshot acceptance** — `test_config_show_invalid_user_toml` now shows `[1m~/.config/worktrunk/config.toml[22m` (literal path, legitimate user-visible bold preserved).

## Test plan

- [x] `cargo run -- hook pre-merge --yes` (3548 tests + lints, all green on macOS)
- [ ] CI (Linux/Windows) green — the actual cross-platform proof

🤖 Generated with [Claude Code](https://claude.com/claude-code)