### PR TITLE
fix(bench): stabilize list-bench fixture and record thread-count findings

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1036,6 +1036,14 @@ fn handle_remove_command(args: RemoveArgs, yes: bool) -> anyhow::Result<()> {
 /// (often blocked on pipe reads) alongside occasional network requests. 2x CPU
 /// cores lets threads waiting on I/O overlap with compute work without excessive
 /// context-switch overhead.
+///
+/// 3x CPU was benchmarked against `divergent_branches/warm` (branch-heavy) and
+/// `worktree_scaling/warm/8` (worktree-heavy) on packed fixtures. 3x is at or
+/// within noise of the optimum on both workloads; 2x trails by 0-5% (divergent:
+/// 259ms vs 257ms, CIs overlap; worktree: 86.6ms vs 82.4ms, ~5% gap). 4x
+/// regresses on branch-heavy workloads. We stay at 2x because the win is small
+/// in absolute terms (≤ 5ms) and 2x has been validated in production across
+/// hardware we haven't benchmarked.
 pub(crate) fn rayon_thread_count() -> usize {
     std::thread::available_parallelism()
         .map(|n| n.get() * 2)

--- a/tests/helpers/wt-perf/src/lib.rs
+++ b/tests/helpers/wt-perf/src/lib.rs
@@ -163,6 +163,18 @@ pub fn create_repo_at(config: &RepoConfig, base_path: &Path) {
     run_git(&repo_path, &["init", "-b", "main"]);
     run_git(&repo_path, &["config", "user.name", "Benchmark"]);
     run_git(&repo_path, &["config", "user.email", "bench@test.com"]);
+    // Disable all background auto-maintenance: rapid commits in the
+    // build loop trigger detached `git gc` / `git maintenance` runs
+    // whose pack-and-prune steps race the foreground `git add` /
+    // `git commit`, producing intermittent "invalid object ..." /
+    // "unable to create temporary file" / "failed to insert into
+    // database" failures partway through a 500-commit fixture. Modern
+    // git enables both `gc.auto` (loose-object threshold) and
+    // `maintenance.auto` (the post-command hook scheduler) by default,
+    // so we have to silence both.
+    run_git(&repo_path, &["config", "gc.auto", "0"]);
+    run_git(&repo_path, &["config", "gc.autoPackLimit", "0"]);
+    run_git(&repo_path, &["config", "maintenance.auto", "false"]);
 
     // Create initial file structure
     let num_files = config.files.max(1);
@@ -230,6 +242,14 @@ pub fn create_repo_at(config: &RepoConfig, base_path: &Path) {
 
     // Set up fake remote for default branch detection
     setup_fake_remote(&repo_path);
+
+    // Pack objects and write the commit-graph once, after all refs
+    // exist. Auto-maintenance is disabled (see above), so we do this
+    // explicitly — the goal is a mature-repo shape: one packfile, a
+    // commit-graph, no loose-object lookup overhead. Without this,
+    // benches measure cold-clone-shaped repos, which exaggerates
+    // per-object I/O cost relative to what users see on day-N repos.
+    run_git(&repo_path, &["gc"]);
 }
 
 /// Add worktrees to an existing repo using worktrunk naming convention.


### PR DESCRIPTION
## Summary

`cargo bench --bench list` was failing ~30% of runs partway through fixture setup with errors like "fatal: unable to read tree", "invalid object ... for 'src/file_N.rs'", "unable to create temporary file", or "failed to insert into database". Root cause: git's auto-maintenance (`gc.auto` + `maintenance.auto`) fires during the 500-commit fixture-build loop and races the foreground `git add` / `git commit`. Partial-failure repos contained 5-6 pack files plus a `tmp_pack_*` — smoking gun for a detached pack/prune in flight.

`create_repo_at` now silences both auto-maintenance knobs after `git init`, and runs one explicit `git gc` at the end after all commits, branches, and worktrees are in place. The result: 10/10 sequential `wt-perf setup typical-8` builds pass, and fixtures land in a packed shape (one packfile + commit-graph, zero loose objects) that matches day-N user repos rather than the loose-object cold-clone shape they had before.

## Thread-count follow-up to #2662

Using the stabilized benches to answer the question in #2662's "Follow-ups": should `rayon_thread_count` bump from 2× CPU now that we have one pool instead of two? Swept `RAYON_NUM_THREADS` across {0.5×, 1×, 1.5×, 2×, 3×, 4×, 6×} on an 18-CPU machine against `divergent_branches/warm` (branch-heavy) and `worktree_scaling/warm/8` (worktree-heavy). 3× CPU was at or within noise of the per-workload optimum on both; 2× trailed by 0–5% (divergent 259ms vs 257ms with overlapping CIs; worktree 86.6ms vs 82.4ms, ~5% gap). 4× regressed on branch-heavy workloads.

Stayed at 2×: the win is small in absolute terms (≤ 5ms) and 2× has been validated in production on hardware we haven't benchmarked. Docstring on `rayon_thread_count` records the test and the reasoning so the next person who asks doesn't have to redo the experiment.

## Test plan

- [x] `cargo run -- hook pre-merge --yes` — 3547 tests pass
- [x] `wt-perf setup typical-8 --persist` × 10 sequential — no failures (pre-fix: ~30% failure rate)
- [x] `cargo bench --bench list divergent_branches/warm` — completes, packed shape (1 pack, 0 loose)
- [x] `cargo bench --bench list worktree_scaling/warm/8` — completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
