### PR TITLE
perf(bench): cheaper `cargo bench --bench list` (lazy fixtures + lighter real-repo sampling)

### DIFF
--- a/benches/list.rs
+++ b/benches/list.rs
@@ -104,14 +104,14 @@ fn bench_skeleton(c: &mut Criterion) {
     for worktrees in [1, 4, 8] {
         for cold in [false, true] {
             let config = BenchConfig::typical(worktrees, cold);
-            let temp = create_repo(&config.repo);
-            let repo_path = temp.path().join("repo");
-            setup_fake_remote(&repo_path);
 
             group.bench_with_input(
                 BenchmarkId::new(config.label(), worktrees),
                 &config,
                 |b, config| {
+                    let temp = create_repo(&config.repo);
+                    let repo_path = temp.path().join("repo");
+                    setup_fake_remote(&repo_path);
                     run_benchmark(
                         b,
                         binary,
@@ -135,14 +135,14 @@ fn bench_full(c: &mut Criterion) {
     for worktrees in [1, 4, 8] {
         for cold in [false, true] {
             let config = BenchConfig::typical(worktrees, cold);
-            let temp = create_repo(&config.repo);
-            let repo_path = temp.path().join("repo");
-            setup_fake_remote(&repo_path);
 
             group.bench_with_input(
                 BenchmarkId::new(config.label(), worktrees),
                 &config,
                 |b, config| {
+                    let temp = create_repo(&config.repo);
+                    let repo_path = temp.path().join("repo");
+                    setup_fake_remote(&repo_path);
                     run_benchmark(b, binary, &repo_path, config, &["list"], None);
                 },
             );
@@ -159,14 +159,14 @@ fn bench_worktree_scaling(c: &mut Criterion) {
     for worktrees in [1, 4, 8] {
         for cold in [false, true] {
             let config = BenchConfig::typical(worktrees, cold);
-            let temp = create_repo(&config.repo);
-            let repo_path = temp.path().join("repo");
-            run_git(&repo_path, &["status"]);
 
             group.bench_with_input(
                 BenchmarkId::new(config.label(), worktrees),
                 &config,
                 |b, config| {
+                    let temp = create_repo(&config.repo);
+                    let repo_path = temp.path().join("repo");
+                    run_git(&repo_path, &["status"]);
                     run_benchmark(b, binary, &repo_path, config, &["list"], None);
                 },
             );
@@ -228,11 +228,11 @@ fn bench_many_branches(c: &mut Criterion) {
 
     for cold in [false, true] {
         let config = BenchConfig::branches(100, 2, cold);
-        let temp = create_repo(&config.repo);
-        let repo_path = temp.path().join("repo");
-        run_git(&repo_path, &["status"]);
 
         group.bench_function(config.label(), |b| {
+            let temp = create_repo(&config.repo);
+            let repo_path = temp.path().join("repo");
+            run_git(&repo_path, &["status"]);
             run_benchmark(
                 b,
                 binary,
@@ -256,11 +256,11 @@ fn bench_divergent_branches(c: &mut Criterion) {
 
     for cold in [false, true] {
         let config = BenchConfig::many_divergent_branches(cold);
-        let temp = create_repo(&config.repo);
-        let repo_path = temp.path().join("repo");
-        run_git(&repo_path, &["status"]);
 
         group.bench_function(config.label(), |b| {
+            let temp = create_repo(&config.repo);
+            let repo_path = temp.path().join("repo");
+            run_git(&repo_path, &["status"]);
             run_benchmark(
                 b,
                 binary,

--- a/benches/list.rs
+++ b/benches/list.rs
@@ -299,8 +299,13 @@ fn setup_rust_workspace_with_branches(temp: &tempfile::TempDir, num_branches: us
 /// regardless of how many refs are queried. Skipping branch enumeration entirely avoids this.
 fn bench_real_repo_many_branches(c: &mut Criterion) {
     let mut group = c.benchmark_group("real_repo_many_branches");
-    group.measurement_time(std::time::Duration::from_secs(60));
-    group.sample_size(10);
+    // rust-lang/rust runs ~3.7s per `wt list --branches` iteration; warm-path
+    // variance is dominated by the slowest single subprocess (a deep
+    // `git merge-base` walking history), not measurement noise, so 5 samples
+    // suffices. A 20s budget is ≈ one iteration per sample (~18s), down from
+    // the ~74s criterion spent filling the old 60s budget.
+    group.measurement_time(std::time::Duration::from_secs(20));
+    group.sample_size(5);
 
     let binary = Path::new(env!("CARGO_BIN_EXE_wt"));
 


### PR DESCRIPTION
## Summary

Two changes that make `cargo bench --bench list` cheaper to run, especially when filtered. No production code, no change to what the benches measure on a full run.

**1. Lazy fixture creation.** The synthetic `wt list` bench groups built their fixture repos *eagerly* at group-registration time: `bench_skeleton`, `bench_full`, `bench_worktree_scaling`, `bench_many_branches`, and `bench_divergent_branches` looped over their `(worktrees, cold)` variants and called `create_repo` for every one — before Criterion applied its positional `FILTER`. So `cargo bench --bench list skeleton/warm/8` still paid to build all 6 skeleton fixtures plus all 6 `full`, all 6 `worktree_scaling`, both `many_branches` (100 branches each), and both `divergent_branches` (200 branches × 20 commits each) before measuring one benchmark.

This moves `create_repo` (and the `setup_fake_remote` / `git status` prep) inside the `bench_with_input` / `bench_function` closure — exactly how `bench_real_repo` and `bench_real_repo_many_branches` already work. Criterion invokes that closure once per benchmark and only for benchmarks the filter selects, so an excluded variant now creates no fixture at all.

*Hermeticity is unchanged*: each benchmark still gets its own fresh `TempDir` + repo via `create_repo`, created exactly once, before `b.iter` (so never inside the measured region), alive for the whole measurement loop, dropped right after. Marginally cleaner if anything — a filtered-out benchmark now produces zero state instead of a stray TempDir.

**2. Trim `real_repo_many_branches` sampling.** That group ran 10 samples against a 60s `measurement_time` — but at ~3.7s per `wt list --branches` iteration on rust-lang/rust, Criterion filled the budget with ~2 iterations per sample (~74s of measured time per `bench_function`). The warm-path variance is dominated by the slowest single subprocess (a deep `git merge-base` walking history), not measurement noise, so 5 samples already pins the signal. Cut to `sample_size(5)` + `measurement_time(20s)` — ≈ one iteration per sample (~18s), so the group's two bench_functions drop from ~3.6min to ~1.7min of measured time. (Cutting `sample_size` alone would have saved nothing — Criterion sizes iterations-per-sample to fill `measurement_time`.)

## Effect

- `cargo bench --bench list <non-matching-filter>` → ~0.2s (measured), down from minutes of fixture churn
- `cargo bench --bench list skeleton/warm/1` → 1 fixture built, was 6
- `real_repo_many_branches` group → ~1.7min measured, was ~3.6min
- Full unfiltered `cargo bench --bench list` → fixture count unchanged; real-repo group ~2min faster

## Test plan

- [x] `cargo check --benches`
- [x] `cargo bench --bench list -- --test skeleton` — all 6 variants pass
- [x] `cargo bench --bench list -- --test <non-matching>` — 0.23s, no fixtures created
- [x] `cargo run -- hook pre-merge --yes` — 3585 tests pass, lints pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
