### PR TITLE
fix(ci): dedup "invalid CI platform" warning across branches

### DIFF
--- a/src/commands/list/ci_status/platform.rs
+++ b/src/commands/list/ci_status/platform.rs
@@ -12,6 +12,12 @@ use super::{CiBranchName, PrStatus, github, gitlab, tool_available};
 /// Cached CI tool availability.
 static CI_TOOLS: OnceLock<CiToolsAvailable> = OnceLock::new();
 
+/// Cached resolution of the project-config CI platform override.
+///
+/// Resolved once per process, so the warning for an unrecognized value fires
+/// once per `wt list` invocation rather than once per branch.
+static CONFIG_PLATFORM_OVERRIDE: OnceLock<Option<CiPlatform>> = OnceLock::new();
+
 /// Cached availability of CI CLI tools (`gh`, `glab`).
 ///
 /// Probed once on first access via `--version` check.
@@ -124,21 +130,9 @@ pub fn detect_platform_from_url(url: &str) -> Option<CiPlatform> {
 /// For remote branches, pass the branch's remote as `remote_hint` to ensure
 /// the correct platform is detected in mixed-remote repos (e.g., GitHub + GitLab).
 pub fn platform_for_repo(repo: &Repository, remote_hint: Option<&str>) -> Option<CiPlatform> {
-    // Config override takes precedence
-    if let Some(platform_str) = repo
-        .load_project_config()
-        .ok()
-        .flatten()
-        .and_then(|c| c.forge_platform().map(str::to_string))
-    {
-        if let Ok(platform) = platform_str.parse::<CiPlatform>() {
-            log::debug!("Using CI platform from config override: {}", platform);
-            return Some(platform);
-        }
-        log::warn!(
-            "Invalid CI platform in config: '{}'. Expected 'github' or 'gitlab'.",
-            platform_str
-        );
+    // Config override takes precedence.
+    if let Some(platform) = config_platform_override(repo) {
+        return Some(platform);
     }
 
     // If we have a specific remote hint (e.g., from a remote branch), use that first.
@@ -165,6 +159,38 @@ pub fn platform_for_repo(repo: &Repository, remote_hint: Option<&str>) -> Option
     }
 
     None
+}
+
+/// Resolve the project-config CI platform override (`forge.platform`, or the
+/// deprecated `ci.platform`), cached for the process.
+///
+/// Returns `None` when no override is set or the value is unrecognized. An
+/// unrecognized value logs a warning — and because the result is cached, that
+/// warning fires once per `wt list` invocation rather than once per branch.
+///
+/// The cache is process-wide and so assumes a single repository per process,
+/// which holds for the CLI: `platform_for_repo` is reached only from `wt list`
+/// (per branch) and `wt config show` (once).
+fn config_platform_override(repo: &Repository) -> Option<CiPlatform> {
+    *CONFIG_PLATFORM_OVERRIDE.get_or_init(|| {
+        let platform_str = repo
+            .load_project_config()
+            .ok()
+            .flatten()
+            .and_then(|c| c.forge_platform().map(str::to_string))?;
+        match platform_str.parse::<CiPlatform>() {
+            Ok(platform) => {
+                log::debug!("Using CI platform from config override: {platform}");
+                Some(platform)
+            }
+            Err(_) => {
+                log::warn!(
+                    "Invalid CI platform in config: '{platform_str}'. Expected 'github' or 'gitlab'."
+                );
+                None
+            }
+        }
+    })
 }
 
 #[cfg(test)]

--- a/src/commands/list/ci_status/platform.rs
+++ b/src/commands/list/ci_status/platform.rs
@@ -12,11 +12,11 @@ use super::{CiBranchName, PrStatus, github, gitlab, tool_available};
 /// Cached CI tool availability.
 static CI_TOOLS: OnceLock<CiToolsAvailable> = OnceLock::new();
 
-/// Cached resolution of the project-config CI platform override.
+/// CI platform from project config (`forge.platform` / `ci.platform`), cached.
 ///
 /// Resolved once per process, so the warning for an unrecognized value fires
 /// once per `wt list` invocation rather than once per branch.
-static CONFIG_PLATFORM_OVERRIDE: OnceLock<Option<CiPlatform>> = OnceLock::new();
+static CONFIGURED_PLATFORM: OnceLock<Option<CiPlatform>> = OnceLock::new();
 
 /// Cached availability of CI CLI tools (`gh`, `glab`).
 ///
@@ -130,8 +130,8 @@ pub fn detect_platform_from_url(url: &str) -> Option<CiPlatform> {
 /// For remote branches, pass the branch's remote as `remote_hint` to ensure
 /// the correct platform is detected in mixed-remote repos (e.g., GitHub + GitLab).
 pub fn platform_for_repo(repo: &Repository, remote_hint: Option<&str>) -> Option<CiPlatform> {
-    // Config override takes precedence.
-    if let Some(platform) = config_platform_override(repo) {
+    // Project config takes precedence.
+    if let Some(platform) = platform_from_config(repo) {
         return Some(platform);
     }
 
@@ -161,31 +161,31 @@ pub fn platform_for_repo(repo: &Repository, remote_hint: Option<&str>) -> Option
     None
 }
 
-/// Resolve the project-config CI platform override (`forge.platform`, or the
+/// Read the CI platform from project config (`forge.platform`, or the
 /// deprecated `ci.platform`), cached for the process.
 ///
-/// Returns `None` when no override is set or the value is unrecognized. An
+/// Returns `None` when nothing is configured or the value is unrecognized. An
 /// unrecognized value logs a warning — and because the result is cached, that
 /// warning fires once per `wt list` invocation rather than once per branch.
 ///
 /// The cache is process-wide and so assumes a single repository per process,
 /// which holds for the CLI: `platform_for_repo` is reached only from `wt list`
 /// (per branch) and `wt config show` (once).
-fn config_platform_override(repo: &Repository) -> Option<CiPlatform> {
-    *CONFIG_PLATFORM_OVERRIDE.get_or_init(|| {
-        let platform_str = repo
+fn platform_from_config(repo: &Repository) -> Option<CiPlatform> {
+    *CONFIGURED_PLATFORM.get_or_init(|| {
+        let configured = repo
             .load_project_config()
             .ok()
             .flatten()
             .and_then(|c| c.forge_platform().map(str::to_string))?;
-        match platform_str.parse::<CiPlatform>() {
+        match configured.parse::<CiPlatform>() {
             Ok(platform) => {
-                log::debug!("Using CI platform from config override: {platform}");
+                log::debug!("Using CI platform from config: {platform}");
                 Some(platform)
             }
             Err(_) => {
                 log::warn!(
-                    "Invalid CI platform in config: '{platform_str}'. Expected 'github' or 'gitlab'."
+                    "Invalid CI platform in config: '{configured}'. Expected 'github' or 'gitlab'."
                 );
                 None
             }

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_invalid_platform_override.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_invalid_platform_override.snap
@@ -11,10 +11,15 @@ info:
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
     GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
     GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
@@ -30,13 +35,17 @@ info:
     WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
@@ -54,8 +63,4 @@ exit_code: 0
 ----- stderr -----
 [33m▲[39m [33mProject config: [1m[ci][22m is deprecated in favor of [1m[forge][22m[39m
 [2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
-[2m[W][22m Invalid CI platform in config: 'invalid_platform'. Expected 'github' or 'gitlab'.
-[2m[W][22m Invalid CI platform in config: 'invalid_platform'. Expected 'github' or 'gitlab'.
-[2m[W][22m Invalid CI platform in config: 'invalid_platform'. Expected 'github' or 'gitlab'.
-[2m[W][22m Invalid CI platform in config: 'invalid_platform'. Expected 'github' or 'gitlab'.
 [2m[W][22m Invalid CI platform in config: 'invalid_platform'. Expected 'github' or 'gitlab'.


### PR DESCRIPTION
`wt list` resolves the CI platform once per branch, and the config branch of `platform_for_repo` re-parsed `forge.platform` (or the deprecated `ci.platform`) and re-emitted the `Invalid CI platform in config` warning on every call — so a repo with N branches printed N identical warnings for one misconfiguration.

The fix caches the configured platform in a process-wide `OnceLock<Option<CiPlatform>>`, with the `log::warn!` inside the `get_or_init` closure, so the warning fires once per `wt list` invocation. This mirrors the existing `CI_TOOLS` static in the same module. The remote-URL detection part of `platform_for_repo` depends on the per-branch remote hint, so it's deliberately left uncached.

A per-`RepoCache` field would be the natural home, but `CiPlatform` lives in the binary crate while `RepoCache` lives in the `worktrunk` library crate — wiring it there would mean moving `CiPlatform` to the lib, a refactor out of scope for this fix. The process-wide cache is safe here because `platform_for_repo` is only reached from `wt list` (per branch) and `wt config show` (once), and `wt` is one repo per invocation.

The `test_list_full_with_invalid_platform_override` snapshot now shows one warning instead of five (the env-var additions in the snapshot are pre-existing test-infra drift from regenerating it). `cargo run -- hook pre-merge --yes` passes.
