### PR TITLE
fix(bench): trim real_repo sampling; restore sample_size(10) criterion floor

### DIFF
--- a/benches/list.rs
+++ b/benches/list.rs
@@ -178,6 +178,20 @@ fn bench_worktree_scaling(c: &mut Criterion) {
 
 fn bench_real_repo(c: &mut Criterion) {
     let mut group = c.benchmark_group("real_repo");
+    // `wt list` on rust-lang/rust runs ~2s warm — dominated by one deep
+    // `git for-each-ref %(ahead-behind:main)` walk — and several times
+    // that for cold/8, where each iteration also rebuilds eight 59k-entry
+    // indexes via `git status`. Warm-path variance is that slowest single
+    // subprocess, not measurement noise, so the inherited 30-sample / 15s
+    // default just burns time: at >1s/iter Criterion can't fit 30 samples
+    // in 15s, so it runs 30 single-iteration samples regardless. 10 is
+    // Criterion's minimum (`sample_size` < 10 panics); the 20s budget
+    // caps the cheap warm variants at ≤2 iterations per sample. Cuts the
+    // group's measured time ~3× — the expensive cold variants drop from
+    // 30 iterations to 10.
+    group.measurement_time(std::time::Duration::from_secs(20));
+    group.sample_size(10);
+
     let binary = Path::new(env!("CARGO_BIN_EXE_wt"));
 
     for worktrees in [1, 4, 8] {
@@ -301,11 +315,12 @@ fn bench_real_repo_many_branches(c: &mut Criterion) {
     let mut group = c.benchmark_group("real_repo_many_branches");
     // rust-lang/rust runs ~3.7s per `wt list --branches` iteration; warm-path
     // variance is dominated by the slowest single subprocess (a deep
-    // `git merge-base` walking history), not measurement noise, so 5 samples
-    // suffices. A 20s budget is ≈ one iteration per sample (~18s), down from
-    // the ~74s criterion spent filling the old 60s budget.
+    // `git merge-base` walking history), not measurement noise, so 10 samples
+    // (criterion's minimum — `sample_size` < 10 panics) suffices. A 20s budget
+    // is ≈ one iteration per sample (~37s/function), down from the
+    // ~74s/function criterion spent filling the old 60s budget.
     group.measurement_time(std::time::Duration::from_secs(20));
-    group.sample_size(5);
+    group.sample_size(10);
 
     let binary = Path::new(env!("CARGO_BIN_EXE_wt"));
 


### PR DESCRIPTION
## Summary

Two changes to `benches/list.rs`, no production code.

**1. Trim `bench_real_repo` sampling.** It inherited the `criterion_group` default `sample_size(30)` / `measurement_time(15s)`. On rust-lang/rust `wt list` runs ~2s warm (dominated by one deep `git for-each-ref %(ahead-behind:main)` walk) and several times that for `cold/8`, where every iteration also rebuilds eight 59k-entry git indexes via `git status`. At >1s/iter Criterion can't fit 30 samples in 15s, so it just runs 30 single-iteration samples per variant — the group as a whole runs ~15–20 min, dominated by `real_repo/cold/{4,8}`. Set `sample_size(10)` (criterion 0.8's hard minimum) + `measurement_time(20s)`, mirroring what #2685 did for `bench_real_repo_many_branches`. The expensive cold variants drop from 30 to 10 iterations → group's measured time roughly thirds (~6–8 min). No change to what `wt list` runs or measures.

**2. Fix a latent panic in `bench_real_repo_many_branches`.** #2685 set it to `sample_size(5)`, but criterion 0.8's `sample_size` does `assert!(n >= 10)` (`benchmark_group.rs:97`), so `cargo bench --bench list` currently **panics on `main` during group registration** — for any filter, before any benchmark runs. Restored to `sample_size(10)`. (This was also a prerequisite for running `bench_real_repo` to validate change #1.)

## Why not sparse-checkout the rust clone

A sparse checkout would make the per-variant setup near-instant and `git status` / `git diff --shortstat HEAD` on the rust worktrees ~10ms instead of ~1.8s / ~0.8s — but those costs are exactly what the `cold` (cold 59k-entry index rebuild) and `warm` (working-tree scan over 59k files) variants exist to measure. Sparse-checkout would turn "cold index on a huge repo" into "cold index on ~20 files", erasing the documented `cold ~4×` insight. The mechanism works; it's the wrong tradeoff. Sharing one rust workspace across the warm/cold pair was also considered and dropped — after the sampling trim, setup is a small slice (~1.5–2 min of ~7 min), and sharing would require up to ~10 GB of simultaneous rust checkouts (CI disk risk) for a marginal gain.

## Before / after

`real_repo/warm/1` (rust-lang/rust clone, one worktree): median **1.809s** (30 samples) → **1.794s** (10 samples). Criterion's regression check on the after run: `change: [−23.1% −7.0% +10.8%] (p = 0.59)` → "No change in performance detected." The cold variants — the bulk of the group — drop 3× by arithmetic (30→10 single iterations of the same operation).

## Test plan

- [x] `cargo run -- hook pre-merge --yes` — 3645 tests pass, clippy + fmt + pre-commit hooks pass
- [x] `cargo bench --bench list -- 'real_repo/warm/1'` — runs cleanly, `sample_size(10)` accepted ("Collecting 10 samples"), result above
- [x] `cargo clippy --benches -- -D warnings`, `cargo check --benches`, `cargo fmt --check`
