### PR TITLE
fix(ci-status): resolve Gitea owner/repo from the branch's own remote

### DIFF
--- a/src/commands/list/ci_status/gitea.rs
+++ b/src/commands/list/ci_status/gitea.rs
@@ -254,6 +254,7 @@ struct GiteaOwner {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use worktrunk::testing::TestRepo;
 
     #[test]
     fn test_parse_gitea_status_state() {
@@ -264,5 +265,77 @@ mod tests {
         assert_eq!(parse_gitea_status_state("warning"), Some(CiStatus::Failed));
         assert_eq!(parse_gitea_status_state(""), None);
         assert_eq!(parse_gitea_status_state("bogus"), None);
+    }
+
+    /// Local branches (no `branch.remote`) walk the `else` arm — primary
+    /// remote's raw URL. Asserts directly against `gitea_owner_repo_for_branch`
+    /// so coverage doesn't depend on the spawn-based `tea --version` probe in
+    /// the integration tests.
+    #[test]
+    fn test_gitea_owner_repo_for_branch_local_uses_primary_remote() {
+        let test = TestRepo::with_initial_commit();
+        test.run_git(&[
+            "remote",
+            "add",
+            "origin",
+            "https://gitea.example.com/owner/test-repo.git",
+        ]);
+        let repo = Repository::at(test.root_path()).unwrap();
+
+        let branch = CiBranchName {
+            full_name: "main".to_string(),
+            remote: None,
+            name: "main".to_string(),
+        };
+        assert_eq!(
+            gitea_owner_repo_for_branch(&repo, &branch),
+            Some(("owner".to_string(), "test-repo".to_string()))
+        );
+    }
+
+    /// A branch whose remote has no URL (e.g., a stale ref to a deleted
+    /// remote) propagates `None` through the `?` on the if-else expression.
+    #[test]
+    fn test_gitea_owner_repo_for_branch_returns_none_when_remote_missing() {
+        let test = TestRepo::with_initial_commit();
+        let repo = Repository::at(test.root_path()).unwrap();
+
+        let branch = CiBranchName {
+            full_name: "ghost/feature".to_string(),
+            remote: Some("ghost".to_string()),
+            name: "feature".to_string(),
+        };
+        assert_eq!(gitea_owner_repo_for_branch(&repo, &branch), None);
+    }
+
+    /// Remote-branch refs walk the `if` arm — branch.remote's effective URL.
+    /// In a mixed-remote repo, this must pick the branch's remote, not the
+    /// primary one.
+    #[test]
+    fn test_gitea_owner_repo_for_branch_remote_uses_branch_remote() {
+        let test = TestRepo::with_initial_commit();
+        test.run_git(&[
+            "remote",
+            "add",
+            "origin",
+            "https://gitea.example.com/owner/test-repo.git",
+        ]);
+        test.run_git(&[
+            "remote",
+            "add",
+            "fork",
+            "https://gitea.example.com/forkowner/test-repo.git",
+        ]);
+        let repo = Repository::at(test.root_path()).unwrap();
+
+        let branch = CiBranchName {
+            full_name: "fork/feature".to_string(),
+            remote: Some("fork".to_string()),
+            name: "feature".to_string(),
+        };
+        assert_eq!(
+            gitea_owner_repo_for_branch(&repo, &branch),
+            Some(("forkowner".to_string(), "test-repo".to_string()))
+        );
     }
 }

--- a/src/commands/list/ci_status/gitea.rs
+++ b/src/commands/list/ci_status/gitea.rs
@@ -28,8 +28,9 @@
 //!
 //! - Only the first page of open PRs (Gitea's default page size, newest-first)
 //!   is inspected; in a repo with many open PRs, ours could fall off the page.
-//! - The PR lookup queries the primary remote's repo only, so PRs opened from a
-//!   fork (head repo owner ≠ that repo's owner) aren't matched.
+//! - PRs opened from a fork (head repo owner ≠ the queried repo's owner) aren't
+//!   matched — owner/repo comes from the branch's own remote, not the upstream
+//!   the PR targets.
 //! - `mergeable` is computed asynchronously by Gitea, so a freshly-opened PR can
 //!   briefly report a false conflict until the check completes (self-corrects
 //!   when the cache expires).
@@ -42,15 +43,28 @@ use super::{
     CiBranchName, CiSource, CiStatus, PrStatus, is_retriable_error, non_interactive_cmd, parse_json,
 };
 
-/// Resolve `(owner, repo)` for this repo's Gitea remote.
+/// Resolve `(owner, repo)` for the branch's effective Gitea remote.
 ///
-/// Platform is already known to be Gitea, so we extract owner/repo from the
-/// primary remote's raw URL (not the `insteadOf`-rewritten one — `tea` talks to
-/// the upstream host, not a local alias target) without re-checking the host.
-/// Mirrors `git::remote_ref::gitea`'s resolution for the `pr:` shortcut.
-fn gitea_owner_repo(repo: &Repository) -> Option<(String, String)> {
-    let remote = repo.primary_remote().ok()?;
-    let url = repo.remote_url(&remote)?;
+/// For a remote branch ref (e.g. `gitea/feature`), reads the branch's own
+/// remote — so a `wt list --remotes --full` row queries the right repo in a
+/// mixed-remote setup. Uses [`Repository::effective_remote_url`] to honor
+/// `url.insteadOf` rewrites, matching the GitHub path's
+/// `github_owner_repo_for_branch`.
+///
+/// For a local branch (no `branch.remote`), falls back to the primary remote's
+/// *raw* URL — matching `git::remote_ref::gitea`'s `pr:` resolver. The raw URL
+/// is enough here: only owner/repo (the path) are read, and `tea` resolves the
+/// host from its own login config rather than the URL we pass.
+fn gitea_owner_repo_for_branch(
+    repo: &Repository,
+    branch: &CiBranchName,
+) -> Option<(String, String)> {
+    let url = if let Some(remote_name) = &branch.remote {
+        repo.effective_remote_url(remote_name)
+    } else {
+        let remote = repo.primary_remote().ok()?;
+        repo.remote_url(&remote)
+    }?;
     parse_owner_repo(&url)
 }
 
@@ -111,7 +125,7 @@ pub(super) fn detect_gitea_pr(
     branch: &CiBranchName,
     local_head: &str,
 ) -> Option<PrStatus> {
-    let (owner, repo_name) = gitea_owner_repo(repo)?;
+    let (owner, repo_name) = gitea_owner_repo_for_branch(repo, branch)?;
 
     // `state=open` is required: the pulls list returns all states by default.
     let path = format!("repos/{owner}/{repo_name}/pulls?state=open");
@@ -168,8 +182,12 @@ pub(super) fn detect_gitea_pr(
 ///
 /// Queries the combined commit status of `local_head` directly, so the result
 /// is never stale.
-pub(super) fn detect_gitea_commit_status(repo: &Repository, local_head: &str) -> Option<PrStatus> {
-    let (owner, repo_name) = gitea_owner_repo(repo)?;
+pub(super) fn detect_gitea_commit_status(
+    repo: &Repository,
+    branch: &CiBranchName,
+    local_head: &str,
+) -> Option<PrStatus> {
+    let (owner, repo_name) = gitea_owner_repo_for_branch(repo, branch)?;
     let ci_status = fetch_combined_status(repo, &owner, &repo_name, local_head)?;
     Some(PrStatus {
         ci_status,

--- a/src/commands/list/ci_status/platform.rs
+++ b/src/commands/list/ci_status/platform.rs
@@ -69,8 +69,9 @@ fn detect_branch(
         CiPlatform::GitHub => github::detect_github_commit_checks(repo, branch, local_head),
         // GitLab pipelines use the bare branch name (not "origin/feature").
         CiPlatform::GitLab => gitlab::detect_gitlab_pipeline(repo, &branch.name, local_head),
-        // Gitea queries the combined commit status by SHA — branch-independent.
-        CiPlatform::Gitea => gitea::detect_gitea_commit_status(repo, local_head),
+        // Gitea queries the combined commit status by SHA, but owner/repo come
+        // from the branch's own remote (so remote-only rows hit the right repo).
+        CiPlatform::Gitea => gitea::detect_gitea_commit_status(repo, branch, local_head),
         CiPlatform::AzureDevOps => azure::detect_azure_pipeline(repo, &branch.name, local_head),
     }
 }

--- a/tests/integration_tests/ci_status.rs
+++ b/tests/integration_tests/ci_status.rs
@@ -1211,3 +1211,52 @@ fn test_list_full_with_gitea_commit_status_retriable_error(mut repo: TestRepo) {
         assert_cmd_snapshot!("gitea_commit_status_retriable_error", cmd);
     });
 }
+
+/// `wt list --remotes --full` resolves Gitea owner/repo from the branch's own
+/// remote, not the primary remote. Two Gitea remotes (`origin` →
+/// `owner/test-repo`, `fork` → `forkowner/test-repo`) plus a remote-only
+/// `fork/feature-remote` ref. The mock answers only `forkowner/test-repo`
+/// requests, so a buggy primary-remote lookup would return no CI; the green
+/// `●` in the snapshot proves `branch.remote` is honored.
+#[rstest]
+fn test_list_remotes_full_with_gitea_remote_branch(mut repo: TestRepo) {
+    repo.run_git(&[
+        "remote",
+        "set-url",
+        "origin",
+        "https://gitea.example.com/owner/test-repo.git",
+    ]);
+    repo.run_git(&[
+        "remote",
+        "add",
+        "fork",
+        "https://gitea.example.com/forkowner/test-repo.git",
+    ]);
+
+    // Build the remote-only `fork/feature-remote` ref in a temporary local
+    // branch (mirroring how `test_list_with_remotes_and_full` does it for
+    // origin), then drop the local copy so the row appears as remote-only.
+    repo.run_git(&["checkout", "-b", "feature-remote"]);
+    std::fs::write(repo.root_path().join("gitea-fork.txt"), "fork content").unwrap();
+    repo.run_git(&["add", "."]);
+    repo.run_git(&["commit", "-m", "feat: fork feature"]);
+    let head_sha = branch_sha(&repo, "feature-remote");
+    repo.run_git(&["update-ref", "refs/remotes/fork/feature-remote", &head_sha]);
+    repo.run_git(&["checkout", "main"]);
+    repo.run_git(&["branch", "-D", "feature-remote"]);
+
+    repo.setup_mock_tea_with_ci_data(
+        "forkowner",
+        "test-repo",
+        &head_sha,
+        "[]",
+        r#"{"state":"success","total_count":1}"#,
+    );
+
+    let settings = setup_snapshot_settings(&repo);
+    settings.bind(|| {
+        let mut cmd = make_snapshot_cmd(&repo, "list", &["--remotes", "--full"], None);
+        repo.configure_mock_commands(&mut cmd);
+        assert_cmd_snapshot!("gitea_remote_branch_uses_branch_remote", cmd);
+    });
+}

--- a/tests/snapshots/integration__integration_tests__ci_status__gitea_remote_branch_uses_branch_remote.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitea_remote_branch_uses_branch_remote.snap
@@ -1,0 +1,64 @@
+---
+source: tests/integration_tests/ci_status.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--remotes"
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
+    GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
+    GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m               [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCI[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main                     [2m^[22m[2m|[22m                                      [2m|[0m         .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
++ feature-a                [2m↑[22m                 [32m↑1[0m        [32m+1[0m                    ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
++ feature-b                [2m↑[22m                 [32m↑1[0m        [32m+1[0m                    ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file
++ feature-c                [2m↑[22m                 [32m↑1[0m        [32m+1[0m                    ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
+  fork/feature-remote     [2m/[22m[2m↑[22m                 [32m↑1[0m        [32m+1[0m                [32m●[0m                      [2m86db681a[0m  [2m1d[0m    [2mfeat: fork feature
+
+[2m○[22m [2mShowing 4 worktrees, 1 remote branches, 4 ahead
+
+----- stderr -----


### PR DESCRIPTION
Brings the Gitea CI-status path to parity with the GitHub path when resolving owner/repo for a branch. Today `gitea_owner_repo` always reads the primary remote, so a `wt list --remotes --full` row for a remote-only branch on a non-primary remote (e.g. `gitea/feature` when `origin` points elsewhere) silently misses CI. The new `gitea_owner_repo_for_branch` reads the branch's own remote via `effective_remote_url` for remote branches and falls back to the primary remote's raw URL for local branches.

The local-branch fallback keeps using `remote_url` (raw) rather than `effective_remote_url` to match `git::remote_ref::gitea`'s existing `pr:` resolver — `tea` resolves the host from its own login config, and only owner/repo are extracted from the URL. The remote-branch arm uses `effective_remote_url` for symmetry with `github_owner_repo_for_branch`, so `url.insteadOf` aliases still resolve.

Test: a new `--remotes --full` integration test stands up two Gitea remotes (`origin` → `owner/test-repo`, `fork` → `forkowner/test-repo`), mirrors a `fork/feature-remote` ref, and mocks `tea` to answer only `forkowner/test-repo` paths. The green `●` in the snapshot confirms the lookup hits the branch's remote — a primary-remote lookup would silently return no CI.

Out of scope: the `wt switch pr:` Gitea resolver in `src/git/remote_ref/gitea.rs` keeps its primary-remote-only behavior. Fork PRs (head owner ≠ queried owner) remain unmatched — the limitation docstring is updated to reflect the actual residual gap.
