### PR TITLE
fix(hooks): propagate Repository::at errors in pre-remove config resolution

### DIFF
--- a/src/commands/step/prune.rs
+++ b/src/commands/step/prune.rs
@@ -412,9 +412,11 @@ fn approve_prune_hooks(
             continue;
         };
         let wt = &worktrees[*wt_idx];
-        let wt_repo = match Repository::at(&wt.path) {
-            Ok(r) if r.load_project_config().ok().flatten().is_some() => r,
-            _ => primary_repo.clone(),
+        let wt_at_path = Repository::at(&wt.path)?;
+        let wt_repo = if wt_at_path.load_project_config().ok().flatten().is_some() {
+            wt_at_path
+        } else {
+            primary_repo.clone()
         };
         if let Some(cfg) = wt_repo.load_project_config()? {
             all_commands.extend(collect_commands_for_hooks(&cfg, &[HookType::PreRemove]));

--- a/src/main.rs
+++ b/src/main.rs
@@ -917,9 +917,11 @@ fn handle_remove_command(args: RemoveArgs, yes: bool) -> anyhow::Result<()> {
                 let primary_path = repo.home_path()?;
                 let primary_repo = Repository::at(&primary_path)?;
                 for &wt_path in removed_worktree_paths {
-                    let wt_repo = match Repository::at(wt_path) {
-                        Ok(r) if r.load_project_config().ok().flatten().is_some() => r,
-                        _ => primary_repo.clone(),
+                    let wt_at_path = Repository::at(wt_path)?;
+                    let wt_repo = if wt_at_path.load_project_config().ok().flatten().is_some() {
+                        wt_at_path
+                    } else {
+                        primary_repo.clone()
                     };
                     let ctx = CommandContext::new(
                         &wt_repo,

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -1197,9 +1197,17 @@ fn execute_pre_remove_hooks_if_needed(
     // — e.g. it was branched before the project added one — fall back to `repo`
     // so a project-wide `pre-remove` on the default branch still applies. The
     // `wt remove` approval helper in `main.rs` resolves the same config.
-    let pre_remove_repo = match Repository::at(ctx.worktree_path) {
-        Ok(wt_repo) if wt_repo.load_project_config().ok().flatten().is_some() => wt_repo,
-        _ => repo.clone(),
+    //
+    // A `Repository::at` failure means git can't recognize the path as a
+    // worktree — propagate rather than silently fall back, matching the
+    // approval helpers (`main.rs::approve_remove`, `prune::approve_prune_hooks`).
+    // The `UserConfig::load()` silent-skip above is a different case: user
+    // config can be benignly malformed and shouldn't fail a remove.
+    let wt_at_path = Repository::at(ctx.worktree_path)?;
+    let pre_remove_repo = if wt_at_path.load_project_config().ok().flatten().is_some() {
+        wt_at_path
+    } else {
+        repo.clone()
     };
     let command_ctx = CommandContext::new(
         &pre_remove_repo,


### PR DESCRIPTION
Each of the three `pre-remove` config-resolution call sites — the two approval helpers (`main.rs::approve_remove`, `prune::approve_prune_hooks`) and the executor (`handlers::execute_pre_remove_hooks_if_needed`) — used a `match` that incidentally swallowed `Err(_)` from `Repository::at(wt_path)` into the legitimate "no `.config/wt.toml`" fallback. Rewrite as two-step so `Repository::at` errors propagate; the fallback now fires only when the removed worktree has no project config.

The executor's inline comment notes why we propagate here rather than follow the `UserConfig::load()` silent-skip a few lines above: user config can be benignly malformed, but a path git no longer recognizes as a worktree is a different kind of failure.

Follows the same shape as the sibling fix in #2701, which replaced `Repository::at(&primary_path).unwrap_or_else(|_| repo.clone())` with `?` for the same reason.

`merge.rs::collect_merge_commands` already uses `?` for its `Repository::at(destination_path)` (refactored in #2690), so it's untouched.
