### PR TITLE
fix(config): pass `--end-of-options` when reading project config at a ref

### DIFF
--- a/src/git/repository/config.rs
+++ b/src/git/repository/config.rs
@@ -636,8 +636,14 @@ impl Repository {
         if std::env::var_os("WORKTRUNK_PROJECT_CONFIG_PATH").is_some() {
             return self.load_project_config().ok().flatten();
         }
+        // `--end-of-options` keeps a ref like `-foo` from being parsed as a
+        // flag (git's option parser would otherwise reject `-foo:.config/wt.toml`).
         let content = self
-            .run_command(&["show", &format!("{gitref}:.config/wt.toml")])
+            .run_command(&[
+                "show",
+                "--end-of-options",
+                &format!("{gitref}:.config/wt.toml"),
+            ])
             .ok()?;
         let migrated = crate::config::migrate_content(&content);
         toml::from_str::<ProjectConfig>(&migrated).ok()
@@ -672,6 +678,31 @@ mod tests {
         test.run_git(&["add", ".config/wt.toml"]);
         test.run_git(&["commit", "-m", "Break config"]);
         assert!(repo.project_config_at_ref("HEAD").is_none());
+    }
+
+    /// A ref literally named `-foo` must round-trip through
+    /// [`project_config_at_ref`] without git's option parser eating the
+    /// leading `-`. Without `--end-of-options`, `git show` would reject
+    /// `-foo:.config/wt.toml` as a flag and the helper would silently
+    /// return `None` even though the file exists on the ref.
+    #[test]
+    fn project_config_at_ref_handles_hyphen_prefixed_ref() {
+        let test = TestRepo::with_initial_commit();
+        let repo = Repository::at(test.root_path()).unwrap();
+
+        test.write_project_config(r#"post-start = "echo hi""#);
+        test.run_git(&["add", ".config/wt.toml"]);
+        test.run_git(&["commit", "-m", "Add config"]);
+
+        // `git branch -- -foo` is rejected by recent git, but `update-ref`
+        // happily writes the ref — which is the worst case we want to be
+        // robust against.
+        test.run_git(&["update-ref", "refs/heads/-foo", "HEAD"]);
+
+        let cfg = repo
+            .project_config_at_ref("-foo")
+            .expect("config readable at hyphen-prefixed ref");
+        assert!(cfg.hooks.post_start.is_some());
     }
 
     #[test]


### PR DESCRIPTION
`Repository::project_config_at_ref` (added in #2703) runs `git show <ref>:.config/wt.toml`. If the ref starts with `-` — e.g. a branch literally named `-foo` — git's option parser rejects the argument as a flag and the helper silently returns `None` even though the file exists. Passing `--end-of-options` tells git's parser everything after it is positional, which fixes the bare-ref case used by `wt switch`'s `pre-start` / `post-start` / `post-switch` hook-approval gate.

The vulnerable refs in practice are the explicit `--create --base <ref>` argument, a local branch name, and `<remote>/<branch>` — `HEAD` / `FETCH_HEAD` are safe. Creating such a branch is hard but possible (`git update-ref refs/heads/-foo HEAD`), and the fix is one extra arg.

Added a unit test that creates `refs/heads/-foo` via `update-ref` (modern git rejects `git branch -- -foo`) and asserts the config round-trips through `project_config_at_ref`.
