### PR TITLE
fix(picker): pre-flight template validation in picker-create

### DIFF
--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -111,7 +111,7 @@ use super::worktree::hooks::PostRemoveContext;
 use super::worktree::{
     RemoveResult, SwitchBranchInfo, SwitchResult, approve_switch_hooks, execute_switch,
     offer_bare_repo_worktree_path_fix, path_mismatch, plan_switch, run_pre_switch_hooks,
-    spawn_switch_background_hooks, switch_hook_project_config,
+    spawn_switch_background_hooks, switch_hook_project_config, validate_switch_templates,
 };
 use crate::commands::command_executor::CommandContext;
 use crate::output::handle_switch_output;
@@ -794,6 +794,21 @@ pub fn handle_picker(
             true,
             hook_project_config.as_ref(),
         )?;
+
+        // Pre-flight: validate all templates before mutation (worktree creation).
+        // Without this, picker-create would have the half-state risk that
+        // `wt switch --create` already guards against — a broken template would
+        // fail after `git worktree add`, leaving the worktree behind.
+        validate_switch_templates(
+            &repo,
+            &config,
+            &plan,
+            None,
+            &[],
+            hooks_approved,
+            hook_project_config.as_ref(),
+        )?;
+
         let (result, branch_info) = execute_switch(&repo, plan, &config, false, hooks_approved)?;
 
         // Compute path mismatch lazily (deferred from plan_switch for existing worktrees).

--- a/src/commands/worktree/mod.rs
+++ b/src/commands/worktree/mod.rs
@@ -101,7 +101,7 @@ pub use switch::{SwitchOptions, run_switch};
 #[cfg(unix)]
 pub(crate) use switch::{
     approve_switch_hooks, run_pre_switch_hooks, spawn_switch_background_hooks,
-    switch_hook_project_config,
+    switch_hook_project_config, validate_switch_templates,
 };
 #[cfg(unix)]
 pub use switch::{execute_switch, plan_switch};

--- a/src/commands/worktree/switch.rs
+++ b/src/commands/worktree/switch.rs
@@ -1766,7 +1766,7 @@ pub fn run_switch(
 /// - `--execute` command template (if present)
 /// - `--execute` trailing arg templates (if present)
 /// - Hook templates (pre-start, post-start, post-switch) from user and project config
-fn validate_switch_templates(
+pub(crate) fn validate_switch_templates(
     repo: &Repository,
     config: &UserConfig,
     plan: &SwitchPlan,

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -1038,6 +1038,103 @@ fn test_switch_picker_create_with_empty_query_fails(mut repo: TestRepo) {
     );
 }
 
+/// Picker-create validates hook templates *before* `git worktree add`, mirroring
+/// the pre-flight that `wt switch --create` already performs.
+///
+/// Without this, a broken `pre-start` template would let the worktree be
+/// created, then fail at expansion time — leaving a half-state that blocks
+/// re-running (the branch already exists). The test commits a syntax-broken
+/// `pre-start` to the user config, fires picker-create, asserts that no branch
+/// or worktree was created, then fixes the template and confirms re-running
+/// succeeds — proving the pre-flight aborts cleanly rather than leaving a
+/// half-created worktree behind.
+#[rstest]
+fn test_switch_picker_create_validates_templates_before_worktree(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["remote", "remove", "origin"]);
+
+    // Broken `pre-start` in user config: unbalanced `{{` is a minijinja parse
+    // error, so `validate_template` rejects it without needing approvals.
+    // Project config would also trigger the validation path, but it routes
+    // through the approval gate first and would prompt for a TTY response —
+    // user-config hooks are trusted and exercise validation directly.
+    repo.write_test_config(r#"pre-start = "echo {{ unclosed""#);
+
+    let env_vars = repo.test_env_vars();
+
+    let result = exec_in_pty_with_input_expectations(
+        wt_bin().to_str().unwrap(),
+        &["switch"],
+        repo.root_path(),
+        &env_vars,
+        &[
+            ("new-feature", None), // Type the branch name
+            ("\x1bc", None),       // Alt-C: create
+        ],
+    );
+
+    assert_ne!(
+        result.exit_code,
+        0,
+        "Expected non-zero exit when pre-start template is broken.\nScreen:\n{}",
+        result.screen()
+    );
+
+    // Branch must not have been created — pre-flight runs before any
+    // `git worktree add` / `git branch`.
+    let branch_output = repo
+        .git_command()
+        .args(["branch", "--list", "new-feature"])
+        .run()
+        .unwrap();
+    assert!(
+        String::from_utf8_lossy(&branch_output.stdout)
+            .trim()
+            .is_empty(),
+        "Branch `new-feature` should NOT exist, got:\n{}",
+        String::from_utf8_lossy(&branch_output.stdout)
+    );
+
+    // Worktree directory must not exist either.
+    let repo_name = repo.root_path().file_name().unwrap().to_str().unwrap();
+    let worktree_dir = repo
+        .root_path()
+        .parent()
+        .unwrap()
+        .join(format!("{repo_name}.new-feature"));
+    assert!(
+        !worktree_dir.exists(),
+        "Worktree dir {worktree_dir:?} should NOT have been created"
+    );
+
+    // Fix the template and re-run — proves no half-state was left behind.
+    repo.write_test_config(r#"pre-start = "true""#);
+
+    let result = exec_in_pty_with_input_expectations(
+        wt_bin().to_str().unwrap(),
+        &["switch"],
+        repo.root_path(),
+        &env_vars,
+        &[("new-feature", None), ("\x1bc", None)],
+    );
+    assert_eq!(
+        result.exit_code,
+        0,
+        "Re-running picker-create with fixed template should succeed.\nScreen:\n{}",
+        result.screen()
+    );
+
+    let branch_output = repo
+        .git_command()
+        .args(["branch", "--list", "new-feature"])
+        .run()
+        .unwrap();
+    assert!(
+        String::from_utf8_lossy(&branch_output.stdout).contains("new-feature"),
+        "Branch `new-feature` should exist after fix"
+    );
+}
+
 #[rstest]
 fn test_switch_picker_switch_to_existing_worktree(mut repo: TestRepo) {
     repo.remove_fixture_worktrees();


### PR DESCRIPTION
The interactive picker's create path (Alt-C in `wt switch`) skipped the template pre-flight that `wt switch --create` performs. If a user's project config had a broken hook template (syntax error, undefined variable), picking a branch with Alt-C succeeded at `git worktree add`, then failed when `pre-start` expansion errored — and the worktree existed, blocking re-running with the same name.

`run_switch` already calls `validate_switch_templates` between `approve_switch_hooks` and `execute_switch` for exactly this reason (see its module docstring, "Why only switch needs pre-flight validation"). This PR adds the same call in `handle_picker`. The helper goes from `fn` to `pub(crate) fn` and is re-exported from `commands/worktree`.

A PTY test in `switch_picker.rs` commits a syntax-broken `pre-start = "echo {{ unclosed"` to the user config, drives picker-create via Alt-C, and asserts no branch + no worktree dir + non-zero exit. It then fixes the template and re-runs to confirm no half-state was left behind. Verified the test fails as expected when the picker fix is reverted (branch and worktree get created).
