### PR TITLE
fix(testing): propagate LLVM coverage env from `isolate_subprocess_env`

### DIFF
--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -295,6 +295,18 @@ const DEFAULT_ISOLATED_APPROVALS: &str = "/nonexistent/wt/approvals.toml";
 /// file doesn't actually exist on test/CI machines.
 const DEFAULT_ISOLATED_SYSTEM_CONFIG: &str = "/etc/xdg/worktrunk/config.toml";
 
+/// LLVM coverage env vars that the parent's `cargo llvm-cov` / `cargo affected`
+/// run sets to point spawned binaries at the right `.profraw` file. Mirrored
+/// in `tests/common/mod.rs::pass_coverage_env_to_pty_cmd` for PTY tests that
+/// `env_clear()`. Keep both lists in sync — dropping `LLVM_PROFILE_FILE` makes
+/// an instrumented child fall back to LLVM's default `default_*.profraw` in
+/// the child's cwd, leaving stray files at the repo root.
+pub const COVERAGE_ENV_VARS: &[&str] = &[
+    "LLVM_PROFILE_FILE",
+    "CARGO_LLVM_COV",
+    "CARGO_LLVM_COV_TARGET_DIR",
+];
+
 /// Prepare a subprocess to run with a clean wt environment.
 ///
 /// Strips every `GIT_*` and `WORKTRUNK_*` from the parent env, plus
@@ -304,6 +316,11 @@ const DEFAULT_ISOLATED_SYSTEM_CONFIG: &str = "/etc/xdg/worktrunk/config.toml";
 /// - `WORKTRUNK_CONFIG_PATH` ← `user_config` (or [`DEFAULT_ISOLATED_USER_CONFIG`])
 /// - `WORKTRUNK_SYSTEM_CONFIG_PATH` ← real XDG location (typically nonexistent on CI)
 /// - `WORKTRUNK_APPROVALS_PATH` ← nonexistent file
+///
+/// Also re-applies [`COVERAGE_ENV_VARS`] from the parent so an instrumented
+/// child writes its `.profraw` to the path `cargo llvm-cov` chose, not to a
+/// `default_*.profraw` in the child's cwd. The re-apply is defensive: a caller
+/// that did `env_clear()` before us would otherwise drop the inherited values.
 ///
 /// Shared by [`configure_cli_command`] (test-side, layers on test
 /// determinism: forced colors, fixed timestamps, log level, etc.) and
@@ -345,6 +362,12 @@ where
         DEFAULT_ISOLATED_SYSTEM_CONFIG,
     );
     cmd.env("WORKTRUNK_APPROVALS_PATH", DEFAULT_ISOLATED_APPROVALS);
+
+    for key in COVERAGE_ENV_VARS {
+        if let Ok(val) = std::env::var(key) {
+            cmd.env(key, val);
+        }
+    }
 }
 
 /// `env_remove` the [`INHERITED_GIT_PATH_VARS`] from `cmd`. Call this on
@@ -495,18 +518,8 @@ pub fn configure_cli_command(cmd: &mut Command) {
     // Not in STATIC_TEST_ENV_VARS because PTY tests need a TERM with valid terminfo.
     cmd.env("TERM", "alacritty");
 
-    // Pass through LLVM coverage profiling environment for subprocess coverage collection.
-    // When running under cargo-llvm-cov, spawned binaries need LLVM_PROFILE_FILE to record
-    // their coverage data. Without this, integration test coverage isn't captured.
-    for key in [
-        "LLVM_PROFILE_FILE",
-        "CARGO_LLVM_COV",
-        "CARGO_LLVM_COV_TARGET_DIR",
-    ] {
-        if let Ok(val) = std::env::var(key) {
-            cmd.env(key, val);
-        }
-    }
+    // LLVM coverage env propagation lives in `isolate_subprocess_env` so bench
+    // callers get the same defense; nothing extra needed here.
 }
 
 /// Configure a git command with isolated environment for testing.

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -446,16 +446,16 @@ pub fn configure_pty_command(cmd: &mut portable_pty::CommandBuilder) {
 /// Pass through LLVM coverage profiling environment to a portable_pty::CommandBuilder.
 ///
 /// PTY tests use `cmd.env_clear()` for isolation, which removes LLVM_PROFILE_FILE.
-/// Without this, spawned binaries can't write coverage data.
+/// Without this, an instrumented child writes `default_*.profraw` into its cwd
+/// (i.e. the repo root for tests that don't override it) instead of the path
+/// `cargo llvm-cov` chose. The non-PTY equivalent lives inside
+/// `worktrunk::testing::isolate_subprocess_env`; both paths share
+/// [`worktrunk::testing::COVERAGE_ENV_VARS`].
 ///
 /// Use `configure_pty_command()` for the full setup, or call this directly if you
 /// need custom env_clear handling (e.g., shell-specific env vars).
 pub fn pass_coverage_env_to_pty_cmd(cmd: &mut portable_pty::CommandBuilder) {
-    for key in [
-        "LLVM_PROFILE_FILE",
-        "CARGO_LLVM_COV",
-        "CARGO_LLVM_COV_TARGET_DIR",
-    ] {
+    for key in worktrunk::testing::COVERAGE_ENV_VARS {
         if let Ok(val) = std::env::var(key) {
             cmd.env(key, val);
         }

--- a/tests/common/progressive_output.rs
+++ b/tests/common/progressive_output.rs
@@ -557,11 +557,7 @@ fn configure_pty_environment(cmd: &mut CommandBuilder, repo: &TestRepo) {
     // Pass through LLVM coverage profiling environment for subprocess coverage collection.
     // When running under cargo-llvm-cov, spawned binaries need LLVM_PROFILE_FILE to record
     // their coverage data.
-    for key in [
-        "LLVM_PROFILE_FILE",
-        "CARGO_LLVM_COV",
-        "CARGO_LLVM_COV_TARGET_DIR",
-    ] {
+    for key in worktrunk::testing::COVERAGE_ENV_VARS {
         if let Ok(val) = std::env::var(key) {
             cmd.env(key, val);
         }


### PR DESCRIPTION
## Summary

Move the `LLVM_PROFILE_FILE` / `CARGO_LLVM_COV*` passthrough loop into `isolate_subprocess_env` and hoist the env-var list to a shared `COVERAGE_ENV_VARS` constant. Today the passthrough only runs inside `configure_cli_command` (the test-side superset). Benches use `isolate_subprocess_env` directly per its docstring, so any future caller that `env_clear()`s before us would silently drop the coverage env and the instrumented child would write `default_<hash>_<pid>_*.profraw` next to its cwd instead of the path `cargo llvm-cov` chose.

The original report was a stray `default_*.profraw` at the worktree root from an earlier session. I could not deterministically reproduce the leak under `cargo llvm-cov --benches` or `cargo llvm-cov --test integration` after auditing the test/bench call sites, so this is defense-in-depth at the helper that owns the contract rather than a targeted root-cause fix — flagged in commentary above the new const.

## Changes

- `src/testing/mod.rs` — new `pub const COVERAGE_ENV_VARS`; `isolate_subprocess_env` re-applies them at the end; matching block removed from `configure_cli_command`.
- `tests/common/mod.rs`, `tests/common/progressive_output.rs` — the PTY helpers (`pass_coverage_env_to_pty_cmd`, `configure_pty_environment`) iterate the same constant.

`.gitignore` is intentionally untouched so a future regression surfaces in `git status` instead of getting silently hidden.

## Test plan

- `cargo run -- hook pre-merge --yes` — green (3627 tests passed, pre-commit hooks clean, doctest + cargo doc clean).
- `cargo llvm-cov --benches --no-report -- skeleton/warm/1` — green, no stray `*.profraw` at repo root.
- `cargo llvm-cov --test integration --no-report -- 'integration_tests::shell_wrapper::...test_bash_completion_produces_correct_output' '...user_hooks::test_var_flag_invalid_format_fails' '...readme_sync' '...help::'` — 61 passed, no stray `*.profraw`.
- Existing `isolate_subprocess_env_scrubs_git_and_worktrunk_keys` unit test still passes.
