### PR TITLE
Support Omarchy dynamic themes in switch picker

### DIFF
--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -58,6 +58,8 @@ Shortcuts also apply to `--base`. For a fork PR/MR, the head commit is fetched a
 
 When called without arguments, `wt switch` opens an interactive picker to browse and select worktrees with live preview.
 
+On Omarchy, the picker reads `~/.config/omarchy/current/theme/colors.toml` each time it opens and uses the active theme's colors. Theme changes apply the next time the picker opens. When that file is unavailable, the picker falls back to Worktrunk's built-in palette.
+
 <figure class="demo">
 <picture>
   <source srcset="/assets/docs/dark/wt-switch-picker.gif" media="(prefers-color-scheme: dark)">

--- a/skills/worktrunk/reference/switch.md
+++ b/skills/worktrunk/reference/switch.md
@@ -60,6 +60,8 @@ Shortcuts also apply to `--base`. For a fork PR/MR, the head commit is fetched a
 
 When called without arguments, `wt switch` opens an interactive picker to browse and select worktrees with live preview.
 
+On Omarchy, the picker reads `~/.config/omarchy/current/theme/colors.toml` each time it opens and uses the active theme's colors. Theme changes apply the next time the picker opens. When that file is unavailable, the picker falls back to Worktrunk's built-in palette.
+
 **Keybindings:**
 
 | Key | Action |

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -587,6 +587,8 @@ Shortcuts also apply to `--base`. For a fork PR/MR, the head commit is fetched a
 
 When called without arguments, `wt switch` opens an interactive picker to browse and select worktrees with live preview.
 
+On Omarchy, the picker reads `~/.config/omarchy/current/theme/colors.toml` each time it opens and uses the active theme's colors. Theme changes apply the next time the picker opens. When that file is unavailable, the picker falls back to Worktrunk's built-in palette.
+
 <!-- demo: wt-switch-picker.gif 1600x800 -->
 **Keybindings:**
 

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -86,6 +86,7 @@ pub(crate) mod preview_cache;
 mod preview_orchestrator;
 mod progressive_handler;
 mod summary;
+mod theme;
 
 use std::cell::RefCell;
 use std::io::IsTerminal;
@@ -122,6 +123,7 @@ use worktrunk::git::{
 use items::{PreviewCache, WorktreeSkimItem};
 use preview::{PreviewLayout, PreviewMode, PreviewState};
 use preview_orchestrator::PreviewOrchestrator;
+use theme::picker_color_scheme;
 
 /// Drain stashed warnings to stderr. Called after skim has released the
 /// terminal (or in the dry-run path after the bg thread joins) — eprintln
@@ -575,23 +577,7 @@ pub fn handle_picker(
         // effect, `clear_on_start = false`, is harmless for us — skim
         // immediately overdraws the rows it allocates.
         .no_clear_start(true)
-        // Color scheme using fzf's --color=light values: dark text (237) on light gray bg (251)
-        //
-        // Terminal color compatibility is tricky:
-        // - current_bg:254 (original): too bright on dark terminals, washes out text
-        // - current_bg:236 (fzf dark): too dark on light terminals, jarring contrast
-        // - current_bg:251 + current:-1: light bg works on both, but unstyled text
-        //   becomes unreadable on dark terminals (light-on-light)
-        // - current_bg:251 + current:237: fzf's light theme, best compromise
-        //
-        // The light theme works universally because:
-        // - On dark terminals: light gray highlight stands out clearly
-        // - On light terminals: light gray is subtle but visible
-        // - Dark text (237) ensures readability regardless of terminal theme
-        .color(Some(
-            "fg:-1,bg:-1,header:-1,matched:108,current:237,current_bg:251,current_match:108"
-                .to_string(),
-        ))
+        .color(Some(picker_color_scheme()))
         .cmd_collector(Rc::new(RefCell::new(collector)) as Rc<RefCell<dyn CommandCollector>>)
         .bind(vec![
             // Mode switching (1/2/3/4/5 keys change preview content)

--- a/src/commands/picker/theme.rs
+++ b/src/commands/picker/theme.rs
@@ -8,6 +8,7 @@
 use std::path::Path;
 
 use serde::Deserialize;
+use worktrunk::path::home_dir;
 
 const FALLBACK_PICKER_COLORS: &str =
     "fg:-1,bg:-1,header:-1,matched:108,current:237,current_bg:251,current_match:108";
@@ -71,15 +72,17 @@ info:{color5},prompt:{color4},cursor:{color1},selected:{color1},header:{color6},
 }
 
 pub(super) fn picker_color_scheme() -> String {
-    omarchy_colors_path()
-        .as_deref()
-        .and_then(OmarchyColors::from_path)
+    picker_color_scheme_from_path(omarchy_colors_path().as_deref())
+}
+
+fn picker_color_scheme_from_path(path: Option<&Path>) -> String {
+    path.and_then(OmarchyColors::from_path)
         .map(|colors| colors.to_skim_color_scheme())
         .unwrap_or_else(|| FALLBACK_PICKER_COLORS.to_string())
 }
 
 fn omarchy_colors_path() -> Option<std::path::PathBuf> {
-    home::home_dir().map(|home| {
+    home_dir().map(|home| {
         home.join(".config")
             .join("omarchy")
             .join("current")
@@ -159,12 +162,8 @@ color8 = "#585b70"
     #[test]
     fn missing_omarchy_colors_falls_back_to_existing_picker_palette() {
         assert_eq!(
-            OmarchyColors::from_path(Path::new("/path/that/does/not/exist")),
-            None
-        );
-        assert_eq!(
-            FALLBACK_PICKER_COLORS,
-            "fg:-1,bg:-1,header:-1,matched:108,current:237,current_bg:251,current_match:108"
+            picker_color_scheme_from_path(Some(Path::new("/path/that/does/not/exist"))),
+            FALLBACK_PICKER_COLORS
         );
     }
 }

--- a/src/commands/picker/theme.rs
+++ b/src/commands/picker/theme.rs
@@ -1,0 +1,170 @@
+//! Theme resolution for the `wt switch` picker.
+//!
+//! Most Worktrunk output uses basic ANSI colors and naturally follows the
+//! terminal palette. The skim picker is different: selected-row colors are
+//! configured through skim's own `--color` string, so hard-coded 256-color
+//! values can clash with desktop-managed terminal themes.
+
+use std::path::Path;
+
+use serde::Deserialize;
+
+const FALLBACK_PICKER_COLORS: &str =
+    "fg:-1,bg:-1,header:-1,matched:108,current:237,current_bg:251,current_match:108";
+
+#[derive(Debug, Deserialize, PartialEq)]
+struct OmarchyColors {
+    cursor: String,
+    foreground: String,
+    background: String,
+    color0: String,
+    color1: String,
+    color2: String,
+    color4: String,
+    color5: String,
+    color6: String,
+    color8: String,
+}
+
+impl OmarchyColors {
+    fn from_path(path: &Path) -> Option<Self> {
+        let content = std::fs::read_to_string(path).ok()?;
+        let colors: Self = toml::from_str(&content).ok()?;
+        colors.is_valid().then_some(colors)
+    }
+
+    fn is_valid(&self) -> bool {
+        [
+            &self.cursor,
+            &self.foreground,
+            &self.background,
+            &self.color0,
+            &self.color1,
+            &self.color2,
+            &self.color4,
+            &self.color5,
+            &self.color6,
+            &self.color8,
+        ]
+        .into_iter()
+        .all(|color| is_hex_color(color))
+    }
+
+    // Keep this mapping aligned with Omarchy's generated Skim palette in fzf.sh.tpl.
+    fn to_skim_color_scheme(&self) -> String {
+        format!(
+            "fg:{fg},bg:{bg},matched:{color0},matched_bg:{cursor},current:{fg},\
+current_bg:{color8},current_match:{bg},current_match_bg:{cursor},spinner:{color2},\
+info:{color5},prompt:{color4},cursor:{color1},selected:{color1},header:{color6},border:{color8}",
+            fg = self.foreground,
+            bg = self.background,
+            cursor = self.cursor,
+            color0 = self.color0,
+            color1 = self.color1,
+            color2 = self.color2,
+            color4 = self.color4,
+            color5 = self.color5,
+            color6 = self.color6,
+            color8 = self.color8,
+        )
+    }
+}
+
+pub(super) fn picker_color_scheme() -> String {
+    omarchy_colors_path()
+        .as_deref()
+        .and_then(OmarchyColors::from_path)
+        .map(|colors| colors.to_skim_color_scheme())
+        .unwrap_or_else(|| FALLBACK_PICKER_COLORS.to_string())
+}
+
+fn omarchy_colors_path() -> Option<std::path::PathBuf> {
+    home::home_dir().map(|home| {
+        home.join(".config")
+            .join("omarchy")
+            .join("current")
+            .join("theme")
+            .join("colors.toml")
+    })
+}
+
+fn is_hex_color(value: &str) -> bool {
+    let Some(hex) = value.strip_prefix('#') else {
+        return false;
+    };
+
+    hex.len() == 6 && hex.bytes().all(|byte| byte.is_ascii_hexdigit())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn omarchy_colors_parse_active_theme_file() {
+        let path = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            path.path(),
+            r##"
+accent = "#89b4fa"
+cursor = "#f5e0dc"
+foreground = "#cdd6f4"
+background = "#1e1e2e"
+color0 = "#45475a"
+color1 = "#f38ba8"
+color2 = "#a6e3a1"
+color4 = "#89b4fa"
+color5 = "#f5c2e7"
+color6 = "#94e2d5"
+color8 = "#585b70"
+"##,
+        )
+        .unwrap();
+
+        let colors = OmarchyColors::from_path(path.path()).unwrap();
+
+        assert_eq!(
+            colors.to_skim_color_scheme(),
+            "fg:#cdd6f4,bg:#1e1e2e,matched:#45475a,matched_bg:#f5e0dc,\
+current:#cdd6f4,current_bg:#585b70,current_match:#1e1e2e,\
+current_match_bg:#f5e0dc,spinner:#a6e3a1,info:#f5c2e7,prompt:#89b4fa,\
+cursor:#f38ba8,selected:#f38ba8,header:#94e2d5,border:#585b70"
+        );
+    }
+
+    #[test]
+    fn omarchy_colors_rejects_missing_or_invalid_colors() {
+        let path = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            path.path(),
+            r##"
+accent = "#89b4fa"
+cursor = "#f5e0dc"
+foreground = "cdd6f4"
+background = "#1e1e2e"
+color0 = "#45475a"
+color1 = "#f38ba8"
+color2 = "#a6e3a1"
+color4 = "#89b4fa"
+color5 = "#f5c2e7"
+color6 = "#94e2d5"
+color8 = "#585b70"
+"##,
+        )
+        .unwrap();
+
+        assert_eq!(OmarchyColors::from_path(path.path()), None);
+    }
+
+    #[test]
+    fn missing_omarchy_colors_falls_back_to_existing_picker_palette() {
+        assert_eq!(
+            OmarchyColors::from_path(Path::new("/path/that/does/not/exist")),
+            None
+        );
+        assert_eq!(
+            FALLBACK_PICKER_COLORS,
+            "fg:-1,bg:-1,header:-1,matched:108,current:237,current_bg:251,current_match:108"
+        );
+    }
+}

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -174,6 +174,8 @@ Shortcuts also apply to [2m--base[0m. For a fork PR/MR, the head commit is fet
 
 When called without arguments, [2mwt switch[0m opens an interactive picker to browse and select worktrees with live preview.
 
+On Omarchy, the picker reads [2m~/.config/omarchy/current/theme/colors.toml[0m each time it opens and uses the active theme's colors. Theme changes apply the next time the picker opens. When that file is unavailable, the picker falls back to Worktrunk's built-in palette.
+
 [1mKeybindings:[0m
 
       Key                       Action                   


### PR DESCRIPTION
## Summary

- read Omarchy's active `colors.toml` when the `wt switch` picker opens
- map Omarchy theme colors into Skim's `--color` scheme when that Omarchy theme file is present and valid
- preserve the existing built-in picker palette for non-Omarchy users, missing theme files, and invalid color data
- document the behavior in switch help, generated docs, skill reference, and the help snapshot
- address draft review feedback by using the project home-directory helper and directly testing the fallback resolver path

## How does it look like?

### Omarchy / Catpuccin

<img width="2564" height="622" alt="screenshot-2026-05-11_15-25-09" src="https://github.com/user-attachments/assets/6435086a-6baf-4f85-9816-a423d6252f06" />

### Omarchy / Evergreen

<img width="2564" height="610" alt="screenshot-2026-05-11_15-24-31" src="https://github.com/user-attachments/assets/b37d36fc-3adf-4124-94f3-83372e4222f9" />

## User Impact

This only changes the `wt switch` interactive picker when Worktrunk is running in an Omarchy environment with a valid active theme at `~/.config/omarchy/current/theme/colors.toml`.

For users not on Omarchy Linux, nothing changes: the picker continues to use Worktrunk's existing built-in color palette. Omarchy users also get the same fallback behavior if the theme file is missing, unreadable, or invalid.

Theme changes are picked up the next time the picker opens. An already-running picker is not repainted after an Omarchy theme switch because Skim receives its color scheme at startup.

## Commit Structure

1. `Support Omarchy colors in switch picker`
   - Adds the theme resolver/parser and switches the picker from a fixed color string to dynamic resolution.
2. `Document Omarchy switch picker theming`
   - Documents that the picker reads Omarchy colors each time it opens and that theme changes apply on the next picker invocation.
3. `Address Omarchy picker review feedback`
   - Uses Worktrunk's `home_dir` re-export and makes the fallback color resolver directly testable.

## Validation

- `cargo test picker::theme`
- `cargo test --test integration switch_picker_dry_run`
- `cargo test --test integration test_docs_are_in_sync`
- `cargo insta test --accept -- --test integration "test_help"`
- `cargo test --test integration test_help`
- `cargo clippy --all-targets -- -D warnings`
- `git diff --check`
