### PR TITLE
ci(test): fail if tests leave files behind in the working tree

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -105,6 +105,19 @@ jobs:
     - name: 🧪 Pre-merge hooks
       run: wt hook pre-merge --yes insta doctest doc
 
+    # Anything tests leave behind in the working tree is a leak we want to see
+    # before it lands. `target/` is gitignored, so a normal run is clean —
+    # untracked files here mean a test wrote outside its sandbox (the
+    # `default_*.profraw` stray that prompted this guard is the canonical case).
+    - name: 🧹 Verify clean working tree
+      shell: bash
+      run: |
+        if [ -n "$(git status --porcelain)" ]; then
+          echo "::error::tests left files behind in the working tree:"
+          git status --porcelain
+          exit 1
+        fi
+
     - name: 📊 Upload test timing
       if: always()
       uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Summary

Adds a `git status --porcelain` check after `wt hook pre-merge --yes` on each `test (linux/macos/windows)` job. If anything's been written into the working tree (outside `target/`), CI fails with the file list. Catches profraw strays, leftover hook logs, generated files tests forgot to clean, etc.

Motivated by the `default_*_<pid>.profraw` stray that prompted #2713 — that PR defended the helper, this PR detects future regressions of the same class (whatever the source). `.gitignore` is intentionally untouched: future leaks surface here rather than being silently hidden.

## Test plan

- [ ] CI passes on this PR (sanity check: the guard itself doesn't fire on a clean run).
- [ ] If it does fire on something pre-existing, surface what and fix.
