### PR TITLE
bench: measure `wt switch` picker preview pre-compute workload

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -204,6 +204,10 @@ harness = false
 name = "remove"
 harness = false
 
+[[bench]]
+name = "picker_preview"
+harness = false
+
 [lints.rust]
 unsafe_code = "forbid"
 

--- a/benches/CLAUDE.md
+++ b/benches/CLAUDE.md
@@ -22,6 +22,10 @@ cargo bench --bench list
 # Time-to-first-output benchmarks
 cargo bench --bench time_to_first_output         # all commands
 cargo bench --bench time_to_first_output remove  # just remove
+
+# Picker preview pre-compute (wt switch preview workload)
+cargo bench --bench picker_preview               # all variants
+cargo bench --bench picker_preview warm          # warm only
 ```
 
 ## Rust Repo Caching
@@ -49,6 +53,20 @@ user-visible output would appear. Used by `time_to_first_output` benchmarks to m
 startup latency without output rendering or post-output work (mismatch warnings, hooks).
 
 Supported commands: `switch`, `remove`, `list`.
+
+## WORKTRUNK_PREVIEW_BENCH
+
+Setting `WORKTRUNK_PREVIEW_BENCH=1` runs `wt switch`'s interactive picker prelude
+end-to-end — collect, speculative spawn, skeleton, initial pre-compute, deferred
+pre-compute — and exits immediately after `PreviewOrchestrator::wait_for_idle()`,
+before skim launches and before any JSON serialization or stderr drain. Used by
+`picker_preview` benchmarks to measure the preview pool workload without standing
+up a PTY. Bypasses the picker's TTY check, like `WORKTRUNK_PICKER_DRY_RUN=1`.
+
+The hot path inside the env-gated block is identical to the dry-run path; only the
+post-drain output (cache JSON dump + stashed-warning drain) is conditional. Keep new
+post-drain work out of the bench path unless it's part of the workload being
+measured.
 
 ## Cache Handling
 
@@ -86,7 +104,8 @@ setup).
 |---------|------------|-------|
 | `wt list` | Yes | Post-skeleton tasks. Exits early under `WORKTRUNK_SKELETON_ONLY=1` / `WORKTRUNK_FIRST_OUTPUT=1` — those skip the writing phase. |
 | `wt remove` | Yes | `prepare_worktree_removal` → `compute_integration_lazy` writes `is-ancestor` / `has-added-changes` / `merge-add-probe` whenever `BranchDeletionMode` is not `ForceDelete` (CLI `--force` is `force_worktree`, not `--force-delete`). |
-| `wt switch` | No | No sha_cache writers on the switch path. |
+| `wt switch <branch>` | No | No sha_cache writers on the direct-switch path. |
+| `wt switch` (picker) | Yes | Preview pre-compute writes `picker-preview/{log,branch-diff,upstream-diff}-…` entries. Exercised under `WORKTRUNK_PREVIEW_BENCH=1` / `WORKTRUNK_PICKER_DRY_RUN=1`. |
 | `wt` (completion via `COMPLETE=$SHELL`) | No | Only `for-each-ref` + worktree list. |
 
 Default-branch cache contribution is ~17ms per iteration on a typical-8 synthetic repo

--- a/benches/picker_preview.rs
+++ b/benches/picker_preview.rs
@@ -1,0 +1,146 @@
+// Benchmarks for the `wt switch` picker's preview pre-compute workload
+//
+// Unix-only: `wt switch` (no branch arg) only routes to the interactive
+// picker on Unix; on Windows it prints "interactive picker unavailable"
+// and exits with code 2 before `WORKTRUNK_PREVIEW_BENCH` is consulted.
+// Gating with `cfg(unix)` keeps `cargo bench` runnable on Windows by
+// emitting an empty `main` there.
+//
+// What this measures
+// ------------------
+// `wt switch` (interactive picker) submits one preview-compute task per row
+// (worktree/branch) into the global rayon pool. Each task gathers the data
+// that fills the picker's preview pane — diff stats, log lines, ahead/behind
+// — and stores it in the in-memory preview cache. The user-visible quantity
+// to optimize is "time from picker launch to all previews ready": that's
+// the responsiveness window where j/k navigation should land on warm
+// content.
+//
+// We measure that wall clock headlessly by spawning `wt` with
+// `WORKTRUNK_PREVIEW_BENCH=1`, which runs the full picker prelude (collect,
+// speculative spawn, skeleton, initial precompute, deferred precompute) and
+// then exits right after `orchestrator.wait_for_idle()` — before skim
+// launches and before any JSON serialization / stderr drain. The PTY route
+// (option 2 from the task: "spawn → first interactive-ready point") would
+// require a TTY harness; the documented nextest/SIGTTOU pain on
+// `shell-integration-tests` (see project `CLAUDE.md`) makes that a follow-up
+// rather than a prerequisite. The headless path captures the full pool
+// workload, which is the variable the optimization work in #2662 / #2683 /
+// #2685 / #2704 actually pushes on.
+//
+// Benchmark variants:
+//   - picker_preview/warm/typical-8
+//   - picker_preview/cold/typical-8
+//
+// Run examples:
+//   cargo bench --bench picker_preview                 # all variants
+//   cargo bench --bench picker_preview warm            # warm only
+//   cargo bench --bench picker_preview -- --exact picker_preview/warm/typical-8
+
+#[cfg(not(unix))]
+fn main() {
+    // Picker is Unix-only; benchmark is a no-op on Windows.
+}
+
+#[cfg(unix)]
+use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
+#[cfg(unix)]
+use std::path::Path;
+#[cfg(unix)]
+use std::process::Command;
+#[cfg(unix)]
+use worktrunk::testing::isolate_subprocess_env;
+#[cfg(unix)]
+use wt_perf::{RepoConfig, create_repo, invalidate_caches_auto, setup_fake_remote};
+
+#[cfg(unix)]
+fn bench_picker_preview(c: &mut Criterion) {
+    let mut group = c.benchmark_group("picker_preview");
+    // The picker workload runs a few hundred ms warm on typical-8 (the
+    // ~1.4s median quoted in `src/commands/picker/mod.rs` is on a different
+    // fixture; measured ~320ms / ~370ms warm/cold here on a 14-core M-series
+    // box). Sticking with `sample_size(10)` per #2685's lead and budgeting
+    // 35s gives Criterion enough headroom to fit 10 samples without the
+    // "increase target time" warning under either cache mode.
+    group.sample_size(10);
+    group.measurement_time(std::time::Duration::from_secs(35));
+
+    let binary = Path::new(env!("CARGO_BIN_EXE_wt"));
+
+    for worktrees in [8] {
+        for cold in [false, true] {
+            let label = if cold { "cold" } else { "warm" };
+            let config = RepoConfig::typical(worktrees);
+
+            group.bench_with_input(
+                BenchmarkId::new(label, format!("typical-{worktrees}")),
+                &(config, cold),
+                |b, (config, cold)| {
+                    let temp = create_repo(config);
+                    let repo_path = temp.path().join("repo");
+                    setup_fake_remote(&repo_path);
+
+                    let make_cmd = || {
+                        let mut cmd = Command::new(binary);
+                        cmd.args(["switch", "--no-cd"]).current_dir(&repo_path);
+                        isolate_subprocess_env(&mut cmd, None);
+                        cmd.env("WORKTRUNK_PREVIEW_BENCH", "1");
+                        cmd
+                    };
+
+                    if *cold {
+                        // The picker writes to `.git/wt/cache/picker-preview/`
+                        // (Log / BranchDiff / UpstreamDiff entries). Without
+                        // invalidation, iter 1 measures real cost and iter 2+
+                        // measure cache hits.
+                        //
+                        // `BatchSize::PerIteration` (not `SmallInput`):
+                        // under `SmallInput`, criterion calls `setup` for an
+                        // entire batch up front and then runs the timed
+                        // routines back-to-back — so the first `wt switch`
+                        // in a batch is cold but the rest hit a freshly
+                        // populated `.git/wt/cache/`, biasing the "cold"
+                        // measurement warm. `PerIteration` invalidates
+                        // immediately before every measured iteration; the
+                        // setup itself is far cheaper than a `wt switch`
+                        // invocation, so per-iteration `Instant::now`
+                        // overhead doesn't dominate.
+                        b.iter_batched(
+                            || invalidate_caches_auto(&repo_path),
+                            |_| {
+                                let output = make_cmd().output().unwrap();
+                                assert!(
+                                    output.status.success(),
+                                    "Benchmark command failed:\nstderr: {}",
+                                    String::from_utf8_lossy(&output.stderr)
+                                );
+                            },
+                            criterion::BatchSize::PerIteration,
+                        );
+                    } else {
+                        b.iter(|| {
+                            let output = make_cmd().output().unwrap();
+                            assert!(
+                                output.status.success(),
+                                "Benchmark command failed:\nstderr: {}",
+                                String::from_utf8_lossy(&output.stderr)
+                            );
+                        });
+                    }
+                },
+            );
+        }
+    }
+
+    group.finish();
+}
+
+#[cfg(unix)]
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(std::time::Duration::from_secs(3));
+    targets = bench_picker_preview
+}
+#[cfg(unix)]
+criterion_main!(benches);

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -68,6 +68,13 @@
 //! cargo bench --bench time_to_first_output -- switch
 //! ```
 //!
+//! Preview pre-compute workload — spawn → all preview tasks drained,
+//! skim bypassed (criterion, synthetic repo):
+//!
+//! ```bash
+//! cargo bench --bench picker_preview
+//! ```
+//!
 //! Per-phase breakdown on a specific repo (a single trace is usually enough
 //! to spot where time goes; re-run a few times if you want variance):
 //!
@@ -381,10 +388,14 @@ pub fn handle_picker(
     cli_remotes: bool,
     change_dir_flag: Option<bool>,
 ) -> anyhow::Result<()> {
-    // Interactive picker requires a terminal for the TUI. The dry-run path
-    // bypasses skim entirely, so no TTY is required — useful for tests and
-    // for diagnosing the pre-compute pipeline from scripts.
-    if std::env::var_os("WORKTRUNK_PICKER_DRY_RUN").is_none() && !std::io::stdin().is_terminal() {
+    // Interactive picker requires a terminal for the TUI. The dry-run and
+    // preview-bench paths bypass skim entirely, so no TTY is required —
+    // useful for tests, for diagnosing the pre-compute pipeline from scripts,
+    // and for benchmarking the preview workload headlessly.
+    let is_dry_run = std::env::var_os("WORKTRUNK_PICKER_DRY_RUN").is_some();
+    let is_preview_bench = std::env::var_os("WORKTRUNK_PREVIEW_BENCH").is_some();
+    let skip_tui = is_dry_run || is_preview_bench;
+    if !skip_tui && !std::io::stdin().is_terminal() {
         anyhow::bail!("Interactive picker requires an interactive terminal");
     }
     worktrunk::trace::instant("Picker started");
@@ -690,15 +701,21 @@ pub fn handle_picker(
     drop(tx);
     drop(handler);
 
-    // Dry-run: skim is bypassed. Wait for collect (which spawns previews
-    // via the handler) to finish, then for the orchestrator's pending
-    // tasks to drain on the global rayon pool, then dump the cache.
-    if std::env::var_os("WORKTRUNK_PICKER_DRY_RUN").is_some() {
+    // Dry-run / preview-bench: skim is bypassed. Wait for collect (which
+    // spawns previews via the handler) to finish, then for the orchestrator's
+    // pending tasks to drain on the global rayon pool. Dry-run additionally
+    // drains stashed warnings and dumps the cache inventory; preview-bench
+    // returns immediately so the measured wall clock is just "spawn → all
+    // preview tasks drained", with no JSON serialization or stderr I/O in
+    // the hot path.
+    if skip_tui {
         drop(rx);
         let _ = bg_handle.join();
         orchestrator.wait_for_idle();
-        drain_stashed_warnings(&stashed_warnings);
-        println!("{}", orchestrator.dump_cache_json());
+        if is_dry_run {
+            drain_stashed_warnings(&stashed_warnings);
+            println!("{}", orchestrator.dump_cache_json());
+        }
         return Ok(());
     }
 

--- a/tests/integration_tests/switch_picker_dry_run.rs
+++ b/tests/integration_tests/switch_picker_dry_run.rs
@@ -133,3 +133,40 @@ fn test_picker_dry_run_with_summary(mut repo: TestRepo) {
         "expected at least one Summary entry, got: {stdout}"
     );
 }
+
+/// `WORKTRUNK_PREVIEW_BENCH=1` shares the dry-run early-exit path but
+/// suppresses the JSON dump and stashed-warning drain so the benchmark
+/// measures just the preview-pool workload (spawn → all preview tasks
+/// drained). Asserts the env-gated branch produces no stdout/stderr,
+/// keeping the bench's hot path I/O-free.
+#[rstest]
+fn test_picker_preview_bench_produces_no_output(mut repo: TestRepo) {
+    repo.add_worktree("feature-a");
+    // Persist a default branch that doesn't exist locally — under dry-run
+    // this becomes a stale-default warning on stderr; under preview-bench
+    // the warning must stay stashed so I/O isn't part of the measurement.
+    repo.run_git(&["config", "worktrunk.default-branch", "nonexistent"]);
+
+    let output = repo
+        .wt_command()
+        .args(["switch"])
+        .env("WORKTRUNK_PREVIEW_BENCH", "1")
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "preview-bench should exit 0; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stdout.is_empty(),
+        "preview-bench must not write to stdout; got: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "preview-bench must not write to stderr; got: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `picker_preview` benchmark group measuring "process spawn → all preview tasks drained" for `wt switch`'s interactive picker.
- Introduces `WORKTRUNK_PREVIEW_BENCH=1`, an early-exit gate inside `handle_picker` that runs the full prelude (collect, speculative spawn, skeleton, initial + deferred precompute, `orchestrator.wait_for_idle()`) and returns before skim launches or any JSON / stderr I/O. Shares the dry-run path; behavior with the env var unset is unchanged.
- Closes the coverage gap behind #2662 / #2683 / #2685 / #2704, which were tuned against `wt list` as a proxy because no direct picker measurement existed.

## Why this measurement

Picker submits one preview-compute task per row to the global rayon pool. The user-visible quantity to optimize is the responsiveness window between picker launch and "all previews ready" (j/k navigation hits cached content). Option 1 from the task — headless wall clock to drain — is the cleanest measurable proxy and avoids the PTY route, which hits the documented nextest/SIGTTOU pain on `shell-integration-tests`. PTY-driven first-interactive-ready can be a follow-up.

## Variants

- `picker_preview/warm/typical-8`
- `picker_preview/cold/typical-8`

Cold uses `BatchSize::PerIteration` (not `SmallInput`): `SmallInput` calls `setup` for an entire batch up front and then runs timed routines back-to-back, so only the first iter in each batch is genuinely cold — the rest hit a freshly populated `.git/wt/cache/`. `PerIteration` invalidates immediately before every measured iteration; setup is far cheaper than `wt switch`, so per-iter `Instant::now` doesn't dominate.

`sample_size(10)` + `measurement_time(35s)` per #2685's lead — slow benches don't benefit from the default 30 samples.

`cfg(unix)`-gated with a no-op `main` on Windows; the picker is Unix-only and `wt switch` (no args) hits the unavailable path before the env var is consulted.

## Sample run

```
picker_preview/warm/typical-8   time:   [185.62 ms 191.72 ms 200.77 ms]
picker_preview/cold/typical-8   time:   [209.34 ms 226.23 ms 239.29 ms]
```

## Test plan

- [x] `cargo bench --bench picker_preview` runs cleanly on both variants
- [x] `cargo run -- hook pre-merge --yes` — 3667 tests pass
- [x] New `test_picker_preview_bench_produces_no_output` asserts `WORKTRUNK_PREVIEW_BENCH=1` keeps stdout/stderr empty (covers the env-gated branch, locks the no-I/O contract)
- [x] Smoke test: `wt switch` with `WORKTRUNK_PREVIEW_BENCH` unset still hits the TTY error path (user-visible behavior unchanged)
- [x] Smoke test: `WORKTRUNK_PICKER_DRY_RUN=1` still emits the cache JSON dump (regression check)
- [x] `/review-codex` pass clean after iterating on three findings (packed-refs fix already on `main` via #2697 once branch was rebased; `BatchSize::PerIteration` for true per-iter invalidation; `cfg(unix)` gate for Windows)

> _This was written by Claude Code on behalf of Maximilian Roos_

🤖 Generated with [Claude Code](https://claude.com/claude-code)