### PR TITLE
refactor(ci-status): share output/URL helpers across forge backends

### DIFF
--- a/src/commands/list/ci_status/azure.rs
+++ b/src/commands/list/ci_status/azure.rs
@@ -8,17 +8,21 @@ use worktrunk::git::remote_ref::azure as az_url;
 use worktrunk::git::{GitRemoteUrl, Repository};
 
 use super::{
-    CiBranchName, CiSource, CiStatus, PrStatus, is_retriable_error, non_interactive_cmd, parse_json,
+    CiBranchName, CiSource, CiStatus, PrStatus, branch_remote_url, non_interactive_cmd, parse_json,
+    retriable_pr_error,
 };
 
 /// Resolve the Azure DevOps context (host, org, project, `--org` URL) for this
-/// repo's `az` invocations.
+/// branch's `az` invocations.
 ///
-/// Prefers the primary remote so fork workflows hit the right tenant. Falls
-/// back to the first Azure remote found if the primary isn't Azure DevOps.
+/// Walks the shared [`branch_remote_url`] chain first — so a remote-branch
+/// row from `wt list --remotes --full` queries the right tenant in
+/// multi-org setups. Falls back to scanning every configured remote for
+/// any Azure URL when the resolved remote isn't Azure DevOps (e.g., a
+/// branch tracks a non-Azure mirror but another remote is the real one).
 /// Returns `None` if no remote points at Azure DevOps.
-fn azure_context(repo: &Repository) -> Option<AzureContext> {
-    let try_remote = |url: &str| -> Option<AzureContext> {
+fn azure_context(repo: &Repository, branch: &CiBranchName) -> Option<AzureContext> {
+    let try_url = |url: &str| -> Option<AzureContext> {
         let parsed = GitRemoteUrl::parse(url)?;
         if !parsed.is_azure_devops() {
             return None;
@@ -35,14 +39,13 @@ fn azure_context(repo: &Repository) -> Option<AzureContext> {
         })
     };
 
-    if let Ok(remote) = repo.primary_remote()
-        && let Some(url) = repo.effective_remote_url(&remote)
-        && let Some(ctx) = try_remote(&url)
+    if let Some(url) = branch_remote_url(repo, branch)
+        && let Some(ctx) = try_url(&url)
     {
         return Some(ctx);
     }
     for (_, url) in repo.all_remote_urls() {
-        if let Some(ctx) = try_remote(&url) {
+        if let Some(ctx) = try_url(&url) {
             return Some(ctx);
         }
     }
@@ -65,7 +68,7 @@ pub(super) fn detect_azure_pr(
     local_head: &str,
 ) -> Option<PrStatus> {
     let repo_root = repo.repo_path().ok()?;
-    let ctx = azure_context(repo)?;
+    let ctx = azure_context(repo, branch)?;
 
     // `az repos pr list --source-branch` expects a full ref name.
     let source_ref = format!("refs/heads/{}", branch.name);
@@ -100,11 +103,7 @@ pub(super) fn detect_azure_pr(
     };
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if is_retriable_error(&stderr) {
-            return Some(PrStatus::error());
-        }
-        return None;
+        return retriable_pr_error(&output);
     }
 
     let pr_list: Vec<AzPrListEntry> =
@@ -145,13 +144,13 @@ pub(super) fn detect_azure_pr(
 /// can dim the indicator rather than reporting fresh status against stale data.
 pub(super) fn detect_azure_pipeline(
     repo: &Repository,
-    branch: &str,
+    branch: &CiBranchName,
     local_head: &str,
 ) -> Option<PrStatus> {
     let repo_root = repo.repo_path().ok()?;
-    let ctx = azure_context(repo)?;
+    let ctx = azure_context(repo, branch)?;
 
-    let branch_ref = format!("refs/heads/{}", branch);
+    let branch_ref = format!("refs/heads/{}", branch.name);
     let output = match non_interactive_cmd("az")
         .args([
             "pipelines",
@@ -175,7 +174,7 @@ pub(super) fn detect_azure_pipeline(
         Err(e) => {
             log::warn!(
                 "az pipelines runs list failed to execute for branch {}: {}",
-                branch,
+                branch.full_name,
                 e
             );
             return None;
@@ -183,14 +182,11 @@ pub(super) fn detect_azure_pipeline(
     };
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if is_retriable_error(&stderr) {
-            return Some(PrStatus::error());
-        }
-        return None;
+        return retriable_pr_error(&output);
     }
 
-    let runs: Vec<AzPipelineRun> = parse_json(&output.stdout, "az pipelines runs list", branch)?;
+    let runs: Vec<AzPipelineRun> =
+        parse_json(&output.stdout, "az pipelines runs list", &branch.full_name)?;
     let run = runs.first()?;
 
     let ci_status = parse_azure_pipeline_status(run.status.as_deref(), run.result.as_deref());

--- a/src/commands/list/ci_status/azure.rs
+++ b/src/commands/list/ci_status/azure.rs
@@ -287,6 +287,59 @@ struct AzPipelineRun {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use worktrunk::testing::TestRepo;
+
+    /// `azure_context` first walks the branch's remote, then scans every
+    /// configured remote for any Azure URL — covering the case where a
+    /// branch tracks (or the primary remote is) something non-Azure but
+    /// another remote is the real Azure DevOps mirror.
+    #[test]
+    fn test_azure_context_falls_back_to_all_remote_urls() {
+        let test = TestRepo::with_initial_commit();
+        // Primary remote isn't Azure — the branch-aware path returns None.
+        test.run_git(&[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/owner/test-repo.git",
+        ]);
+        // Secondary Azure remote — the all_remote_urls scan must find this.
+        test.run_git(&[
+            "remote",
+            "add",
+            "azure",
+            "https://dev.azure.com/myorg/myproject/_git/myrepo",
+        ]);
+        let repo = Repository::at(test.root_path()).unwrap();
+        let branch = CiBranchName {
+            full_name: "ghost-local".to_string(),
+            remote: None,
+            name: "ghost-local".to_string(),
+        };
+
+        let ctx = azure_context(&repo, &branch).expect("scan should find the azure remote");
+        assert_eq!(ctx.organization, "myorg");
+        assert_eq!(ctx.project, "myproject");
+    }
+
+    /// No Azure remote anywhere → `None`.
+    #[test]
+    fn test_azure_context_returns_none_without_azure_remote() {
+        let test = TestRepo::with_initial_commit();
+        test.run_git(&[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/owner/test-repo.git",
+        ]);
+        let repo = Repository::at(test.root_path()).unwrap();
+        let branch = CiBranchName {
+            full_name: "ghost-local".to_string(),
+            remote: None,
+            name: "ghost-local".to_string(),
+        };
+        assert!(azure_context(&repo, &branch).is_none());
+    }
 
     #[test]
     fn test_parse_azure_pipeline_status() {

--- a/src/commands/list/ci_status/gitea.rs
+++ b/src/commands/list/ci_status/gitea.rs
@@ -37,26 +37,12 @@
 
 use serde::Deserialize;
 use std::process::Output;
-use worktrunk::git::{GitRemoteUrl, Repository};
+use worktrunk::git::Repository;
 
 use super::{
-    CiBranchName, CiSource, CiStatus, PrStatus, branch_owner_repo_for_platform, is_retriable_error,
+    CiBranchName, CiSource, CiStatus, PrStatus, branch_owner_repo, is_retriable_error,
     non_interactive_cmd, output_error_text, parse_json, retriable_pr_error,
 };
-
-/// Resolve `(owner, repo)` for the branch's effective Gitea remote.
-///
-/// Mirrors the GitHub path: remote-branch refs read from the branch's own
-/// remote (so `wt list --remotes --full` queries the right repo in a
-/// mixed-remote setup), local branches walk the push-destination chain
-/// (`branch.<n>.pushRemote` → `remote.pushDefault` → tracking remote →
-/// primary fallback), and non-Gitea URLs are filtered out.
-fn gitea_owner_repo_for_branch(
-    repo: &Repository,
-    branch: &CiBranchName,
-) -> Option<(String, String)> {
-    branch_owner_repo_for_platform(repo, branch, GitRemoteUrl::is_gitea)
-}
 
 /// Run `tea api <path>` from the worktree root.
 ///
@@ -107,7 +93,7 @@ pub(super) fn detect_gitea_pr(
     branch: &CiBranchName,
     local_head: &str,
 ) -> Option<PrStatus> {
-    let (owner, repo_name) = gitea_owner_repo_for_branch(repo, branch)?;
+    let (owner, repo_name) = branch_owner_repo(repo, branch)?;
 
     // `state=open` is required: the pulls list returns all states by default.
     let path = format!("repos/{owner}/{repo_name}/pulls?state=open");
@@ -170,7 +156,7 @@ pub(super) fn detect_gitea_commit_status(
     branch: &CiBranchName,
     local_head: &str,
 ) -> Option<PrStatus> {
-    let (owner, repo_name) = gitea_owner_repo_for_branch(repo, branch)?;
+    let (owner, repo_name) = branch_owner_repo(repo, branch)?;
     let ci_status = fetch_combined_status(repo, &owner, &repo_name, local_head)?;
     Some(PrStatus {
         ci_status,
@@ -252,11 +238,11 @@ mod tests {
 
     /// Local branches walk the push-destination chain; with no explicit
     /// pushRemote and no tracking, the primary remote is the fallback.
-    /// Asserts directly against `gitea_owner_repo_for_branch` so coverage
-    /// doesn't depend on the spawn-based `tea --version` probe in the
-    /// integration tests.
+    /// Asserts directly against the shared resolver so coverage doesn't
+    /// depend on the spawn-based `tea --version` probe in the integration
+    /// tests.
     #[test]
-    fn test_gitea_owner_repo_for_branch_local_uses_primary_remote() {
+    fn test_branch_owner_repo_local_uses_primary_remote() {
         let test = TestRepo::with_initial_commit();
         test.run_git(&[
             "remote",
@@ -274,7 +260,7 @@ mod tests {
             name: "ghost-local".to_string(),
         };
         assert_eq!(
-            gitea_owner_repo_for_branch(&repo, &branch),
+            branch_owner_repo(&repo, &branch),
             Some(("owner".to_string(), "test-repo".to_string()))
         );
     }
@@ -282,7 +268,7 @@ mod tests {
     /// A branch whose remote has no URL (e.g., a stale ref to a deleted
     /// remote) propagates `None` through `branch_remote_url`.
     #[test]
-    fn test_gitea_owner_repo_for_branch_returns_none_when_remote_missing() {
+    fn test_branch_owner_repo_returns_none_when_remote_missing() {
         let test = TestRepo::with_initial_commit();
         let repo = Repository::at(test.root_path()).unwrap();
 
@@ -291,14 +277,14 @@ mod tests {
             remote: Some("ghost".to_string()),
             name: "feature".to_string(),
         };
-        assert_eq!(gitea_owner_repo_for_branch(&repo, &branch), None);
+        assert_eq!(branch_owner_repo(&repo, &branch), None);
     }
 
     /// Remote-branch refs read from `branch.remote`'s effective URL. In a
     /// mixed-remote repo, this must pick the branch's remote, not the
     /// primary one.
     #[test]
-    fn test_gitea_owner_repo_for_branch_remote_uses_branch_remote() {
+    fn test_branch_owner_repo_remote_uses_branch_remote() {
         let test = TestRepo::with_initial_commit();
         test.run_git(&[
             "remote",
@@ -320,22 +306,25 @@ mod tests {
             name: "feature".to_string(),
         };
         assert_eq!(
-            gitea_owner_repo_for_branch(&repo, &branch),
+            branch_owner_repo(&repo, &branch),
             Some(("forkowner".to_string(), "test-repo".to_string()))
         );
     }
 
-    /// A non-Gitea URL (e.g., a github primary remote in a project whose
-    /// project config forces `forge.platform = "gitea"` for the branch's
-    /// own remote) is filtered out by the `is_gitea` predicate.
+    /// A Forgejo / non-canonically-named Gitea host (e.g. `codeberg.org`)
+    /// must still resolve through `branch_owner_repo` — the platform comes
+    /// from explicit `forge.platform` config, so the host heuristic
+    /// (`is_gitea` substring check) is not used here. Re-introducing such a
+    /// filter would silently drop CI status for legitimate Forgejo users
+    /// (see `src/git/ci_platform.rs:186`).
     #[test]
-    fn test_gitea_owner_repo_for_branch_filters_non_gitea_urls() {
+    fn test_branch_owner_repo_resolves_non_canonical_gitea_host() {
         let test = TestRepo::with_initial_commit();
         test.run_git(&[
             "remote",
             "add",
             "origin",
-            "https://github.com/owner/test-repo.git",
+            "https://codeberg.org/owner/test-repo.git",
         ]);
         let repo = Repository::at(test.root_path()).unwrap();
 
@@ -344,6 +333,9 @@ mod tests {
             remote: None,
             name: "ghost-local".to_string(),
         };
-        assert_eq!(gitea_owner_repo_for_branch(&repo, &branch), None);
+        assert_eq!(
+            branch_owner_repo(&repo, &branch),
+            Some(("owner".to_string(), "test-repo".to_string()))
+        );
     }
 }

--- a/src/commands/list/ci_status/gitea.rs
+++ b/src/commands/list/ci_status/gitea.rs
@@ -37,35 +37,25 @@
 
 use serde::Deserialize;
 use std::process::Output;
-use worktrunk::git::{Repository, parse_owner_repo};
+use worktrunk::git::{GitRemoteUrl, Repository};
 
 use super::{
-    CiBranchName, CiSource, CiStatus, PrStatus, is_retriable_error, non_interactive_cmd, parse_json,
+    CiBranchName, CiSource, CiStatus, PrStatus, branch_owner_repo_for_platform, is_retriable_error,
+    non_interactive_cmd, output_error_text, parse_json, retriable_pr_error,
 };
 
 /// Resolve `(owner, repo)` for the branch's effective Gitea remote.
 ///
-/// For a remote branch ref (e.g. `gitea/feature`), reads the branch's own
-/// remote — so a `wt list --remotes --full` row queries the right repo in a
-/// mixed-remote setup. Uses [`Repository::effective_remote_url`] to honor
-/// `url.insteadOf` rewrites, matching the GitHub path's
-/// `github_owner_repo_for_branch`.
-///
-/// For a local branch (no `branch.remote`), falls back to the primary remote's
-/// *raw* URL — matching `git::remote_ref::gitea`'s `pr:` resolver. The raw URL
-/// is enough here: only owner/repo (the path) are read, and `tea` resolves the
-/// host from its own login config rather than the URL we pass.
+/// Mirrors the GitHub path: remote-branch refs read from the branch's own
+/// remote (so `wt list --remotes --full` queries the right repo in a
+/// mixed-remote setup), local branches walk the push-destination chain
+/// (`branch.<n>.pushRemote` → `remote.pushDefault` → tracking remote →
+/// primary fallback), and non-Gitea URLs are filtered out.
 fn gitea_owner_repo_for_branch(
     repo: &Repository,
     branch: &CiBranchName,
 ) -> Option<(String, String)> {
-    let url = if let Some(remote_name) = &branch.remote {
-        repo.effective_remote_url(remote_name)
-    } else {
-        let remote = repo.primary_remote().ok()?;
-        repo.remote_url(&remote)
-    }?;
-    parse_owner_repo(&url)
+    branch_owner_repo_for_platform(repo, branch, GitRemoteUrl::is_gitea)
 }
 
 /// Run `tea api <path>` from the worktree root.
@@ -82,17 +72,6 @@ fn tea_api(repo: &Repository, path: &str) -> Option<Output> {
         .ok()
 }
 
-/// Combine stderr and stdout for retriable-error sniffing. `tea` reports API
-/// errors as a JSON `{"message": "..."}` on stdout, but transport errors land
-/// on stderr — check both.
-fn error_text(output: &Output) -> String {
-    format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stderr),
-        String::from_utf8_lossy(&output.stdout)
-    )
-}
-
 /// Fetch the combined CI status for a commit SHA.
 ///
 /// Returns `Some(CiStatus::Error)` for retriable failures (rate limit, network),
@@ -106,7 +85,10 @@ fn fetch_combined_status(
     let path = format!("repos/{owner}/{repo_name}/commits/{sha}/status");
     let output = tea_api(repo, &path)?;
     if !output.status.success() {
-        return is_retriable_error(&error_text(&output)).then_some(CiStatus::Error);
+        // The PR-status warning from `retriable_pr_error` is the wrong shape
+        // here (this returns just CiStatus); reuse `output_error_text` so
+        // both stdout and stderr are sniffed.
+        return is_retriable_error(&output_error_text(&output)).then_some(CiStatus::Error);
     }
     let combined: GiteaCombinedStatus = parse_json(&output.stdout, "tea api commit status", sha)?;
     if combined.total_count == 0 {
@@ -131,15 +113,16 @@ pub(super) fn detect_gitea_pr(
     let path = format!("repos/{owner}/{repo_name}/pulls?state=open");
     let output = tea_api(repo, &path)?;
     if !output.status.success() {
-        return is_retriable_error(&error_text(&output)).then(PrStatus::error);
+        return retriable_pr_error(&output);
     }
 
     let prs: Vec<GiteaPr> = parse_json(&output.stdout, "tea api pulls", &branch.full_name)?;
 
     // Match by head branch name; require the head repo owner (when present) to
-    // be the repo we queried — same-repo PRs only, since this branch looks at
-    // the primary remote alone (fork PRs are out of scope). A missing owner is
-    // treated as a potential match, as in the GitHub path.
+    // be the repo we queried — same-repo PRs only, since the resolver scopes
+    // owner/repo to the branch's own remote (fork PRs are out of scope; see
+    // the module-level "Known limitations"). A missing owner is treated as a
+    // potential match, as in the GitHub path.
     let pr = prs.iter().find(|pr| {
         pr.head.ref_name == branch.name
             && pr
@@ -267,10 +250,11 @@ mod tests {
         assert_eq!(parse_gitea_status_state("bogus"), None);
     }
 
-    /// Local branches (no `branch.remote`) walk the `else` arm — primary
-    /// remote's raw URL. Asserts directly against `gitea_owner_repo_for_branch`
-    /// so coverage doesn't depend on the spawn-based `tea --version` probe in
-    /// the integration tests.
+    /// Local branches walk the push-destination chain; with no explicit
+    /// pushRemote and no tracking, the primary remote is the fallback.
+    /// Asserts directly against `gitea_owner_repo_for_branch` so coverage
+    /// doesn't depend on the spawn-based `tea --version` probe in the
+    /// integration tests.
     #[test]
     fn test_gitea_owner_repo_for_branch_local_uses_primary_remote() {
         let test = TestRepo::with_initial_commit();
@@ -282,10 +266,12 @@ mod tests {
         ]);
         let repo = Repository::at(test.root_path()).unwrap();
 
+        // Use a name that doesn't exist locally — `push_remote_url` returns
+        // None for it, so we land on the primary-remote fallback.
         let branch = CiBranchName {
-            full_name: "main".to_string(),
+            full_name: "ghost-local".to_string(),
             remote: None,
-            name: "main".to_string(),
+            name: "ghost-local".to_string(),
         };
         assert_eq!(
             gitea_owner_repo_for_branch(&repo, &branch),
@@ -294,7 +280,7 @@ mod tests {
     }
 
     /// A branch whose remote has no URL (e.g., a stale ref to a deleted
-    /// remote) propagates `None` through the `?` on the if-else expression.
+    /// remote) propagates `None` through `branch_remote_url`.
     #[test]
     fn test_gitea_owner_repo_for_branch_returns_none_when_remote_missing() {
         let test = TestRepo::with_initial_commit();
@@ -308,8 +294,8 @@ mod tests {
         assert_eq!(gitea_owner_repo_for_branch(&repo, &branch), None);
     }
 
-    /// Remote-branch refs walk the `if` arm — branch.remote's effective URL.
-    /// In a mixed-remote repo, this must pick the branch's remote, not the
+    /// Remote-branch refs read from `branch.remote`'s effective URL. In a
+    /// mixed-remote repo, this must pick the branch's remote, not the
     /// primary one.
     #[test]
     fn test_gitea_owner_repo_for_branch_remote_uses_branch_remote() {
@@ -337,5 +323,27 @@ mod tests {
             gitea_owner_repo_for_branch(&repo, &branch),
             Some(("forkowner".to_string(), "test-repo".to_string()))
         );
+    }
+
+    /// A non-Gitea URL (e.g., a github primary remote in a project whose
+    /// project config forces `forge.platform = "gitea"` for the branch's
+    /// own remote) is filtered out by the `is_gitea` predicate.
+    #[test]
+    fn test_gitea_owner_repo_for_branch_filters_non_gitea_urls() {
+        let test = TestRepo::with_initial_commit();
+        test.run_git(&[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/owner/test-repo.git",
+        ]);
+        let repo = Repository::at(test.root_path()).unwrap();
+
+        let branch = CiBranchName {
+            full_name: "ghost-local".to_string(),
+            remote: None,
+            name: "ghost-local".to_string(),
+        };
+        assert_eq!(gitea_owner_repo_for_branch(&repo, &branch), None);
     }
 }

--- a/src/commands/list/ci_status/github.rs
+++ b/src/commands/list/ci_status/github.rs
@@ -3,36 +3,22 @@
 //! Detects CI status from GitHub PRs and workflow runs using the `gh` CLI.
 
 use serde::Deserialize;
-use worktrunk::git::{Repository, parse_owner_repo};
+use worktrunk::git::{GitRemoteUrl, Repository};
 
 use super::{
-    CiBranchName, CiSource, CiStatus, MAX_PRS_TO_FETCH, PrStatus, is_retriable_error,
-    non_interactive_cmd, parse_json,
+    CiBranchName, CiSource, CiStatus, MAX_PRS_TO_FETCH, PrStatus, branch_owner_repo_for_platform,
+    non_interactive_cmd, parse_json, retriable_pr_error,
 };
 
-/// Get the owner and repo name from the primary remote.
+/// Get the owner and repo name for the branch's effective GitHub remote.
 ///
-/// Used for GitHub API calls that require `repos/{owner}/{repo}/...` paths.
-/// Platform is already known to be GitHub when this runs, so we extract
-/// directly from the primary remote's raw URL without checking the hostname.
-fn github_owner_repo(repo: &Repository) -> Option<(String, String)> {
-    let remote = repo.primary_remote().ok()?;
-    let url = repo.remote_url(&remote)?;
-    parse_owner_repo(&url)
-}
-
-/// Get the owner and repo name for the branch's effective push destination.
+/// Resolves through the shared `branch_remote_url` chain (branch.remote →
+/// push remote → primary), filtered to GitHub URLs.
 fn github_owner_repo_for_branch(
     repo: &Repository,
     branch: &CiBranchName,
 ) -> Option<(String, String)> {
-    let url = if let Some(remote_name) = &branch.remote {
-        repo.effective_remote_url(remote_name)
-    } else {
-        repo.branch(&branch.name).github_push_url()
-    }?;
-
-    parse_owner_repo(&url)
+    branch_owner_repo_for_platform(repo, branch, GitRemoteUrl::is_github)
 }
 
 /// Detect GitHub PR CI status for a branch.
@@ -110,11 +96,7 @@ pub(super) fn detect_github(
     };
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if is_retriable_error(&stderr) {
-            return Some(PrStatus::error());
-        }
-        return None;
+        return retriable_pr_error(&output);
     }
 
     // gh pr list returns an array - find the first PR from our origin
@@ -171,8 +153,7 @@ pub(super) fn detect_github_commit_checks(
     local_head: &str,
 ) -> Option<PrStatus> {
     let repo_root = repo.current_worktree().root().ok()?;
-    let (owner, repo_name) =
-        github_owner_repo_for_branch(repo, branch).or_else(|| github_owner_repo(repo))?;
+    let (owner, repo_name) = github_owner_repo_for_branch(repo, branch)?;
 
     // Only pass --hostname when explicitly configured (for GHE / self-hosted)
     let hostname = repo
@@ -206,11 +187,7 @@ pub(super) fn detect_github_commit_checks(
     };
 
     if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if is_retriable_error(&stderr) {
-            return Some(PrStatus::error());
-        }
-        return None;
+        return retriable_pr_error(&output);
     }
 
     let checks: Vec<GitHubCheck> = parse_json(&output.stdout, "gh api check-runs", local_head)?;

--- a/src/commands/list/ci_status/github.rs
+++ b/src/commands/list/ci_status/github.rs
@@ -3,23 +3,12 @@
 //! Detects CI status from GitHub PRs and workflow runs using the `gh` CLI.
 
 use serde::Deserialize;
-use worktrunk::git::{GitRemoteUrl, Repository};
+use worktrunk::git::Repository;
 
 use super::{
-    CiBranchName, CiSource, CiStatus, MAX_PRS_TO_FETCH, PrStatus, branch_owner_repo_for_platform,
+    CiBranchName, CiSource, CiStatus, MAX_PRS_TO_FETCH, PrStatus, branch_owner_repo,
     non_interactive_cmd, parse_json, retriable_pr_error,
 };
-
-/// Get the owner and repo name for the branch's effective GitHub remote.
-///
-/// Resolves through the shared `branch_remote_url` chain (branch.remote →
-/// push remote → primary), filtered to GitHub URLs.
-fn github_owner_repo_for_branch(
-    repo: &Repository,
-    branch: &CiBranchName,
-) -> Option<(String, String)> {
-    branch_owner_repo_for_platform(repo, branch, GitRemoteUrl::is_github)
-}
 
 /// Detect GitHub PR CI status for a branch.
 ///
@@ -49,11 +38,11 @@ pub(super) fn detect_github(
     // Get the owner of the branch's push remote for filtering PRs by source repository.
     // For local branches: uses @{push} which resolves through pushRemote → remote.pushDefault → tracking remote.
     // For remote branches: use the remote's effective URL (handles insteadOf aliases).
-    let branch_owner = github_owner_repo_for_branch(repo, branch).map(|(owner, _)| owner);
+    let branch_owner = branch_owner_repo(repo, branch).map(|(owner, _)| owner);
 
     let Some(branch_owner) = branch_owner else {
         log::debug!(
-            "Branch {} has no GitHub push remote; skipping PR-based CI detection",
+            "Branch {} has no resolvable push remote; skipping PR-based CI detection",
             branch.full_name
         );
         return None;
@@ -153,7 +142,7 @@ pub(super) fn detect_github_commit_checks(
     local_head: &str,
 ) -> Option<PrStatus> {
     let repo_root = repo.current_worktree().root().ok()?;
-    let (owner, repo_name) = github_owner_repo_for_branch(repo, branch)?;
+    let (owner, repo_name) = branch_owner_repo(repo, branch)?;
 
     // Only pass --hostname when explicitly configured (for GHE / self-hosted)
     let hostname = repo

--- a/src/commands/list/ci_status/mod.rs
+++ b/src/commands/list/ci_status/mod.rs
@@ -618,4 +618,51 @@ mod tests {
         // Just verify it doesn't panic and returns a style
         let _ = format!("{style}test{style:#}");
     }
+
+    /// Build a synthetic non-success `Output` with the given stderr/stdout
+    /// bodies — `Command::output()` is the only "real" constructor and
+    /// would require spawning a process. Status uses `ExitStatus::default()`
+    /// (success), but the retriable-error helpers ignore status and only
+    /// look at the bytes.
+    fn fake_output(stderr: &str, stdout: &str) -> Output {
+        Output {
+            status: Default::default(),
+            stdout: stdout.as_bytes().to_vec(),
+            stderr: stderr.as_bytes().to_vec(),
+        }
+    }
+
+    /// `output_error_text` must combine both streams — `tea` routes API
+    /// errors to stdout while transport errors land on stderr, so a
+    /// stderr-only sniff would miss rate-limit messages from the JSON body.
+    #[test]
+    fn test_output_error_text_combines_streams() {
+        let out = fake_output("transport: connection reset", r#"{"message":"rate limit"}"#);
+        let text = output_error_text(&out);
+        assert!(text.contains("transport: connection reset"));
+        assert!(text.contains("rate limit"));
+    }
+
+    /// `retriable_pr_error` returns `Some(PrStatus::error())` when either
+    /// stream contains a retriable marker, and `None` otherwise — the
+    /// fall-through case where `?` propagates "no CI status".
+    #[test]
+    fn test_retriable_pr_error_routing() {
+        // Retriable from stderr.
+        let out = fake_output("HTTP 429 Too Many Requests", "");
+        let status = retriable_pr_error(&out).expect("retriable should yield Some");
+        assert_eq!(status.ci_status, CiStatus::Error);
+
+        // Retriable from stdout (the `tea` shape).
+        let out = fake_output("", r#"{"message":"rate limit exceeded"}"#);
+        assert!(retriable_pr_error(&out).is_some());
+
+        // Non-retriable failure → None, so caller's `?` falls through.
+        let out = fake_output("not found", "");
+        assert!(retriable_pr_error(&out).is_none());
+
+        // No body at all → None.
+        let out = fake_output("", "");
+        assert!(retriable_pr_error(&out).is_none());
+    }
 }

--- a/src/commands/list/ci_status/mod.rs
+++ b/src/commands/list/ci_status/mod.rs
@@ -12,10 +12,12 @@ mod github;
 mod gitlab;
 mod platform;
 
+use std::process::Output;
+
 use anstyle::{AnsiColor, Color, Style};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use worktrunk::git::{BranchRef, Repository};
+use worktrunk::git::{BranchRef, GitRemoteUrl, Repository, parse_owner_repo};
 use worktrunk::shell_exec::Cmd;
 use worktrunk::utils::epoch_now;
 
@@ -128,6 +130,68 @@ fn parse_json<T: DeserializeOwned>(stdout: &[u8], command: &str, branch: &str) -
     serde_json::from_slice(stdout)
         .map_err(|e| log::warn!("Failed to parse {} JSON for {}: {}", command, branch, e))
         .ok()
+}
+
+/// Combine stderr and stdout for retriable-error sniffing.
+///
+/// Some CLIs (notably `tea`) report API errors as JSON on stdout while
+/// transport errors land on stderr — checking both avoids missing retriable
+/// errors when the tool routes them differently.
+fn output_error_text(output: &Output) -> String {
+    format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stderr),
+        String::from_utf8_lossy(&output.stdout)
+    )
+}
+
+/// If a non-success `Output` indicates a retriable failure, surface it as a
+/// PR-status warning. Returns `None` for non-retriable failures so callers
+/// can `?` it to fall through to "no CI status".
+fn retriable_pr_error(output: &Output) -> Option<PrStatus> {
+    is_retriable_error(&output_error_text(output)).then(PrStatus::error)
+}
+
+/// Resolve `(owner, repo)` for a branch's effective remote, scoped to the
+/// given platform.
+///
+/// - Remote-branch refs (`origin/feature`) read from the branch's own
+///   remote via [`Repository::effective_remote_url`] (honors
+///   `url.insteadOf` rewrites).
+/// - Local branches prefer the branch's push destination
+///   (`branch.<n>.pushRemote` → `remote.pushDefault` → tracking remote),
+///   falling back to the repo's primary remote so a tracking-less branch
+///   still resolves.
+///
+/// `is_platform` filters out URLs that don't belong to the calling backend
+/// (e.g., a primary github remote alongside an azure secondary): the
+/// platform was selected upstream from one remote, so a different remote
+/// must not be queried with mismatched API shapes.
+fn branch_owner_repo_for_platform(
+    repo: &Repository,
+    branch: &CiBranchName,
+    is_platform: impl Fn(&GitRemoteUrl) -> bool,
+) -> Option<(String, String)> {
+    let url = branch_remote_url(repo, branch)?;
+    let parsed = GitRemoteUrl::parse(&url)?;
+    is_platform(&parsed).then_some(())?;
+    parse_owner_repo(&url)
+}
+
+/// Resolve the effective URL for a branch's remote without parsing.
+///
+/// See [`branch_owner_repo_for_platform`] for the resolution chain — this is
+/// the URL-only primitive backends compose with their own URL parsers
+/// (Azure DevOps' org/project shape doesn't fit `parse_owner_repo`).
+fn branch_remote_url(repo: &Repository, branch: &CiBranchName) -> Option<String> {
+    if let Some(remote_name) = &branch.remote {
+        repo.effective_remote_url(remote_name)
+    } else {
+        repo.branch(&branch.name).push_remote_url().or_else(|| {
+            let remote = repo.primary_remote().ok()?;
+            repo.effective_remote_url(&remote)
+        })
+    }
 }
 
 /// Check if stderr indicates a retriable error (rate limit, network issues)

--- a/src/commands/list/ci_status/mod.rs
+++ b/src/commands/list/ci_status/mod.rs
@@ -17,7 +17,7 @@ use std::process::Output;
 use anstyle::{AnsiColor, Color, Style};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
-use worktrunk::git::{BranchRef, GitRemoteUrl, Repository, parse_owner_repo};
+use worktrunk::git::{BranchRef, Repository, parse_owner_repo};
 use worktrunk::shell_exec::Cmd;
 use worktrunk::utils::epoch_now;
 
@@ -152,9 +152,22 @@ fn retriable_pr_error(output: &Output) -> Option<PrStatus> {
     is_retriable_error(&output_error_text(output)).then(PrStatus::error)
 }
 
-/// Resolve `(owner, repo)` for a branch's effective remote, scoped to the
-/// given platform.
+/// Resolve `(owner, repo)` for a branch's effective remote.
 ///
+/// Thin wrapper over [`branch_remote_url`] + [`parse_owner_repo`]. The
+/// platform was already chosen upstream by [`Repository::ci_platform`] —
+/// either from explicit `forge.platform` config or from the URL host —
+/// so backends don't re-filter here. Re-checking via the host heuristic
+/// (`is_gitea` / `is_github`) would silently drop legitimate hosts that
+/// rely on the explicit override (e.g. `codeberg.org` for Forgejo,
+/// `git.mycompany.com` for self-hosted GHE).
+fn branch_owner_repo(repo: &Repository, branch: &CiBranchName) -> Option<(String, String)> {
+    parse_owner_repo(&branch_remote_url(repo, branch)?)
+}
+
+/// Resolve the effective URL for a branch's remote without parsing.
+///
+/// Resolution chain:
 /// - Remote-branch refs (`origin/feature`) read from the branch's own
 ///   remote via [`Repository::effective_remote_url`] (honors
 ///   `url.insteadOf` rewrites).
@@ -163,26 +176,9 @@ fn retriable_pr_error(output: &Output) -> Option<PrStatus> {
 ///   falling back to the repo's primary remote so a tracking-less branch
 ///   still resolves.
 ///
-/// `is_platform` filters out URLs that don't belong to the calling backend
-/// (e.g., a primary github remote alongside an azure secondary): the
-/// platform was selected upstream from one remote, so a different remote
-/// must not be queried with mismatched API shapes.
-fn branch_owner_repo_for_platform(
-    repo: &Repository,
-    branch: &CiBranchName,
-    is_platform: impl Fn(&GitRemoteUrl) -> bool,
-) -> Option<(String, String)> {
-    let url = branch_remote_url(repo, branch)?;
-    let parsed = GitRemoteUrl::parse(&url)?;
-    is_platform(&parsed).then_some(())?;
-    parse_owner_repo(&url)
-}
-
-/// Resolve the effective URL for a branch's remote without parsing.
-///
-/// See [`branch_owner_repo_for_platform`] for the resolution chain — this is
-/// the URL-only primitive backends compose with their own URL parsers
-/// (Azure DevOps' org/project shape doesn't fit `parse_owner_repo`).
+/// Backends with their own URL parser (e.g. Azure DevOps' org/project shape)
+/// compose this directly; backends that want `(owner, repo)` use
+/// [`branch_owner_repo`].
 fn branch_remote_url(repo: &Repository, branch: &CiBranchName) -> Option<String> {
     if let Some(remote_name) = &branch.remote {
         repo.effective_remote_url(remote_name)

--- a/src/commands/list/ci_status/platform.rs
+++ b/src/commands/list/ci_status/platform.rs
@@ -72,7 +72,7 @@ fn detect_branch(
         // Gitea queries the combined commit status by SHA, but owner/repo come
         // from the branch's own remote (so remote-only rows hit the right repo).
         CiPlatform::Gitea => gitea::detect_gitea_commit_status(repo, branch, local_head),
-        CiPlatform::AzureDevOps => azure::detect_azure_pipeline(repo, &branch.name, local_head),
+        CiPlatform::AzureDevOps => azure::detect_azure_pipeline(repo, branch, local_head),
     }
 }
 

--- a/src/git/repository/branch.rs
+++ b/src/git/repository/branch.rs
@@ -1,7 +1,5 @@
 //! Branch - a handle for branch-specific git operations.
 
-use crate::git::GitRemoteUrl;
-
 use super::Repository;
 
 /// A handle for running git commands on a specific branch.
@@ -143,10 +141,10 @@ impl<'a> Branch<'a> {
     /// Returns `None` if no push remote is configured or the remote has no URL.
     ///
     /// Result is cached on `RepoCache.push_remote_urls`. The CI-status detector
-    /// calls `github_push_url` from both `detect_github` (PR-based) and
-    /// `detect_github_commit_checks` (branch fallback), so without the cache the
-    /// `for-each-ref` runs twice for the same branch on the no-PR path.
-    fn push_remote_url(&self) -> Option<String> {
+    /// calls this from both the PR-based path and the branch fallback, so
+    /// without the cache the `for-each-ref` runs twice for the same branch
+    /// on the no-PR path.
+    pub fn push_remote_url(&self) -> Option<String> {
         self.repo
             .cache
             .push_remote_urls
@@ -173,19 +171,5 @@ impl<'a> Branch<'a> {
                 }
             })
             .clone()
-    }
-
-    /// Get the GitHub URL for this branch's push remote, if it's a GitHub URL.
-    ///
-    /// Returns the push remote URL if configured and pointing to GitHub,
-    /// otherwise returns `None`. Handles `url.insteadOf` aliases via
-    /// `effective_remote_url` (cached).
-    ///
-    /// Handles both remote-name and URL-based pushremotes (the latter is set by
-    /// `gh pr checkout` for fork PRs).
-    pub fn github_push_url(&self) -> Option<String> {
-        let url = self.push_remote_url()?;
-        let parsed = GitRemoteUrl::parse(&url)?;
-        parsed.is_github().then_some(url)
     }
 }

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -277,10 +277,10 @@ pub(super) struct RepoCache {
     /// Per-branch effective push URL: branch_name -> push URL (or None if
     /// no push remote is configured). One `for-each-ref %(push:remotename)`
     /// per branch, then `effective_remote_url` for the resolved remote name.
-    /// `wt list`'s CI-status detection calls `github_push_url` from both
-    /// `detect_github` (PR-based) and `detect_github_commit_checks` (commit
-    /// fallback), so the same branch is queried twice on the no-PR path —
-    /// this cache collapses that to one subprocess.
+    /// `wt list`'s CI-status detection calls `push_remote_url` from both the
+    /// PR-based path and the branch fallback (via `branch_remote_url`), so
+    /// the same branch is queried twice on the no-PR path — this cache
+    /// collapses that to one subprocess.
     pub(super) push_remote_urls: DashMap<String, Option<String>>,
 
     /// Local branch inventory: one `git for-each-ref refs/heads/` scan, cached

--- a/tests/integration_tests/default_branch.rs
+++ b/tests/integration_tests/default_branch.rs
@@ -543,9 +543,12 @@ fn test_find_remote_by_url_insteadof(repo: TestRepo) {
     assert_eq!(found.as_deref(), Some("origin"));
 }
 
-/// Test github_push_url: resolves through insteadOf on push remote.
+/// `push_remote_url`: resolves through `insteadOf` on the push remote.
+///
+/// CI-status detection composes this with a per-platform host check (e.g.
+/// `is_github`) — here we assert the URL resolves and points at GitHub.
 #[rstest]
-fn test_github_push_url_insteadof_fallback(repo: TestRepo) {
+fn test_push_remote_url_insteadof_fallback(repo: TestRepo) {
     setup_insteadof(
         &repo,
         "origin",
@@ -557,41 +560,48 @@ fn test_github_push_url_insteadof_fallback(repo: TestRepo) {
     let git_repo = Repository::at(repo.root_path()).unwrap();
     let url = git_repo
         .branch("main")
-        .github_push_url()
-        .expect("github_push_url should resolve via insteadOf");
+        .push_remote_url()
+        .expect("push_remote_url should resolve via insteadOf");
     let parsed = GitRemoteUrl::parse(&url).unwrap();
     assert!(parsed.is_github());
     assert_eq!(parsed.host(), "github.com");
 }
 
-/// Test github_push_url: returns None for non-GitHub forge (GitLab).
+/// `push_remote_url`: returns a non-GitHub URL untouched. CI-status callers
+/// filter via `GitRemoteUrl::is_github` etc. — the primitive itself is
+/// platform-agnostic.
 #[rstest]
-fn test_github_push_url_non_github_forge_returns_none(repo: TestRepo) {
+fn test_push_remote_url_returns_non_github_url(repo: TestRepo) {
     repo.run_git(&["config", "remote.origin.url", "git@gitlab.com:org/repo.git"]);
     setup_push_tracking(&repo, "main", "origin");
 
     let git_repo = Repository::at(repo.root_path()).unwrap();
-    assert!(git_repo.branch("main").github_push_url().is_none());
+    let url = git_repo
+        .branch("main")
+        .push_remote_url()
+        .expect("push_remote_url resolves the configured remote regardless of host");
+    let parsed = GitRemoteUrl::parse(&url).unwrap();
+    assert!(!parsed.is_github());
+    assert!(parsed.is_gitlab());
 }
 
-/// Test github_push_url: result is cached on the Repository.
+/// `push_remote_url`: result is cached on the Repository.
 ///
-/// `wt list`'s CI-status detection calls `github_push_url` from both
-/// `detect_github` (PR-based) and `detect_github_commit_checks` (branch
-/// fallback) — without caching the underlying `for-each-ref %(push:remotename)`
-/// runs twice for the same branch on the no-PR path (worktrunk#2672).
-/// Mutating the branch's push tracking after the first call must not
-/// change the cached value.
+/// `wt list`'s CI-status detection calls `push_remote_url` from both the
+/// PR-based path and the branch fallback — without caching the underlying
+/// `for-each-ref %(push:remotename)` runs twice for the same branch on the
+/// no-PR path (worktrunk#2672). Mutating the branch's push tracking after
+/// the first call must not change the cached value.
 #[rstest]
-fn test_github_push_url_is_cached(repo: TestRepo) {
+fn test_push_remote_url_is_cached(repo: TestRepo) {
     repo.run_git(&["config", "remote.origin.url", "git@github.com:org/repo.git"]);
     setup_push_tracking(&repo, "main", "origin");
 
     let git_repo = Repository::at(repo.root_path()).unwrap();
     let first = git_repo
         .branch("main")
-        .github_push_url()
-        .expect("first call resolves to a GitHub URL");
+        .push_remote_url()
+        .expect("first call resolves to a URL");
 
     // Remove the push tracking config. A fresh `for-each-ref
     // %(push:remotename)` would now return empty, so a non-cached
@@ -601,14 +611,15 @@ fn test_github_push_url_is_cached(repo: TestRepo) {
 
     let second = git_repo
         .branch("main")
-        .github_push_url()
+        .push_remote_url()
         .expect("second call returns the cached URL");
     assert_eq!(first, second);
 }
 
-/// Test github_push_url: returns None when insteadOf resolves to GitLab (not GitHub).
+/// `push_remote_url`: when `insteadOf` resolves to a GitLab URL, returns
+/// that GitLab URL. The primitive isn't host-filtered — callers do that.
 #[rstest]
-fn test_github_push_url_unknown_host_non_github_insteadof(repo: TestRepo) {
+fn test_push_remote_url_insteadof_resolves_to_non_github(repo: TestRepo) {
     setup_insteadof(
         &repo,
         "origin",
@@ -618,7 +629,13 @@ fn test_github_push_url_unknown_host_non_github_insteadof(repo: TestRepo) {
     setup_push_tracking(&repo, "main", "origin");
 
     let git_repo = Repository::at(repo.root_path()).unwrap();
-    assert!(git_repo.branch("main").github_push_url().is_none());
+    let url = git_repo
+        .branch("main")
+        .push_remote_url()
+        .expect("push_remote_url resolves through insteadOf regardless of host");
+    let parsed = GitRemoteUrl::parse(&url).unwrap();
+    assert!(parsed.is_gitlab());
+    assert!(!parsed.is_github());
 }
 
 // --- `-C` and discovery-path independence ---


### PR DESCRIPTION
## Summary

Pulls the duplicated retriable-error handling and remote-URL resolution out of the four forge backends into shared helpers in `ci_status/mod.rs`, and brings Gitea / Azure up to GitHub's standard along the way.

## What changed

**Shared helpers (in `mod.rs`):**
- `output_error_text` + `retriable_pr_error` collapse 6× copies of the "if non-success → check stderr → maybe `PrStatus::error()`" pattern. Both stdout and stderr are sniffed (previously only `tea` did this).
- `branch_remote_url` codifies the chain *branch's own remote → push remote → primary fallback*.
- `branch_owner_repo` is the two-line `parse_owner_repo` composition over that. No platform host filter — when `Repository::ci_platform()` returned the platform from explicit `forge.platform` config, the `is_gitea`/`is_github` substring heuristic would wrongly reject legitimate hosts (Forgejo / `codeberg.org`, GHE on a custom host); when it returned the platform from URL inference the filter was redundant.

**Gitea brought to standard:**
- Local branches now honor `branch.<n>.pushRemote` instead of always going to the primary remote.

**Azure brought to standard:**
- `azure_context` is now branch-aware — a `remote/feature` row from `wt list --remotes --full` queries that remote's tenant in multi-org setups rather than always the primary. The `all_remote_urls` scan still handles the case where the resolved remote isn't Azure but another remote is.
- `detect_azure_pipeline` takes `&CiBranchName` instead of `&str` so the new resolver has the branch.remote it needs.

**Primitive promoted:**
- `Branch::push_remote_url` is now `pub`; the single-caller `github_push_url` wrapper is deleted. The `is_github` filter at the call site is gone too — same reasoning as above.

## Test plan

- [x] `cargo run -- hook pre-merge --yes` — 3669/3669 tests pass, all lints green, no snapshot drift
- [x] New unit tests for `output_error_text`, `retriable_pr_error` (both branches), `azure_context`'s `all_remote_urls` fallback, and a Forgejo (`codeberg.org`) regression guard so a future re-introduction of the host filter trips the suite
- [x] `default_branch.rs` tests for `github_push_url` rewritten in terms of `push_remote_url` (the primitive) + `GitRemoteUrl::is_github` (the call-site composition)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
