### PR TITLE
fix(testing): default LLVM_PROFILE_FILE to a temp-dir path when not inherited

### DIFF
--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -295,17 +295,12 @@ const DEFAULT_ISOLATED_APPROVALS: &str = "/nonexistent/wt/approvals.toml";
 /// file doesn't actually exist on test/CI machines.
 const DEFAULT_ISOLATED_SYSTEM_CONFIG: &str = "/etc/xdg/worktrunk/config.toml";
 
-/// LLVM coverage env vars that the parent's `cargo llvm-cov` / `cargo affected`
-/// run sets to point spawned binaries at the right `.profraw` file. Mirrored
-/// in `tests/common/mod.rs::pass_coverage_env_to_pty_cmd` for PTY tests that
-/// `env_clear()`. Keep both lists in sync — dropping `LLVM_PROFILE_FILE` makes
-/// an instrumented child fall back to LLVM's default `default_*.profraw` in
-/// the child's cwd, leaving stray files at the repo root.
-pub const COVERAGE_ENV_VARS: &[&str] = &[
-    "LLVM_PROFILE_FILE",
-    "CARGO_LLVM_COV",
-    "CARGO_LLVM_COV_TARGET_DIR",
-];
+/// `cargo llvm-cov` / `cargo affected` coverage env vars that propagate
+/// verbatim from parent to test subprocesses. `LLVM_PROFILE_FILE` is *not*
+/// in this list — it's resolved by [`default_llvm_profile_file`] so an
+/// instrumented child writing to its cwd is impossible even when nothing's
+/// inherited. Mirrored at the PTY call sites in `tests/common/`.
+pub const COVERAGE_ENV_VARS: &[&str] = &["CARGO_LLVM_COV", "CARGO_LLVM_COV_TARGET_DIR"];
 
 /// Resolve the `LLVM_PROFILE_FILE` value to set on test subprocesses.
 ///
@@ -321,7 +316,16 @@ pub const COVERAGE_ENV_VARS: &[&str] = &[
 /// The `%m` and `%p` placeholders are expanded by the LLVM runtime in the
 /// instrumented child; uninstrumented children ignore the env var entirely.
 pub fn default_llvm_profile_file() -> std::ffi::OsString {
-    if let Some(inherited) = std::env::var_os("LLVM_PROFILE_FILE") {
+    default_llvm_profile_file_with(std::env::var_os("LLVM_PROFILE_FILE"))
+}
+
+/// Inner form of [`default_llvm_profile_file`] that takes the inherited value
+/// as a parameter instead of reading [`std::env::var_os`]. CI always runs
+/// under `cargo llvm-cov`, so the production caller always takes the
+/// inherited branch — this split lets a unit test exercise the fallback
+/// without mutating process env (which races with parallel tests).
+fn default_llvm_profile_file_with(inherited: Option<std::ffi::OsString>) -> std::ffi::OsString {
+    if let Some(inherited) = inherited {
         return inherited;
     }
     let dir = std::env::temp_dir().join("wt-test-profraw");
@@ -339,10 +343,12 @@ pub fn default_llvm_profile_file() -> std::ffi::OsString {
 /// - `WORKTRUNK_SYSTEM_CONFIG_PATH` ← real XDG location (typically nonexistent on CI)
 /// - `WORKTRUNK_APPROVALS_PATH` ← nonexistent file
 ///
-/// Also re-applies [`COVERAGE_ENV_VARS`] from the parent so an instrumented
-/// child writes its `.profraw` to the path `cargo llvm-cov` chose, not to a
-/// `default_*.profraw` in the child's cwd. The re-apply is defensive: a caller
-/// that did `env_clear()` before us would otherwise drop the inherited values.
+/// Also sets `LLVM_PROFILE_FILE` via [`default_llvm_profile_file`] and
+/// re-applies [`COVERAGE_ENV_VARS`] from the parent so an instrumented child
+/// writes its `.profraw` to the path `cargo llvm-cov` chose (or to a temp-dir
+/// fallback when nothing's inherited), not to a `default_*.profraw` in the
+/// child's cwd. The re-apply is defensive: a caller that did `env_clear()`
+/// before us would otherwise drop the inherited values.
 ///
 /// Shared by [`configure_cli_command`] (test-side, layers on test
 /// determinism: forced colors, fixed timestamps, log level, etc.) and
@@ -390,7 +396,7 @@ where
     // falls back to writing `default_*.profraw` into its cwd. See
     // [`default_llvm_profile_file`] for the rationale.
     cmd.env("LLVM_PROFILE_FILE", default_llvm_profile_file());
-    for key in ["CARGO_LLVM_COV", "CARGO_LLVM_COV_TARGET_DIR"] {
+    for key in COVERAGE_ENV_VARS {
         if let Ok(val) = std::env::var(key) {
             cmd.env(key, val);
         }
@@ -2904,6 +2910,34 @@ mod tests {
         assert_eq!(
             removed.get("WORKTRUNK_APPROVALS_PATH"),
             Some(&Some(DEFAULT_ISOLATED_APPROVALS.to_string()))
+        );
+    }
+
+    #[test]
+    fn default_llvm_profile_file_with_inherited_value_returns_it_verbatim() {
+        let inherited = std::ffi::OsString::from("/cov/expected-%p.profraw");
+        let resolved = default_llvm_profile_file_with(Some(inherited.clone()));
+        assert_eq!(resolved, inherited);
+    }
+
+    #[test]
+    fn default_llvm_profile_file_falls_back_to_temp_dir_when_uninherited() {
+        let resolved = default_llvm_profile_file_with(None);
+        let expected_dir = std::env::temp_dir().join("wt-test-profraw");
+        // The returned path is `<temp>/wt-test-profraw/cov-%m_%p.profraw`. We
+        // assert the parent dir lives under temp and the file name carries the
+        // LLVM templating placeholders — the runtime expands those in the
+        // instrumented child, so the literal `%m_%p` in this string is correct.
+        let resolved_path = std::path::PathBuf::from(&resolved);
+        assert_eq!(resolved_path.parent(), Some(expected_dir.as_path()));
+        assert_eq!(
+            resolved_path.file_name().and_then(|n| n.to_str()),
+            Some("cov-%m_%p.profraw"),
+        );
+        assert!(
+            expected_dir.is_dir(),
+            "fallback should have created {}",
+            expected_dir.display(),
         );
     }
 }

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -307,6 +307,28 @@ pub const COVERAGE_ENV_VARS: &[&str] = &[
     "CARGO_LLVM_COV_TARGET_DIR",
 ];
 
+/// Resolve the `LLVM_PROFILE_FILE` value to set on test subprocesses.
+///
+/// Returns the inherited value when the parent is running under
+/// `cargo llvm-cov` (so coverage data lands where the runner expects). When
+/// nothing is inherited, returns a per-binary, per-pid path under the system
+/// temp dir so an instrumented child (e.g. a stale `mock-stub` left
+/// instrumented by an earlier coverage build) can't fall back to writing
+/// `default_<hash>_<pid>.profraw` into the subprocess's cwd. That cwd is the
+/// test worktree for any `wt list` snapshot that spawns a mock, and a stray
+/// profraw there flips `wt list` to "1 with changes" and flakes the snapshot.
+///
+/// The `%m` and `%p` placeholders are expanded by the LLVM runtime in the
+/// instrumented child; uninstrumented children ignore the env var entirely.
+pub fn default_llvm_profile_file() -> std::ffi::OsString {
+    if let Some(inherited) = std::env::var_os("LLVM_PROFILE_FILE") {
+        return inherited;
+    }
+    let dir = std::env::temp_dir().join("wt-test-profraw");
+    let _ = std::fs::create_dir_all(&dir);
+    dir.join("cov-%m_%p.profraw").into_os_string()
+}
+
 /// Prepare a subprocess to run with a clean wt environment.
 ///
 /// Strips every `GIT_*` and `WORKTRUNK_*` from the parent env, plus
@@ -363,7 +385,12 @@ where
     );
     cmd.env("WORKTRUNK_APPROVALS_PATH", DEFAULT_ISOLATED_APPROVALS);
 
-    for key in COVERAGE_ENV_VARS {
+    // Always set LLVM_PROFILE_FILE — to the inherited value under coverage,
+    // or to a temp-dir default otherwise — so an instrumented child never
+    // falls back to writing `default_*.profraw` into its cwd. See
+    // [`default_llvm_profile_file`] for the rationale.
+    cmd.env("LLVM_PROFILE_FILE", default_llvm_profile_file());
+    for key in ["CARGO_LLVM_COV", "CARGO_LLVM_COV_TARGET_DIR"] {
         if let Ok(val) = std::env::var(key) {
             cmd.env(key, val);
         }

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -2934,10 +2934,7 @@ mod tests {
             resolved_path.file_name().and_then(|n| n.to_str()),
             Some("cov-%m_%p.profraw"),
         );
-        assert!(
-            expected_dir.is_dir(),
-            "fallback should have created {}",
-            expected_dir.display(),
-        );
+        // The fallback creates the dir if absent.
+        assert!(expected_dir.is_dir());
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -450,12 +450,17 @@ pub fn configure_pty_command(cmd: &mut portable_pty::CommandBuilder) {
 /// (i.e. the repo root for tests that don't override it) instead of the path
 /// `cargo llvm-cov` chose. The non-PTY equivalent lives inside
 /// `worktrunk::testing::isolate_subprocess_env`; both paths share
-/// [`worktrunk::testing::COVERAGE_ENV_VARS`].
+/// [`worktrunk::testing::default_llvm_profile_file`] for the
+/// inherit-or-temp-dir resolution.
 ///
 /// Use `configure_pty_command()` for the full setup, or call this directly if you
 /// need custom env_clear handling (e.g., shell-specific env vars).
 pub fn pass_coverage_env_to_pty_cmd(cmd: &mut portable_pty::CommandBuilder) {
-    for key in worktrunk::testing::COVERAGE_ENV_VARS {
+    cmd.env(
+        "LLVM_PROFILE_FILE",
+        worktrunk::testing::default_llvm_profile_file(),
+    );
+    for key in ["CARGO_LLVM_COV", "CARGO_LLVM_COV_TARGET_DIR"] {
         if let Ok(val) = std::env::var(key) {
             cmd.env(key, val);
         }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -460,7 +460,7 @@ pub fn pass_coverage_env_to_pty_cmd(cmd: &mut portable_pty::CommandBuilder) {
         "LLVM_PROFILE_FILE",
         worktrunk::testing::default_llvm_profile_file(),
     );
-    for key in ["CARGO_LLVM_COV", "CARGO_LLVM_COV_TARGET_DIR"] {
+    for key in worktrunk::testing::COVERAGE_ENV_VARS {
         if let Ok(val) = std::env::var(key) {
             cmd.env(key, val);
         }

--- a/tests/common/progressive_output.rs
+++ b/tests/common/progressive_output.rs
@@ -562,7 +562,7 @@ fn configure_pty_environment(cmd: &mut CommandBuilder, repo: &TestRepo) {
         "LLVM_PROFILE_FILE",
         worktrunk::testing::default_llvm_profile_file(),
     );
-    for key in ["CARGO_LLVM_COV", "CARGO_LLVM_COV_TARGET_DIR"] {
+    for key in worktrunk::testing::COVERAGE_ENV_VARS {
         if let Ok(val) = std::env::var(key) {
             cmd.env(key, val);
         }

--- a/tests/common/progressive_output.rs
+++ b/tests/common/progressive_output.rs
@@ -556,8 +556,13 @@ fn configure_pty_environment(cmd: &mut CommandBuilder, repo: &TestRepo) {
 
     // Pass through LLVM coverage profiling environment for subprocess coverage collection.
     // When running under cargo-llvm-cov, spawned binaries need LLVM_PROFILE_FILE to record
-    // their coverage data.
-    for key in worktrunk::testing::COVERAGE_ENV_VARS {
+    // their coverage data; otherwise, point it at a temp-dir default so an
+    // instrumented child can't write `default_*.profraw` into the repo root.
+    cmd.env(
+        "LLVM_PROFILE_FILE",
+        worktrunk::testing::default_llvm_profile_file(),
+    );
+    for key in ["CARGO_LLVM_COV", "CARGO_LLVM_COV_TARGET_DIR"] {
         if let Ok(val) = std::env::var(key) {
             cmd.env(key, val);
         }


### PR DESCRIPTION
## Summary

Defaults `LLVM_PROFILE_FILE` to `std::env::temp_dir()/wt-test-profraw/cov-%m_%p.profraw` when nothing is inherited from the parent. `isolate_subprocess_env` previously only *propagated* the var (per #2713), leaving it unset under plain `cargo test`. An instrumented child — most commonly a stale `mock-stub` left instrumented by an earlier coverage build — then fell back to writing `default_<hash>_<pid>.profraw` into its cwd. For any `wt list` snapshot that spawns a mock, that cwd is the test worktree, so `git status --porcelain` saw the profraw as an untracked file and `wt list` rendered "Showing 5 worktrees, 1 with changes, …" instead of "Showing 5 worktrees, 4 ahead". Different subsets of the gitea CI-status tests would flake every parallel run.

`default_llvm_profile_file()` is a thin wrapper over `default_llvm_profile_file_with(inherited)` (same outer/inner split as `isolate_subprocess_env` / `isolate_subprocess_env_from`) so a unit test exercises both the inherited and the temp-dir-fallback branches without mutating process env. `COVERAGE_ENV_VARS` is shrunk to `[CARGO_LLVM_COV, CARGO_LLVM_COV_TARGET_DIR]` — `LLVM_PROFILE_FILE` is no longer in it because it's now governed by `default_llvm_profile_file()` — and all three call sites (`isolate_subprocess_env`, `pass_coverage_env_to_pty_cmd`, `configure_pty_environment`) route through that helper plus the constant.

Under `cargo llvm-cov`, behavior is unchanged: the inherited `LLVM_PROFILE_FILE` wins, and profraws still land at the path the runner chose. The `%m_%p` placeholders are expanded by the LLVM runtime in the instrumented child; uninstrumented children ignore the env var entirely. The CI guard from #2719 will catch any future helper that bypasses this contract.

## Test plan

Verified against a deliberately-reinstalled instrumented `mock-stub` each time:

- [x] 5× `cargo test --test integration -- ci_status::test_list_full_with_gitea` — 9/9 pass each run (was flaking ~50%)
- [x] 5× `cargo nextest run --test integration ci_status` (67 tests, parallel) — all pass each run
- [x] `cargo llvm-cov nextest --test integration ci_status::test_list_full_with_gitea_pr_status::case_1` — passes; profraws land in `target/llvm-cov-target/…` (cargo-llvm-cov's chosen path), not in the worktree
- [x] `cargo test --test integration -- ci_status` (full 67) — pass
- [x] `cargo test --lib testing::tests::default_llvm` — both new unit tests green (inherited branch + temp-dir fallback)
- [x] `cargo clippy --workspace --tests --features shell-integration-tests -- -D warnings` — clean
- [x] No stray `default_*.profraw` anywhere after the runs; redirected profraws land in `$TMPDIR/wt-test-profraw/cov-%m_%p.profraw`
