### PR TITLE
bench(alias): use BatchSize::PerIteration for cold-cache variants

### DIFF
--- a/benches/alias.rs
+++ b/benches/alias.rs
@@ -129,10 +129,16 @@ fn bench_dispatch(c: &mut Criterion) {
                         );
                     };
                     if cold {
+                        // `PerIteration` so every measured run is actually
+                        // cold — `build_hook_context` resolves the default
+                        // branch, which writes `worktrunk.default-branch`
+                        // and would be a cache hit on iters 2-N under
+                        // `SmallInput`. See `benches/CLAUDE.md` →
+                        // "Cache Handling" for the full rationale.
                         b.iter_batched(
                             || invalidate_caches_auto(&repo_path),
                             |_| run(),
-                            criterion::BatchSize::SmallInput,
+                            criterion::BatchSize::PerIteration,
                         );
                     } else {
                         b.iter(run);


### PR DESCRIPTION
## Summary

Follow-up to #2728. `benches/alias.rs` was the last `iter_batched(invalidate_caches_auto, …, BatchSize::SmallInput)` site in the bench suite. Under `SmallInput`, criterion calls the setup closure once per batch and times the routines back-to-back inside one timing window — so only iter 1 per batch is actually cold, and iters 2-N hit the `worktrunk.default-branch` git-config entry that `build_hook_context` wrote on iter 1 (default-branch resolution is ~17ms on a synthetic repo per `benches/CLAUDE.md`). `BatchSize::PerIteration` runs `setup → time(routine)` per iter, so every measurement is genuinely cold.

## Measurement

`dispatch/cold/1` (stub alias, 1 worktree):

| | Before | After |
|---|---|---|
| Median | 23.14 ms | 23.94 ms |
| Range | [22.34, 24.01] | [22.91, 25.03] |

Median +6.9% (p=0.05, "Change within noise threshold"). The correction is small — alias dispatch is cheap (~23ms) and only the default-branch cache is being repopulated, so each warm iter saved ~1ms — but the direction is right and it brings the bench in line with the rest of the suite (#2728) and the `benches/CLAUDE.md` "Cache Handling" guidance.

## Test plan

- [x] `cargo run -- hook pre-merge --yes` — 3684 tests pass, 0 failed
- [x] `dispatch/cold/1` run before+after on this branch with `--save-baseline` / `--baseline`
