### PR TITLE
refactor(ci-status): align Gitea PR detection with the GitHub backend

### DIFF
--- a/src/commands/list/ci_status/gitea.rs
+++ b/src/commands/list/ci_status/gitea.rs
@@ -1,47 +1,15 @@
 //! Gitea CI status detection.
 //!
-//! Detects CI status from Gitea pull requests and commit statuses using the
-//! `tea` CLI. Gitea's API is GitHub-compatible:
-//!
-//! - `GET /repos/{owner}/{repo}/commits/{sha}/status` returns a *combined*
-//!   commit status (`state` + `total_count`). Both Gitea Actions and external
-//!   CI report into commit statuses, so this is the pass/fail/pending rollup —
-//!   the equivalent of GitHub's check-runs API.
-//! - `GET /repos/{owner}/{repo}/pulls?state=open` lists open PRs (the `state`
-//!   filter is required — the endpoint returns *all* states by default); each
-//!   PR carries `mergeable`, which surfaces merge conflicts.
-//!
-//! ## Two paths (mirrors [`super::azure`])
-//!
-//! - [`detect_gitea_pr`] — finds an open PR whose head branch matches, surfaces
-//!   conflicts from `mergeable` and the real CI state from the PR head commit's
-//!   combined status, and yields the PR's `html_url` for the clickable
-//!   indicator.
-//! - [`detect_gitea_commit_status`] — the branch fallback when no PR exists:
-//!   queries the combined status of the local HEAD SHA.
-//!
-//! When a PR exists, two API calls are made (pulls list + combined status);
-//! results are cached for 30–60s by the caller, so `wt list` over many branches
-//! doesn't refetch.
-//!
-//! ## Known limitations (experimental)
-//!
-//! - Only the first page of open PRs (Gitea's default page size, newest-first)
-//!   is inspected; in a repo with many open PRs, ours could fall off the page.
-//! - PRs opened from a fork (head repo owner ≠ the queried repo's owner) aren't
-//!   matched — owner/repo comes from the branch's own remote, not the upstream
-//!   the PR targets.
-//! - `mergeable` is computed asynchronously by Gitea, so a freshly-opened PR can
-//!   briefly report a false conflict until the check completes (self-corrects
-//!   when the cache expires).
+//! Detects CI status from Gitea PRs and commit statuses using the `tea` CLI.
+//! Experimental.
 
 use serde::Deserialize;
 use std::process::Output;
-use worktrunk::git::Repository;
+use worktrunk::git::{Repository, parse_owner_repo};
 
 use super::{
-    CiBranchName, CiSource, CiStatus, PrStatus, branch_owner_repo, is_retriable_error,
-    non_interactive_cmd, output_error_text, parse_json, retriable_pr_error,
+    CiBranchName, CiSource, CiStatus, MAX_PRS_TO_FETCH, PrStatus, branch_owner_repo,
+    is_retriable_error, non_interactive_cmd, output_error_text, parse_json, retriable_pr_error,
 };
 
 /// Run `tea api <path>` from the worktree root.
@@ -85,18 +53,25 @@ fn fetch_combined_status(
 
 /// Detect Gitea PR CI status for a branch.
 ///
-/// Lists open PRs (`tea api repos/{owner}/{repo}/pulls?state=open`), finds the
-/// one whose head branch matches `branch.name`, then reports conflicts
-/// (`mergeable`) and the head commit's combined CI status.
+/// Lists open PRs on the primary remote, finds the one whose head branch +
+/// head owner matches, then reports conflicts (`mergeable`) and the head
+/// commit's combined CI status.
 pub(super) fn detect_gitea_pr(
     repo: &Repository,
     branch: &CiBranchName,
     local_head: &str,
 ) -> Option<PrStatus> {
-    let (owner, repo_name) = branch_owner_repo(repo, branch)?;
+    // Query the primary remote (typically the upstream), then filter by the
+    // branch's push owner — same pattern as github.rs, so fork PRs match.
+    let primary_remote = repo.primary_remote().ok()?;
+    let primary_url = repo.effective_remote_url(&primary_remote)?;
+    let (query_owner, query_repo) = parse_owner_repo(&primary_url)?;
+    let branch_owner = branch_owner_repo(repo, branch).map(|(owner, _)| owner)?;
 
-    // `state=open` is required: the pulls list returns all states by default.
-    let path = format!("repos/{owner}/{repo_name}/pulls?state=open");
+    // `state=open` required (default returns all states); `limit` matches the
+    // github backend's MAX_PRS_TO_FETCH so both have identical page semantics.
+    let path =
+        format!("repos/{query_owner}/{query_repo}/pulls?state=open&limit={MAX_PRS_TO_FETCH}");
     let output = tea_api(repo, &path)?;
     if !output.status.success() {
         return retriable_pr_error(&output);
@@ -104,28 +79,28 @@ pub(super) fn detect_gitea_pr(
 
     let prs: Vec<GiteaPr> = parse_json(&output.stdout, "tea api pulls", &branch.full_name)?;
 
-    // Match by head branch name; require the head repo owner (when present) to
-    // be the repo we queried — same-repo PRs only, since the resolver scopes
-    // owner/repo to the branch's own remote (fork PRs are out of scope; see
-    // the module-level "Known limitations"). A missing owner is treated as a
-    // potential match, as in the GitHub path.
+    // Match by head branch + head owner. Missing owner → potential match,
+    // mirroring github.rs.
     let pr = prs.iter().find(|pr| {
         pr.head.ref_name == branch.name
             && pr
                 .head
                 .repo
                 .as_ref()
-                .map(|r| r.owner.login.eq_ignore_ascii_case(&owner))
+                .map(|r| r.owner.login.eq_ignore_ascii_case(&branch_owner))
                 .unwrap_or(true)
     })?;
 
     let base_status = fetch_combined_status(
         repo,
-        &owner,
-        &repo_name,
+        &query_owner,
+        &query_repo,
         pr.head.sha.as_deref().unwrap_or(local_head),
     )
     .unwrap_or(CiStatus::NoCI);
+    // `mergeable` is computed asynchronously by Gitea — a freshly-opened PR
+    // can briefly report `Some(false)` until the check completes (self-
+    // corrects when the cache expires).
     let ci_status = if pr.mergeable == Some(false) {
         CiStatus::Conflicts
     } else {

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -2092,7 +2092,9 @@ impl TestRepo {
         std::fs::write(mock_bin.join("tea_pulls.json"), pulls_json).unwrap();
         std::fs::write(mock_bin.join("tea_status.json"), status_json).unwrap();
 
-        let pulls_path = format!("api repos/{owner}/{repo_name}/pulls?state=open");
+        // Keep `&limit=20` in sync with `MAX_PRS_TO_FETCH` in
+        // `src/commands/list/ci_status/mod.rs`.
+        let pulls_path = format!("api repos/{owner}/{repo_name}/pulls?state=open&limit=20");
         let status_path = format!("api repos/{owner}/{repo_name}/commits/{head_sha}/status");
 
         MockConfig::new("tea")
@@ -2152,7 +2154,9 @@ impl TestRepo {
         MockConfig::new("tea")
             .version("tea version development (mock)")
             .command(
-                "api repos/owner/test-repo/pulls?state=open",
+                // Keep `&limit=20` in sync with `MAX_PRS_TO_FETCH` in
+                // `src/commands/list/ci_status/mod.rs`.
+                "api repos/owner/test-repo/pulls?state=open&limit=20",
                 MockResponse::file("tea_pulls.json"),
             )
             .command(

--- a/tests/integration_tests/ci_status.rs
+++ b/tests/integration_tests/ci_status.rs
@@ -1263,3 +1263,69 @@ fn test_list_remotes_full_with_gitea_remote_branch(mut repo: TestRepo) {
         assert_cmd_snapshot!("gitea_remote_branch_uses_branch_remote", cmd);
     });
 }
+
+/// A PR opened from a fork (head owner ≠ the queried upstream owner) is
+/// matched: `wt list --full` lists the *primary* remote's open PRs and filters
+/// by the branch's push owner against `head.repo.owner.login`. Two Gitea
+/// remotes (`origin` → `upstream/test-repo`, `fork` → `forkowner/test-repo`)
+/// and the `feature` branch pushes to `fork`. The mock returns two open PRs for
+/// the `feature` ref — a decoy from `other-owner` that must be filtered out and
+/// the real one from `forkowner` — and answers the upstream's commit-status
+/// lookup with `success`. The green `●` proves the fork PR matched; a revert to
+/// querying/filtering by the branch's own remote would query `forkowner`'s
+/// (unmocked) `/pulls` and lose the indicator. Mirrors the GitHub backend's
+/// `test_list_full_filters_by_repo_owner`.
+#[rstest]
+fn test_list_full_with_gitea_fork_pr(mut repo: TestRepo) {
+    repo.run_git(&[
+        "remote",
+        "set-url",
+        "origin",
+        "https://gitea.example.com/upstream/test-repo.git",
+    ]);
+    repo.run_git(&[
+        "remote",
+        "add",
+        "fork",
+        "https://gitea.example.com/forkowner/test-repo.git",
+    ]);
+    let feature_wt = repo.add_worktree("feature");
+    repo.commit_in_worktree(
+        &feature_wt,
+        "gitea-fork-ci.txt",
+        "gitea fork ci test",
+        "feat: gitea fork feature",
+    );
+    setup_tracking_for_all_branches(&repo, "fork");
+    let head_sha = branch_sha(&repo, "feature");
+
+    let pulls_json = format!(
+        r#"[
+        {{
+            "mergeable": true,
+            "html_url": "https://gitea.example.com/upstream/test-repo/pulls/98",
+            "head": {{"ref": "feature", "sha": "wrong_sha", "repo": {{"owner": {{"login": "other-owner"}}}}}}
+        }},
+        {{
+            "mergeable": true,
+            "html_url": "https://gitea.example.com/upstream/test-repo/pulls/7",
+            "head": {{"ref": "feature", "sha": "{head_sha}", "repo": {{"owner": {{"login": "forkowner"}}}}}}
+        }}
+    ]"#
+    );
+
+    repo.setup_mock_tea_with_ci_data(
+        "upstream",
+        "test-repo",
+        &head_sha,
+        &pulls_json,
+        r#"{"state":"success","total_count":1}"#,
+    );
+
+    let settings = setup_snapshot_settings(&repo);
+    settings.bind(|| {
+        let mut cmd = make_snapshot_cmd(&repo, "list", &["--full"], None);
+        repo.configure_mock_commands(&mut cmd);
+        assert_cmd_snapshot!("gitea_fork_pr", cmd);
+    });
+}

--- a/tests/integration_tests/ci_status.rs
+++ b/tests/integration_tests/ci_status.rs
@@ -1212,12 +1212,15 @@ fn test_list_full_with_gitea_commit_status_retriable_error(mut repo: TestRepo) {
     });
 }
 
-/// `wt list --remotes --full` resolves Gitea owner/repo from the branch's own
-/// remote, not the primary remote. Two Gitea remotes (`origin` →
-/// `owner/test-repo`, `fork` → `forkowner/test-repo`) plus a remote-only
-/// `fork/feature-remote` ref. The mock answers only `forkowner/test-repo`
-/// requests, so a buggy primary-remote lookup would return no CI; the green
-/// `●` in the snapshot proves `branch.remote` is honored.
+/// `wt list --remotes --full` exercises the commit-status fallback for a
+/// remote-only branch and proves it queries the branch's own remote, not the
+/// primary one. Two Gitea remotes (`origin` → `owner/test-repo`, `fork` →
+/// `forkowner/test-repo`) plus a remote-only `fork/feature-remote` ref. The
+/// mock answers only `forkowner/test-repo` SHA-status requests, so a primary-
+/// remote lookup in the fallback would return no CI; the green `●` in the
+/// snapshot proves the SHA-status path honors `branch.remote`. (The PR path
+/// intentionally uses the primary remote, mirroring the `gh` backend; for this
+/// branch it returns no PR and we fall through to the SHA-status path.)
 #[rstest]
 fn test_list_remotes_full_with_gitea_remote_branch(mut repo: TestRepo) {
     repo.run_git(&[

--- a/tests/snapshots/integration__integration_tests__ci_status__gitea_fork_pr.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitea_fork_pr.snap
@@ -1,0 +1,63 @@
+---
+source: tests/integration_tests/ci_status.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
+    GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
+    GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCI[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m         .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
++ feature-a      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m         ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
++ feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m         ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file
++ feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m         ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
++ feature        [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [32m●[0m   ../repo.feature    [2m9a059eb4[0m  [2m1d[0m    [2mfeat: gitea fork feature
+
+[2m○[22m [2mShowing 5 worktrees, 4 ahead
+
+----- stderr -----


### PR DESCRIPTION
Mirrors the GitHub backend's PR-resolution shape in the Gitea backend: query the primary remote's open PRs and filter by the branch's push owner against `head.repo.owner.login`. PRs opened from a fork (head owner ≠ upstream owner) now match — previously the Gitea path queried the fork's own (usually empty) `/pulls` and never found them.

Adds an explicit `&limit` matching `MAX_PRS_TO_FETCH`, so the Gitea and GitHub backends fetch the same number of candidate PRs instead of relying on Gitea's default page size.

With the fork-PR and page-size limitations resolved in code, the module docstring drops from ~36 lines (API spec, "two paths", "known limitations") to a short header matching `github.rs` / `azure.rs`. The remaining per-quirk note (`mergeable` is computed asynchronously) moves inline next to the conflict check.

The `--remotes` test that previously asserted the PR path used the branch's own remote now documents that the PR path intentionally uses the primary remote; it still verifies the SHA-status fallback honors `branch.remote` (it passes via that fallback).

A Gitea analogue of github's `test_list_full_filters_by_repo_owner` (`test_list_full_with_gitea_fork_pr`) locks in the fork-PR match: two Gitea remotes, the `feature` branch pushes to the fork, and the mock includes a decoy PR from a different head owner. The green CI indicator fails loudly if a future change reverts to querying/filtering by the branch's own remote.
