### PR TITLE
skills(running-tend): tighten transient-failure disposition to an allowlist

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -87,10 +87,11 @@ Artifact paths: `-home-runner-work-worktrunk-worktrunk/<session-id>.jsonl`
 Before opening a `fix/ci-*` PR, classify the failure:
 
 - **Transient infrastructure** (link-check timeouts, apt-get flakes, GitHub
-  outages, runner disk issues, codecov upload blips) — do **not** create a
-  PR. The maintainer will rerun CI. Comment on the run or exit silently; a
-  permanent config change for a one-off timeout is churn the maintainer will
-  close.
+  outages, runner disk issues, codecov upload blips) — permitted
+  dispositions are (1) comment on the run, or (2) exit silently. Do not
+  open a PR, an audit issue, or any other artifact. The maintainer will
+  rerun CI; a permanent config change for a one-off timeout is churn the
+  maintainer will close.
 - **Flaky test** (known-flaky or first-seen PTY/shell test) — exit without a
   PR (same behavior as prior test-flake ci-fix runs).
 - **Real regression** — proceed with a fix PR.


### PR DESCRIPTION
Tighten the transient-failure disposition rule in the `running-tend` overlay so it implicitly excludes future bundled recipes — including the bundled `ci-fix` skill's section 3a open-and-close template that has been firing as the default.

The previous text forbade a *PR* explicitly ("do **not** create a PR") but only suggested "comment on the run or exit silently" as alternatives without ruling out other artifacts. Bundled `tend-ci-fix` section 3a (added in max-sixty/tend#367) instructs the bot to open and immediately self-close an audit issue when it classifies a failure as transient — and over the last 24h that template has fired three times on `max-sixty/worktrunk` ([#2694](https://github.com/max-sixty/worktrunk/issues/2694), [#2716](https://github.com/max-sixty/worktrunk/issues/2716), [#2720](https://github.com/max-sixty/worktrunk/issues/2720)), each opened and self-closed within ~4 seconds.

Switching the overlay to an allowlist of permitted dispositions (comment on the run, exit silently) names the surface that's allowed rather than enumerating what's forbidden. Anything the bundled skill suggests outside that set is implicitly excluded.

Motivated by the discussion at max-sixty/tend#426 — closed in favor of this tightening rather than a bundled-skill change, since "bundled skills as defaults, overlays override" is the model. This PR is the overlay override.

```diff
- **Transient infrastructure** (...) — do **not** create a PR. The maintainer will rerun CI. Comment on the run or exit silently; a permanent config change for a one-off timeout is churn the maintainer will close.
+ **Transient infrastructure** (...) — permitted dispositions are (1) comment on the run, or (2) exit silently. Do not open a PR, an audit issue, or any other artifact. The maintainer will rerun CI; a permanent config change for a one-off timeout is churn the maintainer will close.
```
