### PR TITLE
docs: compile-check four doctest examples (ignore → no_run/run)

### DIFF
--- a/src/config/user/resolved.rs
+++ b/src/config/user/resolved.rs
@@ -16,13 +16,17 @@ use super::sections::{
 /// on each config to get values with defaults applied.
 ///
 /// # Example
-/// ```ignore
-/// let resolved = config.resolved(project);
+/// ```
+/// use worktrunk::config::UserConfig;
+///
+/// let config = UserConfig::default();
+/// let resolved = config.resolved(None);                     // or Some(project_id)
 /// let full = resolved.list.full();                          // bool, default applied
 /// let squash = resolved.merge.squash();                     // bool, default applied
 /// let stage = resolved.commit.stage();                      // StageMode, default applied
 /// let pager = resolved.switch_picker.pager();               // Option<&str>
-/// let cd = resolved.switch.cd();                              // bool, default applied
+/// let cd = resolved.switch.cd();                            // bool, default applied
+/// # let _ = (full, squash, stage, pager, cd);
 /// ```
 #[derive(Debug, Clone, PartialEq)]
 pub struct ResolvedConfig {

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -366,13 +366,16 @@ impl SwitchSuggestionCtx {
 ///
 /// # Usage
 ///
-/// ```ignore
-/// // Return a typed error
-/// return Err(GitError::DetachedHead { action: Some("merge".into()) }.into());
+/// ```
+/// use worktrunk::git::GitError;
 ///
-/// // Pattern match on errors
-/// if let Some(GitError::BranchAlreadyExists { branch }) = err.downcast_ref() {
-///     println!("Branch {} exists", branch);
+/// // A typed error converts into a type-erased one (in real code, into `anyhow::Error`).
+/// let err: Box<dyn std::error::Error> =
+///     GitError::DetachedHead { action: Some("merge".into()) }.into();
+///
+/// // Recover the typed error to branch on the variant.
+/// if let Some(GitError::BranchAlreadyExists { branch }) = err.downcast_ref::<GitError>() {
+///     println!("branch {branch} already exists");
 /// }
 /// ```
 #[derive(Debug, Clone)]

--- a/src/git/remote_ref/mod.rs
+++ b/src/git/remote_ref/mod.rs
@@ -10,12 +10,16 @@
 //!
 //! # Usage
 //!
-//! ```ignore
+//! ```no_run
+//! use worktrunk::git::Repository;
 //! use worktrunk::git::remote_ref::{GitHubProvider, RemoteRefProvider};
-//!
+//! # fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! let repo = Repository::at(".")?;
 //! let provider = GitHubProvider;
 //! let info = provider.fetch_info(123, &repo)?;
 //! println!("PR #{}: {}", info.number, info.title);
+//! # Ok(())
+//! # }
 //! ```
 //!
 //! # Platform-Specific Notes

--- a/src/shell_exec.rs
+++ b/src/shell_exec.rs
@@ -541,23 +541,31 @@ fn run_with_timeout_impl(
 /// # Examples
 ///
 /// Capture output:
-/// ```ignore
+/// ```no_run
+/// use worktrunk::shell_exec::Cmd;
+/// # fn example(repo_path: std::path::PathBuf) -> Result<(), Box<dyn std::error::Error>> {
 /// let output = Cmd::new("git")
 ///     .args(["status", "--porcelain"])
 ///     .current_dir(&repo_path)
 ///     .context("my-worktree")
 ///     .run()?;
+/// # let _ = output;
+/// # Ok(())
+/// # }
 /// ```
 ///
 /// Stream output (hooks, interactive):
-/// ```ignore
+/// ```no_run
 /// use std::process::Stdio;
-///
+/// use worktrunk::shell_exec::Cmd;
+/// # fn example(repo_path: std::path::PathBuf) -> Result<(), Box<dyn std::error::Error>> {
 /// Cmd::shell("npm run build")
 ///     .current_dir(&repo_path)
 ///     .stdout(Stdio::from(std::io::stderr()))
 ///     .forward_signals()
 ///     .stream()?;
+/// # Ok(())
+/// # }
 /// ```
 pub struct Cmd {
     /// Program name or shell command string (if shell_wrap is true)


### PR DESCRIPTION
Four doctest examples were fenced ` ```ignore ` — rustdoc parsed them but never compiled or ran them, so they couldn't catch API drift. They were illustrative pseudo-code with placeholder bindings (`config`, `repo`, `repo_path`). This wraps each in just enough scaffolding (a hidden `# fn example(...) -> Result<(), Box<dyn std::error::Error>>` for the ones using `?`) so they compile against the public API; the two side-effect-free ones (`GitError`, `ResolvedConfig`) now also run.

- `shell_exec::Cmd` (capture + stream examples) → `no_run`
- `git::remote_ref` module example → `no_run` (would shell out to `gh`)
- `git::error::GitError` → runnable; the anyhow round-trip became `Box<dyn std::error::Error>` since doctests can't name `anyhow`
- `config::user::resolved::ResolvedConfig` → runnable (`UserConfig::default().resolved(None)` is pure, so it exercises the default-applying accessors); also realigned the `// bool, default applied` comment on the `cd()` line

Left as `ignore` deliberately: `RepoCache` recipes in `git/repository/mod.rs` (reference private fields), `src/testing/*` (`#[doc(hidden)]`, would need a full `TestRepo`), and the `output/*` / `commands/*` snippets (binary-only modules — those fences never run as doctests).

Verified with `cargo test --doc` and `pre-commit run --all-files`.
