### PR TITLE
test(testing): panic with the fix when mock-stub binary is absent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,8 @@ cargo test --test integration           # integration tests (no shell tests)
 cargo test --test integration --features shell-integration-tests  # with shell tests
 ```
 
+A filtered `--test integration` run on a fresh `target/` panics with "mock-stub binary not found" — a target filter skips the helper-bin build. Fix: `cargo build -p mock-stub`, or use `cargo nextest run` / `cargo llvm-cov nextest`.
+
 ### Claude Code Web Environment
 
 Run `task setup-web` to install required shells (zsh, fish, nushell), `gh`, and other dev tools. Install `task` first if needed:

--- a/src/testing/mock_commands.rs
+++ b/src/testing/mock_commands.rs
@@ -18,9 +18,35 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::Path;
 
-/// Path to the mock-stub binary, built by `cargo test`.
+/// Path to the mock-stub binary.
+///
+/// `workspace.default-members` builds it under an unfiltered `cargo test` /
+/// `cargo nextest run`, and `.config/nextest.toml`'s setup-script builds it
+/// under filtered nextest (including `cargo llvm-cov nextest`). A bare
+/// `cargo test --test integration` builds neither path — a target filter
+/// overrides `default-members`, and `cargo test` ignores nextest setup-scripts
+/// — so the binary is absent on a clean `target/`, and always absent under
+/// `cargo llvm-cov --test integration` since cargo-llvm-cov uses its own
+/// target dir. Asserting here surfaces the fix; the alternative is an opaque
+/// failure later inside a mock spawn (ENOENT on a dangling symlink, or a
+/// silently-dropped CI indicator when `tool_available("tea")` returns false).
+///
+/// Folding the helper bins back into the worktrunk crate would let
+/// `cargo test --test integration` build them automatically and delete this
+/// whole layer — it's blocked on cargo-dist; see `.config/nextest.toml` and
+/// `tests/helpers/mock-stub/Cargo.toml`.
 fn mock_stub_binary() -> std::path::PathBuf {
-    super::workspace_bin("mock-stub")
+    let path = super::workspace_bin("mock-stub");
+    assert!(
+        path.exists(),
+        "mock-stub binary not found at {}\n\n\
+         Build it once with `cargo build -p mock-stub`, or use a runner that builds\n\
+         the test helper bins:\n\
+         \n  cargo nextest run --features shell-integration-tests --test integration ...\
+         \n  cargo llvm-cov nextest --features shell-integration-tests --test integration ...\n",
+        path.display(),
+    );
+    path
 }
 
 /// Builder for mock command configuration.

--- a/src/testing/mock_commands.rs
+++ b/src/testing/mock_commands.rs
@@ -37,6 +37,14 @@ use std::path::Path;
 /// `tests/helpers/mock-stub/Cargo.toml`.
 fn mock_stub_binary() -> std::path::PathBuf {
     let path = super::workspace_bin("mock-stub");
+    assert_mock_stub_present(&path);
+    path
+}
+
+/// Panic with build instructions if `path` (the resolved mock-stub location)
+/// doesn't exist. Split out so a unit test can drive the missing-binary arm
+/// without depending on whether the real binary happens to be built.
+fn assert_mock_stub_present(path: &Path) {
     assert!(
         path.exists(),
         "mock-stub binary not found at {}\n\n\
@@ -46,7 +54,6 @@ fn mock_stub_binary() -> std::path::PathBuf {
          \n  cargo llvm-cov nextest --features shell-integration-tests --test integration ...\n",
         path.display(),
     );
-    path
 }
 
 /// Builder for mock command configuration.
@@ -414,5 +421,11 @@ mod tests {
 
         #[cfg(windows)]
         assert!(bin_dir.join("test-cmd.exe").exists());
+    }
+
+    #[test]
+    #[should_panic(expected = "mock-stub binary not found at")]
+    fn assert_mock_stub_present_panics_when_absent() {
+        assert_mock_stub_present(Path::new("/nonexistent/mock-stub"));
     }
 }


### PR DESCRIPTION
## Summary

`cargo test --test integration` and `cargo llvm-cov --test integration` don't build the `mock-stub` / `wt-perf` helper bins: a target filter overrides `workspace.default-members`, and these invocations don't honor `.config/nextest.toml`'s `build-bins` setup-script. So on a clean `target/` (and always under `cargo llvm-cov`, which uses its own target dir) the binary `tests/helpers/mock-stub` is absent. Today that surfaces as an opaque ENOENT on a dangling symlink, or — for the gitea CI-status tests — a silently-dropped `●` indicator when `tool_available("tea")` returns false because the mocked `tea` can't spawn.

`mock_stub_binary()` now resolves the path and hands it to `assert_mock_stub_present()`, which panics with a message pointing at the fix (`cargo build -p mock-stub`, or `cargo nextest run` / `cargo llvm-cov nextest`, which build the helpers via the setup-script). The check is split into its own function so a `#[should_panic]` unit test can drive the missing-binary arm without depending on whether the real binary happens to be built. The assert only fires when a test actually sets up a mock — it's reached via `MockConfig::write` — so mock-free tests are untouched.

Also a one-line note in CLAUDE.md's "faster iteration" block, and the `mock_stub_binary` doc comment now points at the eventual collapse — folding the helper bins back into the worktrunk crate so `cargo test --test integration` builds them automatically and this whole layer goes away — which is blocked on cargo-dist (see `.config/nextest.toml` and `tests/helpers/mock-stub/Cargo.toml`).

This is the symptom-2 follow-up to #2730 (#2730 fixed the profraw-leak flake; this makes the missing-binary case fail loudly instead of mysteriously).

## Test plan

- [x] `cargo test --test integration -- ci_status::test_list_full_with_gitea_no_ci` — passes (normal case unaffected; binary present)
- [x] Same command with `target/debug/mock-stub` moved away — panics with the message above, rendered cleanly
- [x] `cargo test --lib testing::` — 9/9 pass, including the new `assert_mock_stub_present_panics_when_absent` (`#[should_panic]`)
- [x] `cargo clippy --tests --features shell-integration-tests -- -D warnings` — clean
