### PR TITLE
docs(plugin): trim wt-switch-create skill frontmatter to recognized keys

### DIFF
--- a/skills/wt-switch-create/SKILL.md
+++ b/skills/wt-switch-create/SKILL.md
@@ -2,8 +2,6 @@
 name: wt-switch-create
 description: Create a new worktrunk worktree and switch this session's working directory into it. Use when launching a session that should work in its own worktree (e.g. `/wt-switch-create my-branch <task>`), or mid-session to move work into a fresh branch.
 argument-hint: "<branch-name> [task...]"
-license: MIT OR Apache-2.0
-compatibility: Requires the worktrunk CLI (https://worktrunk.dev) and this plugin's WorktreeCreate hook
 ---
 
 Arguments: `$ARGUMENTS`. The **first whitespace-delimited token** is the branch


### PR DESCRIPTION
`license` and `compatibility` aren't recognized Claude Code skill frontmatter keys — Claude Code ignores them. They were copied over from `skills/worktrunk/SKILL.md`, which carries them for the agent-skills discovery feed; a plugin-bundled command skill needs neither. Frontmatter is now just `name`, `description`, `argument-hint`.

Follow-up to #2737.
