### PR TITLE
refactor(picker): route alt-r removal through handle_remove_output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -267,6 +267,14 @@ When no structured alternative exists, document the fragility inline.
 
 When adding a new code path that loops over child processes, call `.interrupt_exit_code()` on per-iteration errors and break.
 
+### Project Commands Run Only After Approval
+
+**Policy:** project-defined commands — `pre-*` / `post-*` hooks, `[aliases]`, `--execute` bodies from project config — are arbitrary code shipped in a repo the user may have just cloned, so they run only after the approval system (`Approvals` plus `approve_command_batch` / `approve_or_skip` in `src/commands/command_approval.rs`) clears them. Never build a code path that runs project commands without that gate. A context that can't prompt for approval — a TUI mid-render, a background recovery path — must consult the approval state read-only and run only the already-approved commands, skipping the rest: `commands::picker::do_removal` checks `Approvals` (no prompt) and passes `verify` to `handle_remove_output` accordingly.
+
+**Why:** the gate is the only thing between `git clone && wt switch` and a `post-switch` hook running `curl … | sh`. A "we already validated the operation, so run the hooks too" shortcut turns every command that touches project config into remote code execution.
+
+**Implementation:** the operation entry points (`wt remove` / `wt merge` / `wt step prune` / `wt switch`) approve the command set up front, then thread the answer through as `verify` / `run_hooks`; when it's false, `execute_pre_remove_hooks_if_needed`, `spawn_hooks_after_remove`, and the switch/merge equivalents early-return. Gate first, run second — never the reverse.
+
 ## Hook Output Logs
 
 Hook output logs are centralized in `.git/wt/logs/` (main worktree's git directory). Per-branch logs live in subtrees; same operation on same branch overwrites the previous log.

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -96,7 +96,7 @@ mod summary;
 
 use std::cell::RefCell;
 use std::io::IsTerminal;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::rc::Rc;
 use std::sync::atomic::AtomicUsize;
 use std::sync::{Arc, Mutex};
@@ -105,26 +105,23 @@ use anyhow::Context;
 // bounded/unbounded/Sender are re-exported by skim::prelude
 use skim::prelude::*;
 use skim::reader::CommandCollector;
+use worktrunk::config::Approvals;
 use worktrunk::git::{Repository, current_or_recover};
 use worktrunk::styling::eprintln;
 
-use super::command_executor::FailureStrategy;
-use super::hooks::{HookAnnouncer, execute_hook};
+use super::hooks::HookAnnouncer;
 use super::list::collect;
 use super::list::progressive::RenderTarget;
+use super::project_config::collect_remove_hook_commands;
 use super::repository_ext::{RemoveTarget, RepositoryCliExt};
 use super::template_vars::TemplateVars;
-use super::worktree::hooks::PostRemoveContext;
 use super::worktree::{
     RemoveResult, SwitchBranchInfo, SwitchResult, approve_switch_hooks, execute_switch,
     offer_bare_repo_worktree_path_fix, path_mismatch, plan_switch, run_pre_switch_hooks,
     spawn_switch_background_hooks, switch_hook_project_config, validate_switch_templates,
 };
-use crate::commands::command_executor::CommandContext;
-use crate::output::handle_switch_output;
-use worktrunk::git::{
-    BranchDeletionMode, RemoveOptions, delete_branch_if_safe, remove_worktree_with_cleanup,
-};
+use crate::output::{handle_remove_output, handle_switch_output};
+use worktrunk::git::{BranchDeletionMode, delete_branch_if_safe};
 
 use items::{PreviewCache, WorktreeSkimItem};
 use preview::{PreviewLayout, PreviewMode, PreviewState};
@@ -165,101 +162,57 @@ struct PickerCollector {
     items: Arc<Mutex<Vec<Arc<dyn SkimItem>>>>,
     signal_path: PathBuf,
     repo: Repository,
+    /// Approvals snapshot, loaded once at picker startup. A queued removal runs
+    /// its `pre-remove` / `post-remove` / `post-switch` hooks only when every
+    /// one is in here — the picker can't show an approval prompt mid-render, so
+    /// unapproved project commands are skipped, never run. See
+    /// [`removal_hooks_approved`].
+    approvals: Arc<Approvals>,
 }
 
 impl PickerCollector {
-    /// Execute removal in background: pre-remove hooks + worktree + branch + post-remove hooks.
+    /// Execute a queued removal in the background.
     ///
-    /// Called from a background thread after the picker optimistically removes the item
-    /// from the list. The entire operation runs off skim's event loop so the TUI stays
-    /// responsive. If pre-remove hooks fail, the removal is aborted (but the item is
-    /// already gone from the picker — a tradeoff until we can show in-progress state).
+    /// A `RemovedWorktree` result goes through [`handle_remove_output`] in its
+    /// silent (TUI) mode — the git worktree removal with no `wt`-generated
+    /// messages, spinner, or `cd` directive (skim owns the terminal). Its
+    /// `pre-remove` / `post-remove` / `post-switch` hooks run only when they're
+    /// already approved ([`removal_hooks_approved`] — a read-only `Approvals`
+    /// check, no prompt): the picker can't prompt mid-render, so unapproved
+    /// project commands are skipped, never run. (A hook that *does* run still
+    /// streams its own output to stderr, like any hook — a rough edge of
+    /// removing inside the picker.) A `BranchOnly` result just deletes the
+    /// branch if it's safe to.
     ///
-    /// `repo` is only used for `BranchOnly` deletion. `RemovedWorktree` constructs
-    /// its own from `main_path` (which may differ from the picker's startup repo in
-    /// bare-repo setups).
-    fn do_removal(repo: &Repository, result: &RemoveResult) -> anyhow::Result<()> {
+    /// Called from a background thread after the picker optimistically removes
+    /// the item from the list, so the whole operation runs off skim's event loop
+    /// and the TUI stays responsive. A removal failure is logged; the item stays
+    /// gone from the picker — a tradeoff until we can show in-progress state.
+    ///
+    /// `repo` is only used for `BranchOnly` deletion; `RemovedWorktree` removal
+    /// is rooted at `main_path` (which may differ from the picker's startup repo
+    /// in bare-repo setups).
+    fn do_removal(
+        repo: &Repository,
+        result: &RemoveResult,
+        approvals: &Approvals,
+    ) -> anyhow::Result<()> {
         match result {
             RemoveResult::RemovedWorktree {
                 main_path,
                 worktree_path,
-                branch_name,
-                deletion_mode,
-                target_branch,
-                force_worktree,
-                removed_commit,
-                removed_project_config,
                 ..
             } => {
                 let main_repo = Repository::at(main_path)?;
-                let config = main_repo.user_config();
-                let hook_branch = branch_name.as_deref().unwrap_or("HEAD");
-
-                // Run pre-remove hooks (synchronously in this background thread).
-                // Rooted at the removed worktree so its `.config/wt.toml` is the
-                // one that fires — same rule as `wt remove`'s
-                // `execute_pre_remove_hooks_if_needed`. Non-zero exit aborts the
-                // removal, matching `wt remove` semantics.
-                let target_ref = main_repo
-                    .worktree_at(main_path)
-                    .branch()
-                    .ok()
-                    .flatten()
-                    .unwrap_or_default();
-                let template_vars = TemplateVars::new()
-                    .with_target(&target_ref)
-                    .with_target_worktree_path(main_path);
-                let removed_repo = Repository::at(worktree_path)?;
-                let pre_ctx = CommandContext::new(
-                    &removed_repo,
-                    config,
-                    Some(hook_branch),
-                    worktree_path,
-                    false,
-                );
-                execute_hook(
-                    &pre_ctx,
-                    worktrunk::HookType::PreRemove,
-                    &template_vars.as_extra_vars(),
-                    FailureStrategy::FailFast,
-                    None, // no display path in TUI context
-                )?;
-
-                let snapshot = main_repo.capture_refs()?;
-                let output = remove_worktree_with_cleanup(
-                    &main_repo,
-                    &snapshot,
-                    worktree_path,
-                    RemoveOptions {
-                        branch: branch_name.clone(),
-                        deletion_mode: *deletion_mode,
-                        target_branch: target_branch.clone(),
-                        force_worktree: *force_worktree,
-                    },
-                )?;
-                if let Some(staged) = output.staged_path {
-                    let _ = std::fs::remove_dir_all(&staged);
-                }
-
-                // Spawn post-remove hooks in background. The removed worktree
-                // is gone, so its `.config/wt.toml` comes from the snapshot —
-                // same source the `wt remove` / `wt merge` teardown paths use.
-                let post_ctx =
-                    CommandContext::new(&main_repo, config, Some(hook_branch), main_path, false);
-                let remove_vars = PostRemoveContext::new(
-                    worktree_path,
-                    removed_commit.as_deref(),
-                    main_path,
-                    &main_repo,
-                );
-                let extra_vars = remove_vars.extra_vars(hook_branch);
-                let mut announcer = HookAnnouncer::new(&main_repo, config, false);
-                announcer.register_with_project_config(
-                    &post_ctx,
-                    removed_project_config.as_deref(),
-                    worktrunk::HookType::PostRemove,
-                    &extra_vars,
-                    None, // no display path in TUI context
+                let verify = removal_hooks_approved(&main_repo, worktree_path, approvals)?;
+                let mut announcer = HookAnnouncer::new(&main_repo, main_repo.user_config(), false);
+                handle_remove_output(
+                    result,
+                    /* foreground */ true,
+                    verify,
+                    /* quiet */ true,
+                    /* silent */ true,
+                    &mut announcer,
                 )?;
                 announcer.flush()?;
             }
@@ -358,10 +311,11 @@ impl CommandCollector for PickerCollector {
                         // Defer actual git removal to a background thread so skim's
                         // event loop stays responsive.
                         let repo = self.repo.clone();
+                        let approvals = Arc::clone(&self.approvals);
                         let _ = std::thread::Builder::new()
                             .name(format!("picker-remove-{selected_output}"))
                             .spawn(move || {
-                                if let Err(e) = Self::do_removal(&repo, &result) {
+                                if let Err(e) = Self::do_removal(&repo, &result, &approvals) {
                                     log::warn!(
                                         "picker: failed to remove '{selected_output}': {e:#}"
                                     );
@@ -394,6 +348,29 @@ impl CommandCollector for PickerCollector {
         let (tx_interrupt, _rx_interrupt) = bounded(1);
         (rx, tx_interrupt)
     }
+}
+
+/// Whether every `pre-remove` / `post-remove` / `post-switch` command this
+/// removal would run is already approved — a read-only check, no prompt.
+///
+/// `wt remove` / `wt merge` collect the same command set and prompt for it at
+/// the gate. The picker can't prompt mid-render, so it runs the removal's hooks
+/// only when they're already approved (e.g. from a prior `wt remove` /
+/// `wt merge`) and skips them otherwise — unapproved project commands must
+/// never run. See CLAUDE.md → "Project Commands Run Only After Approval".
+fn removal_hooks_approved(
+    main_repo: &Repository,
+    worktree_path: &Path,
+    approvals: &Approvals,
+) -> anyhow::Result<bool> {
+    let commands = collect_remove_hook_commands(main_repo, &[worktree_path])?;
+    if commands.is_empty() {
+        return Ok(true); // nothing to run — `verify` is moot
+    }
+    let project_id = main_repo.project_identifier()?;
+    Ok(commands
+        .iter()
+        .all(|c| approvals.is_command_approved(&project_id, &c.command.template)))
 }
 
 pub fn handle_picker(
@@ -555,10 +532,15 @@ pub fn handle_picker(
     // Cleaned up in PreviewState::Drop.
     let signal_path = state.path.with_extension("remove");
 
+    // Approvals snapshot for the session — alt-r removals consult it (read-only)
+    // to decide whether their hooks may run; see `removal_hooks_approved`.
+    let approvals = Arc::new(Approvals::load().context("Failed to load approvals")?);
+
     let collector = PickerCollector {
         items: Arc::clone(&shared_items),
         signal_path: signal_path.clone(),
         repo: repo.clone(),
+        approvals,
     };
 
     let signal_path_escaped =
@@ -919,10 +901,14 @@ fn resolve_identifier(
 #[cfg(test)]
 pub mod tests {
     use super::preview::{PreviewLayout, PreviewMode, PreviewStateData};
-    use super::{PickerAction, PickerCollector, drain_stashed_warnings, resolve_identifier};
+    use super::{
+        PickerAction, PickerCollector, drain_stashed_warnings, removal_hooks_approved,
+        resolve_identifier,
+    };
     use crate::commands::worktree::RemoveResult;
     use std::fs;
     use std::sync::Mutex;
+    use worktrunk::config::Approvals;
     use worktrunk::git::BranchDeletionMode;
 
     /// Empties the stash and emits each line. Verifies post-skim drain
@@ -1013,7 +999,7 @@ pub mod tests {
     }
 
     #[test]
-    fn test_execute_removal_removes_worktree_and_branch() {
+    fn test_do_removal_removes_worktree_and_branch() {
         let test = worktrunk::testing::TestRepo::with_initial_commit();
         let repo = worktrunk::git::Repository::at(test.path()).unwrap();
         let wt_dir = tempfile::tempdir().unwrap();
@@ -1043,7 +1029,7 @@ pub mod tests {
             removed_project_config: None,
         };
 
-        PickerCollector::do_removal(&repo, &result).unwrap();
+        PickerCollector::do_removal(&repo, &result, &Approvals::default()).unwrap();
         assert!(!wt_path.exists(), "worktree should be removed");
 
         let output = repo.run_command(&["branch", "--list", "feature"]).unwrap();
@@ -1065,7 +1051,7 @@ pub mod tests {
             target_branch: None,
             integration_reason: None,
         };
-        PickerCollector::do_removal(&repo, &result).unwrap();
+        PickerCollector::do_removal(&repo, &result, &Approvals::default()).unwrap();
 
         let output = repo.run_command(&["branch", "--list", "feature"]).unwrap();
         assert!(output.is_empty(), "integrated branch should be deleted");
@@ -1091,7 +1077,7 @@ pub mod tests {
             target_branch: None,
             integration_reason: None,
         };
-        PickerCollector::do_removal(&repo, &result).unwrap();
+        PickerCollector::do_removal(&repo, &result, &Approvals::default()).unwrap();
 
         // Branch should be retained — SafeDelete won't delete unmerged branches
         let output = repo.run_command(&["branch", "--list", "unmerged"]).unwrap();
@@ -1140,8 +1126,63 @@ pub mod tests {
             removed_project_config: None,
         };
 
-        PickerCollector::do_removal(&repo, &result).unwrap();
+        PickerCollector::do_removal(&repo, &result, &Approvals::default()).unwrap();
         assert!(!wt_path.exists(), "detached worktree should be removed");
+    }
+
+    /// A `pre-remove` hook the user hasn't approved must not run when the
+    /// picker removes the worktree — the picker can't prompt mid-render, so
+    /// unapproved project commands are skipped. The git removal still happens.
+    #[test]
+    fn test_do_removal_skips_unapproved_pre_remove_hook() {
+        let test = worktrunk::testing::TestRepo::with_initial_commit();
+        let repo = worktrunk::git::Repository::at(test.path()).unwrap();
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("feature");
+        repo.run_command(&[
+            "worktree",
+            "add",
+            "-b",
+            "feature",
+            wt_path.to_str().unwrap(),
+        ])
+        .unwrap();
+
+        // A `pre-remove` hook in the removed worktree's `.config/wt.toml` that
+        // would write a marker (outside the worktree) if it ever ran.
+        let marker_dir = tempfile::tempdir().unwrap();
+        let marker = marker_dir.path().join("pre-remove-ran");
+        fs::create_dir_all(wt_path.join(".config")).unwrap();
+        fs::write(
+            wt_path.join(".config/wt.toml"),
+            format!("pre-remove = {:?}\n", format!("touch {}", marker.display())),
+        )
+        .unwrap();
+
+        let result = RemoveResult::RemovedWorktree {
+            main_path: test.path().to_path_buf(),
+            worktree_path: wt_path.clone(),
+            changed_directory: false,
+            branch_name: Some("feature".to_string()),
+            deletion_mode: BranchDeletionMode::SafeDelete,
+            target_branch: Some("main".to_string()),
+            integration_reason: None,
+            force_worktree: false,
+            expected_path: None,
+            removed_commit: None,
+            removed_project_config: None,
+        };
+
+        // Empty approvals → the hook is unapproved.
+        let approvals = Approvals::default();
+        assert!(
+            !removal_hooks_approved(&repo, &wt_path, &approvals).unwrap(),
+            "an unapproved pre-remove hook is not approved"
+        );
+
+        PickerCollector::do_removal(&repo, &result, &approvals).unwrap();
+        assert!(!wt_path.exists(), "worktree should be removed");
+        assert!(!marker.exists(), "unapproved pre-remove hook must not run");
     }
 
     // Note: skim's `as_any().downcast_ref::<WorktreeSkimItem>()` fails at

--- a/src/commands/step/prune.rs
+++ b/src/commands/step/prune.rs
@@ -177,7 +177,7 @@ fn try_remove(
         }
     };
     let mut announcer = HookAnnouncer::new(repo, config, true);
-    handle_remove_output(&plan, foreground, run_hooks, true, &mut announcer)?;
+    handle_remove_output(&plan, foreground, run_hooks, true, false, &mut announcer)?;
     announcer.flush()?;
     Ok(true)
 }

--- a/src/commands/worktree/finish.rs
+++ b/src/commands/worktree/finish.rs
@@ -162,7 +162,14 @@ pub fn finish_after_merge(
             removed_commit: feature_commit.clone(),
             removed_project_config,
         };
-        crate::output::handle_remove_output(&remove_result, false, verify, false, announcer)?;
+        crate::output::handle_remove_output(
+            &remove_result,
+            false,
+            verify,
+            false,
+            false,
+            announcer,
+        )?;
         true
     };
 

--- a/src/commands/worktree/finish.rs
+++ b/src/commands/worktree/finish.rs
@@ -36,6 +36,7 @@ use crate::commands::repository_ext::{
     check_not_default_branch, compute_integration_reason, is_primary_worktree,
 };
 use crate::commands::template_vars::TemplateVars;
+use crate::output::{handle_remove_output, post_hook_display_path, pre_hook_display_path};
 
 /// Inputs to [`finish_after_merge`]. Owned by the caller; this struct just
 /// bundles them so the function signature stays readable.
@@ -162,14 +163,7 @@ pub fn finish_after_merge(
             removed_commit: feature_commit.clone(),
             removed_project_config,
         };
-        crate::output::handle_remove_output(
-            &remove_result,
-            false,
-            verify,
-            false,
-            false,
-            announcer,
-        )?;
+        handle_remove_output(&remove_result, false, verify, false, false, announcer)?;
         true
     };
 
@@ -190,9 +184,9 @@ pub fn finish_after_merge(
             yes,
         );
         let display_path = if removed {
-            crate::output::post_hook_display_path(&destination_path)
+            post_hook_display_path(&destination_path)
         } else {
-            crate::output::pre_hook_display_path(&destination_path)
+            pre_hook_display_path(&destination_path)
         };
 
         let mut vars = feature_vars.with_target(target_branch);

--- a/src/main.rs
+++ b/src/main.rs
@@ -945,7 +945,14 @@ fn handle_remove_command(args: RemoveArgs, yes: bool) -> anyhow::Result<()> {
                 let run_hooks = verify && approve_remove(removed_path.as_slice(), yes)?;
 
                 let mut announcer = HookAnnouncer::new(&repo, &config, false);
-                handle_remove_output(&result, args.foreground, run_hooks, false, &mut announcer)?;
+                handle_remove_output(
+                    &result,
+                    args.foreground,
+                    run_hooks,
+                    false,
+                    false,
+                    &mut announcer,
+                )?;
                 announcer.flush()?;
                 if json_mode {
                     let json = serde_json::json!([result.to_json()]);
@@ -997,6 +1004,7 @@ fn handle_remove_command(args: RemoveArgs, yes: bool) -> anyhow::Result<()> {
                         result,
                         args.foreground,
                         run_hooks,
+                        false,
                         false,
                         &mut announcer,
                     )?;

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -731,11 +731,22 @@ pub fn execute_user_command(command: &str, display_path: Option<&Path>) -> anyho
 /// hook announce lines include the branch name for batch-context disambiguation.
 /// When `quiet` is true (prune context), suppresses informational messages
 /// like "No worktree found for branch X" that are noise in batch operations.
+///
+/// When `silent` is true (the TUI picker — this runs while skim owns the
+/// terminal), a `RemovedWorktree` result is removed with no progress/success
+/// messages, no trash-cleanup spinner, and no `cd` directive: just the git
+/// removal plus the usual `verify`-gated `pre-remove` / `post-remove` /
+/// `post-switch` hooks. (The picker can't prompt for approval mid-render, so it
+/// passes `verify` from a read-only `Approvals` check — see `do_removal`.) The
+/// removal runs inline regardless of `foreground` (there's no detached `rm` to
+/// background to). `silent` has no effect on `BranchOnly` results — the picker
+/// handles that arm itself.
 pub fn handle_remove_output(
     result: &RemoveResult,
     foreground: bool,
     verify: bool,
     quiet: bool,
+    silent: bool,
     announcer: &mut HookAnnouncer<'_>,
 ) -> anyhow::Result<()> {
     match result {
@@ -766,6 +777,7 @@ pub fn handle_remove_output(
                 removed_project_config: removed_project_config.as_deref(),
                 foreground,
                 verify,
+                silent,
             },
             announcer,
         ),
@@ -1180,6 +1192,10 @@ struct RemovedWorktreeOutputContext<'a> {
     removed_project_config: Option<&'a ProjectConfig>,
     foreground: bool,
     verify: bool,
+    /// TUI (picker) path: do the git removal and hook registration but emit no
+    /// progress/success messages, no trash-cleanup spinner, and no `cd`
+    /// directive — see [`handle_remove_output`].
+    silent: bool,
 }
 
 fn execute_pre_remove_hooks_if_needed(
@@ -1431,6 +1447,15 @@ fn handle_removed_worktree_output(
     let repo = worktrunk::git::Repository::at(ctx.main_path)?;
 
     execute_pre_remove_hooks_if_needed(&repo, &ctx)?;
+
+    // TUI (picker) path: the removal runs in a background thread while skim
+    // owns the terminal, so no messages, no spinner, no `cd` directive (the
+    // picker manages its own cwd). The git removal runs inline — same as the
+    // foreground path, minus the chrome.
+    if ctx.silent {
+        return remove_removed_worktree_silently(&repo, &ctx, announcer);
+    }
+
     prepare_remove_directory_change(ctx.main_path, ctx.changed_directory)?;
 
     // Handle detached HEAD case (no branch known)
@@ -1443,6 +1468,45 @@ fn handle_removed_worktree_output(
     } else {
         handle_named_removed_worktree_background(&repo, &ctx, branch_name, announcer)
     }
+}
+
+/// Remove a `RemovedWorktree` worktree with no terminal output — the TUI
+/// (`wt switch` picker) path of [`handle_remove_output`].
+///
+/// `pre-remove` has already run (when it was approved — `verify`), and the
+/// caller skipped the `cd` directive (the picker manages its own process cwd).
+/// This does the synchronous git worktree removal and registers `post-remove` /
+/// `post-switch` hooks onto `announcer`, but with no progress/success message
+/// and no trash-cleanup spinner — `eprintln!` while skim owns the terminal
+/// would corrupt the frame. A removal failure propagates as-is (the picker logs
+/// it); there's no TTY to render the foreground path's nicer "remaining
+/// entries" error against.
+fn remove_removed_worktree_silently(
+    repo: &Repository,
+    ctx: &RemovedWorktreeOutputContext<'_>,
+    announcer: &mut HookAnnouncer<'_>,
+) -> anyhow::Result<()> {
+    let snapshot = repo.capture_refs()?;
+    let output = remove_worktree_with_cleanup(
+        repo,
+        &snapshot,
+        ctx.worktree_path,
+        RemoveOptions {
+            branch: ctx.branch_name.map(String::from),
+            deletion_mode: ctx.deletion_mode,
+            target_branch: ctx.target_branch.map(String::from),
+            force_worktree: ctx.force_worktree,
+        },
+    )?;
+    if let Some(staged) = output.staged_path {
+        // Best-effort, same as the fast-path cleanup in the foreground handler
+        // but without the TTY spinner (`cleanup_staged_with_progress`).
+        let _ = std::fs::remove_dir_all(&staged);
+    }
+
+    // Post-remove (and post-switch when the picker cd'd away) hooks — registered
+    // onto the caller's announcer, which `flush`es after this returns.
+    spawn_hooks_after_remove(repo, ctx, ctx.branch_name.unwrap_or("HEAD"), announcer)
 }
 
 /// Run a shell command with streaming output, signal forwarding, and ANSI reset.

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -1487,17 +1487,13 @@ fn remove_removed_worktree_silently(
     announcer: &mut HookAnnouncer<'_>,
 ) -> anyhow::Result<()> {
     let snapshot = repo.capture_refs()?;
-    let output = remove_worktree_with_cleanup(
-        repo,
-        &snapshot,
-        ctx.worktree_path,
-        RemoveOptions {
-            branch: ctx.branch_name.map(String::from),
-            deletion_mode: ctx.deletion_mode,
-            target_branch: ctx.target_branch.map(String::from),
-            force_worktree: ctx.force_worktree,
-        },
-    )?;
+    let options = RemoveOptions {
+        branch: ctx.branch_name.map(String::from),
+        deletion_mode: ctx.deletion_mode,
+        target_branch: ctx.target_branch.map(String::from),
+        force_worktree: ctx.force_worktree,
+    };
+    let output = remove_worktree_with_cleanup(repo, &snapshot, ctx.worktree_path, options)?;
     if let Some(staged) = output.staged_path {
         // Best-effort, same as the fast-path cleanup in the foreground handler
         // but without the TTY spinner (`cleanup_staged_with_progress`).


### PR DESCRIPTION
The picker's `alt-r` removal (`PickerCollector::do_removal`) was a parallel reimplementation of the `wt remove` teardown pipeline — `pre-remove` hook → git worktree removal → `post-remove` (and `post-switch`) hooks — that had to be kept in lockstep with `output::handle_remove_output` by hand. #2736 had to fix the same hook-config bug in both. This routes `do_removal` through `handle_remove_output`, so the duplication is gone, and gates the picker's hooks on approval (which the old path didn't do).

## What changed

**`handle_remove_output` gains a `silent` flag** (`src/output/handlers.rs`). When set, a `RemovedWorktree` result is removed with no progress/success messages, no trash-cleanup spinner, and no `cd` directive — just `pre-remove`, the synchronous git worktree removal (`remove_removed_worktree_silently`), and `post-remove` / `post-switch` hook registration. Required because the picker runs `do_removal` from a background thread spawned off skim's event loop, so any `wt`-generated stderr output would corrupt skim's frame. `silent` is the only new knob; it threads through the five `handle_remove_output` call sites as `false` everywhere except the picker.

**`do_removal` is now a thin call into `handle_remove_output`** (`src/commands/picker/mod.rs`). The `RemovedWorktree` arm drops its hand-rolled `pre-remove` (`CommandContext` + `execute_hook`) / git removal / `post-remove` (`PostRemoveContext` + `HookAnnouncer::register_with_project_config`) code — net ~80 lines, plus the `removed_project_config` snapshot plumbing #2736 added now lives in one place. The `BranchOnly` arm is unchanged (it's small and `handle_remove_output`'s `BranchOnly` path prints things the picker can't have).

**The picker's hooks now run only when already approved.** The old `do_removal` ran project `pre-remove` / `post-remove` / `post-switch` hooks *unconditionally* — it was the one removal/switch path that bypassed the approval gate, so a freshly-cloned repo's `post-switch` hook would fire on `alt-r`. The picker can't show an approval prompt mid-render, so it now consults `Approvals` read-only (`removal_hooks_approved` — the same `collect_remove_hook_commands` set `wt remove` would prompt for, checked against `Approvals::is_command_approved`) and passes the result as `verify`; when it's `false`, `execute_pre_remove_hooks_if_needed` and `spawn_hooks_after_remove` early-return. `CLAUDE.md` gains a "Project Commands Run Only After Approval" section stating the general rule (`src/commands/command_approval.rs` is the gate; never build a path that runs project commands without it; a context that can't prompt skips the unapproved ones).

**One behavior delta beyond consolidation:** removing the *current* worktree via `alt-r` now also registers `post-switch` hooks for the home worktree (if approved), matching `wt remove` / `wt merge` / `wt step prune`. The old `do_removal` registered only `post-remove`.

## Testing

`cargo run -- hook pre-merge --yes` is green (3690 tests). The `test_do_removal_*` unit tests cover the silent removal path (worktree + branch + detached), and a new `test_do_removal_skips_unapproved_pre_remove_hook` covers the approval gating (`removal_hooks_approved` is fully covered). Not covered: the two lines in `invoke()`'s `alt-r` spawn block that hand the `Approvals` snapshot to the removal thread — `invoke()` is already documented as not unit-testable ("Full invoke() tests require interactive skim"), and the rest of its body is uncovered too; the approval-check logic itself is. No end-to-end test exercises "hook present *and* approved → runs" through the picker (would need seeding `Approvals` against the test repo's path) — the unit test asserts the logic, just not that exact integration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
