### PR TITLE
chore(plugin): drop off-spec `version` key, align skill frontmatter

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -19,13 +19,7 @@ metadata:
    ```bash
    cargo release X.Y.Z -p worktrunk -x --no-publish --no-push --no-tag --no-verify --no-confirm && cargo check
    ```
-   This bumps `Cargo.toml`, `Cargo.lock`, and applies `pre-release-replacements` (e.g., `SKILL.md`'s `version:` line), then auto-commits. We'll reset this commit in step 9 to fold in the CHANGELOG.
-
-   Then sync the SHA-256 digest of `SKILL.md` in `docs/static/.well-known/agent-skills/index.json` — `cargo-release` doesn't know that file derives from `SKILL.md`, so it stays stale until the docs-sync test rewrites it:
-   ```bash
-   cargo test --test integration test_docs_are_in_sync || cargo test --test integration test_docs_are_in_sync
-   ```
-   The first run rewrites the digest and exits non-zero; the second confirms sync. The regenerated `index.json` is then picked up by `git add -A` in step 9.
+   This bumps `Cargo.toml` and `Cargo.lock`, then auto-commits. We'll reset this commit in step 9 to fold in the CHANGELOG.
 8. **Update CHANGELOG**: Add `## X.Y.Z` section at top with changes (see MANDATORY verification below)
 9. **Commit**: Reset the auto-commit from step 7, stage everything, and create the final release commit:
    ```bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,10 +19,6 @@ default-run = "wt"
 # Allow releases from any branch (GitHub Actions uses detached HEAD)
 allow-branch = ["*"]
 consolidate-commits = true
-pre-release-replacements = [
-    # Update skill version in frontmatter
-    { file = "skills/worktrunk/SKILL.md", search = "version: [0-9.]+", replace = "version: {{version}}" },
-]
 
 [package.metadata.cargo-udeps.ignore]
 # Used only on Windows (#[cfg(windows)] in src/shell_exec.rs)

--- a/docs/static/.well-known/agent-skills/index.json
+++ b/docs/static/.well-known/agent-skills/index.json
@@ -6,7 +6,7 @@
       "type": "skill-md",
       "description": "Guidance for Worktrunk (the `wt` CLI) — git worktree management, hooks, and config. Load when editing .config/wt.toml or ~/.config/worktrunk/config.toml; adding, modifying, or debugging hooks (post-merge, post-start, pre-commit, pre-merge, post-switch, etc.); configuring commit message generation or command aliases; or troubleshooting wt behavior. Also answers general worktrunk/wt questions.",
       "url": "./worktrunk/SKILL.md",
-      "digest": "sha256:78d31acba4f9cfc78e3b7129bf640ae6b52dd20163273645db65d1174c1bee23"
+      "digest": "sha256:50f164a054e60d7f9bac2fc57f700693118ece6ae29482a11b50cd69733fda90"
     }
   ]
 }

--- a/skills/worktrunk/SKILL.md
+++ b/skills/worktrunk/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: worktrunk
 description: Guidance for Worktrunk (the `wt` CLI) — git worktree management, hooks, and config. Load when editing .config/wt.toml or ~/.config/worktrunk/config.toml; adding, modifying, or debugging hooks (post-merge, post-start, pre-commit, pre-merge, post-switch, etc.); configuring commit message generation or command aliases; or troubleshooting wt behavior. Also answers general worktrunk/wt questions.
-version: 0.49.0
 license: MIT OR Apache-2.0
-compatibility: Requires worktrunk CLI (https://worktrunk.dev)
+compatibility: Requires the `wt` CLI (https://worktrunk.dev)
 ---
 
 # Worktrunk

--- a/skills/wt-switch-create/SKILL.md
+++ b/skills/wt-switch-create/SKILL.md
@@ -2,6 +2,8 @@
 name: wt-switch-create
 description: Create a new worktrunk worktree and switch this session's working directory into it. Use when launching a session that should work in its own worktree (e.g. `/wt-switch-create my-branch <task>`), or mid-session to move work into a fresh branch.
 argument-hint: "<branch-name> [task...]"
+license: MIT OR Apache-2.0
+compatibility: Requires the `wt` CLI (https://worktrunk.dev) and this plugin's WorktreeCreate hook
 ---
 
 Arguments: `$ARGUMENTS`. The **first whitespace-delimited token** is the branch


### PR DESCRIPTION
Tidies the plugin skills' YAML frontmatter against the [Agent Skills](https://agentskills.io/specification) spec, and cleans up a release-skill step the change makes stale.

- `skills/worktrunk/SKILL.md`: drop the top-level `version: 0.49.0` key. The spec only defines `name`, `description`, `license`, `compatibility`, `metadata`, `allowed-tools` at the top level (version, if kept, belongs under `metadata`), and Claude Code's own field set doesn't include `version` either. Also drop the `[package.metadata.release].pre-release-replacements` entry in `Cargo.toml` that existed solely to bump that line on release.
- `skills/wt-switch-create/SKILL.md`: add `license` and `compatibility` so both plugin skills carry the same spec-valid metadata.
- `.claude/skills/release/SKILL.md`: step 7 no longer applies `pre-release-replacements`, and `index.json`'s `SKILL.md` digest no longer goes stale on release (`cargo release` doesn't touch `SKILL.md` anymore) — drop the parenthetical and the now-no-op digest-resync sub-step.
- Both `compatibility` lines now say "the `wt` CLI" rather than "worktrunk CLI".
- `docs/static/.well-known/agent-skills/index.json` digest regenerated by `test_docs_are_in_sync`.

Follow-up to #2737 / #2745. No `.rs` changes.
