### PR TITLE
perf(integration): bound patch-id squash-merge scan to 500 commits

### DIFF
--- a/docs/content/remove.md
+++ b/docs/content/remove.md
@@ -46,7 +46,7 @@ Worktrunk checks six conditions (in order of cost):
 3. **No added changes** — Three-dot diff (`target...branch`) is empty. Shows `⊂`.
 4. **Trees match** — Branch tree SHA equals target tree SHA. Shows `⊂`.
 5. **Merge adds nothing** — Simulated merge produces the same tree as target. Handles squash-merged branches where target has advanced with changes to different files. Shows `⊂`.
-6. **Patch-id match** — Branch's entire diff matches a single squash-merge commit on target. Fallback for when the simulated merge conflicts because target later modified the same files the branch touched. Shows `⊂`.
+6. **Patch-id match** — Branch's entire diff matches a single squash-merge commit on target. Fallback for when the simulated merge conflicts because target later modified the same files the branch touched. Shows `⊂`. The default-branch walk is capped so a single check stays fast; a squash merge with hundreds of commits landed since the merge point falls outside the cap and needs `-D` to remove.
 
 The 'same commit' check uses the local default branch; for other checks, 'target' means the default branch, or its upstream (e.g., `origin/main`) when strictly ahead.
 

--- a/skills/worktrunk/reference/remove.md
+++ b/skills/worktrunk/reference/remove.md
@@ -45,7 +45,7 @@ Worktrunk checks six conditions (in order of cost):
 3. **No added changes** — Three-dot diff (`target...branch`) is empty. Shows `⊂`.
 4. **Trees match** — Branch tree SHA equals target tree SHA. Shows `⊂`.
 5. **Merge adds nothing** — Simulated merge produces the same tree as target. Handles squash-merged branches where target has advanced with changes to different files. Shows `⊂`.
-6. **Patch-id match** — Branch's entire diff matches a single squash-merge commit on target. Fallback for when the simulated merge conflicts because target later modified the same files the branch touched. Shows `⊂`.
+6. **Patch-id match** — Branch's entire diff matches a single squash-merge commit on target. Fallback for when the simulated merge conflicts because target later modified the same files the branch touched. Shows `⊂`. The default-branch walk is capped so a single check stays fast; a squash merge with hundreds of commits landed since the merge point falls outside the cap and needs `-D` to remove.
 
 The 'same commit' check uses the local default branch; for other checks, 'target' means the default branch, or its upstream (e.g., `origin/main`) when strictly ahead.
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -983,7 +983,7 @@ Worktrunk checks six conditions (in order of cost):
 3. **No added changes** — Three-dot diff (`target...branch`) is empty. Shows `⊂`.
 4. **Trees match** — Branch tree SHA equals target tree SHA. Shows `⊂`.
 5. **Merge adds nothing** — Simulated merge produces the same tree as target. Handles squash-merged branches where target has advanced with changes to different files. Shows `⊂`.
-6. **Patch-id match** — Branch's entire diff matches a single squash-merge commit on target. Fallback for when the simulated merge conflicts because target later modified the same files the branch touched. Shows `⊂`.
+6. **Patch-id match** — Branch's entire diff matches a single squash-merge commit on target. Fallback for when the simulated merge conflicts because target later modified the same files the branch touched. Shows `⊂`. The default-branch walk is capped so a single check stays fast; a squash merge with hundreds of commits landed since the merge point falls outside the cap and needs `-D` to remove.
 
 The 'same commit' check uses the local default branch; for other checks, 'target' means the default branch, or its upstream (e.g., `origin/main`) when strictly ahead.
 

--- a/src/git/repository/integration.rs
+++ b/src/git/repository/integration.rs
@@ -39,6 +39,37 @@ pub struct MergeProbeResult {
     pub is_patch_id_match: bool,
 }
 
+/// How many commits the patch-id squash-merge fallback is willing to walk on
+/// the target side before giving up.
+///
+/// [`Repository::is_squash_merged_via_patch_id`] runs
+/// `git log -p {merge-base}..{target} | git patch-id` — one patch per commit
+/// in the range. That range is unbounded: on a fast-moving repo an old branch
+/// can sit tens of thousands of commits behind the tip, and a single such
+/// check then dominates `wt list`, `wt remove`, and `wt step prune` (the
+/// latter goes visibly silent waiting for it). A cheap graph-only
+/// `git rev-list --count` pre-flight enforces this cap.
+///
+/// `500` is conservative because count is only a rough proxy for cost — the
+/// per-commit work scales with `changed_files × changed_lines`, so a few
+/// hundred lockfile-bump or large-refactor squashes can be slower than a few
+/// thousand tiny commits. Working back from "keep one check under a few
+/// seconds" on a heavy monorepo (~50-100 KB patches), 500 holds. On a typical
+/// repo (~5-20 KB patches), 500 is well under a second. Branches squash-merged
+/// within a normal review-and-cleanup cycle sit well inside this.
+///
+/// # Limitation
+///
+/// A branch that was squash-merged but whose merge point now sits more than
+/// `PATCH_ID_SCAN_MAX_COMMITS` commits behind the default-branch tip is
+/// reported as *not* integrated. This is the safe direction — the branch is
+/// kept rather than wrongly deleted — and `wt remove -D` still removes it. The
+/// fallback also only runs when `git merge-tree` itself conflicts (the same
+/// files were modified again after the squash), so the affected set is already
+/// narrow. There is no config knob; bump this constant if the trade-off needs
+/// tuning.
+const PATCH_ID_SCAN_MAX_COMMITS: usize = 500;
+
 impl Repository {
     /// Resolve a ref, preferring branches over tags when names collide.
     ///
@@ -388,14 +419,36 @@ impl Repository {
     ///
     /// Only runs when `merge-tree` conflicts (both sides modified the same files),
     /// since `MergeAddsNothing` handles the non-conflict case. Cost scales with the
-    /// number of commits on target since the merge-base (`git log -p`).
+    /// number of commits on target since the merge-base (`git log -p`), so it is
+    /// capped at [`PATCH_ID_SCAN_MAX_COMMITS`].
     ///
     /// Returns `Ok(true)` if a matching squash-merge commit is found on the target,
-    /// `Ok(false)` otherwise (including when patch-id computation fails — conservative).
+    /// `Ok(false)` otherwise (including when the target history is too deep to scan,
+    /// or when patch-id computation fails — both conservative).
     fn is_squash_merged_via_patch_id(&self, branch: &str, target: &str) -> anyhow::Result<bool> {
         let Some(merge_base) = self.merge_base(target, branch)? else {
             return Ok(false);
         };
+
+        // Bound the target-side history walk. `git log -p {merge_base}..{target}`
+        // diffs every commit landed on the default branch since this branch
+        // diverged; on a fast-moving repo with an old branch that is tens of
+        // thousands of commits, turning one integration check into seconds (or
+        // tens of seconds) of work — visible as `wt step prune` / `wt list`
+        // going silent. A `git rev-list --count` pre-flight (graph walk only,
+        // no diffs) is cheap; bail above the cap. See the limitation note on
+        // [`PATCH_ID_SCAN_MAX_COMMITS`].
+        let target_commit_count: usize = self
+            .run_command(&["rev-list", "--count", &format!("{merge_base}..{target}")])?
+            .trim()
+            .parse()
+            .unwrap_or(0);
+        if target_commit_count > PATCH_ID_SCAN_MAX_COMMITS {
+            log::debug!(
+                "skipping patch-id squash-merge check: {target_commit_count} commits in {merge_base}..{target} exceeds cap of {PATCH_ID_SCAN_MAX_COMMITS}"
+            );
+            return Ok(false);
+        }
 
         // Compute the squashed patch-id (combined diff of all branch changes).
         let branch_pids = self.patch_ids_from(&["diff-tree", "-p", &merge_base, branch])?;
@@ -794,5 +847,108 @@ mod hex_sha_tests {
         assert!(!is_hex_commit_sha(
             "z73f078bd20a09f1a524aae48fcb1771ceac9b5d"
         ));
+    }
+}
+
+#[cfg(test)]
+mod patch_id_cap_tests {
+    use super::*;
+    use crate::testing::TestRepo;
+    use std::fmt::Write as _;
+
+    /// Build the topology
+    ///
+    /// ```text
+    /// base ─── feature  (file: A → B)
+    ///   └────── squash ── pad1 ── … ── padN  = target  (each pad reuses parent's tree)
+    /// ```
+    ///
+    /// via a single `git fast-import` stream — instant even at N = 2000, where
+    /// running `git commit` once per pad would dominate the test.
+    /// `merge_base(target, feature)` is `base`; `squash`'s combined patch
+    /// equals `feature`'s; `rev-list --count base..target` is `1 + n_padding`.
+    fn build(test: &TestRepo, n_padding: usize) {
+        let mut s = String::new();
+        s.push_str("blob\nmark :10\ndata 1\nA\n");
+        s.push_str("blob\nmark :11\ndata 1\nB\n");
+        writeln!(
+            s,
+            "commit refs/heads/base\nmark :1\ncommitter T <t@x> 1700000000 +0000\ndata 0\nM 100644 :10 file\n"
+        )
+        .unwrap();
+        writeln!(
+            s,
+            "commit refs/heads/feature\nmark :2\ncommitter T <t@x> 1700000001 +0000\ndata 0\nfrom :1\nM 100644 :11 file\n"
+        )
+        .unwrap();
+        writeln!(
+            s,
+            "commit refs/heads/target\nmark :3\ncommitter T <t@x> 1700000002 +0000\ndata 0\nfrom :1\nM 100644 :11 file\n"
+        )
+        .unwrap();
+        for i in 0..n_padding {
+            let mark = 4 + i;
+            let parent = if i == 0 { 3 } else { mark - 1 };
+            writeln!(
+                s,
+                "commit refs/heads/target\nmark :{mark}\ncommitter T <t@x> {} +0000\ndata 0\nfrom :{parent}\n",
+                1_700_000_003 + i
+            )
+            .unwrap();
+        }
+        let output = test
+            .git_command()
+            .args(["fast-import", "--quiet"])
+            .stdin_bytes(s.into_bytes())
+            .run()
+            .expect("fast-import spawn");
+        assert!(
+            output.status.success(),
+            "fast-import failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn rev_parse(repo: &Repository, r: &str) -> String {
+        repo.run_command(&["rev-parse", r])
+            .unwrap()
+            .trim()
+            .to_string()
+    }
+
+    #[test]
+    fn detects_squash_when_range_is_under_cap() {
+        let test = TestRepo::new();
+        // base..target = 2 commits (squash + one pad). Well under the cap.
+        build(&test, 1);
+        let repo = Repository::at(test.root_path()).unwrap();
+        let feature = rev_parse(&repo, "refs/heads/feature");
+        let target = rev_parse(&repo, "refs/heads/target");
+
+        assert!(
+            repo.is_squash_merged_via_patch_id(&feature, &target)
+                .unwrap(),
+            "squash commit's patch-id matches feature's; should be detected within the cap"
+        );
+    }
+
+    #[test]
+    fn bails_when_range_exceeds_cap() {
+        let test = TestRepo::new();
+        // base..target = 1 (squash) + PATCH_ID_SCAN_MAX_COMMITS pads — one
+        // over the cap. The squash is still in the range; we just refuse to
+        // walk that far. Asserting `false` while the under-cap case asserts
+        // `true` pins the difference to the cap, not the topology.
+        build(&test, PATCH_ID_SCAN_MAX_COMMITS);
+        let repo = Repository::at(test.root_path()).unwrap();
+        let feature = rev_parse(&repo, "refs/heads/feature");
+        let target = rev_parse(&repo, "refs/heads/target");
+
+        assert!(
+            !repo
+                .is_squash_merged_via_patch_id(&feature, &target)
+                .unwrap(),
+            "should bail (return false) when base..target exceeds {PATCH_ID_SCAN_MAX_COMMITS}"
+        );
     }
 }

--- a/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_remove_long.snap
@@ -11,6 +11,7 @@ info:
     GIT_EDITOR: ""
     LANG: C
     LC_ALL: C
+    LLVM_PROFILE_FILE: /var/folders/v3/8k5q0_6j3_q6gl4h8czr66sh0000gn/T/wt-test-profraw/cov-%m_%p.profraw
     NO_COLOR: ""
     PSModulePath: ""
     RUST_LOG: warn
@@ -19,13 +20,17 @@ info:
     WORKTRUNK_APPROVALS_PATH: /nonexistent/wt/approvals.toml
     WORKTRUNK_CONFIG_PATH: /nonexistent/wt/config.toml
     WORKTRUNK_SYSTEM_CONFIG_PATH: /etc/xdg/worktrunk/config.toml
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
 ---
 success: true
 exit_code: 0
@@ -121,7 +126,7 @@ Worktrunk checks six conditions (in order of cost):
 3. [1mNo added changes[0m — Three-dot diff ([2mtarget...branch[0m) is empty. Shows [2m⊂[0m.
 4. [1mTrees match[0m — Branch tree SHA equals target tree SHA. Shows [2m⊂[0m.
 5. [1mMerge adds nothing[0m — Simulated merge produces the same tree as target. Handles squash-merged branches where target has advanced with changes to different files. Shows [2m⊂[0m.
-6. [1mPatch-id match[0m — Branch's entire diff matches a single squash-merge commit on target. Fallback for when the simulated merge conflicts because target later modified the same files the branch touched. Shows [2m⊂[0m.
+6. [1mPatch-id match[0m — Branch's entire diff matches a single squash-merge commit on target. Fallback for when the simulated merge conflicts because target later modified the same files the branch touched. Shows [2m⊂[0m. The default-branch walk is capped so a single check stays fast; a squash merge with hundreds of commits landed since the merge point falls outside the cap and needs [2m-D[0m to remove.
 
 The 'same commit' check uses the local default branch; for other checks, 'target' means the default branch, or its upstream (e.g., [2morigin/main[0m) when strictly ahead.
 


### PR DESCRIPTION
## Summary

`is_squash_merged_via_patch_id` runs `git log -p {merge-base}..{target} | git patch-id` over the *entire* target-side history. The range is unbounded: on a fast-moving repo with an old branch — tens of thousands of commits since divergence — a single integration check takes seconds to tens of seconds, which surfaces as `wt step prune` (and `wt list`) going visibly silent on the parallel check tail in #1888.

This caps the scan at `PATCH_ID_SCAN_MAX_COMMITS = 500` commits via a cheap graph-only `git rev-list --count` pre-flight. Above the cap, the check returns `Ok(false)` — the safe direction (branch kept, not wrongly deleted); `wt remove -D` still removes branches that fall past the cap.

## Why 500

Count is a rough proxy — per-commit cost scales with `changed_files × changed_lines`, not just count. Working back from "keep one check under a few seconds":

- typical repo (~5-20 KB patches): 500 ≈ well under 1s
- heavy monorepo (~50-100 KB patches): 500 ≈ 2-5s

Branches merged within a normal review-and-cleanup cycle sit well inside this. Anything older is `-D` territory.

## Scope

The cap is in the shared probe, so it applies to `wt list`'s status column, `wt remove`, `wt merge`, and `wt step prune` — anywhere `integration_reason` is called. Behavior change only when a branch was squash-merged *and* `git merge-tree` conflicts (the same files were modified again after the squash) *and* the default branch has advanced > 500 commits since the merge point. Narrow.

## Test plan

- Two new unit tests in `patch_id_cap_tests` using `git fast-import` (501-commit history built in milliseconds): under-cap finds the squash, over-cap bails despite the squash being in range. The pair pins the difference to the cap, not the topology.
- Existing squash-merge integration tests (`test_remove_squash_merged_*`, `test_prune_squash_merged_*`, `test_list_integrated_when_squash_merged_*`) keep small histories well under the cap and continue to pass — regression guard for the wiring.

Refs #1888.

@ortonomy — would you mind running this against the repo from #1888? The simplest check is `cargo install --git https://github.com/max-sixty/worktrunk --branch prune-speed wt` (or build locally), clear the disk cache to force a cold run (`rm -rf .git/wt/cache`), then time `wt step prune`. Most interested in whether the silent stretch is gone; if it isn't, `wt -vv step prune` writes `.git/wt/logs/trace.log` showing which `git` invocations are slow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
