### PR TITLE
feat(list,statusline): include untracked in HEAD± for --full and statusline

### DIFF
--- a/src/commands/list/collect/execution.rs
+++ b/src/commands/list/collect/execution.rs
@@ -358,6 +358,7 @@ pub fn work_items_for_worktree(
         default_branch: options.default_branch.clone(),
         integration_targets: options.integration_targets.clone(),
         snapshot: options.snapshot.clone(),
+        include_untracked_in_working_diff: options.include_untracked_in_working_diff,
     };
 
     let has_commits = wt.has_commits();
@@ -469,6 +470,9 @@ pub fn work_items_for_branch(
         default_branch: options.default_branch.clone(),
         integration_targets: options.integration_targets.clone(),
         snapshot: options.snapshot.clone(),
+        // Branches have no working tree; the flag is only consumed by
+        // WorkingTreeDiffTask, which doesn't run for branch items.
+        include_untracked_in_working_diff: false,
     };
 
     let mut items = Vec::with_capacity(11);
@@ -543,10 +547,7 @@ mod tests {
         let options = CollectOptions {
             skip_tasks,
             url_template: Some("http://localhost/{{ branch }}".to_string()),
-            llm_command: None,
-            default_branch: None,
-            integration_targets: None,
-            snapshot: None,
+            ..Default::default()
         };
 
         let expected_results = Arc::new(ExpectedResults::default());
@@ -585,14 +586,7 @@ mod tests {
         };
 
         // No llm_command, no skip_tasks — SummaryGenerate should still be skipped
-        let options = CollectOptions {
-            skip_tasks: HashSet::new(),
-            llm_command: None,
-            url_template: None,
-            default_branch: None,
-            integration_targets: None,
-            snapshot: None,
-        };
+        let options = CollectOptions::default();
 
         let expected_results = Arc::new(ExpectedResults::default());
         let (tx, _rx) = chan::unbounded::<Result<TaskResult, TaskError>>();

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -323,6 +323,11 @@ pub struct CollectOptions {
     /// of cached methods — bypassing the ambient ref→SHA cache entirely.
     /// `None` when capture failed (degraded mode).
     pub snapshot: Option<std::sync::Arc<worktrunk::git::RefSnapshot>>,
+
+    /// Whether `WorkingTreeDiffTask` should include untracked files in
+    /// `HEAD±`. Set by `wt list --full` and `wt statusline`; consumed
+    /// in `tasks.rs` where the cost/cutover rationale lives.
+    pub include_untracked_in_working_diff: bool,
 }
 
 fn worktree_branch_set(worktrees: &[WorktreeInfo]) -> HashSet<&str> {
@@ -644,6 +649,7 @@ pub fn collect(
         collect_deadline,
         list_width,
         progressive_handler,
+        include_untracked_in_working_diff,
     ) = match show_config {
         ShowConfig::Resolved {
             show_branches,
@@ -661,6 +667,10 @@ pub fn collect(
             collect_deadline,
             list_width,
             progressive_handler,
+            // Picker is the only `Resolved` caller and runs the same fast
+            // bucket as default `wt list` (skips BranchDiff/CiStatus), so
+            // it also opts out of the untracked-inclusive working diff.
+            false,
         ),
         ShowConfig::DeferredToParallel {
             cli_branches,
@@ -698,6 +708,7 @@ pub fn collect(
                 collect_deadline,
                 None,
                 None,
+                show_full,
             )
         }
     };
@@ -986,6 +997,7 @@ pub fn collect(
         default_branch: default_branch.clone(),
         integration_targets: None,
         snapshot: None,
+        include_untracked_in_working_diff,
     };
 
     // Track expected results per item - populated as spawns are queued

--- a/src/commands/list/collect/tasks.rs
+++ b/src/commands/list/collect/tasks.rs
@@ -64,6 +64,9 @@ pub struct TaskContext {
     /// ref→SHA cache. `None` when snapshot capture failed (degraded
     /// mode — tasks fall back to ref-taking methods).
     pub snapshot: Option<Arc<RefSnapshot>>,
+    /// Whether `WorkingTreeDiffTask` should include untracked files in
+    /// its `HEAD±` line counts. See `CollectOptions` for rationale.
+    pub include_untracked_in_working_diff: bool,
 }
 
 impl TaskContext {
@@ -522,11 +525,20 @@ impl Task for WorkingTreeDiffTask {
         let (working_tree_status, is_dirty, has_conflicts) =
             parse_working_tree_status(&status_output);
 
-        let working_tree_diff = if is_dirty {
-            wt.working_tree_diff_stats()
+        // The default `wt list` path keeps `HEAD±` as a fast `git diff
+        // --shortstat HEAD` over tracked files only. `--full` and statusline
+        // ask for the same untracked-inclusive stat that `wt step diff`
+        // shows; honour it only when the cached porcelain actually has
+        // untracked entries (otherwise the fast path is identical and we
+        // skip the index copy + intent-to-add walk).
+        let working_tree_diff = if !is_dirty {
+            LineDiff::default()
+        } else if ctx.include_untracked_in_working_diff && working_tree_status.untracked {
+            wt.working_tree_diff_stats_with_untracked()
                 .map_err(|e| ctx.error(Self::KIND, &e))?
         } else {
-            LineDiff::default()
+            wt.working_tree_diff_stats()
+                .map_err(|e| ctx.error(Self::KIND, &e))?
         };
 
         Ok(TaskResult::WorkingTreeDiff {
@@ -668,7 +680,20 @@ impl Task for WorkingTreeConflictsTask {
             .any(|l| l.starts_with("??") || l.as_bytes().get(1) != Some(&b' '));
 
         let tree_sha = if needs_working_tree {
-            write_tree_with_working_tree(&wt).map_err(|e| ctx.error(Self::KIND, &e))?
+            // Stage all dirty + untracked entries into a temp index so
+            // `write-tree` produces a tree representing the full working
+            // state. Real index untouched. See `WorkingTree::temp_index`.
+            let idx = wt.temp_index().map_err(|e| ctx.error(Self::KIND, &e))?;
+            idx.git(["add", "-A"])
+                .run()
+                .context("Failed to stage working tree changes")
+                .map_err(|e| ctx.error(Self::KIND, &e))?;
+            let output = idx
+                .git(["write-tree"])
+                .run()
+                .context("Failed to write tree from temporary index")
+                .map_err(|e| ctx.error(Self::KIND, &e))?;
+            String::from_utf8_lossy(&output.stdout).trim().to_string()
         } else {
             wt.run_command(&["write-tree"])
                 .map(|s| s.trim().to_string())
@@ -692,52 +717,6 @@ impl Task for WorkingTreeConflictsTask {
             has_working_tree_conflicts: Some(has_conflicts),
         })
     }
-}
-
-/// Build a tree SHA representing the full working tree state (staged +
-/// unstaged + untracked) by staging everything into a temporary index.
-///
-/// Copies the real index (preserving git's stat cache for unchanged files),
-/// then `git add -A` to stage all modifications and untracked files, then
-/// `git write-tree` to produce the tree SHA. The real index is untouched.
-fn write_tree_with_working_tree(wt: &worktrunk::git::WorkingTree) -> anyhow::Result<String> {
-    use worktrunk::shell_exec::Cmd;
-
-    let git_dir = wt.git_dir()?;
-    let worktree_root = wt.root()?;
-    let real_index = git_dir.join("index");
-    let log_ctx = wt
-        .path()
-        .file_name()
-        .and_then(|n| n.to_str())
-        .unwrap_or(".")
-        .to_string();
-
-    let temp_index = tempfile::NamedTempFile::new().context("Failed to create temporary index")?;
-    std::fs::copy(&real_index, temp_index.path()).context("Failed to copy index file")?;
-    let temp_index_path = temp_index
-        .path()
-        .to_str()
-        .context("Temporary index path is not valid UTF-8")?;
-
-    // Stage all changes (unstaged modifications + untracked files)
-    Cmd::new("git")
-        .args(["add", "-A"])
-        .current_dir(&worktree_root)
-        .context(&log_ctx)
-        .env("GIT_INDEX_FILE", temp_index_path)
-        .run()
-        .context("Failed to stage working tree changes")?;
-
-    let output = Cmd::new("git")
-        .args(["write-tree"])
-        .current_dir(&worktree_root)
-        .context(&log_ctx)
-        .env("GIT_INDEX_FILE", temp_index_path)
-        .run()
-        .context("Failed to write tree from temporary index")?;
-
-    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
 }
 
 /// Task 7 (worktree only): Git operation state detection (rebase/merge)

--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -303,6 +303,12 @@ fn run_json() -> Result<()> {
     // Build collect options with URL template (compute everything for complete data)
     let options = CollectOptions {
         url_template,
+        // Match `wt list --full`: include untracked files in the working
+        // diff (`HEAD±`) so the segment counts the same lines `wt step
+        // diff` would show. Statusline already runs the full task set;
+        // this keeps the diff number consistent with the rest of the
+        // statusline data.
+        include_untracked_in_working_diff: true,
         ..Default::default()
     };
 
@@ -408,6 +414,12 @@ fn git_status_segments(
     // Build collect options with URL template
     let options = CollectOptions {
         url_template,
+        // Match `wt list --full`: include untracked files in the working
+        // diff (`HEAD±`) so the segment counts the same lines `wt step
+        // diff` would show. Statusline already runs the full task set;
+        // this keeps the diff number consistent with the rest of the
+        // statusline data.
+        include_untracked_in_working_diff: true,
         ..Default::default()
     };
 

--- a/src/commands/step/diff.rs
+++ b/src/commands/step/diff.rs
@@ -2,60 +2,31 @@
 
 use anyhow::Context;
 use worktrunk::git::Repository;
-use worktrunk::shell_exec::Cmd;
 
 /// Handle `wt step diff` command
 ///
 /// Shows all changes since branching from the target: committed, staged, unstaged,
-/// and untracked files in a single diff. Copies the real index to preserve git's stat
-/// cache (avoiding re-reads of unchanged files), then registers untracked files with
-/// `git add -N` so they appear in the diff.
+/// and untracked files in a single diff. Stages untracked files into a temp index
+/// (`WorkingTree::temp_index`) so they appear in the diff without mutating the
+/// real index — git's stat cache stays warm and tracked files aren't re-hashed.
 pub fn step_diff(target: Option<&str>, extra_args: &[String]) -> anyhow::Result<()> {
     let repo = Repository::current()?;
     let wt = repo.current_worktree();
 
-    // Get and validate target ref
     let integration_target = repo.require_target_ref(target)?;
-
-    // Get merge base
     let merge_base = repo
         .merge_base("HEAD", &integration_target)?
         .context("No common ancestor with target branch")?;
 
-    let current_branch = wt.branch()?.unwrap_or_else(|| "HEAD".to_string());
-
-    // Copy the real index so git's stat cache is warm for tracked files, then
-    // register untracked files with `git add -N .` so they appear in the diff.
-    // This avoids re-reading and hashing every tracked file during `git diff`.
-    let worktree_root = wt.root()?;
-
-    let real_index = wt.git_dir()?.join("index");
-    let temp_index = tempfile::NamedTempFile::new().context("Failed to create temporary index")?;
-    let temp_index_path = temp_index
-        .path()
-        .to_str()
-        .context("Temporary index path is not valid UTF-8")?;
-
-    std::fs::copy(&real_index, temp_index.path()).context("Failed to copy index file")?;
-
-    // Register untracked files as intent-to-add (tracked files already have entries)
-    Cmd::new("git")
-        .args(["add", "--intent-to-add", "."])
-        .current_dir(&worktree_root)
-        .context(&current_branch)
-        .env("GIT_INDEX_FILE", temp_index_path)
+    let idx = wt.temp_index()?;
+    idx.git(["add", "--intent-to-add", "."])
         .run()
         .context("Failed to register untracked files")?;
 
-    // Stream diff to stdout — git handles pager and coloring
+    // Stream diff to stdout — git handles pager and coloring.
     let mut diff_args = vec!["diff".to_string(), merge_base];
     diff_args.extend_from_slice(extra_args);
-    Cmd::new("git")
-        .args(&diff_args)
-        .current_dir(&worktree_root)
-        .context(&current_branch)
-        .env("GIT_INDEX_FILE", temp_index_path)
-        .stream()?;
+    idx.git(diff_args).stream()?;
 
     Ok(())
 }

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -74,7 +74,7 @@ pub use remove::{
 };
 pub use repository::sha_cache;
 pub use repository::{
-    Branch, IntegrationTargets, RefSnapshot, Repository, ResolvedWorktree, WorkingTree,
+    Branch, IntegrationTargets, RefSnapshot, Repository, ResolvedWorktree, TempIndex, WorkingTree,
     set_base_path,
 };
 pub use url::GitRemoteUrl;

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -126,8 +126,8 @@ mod worktrees;
 pub use branch::Branch;
 pub use integration::IntegrationTargets;
 pub use ref_snapshot::RefSnapshot;
-pub use working_tree::WorkingTree;
 pub(super) use working_tree::path_to_logging_context;
+pub use working_tree::{TempIndex, WorkingTree};
 
 /// Structured error from [`Repository::run_command_delayed_stream`].
 ///

--- a/src/git/repository/working_tree.rs
+++ b/src/git/repository/working_tree.rs
@@ -457,6 +457,49 @@ impl<'a> WorkingTree<'a> {
         Ok(LineDiff::from_shortstat(&stdout))
     }
 
+    /// Working-tree diff stats vs HEAD that also count untracked files,
+    /// matching the diff `wt step diff` shows.
+    ///
+    /// Registers untracked files in a [`TempIndex`] via
+    /// `git add --intent-to-add .`, then runs `git diff --shortstat HEAD`
+    /// against that temp index. The real index is untouched.
+    pub fn working_tree_diff_stats_with_untracked(&self) -> anyhow::Result<LineDiff> {
+        let idx = self.temp_index()?;
+        idx.git(["add", "--intent-to-add", "."])
+            .run()
+            .context("Failed to register untracked files")?;
+        let output = idx
+            .git(["diff", "--shortstat", "HEAD"])
+            .run()
+            .context("Failed to compute working-tree diff stats")?;
+        Ok(LineDiff::from_shortstat(&String::from_utf8_lossy(
+            &output.stdout,
+        )))
+    }
+
+    /// Open a working copy of this worktree's index for staging
+    /// operations that must not mutate the real index. See
+    /// [`TempIndex`] for the rationale and call sites.
+    pub fn temp_index(&self) -> anyhow::Result<TempIndex> {
+        let git_dir = self.git_dir()?;
+        let worktree_root = self.root()?;
+        let real_index = git_dir.join("index");
+        let log_ctx = path_to_logging_context(self.path());
+
+        let temp = tempfile::NamedTempFile::new().context("Failed to create temporary index")?;
+        std::fs::copy(&real_index, temp.path()).context("Failed to copy index file")?;
+        // Validate UTF-8 once so `TempIndex::path` is infallible.
+        temp.path()
+            .to_str()
+            .context("Temporary index path is not valid UTF-8")?;
+
+        Ok(TempIndex {
+            temp,
+            worktree_root,
+            log_ctx,
+        })
+    }
+
     /// Determine whether there are staged changes in the index.
     ///
     /// Returns `Ok(true)` when staged changes are present, `Ok(false)` otherwise.
@@ -539,6 +582,55 @@ impl<'a> WorkingTree<'a> {
         .context("Failed to create backup ref")?;
 
         self.repo().short_sha(&backup_sha)
+    }
+}
+
+/// A temporary copy of a worktree's index, plus the bits needed to run
+/// `git` commands against it.
+///
+/// Built by [`WorkingTree::temp_index`]. Drop deletes the temp file.
+///
+/// Some operations need to "stage something" — register untracked files,
+/// or `git add -A` everything — to feed a follow-up `git diff` /
+/// `git write-tree` / `git diff --shortstat`. Doing that against the real
+/// index would mutate the user's staging state. The trick is to copy the
+/// real index, point `GIT_INDEX_FILE` at the copy, and run those
+/// operations there. Today the callers are
+/// [`WorkingTree::working_tree_diff_stats_with_untracked`] (HEAD± with
+/// untracked, used by `wt list --full` / `wt statusline`),
+/// `WorkingTreeConflictsTask` (write-tree of dirty + untracked, for
+/// merge-conflict probing), and `wt step diff` (diff vs target merge-base
+/// with untracked).
+pub struct TempIndex {
+    temp: tempfile::NamedTempFile,
+    worktree_root: PathBuf,
+    log_ctx: String,
+}
+
+impl TempIndex {
+    /// UTF-8 path to the temp index file. Validated at construction.
+    pub fn path(&self) -> &str {
+        self.temp
+            .path()
+            .to_str()
+            .expect("validated in temp_index()")
+    }
+
+    /// Build a `git` command pointed at this temp index.
+    ///
+    /// Wires `current_dir` to the worktree root, the worktree's logging
+    /// context, and `GIT_INDEX_FILE`. The caller adds the subcommand and
+    /// chooses `.run()` / `.stream()`.
+    pub fn git<I, S>(&self, args: I) -> Cmd
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        Cmd::new("git")
+            .args(args)
+            .current_dir(&self.worktree_root)
+            .context(self.log_ctx.clone())
+            .env("GIT_INDEX_FILE", self.path())
     }
 }
 
@@ -733,5 +825,40 @@ mod tests {
         // `head_sha()` returns None on unborn HEAD — `rev-parse HEAD` errors,
         // mapped to None so detached and unborn callers look the same.
         assert!(wt.head_sha().unwrap().is_none());
+    }
+
+    #[test]
+    fn working_tree_diff_stats_with_untracked_counts_untracked_and_preserves_real_index() {
+        // Two-line untracked file plus a one-line tracked modification:
+        // the with-untracked variant must sum both, while the real index
+        // must remain byte-identical (the temp-index trick is the
+        // mechanism — this test guards that contract).
+        let test = TestRepo::with_initial_commit();
+        std::fs::write(test.root_path().join("tracked.txt"), "old\n").unwrap();
+        test.run_git(&["add", "tracked.txt"]);
+        test.run_git(&["commit", "-m", "add tracked"]);
+
+        std::fs::write(test.root_path().join("tracked.txt"), "new\n").unwrap();
+        std::fs::write(test.root_path().join("untracked.txt"), "a\nb\n").unwrap();
+
+        let repo = Repository::at(test.root_path()).unwrap();
+        let wt = repo.worktree_at(test.root_path());
+        let real_index = wt.git_dir().unwrap().join("index");
+        let index_before = std::fs::read(&real_index).unwrap();
+
+        // Tracked-only path skips the untracked file entirely.
+        let tracked_only = wt.working_tree_diff_stats().unwrap();
+        assert_eq!(tracked_only.added, 1);
+        assert_eq!(tracked_only.deleted, 1);
+
+        let with_untracked = wt.working_tree_diff_stats_with_untracked().unwrap();
+        assert_eq!(with_untracked.added, 3, "1 modified line + 2 untracked");
+        assert_eq!(with_untracked.deleted, 1);
+
+        let index_after = std::fs::read(&real_index).unwrap();
+        assert_eq!(
+            index_before, index_after,
+            "real index must not be mutated by the temp-index path"
+        );
     }
 }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -575,6 +575,21 @@ pub fn add_standard_env_redactions(settings: &mut insta::Settings) {
             value
         }
     });
+
+    // Redact cargo-llvm-cov env from snapshot info blocks. `LLVM_PROFILE_FILE`
+    // is set on every test subprocess by `isolate_subprocess_env` (#2730) —
+    // its `<temp_dir>/wt-test-profraw/cov-%m_%p.profraw` value is platform-
+    // and host-specific and would leak into snapshots regenerated on any
+    // other machine. CARGO_LLVM_COV* propagate by the same path under
+    // `cargo llvm-cov`. `add_redaction` is the right hammer here:
+    // `add_filter` substitutes only on the captured snapshot content, not
+    // the YAML info/env block where these entries live.
+    settings.add_redaction(".env.LLVM_PROFILE_FILE", "[LLVM_PROFILE_FILE]");
+    settings.add_redaction(".env.CARGO_LLVM_COV", "[CARGO_LLVM_COV]");
+    settings.add_redaction(
+        ".env.CARGO_LLVM_COV_TARGET_DIR",
+        "[CARGO_LLVM_COV_TARGET_DIR]",
+    );
 }
 
 fn canonical_home_dir() -> Option<PathBuf> {
@@ -1091,13 +1106,6 @@ fn setup_snapshot_settings_for_paths_with_home(
     // Pattern 3: Git log style "* <hash> message" lines
     // Format: "* " + yellow code + 7-char hex hash + reset
     settings.add_filter(r"\* \x1b\[33m[a-f0-9]{7}\x1b\[m", "* \x1b[33m[HASH]\x1b[m");
-
-    // Filter out cargo-llvm-cov env variables from snapshot YAML headers.
-    // These are only present during coverage runs and cause snapshot mismatches.
-    // Note: YAML indentation in the info.env section is 4 spaces.
-    settings.add_filter(r#"    CARGO_LLVM_COV: "1"\n"#, "");
-    settings.add_filter(r#"    CARGO_LLVM_COV_TARGET_DIR: "[^"]+"\n"#, "");
-    settings.add_filter(r#"    LLVM_PROFILE_FILE: "[^"]+"\n"#, "");
 
     // Last so every placeholder established above (e.g. [TEST_CONFIG],
     // [PROJECT_ID], [TEMP_HOME], [HASH]) is in place when we strip styling

--- a/tests/integration_tests/statusline.rs
+++ b/tests/integration_tests/statusline.rs
@@ -110,7 +110,7 @@ fn test_statusline_basic(repo: TestRepo) {
 fn test_statusline_with_changes(repo: TestRepo) {
     add_uncommitted_changes(&repo);
     let output = run_statusline(&repo, &[], None);
-    assert_snapshot!(output, @"[0m main  [36m?[0m[2m^[22m[2m|[22m");
+    assert_snapshot!(output, @"[0m main  [36m?[0m[2m^[22m[2m|[22m  @[32m+1");
 }
 
 #[rstest]
@@ -171,7 +171,7 @@ fn test_statusline_claude_code_full_context(repo: TestRepo) {
 
     let output = run_statusline(&repo, &["--format=claude-code"], Some(&json));
     claude_code_snapshot_settings().bind(|| {
-        assert_snapshot!(output, @"[PATH]  main  [36m?[0m[2m^[22m[2m|[22m  | Opus");
+        assert_snapshot!(output, @"[PATH]  main  [36m?[0m[2m^[22m[2m|[22m  @[32m+1[0m  | Opus");
     });
 }
 
@@ -365,7 +365,7 @@ url = "http://{{ branch }}.localhost:3000"
 
     let output = run_statusline(&repo, &[], None);
     // Shows `?` because writing project config creates uncommitted file
-    assert_snapshot!(output, @"[0m main  [36m?[0m[2m^[22m[2m|[22m  http://main.localhost:3000");
+    assert_snapshot!(output, @"[0m main  [36m?[0m[2m^[22m[2m|[22m  @[32m+2[0m  http://main.localhost:3000");
 }
 
 #[rstest]

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_configured_platform_github.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_configured_platform_github.snap
@@ -23,7 +23,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    LLVM_PROFILE_FILE: /var/folders/v3/8k5q0_6j3_q6gl4h8czr66sh0000gn/T/wt-test-profraw/cov-%m_%p.profraw
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     NO_COLOR: ""
     OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_configured_platform_github.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_configured_platform_github.snap
@@ -11,13 +11,19 @@ info:
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
     GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
     GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    LLVM_PROFILE_FILE: /var/folders/v3/8k5q0_6j3_q6gl4h8czr66sh0000gn/T/wt-test-profraw/cov-%m_%p.profraw
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     NO_COLOR: ""
     OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
@@ -30,20 +36,24 @@ info:
     WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
 exit_code: 0
 ----- stdout -----
   [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCI[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage
-@ main         [36m?[39m [2m^[22m[2m|[22m                                      [2m|[0m     [32m●[0m   .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
+@ main         [36m?[39m [2m^[22m[2m|[22m      [32m+3[0m                              [2m|[0m     [32m●[0m   .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
 + [2mfeature[0m        [2m_[22m[2m|[22m                                      [2m|[0m     [32m●[0m   [2m../repo.feature[0m    [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
 + feature-a      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m●[0m   ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m●[0m   ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_gitea_forge_platform.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_gitea_forge_platform.snap
@@ -23,6 +23,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    LLVM_PROFILE_FILE: /var/folders/v3/8k5q0_6j3_q6gl4h8czr66sh0000gn/T/wt-test-profraw/cov-%m_%p.profraw
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     NO_COLOR: ""
     OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
@@ -52,7 +53,7 @@ success: true
 exit_code: 0
 ----- stdout -----
   [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCI[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage
-@ main         [36m?[39m [2m^[22m[2m|[22m                                      [2m|[0m         .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
+@ main         [36m?[39m [2m^[22m[2m|[22m      [32m+2[0m                              [2m|[0m         .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
 + [2mfeature[0m        [2m_[22m                                                 [2m../repo.feature[0m    [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
 + feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                    ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                    ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_gitea_forge_platform.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_gitea_forge_platform.snap
@@ -23,7 +23,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    LLVM_PROFILE_FILE: /var/folders/v3/8k5q0_6j3_q6gl4h8czr66sh0000gn/T/wt-test-profraw/cov-%m_%p.profraw
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     NO_COLOR: ""
     OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_invalid_configured_platform.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_invalid_configured_platform.snap
@@ -23,6 +23,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    LLVM_PROFILE_FILE: /var/folders/v3/8k5q0_6j3_q6gl4h8czr66sh0000gn/T/wt-test-profraw/cov-%m_%p.profraw
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     NO_COLOR: ""
     OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
@@ -52,7 +53,7 @@ success: true
 exit_code: 0
 ----- stdout -----
   [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCI[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage
-@ main         [36m?[39m [2m^[22m[2m|[22m                                      [2m|[0m     [32m●[0m   .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
+@ main         [36m?[39m [2m^[22m[2m|[22m      [32m+3[0m                              [2m|[0m     [32m●[0m   .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
 + [2mfeature[0m        [2m_[22m[2m|[22m                                      [2m|[0m     [32m●[0m   [2m../repo.feature[0m    [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
 + feature-a      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m●[0m   ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m●[0m   ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_invalid_configured_platform.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_invalid_configured_platform.snap
@@ -23,7 +23,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    LLVM_PROFILE_FILE: /var/folders/v3/8k5q0_6j3_q6gl4h8czr66sh0000gn/T/wt-test-profraw/cov-%m_%p.profraw
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     NO_COLOR: ""
     OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"

--- a/tests/snapshots/integration__integration_tests__list__list_task_dag_full_with_diffs.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_task_dag_full_with_diffs.snap
@@ -12,13 +12,19 @@ info:
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
     GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
     GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    LLVM_PROFILE_FILE: /var/folders/v3/8k5q0_6j3_q6gl4h8czr66sh0000gn/T/wt-test-profraw/cov-%m_%p.profraw
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     NO_COLOR: ""
     OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
@@ -31,13 +37,17 @@ info:
     WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
@@ -45,7 +55,7 @@ exit_code: 0
 ----- stdout -----
   [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCI[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage
 @ main           [2m^[22m[2m|[22m                                      [2m|[0m         .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
-+ feature-a    [36m?[39m [2m↑[22m                 [32m↑1[0m        [32m+1[0m                    ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
++ feature-a    [36m?[39m [2m↑[22m       [32m+1[0m        [32m↑1[0m        [32m+1[0m                    ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                    ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
 + feature-b      [2m↑[22m                 [32m↑2[0m        [32m+2[0m   [31m-1[0m               ../repo.feature-b  [2m391b2a76[0m  [2m1d[0m    [2mTest commit
 

--- a/tests/snapshots/integration__integration_tests__list__list_task_dag_full_with_diffs.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_task_dag_full_with_diffs.snap
@@ -24,7 +24,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    LLVM_PROFILE_FILE: /var/folders/v3/8k5q0_6j3_q6gl4h8czr66sh0000gn/T/wt-test-profraw/cov-%m_%p.profraw
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     NO_COLOR: ""
     OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"

--- a/tests/snapshots/integration__integration_tests__list__maximum_status_symbols.snap
+++ b/tests/snapshots/integration__integration_tests__list__maximum_status_symbols.snap
@@ -11,13 +11,19 @@ info:
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
     GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
     GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    LLVM_PROFILE_FILE: /var/folders/v3/8k5q0_6j3_q6gl4h8czr66sh0000gn/T/wt-test-profraw/cov-%m_%p.profraw
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     NO_COLOR: ""
     OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
@@ -30,13 +36,17 @@ info:
     WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
@@ -47,7 +57,7 @@ exit_code: 0
 + feature-a      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                    ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
 + feature-b      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                    ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file
 + feature-c      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                    ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
-+ feature    [36m+[39m[36m![39m[36m?[39m[33m⊞[39m[33m✗[39m[2m⇅[22m🤖    [32m+2[0m   [31m-2[0m   [32m↑2[0m  [2m[31m↓1[0m    [32m+3[0m   [31m-1[0m   [32m⇡1[0m  [2m[31m⇣1[0m      ../repo.feature    [2m342be366[0m  [2m1d[0m    [2mLocal commit
++ feature    [36m+[39m[36m![39m[36m?[39m[33m⊞[39m[33m✗[39m[2m⇅[22m🤖    [32m+3[0m   [31m-2[0m   [32m↑2[0m  [2m[31m↓1[0m    [32m+3[0m   [31m-1[0m   [32m⇡1[0m  [2m[31m⇣1[0m      ../repo.feature    [2m342be366[0m  [2m1d[0m    [2mLocal commit
 
 [2m○[22m [2mShowing 5 worktrees, 1 with changes, 4 ahead
 

--- a/tests/snapshots/integration__integration_tests__list__maximum_status_symbols.snap
+++ b/tests/snapshots/integration__integration_tests__list__maximum_status_symbols.snap
@@ -23,7 +23,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    LLVM_PROFILE_FILE: /var/folders/v3/8k5q0_6j3_q6gl4h8czr66sh0000gn/T/wt-test-profraw/cov-%m_%p.profraw
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     NO_COLOR: ""
     OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"

--- a/tests/snapshots/integration__integration_tests__list__maximum_status_with_git_operation.snap
+++ b/tests/snapshots/integration__integration_tests__list__maximum_status_with_git_operation.snap
@@ -11,13 +11,19 @@ info:
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
     GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
     GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    LLVM_PROFILE_FILE: /var/folders/v3/8k5q0_6j3_q6gl4h8czr66sh0000gn/T/wt-test-profraw/cov-%m_%p.profraw
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     NO_COLOR: ""
     OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
@@ -30,13 +36,17 @@ info:
     WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
     WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
 success: true
@@ -47,7 +57,7 @@ exit_code: 0
 + feature-a      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                    ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
 + feature-b      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                    ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file
 + feature-c      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                    ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
-+ feature    [36m+[39m[36m![39m[36m?[39m[31m✘[39m[33m✗[39m 🤖    [32m+7[0m        [32m↑1[0m  [2m[31m↓1[0m    [32m+3[0m   [31m-2[0m               ../repo.feature    [2m27eb0ee8[0m  [2m1d[0m    [2mMain conflicting changes
++ feature    [36m+[39m[36m![39m[36m?[39m[31m✘[39m[33m✗[39m 🤖    [32m+8[0m        [32m↑1[0m  [2m[31m↓1[0m    [32m+3[0m   [31m-2[0m               ../repo.feature    [2m27eb0ee8[0m  [2m1d[0m    [2mMain conflicting changes
 
 [2m○[22m [2mShowing 5 worktrees, 1 with changes, 4 ahead
 

--- a/tests/snapshots/integration__integration_tests__list__maximum_status_with_git_operation.snap
+++ b/tests/snapshots/integration__integration_tests__list__maximum_status_with_git_operation.snap
@@ -23,7 +23,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
-    LLVM_PROFILE_FILE: /var/folders/v3/8k5q0_6j3_q6gl4h8czr66sh0000gn/T/wt-test-profraw/cov-%m_%p.profraw
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     NO_COLOR: ""
     OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"


### PR DESCRIPTION
`wt list --full` and `wt statusline` now count untracked-file lines in the `HEAD±` working-diff segment, matching what `wt step diff` shows. Default `wt list` and the picker stay on the cheap `git diff --shortstat HEAD` path (tracked-only). Putting the untracked-inclusive variant behind the same `--full` boundary as `BranchDiff` / `CiStatus` / `SummaryGenerate` means the explanation stays simple — "`--full` includes untracked too" — with no new exception class.

## Mechanism

`WorkingTree::working_tree_diff_stats_with_untracked()` registers untracked files in a temporary copy of the index via `git add --intent-to-add .`, then runs `git diff --shortstat HEAD` against that temp index. Same trick `wt step diff` uses; the worktree's real index is never touched (a unit test diffs the index bytes before/after to lock that contract in).

`WorkingTreeDiffTask` branches on the new flag and on the cached porcelain — when no untracked entries exist, the expensive path is skipped (the two paths are bit-equivalent for tracked-only worktrees).

## Refactor

A new `TempIndex` helper consolidates the "copy index + stage stuff into it + run a follow-up git command" pattern that was previously open-coded in three places (`wt step diff`, `WorkingTreeConflictsTask::write_tree_with_working_tree`, and the new method above). `TempIndex::git(args)` returns a `Cmd` already wired with `current_dir`, log context, and `GIT_INDEX_FILE`, so each caller collapses to a few lines.

## Wiring

A new `include_untracked_in_working_diff: bool` on `CollectOptions` flows through `TaskContext` to `WorkingTreeDiffTask`. Set from `show_full` in `collect/mod.rs`, hard-coded `true` in `statusline.rs`, hard-coded `false` for the picker (the only other `ShowConfig::Resolved` consumer, which intentionally runs the same fast bucket as default `wt list`).

## Snapshot env scrub fix (second commit)

A pre-existing latent bug surfaced when regenerating the six `--full` / statusline snapshots: `LLVM_PROFILE_FILE` (set on every test subprocess by `isolate_subprocess_env` since #2730) leaked into the env block as a platform-specific tempdir path. The intended scrub at `setup_snapshot_settings` was using `add_filter`, which only substitutes on captured snapshot content — never on the YAML info/env block — so it was dead code. Replaced with `add_redaction(".env.LLVM_PROFILE_FILE", ...)` (and the same for `CARGO_LLVM_COV*`) inside `add_standard_env_redactions`, which is already bound by the `repo` rstest fixture; values now render as stable `[LLVM_PROFILE_FILE]` placeholders matching the existing convention for HOME / GIT_CONFIG_GLOBAL / etc.

## Tests

3695 pass: one new unit test for `working_tree_diff_stats_with_untracked` (verifies untracked lines counted, real index byte-identical), plus snapshot updates for nine `--full` / statusline tests where untracked files now contribute to `HEAD±`.
