### PR TITLE
chore: grant standing exception for filing issues in agent-equipped repos

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -12,6 +12,13 @@ CLI for managing git worktrees). The generic skills (`tend-running-in-ci`,
 `tend-review`, `tend-triage`, etc.) provide the workflow framework;
 this skill adds worktrunk conventions.
 
+## Filing issues in other repos
+
+Standing exception granted: file directly in agent-equipped targets (per
+**Filing Issues in Other Repos** in the bundled `running-in-ci` skill) without
+asking permission here first. The default rule (open an issue here asking
+permission first) still applies when the target shows no agent signals.
+
 ## Codecov Monitoring
 
 After required CI checks pass, poll `codecov/patch` — it is mandatory despite


### PR DESCRIPTION
Grants a standing exception for cross-repo issue filing, paired with the bundled-skill rule landing in `max-sixty/tend` (see [max-sixty/tend#509](https://github.com/max-sixty/tend/pull/509)).

Tend's default behaviour is: open an issue in the current repo asking permission first. This overlay grants a standing exception so the bot files directly in **agent-equipped** targets — repos with their own coding agent, detected from tend workflows, `claude-code-action` use, or recent bot-authored PRs/issues with no human pushback.

A no-op until tend's next release ships the new bundled section; safe to land in any order.
