### PR TITLE
config(tend): drop redundant secret-name overrides

### DIFF
--- a/.config/tend.yaml
+++ b/.config/tend.yaml
@@ -2,8 +2,6 @@ bot_name: worktrunk-bot
 setup:
 - uses: ./.github/actions/claude-setup
 secrets:
-  bot_token: WORKTRUNK_BOT_TOKEN
-  claude_token: CLAUDE_CODE_OAUTH_TOKEN
   allowed:
   - CODECOV_TOKEN
 workflows:


### PR DESCRIPTION
## Summary

Tend 0.0.23 made `TEND_BOT_TOKEN` the default bot-token secret name, and `CLAUDE_CODE_OAUTH_TOKEN` was already the default for the Claude OAuth token. Both overrides in `.config/tend.yaml` are now redundant — drop them.

The `TEND_BOT_TOKEN` repo secret is already populated with the worktrunk-bot PAT.

## Test plan

- [ ] Wait for nightly to regenerate `tend-*.yaml`. The regen will rewrite `${{ secrets.WORKTRUNK_BOT_TOKEN }}` → `${{ secrets.TEND_BOT_TOKEN }}` in every workflow.
- [ ] After the regen PR merges, delete the obsolete `WORKTRUNK_BOT_TOKEN` and `BOT_TOKEN` secrets from this repo.

> _This was written by Claude Code on behalf of @max-sixty_

Co-authored-by: Claude <noreply@anthropic.com>