### PR TITLE
feat(commit): experimental project-level commit-message guidance

### DIFF
--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -277,9 +277,7 @@
 # """
 # <!-- DEFAULT_SQUASH_TEMPLATE_END -->
 #
-# #### Appending to the prompt
-#
-# <span class="badge-experimental"></span>
+# #### Appending to the prompt [experimental]
 #
 # `template-append` adds to the prompt instead of replacing it. The value is rendered as its own minijinja template (same variables) and injected into the default templates' `{{ user_guidance }}` slot — a `<user-guidance>` block right after `<style>`. It applies to both commit and squash. Use it for personal preferences without restating the whole template:
 #

--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -181,7 +181,7 @@
 # - `{{ git_diff }}`, `{{ git_diff_stat }}` — diff content
 # - `{{ branch }}`, `{{ repo }}` — context
 # - `{{ recent_commits }}` — recent commit messages
-# - `{{ user_guidance }}`, `{{ project_guidance }}` — rendered append fragments (see Appending to the prompt (#appending-to-the-prompt))
+# - `{{ user_guidance }}`, `{{ project_guidance }}` — rendered append fragments (see Appending to the prompt (https://worktrunk.dev/config/#appending-to-the-prompt))
 #
 # Default template:
 #

--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -200,7 +200,11 @@
 # - Match recent commit style (conventional commits if used)
 # - Describe the change, not the intent or benefit
 # </style>
-#
+# {% if project_guidance %}
+# <project_guidance>
+# {{ project_guidance }}
+# </project_guidance>
+# {% endif %}
 # <diffstat>
 # {{ git_diff_stat }}
 # </diffstat>
@@ -244,7 +248,11 @@
 # - Match the style of commits being squashed (conventional commits if used)
 # - Describe the change, not the intent or benefit
 # </style>
-#
+# {% if project_guidance %}
+# <project_guidance>
+# {{ project_guidance }}
+# </project_guidance>
+# {% endif %}
 # <commits branch="{{ branch }}" target="{{ target_branch }}">
 # {% for commit in commits %}- {{ commit }}
 # {% endfor %}</commits>

--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -200,10 +200,10 @@
 # - Match recent commit style (conventional commits if used)
 # - Describe the change, not the intent or benefit
 # </style>
-# {% if project_guidance %}
-# <project_guidance>
-# {{ project_guidance }}
-# </project_guidance>
+# {% if project_template %}
+# <project_template>
+# {{ project_template }}
+# </project_template>
 # {% endif %}
 # <diffstat>
 # {{ git_diff_stat }}
@@ -248,10 +248,10 @@
 # - Match the style of commits being squashed (conventional commits if used)
 # - Describe the change, not the intent or benefit
 # </style>
-# {% if project_guidance %}
-# <project_guidance>
-# {{ project_guidance }}
-# </project_guidance>
+# {% if project_template %}
+# <project_template>
+# {{ project_template }}
+# </project_template>
 # {% endif %}
 # <commits branch="{{ branch }}" target="{{ target_branch }}">
 # {% for commit in commits %}- {{ commit }}

--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -181,6 +181,7 @@
 # - `{{ git_diff }}`, `{{ git_diff_stat }}` — diff content
 # - `{{ branch }}`, `{{ repo }}` — context
 # - `{{ recent_commits }}` — recent commit messages
+# - `{{ user_guidance }}`, `{{ project_guidance }}` — rendered append fragments (see Appending to the prompt (#appending-to-the-prompt))
 #
 # Default template:
 #
@@ -200,10 +201,14 @@
 # - Match recent commit style (conventional commits if used)
 # - Describe the change, not the intent or benefit
 # </style>
-# {% if project_template %}
-# <project_template>
-# {{ project_template }}
-# </project_template>
+# {% if user_guidance %}
+# <user-guidance>
+# {{ user_guidance }}
+# </user-guidance>
+# {% endif %}{% if project_guidance %}
+# <project-guidance>
+# {{ project_guidance }}
+# </project-guidance>
 # {% endif %}
 # <diffstat>
 # {{ git_diff_stat }}
@@ -248,10 +253,14 @@
 # - Match the style of commits being squashed (conventional commits if used)
 # - Describe the change, not the intent or benefit
 # </style>
-# {% if project_template %}
-# <project_template>
-# {{ project_template }}
-# </project_template>
+# {% if user_guidance %}
+# <user-guidance>
+# {{ user_guidance }}
+# </user-guidance>
+# {% endif %}{% if project_guidance %}
+# <project-guidance>
+# {{ project_guidance }}
+# </project-guidance>
 # {% endif %}
 # <commits branch="{{ branch }}" target="{{ target_branch }}">
 # {% for commit in commits %}- {{ commit }}
@@ -267,6 +276,19 @@
 #
 # """
 # <!-- DEFAULT_SQUASH_TEMPLATE_END -->
+#
+# #### Appending to the prompt
+#
+# <span class="badge-experimental"></span>
+#
+# `template-append` adds to the prompt instead of replacing it. The value is rendered as its own minijinja template (same variables) and injected into the default templates' `{{ user_guidance }}` slot — a `<user-guidance>` block right after `<style>`. It applies to both commit and squash. Use it for personal preferences without restating the whole template:
+#
+# [commit.generation]
+# template-append = """
+# - Explain the rationale in the body, not just the change
+# """
+#
+# The project config (https://worktrunk.dev/config/#project-configuration) has a `template-append` of its own; it renders into a separate `<project-guidance>` block right after `<user-guidance>`.
 #
 # ## Hooks
 #

--- a/dev/wt.example.toml
+++ b/dev/wt.example.toml
@@ -27,19 +27,19 @@
 # platform = "github"  # or "gitlab", "gitea" (experimental), "azure-devops" (experimental)
 # hostname = "github.example.com"  # Example: API host (GHE / self-hosted GitLab)
 #
-# ## Commit-message guidance
+# ## Commit-message template
 #
 # <span class="badge-experimental"></span>
 #
-# Project-wide commit-message style notes appended to the LLM prompt inside a `<project_guidance>` block. The first time the guidance changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
+# Project-wide commit-message conventions appended to the LLM prompt inside a `<project_template>` block. Rendered as a minijinja (https://docs.rs/minijinja/) template with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, etc.), so the fragment can reference them directly. The first time the fragment changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
 #
 # [commit.generation]
-# guidance = """
+# template = """
 # - Use conventional commits (feat:, fix:, docs:, …)
 # - Reference the relevant issue ID in the body
 # """
 #
-# Only `guidance` is honored from the project file. The LLM command and the full template stay in user config (https://worktrunk.dev/config/) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
+# Only `template` is honored from the project file. The LLM command and the main prompt template stay in user config (https://worktrunk.dev/config/) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
 #
 # ## Copy-ignored excludes
 #

--- a/dev/wt.example.toml
+++ b/dev/wt.example.toml
@@ -27,9 +27,7 @@
 # platform = "github"  # or "gitlab", "gitea" (experimental), "azure-devops" (experimental)
 # hostname = "github.example.com"  # Example: API host (GHE / self-hosted GitLab)
 #
-# ## Commit-message append
-#
-# <span class="badge-experimental"></span>
+# ## Commit-message append [experimental]
 #
 # Project-wide commit-message conventions appended to the LLM commit and squash prompts inside a `<project-guidance>` block, after the main template's `<style>` section (and after any user `<user-guidance>`). Rendered as a minijinja (https://docs.rs/minijinja/) template with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, etc.), so it can reference them directly. The first time the fragment changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
 #

--- a/dev/wt.example.toml
+++ b/dev/wt.example.toml
@@ -27,6 +27,20 @@
 # platform = "github"  # or "gitlab", "gitea" (experimental), "azure-devops" (experimental)
 # hostname = "github.example.com"  # Example: API host (GHE / self-hosted GitLab)
 #
+# ## Commit-message guidance
+#
+# <span class="badge-experimental"></span>
+#
+# Project-wide commit-message style notes appended to the LLM prompt inside a `<project_guidance>` block. The first time the guidance changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
+#
+# [commit.generation]
+# guidance = """
+# - Use conventional commits (feat:, fix:, docs:, …)
+# - Reference the relevant issue ID in the body
+# """
+#
+# Only `guidance` is honored from the project file. The LLM command and the full template stay in user config (https://worktrunk.dev/config/) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
+#
 # ## Copy-ignored excludes
 #
 # Additional excludes for `wt step copy-ignored`:

--- a/dev/wt.example.toml
+++ b/dev/wt.example.toml
@@ -27,19 +27,19 @@
 # platform = "github"  # or "gitlab", "gitea" (experimental), "azure-devops" (experimental)
 # hostname = "github.example.com"  # Example: API host (GHE / self-hosted GitLab)
 #
-# ## Commit-message template
+# ## Commit-message append
 #
 # <span class="badge-experimental"></span>
 #
-# Project-wide commit-message conventions appended to the LLM prompt inside a `<project_template>` block. Rendered as a minijinja (https://docs.rs/minijinja/) template with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, etc.), so the fragment can reference them directly. The first time the fragment changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
+# Project-wide commit-message conventions appended to the LLM commit and squash prompts inside a `<project-guidance>` block, after the main template's `<style>` section (and after any user `<user-guidance>`). Rendered as a minijinja (https://docs.rs/minijinja/) template with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, etc.), so it can reference them directly. The first time the fragment changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
 #
 # [commit.generation]
-# template = """
+# template-append = """
 # - Use conventional commits (feat:, fix:, docs:, …)
 # - Reference the relevant issue ID in the body
 # """
 #
-# Only `template` is honored from the project file. The LLM command and the main prompt template stay in user config (https://worktrunk.dev/config/) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
+# Only `template-append` is honored from the project file. The LLM command and the main prompt template stay in user config (https://worktrunk.dev/config/) — they describe per-developer environment (which CLI is installed, which agent the developer prefers). User config has a `[commit.generation] template-append` of its own; it renders into a separate `<user-guidance>` block immediately before this one.
 #
 # ## Copy-ignored excludes
 #

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -303,10 +303,10 @@ template = """
 - Match recent commit style (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-{% if project_guidance %}
-<project_guidance>
-{{ project_guidance }}
-</project_guidance>
+{% if project_template %}
+<project_template>
+{{ project_template }}
+</project_template>
 {% endif %}
 <diffstat>
 {{ git_diff_stat }}
@@ -353,10 +353,10 @@ squash-template = """
 - Match the style of commits being squashed (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-{% if project_guidance %}
-<project_guidance>
-{{ project_guidance }}
-</project_guidance>
+{% if project_template %}
+<project_template>
+{{ project_template }}
+</project_template>
 {% endif %}
 <commits branch="{{ branch }}" target="{{ target_branch }}">
 {% for commit in commits %}- {{ commit }}
@@ -414,21 +414,21 @@ platform = "github"  # or "gitlab", "gitea" (experimental), "azure-devops" (expe
 hostname = "github.example.com"  # Example: API host (GHE / self-hosted GitLab)
 ```
 
-## Commit-message guidance
+## Commit-message template
 
 <span class="badge-experimental"></span>
 
-Project-wide commit-message style notes appended to the LLM prompt inside a `<project_guidance>` block. The first time the guidance changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
+Project-wide commit-message conventions appended to the LLM prompt inside a `<project_template>` block. Rendered as a [minijinja](https://docs.rs/minijinja/) template with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, etc.), so the fragment can reference them directly. The first time the fragment changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
 
 ```toml
 [commit.generation]
-guidance = """
+template = """
 - Use conventional commits (feat:, fix:, docs:, …)
 - Reference the relevant issue ID in the body
 """
 ```
 
-Only `guidance` is honored from the project file. The LLM command and the full template stay in [user config](@/config.md) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
+Only `template` is honored from the project file. The LLM command and the main prompt template stay in [user config](@/config.md) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
 
 ## Copy-ignored excludes
 

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -283,7 +283,7 @@ Available variables:
 - `{{ git_diff }}`, `{{ git_diff_stat }}` — diff content
 - `{{ branch }}`, `{{ repo }}` — context
 - `{{ recent_commits }}` — recent commit messages
-- `{{ user_guidance }}`, `{{ project_guidance }}` — rendered append fragments (see [Appending to the prompt](#appending-to-the-prompt))
+- `{{ user_guidance }}`, `{{ project_guidance }}` — rendered append fragments (see [Appending to the prompt](@/config.md#appending-to-the-prompt))
 
 Default template:
 

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -283,6 +283,7 @@ Available variables:
 - `{{ git_diff }}`, `{{ git_diff_stat }}` — diff content
 - `{{ branch }}`, `{{ repo }}` — context
 - `{{ recent_commits }}` — recent commit messages
+- `{{ user_guidance }}`, `{{ project_guidance }}` — rendered append fragments (see [Appending to the prompt](#appending-to-the-prompt))
 
 Default template:
 
@@ -303,10 +304,14 @@ template = """
 - Match recent commit style (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-{% if project_template %}
-<project_template>
-{{ project_template }}
-</project_template>
+{% if user_guidance %}
+<user-guidance>
+{{ user_guidance }}
+</user-guidance>
+{% endif %}{% if project_guidance %}
+<project-guidance>
+{{ project_guidance }}
+</project-guidance>
 {% endif %}
 <diffstat>
 {{ git_diff_stat }}
@@ -353,10 +358,14 @@ squash-template = """
 - Match the style of commits being squashed (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-{% if project_template %}
-<project_template>
-{{ project_template }}
-</project_template>
+{% if user_guidance %}
+<user-guidance>
+{{ user_guidance }}
+</user-guidance>
+{% endif %}{% if project_guidance %}
+<project-guidance>
+{{ project_guidance }}
+</project-guidance>
 {% endif %}
 <commits branch="{{ branch }}" target="{{ target_branch }}">
 {% for commit in commits %}- {{ commit }}
@@ -373,6 +382,21 @@ squash-template = """
 """
 ```
 <!-- DEFAULT_SQUASH_TEMPLATE_END -->
+
+#### Appending to the prompt
+
+<span class="badge-experimental"></span>
+
+`template-append` adds to the prompt instead of replacing it. The value is rendered as its own minijinja template (same variables) and injected into the default templates' `{{ user_guidance }}` slot — a `<user-guidance>` block right after `<style>`. It applies to both commit and squash. Use it for personal preferences without restating the whole template:
+
+```toml
+[commit.generation]
+template-append = """
+- Explain the rationale in the body, not just the change
+"""
+```
+
+The [project config](@/config.md#project-configuration) has a `template-append` of its own; it renders into a separate `<project-guidance>` block right after `<user-guidance>`.
 
 ## Hooks
 
@@ -414,21 +438,21 @@ platform = "github"  # or "gitlab", "gitea" (experimental), "azure-devops" (expe
 hostname = "github.example.com"  # Example: API host (GHE / self-hosted GitLab)
 ```
 
-## Commit-message template
+## Commit-message append
 
 <span class="badge-experimental"></span>
 
-Project-wide commit-message conventions appended to the LLM prompt inside a `<project_template>` block. Rendered as a [minijinja](https://docs.rs/minijinja/) template with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, etc.), so the fragment can reference them directly. The first time the fragment changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
+Project-wide commit-message conventions appended to the LLM commit and squash prompts inside a `<project-guidance>` block, after the main template's `<style>` section (and after any user `<user-guidance>`). Rendered as a [minijinja](https://docs.rs/minijinja/) template with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, etc.), so it can reference them directly. The first time the fragment changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
 
 ```toml
 [commit.generation]
-template = """
+template-append = """
 - Use conventional commits (feat:, fix:, docs:, …)
 - Reference the relevant issue ID in the body
 """
 ```
 
-Only `template` is honored from the project file. The LLM command and the main prompt template stay in [user config](@/config.md) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
+Only `template-append` is honored from the project file. The LLM command and the main prompt template stay in [user config](@/config.md) — they describe per-developer environment (which CLI is installed, which agent the developer prefers). User config has a `[commit.generation] template-append` of its own; it renders into a separate `<user-guidance>` block immediately before this one.
 
 ## Copy-ignored excludes
 

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -303,7 +303,11 @@ template = """
 - Match recent commit style (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-
+{% if project_guidance %}
+<project_guidance>
+{{ project_guidance }}
+</project_guidance>
+{% endif %}
 <diffstat>
 {{ git_diff_stat }}
 </diffstat>
@@ -349,7 +353,11 @@ squash-template = """
 - Match the style of commits being squashed (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-
+{% if project_guidance %}
+<project_guidance>
+{{ project_guidance }}
+</project_guidance>
+{% endif %}
 <commits branch="{{ branch }}" target="{{ target_branch }}">
 {% for commit in commits %}- {{ commit }}
 {% endfor %}</commits>
@@ -405,6 +413,22 @@ Name the forge explicitly for SSH aliases or self-hosted instances, where it can
 platform = "github"  # or "gitlab", "gitea" (experimental), "azure-devops" (experimental)
 hostname = "github.example.com"  # Example: API host (GHE / self-hosted GitLab)
 ```
+
+## Commit-message guidance
+
+<span class="badge-experimental"></span>
+
+Project-wide commit-message style notes appended to the LLM prompt inside a `<project_guidance>` block. The first time the guidance changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
+
+```toml
+[commit.generation]
+guidance = """
+- Use conventional commits (feat:, fix:, docs:, …)
+- Reference the relevant issue ID in the body
+"""
+```
+
+Only `guidance` is honored from the project file. The LLM command and the full template stay in [user config](@/config.md) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
 
 ## Copy-ignored excludes
 

--- a/docs/content/llm-commits.md
+++ b/docs/content/llm-commits.md
@@ -187,7 +187,8 @@ Diff:
 | `{{ recent_commits }}` | Recent commit subjects (for style reference) |
 | `{{ commits }}` | Commits being squashed (squash template only) |
 | `{{ target_branch }}` | Merge target branch (squash template only) |
-| `{{ project_template }}` | Project-level template fragment from `.config/wt.toml`, pre-rendered (see below) |
+| `{{ user_guidance }}` | Rendered user `template-append` fragment (see below) |
+| `{{ project_guidance }}` | Rendered project `template-append` fragment (see below) |
 
 ### Template syntax
 
@@ -202,24 +203,26 @@ Templates use [minijinja](https://docs.rs/minijinja/latest/minijinja/syntax/inde
 
 See `wt config create --help` for the full default templates.
 
-## Project commit template
+## Appending to the prompt
 
 <span class="badge-experimental"></span>
 
-Project-level commit-message conventions can be checked into the repo so every teammate's LLM sees the same style guide. The fragment is itself a [minijinja](https://docs.rs/minijinja/) template — Worktrunk renders it with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, …), then appends the result inside a `<project_template>` block:
+`template-append` adds to the commit and squash prompts instead of replacing them. It lives in both user config (personal preferences) and project config (`.config/wt.toml`, shared so every teammate's LLM sees the same style guide). Each fragment is itself a [minijinja](https://docs.rs/minijinja/) template — Worktrunk renders it with the same variables as the main template (`{{ branch }}`, `{{ git_diff }}`, …), then appends the result after `<style>`. The user fragment renders into a `<user-guidance>` block and the project fragment into a `<project-guidance>` block, so the LLM can tell personal preference from shared convention:
 
 ```toml
 # .config/wt.toml
 [commit.generation]
-template = """
+template-append = """
 - Use conventional commits (feat:, fix:, docs:, …)
 - Reference the related issue ID in the body
 """
 ```
 
-The first time the rendered text is sent to the LLM, Worktrunk shows the raw fragment in an approval prompt — the same one-shot gate as project-defined hooks. Subsequent commits don't re-prompt unless the fragment changes. Declining is non-fatal: the LLM runs without the project template.
+When both the user and project set `template-append`, the `<user-guidance>` block comes first, then `<project-guidance>`.
 
-Custom user templates that don't reference `{{ project_template }}` opt out of the appended block — the pre-rendered value is injected only where the template places it.
+The user fragment needs no approval — it's the developer's own config. For the project fragment, the first time the rendered text is sent to the LLM, Worktrunk shows the raw fragment in an approval prompt — the same one-shot gate as project-defined hooks. Subsequent commits don't re-prompt unless the fragment changes. Declining is non-fatal: the LLM runs with just the user fragment (if any).
+
+Custom user templates that don't reference `{{ user_guidance }}` / `{{ project_guidance }}` opt out of the appended blocks — the rendered values are injected only where the template places them.
 
 ## Fallback behavior
 

--- a/docs/content/llm-commits.md
+++ b/docs/content/llm-commits.md
@@ -187,6 +187,7 @@ Diff:
 | `{{ recent_commits }}` | Recent commit subjects (for style reference) |
 | `{{ commits }}` | Commits being squashed (squash template only) |
 | `{{ target_branch }}` | Merge target branch (squash template only) |
+| `{{ project_guidance }}` | Project-level guidance from `.config/wt.toml` (see below) |
 
 ### Template syntax
 
@@ -200,6 +201,25 @@ Templates use [minijinja](https://docs.rs/minijinja/latest/minijinja/syntax/inde
 - **Whitespace control**: `{%- ... -%}` strips surrounding whitespace
 
 See `wt config create --help` for the full default templates.
+
+## Project commit guidance
+
+<span class="badge-experimental"></span>
+
+Project-level commit-message conventions can be checked into the repo so every teammate's LLM sees the same style guide. The text is appended to the prompt inside a `<project_guidance>` block:
+
+```toml
+# .config/wt.toml
+[commit.generation]
+guidance = """
+- Use conventional commits (feat:, fix:, docs:, …)
+- Reference the related issue ID in the body
+"""
+```
+
+The first time the guidance is sent to the LLM, Worktrunk shows the text in an approval prompt — the same one-shot gate as project-defined hooks. Subsequent commits don't re-prompt unless the guidance changes. Declining is non-fatal: the LLM runs without the project guidance.
+
+Custom templates that don't reference `{{ project_guidance }}` opt out of the appended block — the variable is rendered only where the template places it.
 
 ## Fallback behavior
 

--- a/docs/content/llm-commits.md
+++ b/docs/content/llm-commits.md
@@ -187,7 +187,7 @@ Diff:
 | `{{ recent_commits }}` | Recent commit subjects (for style reference) |
 | `{{ commits }}` | Commits being squashed (squash template only) |
 | `{{ target_branch }}` | Merge target branch (squash template only) |
-| `{{ project_guidance }}` | Project-level guidance from `.config/wt.toml` (see below) |
+| `{{ project_template }}` | Project-level template fragment from `.config/wt.toml`, pre-rendered (see below) |
 
 ### Template syntax
 
@@ -202,24 +202,24 @@ Templates use [minijinja](https://docs.rs/minijinja/latest/minijinja/syntax/inde
 
 See `wt config create --help` for the full default templates.
 
-## Project commit guidance
+## Project commit template
 
 <span class="badge-experimental"></span>
 
-Project-level commit-message conventions can be checked into the repo so every teammate's LLM sees the same style guide. The text is appended to the prompt inside a `<project_guidance>` block:
+Project-level commit-message conventions can be checked into the repo so every teammate's LLM sees the same style guide. The fragment is itself a [minijinja](https://docs.rs/minijinja/) template — Worktrunk renders it with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, …), then appends the result inside a `<project_template>` block:
 
 ```toml
 # .config/wt.toml
 [commit.generation]
-guidance = """
+template = """
 - Use conventional commits (feat:, fix:, docs:, …)
 - Reference the related issue ID in the body
 """
 ```
 
-The first time the guidance is sent to the LLM, Worktrunk shows the text in an approval prompt — the same one-shot gate as project-defined hooks. Subsequent commits don't re-prompt unless the guidance changes. Declining is non-fatal: the LLM runs without the project guidance.
+The first time the rendered text is sent to the LLM, Worktrunk shows the raw fragment in an approval prompt — the same one-shot gate as project-defined hooks. Subsequent commits don't re-prompt unless the fragment changes. Declining is non-fatal: the LLM runs without the project template.
 
-Custom templates that don't reference `{{ project_guidance }}` opt out of the appended block — the variable is rendered only where the template places it.
+Custom user templates that don't reference `{{ project_template }}` opt out of the appended block — the pre-rendered value is injected only where the template places it.
 
 ## Fallback behavior
 

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -282,7 +282,7 @@ Available variables:
 - `{{ git_diff }}`, `{{ git_diff_stat }}` — diff content
 - `{{ branch }}`, `{{ repo }}` — context
 - `{{ recent_commits }}` — recent commit messages
-- `{{ user_guidance }}`, `{{ project_guidance }}` — rendered append fragments (see [Appending to the prompt](#appending-to-the-prompt))
+- `{{ user_guidance }}`, `{{ project_guidance }}` — rendered append fragments (see [Appending to the prompt](https://worktrunk.dev/config/#appending-to-the-prompt))
 
 Default template:
 

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -282,6 +282,7 @@ Available variables:
 - `{{ git_diff }}`, `{{ git_diff_stat }}` — diff content
 - `{{ branch }}`, `{{ repo }}` — context
 - `{{ recent_commits }}` — recent commit messages
+- `{{ user_guidance }}`, `{{ project_guidance }}` — rendered append fragments (see [Appending to the prompt](#appending-to-the-prompt))
 
 Default template:
 
@@ -302,10 +303,14 @@ template = """
 - Match recent commit style (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-{% if project_template %}
-<project_template>
-{{ project_template }}
-</project_template>
+{% if user_guidance %}
+<user-guidance>
+{{ user_guidance }}
+</user-guidance>
+{% endif %}{% if project_guidance %}
+<project-guidance>
+{{ project_guidance }}
+</project-guidance>
 {% endif %}
 <diffstat>
 {{ git_diff_stat }}
@@ -352,10 +357,14 @@ squash-template = """
 - Match the style of commits being squashed (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-{% if project_template %}
-<project_template>
-{{ project_template }}
-</project_template>
+{% if user_guidance %}
+<user-guidance>
+{{ user_guidance }}
+</user-guidance>
+{% endif %}{% if project_guidance %}
+<project-guidance>
+{{ project_guidance }}
+</project-guidance>
 {% endif %}
 <commits branch="{{ branch }}" target="{{ target_branch }}">
 {% for commit in commits %}- {{ commit }}
@@ -372,6 +381,21 @@ squash-template = """
 """
 ```
 <!-- DEFAULT_SQUASH_TEMPLATE_END -->
+
+#### Appending to the prompt
+
+<span class="badge-experimental"></span>
+
+`template-append` adds to the prompt instead of replacing it. The value is rendered as its own minijinja template (same variables) and injected into the default templates' `{{ user_guidance }}` slot — a `<user-guidance>` block right after `<style>`. It applies to both commit and squash. Use it for personal preferences without restating the whole template:
+
+```toml
+[commit.generation]
+template-append = """
+- Explain the rationale in the body, not just the change
+"""
+```
+
+The [project config](https://worktrunk.dev/config/#project-configuration) has a `template-append` of its own; it renders into a separate `<project-guidance>` block right after `<user-guidance>`.
 
 ## Hooks
 
@@ -413,21 +437,21 @@ platform = "github"  # or "gitlab", "gitea" (experimental), "azure-devops" (expe
 hostname = "github.example.com"  # Example: API host (GHE / self-hosted GitLab)
 ```
 
-## Commit-message template
+## Commit-message append
 
 <span class="badge-experimental"></span>
 
-Project-wide commit-message conventions appended to the LLM prompt inside a `<project_template>` block. Rendered as a [minijinja](https://docs.rs/minijinja/) template with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, etc.), so the fragment can reference them directly. The first time the fragment changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
+Project-wide commit-message conventions appended to the LLM commit and squash prompts inside a `<project-guidance>` block, after the main template's `<style>` section (and after any user `<user-guidance>`). Rendered as a [minijinja](https://docs.rs/minijinja/) template with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, etc.), so it can reference them directly. The first time the fragment changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
 
 ```toml
 [commit.generation]
-template = """
+template-append = """
 - Use conventional commits (feat:, fix:, docs:, …)
 - Reference the relevant issue ID in the body
 """
 ```
 
-Only `template` is honored from the project file. The LLM command and the main prompt template stay in [user config](https://worktrunk.dev/config/) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
+Only `template-append` is honored from the project file. The LLM command and the main prompt template stay in [user config](https://worktrunk.dev/config/) — they describe per-developer environment (which CLI is installed, which agent the developer prefers). User config has a `[commit.generation] template-append` of its own; it renders into a separate `<user-guidance>` block immediately before this one.
 
 ## Copy-ignored excludes
 

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -302,10 +302,10 @@ template = """
 - Match recent commit style (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-{% if project_guidance %}
-<project_guidance>
-{{ project_guidance }}
-</project_guidance>
+{% if project_template %}
+<project_template>
+{{ project_template }}
+</project_template>
 {% endif %}
 <diffstat>
 {{ git_diff_stat }}
@@ -352,10 +352,10 @@ squash-template = """
 - Match the style of commits being squashed (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-{% if project_guidance %}
-<project_guidance>
-{{ project_guidance }}
-</project_guidance>
+{% if project_template %}
+<project_template>
+{{ project_template }}
+</project_template>
 {% endif %}
 <commits branch="{{ branch }}" target="{{ target_branch }}">
 {% for commit in commits %}- {{ commit }}
@@ -413,21 +413,21 @@ platform = "github"  # or "gitlab", "gitea" (experimental), "azure-devops" (expe
 hostname = "github.example.com"  # Example: API host (GHE / self-hosted GitLab)
 ```
 
-## Commit-message guidance
+## Commit-message template
 
 <span class="badge-experimental"></span>
 
-Project-wide commit-message style notes appended to the LLM prompt inside a `<project_guidance>` block. The first time the guidance changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
+Project-wide commit-message conventions appended to the LLM prompt inside a `<project_template>` block. Rendered as a [minijinja](https://docs.rs/minijinja/) template with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, etc.), so the fragment can reference them directly. The first time the fragment changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
 
 ```toml
 [commit.generation]
-guidance = """
+template = """
 - Use conventional commits (feat:, fix:, docs:, …)
 - Reference the relevant issue ID in the body
 """
 ```
 
-Only `guidance` is honored from the project file. The LLM command and the full template stay in [user config](https://worktrunk.dev/config/) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
+Only `template` is honored from the project file. The LLM command and the main prompt template stay in [user config](https://worktrunk.dev/config/) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
 
 ## Copy-ignored excludes
 

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -382,9 +382,7 @@ squash-template = """
 ```
 <!-- DEFAULT_SQUASH_TEMPLATE_END -->
 
-#### Appending to the prompt
-
-<span class="badge-experimental"></span>
+#### Appending to the prompt [experimental]
 
 `template-append` adds to the prompt instead of replacing it. The value is rendered as its own minijinja template (same variables) and injected into the default templates' `{{ user_guidance }}` slot — a `<user-guidance>` block right after `<style>`. It applies to both commit and squash. Use it for personal preferences without restating the whole template:
 
@@ -437,9 +435,7 @@ platform = "github"  # or "gitlab", "gitea" (experimental), "azure-devops" (expe
 hostname = "github.example.com"  # Example: API host (GHE / self-hosted GitLab)
 ```
 
-## Commit-message append
-
-<span class="badge-experimental"></span>
+## Commit-message append [experimental]
 
 Project-wide commit-message conventions appended to the LLM commit and squash prompts inside a `<project-guidance>` block, after the main template's `<style>` section (and after any user `<user-guidance>`). Rendered as a [minijinja](https://docs.rs/minijinja/) template with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, etc.), so it can reference them directly. The first time the fragment changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
 

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -302,7 +302,11 @@ template = """
 - Match recent commit style (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-
+{% if project_guidance %}
+<project_guidance>
+{{ project_guidance }}
+</project_guidance>
+{% endif %}
 <diffstat>
 {{ git_diff_stat }}
 </diffstat>
@@ -348,7 +352,11 @@ squash-template = """
 - Match the style of commits being squashed (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-
+{% if project_guidance %}
+<project_guidance>
+{{ project_guidance }}
+</project_guidance>
+{% endif %}
 <commits branch="{{ branch }}" target="{{ target_branch }}">
 {% for commit in commits %}- {{ commit }}
 {% endfor %}</commits>
@@ -404,6 +412,22 @@ Name the forge explicitly for SSH aliases or self-hosted instances, where it can
 platform = "github"  # or "gitlab", "gitea" (experimental), "azure-devops" (experimental)
 hostname = "github.example.com"  # Example: API host (GHE / self-hosted GitLab)
 ```
+
+## Commit-message guidance
+
+<span class="badge-experimental"></span>
+
+Project-wide commit-message style notes appended to the LLM prompt inside a `<project_guidance>` block. The first time the guidance changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
+
+```toml
+[commit.generation]
+guidance = """
+- Use conventional commits (feat:, fix:, docs:, …)
+- Reference the relevant issue ID in the body
+"""
+```
+
+Only `guidance` is honored from the project file. The LLM command and the full template stay in [user config](https://worktrunk.dev/config/) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
 
 ## Copy-ignored excludes
 

--- a/skills/worktrunk/reference/llm-commits.md
+++ b/skills/worktrunk/reference/llm-commits.md
@@ -161,7 +161,7 @@ Diff:
 | `{{ recent_commits }}` | Recent commit subjects (for style reference) |
 | `{{ commits }}` | Commits being squashed (squash template only) |
 | `{{ target_branch }}` | Merge target branch (squash template only) |
-| `{{ project_guidance }}` | Project-level guidance from `.config/wt.toml` (see below) |
+| `{{ project_template }}` | Project-level template fragment from `.config/wt.toml`, pre-rendered (see below) |
 
 ### Template syntax
 
@@ -176,24 +176,24 @@ Templates use [minijinja](https://docs.rs/minijinja/latest/minijinja/syntax/inde
 
 See `wt config create --help` for the full default templates.
 
-## Project commit guidance
+## Project commit template
 
 [experimental]
 
-Project-level commit-message conventions can be checked into the repo so every teammate's LLM sees the same style guide. The text is appended to the prompt inside a `<project_guidance>` block:
+Project-level commit-message conventions can be checked into the repo so every teammate's LLM sees the same style guide. The fragment is itself a [minijinja](https://docs.rs/minijinja/) template — Worktrunk renders it with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, …), then appends the result inside a `<project_template>` block:
 
 ```toml
 # .config/wt.toml
 [commit.generation]
-guidance = """
+template = """
 - Use conventional commits (feat:, fix:, docs:, …)
 - Reference the related issue ID in the body
 """
 ```
 
-The first time the guidance is sent to the LLM, Worktrunk shows the text in an approval prompt — the same one-shot gate as project-defined hooks. Subsequent commits don't re-prompt unless the guidance changes. Declining is non-fatal: the LLM runs without the project guidance.
+The first time the rendered text is sent to the LLM, Worktrunk shows the raw fragment in an approval prompt — the same one-shot gate as project-defined hooks. Subsequent commits don't re-prompt unless the fragment changes. Declining is non-fatal: the LLM runs without the project template.
 
-Custom templates that don't reference `{{ project_guidance }}` opt out of the appended block — the variable is rendered only where the template places it.
+Custom user templates that don't reference `{{ project_template }}` opt out of the appended block — the pre-rendered value is injected only where the template places it.
 
 ## Fallback behavior
 

--- a/skills/worktrunk/reference/llm-commits.md
+++ b/skills/worktrunk/reference/llm-commits.md
@@ -161,7 +161,8 @@ Diff:
 | `{{ recent_commits }}` | Recent commit subjects (for style reference) |
 | `{{ commits }}` | Commits being squashed (squash template only) |
 | `{{ target_branch }}` | Merge target branch (squash template only) |
-| `{{ project_template }}` | Project-level template fragment from `.config/wt.toml`, pre-rendered (see below) |
+| `{{ user_guidance }}` | Rendered user `template-append` fragment (see below) |
+| `{{ project_guidance }}` | Rendered project `template-append` fragment (see below) |
 
 ### Template syntax
 
@@ -176,24 +177,26 @@ Templates use [minijinja](https://docs.rs/minijinja/latest/minijinja/syntax/inde
 
 See `wt config create --help` for the full default templates.
 
-## Project commit template
+## Appending to the prompt
 
 [experimental]
 
-Project-level commit-message conventions can be checked into the repo so every teammate's LLM sees the same style guide. The fragment is itself a [minijinja](https://docs.rs/minijinja/) template — Worktrunk renders it with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, …), then appends the result inside a `<project_template>` block:
+`template-append` adds to the commit and squash prompts instead of replacing them. It lives in both user config (personal preferences) and project config (`.config/wt.toml`, shared so every teammate's LLM sees the same style guide). Each fragment is itself a [minijinja](https://docs.rs/minijinja/) template — Worktrunk renders it with the same variables as the main template (`{{ branch }}`, `{{ git_diff }}`, …), then appends the result after `<style>`. The user fragment renders into a `<user-guidance>` block and the project fragment into a `<project-guidance>` block, so the LLM can tell personal preference from shared convention:
 
 ```toml
 # .config/wt.toml
 [commit.generation]
-template = """
+template-append = """
 - Use conventional commits (feat:, fix:, docs:, …)
 - Reference the related issue ID in the body
 """
 ```
 
-The first time the rendered text is sent to the LLM, Worktrunk shows the raw fragment in an approval prompt — the same one-shot gate as project-defined hooks. Subsequent commits don't re-prompt unless the fragment changes. Declining is non-fatal: the LLM runs without the project template.
+When both the user and project set `template-append`, the `<user-guidance>` block comes first, then `<project-guidance>`.
 
-Custom user templates that don't reference `{{ project_template }}` opt out of the appended block — the pre-rendered value is injected only where the template places it.
+The user fragment needs no approval — it's the developer's own config. For the project fragment, the first time the rendered text is sent to the LLM, Worktrunk shows the raw fragment in an approval prompt — the same one-shot gate as project-defined hooks. Subsequent commits don't re-prompt unless the fragment changes. Declining is non-fatal: the LLM runs with just the user fragment (if any).
+
+Custom user templates that don't reference `{{ user_guidance }}` / `{{ project_guidance }}` opt out of the appended blocks — the rendered values are injected only where the template places them.
 
 ## Fallback behavior
 

--- a/skills/worktrunk/reference/llm-commits.md
+++ b/skills/worktrunk/reference/llm-commits.md
@@ -161,6 +161,7 @@ Diff:
 | `{{ recent_commits }}` | Recent commit subjects (for style reference) |
 | `{{ commits }}` | Commits being squashed (squash template only) |
 | `{{ target_branch }}` | Merge target branch (squash template only) |
+| `{{ project_guidance }}` | Project-level guidance from `.config/wt.toml` (see below) |
 
 ### Template syntax
 
@@ -174,6 +175,25 @@ Templates use [minijinja](https://docs.rs/minijinja/latest/minijinja/syntax/inde
 - **Whitespace control**: `{%- ... -%}` strips surrounding whitespace
 
 See `wt config create --help` for the full default templates.
+
+## Project commit guidance
+
+[experimental]
+
+Project-level commit-message conventions can be checked into the repo so every teammate's LLM sees the same style guide. The text is appended to the prompt inside a `<project_guidance>` block:
+
+```toml
+# .config/wt.toml
+[commit.generation]
+guidance = """
+- Use conventional commits (feat:, fix:, docs:, …)
+- Reference the related issue ID in the body
+"""
+```
+
+The first time the guidance is sent to the LLM, Worktrunk shows the text in an approval prompt — the same one-shot gate as project-defined hooks. Subsequent commits don't re-prompt unless the guidance changes. Declining is non-fatal: the LLM runs without the project guidance.
+
+Custom templates that don't reference `{{ project_guidance }}` opt out of the appended block — the variable is rendered only where the template places it.
 
 ## Fallback behavior
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1819,6 +1819,7 @@ Available variables:
 - `{{ git_diff }}`, `{{ git_diff_stat }}` — diff content
 - `{{ branch }}`, `{{ repo }}` — context
 - `{{ recent_commits }}` — recent commit messages
+- `{{ user_guidance }}`, `{{ project_guidance }}` — rendered append fragments (see [Appending to the prompt](#appending-to-the-prompt))
 
 Default template:
 
@@ -1839,10 +1840,14 @@ template = """
 - Match recent commit style (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-{% if project_template %}
-<project_template>
-{{ project_template }}
-</project_template>
+{% if user_guidance %}
+<user-guidance>
+{{ user_guidance }}
+</user-guidance>
+{% endif %}{% if project_guidance %}
+<project-guidance>
+{{ project_guidance }}
+</project-guidance>
 {% endif %}
 <diffstat>
 {{ git_diff_stat }}
@@ -1889,10 +1894,14 @@ squash-template = """
 - Match the style of commits being squashed (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-{% if project_template %}
-<project_template>
-{{ project_template }}
-</project_template>
+{% if user_guidance %}
+<user-guidance>
+{{ user_guidance }}
+</user-guidance>
+{% endif %}{% if project_guidance %}
+<project-guidance>
+{{ project_guidance }}
+</project-guidance>
 {% endif %}
 <commits branch="{{ branch }}" target="{{ target_branch }}">
 {% for commit in commits %}- {{ commit }}
@@ -1909,6 +1918,21 @@ squash-template = """
 """
 ```
 <!-- DEFAULT_SQUASH_TEMPLATE_END -->
+
+#### Appending to the prompt
+
+<span class="badge-experimental"></span>
+
+`template-append` adds to the prompt instead of replacing it. The value is rendered as its own minijinja template (same variables) and injected into the default templates' `{{ user_guidance }}` slot — a `<user-guidance>` block right after `<style>`. It applies to both commit and squash. Use it for personal preferences without restating the whole template:
+
+```toml
+[commit.generation]
+template-append = """
+- Explain the rationale in the body, not just the change
+"""
+```
+
+The [project config](@/config.md#project-configuration) has a `template-append` of its own; it renders into a separate `<project-guidance>` block right after `<user-guidance>`.
 
 ## Hooks
 
@@ -1950,21 +1974,21 @@ platform = "github"  # or "gitlab", "gitea" (experimental), "azure-devops" (expe
 hostname = "github.example.com"  # Example: API host (GHE / self-hosted GitLab)
 ```
 
-## Commit-message template
+## Commit-message append
 
 <span class="badge-experimental"></span>
 
-Project-wide commit-message conventions appended to the LLM prompt inside a `<project_template>` block. Rendered as a [minijinja](https://docs.rs/minijinja/) template with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, etc.), so the fragment can reference them directly. The first time the fragment changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
+Project-wide commit-message conventions appended to the LLM commit and squash prompts inside a `<project-guidance>` block, after the main template's `<style>` section (and after any user `<user-guidance>`). Rendered as a [minijinja](https://docs.rs/minijinja/) template with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, etc.), so it can reference them directly. The first time the fragment changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
 
 ```toml
 [commit.generation]
-template = """
+template-append = """
 - Use conventional commits (feat:, fix:, docs:, …)
 - Reference the relevant issue ID in the body
 """
 ```
 
-Only `template` is honored from the project file. The LLM command and the main prompt template stay in [user config](@/config.md) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
+Only `template-append` is honored from the project file. The LLM command and the main prompt template stay in [user config](@/config.md) — they describe per-developer environment (which CLI is installed, which agent the developer prefers). User config has a `[commit.generation] template-append` of its own; it renders into a separate `<user-guidance>` block immediately before this one.
 
 ## Copy-ignored excludes
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1919,9 +1919,7 @@ squash-template = """
 ```
 <!-- DEFAULT_SQUASH_TEMPLATE_END -->
 
-#### Appending to the prompt
-
-<span class="badge-experimental"></span>
+#### Appending to the prompt [experimental]
 
 `template-append` adds to the prompt instead of replacing it. The value is rendered as its own minijinja template (same variables) and injected into the default templates' `{{ user_guidance }}` slot — a `<user-guidance>` block right after `<style>`. It applies to both commit and squash. Use it for personal preferences without restating the whole template:
 
@@ -1974,9 +1972,7 @@ platform = "github"  # or "gitlab", "gitea" (experimental), "azure-devops" (expe
 hostname = "github.example.com"  # Example: API host (GHE / self-hosted GitLab)
 ```
 
-## Commit-message append
-
-<span class="badge-experimental"></span>
+## Commit-message append [experimental]
 
 Project-wide commit-message conventions appended to the LLM commit and squash prompts inside a `<project-guidance>` block, after the main template's `<style>` section (and after any user `<user-guidance>`). Rendered as a [minijinja](https://docs.rs/minijinja/) template with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, etc.), so it can reference them directly. The first time the fragment changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1819,7 +1819,7 @@ Available variables:
 - `{{ git_diff }}`, `{{ git_diff_stat }}` — diff content
 - `{{ branch }}`, `{{ repo }}` — context
 - `{{ recent_commits }}` — recent commit messages
-- `{{ user_guidance }}`, `{{ project_guidance }}` — rendered append fragments (see [Appending to the prompt](#appending-to-the-prompt))
+- `{{ user_guidance }}`, `{{ project_guidance }}` — rendered append fragments (see [Appending to the prompt](@/config.md#appending-to-the-prompt))
 
 Default template:
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1839,7 +1839,11 @@ template = """
 - Match recent commit style (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-
+{% if project_guidance %}
+<project_guidance>
+{{ project_guidance }}
+</project_guidance>
+{% endif %}
 <diffstat>
 {{ git_diff_stat }}
 </diffstat>
@@ -1885,7 +1889,11 @@ squash-template = """
 - Match the style of commits being squashed (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-
+{% if project_guidance %}
+<project_guidance>
+{{ project_guidance }}
+</project_guidance>
+{% endif %}
 <commits branch="{{ branch }}" target="{{ target_branch }}">
 {% for commit in commits %}- {{ commit }}
 {% endfor %}</commits>
@@ -1941,6 +1949,22 @@ Name the forge explicitly for SSH aliases or self-hosted instances, where it can
 platform = "github"  # or "gitlab", "gitea" (experimental), "azure-devops" (experimental)
 hostname = "github.example.com"  # Example: API host (GHE / self-hosted GitLab)
 ```
+
+## Commit-message guidance
+
+<span class="badge-experimental"></span>
+
+Project-wide commit-message style notes appended to the LLM prompt inside a `<project_guidance>` block. The first time the guidance changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
+
+```toml
+[commit.generation]
+guidance = """
+- Use conventional commits (feat:, fix:, docs:, …)
+- Reference the relevant issue ID in the body
+"""
+```
+
+Only `guidance` is honored from the project file. The LLM command and the full template stay in [user config](@/config.md) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
 
 ## Copy-ignored excludes
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1839,10 +1839,10 @@ template = """
 - Match recent commit style (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-{% if project_guidance %}
-<project_guidance>
-{{ project_guidance }}
-</project_guidance>
+{% if project_template %}
+<project_template>
+{{ project_template }}
+</project_template>
 {% endif %}
 <diffstat>
 {{ git_diff_stat }}
@@ -1889,10 +1889,10 @@ squash-template = """
 - Match the style of commits being squashed (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-{% if project_guidance %}
-<project_guidance>
-{{ project_guidance }}
-</project_guidance>
+{% if project_template %}
+<project_template>
+{{ project_template }}
+</project_template>
 {% endif %}
 <commits branch="{{ branch }}" target="{{ target_branch }}">
 {% for commit in commits %}- {{ commit }}
@@ -1950,21 +1950,21 @@ platform = "github"  # or "gitlab", "gitea" (experimental), "azure-devops" (expe
 hostname = "github.example.com"  # Example: API host (GHE / self-hosted GitLab)
 ```
 
-## Commit-message guidance
+## Commit-message template
 
 <span class="badge-experimental"></span>
 
-Project-wide commit-message style notes appended to the LLM prompt inside a `<project_guidance>` block. The first time the guidance changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
+Project-wide commit-message conventions appended to the LLM prompt inside a `<project_template>` block. Rendered as a [minijinja](https://docs.rs/minijinja/) template with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, etc.), so the fragment can reference them directly. The first time the fragment changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.
 
 ```toml
 [commit.generation]
-guidance = """
+template = """
 - Use conventional commits (feat:, fix:, docs:, …)
 - Reference the relevant issue ID in the body
 """
 ```
 
-Only `guidance` is honored from the project file. The LLM command and the full template stay in [user config](@/config.md) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
+Only `template` is honored from the project file. The LLM command and the main prompt template stay in [user config](@/config.md) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
 
 ## Copy-ignored excludes
 

--- a/src/commands/command_approval.rs
+++ b/src/commands/command_approval.rs
@@ -123,7 +123,7 @@ fn prompt_for_batch_approval(
         // Shell commands get bash syntax highlighting; commit guidance is plain
         // text (markdown-ish) and shouldn't be tokenized as bash.
         let body = match cmd.phase {
-            Phase::CommitGuidance => format_with_gutter(&cmd.command.template, None),
+            Phase::CommitTemplate => format_with_gutter(&cmd.command.template, None),
             _ => format_bash_with_gutter(&cmd.command.template),
         };
         eprintln!("{}", body);
@@ -288,19 +288,19 @@ pub fn approve_or_skip(
 /// `--show-prompt` doesn't invoke the LLM, so it always renders the configured
 /// guidance verbatim. `--dry-run` does invoke the LLM, so when an LLM is
 /// configured it goes through the same approval gate as a real commit.
-pub fn resolve_guidance_for_preview(
+pub fn resolve_template_for_preview(
     ctx: &super::command_executor::CommandContext<'_>,
     commit_config: &worktrunk::config::CommitGenerationConfig,
     dry_run: bool,
 ) -> anyhow::Result<Option<String>> {
     if dry_run && commit_config.is_configured() {
-        approve_commit_guidance(ctx)
+        approve_commit_template(ctx)
     } else {
         Ok(ctx
             .repo
             .load_project_config()?
             .as_ref()
-            .and_then(|cfg| cfg.commit_guidance().map(str::to_string)))
+            .and_then(|cfg| cfg.commit_template().map(str::to_string)))
     }
 }
 
@@ -315,13 +315,13 @@ pub fn resolve_guidance_for_preview(
 /// commit`, `wt step squash`, `wt merge`, `wt step commit --dry-run`, etc.).
 /// `--show-prompt` paths skip the gate — they don't execute the LLM, so showing
 /// the guidance text is a preview, not a send.
-pub fn approve_commit_guidance(
+pub fn approve_commit_template(
     ctx: &super::command_executor::CommandContext<'_>,
 ) -> anyhow::Result<Option<String>> {
     let Some(project_config) = ctx.repo.load_project_config()? else {
         return Ok(None);
     };
-    let Some(guidance) = project_config.commit_guidance() else {
+    let Some(guidance) = project_config.commit_template() else {
         return Ok(None);
     };
 
@@ -332,7 +332,7 @@ pub fn approve_commit_guidance(
         return Ok(Some(owned));
     }
 
-    let batch = vec![ApprovableCommand::commit_guidance(owned.clone())];
+    let batch = vec![ApprovableCommand::commit_template(owned.clone())];
     let approved = approve_command_batch(&batch, &project_id, &approvals, ctx.yes, true)?;
     if !approved {
         worktrunk::styling::eprintln!(

--- a/src/commands/command_approval.rs
+++ b/src/commands/command_approval.rs
@@ -25,8 +25,8 @@ use color_print::cformat;
 use worktrunk::config::Approvals;
 use worktrunk::git::{GitError, HookType};
 use worktrunk::styling::{
-    INFO_SYMBOL, WARNING_SYMBOL, eprint, eprintln, format_bash_with_gutter, hint_message,
-    prompt_message, stderr, warning_message,
+    INFO_SYMBOL, WARNING_SYMBOL, eprint, eprintln, format_bash_with_gutter, format_with_gutter,
+    hint_message, prompt_message, stderr, warning_message,
 };
 
 use super::hook_filter::{HookSource, ParsedFilter};
@@ -120,7 +120,13 @@ fn prompt_for_batch_approval(
             None => format!("{INFO_SYMBOL} {phase}:"),
         };
         eprintln!("{}", label);
-        eprintln!("{}", format_bash_with_gutter(&cmd.command.template));
+        // Shell commands get bash syntax highlighting; commit guidance is plain
+        // text (markdown-ish) and shouldn't be tokenized as bash.
+        let body = match cmd.phase {
+            Phase::CommitGuidance => format_with_gutter(&cmd.command.template, None),
+            _ => format_bash_with_gutter(&cmd.command.template),
+        };
+        eprintln!("{}", body);
     }
 
     // Check if stdin is a TTY before attempting to prompt
@@ -275,6 +281,69 @@ pub fn approve_or_skip(
         worktrunk::styling::eprintln!("{}", worktrunk::styling::info_message(on_decline));
     }
     Ok(approved)
+}
+
+/// Resolve project guidance for a preview path (`--show-prompt` / `--dry-run`).
+///
+/// `--show-prompt` doesn't invoke the LLM, so it always renders the configured
+/// guidance verbatim. `--dry-run` does invoke the LLM, so when an LLM is
+/// configured it goes through the same approval gate as a real commit.
+pub fn resolve_guidance_for_preview(
+    ctx: &super::command_executor::CommandContext<'_>,
+    commit_config: &worktrunk::config::CommitGenerationConfig,
+    dry_run: bool,
+) -> anyhow::Result<Option<String>> {
+    if dry_run && commit_config.is_configured() {
+        approve_commit_guidance(ctx)
+    } else {
+        Ok(ctx
+            .repo
+            .load_project_config()?
+            .as_ref()
+            .and_then(|cfg| cfg.commit_guidance().map(str::to_string)))
+    }
+}
+
+/// Approve project-level commit-message guidance before sending it to the LLM.
+///
+/// Returns `Ok(Some(guidance))` when approved (or already approved), `Ok(None)`
+/// when no guidance is configured or the user declined. Declining is non-fatal:
+/// the LLM still runs, just without the project guidance, mirroring the
+/// "commands declined, continuing without hooks" pattern.
+///
+/// Callers should invoke this on every LLM-bearing path (`wt commit`, `wt step
+/// commit`, `wt step squash`, `wt merge`, `wt step commit --dry-run`, etc.).
+/// `--show-prompt` paths skip the gate — they don't execute the LLM, so showing
+/// the guidance text is a preview, not a send.
+pub fn approve_commit_guidance(
+    ctx: &super::command_executor::CommandContext<'_>,
+) -> anyhow::Result<Option<String>> {
+    let Some(project_config) = ctx.repo.load_project_config()? else {
+        return Ok(None);
+    };
+    let Some(guidance) = project_config.commit_guidance() else {
+        return Ok(None);
+    };
+
+    let project_id = ctx.repo.project_identifier()?;
+    let approvals = Approvals::load().context("Failed to load approvals")?;
+    let owned = guidance.to_string();
+    if approvals.is_command_approved(&project_id, &owned) {
+        return Ok(Some(owned));
+    }
+
+    let batch = vec![ApprovableCommand::commit_guidance(owned.clone())];
+    let approved = approve_command_batch(&batch, &project_id, &approvals, ctx.yes, true)?;
+    if !approved {
+        worktrunk::styling::eprintln!(
+            "{}",
+            worktrunk::styling::info_message(
+                "Project commit guidance declined; generating without it",
+            )
+        );
+        return Ok(None);
+    }
+    Ok(Some(owned))
 }
 
 /// Like [`approve_or_skip`] but approves against an already-resolved

--- a/src/commands/command_approval.rs
+++ b/src/commands/command_approval.rs
@@ -120,8 +120,9 @@ fn prompt_for_batch_approval(
             None => format!("{INFO_SYMBOL} {phase}:"),
         };
         eprintln!("{}", label);
-        // Shell commands get bash syntax highlighting; commit guidance is plain
-        // text (markdown-ish) and shouldn't be tokenized as bash.
+        // Shell commands get bash syntax highlighting; the commit template
+        // fragment is plain text (markdown-ish) and shouldn't be tokenized as
+        // bash.
         let body = match cmd.phase {
             Phase::CommitTemplate => format_with_gutter(&cmd.command.template, None),
             _ => format_bash_with_gutter(&cmd.command.template),
@@ -283,10 +284,11 @@ pub fn approve_or_skip(
     Ok(approved)
 }
 
-/// Resolve project guidance for a preview path (`--show-prompt` / `--dry-run`).
+/// Resolve the project commit template for a preview path (`--show-prompt` /
+/// `--dry-run`).
 ///
-/// `--show-prompt` doesn't invoke the LLM, so it always renders the configured
-/// guidance verbatim. `--dry-run` does invoke the LLM, so when an LLM is
+/// `--show-prompt` doesn't invoke the LLM, so it always returns the configured
+/// fragment verbatim. `--dry-run` does invoke the LLM, so when an LLM is
 /// configured it goes through the same approval gate as a real commit.
 pub fn resolve_template_for_preview(
     ctx: &super::command_executor::CommandContext<'_>,
@@ -304,17 +306,17 @@ pub fn resolve_template_for_preview(
     }
 }
 
-/// Approve project-level commit-message guidance before sending it to the LLM.
+/// Approve the project-level commit template fragment before sending it to the LLM.
 ///
-/// Returns `Ok(Some(guidance))` when approved (or already approved), `Ok(None)`
-/// when no guidance is configured or the user declined. Declining is non-fatal:
-/// the LLM still runs, just without the project guidance, mirroring the
+/// Returns `Ok(Some(fragment))` when approved (or already approved), `Ok(None)`
+/// when no fragment is configured or the user declined. Declining is non-fatal:
+/// the LLM still runs, just without the project template, mirroring the
 /// "commands declined, continuing without hooks" pattern.
 ///
 /// Callers should invoke this on every LLM-bearing path (`wt commit`, `wt step
 /// commit`, `wt step squash`, `wt merge`, `wt step commit --dry-run`, etc.).
 /// `--show-prompt` paths skip the gate — they don't execute the LLM, so showing
-/// the guidance text is a preview, not a send.
+/// the fragment is a preview, not a send.
 pub fn approve_commit_template(
     ctx: &super::command_executor::CommandContext<'_>,
 ) -> anyhow::Result<Option<String>> {
@@ -338,7 +340,7 @@ pub fn approve_commit_template(
         worktrunk::styling::eprintln!(
             "{}",
             worktrunk::styling::info_message(
-                "Project commit guidance declined; generating without it",
+                "Project commit template declined; generating without it",
             )
         );
         return Ok(None);

--- a/src/commands/command_approval.rs
+++ b/src/commands/command_approval.rs
@@ -124,7 +124,7 @@ fn prompt_for_batch_approval(
         // fragment is plain text (markdown-ish) and shouldn't be tokenized as
         // bash.
         let body = match cmd.phase {
-            Phase::CommitTemplate => format_with_gutter(&cmd.command.template, None),
+            Phase::CommitTemplateAppend => format_with_gutter(&cmd.command.template, None),
             _ => format_bash_with_gutter(&cmd.command.template),
         };
         eprintln!("{}", body);
@@ -296,51 +296,52 @@ pub fn resolve_template_for_preview(
     dry_run: bool,
 ) -> anyhow::Result<Option<String>> {
     if dry_run && commit_config.is_configured() {
-        approve_commit_template(ctx)
+        approve_commit_template_append(ctx)
     } else {
         Ok(ctx
             .repo
             .load_project_config()?
             .as_ref()
-            .and_then(|cfg| cfg.commit_template().map(str::to_string)))
+            .and_then(|cfg| cfg.commit_template_append().map(str::to_string)))
     }
 }
 
-/// Approve the project-level commit template fragment before sending it to the LLM.
+/// Approve the project-level commit append fragment before sending it to the LLM.
 ///
 /// Returns `Ok(Some(fragment))` when approved (or already approved), `Ok(None)`
 /// when no fragment is configured or the user declined. Declining is non-fatal:
-/// the LLM still runs, just without the project template, mirroring the
-/// "commands declined, continuing without hooks" pattern.
+/// the LLM still runs, just without the project append, mirroring the
+/// "commands declined, continuing without hooks" pattern. The user-level
+/// `template-append` is not gated here — it's the developer's own config.
 ///
 /// Callers should invoke this on every LLM-bearing path (`wt commit`, `wt step
 /// commit`, `wt step squash`, `wt merge`, `wt step commit --dry-run`, etc.).
 /// `--show-prompt` paths skip the gate — they don't execute the LLM, so showing
 /// the fragment is a preview, not a send.
-pub fn approve_commit_template(
+pub fn approve_commit_template_append(
     ctx: &super::command_executor::CommandContext<'_>,
 ) -> anyhow::Result<Option<String>> {
     let Some(project_config) = ctx.repo.load_project_config()? else {
         return Ok(None);
     };
-    let Some(guidance) = project_config.commit_template() else {
+    let Some(fragment) = project_config.commit_template_append() else {
         return Ok(None);
     };
 
     let project_id = ctx.repo.project_identifier()?;
     let approvals = Approvals::load().context("Failed to load approvals")?;
-    let owned = guidance.to_string();
+    let owned = fragment.to_string();
     if approvals.is_command_approved(&project_id, &owned) {
         return Ok(Some(owned));
     }
 
-    let batch = vec![ApprovableCommand::commit_template(owned.clone())];
+    let batch = vec![ApprovableCommand::commit_template_append(owned.clone())];
     let approved = approve_command_batch(&batch, &project_id, &approvals, ctx.yes, true)?;
     if !approved {
         worktrunk::styling::eprintln!(
             "{}",
             worktrunk::styling::info_message(
-                "Project commit template declined; generating without it",
+                "Project commit guidance declined; generating without it",
             )
         );
         return Ok(None);

--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -89,16 +89,17 @@ impl<'a> CommitOptions<'a> {
 
 pub(crate) struct CommitGenerator<'a> {
     config: &'a CommitGenerationConfig,
-    /// Approved project-level guidance to append to the LLM prompt. `None` if
-    /// not configured or the user declined approval.
-    project_template: Option<&'a str>,
+    /// Approved project-level append fragment for the LLM prompt. `None` if
+    /// not configured or the user declined approval. The user-level
+    /// `template-append` rides along inside `config` and needs no approval.
+    project_append: Option<&'a str>,
 }
 
 impl<'a> CommitGenerator<'a> {
-    pub fn new(config: &'a CommitGenerationConfig, project_template: Option<&'a str>) -> Self {
+    pub fn new(config: &'a CommitGenerationConfig, project_append: Option<&'a str>) -> Self {
         Self {
             config,
-            project_template,
+            project_append,
         }
     }
 
@@ -187,7 +188,7 @@ impl<'a> CommitGenerator<'a> {
 
         self.emit_hint_if_needed();
         let commit_message =
-            crate::llm::generate_commit_message(self.config, None, self.project_template)?;
+            crate::llm::generate_commit_message(self.config, None, self.project_append)?;
 
         let formatted_message = self.format_message_for_display(&commit_message);
         eprintln!("{}", format_with_gutter(&formatted_message, None));
@@ -284,14 +285,14 @@ impl CommitOptions<'_> {
         // Skip the approval gate when the LLM isn't configured — the fallback
         // message generator doesn't render the prompt template, so guidance
         // would never reach an LLM anyway.
-        let project_template = match self.guidance {
+        let project_append = match self.guidance {
             super::step::PreApprovedGuidance::Resolved(value) => value,
             super::step::PreApprovedGuidance::RunOwnGate if effective_config.is_configured() => {
-                super::command_approval::approve_commit_template(self.ctx)?
+                super::command_approval::approve_commit_template_append(self.ctx)?
             }
             super::step::PreApprovedGuidance::RunOwnGate => None,
         };
-        let outcome = CommitGenerator::new(&effective_config, project_template.as_deref())
+        let outcome = CommitGenerator::new(&effective_config, project_append.as_deref())
             .commit_staged_changes(
                 &wt,
                 true, // show_progress

--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -91,14 +91,14 @@ pub(crate) struct CommitGenerator<'a> {
     config: &'a CommitGenerationConfig,
     /// Approved project-level guidance to append to the LLM prompt. `None` if
     /// not configured or the user declined approval.
-    project_guidance: Option<&'a str>,
+    project_template: Option<&'a str>,
 }
 
 impl<'a> CommitGenerator<'a> {
-    pub fn new(config: &'a CommitGenerationConfig, project_guidance: Option<&'a str>) -> Self {
+    pub fn new(config: &'a CommitGenerationConfig, project_template: Option<&'a str>) -> Self {
         Self {
             config,
-            project_guidance,
+            project_template,
         }
     }
 
@@ -187,7 +187,7 @@ impl<'a> CommitGenerator<'a> {
 
         self.emit_hint_if_needed();
         let commit_message =
-            crate::llm::generate_commit_message(self.config, None, self.project_guidance)?;
+            crate::llm::generate_commit_message(self.config, None, self.project_template)?;
 
         let formatted_message = self.format_message_for_display(&commit_message);
         eprintln!("{}", format_with_gutter(&formatted_message, None));
@@ -284,14 +284,14 @@ impl CommitOptions<'_> {
         // Skip the approval gate when the LLM isn't configured — the fallback
         // message generator doesn't render the prompt template, so guidance
         // would never reach an LLM anyway.
-        let project_guidance = match self.guidance {
+        let project_template = match self.guidance {
             super::step::PreApprovedGuidance::Resolved(value) => value,
             super::step::PreApprovedGuidance::RunOwnGate if effective_config.is_configured() => {
-                super::command_approval::approve_commit_guidance(self.ctx)?
+                super::command_approval::approve_commit_template(self.ctx)?
             }
             super::step::PreApprovedGuidance::RunOwnGate => None,
         };
-        let outcome = CommitGenerator::new(&effective_config, project_guidance.as_deref())
+        let outcome = CommitGenerator::new(&effective_config, project_template.as_deref())
             .commit_staged_changes(
                 &wt,
                 true, // show_progress

--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -66,6 +66,10 @@ pub struct CommitOptions<'a> {
     pub stage_mode: StageMode,
     pub warn_about_untracked: bool,
     pub show_no_squash_note: bool,
+    /// Whether `commit()` runs its own guidance approval gate or trusts a
+    /// value supplied by the caller (`wt merge` bundles the guidance into
+    /// its hook-approval batch so the user sees one combined prompt).
+    pub guidance: super::step::PreApprovedGuidance,
 }
 
 impl<'a> CommitOptions<'a> {
@@ -78,17 +82,24 @@ impl<'a> CommitOptions<'a> {
             stage_mode: StageMode::All,
             warn_about_untracked: true,
             show_no_squash_note: false,
+            guidance: super::step::PreApprovedGuidance::RunOwnGate,
         }
     }
 }
 
 pub(crate) struct CommitGenerator<'a> {
     config: &'a CommitGenerationConfig,
+    /// Approved project-level guidance to append to the LLM prompt. `None` if
+    /// not configured or the user declined approval.
+    project_guidance: Option<&'a str>,
 }
 
 impl<'a> CommitGenerator<'a> {
-    pub fn new(config: &'a CommitGenerationConfig) -> Self {
-        Self { config }
+    pub fn new(config: &'a CommitGenerationConfig, project_guidance: Option<&'a str>) -> Self {
+        Self {
+            config,
+            project_guidance,
+        }
     }
 
     pub fn format_message_for_display(&self, message: &str) -> String {
@@ -175,7 +186,8 @@ impl<'a> CommitGenerator<'a> {
         }
 
         self.emit_hint_if_needed();
-        let commit_message = crate::llm::generate_commit_message(self.config, None)?;
+        let commit_message =
+            crate::llm::generate_commit_message(self.config, None, self.project_guidance)?;
 
         let formatted_message = self.format_message_for_display(&commit_message);
         eprintln!("{}", format_with_gutter(&formatted_message, None));
@@ -269,12 +281,23 @@ impl CommitOptions<'_> {
         }
 
         let effective_config = self.ctx.commit_generation();
-        let outcome = CommitGenerator::new(&effective_config).commit_staged_changes(
-            &wt,
-            true, // show_progress
-            self.show_no_squash_note,
-            self.stage_mode,
-        )?;
+        // Skip the approval gate when the LLM isn't configured — the fallback
+        // message generator doesn't render the prompt template, so guidance
+        // would never reach an LLM anyway.
+        let project_guidance = match self.guidance {
+            super::step::PreApprovedGuidance::Resolved(value) => value,
+            super::step::PreApprovedGuidance::RunOwnGate if effective_config.is_configured() => {
+                super::command_approval::approve_commit_guidance(self.ctx)?
+            }
+            super::step::PreApprovedGuidance::RunOwnGate => None,
+        };
+        let outcome = CommitGenerator::new(&effective_config, project_guidance.as_deref())
+            .commit_staged_changes(
+                &wt,
+                true, // show_progress
+                self.show_no_squash_note,
+                self.stage_mode,
+            )?;
 
         // Register post-commit hooks onto the caller's announcer (respects --no-hooks).
         if self.hooks.run() {
@@ -294,7 +317,7 @@ mod tests {
     fn test_format_message_for_display() {
         use insta::assert_snapshot;
         let config = CommitGenerationConfig::default();
-        let generator = CommitGenerator::new(&config);
+        let generator = CommitGenerator::new(&config, None);
 
         assert_snapshot!(generator.format_message_for_display("Simple commit message"), @"[1mSimple commit message[22m");
         assert_snapshot!(generator.format_message_for_display("First line\nSecond line\nThird line"), @"
@@ -307,7 +330,7 @@ mod tests {
     #[test]
     fn test_format_message_for_display_empty() {
         let config = CommitGenerationConfig::default();
-        let generator = CommitGenerator::new(&config);
+        let generator = CommitGenerator::new(&config, None);
         let result = generator.format_message_for_display("");
         assert_eq!(result, "");
     }

--- a/src/commands/config/approvals.rs
+++ b/src/commands/config/approvals.rs
@@ -11,7 +11,9 @@ use worktrunk::git::{GitError, Repository};
 use worktrunk::styling::{eprintln, info_message, success_message};
 
 use crate::commands::command_approval::approve_command_batch;
-use crate::commands::project_config::{collect_commands_for_aliases, collect_commands_for_hooks};
+use crate::commands::project_config::{
+    ApprovableCommand, collect_commands_for_aliases, collect_commands_for_hooks,
+};
 
 /// Handle `wt config approvals add` command - approve all hook and alias commands in the project
 pub fn add_approvals(show_all: bool) -> anyhow::Result<()> {
@@ -28,10 +30,13 @@ pub fn add_approvals(show_all: bool) -> anyhow::Result<()> {
         .ok_or(GitError::ProjectConfigNotFound { config_path })?;
 
     // Collect all commands from the project config: hooks first (lifecycle order),
-    // then aliases (alphabetical via BTreeMap).
+    // then aliases (alphabetical via BTreeMap), then any commit-message guidance.
     let all_hooks: Vec<_> = HookType::iter().collect();
     let mut commands = collect_commands_for_hooks(&project_config, &all_hooks);
     commands.extend(collect_commands_for_aliases(&project_config));
+    if let Some(guidance) = project_config.commit_guidance() {
+        commands.push(ApprovableCommand::commit_guidance(guidance.to_string()));
+    }
 
     if commands.is_empty() {
         eprintln!("{}", info_message("No commands configured in project"));

--- a/src/commands/config/approvals.rs
+++ b/src/commands/config/approvals.rs
@@ -34,8 +34,10 @@ pub fn add_approvals(show_all: bool) -> anyhow::Result<()> {
     let all_hooks: Vec<_> = HookType::iter().collect();
     let mut commands = collect_commands_for_hooks(&project_config, &all_hooks);
     commands.extend(collect_commands_for_aliases(&project_config));
-    if let Some(guidance) = project_config.commit_template() {
-        commands.push(ApprovableCommand::commit_template(guidance.to_string()));
+    if let Some(fragment) = project_config.commit_template_append() {
+        commands.push(ApprovableCommand::commit_template_append(
+            fragment.to_string(),
+        ));
     }
 
     if commands.is_empty() {

--- a/src/commands/config/approvals.rs
+++ b/src/commands/config/approvals.rs
@@ -34,8 +34,8 @@ pub fn add_approvals(show_all: bool) -> anyhow::Result<()> {
     let all_hooks: Vec<_> = HookType::iter().collect();
     let mut commands = collect_commands_for_hooks(&project_config, &all_hooks);
     commands.extend(collect_commands_for_aliases(&project_config));
-    if let Some(guidance) = project_config.commit_guidance() {
-        commands.push(ApprovableCommand::commit_guidance(guidance.to_string()));
+    if let Some(guidance) = project_config.commit_template() {
+        commands.push(ApprovableCommand::commit_template(guidance.to_string()));
     }
 
     if commands.is_empty() {

--- a/src/commands/config/snapshots/wt__commands__config__tests__warn_unknown_keys_deprecated_in_wrong_config.snap
+++ b/src/commands/config/snapshots/wt__commands__config__tests__warn_unknown_keys_deprecated_in_wrong_config.snap
@@ -1,5 +1,5 @@
 ---
 source: src/commands/config/mod.rs
-expression: "warn_unknown_keys::<ProjectConfig>(&unknown)"
+expression: "warn_unknown_keys::<ProjectConfig>(\"[commit-generation]\\ncommand = \\\"llm\\\"\\n\")"
 ---
-[33m▲[39m [33mKey [1mcommit-generation[22m belongs in user config as [commit.generation][39m
+[33m▲[39m [33mUnknown key [1mcommit.generation.command[22m will be ignored[39m

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -232,16 +232,16 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
         .config
         .commit_generation(Some(&project_id))
         .is_configured();
-    let project_template_text: Option<String> = if commit && will_create_commit && llm_configured {
+    let project_append_text: Option<String> = if commit && will_create_commit && llm_configured {
         env.repo
             .load_project_config()?
             .as_ref()
-            .and_then(|cfg| cfg.commit_template().map(str::to_string))
+            .and_then(|cfg| cfg.commit_template_append().map(str::to_string))
     } else {
         None
     };
-    if let Some(ref g) = project_template_text {
-        all_commands.push(ApprovableCommand::commit_template(g.clone()));
+    if let Some(ref g) = project_append_text {
+        all_commands.push(ApprovableCommand::commit_template_append(g.clone()));
     }
 
     // Approve all commands in a single batch (shows templates, not expanded values)
@@ -270,7 +270,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
     let mut announcer = HookAnnouncer::new(repo, config, false);
 
     let guidance = super::step::PreApprovedGuidance::Resolved(
-        approved.then_some(project_template_text).flatten(),
+        approved.then_some(project_append_text).flatten(),
     );
 
     // Handle uncommitted changes (skip if --no-commit) - track whether commit occurred

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -215,7 +215,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
     let remove_requested = remove && !on_target;
 
     // Collect and approve all commands upfront for batch permission request
-    let (all_commands, project_id) = collect_merge_commands(
+    let (mut all_commands, project_id) = collect_merge_commands(
         repo,
         &destination_path,
         commit,
@@ -223,6 +223,26 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
         remove_requested,
         squash_enabled,
     )?;
+
+    // Bundle commit guidance into the same batch as hooks so an LLM-bound
+    // merge produces one approval prompt, not two. Only when a commit will
+    // actually be created and an LLM is configured.
+    let will_create_commit = current_wt.is_dirty()? || squash_enabled;
+    let llm_configured = env
+        .config
+        .commit_generation(Some(&project_id))
+        .is_configured();
+    let project_guidance_text: Option<String> = if commit && will_create_commit && llm_configured {
+        env.repo
+            .load_project_config()?
+            .as_ref()
+            .and_then(|cfg| cfg.commit_guidance().map(str::to_string))
+    } else {
+        None
+    };
+    if let Some(ref g) = project_guidance_text {
+        all_commands.push(ApprovableCommand::commit_guidance(g.clone()));
+    }
 
     // Approve all commands in a single batch (shows templates, not expanded values)
     let approvals = Approvals::load().context("Failed to load approvals")?;
@@ -249,6 +269,10 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
     // the end.
     let mut announcer = HookAnnouncer::new(repo, config, false);
 
+    let guidance = super::step::PreApprovedGuidance::Resolved(
+        approved.then_some(project_guidance_text).flatten(),
+    );
+
     // Handle uncommitted changes (skip if --no-commit) - track whether commit occurred
     let committed = if commit && current_wt.is_dirty()? {
         if squash_enabled {
@@ -261,6 +285,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
             options.stage_mode = stage_mode;
             options.warn_about_untracked = stage_mode == super::commit::StageMode::All;
             options.show_no_squash_note = true;
+            options.guidance = guidance.clone();
 
             let _ = options.commit(&mut announcer)?;
             true // Committed directly
@@ -280,6 +305,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
                 commit_hooks,
                 Some(stage_mode),
                 &mut announcer,
+                guidance,
             )?,
             super::step::SquashResult::Squashed { .. }
         )

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -232,16 +232,16 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
         .config
         .commit_generation(Some(&project_id))
         .is_configured();
-    let project_guidance_text: Option<String> = if commit && will_create_commit && llm_configured {
+    let project_template_text: Option<String> = if commit && will_create_commit && llm_configured {
         env.repo
             .load_project_config()?
             .as_ref()
-            .and_then(|cfg| cfg.commit_guidance().map(str::to_string))
+            .and_then(|cfg| cfg.commit_template().map(str::to_string))
     } else {
         None
     };
-    if let Some(ref g) = project_guidance_text {
-        all_commands.push(ApprovableCommand::commit_guidance(g.clone()));
+    if let Some(ref g) = project_template_text {
+        all_commands.push(ApprovableCommand::commit_template(g.clone()));
     }
 
     // Approve all commands in a single batch (shows templates, not expanded values)
@@ -270,7 +270,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
     let mut announcer = HookAnnouncer::new(repo, config, false);
 
     let guidance = super::step::PreApprovedGuidance::Resolved(
-        approved.then_some(project_guidance_text).flatten(),
+        approved.then_some(project_template_text).flatten(),
     );
 
     // Handle uncommitted changes (skip if --no-commit) - track whether commit occurred

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -55,9 +55,9 @@ pub(crate) use picker::handle_picker;
 pub(crate) use repository_ext::RemoveTarget;
 pub(crate) use run_pipeline::run_pipeline;
 pub(crate) use step::{
-    PromoteResult, RebaseResult, SquashResult, handle_promote, handle_rebase, handle_squash,
-    step_commit, step_copy_ignored, step_diff, step_dry_run_squash, step_prune, step_relocate,
-    step_show_squash_prompt,
+    PreApprovedGuidance, PromoteResult, RebaseResult, SquashResult, handle_promote, handle_rebase,
+    handle_squash, step_commit, step_copy_ignored, step_diff, step_dry_run_squash, step_prune,
+    step_relocate, step_show_squash_prompt,
 };
 pub(crate) use worktree::{
     OperationMode, SwitchOptions, is_worktree_at_expected_path, resolve_worktree_arg, run_switch,

--- a/src/commands/project_config.rs
+++ b/src/commands/project_config.rs
@@ -10,10 +10,10 @@ use worktrunk::git::{HookType, Repository};
 pub enum Phase {
     Hook(HookType),
     Alias,
-    /// Project-level commit-message template fragment — not a shell command.
+    /// Project-level commit-message append fragment — not a shell command.
     /// Approving records the raw fragment as "approved" so subsequent LLM
     /// calls include it without re-prompting.
-    CommitTemplate,
+    CommitTemplateAppend,
 }
 
 impl fmt::Display for Phase {
@@ -21,7 +21,7 @@ impl fmt::Display for Phase {
         match self {
             Phase::Hook(hook_type) => write!(f, "{hook_type}"),
             Phase::Alias => write!(f, "alias"),
-            Phase::CommitTemplate => write!(f, "commit-template"),
+            Phase::CommitTemplateAppend => write!(f, "commit-template-append"),
         }
     }
 }
@@ -34,13 +34,13 @@ pub struct ApprovableCommand {
 }
 
 impl ApprovableCommand {
-    /// Build an approvable for the project-level commit template fragment.
+    /// Build an approvable for the project-level commit append fragment.
     /// The raw fragment is reused as the `Command::template` so the
     /// approvals store (`approved-commands`) treats it like any other
     /// approved input.
-    pub fn commit_template(text: String) -> Self {
+    pub fn commit_template_append(text: String) -> Self {
         Self {
-            phase: Phase::CommitTemplate,
+            phase: Phase::CommitTemplateAppend,
             command: Command::new(None, text),
         }
     }

--- a/src/commands/project_config.rs
+++ b/src/commands/project_config.rs
@@ -10,6 +10,10 @@ use worktrunk::git::{HookType, Repository};
 pub enum Phase {
     Hook(HookType),
     Alias,
+    /// Project-level commit-message guidance — not a shell command. Approving
+    /// this records the guidance text as "approved" so subsequent LLM calls
+    /// include it without re-prompting.
+    CommitGuidance,
 }
 
 impl fmt::Display for Phase {
@@ -17,6 +21,7 @@ impl fmt::Display for Phase {
         match self {
             Phase::Hook(hook_type) => write!(f, "{hook_type}"),
             Phase::Alias => write!(f, "alias"),
+            Phase::CommitGuidance => write!(f, "commit-guidance"),
         }
     }
 }
@@ -26,6 +31,18 @@ impl fmt::Display for Phase {
 pub struct ApprovableCommand {
     pub phase: Phase,
     pub command: Command,
+}
+
+impl ApprovableCommand {
+    /// Build an approvable for project-level commit-message guidance. The
+    /// guidance text is reused as the `Command::template` so the approvals
+    /// store (`approved-commands`) treats it like any other approved input.
+    pub fn commit_guidance(text: String) -> Self {
+        Self {
+            phase: Phase::CommitGuidance,
+            command: Command::new(None, text),
+        }
+    }
 }
 
 /// Collect commands for the given hook types, preserving order of the provided hooks.

--- a/src/commands/project_config.rs
+++ b/src/commands/project_config.rs
@@ -10,10 +10,10 @@ use worktrunk::git::{HookType, Repository};
 pub enum Phase {
     Hook(HookType),
     Alias,
-    /// Project-level commit-message guidance — not a shell command. Approving
-    /// this records the guidance text as "approved" so subsequent LLM calls
-    /// include it without re-prompting.
-    CommitGuidance,
+    /// Project-level commit-message template fragment — not a shell command.
+    /// Approving records the raw fragment as "approved" so subsequent LLM
+    /// calls include it without re-prompting.
+    CommitTemplate,
 }
 
 impl fmt::Display for Phase {
@@ -21,7 +21,7 @@ impl fmt::Display for Phase {
         match self {
             Phase::Hook(hook_type) => write!(f, "{hook_type}"),
             Phase::Alias => write!(f, "alias"),
-            Phase::CommitGuidance => write!(f, "commit-guidance"),
+            Phase::CommitTemplate => write!(f, "commit-template"),
         }
     }
 }
@@ -34,12 +34,13 @@ pub struct ApprovableCommand {
 }
 
 impl ApprovableCommand {
-    /// Build an approvable for project-level commit-message guidance. The
-    /// guidance text is reused as the `Command::template` so the approvals
-    /// store (`approved-commands`) treats it like any other approved input.
-    pub fn commit_guidance(text: String) -> Self {
+    /// Build an approvable for the project-level commit template fragment.
+    /// The raw fragment is reused as the `Command::template` so the
+    /// approvals store (`approved-commands`) treats it like any other
+    /// approved input.
+    pub fn commit_template(text: String) -> Self {
         Self {
-            phase: Phase::CommitGuidance,
+            phase: Phase::CommitTemplate,
             command: Command::new(None, text),
         }
     }

--- a/src/commands/relocate.rs
+++ b/src/commands/relocate.rs
@@ -223,7 +223,7 @@ pub struct ValidationResult {
 
 /// Check each candidate for locked/dirty state and optionally auto-commit.
 ///
-/// Returns validated candidates ready for relocation. `project_guidance` is
+/// Returns validated candidates ready for relocation. `project_template` is
 /// the approved project-level guidance appended to each auto-commit prompt.
 /// Resolved once upfront by the caller so per-worktree commits share the
 /// same approved value rather than each running its own approval gate.
@@ -233,7 +233,7 @@ pub fn validate_candidates(
     candidates: Vec<RelocationCandidate>,
     auto_commit: bool,
     repo_path: &Path,
-    project_guidance: Option<&str>,
+    project_template: Option<&str>,
 ) -> anyhow::Result<ValidationResult> {
     let mut validated = Vec::new();
     let mut skipped: Vec<SkippedEntry> = Vec::new();
@@ -274,7 +274,7 @@ pub fn validate_candidates(
                 // Commit using shared pipeline
                 let project_id = repo.project_identifier().ok();
                 let commit_config = config.commit_generation(project_id.as_deref());
-                CommitGenerator::new(&commit_config, project_guidance).commit_staged_changes(
+                CommitGenerator::new(&commit_config, project_template).commit_staged_changes(
                     &worktree,
                     false, // show_progress - already showing "Committing changes in..."
                     false, // show_no_squash_note

--- a/src/commands/relocate.rs
+++ b/src/commands/relocate.rs
@@ -223,13 +223,17 @@ pub struct ValidationResult {
 
 /// Check each candidate for locked/dirty state and optionally auto-commit.
 ///
-/// Returns validated candidates ready for relocation.
+/// Returns validated candidates ready for relocation. `project_guidance` is
+/// the approved project-level guidance appended to each auto-commit prompt.
+/// Resolved once upfront by the caller so per-worktree commits share the
+/// same approved value rather than each running its own approval gate.
 pub fn validate_candidates(
     repo: &Repository,
     config: &UserConfig,
     candidates: Vec<RelocationCandidate>,
     auto_commit: bool,
     repo_path: &Path,
+    project_guidance: Option<&str>,
 ) -> anyhow::Result<ValidationResult> {
     let mut validated = Vec::new();
     let mut skipped: Vec<SkippedEntry> = Vec::new();
@@ -270,7 +274,7 @@ pub fn validate_candidates(
                 // Commit using shared pipeline
                 let project_id = repo.project_identifier().ok();
                 let commit_config = config.commit_generation(project_id.as_deref());
-                CommitGenerator::new(&commit_config).commit_staged_changes(
+                CommitGenerator::new(&commit_config, project_guidance).commit_staged_changes(
                     &worktree,
                     false, // show_progress - already showing "Committing changes in..."
                     false, // show_no_squash_note

--- a/src/commands/relocate.rs
+++ b/src/commands/relocate.rs
@@ -223,17 +223,17 @@ pub struct ValidationResult {
 
 /// Check each candidate for locked/dirty state and optionally auto-commit.
 ///
-/// Returns validated candidates ready for relocation. `project_template` is
-/// the approved project-level guidance appended to each auto-commit prompt.
-/// Resolved once upfront by the caller so per-worktree commits share the
-/// same approved value rather than each running its own approval gate.
+/// Returns validated candidates ready for relocation. `project_append` is
+/// the approved project-level append fragment added to each auto-commit
+/// prompt. Resolved once upfront by the caller so per-worktree commits share
+/// the same approved value rather than each running its own approval gate.
 pub fn validate_candidates(
     repo: &Repository,
     config: &UserConfig,
     candidates: Vec<RelocationCandidate>,
     auto_commit: bool,
     repo_path: &Path,
-    project_template: Option<&str>,
+    project_append: Option<&str>,
 ) -> anyhow::Result<ValidationResult> {
     let mut validated = Vec::new();
     let mut skipped: Vec<SkippedEntry> = Vec::new();
@@ -274,7 +274,7 @@ pub fn validate_candidates(
                 // Commit using shared pipeline
                 let project_id = repo.project_identifier().ok();
                 let commit_config = config.commit_generation(project_id.as_deref());
-                CommitGenerator::new(&commit_config, project_template).commit_staged_changes(
+                CommitGenerator::new(&commit_config, project_append).commit_staged_changes(
                     &worktree,
                     false, // show_progress - already showing "Committing changes in..."
                     false, // show_no_squash_note

--- a/src/commands/step/commit.rs
+++ b/src/commands/step/commit.rs
@@ -100,13 +100,10 @@ fn preview_commit(stage: Option<StageMode>, dry_run: bool, yes: bool) -> anyhow:
     let index_override = temp_index.as_ref().map(|t| t.path());
 
     let ctx = env.context(yes);
-    let project_template = resolve_template_for_preview(&ctx, &commit_config, dry_run)?;
+    let project_append = resolve_template_for_preview(&ctx, &commit_config, dry_run)?;
 
-    let prompt = crate::llm::build_commit_prompt(
-        &commit_config,
-        index_override,
-        project_template.as_deref(),
-    )?;
+    let prompt =
+        crate::llm::build_commit_prompt(&commit_config, index_override, project_append.as_deref())?;
     if !dry_run {
         println!("{}", prompt);
         return Ok(());
@@ -114,7 +111,7 @@ fn preview_commit(stage: Option<StageMode>, dry_run: bool, yes: bool) -> anyhow:
     let message = crate::llm::generate_commit_message(
         &commit_config,
         index_override,
-        project_template.as_deref(),
+        project_append.as_deref(),
     )?;
     print_dry_run(&prompt, &commit_config, &message)
 }

--- a/src/commands/step/commit.rs
+++ b/src/commands/step/commit.rs
@@ -9,7 +9,7 @@ use worktrunk::git::Repository;
 use worktrunk::shell_exec::Cmd;
 use worktrunk::styling::println;
 
-use super::super::command_approval::approve_or_skip;
+use super::super::command_approval::{approve_or_skip, resolve_guidance_for_preview};
 use super::super::commit::{CommitOptions, CommitOutcome, HookGate, StageMode};
 use super::super::context::CommandEnv;
 use super::super::hooks::HookAnnouncer;
@@ -99,12 +99,23 @@ fn preview_commit(stage: Option<StageMode>, dry_run: bool) -> anyhow::Result<()>
     };
     let index_override = temp_index.as_ref().map(|t| t.path());
 
-    let prompt = crate::llm::build_commit_prompt(&commit_config, index_override)?;
+    let ctx = env.context(false);
+    let project_guidance = resolve_guidance_for_preview(&ctx, &commit_config, dry_run)?;
+
+    let prompt = crate::llm::build_commit_prompt(
+        &commit_config,
+        index_override,
+        project_guidance.as_deref(),
+    )?;
     if !dry_run {
         println!("{}", prompt);
         return Ok(());
     }
-    let message = crate::llm::generate_commit_message(&commit_config, index_override)?;
+    let message = crate::llm::generate_commit_message(
+        &commit_config,
+        index_override,
+        project_guidance.as_deref(),
+    )?;
     print_dry_run(&prompt, &commit_config, &message)
 }
 

--- a/src/commands/step/commit.rs
+++ b/src/commands/step/commit.rs
@@ -9,7 +9,7 @@ use worktrunk::git::Repository;
 use worktrunk::shell_exec::Cmd;
 use worktrunk::styling::println;
 
-use super::super::command_approval::{approve_or_skip, resolve_guidance_for_preview};
+use super::super::command_approval::{approve_or_skip, resolve_template_for_preview};
 use super::super::commit::{CommitOptions, CommitOutcome, HookGate, StageMode};
 use super::super::context::CommandEnv;
 use super::super::hooks::HookAnnouncer;
@@ -100,12 +100,12 @@ fn preview_commit(stage: Option<StageMode>, dry_run: bool) -> anyhow::Result<()>
     let index_override = temp_index.as_ref().map(|t| t.path());
 
     let ctx = env.context(false);
-    let project_guidance = resolve_guidance_for_preview(&ctx, &commit_config, dry_run)?;
+    let project_template = resolve_template_for_preview(&ctx, &commit_config, dry_run)?;
 
     let prompt = crate::llm::build_commit_prompt(
         &commit_config,
         index_override,
-        project_guidance.as_deref(),
+        project_template.as_deref(),
     )?;
     if !dry_run {
         println!("{}", prompt);
@@ -114,7 +114,7 @@ fn preview_commit(stage: Option<StageMode>, dry_run: bool) -> anyhow::Result<()>
     let message = crate::llm::generate_commit_message(
         &commit_config,
         index_override,
-        project_guidance.as_deref(),
+        project_template.as_deref(),
     )?;
     print_dry_run(&prompt, &commit_config, &message)
 }

--- a/src/commands/step/commit.rs
+++ b/src/commands/step/commit.rs
@@ -30,7 +30,7 @@ pub fn step_commit(
     // mirrors --stage against a temp index so the previewed prompt matches what a real
     // run would send the LLM. Neither path produces a CommitOutcome.
     if show_prompt || dry_run {
-        preview_commit(stage, dry_run)?;
+        preview_commit(stage, dry_run, yes)?;
         return Ok(None);
     }
 
@@ -78,7 +78,7 @@ pub fn step_commit(
 /// `--stage` against a temp index — so the previewed prompt matches what a real run
 /// would send — then calls the LLM and prints the command and message in three labeled
 /// sections. The user's real index is never modified.
-fn preview_commit(stage: Option<StageMode>, dry_run: bool) -> anyhow::Result<()> {
+fn preview_commit(stage: Option<StageMode>, dry_run: bool, yes: bool) -> anyhow::Result<()> {
     let env = CommandEnv::for_action(UserConfig::load().context("Failed to load config")?)?;
     let commit_config = env.resolved().commit_generation.clone();
 
@@ -99,7 +99,7 @@ fn preview_commit(stage: Option<StageMode>, dry_run: bool) -> anyhow::Result<()>
     };
     let index_override = temp_index.as_ref().map(|t| t.path());
 
-    let ctx = env.context(false);
+    let ctx = env.context(yes);
     let project_template = resolve_template_for_preview(&ctx, &commit_config, dry_run)?;
 
     let prompt = crate::llm::build_commit_prompt(

--- a/src/commands/step/mod.rs
+++ b/src/commands/step/mod.rs
@@ -31,5 +31,5 @@ pub(crate) use prune::step_prune;
 pub(crate) use rebase::{RebaseResult, handle_rebase};
 pub(crate) use relocate::step_relocate;
 pub(crate) use squash::{
-    SquashResult, handle_squash, step_dry_run_squash, step_show_squash_prompt,
+    PreApprovedGuidance, SquashResult, handle_squash, step_dry_run_squash, step_show_squash_prompt,
 };

--- a/src/commands/step/relocate.rs
+++ b/src/commands/step/relocate.rs
@@ -88,10 +88,35 @@ pub fn step_relocate(
     }
 
     // Phase 2: Validate candidates (check locked/dirty, optionally auto-commit)
+    // Approve project commit guidance once for the whole batch so per-worktree
+    // commits share a single approval prompt rather than one per worktree.
+    // Skip approval when the LLM isn't configured for this project — the
+    // fallback message generator doesn't render the prompt template.
+    let project_guidance = if commit {
+        use super::super::command_approval::approve_commit_guidance;
+        use super::super::command_executor::CommandContext;
+        let project_id = repo.project_identifier().ok();
+        let commit_config = config.commit_generation(project_id.as_deref());
+        if commit_config.is_configured() {
+            let ctx = CommandContext::new(&repo, &config, None, &repo_path, false);
+            approve_commit_guidance(&ctx)?
+        } else {
+            None
+        }
+    } else {
+        None
+    };
     let ValidationResult {
         validated,
         skipped: validation_skipped,
-    } = validate_candidates(&repo, &config, candidates, commit, &repo_path)?;
+    } = validate_candidates(
+        &repo,
+        &config,
+        candidates,
+        commit,
+        &repo_path,
+        project_guidance.as_deref(),
+    )?;
 
     if validated.is_empty() {
         if json_mode {

--- a/src/commands/step/relocate.rs
+++ b/src/commands/step/relocate.rs
@@ -88,18 +88,18 @@ pub fn step_relocate(
     }
 
     // Phase 2: Validate candidates (check locked/dirty, optionally auto-commit)
-    // Approve project commit guidance once for the whole batch so per-worktree
+    // Approve the project commit append once for the whole batch so per-worktree
     // commits share a single approval prompt rather than one per worktree.
     // Skip approval when the LLM isn't configured for this project — the
     // fallback message generator doesn't render the prompt template.
-    let project_template = if commit {
-        use super::super::command_approval::approve_commit_template;
+    let project_append = if commit {
+        use super::super::command_approval::approve_commit_template_append;
         use super::super::command_executor::CommandContext;
         let project_id = repo.project_identifier().ok();
         let commit_config = config.commit_generation(project_id.as_deref());
         if commit_config.is_configured() {
             let ctx = CommandContext::new(&repo, &config, None, &repo_path, false);
-            approve_commit_template(&ctx)?
+            approve_commit_template_append(&ctx)?
         } else {
             None
         }
@@ -115,7 +115,7 @@ pub fn step_relocate(
         candidates,
         commit,
         &repo_path,
-        project_template.as_deref(),
+        project_append.as_deref(),
     )?;
 
     if validated.is_empty() {

--- a/src/commands/step/relocate.rs
+++ b/src/commands/step/relocate.rs
@@ -92,14 +92,14 @@ pub fn step_relocate(
     // commits share a single approval prompt rather than one per worktree.
     // Skip approval when the LLM isn't configured for this project — the
     // fallback message generator doesn't render the prompt template.
-    let project_guidance = if commit {
-        use super::super::command_approval::approve_commit_guidance;
+    let project_template = if commit {
+        use super::super::command_approval::approve_commit_template;
         use super::super::command_executor::CommandContext;
         let project_id = repo.project_identifier().ok();
         let commit_config = config.commit_generation(project_id.as_deref());
         if commit_config.is_configured() {
             let ctx = CommandContext::new(&repo, &config, None, &repo_path, false);
-            approve_commit_guidance(&ctx)?
+            approve_commit_template(&ctx)?
         } else {
             None
         }
@@ -115,7 +115,7 @@ pub fn step_relocate(
         candidates,
         commit,
         &repo_path,
-        project_guidance.as_deref(),
+        project_template.as_deref(),
     )?;
 
     if validated.is_empty() {

--- a/src/commands/step/shared.rs
+++ b/src/commands/step/shared.rs
@@ -37,7 +37,7 @@ pub(super) fn print_dry_run(
         Some(cmd) => format_bash_with_gutter(&crate::llm::render_llm_invocation(cmd)?),
         None => format_with_gutter("(LLM not configured — using built-in fallback)", None),
     };
-    let formatted = CommitGenerator::new(commit_config).format_message_for_display(message);
+    let formatted = CommitGenerator::new(commit_config, None).format_message_for_display(message);
     let out = format!(
         "{prompt_heading}\n{prompt}\n\n{command_heading}\n{command_block}\n\n{message_heading}\n{message_block}\n",
         prompt_heading = format_heading("PROMPT", None),

--- a/src/commands/step/squash.rs
+++ b/src/commands/step/squash.rs
@@ -11,7 +11,7 @@ use worktrunk::styling::{
 };
 
 use super::super::command_approval::{
-    approve_commit_template, approve_or_skip, resolve_template_for_preview,
+    approve_commit_template_append, approve_or_skip, resolve_template_for_preview,
 };
 use super::super::command_executor::FailureStrategy;
 use super::super::commit::{CommitGenerator, CommitOutcome, HookGate, StageMode};
@@ -24,13 +24,13 @@ use super::shared::print_dry_run;
 /// Caller's stance on project commit-message guidance approval.
 ///
 /// `wt step squash` runs its own gate (the user invokes squash directly, so
-/// there's no upstream batch to attach to). `wt merge` bundles the guidance
+/// there's no upstream batch to attach to). `wt merge` bundles the append
 /// into its hook-approval batch and passes the result here so the user
 /// doesn't see a second prompt mid-flow.
 #[derive(Debug, Clone)]
 pub enum PreApprovedGuidance {
     /// No pre-approval — `handle_squash` runs its own gate via
-    /// `approve_commit_template` (only if the LLM is configured).
+    /// `approve_commit_template_append` (only if the LLM is configured).
     RunOwnGate,
     /// Caller already resolved the guidance through an upstream batch.
     /// `None` means "guidance not configured or user declined".
@@ -94,7 +94,9 @@ pub fn handle_squash(
     let approve_guidance = || -> anyhow::Result<Option<String>> {
         match &pre_approved_guidance {
             PreApprovedGuidance::Resolved(value) => Ok(value.clone()),
-            PreApprovedGuidance::RunOwnGate if llm_configured => approve_commit_template(&ctx),
+            PreApprovedGuidance::RunOwnGate if llm_configured => {
+                approve_commit_template_append(&ctx)
+            }
             PreApprovedGuidance::RunOwnGate => Ok(None),
         }
     };
@@ -188,9 +190,9 @@ pub fn handle_squash(
         return Ok(SquashResult::AlreadySingleCommit);
     }
 
-    // From here on, an LLM call may happen — gate guidance.
-    let project_template = approve_guidance()?;
-    let generator = CommitGenerator::new(&resolved.commit_generation, project_template.as_deref());
+    // From here on, an LLM call may happen — gate the project append.
+    let project_append = approve_guidance()?;
+    let generator = CommitGenerator::new(&resolved.commit_generation, project_append.as_deref());
 
     if commit_count == 0 && has_staged {
         // Just staged changes, no commits - commit them directly (no squashing needed)
@@ -279,7 +281,7 @@ pub fn handle_squash(
         &current_branch,
         repo_name,
         &resolved.commit_generation,
-        project_template.as_deref(),
+        project_append.as_deref(),
     )?;
 
     // Display the generated commit message
@@ -380,7 +382,7 @@ fn preview_squash(target: Option<&str>, dry_run: bool, yes: bool) -> anyhow::Res
 
     let env = CommandEnv::for_action(config)?;
     let ctx = env.context(yes);
-    let project_template = resolve_template_for_preview(&ctx, &commit_config, dry_run)?;
+    let project_append = resolve_template_for_preview(&ctx, &commit_config, dry_run)?;
 
     let prompt = crate::llm::build_squash_prompt(
         &integration_target,
@@ -389,7 +391,7 @@ fn preview_squash(target: Option<&str>, dry_run: bool, yes: bool) -> anyhow::Res
         &current_branch,
         repo_name,
         &commit_config,
-        project_template.as_deref(),
+        project_append.as_deref(),
     )?;
     if !dry_run {
         println!("{}", prompt);
@@ -402,7 +404,7 @@ fn preview_squash(target: Option<&str>, dry_run: bool, yes: bool) -> anyhow::Res
         &current_branch,
         repo_name,
         &commit_config,
-        project_template.as_deref(),
+        project_append.as_deref(),
     )?;
     print_dry_run(&prompt, &commit_config, &message)
 }

--- a/src/commands/step/squash.rs
+++ b/src/commands/step/squash.rs
@@ -338,21 +338,23 @@ pub fn handle_squash(
 ///
 /// Builds and outputs the squash prompt without running the LLM or squashing.
 pub fn step_show_squash_prompt(target: Option<&str>) -> anyhow::Result<()> {
-    preview_squash(target, false)
+    // `--show-prompt` never invokes the LLM, so the `yes` flag is irrelevant
+    // — pass false; the guidance gate inside `preview_squash` is dry-run only.
+    preview_squash(target, false, false)
 }
 
 /// Handle `wt step squash --dry-run`
 ///
 /// Renders the squash prompt, prints the LLM command, generates the message, and prints
 /// it without resetting, running hooks, or committing.
-pub fn step_dry_run_squash(target: Option<&str>) -> anyhow::Result<()> {
-    preview_squash(target, true)
+pub fn step_dry_run_squash(target: Option<&str>, yes: bool) -> anyhow::Result<()> {
+    preview_squash(target, true, yes)
 }
 
 /// Shared implementation for `--show-prompt` and `--dry-run` on squash. `--show-prompt`
 /// (`dry_run = false`) outputs only the rendered prompt; `--dry-run` additionally calls
 /// the LLM and prints the command and the generated message.
-fn preview_squash(target: Option<&str>, dry_run: bool) -> anyhow::Result<()> {
+fn preview_squash(target: Option<&str>, dry_run: bool, yes: bool) -> anyhow::Result<()> {
     let repo = Repository::current()?;
     let config = UserConfig::load().context("Failed to load config")?;
     let project_id = repo.project_identifier().ok();
@@ -377,7 +379,7 @@ fn preview_squash(target: Option<&str>, dry_run: bool) -> anyhow::Result<()> {
         .unwrap_or("repo");
 
     let env = CommandEnv::for_action(config)?;
-    let ctx = env.context(false);
+    let ctx = env.context(yes);
     let project_template = resolve_template_for_preview(&ctx, &commit_config, dry_run)?;
 
     let prompt = crate::llm::build_squash_prompt(

--- a/src/commands/step/squash.rs
+++ b/src/commands/step/squash.rs
@@ -10,7 +10,9 @@ use worktrunk::styling::{
     success_message,
 };
 
-use super::super::command_approval::approve_or_skip;
+use super::super::command_approval::{
+    approve_commit_guidance, approve_or_skip, resolve_guidance_for_preview,
+};
 use super::super::command_executor::FailureStrategy;
 use super::super::commit::{CommitGenerator, CommitOutcome, HookGate, StageMode};
 use super::super::context::CommandEnv;
@@ -18,6 +20,22 @@ use super::super::hooks::{self, HookAnnouncer, execute_hook};
 use super::super::repository_ext::RepositoryCliExt;
 use super::super::template_vars::TemplateVars;
 use super::shared::print_dry_run;
+
+/// Caller's stance on project commit-message guidance approval.
+///
+/// `wt step squash` runs its own gate (the user invokes squash directly, so
+/// there's no upstream batch to attach to). `wt merge` bundles the guidance
+/// into its hook-approval batch and passes the result here so the user
+/// doesn't see a second prompt mid-flow.
+#[derive(Debug, Clone)]
+pub enum PreApprovedGuidance {
+    /// No pre-approval — `handle_squash` runs its own gate via
+    /// `approve_commit_guidance` (only if the LLM is configured).
+    RunOwnGate,
+    /// Caller already resolved the guidance through an upstream batch.
+    /// `None` means "guidance not configured or user declined".
+    Resolved(Option<String>),
+}
 
 /// Result of a squash operation
 #[derive(Debug, Clone)]
@@ -55,6 +73,7 @@ pub fn handle_squash(
     hooks: HookGate,
     stage: Option<StageMode>,
     announcer: &mut HookAnnouncer<'_>,
+    pre_approved_guidance: PreApprovedGuidance,
 ) -> anyhow::Result<SquashResult> {
     // Load config once, run LLM setup prompt, then reuse config
     let mut config = UserConfig::load().context("Failed to load config")?;
@@ -67,7 +86,18 @@ pub fn handle_squash(
     let current_branch = env.require_branch("squash")?.to_string();
     let ctx = env.context(yes);
     let resolved = env.resolved();
-    let generator = CommitGenerator::new(&resolved.commit_generation);
+    // Defer project-guidance approval until we know an LLM call will happen
+    // (after the NoCommitsAhead / AlreadySingleCommit early-exits). When the
+    // caller pre-approved via an upstream batch (e.g. `wt merge`), use that
+    // value directly to avoid a second prompt mid-flow.
+    let llm_configured = resolved.commit_generation.is_configured();
+    let approve_guidance = || -> anyhow::Result<Option<String>> {
+        match &pre_approved_guidance {
+            PreApprovedGuidance::Resolved(value) => Ok(value.clone()),
+            PreApprovedGuidance::RunOwnGate if llm_configured => approve_commit_guidance(&ctx),
+            PreApprovedGuidance::RunOwnGate => Ok(None),
+        }
+    };
 
     // CLI flag overrides config value
     let stage_mode = stage.unwrap_or(resolved.commit.stage());
@@ -153,6 +183,15 @@ pub fn handle_squash(
         return Ok(SquashResult::NoCommitsAhead(integration_target));
     }
 
+    if commit_count == 1 && !has_staged {
+        // Single commit, no staged changes - already squashed
+        return Ok(SquashResult::AlreadySingleCommit);
+    }
+
+    // From here on, an LLM call may happen — gate guidance.
+    let project_guidance = approve_guidance()?;
+    let generator = CommitGenerator::new(&resolved.commit_generation, project_guidance.as_deref());
+
     if commit_count == 0 && has_staged {
         // Just staged changes, no commits - commit them directly (no squashing needed)
         let CommitOutcome {
@@ -165,11 +204,6 @@ pub fn handle_squash(
             message,
             stage_mode,
         });
-    }
-
-    if commit_count == 1 && !has_staged {
-        // Single commit, no staged changes - already squashed
-        return Ok(SquashResult::AlreadySingleCommit);
     }
 
     // Either multiple commits OR single commit with staged changes - squash them
@@ -245,6 +279,7 @@ pub fn handle_squash(
         &current_branch,
         repo_name,
         &resolved.commit_generation,
+        project_guidance.as_deref(),
     )?;
 
     // Display the generated commit message
@@ -341,6 +376,10 @@ fn preview_squash(target: Option<&str>, dry_run: bool) -> anyhow::Result<()> {
         .and_then(|n| n.to_str())
         .unwrap_or("repo");
 
+    let env = CommandEnv::for_action(config)?;
+    let ctx = env.context(false);
+    let project_guidance = resolve_guidance_for_preview(&ctx, &commit_config, dry_run)?;
+
     let prompt = crate::llm::build_squash_prompt(
         &integration_target,
         &merge_base,
@@ -348,6 +387,7 @@ fn preview_squash(target: Option<&str>, dry_run: bool) -> anyhow::Result<()> {
         &current_branch,
         repo_name,
         &commit_config,
+        project_guidance.as_deref(),
     )?;
     if !dry_run {
         println!("{}", prompt);
@@ -360,6 +400,7 @@ fn preview_squash(target: Option<&str>, dry_run: bool) -> anyhow::Result<()> {
         &current_branch,
         repo_name,
         &commit_config,
+        project_guidance.as_deref(),
     )?;
     print_dry_run(&prompt, &commit_config, &message)
 }

--- a/src/commands/step/squash.rs
+++ b/src/commands/step/squash.rs
@@ -11,7 +11,7 @@ use worktrunk::styling::{
 };
 
 use super::super::command_approval::{
-    approve_commit_guidance, approve_or_skip, resolve_guidance_for_preview,
+    approve_commit_template, approve_or_skip, resolve_template_for_preview,
 };
 use super::super::command_executor::FailureStrategy;
 use super::super::commit::{CommitGenerator, CommitOutcome, HookGate, StageMode};
@@ -30,7 +30,7 @@ use super::shared::print_dry_run;
 #[derive(Debug, Clone)]
 pub enum PreApprovedGuidance {
     /// No pre-approval — `handle_squash` runs its own gate via
-    /// `approve_commit_guidance` (only if the LLM is configured).
+    /// `approve_commit_template` (only if the LLM is configured).
     RunOwnGate,
     /// Caller already resolved the guidance through an upstream batch.
     /// `None` means "guidance not configured or user declined".
@@ -94,7 +94,7 @@ pub fn handle_squash(
     let approve_guidance = || -> anyhow::Result<Option<String>> {
         match &pre_approved_guidance {
             PreApprovedGuidance::Resolved(value) => Ok(value.clone()),
-            PreApprovedGuidance::RunOwnGate if llm_configured => approve_commit_guidance(&ctx),
+            PreApprovedGuidance::RunOwnGate if llm_configured => approve_commit_template(&ctx),
             PreApprovedGuidance::RunOwnGate => Ok(None),
         }
     };
@@ -189,8 +189,8 @@ pub fn handle_squash(
     }
 
     // From here on, an LLM call may happen — gate guidance.
-    let project_guidance = approve_guidance()?;
-    let generator = CommitGenerator::new(&resolved.commit_generation, project_guidance.as_deref());
+    let project_template = approve_guidance()?;
+    let generator = CommitGenerator::new(&resolved.commit_generation, project_template.as_deref());
 
     if commit_count == 0 && has_staged {
         // Just staged changes, no commits - commit them directly (no squashing needed)
@@ -279,7 +279,7 @@ pub fn handle_squash(
         &current_branch,
         repo_name,
         &resolved.commit_generation,
-        project_guidance.as_deref(),
+        project_template.as_deref(),
     )?;
 
     // Display the generated commit message
@@ -378,7 +378,7 @@ fn preview_squash(target: Option<&str>, dry_run: bool) -> anyhow::Result<()> {
 
     let env = CommandEnv::for_action(config)?;
     let ctx = env.context(false);
-    let project_guidance = resolve_guidance_for_preview(&ctx, &commit_config, dry_run)?;
+    let project_template = resolve_template_for_preview(&ctx, &commit_config, dry_run)?;
 
     let prompt = crate::llm::build_squash_prompt(
         &integration_target,
@@ -387,7 +387,7 @@ fn preview_squash(target: Option<&str>, dry_run: bool) -> anyhow::Result<()> {
         &current_branch,
         repo_name,
         &commit_config,
-        project_guidance.as_deref(),
+        project_template.as_deref(),
     )?;
     if !dry_run {
         println!("{}", prompt);
@@ -400,7 +400,7 @@ fn preview_squash(target: Option<&str>, dry_run: bool) -> anyhow::Result<()> {
         &current_branch,
         repo_name,
         &commit_config,
-        project_guidance.as_deref(),
+        project_template.as_deref(),
     )?;
     print_dry_run(&prompt, &commit_config, &message)
 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -128,7 +128,10 @@ pub use expansion::{
     validate_template_syntax, vars_available_in,
 };
 pub use hooks::HooksConfig;
-pub use project::{ProjectCiConfig, ProjectConfig, ProjectListConfig, valid_project_config_keys};
+pub use project::{
+    ProjectCiConfig, ProjectCommitConfig, ProjectCommitGenerationConfig, ProjectConfig,
+    ProjectListConfig, valid_project_config_keys,
+};
 pub use unknown_tree::{
     UnknownAnalysis, UnknownTree, UnknownWarning, collect_unknown_warnings, compute_unknown_tree,
 };

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -606,6 +606,7 @@ squash-template-file = "~/file.txt"
             template_file: None,
             squash_template: None,
             squash_template_file: None,
+            template_append: None,
         };
 
         assert_snapshot!(toml::to_string(&config).unwrap(), @r#"

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -77,17 +77,17 @@ pub struct ProjectCommitConfig {
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, JsonSchema)]
 pub struct ProjectCommitGenerationConfig {
     /// Text appended to the commit and squash prompts inside a
-    /// `<template_append>` block.
+    /// `<project-guidance>` block.
     ///
     /// Rendered with the same minijinja context as the main commit/squash
     /// template (`{{ branch }}`, `{{ git_diff }}`, etc.), so it can
     /// reference template variables directly. Use this for project-wide
     /// commit conventions (e.g. "use conventional commits", "reference
     /// issue numbers"). The user config has a `[commit.generation]
-    /// template-append` of its own; both are appended (user first). The
-    /// first time the rendered text would reach the LLM, worktrunk prompts
-    /// the user to approve the raw fragment — the same gate as
-    /// project-defined commands.
+    /// template-append` of its own; it renders into a separate
+    /// `<user-guidance>` block immediately before this one. The first time
+    /// the rendered text would reach the LLM, worktrunk prompts the user to
+    /// approve the raw fragment — the same gate as project-defined commands.
     #[serde(default, rename = "template-append")]
     pub template_append: Option<String>,
 }
@@ -162,7 +162,7 @@ impl ProjectConfig {
     /// treated as unset).
     ///
     /// Rendered with the main commit/squash template's variable context and
-    /// appended to the LLM prompt inside a `<template_append>` block.
+    /// appended to the LLM prompt inside a `<project-guidance>` block.
     /// Callers must gate the first use through the approval system before
     /// sending the rendered output to the LLM.
     pub fn commit_template_append(&self) -> Option<&str> {
@@ -530,7 +530,7 @@ template-append = "Use conventional commits"
     }
 
     /// `commit_template_append()` trims whitespace and treats a blank value
-    /// as unset. Otherwise an empty `<template_append>` block would still
+    /// as unset. Otherwise an empty `<project-guidance>` block would still
     /// render (confusing the LLM) and an empty approval would prompt.
     #[test]
     fn test_commit_template_append_blank_treated_as_unset() {

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -76,15 +76,18 @@ pub struct ProjectCommitConfig {
 /// Project-level commit message generation settings.
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, JsonSchema)]
 pub struct ProjectCommitGenerationConfig {
-    /// Extra commit-message guidance appended to the user's prompt template
-    /// inside a `<project_guidance>` block.
+    /// Project-level template fragment appended to the user's prompt inside
+    /// a `<project_template>` block.
     ///
-    /// Use this for project-wide commit conventions (e.g. "use conventional
-    /// commits", "reference issue numbers"). The first time the LLM would
-    /// see this text, worktrunk prompts the user to approve it — the same
-    /// gate as project-defined commands.
+    /// Rendered with the same minijinja context as the main commit/squash
+    /// template (`{{ branch }}`, `{{ git_diff }}`, etc.), so the fragment
+    /// can reference template variables directly. Use this for project-wide
+    /// commit conventions (e.g. "use conventional commits", "reference
+    /// issue numbers"). The first time the rendered text would reach the
+    /// LLM, worktrunk prompts the user to approve the raw fragment — the
+    /// same gate as project-defined commands.
     #[serde(default)]
-    pub guidance: Option<String>,
+    pub template: Option<String>,
 }
 
 /// Project-level forge configuration.
@@ -153,16 +156,18 @@ impl ProjectConfig {
         self.step.copy_ignored.as_ref()
     }
 
-    /// Project-level commit-message guidance, trimmed, empty treated as unset.
+    /// Project-level commit-message template fragment (trimmed, empty
+    /// treated as unset).
     ///
-    /// The text is appended to the LLM prompt inside a `<project_guidance>`
-    /// block. Callers must gate the first use through the approval system
-    /// (`approve_commit_guidance`) before sending it to the LLM.
-    pub fn commit_guidance(&self) -> Option<&str> {
+    /// Rendered with the main commit/squash template's variable context and
+    /// appended to the LLM prompt inside a `<project_template>` block.
+    /// Callers must gate the first use through the approval system before
+    /// sending the rendered output to the LLM.
+    pub fn commit_template(&self) -> Option<&str> {
         self.commit
             .generation
             .as_ref()
-            .and_then(|g| g.guidance.as_deref())
+            .and_then(|g| g.template.as_deref())
             .map(str::trim)
             .filter(|s| !s.is_empty())
     }
@@ -510,49 +515,46 @@ platform = "github"
     // ============================================================================
 
     #[test]
-    fn test_commit_guidance_parses() {
+    fn test_commit_template_parses() {
         let toml = r#"
 [commit.generation]
-guidance = "Use conventional commits"
+template = "Use conventional commits"
 "#;
         let config: ProjectConfig = toml::from_str(toml).unwrap();
-        assert_eq!(config.commit_guidance(), Some("Use conventional commits"));
+        assert_eq!(config.commit_template(), Some("Use conventional commits"));
     }
 
-    /// `commit_guidance()` trims whitespace and treats blank guidance as unset.
-    /// This matters because empty / whitespace-only guidance would still render
-    /// the `<project_guidance>` block but with no content — confusing the LLM
-    /// and prompting an empty approval. Failing to filter would also produce a
-    /// `truthy` minijinja value, so the template's `{% if project_guidance %}`
-    /// branch can't be the second line of defense.
+    /// `commit_template()` trims whitespace and treats a blank template as
+    /// unset. Otherwise an empty `<project_template>` block would still render
+    /// (confusing the LLM) and an empty approval would prompt.
     #[test]
-    fn test_commit_guidance_blank_treated_as_unset() {
+    fn test_commit_template_blank_treated_as_unset() {
         let toml = r#"
 [commit.generation]
-guidance = "   \n\t  "
+template = "   \n\t  "
 "#;
         let config: ProjectConfig = toml::from_str(toml).unwrap();
-        assert_eq!(config.commit_guidance(), None);
+        assert_eq!(config.commit_template(), None);
 
         // Whitespace inside the body is preserved — only leading/trailing trimmed.
         let toml = r#"
 [commit.generation]
-guidance = "  - a\n  - b  "
+template = "  - a\n  - b  "
 "#;
         let config: ProjectConfig = toml::from_str(toml).unwrap();
-        assert_eq!(config.commit_guidance(), Some("- a\n  - b"));
+        assert_eq!(config.commit_template(), Some("- a\n  - b"));
     }
 
     #[test]
-    fn test_commit_guidance_missing_returns_none() {
+    fn test_commit_template_missing_returns_none() {
         let config = ProjectConfig::default();
-        assert_eq!(config.commit_guidance(), None);
+        assert_eq!(config.commit_template(), None);
 
-        // `[commit.generation]` present but no `guidance` field also returns None.
+        // `[commit.generation]` present but no `template` field also returns None.
         let toml = r#"
 [commit.generation]
 "#;
         let config: ProjectConfig = toml::from_str(toml).unwrap();
-        assert_eq!(config.commit_guidance(), None);
+        assert_eq!(config.commit_template(), None);
     }
 }

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -59,6 +59,34 @@ pub struct ProjectCiConfig {
     pub platform: Option<String>,
 }
 
+/// Project-level commit message configuration. *(Experimental — fields may
+/// change in future releases.)*
+///
+/// Only fields appropriate as shared, checked-in team conventions live here.
+/// The LLM command and full template stay in user/system config — they
+/// describe per-developer environment (which CLI is installed, which agent
+/// they prefer).
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, JsonSchema)]
+pub struct ProjectCommitConfig {
+    /// Commit message generation settings shared across the team.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub generation: Option<ProjectCommitGenerationConfig>,
+}
+
+/// Project-level commit message generation settings.
+#[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, JsonSchema)]
+pub struct ProjectCommitGenerationConfig {
+    /// Extra commit-message guidance appended to the user's prompt template
+    /// inside a `<project_guidance>` block.
+    ///
+    /// Use this for project-wide commit conventions (e.g. "use conventional
+    /// commits", "reference issue numbers"). The first time the LLM would
+    /// see this text, worktrunk prompts the user to approve it — the same
+    /// gate as project-defined commands.
+    #[serde(default)]
+    pub guidance: Option<String>,
+}
+
 /// Project-level forge configuration.
 ///
 /// Names the forge explicitly, for repos where URL-based detection can't
@@ -124,6 +152,20 @@ impl ProjectConfig {
     pub fn copy_ignored(&self) -> Option<&CopyIgnoredConfig> {
         self.step.copy_ignored.as_ref()
     }
+
+    /// Project-level commit-message guidance, trimmed, empty treated as unset.
+    ///
+    /// The text is appended to the LLM prompt inside a `<project_guidance>`
+    /// block. Callers must gate the first use through the approval system
+    /// (`approve_commit_guidance`) before sending it to the LLM.
+    pub fn commit_guidance(&self) -> Option<&str> {
+        self.commit
+            .generation
+            .as_ref()
+            .and_then(|g| g.guidance.as_deref())
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+    }
 }
 
 /// Project-specific configuration with hooks.
@@ -171,6 +213,10 @@ pub struct ProjectConfig {
     /// Forge configuration (platform, API hostname)
     #[serde(default, skip_serializing_if = "is_default")]
     pub forge: ProjectForgeConfig,
+
+    /// Project-wide commit message settings (shared across teammates)
+    #[serde(default, skip_serializing_if = "is_default")]
+    pub commit: ProjectCommitConfig,
 
     /// Configuration for `wt step` subcommands.
     #[serde(default, skip_serializing_if = "is_default")]
@@ -457,5 +503,56 @@ platform = "github"
         let config: ProjectConfig = toml::from_str(contents).unwrap();
         let cloned = config.clone();
         assert_eq!(config, cloned);
+    }
+
+    // ============================================================================
+    // ProjectCommitConfig Tests
+    // ============================================================================
+
+    #[test]
+    fn test_commit_guidance_parses() {
+        let toml = r#"
+[commit.generation]
+guidance = "Use conventional commits"
+"#;
+        let config: ProjectConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.commit_guidance(), Some("Use conventional commits"));
+    }
+
+    /// `commit_guidance()` trims whitespace and treats blank guidance as unset.
+    /// This matters because empty / whitespace-only guidance would still render
+    /// the `<project_guidance>` block but with no content — confusing the LLM
+    /// and prompting an empty approval. Failing to filter would also produce a
+    /// `truthy` minijinja value, so the template's `{% if project_guidance %}`
+    /// branch can't be the second line of defense.
+    #[test]
+    fn test_commit_guidance_blank_treated_as_unset() {
+        let toml = r#"
+[commit.generation]
+guidance = "   \n\t  "
+"#;
+        let config: ProjectConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.commit_guidance(), None);
+
+        // Whitespace inside the body is preserved — only leading/trailing trimmed.
+        let toml = r#"
+[commit.generation]
+guidance = "  - a\n  - b  "
+"#;
+        let config: ProjectConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.commit_guidance(), Some("- a\n  - b"));
+    }
+
+    #[test]
+    fn test_commit_guidance_missing_returns_none() {
+        let config = ProjectConfig::default();
+        assert_eq!(config.commit_guidance(), None);
+
+        // `[commit.generation]` present but no `guidance` field also returns None.
+        let toml = r#"
+[commit.generation]
+"#;
+        let config: ProjectConfig = toml::from_str(toml).unwrap();
+        assert_eq!(config.commit_guidance(), None);
     }
 }

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -62,8 +62,8 @@ pub struct ProjectCiConfig {
 /// Project-level commit message configuration. *(Experimental — fields may
 /// change in future releases.)*
 ///
-/// Only fields appropriate as shared, checked-in team conventions live here.
-/// The LLM command and full template stay in user/system config — they
+/// Only fields appropriate as shared, checked-in settings live here. The LLM
+/// command and full prompt template stay in user/system config — they
 /// describe per-developer environment (which CLI is installed, which agent
 /// they prefer).
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, JsonSchema)]
@@ -76,18 +76,20 @@ pub struct ProjectCommitConfig {
 /// Project-level commit message generation settings.
 #[derive(Debug, Serialize, Deserialize, Clone, Default, PartialEq, JsonSchema)]
 pub struct ProjectCommitGenerationConfig {
-    /// Project-level template fragment appended to the user's prompt inside
-    /// a `<project_template>` block.
+    /// Text appended to the commit and squash prompts inside a
+    /// `<template_append>` block.
     ///
     /// Rendered with the same minijinja context as the main commit/squash
-    /// template (`{{ branch }}`, `{{ git_diff }}`, etc.), so the fragment
-    /// can reference template variables directly. Use this for project-wide
+    /// template (`{{ branch }}`, `{{ git_diff }}`, etc.), so it can
+    /// reference template variables directly. Use this for project-wide
     /// commit conventions (e.g. "use conventional commits", "reference
-    /// issue numbers"). The first time the rendered text would reach the
-    /// LLM, worktrunk prompts the user to approve the raw fragment — the
-    /// same gate as project-defined commands.
-    #[serde(default)]
-    pub template: Option<String>,
+    /// issue numbers"). The user config has a `[commit.generation]
+    /// template-append` of its own; both are appended (user first). The
+    /// first time the rendered text would reach the LLM, worktrunk prompts
+    /// the user to approve the raw fragment — the same gate as
+    /// project-defined commands.
+    #[serde(default, rename = "template-append")]
+    pub template_append: Option<String>,
 }
 
 /// Project-level forge configuration.
@@ -156,18 +158,18 @@ impl ProjectConfig {
         self.step.copy_ignored.as_ref()
     }
 
-    /// Project-level commit-message template fragment (trimmed, empty
+    /// Project-level commit-message append fragment (trimmed, empty
     /// treated as unset).
     ///
     /// Rendered with the main commit/squash template's variable context and
-    /// appended to the LLM prompt inside a `<project_template>` block.
+    /// appended to the LLM prompt inside a `<template_append>` block.
     /// Callers must gate the first use through the approval system before
     /// sending the rendered output to the LLM.
-    pub fn commit_template(&self) -> Option<&str> {
+    pub fn commit_template_append(&self) -> Option<&str> {
         self.commit
             .generation
             .as_ref()
-            .and_then(|g| g.template.as_deref())
+            .and_then(|g| g.template_append.as_deref())
             .map(str::trim)
             .filter(|s| !s.is_empty())
     }
@@ -515,46 +517,49 @@ platform = "github"
     // ============================================================================
 
     #[test]
-    fn test_commit_template_parses() {
+    fn test_commit_template_append_parses() {
         let toml = r#"
 [commit.generation]
-template = "Use conventional commits"
+template-append = "Use conventional commits"
 "#;
         let config: ProjectConfig = toml::from_str(toml).unwrap();
-        assert_eq!(config.commit_template(), Some("Use conventional commits"));
+        assert_eq!(
+            config.commit_template_append(),
+            Some("Use conventional commits")
+        );
     }
 
-    /// `commit_template()` trims whitespace and treats a blank template as
-    /// unset. Otherwise an empty `<project_template>` block would still render
-    /// (confusing the LLM) and an empty approval would prompt.
+    /// `commit_template_append()` trims whitespace and treats a blank value
+    /// as unset. Otherwise an empty `<template_append>` block would still
+    /// render (confusing the LLM) and an empty approval would prompt.
     #[test]
-    fn test_commit_template_blank_treated_as_unset() {
+    fn test_commit_template_append_blank_treated_as_unset() {
         let toml = r#"
 [commit.generation]
-template = "   \n\t  "
+template-append = "   \n\t  "
 "#;
         let config: ProjectConfig = toml::from_str(toml).unwrap();
-        assert_eq!(config.commit_template(), None);
+        assert_eq!(config.commit_template_append(), None);
 
         // Whitespace inside the body is preserved — only leading/trailing trimmed.
         let toml = r#"
 [commit.generation]
-template = "  - a\n  - b  "
+template-append = "  - a\n  - b  "
 "#;
         let config: ProjectConfig = toml::from_str(toml).unwrap();
-        assert_eq!(config.commit_template(), Some("- a\n  - b"));
+        assert_eq!(config.commit_template_append(), Some("- a\n  - b"));
     }
 
     #[test]
-    fn test_commit_template_missing_returns_none() {
+    fn test_commit_template_append_missing_returns_none() {
         let config = ProjectConfig::default();
-        assert_eq!(config.commit_template(), None);
+        assert_eq!(config.commit_template_append(), None);
 
-        // `[commit.generation]` present but no `template` field also returns None.
+        // `[commit.generation]` present but no `template-append` field also returns None.
         let toml = r#"
 [commit.generation]
 "#;
         let config: ProjectConfig = toml::from_str(toml).unwrap();
-        assert_eq!(config.commit_template(), None);
+        assert_eq!(config.commit_template_append(), None);
     }
 }

--- a/src/config/user/sections.rs
+++ b/src/config/user/sections.rs
@@ -88,16 +88,6 @@ impl CommitGenerationConfig {
             .map(|s| !s.trim().is_empty())
             .unwrap_or(false)
     }
-
-    /// User-level commit-message append fragment (trimmed; blank treated as
-    /// unset, so an empty value doesn't render an empty `<template_append>`
-    /// block).
-    pub fn template_append(&self) -> Option<&str> {
-        self.template_append
-            .as_deref()
-            .map(str::trim)
-            .filter(|s| !s.is_empty())
-    }
 }
 
 impl Merge for CommitGenerationConfig {

--- a/src/config/user/sections.rs
+++ b/src/config/user/sections.rs
@@ -64,6 +64,20 @@ pub struct CommitGenerationConfig {
     /// Supports tilde expansion (e.g., "~/.config/worktrunk/squash-template.txt")
     #[serde(default, rename = "squash-template-file")]
     pub squash_template_file: Option<String>,
+
+    /// Inline text appended to the commit and squash prompts inside a
+    /// `<user-guidance>` block, after the main template's `<style>`
+    /// section. Rendered as a minijinja template with the same variables
+    /// (`{{ branch }}`, `{{ git_diff }}`, etc.). Unlike `template`, this
+    /// *adds to* the default prompt instead of replacing it — use it for
+    /// personal commit-message preferences without restating the whole
+    /// template. The project config has a `[commit.generation]
+    /// template-append` of its own; it renders into a separate
+    /// `<project-guidance>` block right after this one.
+    ///
+    /// *(Experimental — may change in future releases.)*
+    #[serde(default, rename = "template-append")]
+    pub template_append: Option<String>,
 }
 
 impl CommitGenerationConfig {
@@ -73,6 +87,16 @@ impl CommitGenerationConfig {
             .as_ref()
             .map(|s| !s.trim().is_empty())
             .unwrap_or(false)
+    }
+
+    /// User-level commit-message append fragment (trimmed; blank treated as
+    /// unset, so an empty value doesn't render an empty `<template_append>`
+    /// block).
+    pub fn template_append(&self) -> Option<&str> {
+        self.template_append
+            .as_deref()
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
     }
 }
 
@@ -105,6 +129,10 @@ impl Merge for CommitGenerationConfig {
             template_file,
             squash_template,
             squash_template_file,
+            template_append: other
+                .template_append
+                .clone()
+                .or_else(|| self.template_append.clone()),
         }
     }
 }

--- a/src/config/user/tests.rs
+++ b/src/config/user/tests.rs
@@ -750,6 +750,7 @@ fn test_merge_commit_generation_config() {
         template_file: Some("~/.config/template.txt".to_string()),
         squash_template: None,
         squash_template_file: None,
+        template_append: None,
     };
     let override_config = CommitGenerationConfig {
         command: Some("claude -p --model=haiku".to_string()), // Override
@@ -757,6 +758,7 @@ fn test_merge_commit_generation_config() {
         template_file: None,                                  // Fall back to base
         squash_template: None,
         squash_template_file: None,
+        template_append: None,
     };
 
     let merged = base.merge_with(&override_config);
@@ -764,6 +766,28 @@ fn test_merge_commit_generation_config() {
     assert_eq!(merged.template, Some("custom".to_string()));
     // When project sets template, template_file is cleared to maintain mutual exclusivity
     assert_eq!(merged.template_file, None);
+}
+
+#[test]
+fn test_merge_commit_generation_template_append() {
+    // Override wins when set; otherwise the base value carries through.
+    let base = CommitGenerationConfig {
+        template_append: Some("base append".to_string()),
+        ..Default::default()
+    };
+    let override_config = CommitGenerationConfig {
+        template_append: Some("override append".to_string()),
+        ..Default::default()
+    };
+    assert_eq!(
+        base.merge_with(&override_config).template_append,
+        Some("override append".to_string())
+    );
+    assert_eq!(
+        base.merge_with(&CommitGenerationConfig::default())
+            .template_append,
+        Some("base append".to_string())
+    );
 }
 
 #[test]

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -1155,6 +1155,42 @@ mod tests {
         "#);
     }
 
+    /// The project fragment is itself a minijinja template — variables in it
+    /// expand against the same context as the main template. Without this
+    /// test, the pre-render pass in `build_prompt` could regress to a raw
+    /// string injection and nothing else would catch it.
+    #[test]
+    fn test_project_fragment_expands_template_variables() {
+        let config = CommitGenerationConfig::default();
+        let mut context = commit_context("diff", "feature/auth", None, "myrepo");
+        context.project_template = Some("Branch: {{ branch }} ({{ repo }})");
+        let prompt = build_prompt(&config, TemplateType::Commit, &context).unwrap();
+        assert!(
+            prompt.contains("Branch: feature/auth (myrepo)"),
+            "expected minijinja-expanded fragment in prompt, got:\n{prompt}"
+        );
+        // Make sure the unexpanded form didn't sneak through.
+        assert!(
+            !prompt.contains("{{ branch }}"),
+            "fragment was not rendered:\n{prompt}"
+        );
+    }
+
+    /// A malformed fragment must surface its render error rather than slipping
+    /// into the LLM prompt as literal text.
+    #[test]
+    fn test_project_fragment_render_error_propagates() {
+        let config = CommitGenerationConfig::default();
+        let mut context = commit_context("diff", "main", None, "repo");
+        context.project_template = Some("Unclosed {{ branch");
+        let err = build_prompt(&config, TemplateType::Commit, &context).unwrap_err();
+        assert!(
+            err.to_string().contains("syntax error")
+                || err.to_string().to_lowercase().contains("unexpected"),
+            "expected minijinja syntax error, got: {err}"
+        );
+    }
+
     #[test]
     fn test_default_squash_template_renders_project_fragment() {
         let config = CommitGenerationConfig::default();

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -251,9 +251,12 @@ struct TemplateContext<'a> {
     commits: &'a [String],
     /// Target branch for merge (squash only)
     target_branch: Option<&'a str>,
-    /// Project-level commit guidance appended in a `<project_guidance>` block.
-    /// `None` when no project guidance is set or the user declined approval.
-    project_guidance: Option<&'a str>,
+    /// Project-level template fragment appended in a `<project_template>`
+    /// block. `None` when no project template is set or the user declined
+    /// approval. The fragment is itself a minijinja template — `build_prompt`
+    /// renders it first and passes the result to the parent template via
+    /// the `project_template` variable.
+    project_template: Option<&'a str>,
 }
 
 /// Default template for commit message prompts
@@ -272,10 +275,10 @@ const DEFAULT_TEMPLATE: &str = r#"<task>Write a commit message for the staged ch
 - Match recent commit style (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-{% if project_guidance %}
-<project_guidance>
-{{ project_guidance }}
-</project_guidance>
+{% if project_template %}
+<project_template>
+{{ project_template }}
+</project_template>
 {% endif %}
 <diffstat>
 {{ git_diff_stat }}
@@ -309,10 +312,10 @@ const DEFAULT_SQUASH_TEMPLATE: &str = r#"<task>Write a commit message for the co
 - Match the style of commits being squashed (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-{% if project_guidance %}
-<project_guidance>
-{{ project_guidance }}
-</project_guidance>
+{% if project_template %}
+<project_template>
+{{ project_template }}
+</project_template>
 {% endif %}
 <commits branch="{{ branch }}" target="{{ target_branch }}">
 {% for commit in commits %}- {{ commit }}
@@ -498,6 +501,26 @@ fn build_prompt(
     // Reverse commits so they're in chronological order (oldest first)
     let commits_chronological: Vec<&String> = context.commits.iter().rev().collect();
 
+    // Pre-render the project's template fragment with the same context so the
+    // parent template can inject the result via `{{ project_template }}`.
+    // Done as a separate pass so the fragment doesn't share scope with the
+    // parent template (and can't recursively reference itself).
+    let project_template_rendered = match context.project_template {
+        Some(fragment) => {
+            let project_tmpl = env.template_from_str(fragment)?;
+            Some(project_tmpl.render(minijinja::context! {
+                git_diff => context.git_diff,
+                git_diff_stat => context.git_diff_stat,
+                branch => context.branch,
+                recent_commits => context.recent_commits.unwrap_or(&vec![]),
+                repo => context.repo_name,
+                commits => &commits_chronological,
+                target_branch => context.target_branch.unwrap_or(""),
+            })?)
+        }
+        None => None,
+    };
+
     let rendered = tmpl.render(minijinja::context! {
         git_diff => context.git_diff,
         git_diff_stat => context.git_diff_stat,
@@ -506,7 +529,7 @@ fn build_prompt(
         repo => context.repo_name,
         commits => commits_chronological,
         target_branch => context.target_branch.unwrap_or(""),
-        project_guidance => context.project_guidance.unwrap_or(""),
+        project_template => project_template_rendered.as_deref().unwrap_or(""),
     })?;
 
     Ok(rendered)
@@ -515,11 +538,13 @@ fn build_prompt(
 /// `index_override` is forwarded to git operations that read the staging area, so
 /// `--dry-run` can preview against a temp index without touching the user's real one.
 ///
-/// `project_guidance` is the approved project-level guidance (or `None` to skip).
+/// `project_template` is the approved project-level template fragment (or
+/// `None` to skip). It is rendered with the main template's context and
+/// appended to the prompt inside a `<project_template>` block.
 pub(crate) fn generate_commit_message(
     commit_generation_config: &CommitGenerationConfig,
     index_override: Option<&Path>,
-    project_guidance: Option<&str>,
+    project_template: Option<&str>,
 ) -> anyhow::Result<String> {
     // Check if commit generation is configured (non-empty command)
     if commit_generation_config.is_configured() {
@@ -529,7 +554,7 @@ pub(crate) fn generate_commit_message(
             command,
             commit_generation_config,
             index_override,
-            project_guidance,
+            project_template,
         )
         .map_err(|e| {
             worktrunk::git::GitError::LlmCommandFailed {
@@ -583,9 +608,9 @@ fn try_generate_commit_message(
     command: &str,
     config: &CommitGenerationConfig,
     index_override: Option<&Path>,
-    project_guidance: Option<&str>,
+    project_template: Option<&str>,
 ) -> anyhow::Result<String> {
-    let prompt = build_commit_prompt(config, index_override, project_guidance)?;
+    let prompt = build_commit_prompt(config, index_override, project_template)?;
     execute_llm_command(command, &prompt)
 }
 
@@ -617,7 +642,7 @@ fn run_git_capture(cmd: Cmd, what: &str) -> anyhow::Result<String> {
 pub(crate) fn build_commit_prompt(
     config: &CommitGenerationConfig,
     index_override: Option<&Path>,
-    project_guidance: Option<&str>,
+    project_template: Option<&str>,
 ) -> anyhow::Result<String> {
     let repo = Repository::current()?;
     let cwd = repo.discovery_path().to_path_buf();
@@ -667,7 +692,7 @@ pub(crate) fn build_commit_prompt(
         repo_name,
         commits: &[],
         target_branch: None,
-        project_guidance,
+        project_template,
     };
     build_prompt(config, TemplateType::Commit, &context)
 }
@@ -679,7 +704,7 @@ pub(crate) fn generate_squash_message(
     current_branch: &str,
     repo_name: &str,
     commit_generation_config: &CommitGenerationConfig,
-    project_guidance: Option<&str>,
+    project_template: Option<&str>,
 ) -> anyhow::Result<String> {
     // Check if commit generation is configured (non-empty command)
     if commit_generation_config.is_configured() {
@@ -692,7 +717,7 @@ pub(crate) fn generate_squash_message(
             current_branch,
             repo_name,
             commit_generation_config,
-            project_guidance,
+            project_template,
         )?;
 
         return execute_llm_command(command, &prompt).map_err(|e| {
@@ -729,7 +754,7 @@ pub(crate) fn build_squash_prompt(
     current_branch: &str,
     repo_name: &str,
     config: &CommitGenerationConfig,
-    project_guidance: Option<&str>,
+    project_template: Option<&str>,
 ) -> anyhow::Result<String> {
     let repo = Repository::current()?;
 
@@ -759,7 +784,7 @@ pub(crate) fn build_squash_prompt(
         repo_name,
         commits: subjects,
         target_branch: Some(target_branch),
-        project_guidance,
+        project_template,
     };
     build_prompt(config, TemplateType::Squash, &context)
 }
@@ -814,7 +839,7 @@ pub(crate) fn test_commit_generation(
         // The connectivity test sends a synthetic prompt — keep it independent
         // of any project guidance so it doesn't surface team-policy text in
         // `wt config show`.
-        project_guidance: None,
+        project_template: None,
     };
     let prompt = build_prompt(commit_generation_config, TemplateType::Commit, &context)?;
 
@@ -891,7 +916,7 @@ mod tests {
             repo_name,
             commits: &[],
             target_branch: None,
-            project_guidance: None,
+            project_template: None,
         }
     }
 
@@ -912,7 +937,7 @@ mod tests {
             repo_name,
             commits,
             target_branch: Some(target_branch),
-            project_guidance: None,
+            project_template: None,
         }
     }
 
@@ -1089,10 +1114,10 @@ mod tests {
     }
 
     #[test]
-    fn test_default_commit_template_renders_project_guidance() {
+    fn test_default_commit_template_renders_project_fragment() {
         let config = CommitGenerationConfig::default();
         let mut context = commit_context("diff content", "main", None, "myrepo");
-        context.project_guidance = Some("- Use conventional commits\n- Reference the issue");
+        context.project_template = Some("- Use conventional commits\n- Reference the issue");
         let prompt = build_prompt(&config, TemplateType::Commit, &context).unwrap();
         // The block lives between `<style>` and `<diffstat>`, only when guidance is set.
         assert_snapshot!(prompt, @r#"
@@ -1110,10 +1135,10 @@ mod tests {
         - Describe the change, not the intent or benefit
         </style>
 
-        <project_guidance>
+        <project_template>
         - Use conventional commits
         - Reference the issue
-        </project_guidance>
+        </project_template>
 
         <diffstat>
 
@@ -1131,11 +1156,11 @@ mod tests {
     }
 
     #[test]
-    fn test_default_squash_template_renders_project_guidance() {
+    fn test_default_squash_template_renders_project_fragment() {
         let config = CommitGenerationConfig::default();
         let commits = vec!["feat: A".to_string(), "fix: B".to_string()];
         let mut context = squash_context("diff content", "feature", None, "repo", &commits, "main");
-        context.project_guidance = Some("- Reference the related issue");
+        context.project_template = Some("- Reference the related issue");
         let prompt = build_prompt(&config, TemplateType::Squash, &context).unwrap();
         assert_snapshot!(prompt, @r#"
         <task>Write a commit message for the combined effect of these commits.</task>
@@ -1152,9 +1177,9 @@ mod tests {
         - Describe the change, not the intent or benefit
         </style>
 
-        <project_guidance>
+        <project_template>
         - Reference the related issue
-        </project_guidance>
+        </project_template>
 
         <commits branch="feature" target="main">
         - fix: B

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -251,12 +251,15 @@ struct TemplateContext<'a> {
     commits: &'a [String],
     /// Target branch for merge (squash only)
     target_branch: Option<&'a str>,
-    /// Project-level template fragment appended in a `<project_template>`
-    /// block. `None` when no project template is set or the user declined
-    /// approval. The fragment is itself a minijinja template — `build_prompt`
-    /// renders it first and passes the result to the parent template via
-    /// the `project_template` variable.
-    project_template: Option<&'a str>,
+    /// Approved project-level append fragment. `None` when no project
+    /// `template-append` is set or the user declined approval. The
+    /// user-level append fragment is read from the [`CommitGenerationConfig`]
+    /// directly (it needs no approval). Both fragments are themselves
+    /// minijinja templates — `build_prompt` renders each one and exposes
+    /// them as the `user_guidance` and `project_guidance` variables, which
+    /// the default templates wrap in `<user-guidance>` / `<project-guidance>`
+    /// blocks.
+    project_append: Option<&'a str>,
 }
 
 /// Default template for commit message prompts
@@ -275,10 +278,14 @@ const DEFAULT_TEMPLATE: &str = r#"<task>Write a commit message for the staged ch
 - Match recent commit style (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-{% if project_template %}
-<project_template>
-{{ project_template }}
-</project_template>
+{% if user_guidance %}
+<user-guidance>
+{{ user_guidance }}
+</user-guidance>
+{% endif %}{% if project_guidance %}
+<project-guidance>
+{{ project_guidance }}
+</project-guidance>
 {% endif %}
 <diffstat>
 {{ git_diff_stat }}
@@ -312,10 +319,14 @@ const DEFAULT_SQUASH_TEMPLATE: &str = r#"<task>Write a commit message for the co
 - Match the style of commits being squashed (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-{% if project_template %}
-<project_template>
-{{ project_template }}
-</project_template>
+{% if user_guidance %}
+<user-guidance>
+{{ user_guidance }}
+</user-guidance>
+{% endif %}{% if project_guidance %}
+<project-guidance>
+{{ project_guidance }}
+</project-guidance>
 {% endif %}
 <commits branch="{{ branch }}" target="{{ target_branch }}">
 {% for commit in commits %}- {{ commit }}
@@ -500,36 +511,53 @@ fn build_prompt(
 
     // Reverse commits so they're in chronological order (oldest first)
     let commits_chronological: Vec<&String> = context.commits.iter().rev().collect();
+    let empty_commits: Vec<String> = vec![];
 
-    // Pre-render the project's template fragment with the same context so the
-    // parent template can inject the result via `{{ project_template }}`.
-    // Done as a separate pass so the fragment doesn't share scope with the
-    // parent template (and can't recursively reference itself).
-    let project_template_rendered = match context.project_template {
-        Some(fragment) => {
-            let project_tmpl = env.template_from_str(fragment)?;
-            Some(project_tmpl.render(minijinja::context! {
-                git_diff => context.git_diff,
-                git_diff_stat => context.git_diff_stat,
-                branch => context.branch,
-                recent_commits => context.recent_commits.unwrap_or(&vec![]),
-                repo => context.repo_name,
-                commits => &commits_chronological,
-                target_branch => context.target_branch.unwrap_or(""),
-            })?)
-        }
-        None => None,
+    // The append fragments are themselves minijinja templates. Render each
+    // one in its own pass with the same variable context so it doesn't share
+    // scope with the parent template (and can't recursively reference
+    // itself), then expose them separately as `user_guidance` /
+    // `project_guidance` so the default templates can label each by
+    // provenance. The user fragment needs no approval (it's the developer's
+    // own config); the project fragment is gated upstream and arrives here
+    // as `context.project_append` (or `None` if declined). Empty string when
+    // a source is absent — the templates gate the block on truthiness.
+    let render_fragment = |fragment: &str| -> anyhow::Result<String> {
+        let frag_tmpl = env.template_from_str(fragment)?;
+        Ok(frag_tmpl.render(minijinja::context! {
+            git_diff => context.git_diff,
+            git_diff_stat => context.git_diff_stat,
+            branch => context.branch,
+            recent_commits => context.recent_commits.unwrap_or(&empty_commits),
+            repo => context.repo_name,
+            commits => &commits_chronological,
+            target_branch => context.target_branch.unwrap_or(""),
+        })?)
+    };
+    let user_guidance = match config
+        .template_append
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+    {
+        Some(fragment) => render_fragment(fragment)?,
+        None => String::new(),
+    };
+    let project_guidance = match context.project_append {
+        Some(fragment) => render_fragment(fragment)?,
+        None => String::new(),
     };
 
     let rendered = tmpl.render(minijinja::context! {
         git_diff => context.git_diff,
         git_diff_stat => context.git_diff_stat,
         branch => context.branch,
-        recent_commits => context.recent_commits.unwrap_or(&vec![]),
+        recent_commits => context.recent_commits.unwrap_or(&empty_commits),
         repo => context.repo_name,
         commits => commits_chronological,
         target_branch => context.target_branch.unwrap_or(""),
-        project_template => project_template_rendered.as_deref().unwrap_or(""),
+        user_guidance => user_guidance,
+        project_guidance => project_guidance,
     })?;
 
     Ok(rendered)
@@ -538,13 +566,15 @@ fn build_prompt(
 /// `index_override` is forwarded to git operations that read the staging area, so
 /// `--dry-run` can preview against a temp index without touching the user's real one.
 ///
-/// `project_template` is the approved project-level template fragment (or
+/// `project_append` is the approved project-level append fragment (or
 /// `None` to skip). It is rendered with the main template's context and
-/// appended to the prompt inside a `<project_template>` block.
+/// appended to the prompt inside a `<project-guidance>` block; the
+/// user-level append fragment from the [`CommitGenerationConfig`] renders
+/// separately into `<user-guidance>`.
 pub(crate) fn generate_commit_message(
     commit_generation_config: &CommitGenerationConfig,
     index_override: Option<&Path>,
-    project_template: Option<&str>,
+    project_append: Option<&str>,
 ) -> anyhow::Result<String> {
     // Check if commit generation is configured (non-empty command)
     if commit_generation_config.is_configured() {
@@ -554,7 +584,7 @@ pub(crate) fn generate_commit_message(
             command,
             commit_generation_config,
             index_override,
-            project_template,
+            project_append,
         )
         .map_err(|e| {
             worktrunk::git::GitError::LlmCommandFailed {
@@ -608,9 +638,9 @@ fn try_generate_commit_message(
     command: &str,
     config: &CommitGenerationConfig,
     index_override: Option<&Path>,
-    project_template: Option<&str>,
+    project_append: Option<&str>,
 ) -> anyhow::Result<String> {
-    let prompt = build_commit_prompt(config, index_override, project_template)?;
+    let prompt = build_commit_prompt(config, index_override, project_append)?;
     execute_llm_command(command, &prompt)
 }
 
@@ -642,7 +672,7 @@ fn run_git_capture(cmd: Cmd, what: &str) -> anyhow::Result<String> {
 pub(crate) fn build_commit_prompt(
     config: &CommitGenerationConfig,
     index_override: Option<&Path>,
-    project_template: Option<&str>,
+    project_append: Option<&str>,
 ) -> anyhow::Result<String> {
     let repo = Repository::current()?;
     let cwd = repo.discovery_path().to_path_buf();
@@ -692,7 +722,7 @@ pub(crate) fn build_commit_prompt(
         repo_name,
         commits: &[],
         target_branch: None,
-        project_template,
+        project_append,
     };
     build_prompt(config, TemplateType::Commit, &context)
 }
@@ -704,7 +734,7 @@ pub(crate) fn generate_squash_message(
     current_branch: &str,
     repo_name: &str,
     commit_generation_config: &CommitGenerationConfig,
-    project_template: Option<&str>,
+    project_append: Option<&str>,
 ) -> anyhow::Result<String> {
     // Check if commit generation is configured (non-empty command)
     if commit_generation_config.is_configured() {
@@ -717,7 +747,7 @@ pub(crate) fn generate_squash_message(
             current_branch,
             repo_name,
             commit_generation_config,
-            project_template,
+            project_append,
         )?;
 
         return execute_llm_command(command, &prompt).map_err(|e| {
@@ -754,7 +784,7 @@ pub(crate) fn build_squash_prompt(
     current_branch: &str,
     repo_name: &str,
     config: &CommitGenerationConfig,
-    project_template: Option<&str>,
+    project_append: Option<&str>,
 ) -> anyhow::Result<String> {
     let repo = Repository::current()?;
 
@@ -784,7 +814,7 @@ pub(crate) fn build_squash_prompt(
         repo_name,
         commits: subjects,
         target_branch: Some(target_branch),
-        project_template,
+        project_append,
     };
     build_prompt(config, TemplateType::Squash, &context)
 }
@@ -839,7 +869,7 @@ pub(crate) fn test_commit_generation(
         // The connectivity test sends a synthetic prompt — keep it independent
         // of any project guidance so it doesn't surface team-policy text in
         // `wt config show`.
-        project_template: None,
+        project_append: None,
     };
     let prompt = build_prompt(commit_generation_config, TemplateType::Commit, &context)?;
 
@@ -916,7 +946,7 @@ mod tests {
             repo_name,
             commits: &[],
             target_branch: None,
-            project_template: None,
+            project_append: None,
         }
     }
 
@@ -937,7 +967,7 @@ mod tests {
             repo_name,
             commits,
             target_branch: Some(target_branch),
-            project_template: None,
+            project_append: None,
         }
     }
 
@@ -1055,6 +1085,7 @@ mod tests {
             template_file: None,
             squash_template: None,
             squash_template_file: None,
+            template_append: None,
         };
         let context = commit_context("my diff", "feature", None, "repo");
         let result = build_prompt(&config, TemplateType::Commit, &context);
@@ -1070,6 +1101,7 @@ mod tests {
             template_file: None,
             squash_template: None,
             squash_template_file: None,
+            template_append: None,
         };
         let context = commit_context("diff", "main", None, "repo");
         let result = build_prompt(&config, TemplateType::Commit, &context);
@@ -1084,6 +1116,7 @@ mod tests {
             template_file: None,
             squash_template: None,
             squash_template_file: None,
+            template_append: None,
         };
         let context = commit_context("diff", "main", None, "repo");
         let result = build_prompt(&config, TemplateType::Commit, &context);
@@ -1101,6 +1134,7 @@ mod tests {
             template_file: None,
             squash_template: None,
             squash_template_file: None,
+            template_append: None,
         };
         let commits = vec!["commit1".to_string(), "commit2".to_string()];
         let context = commit_context("my diff", "feature", Some(&commits), "myrepo");
@@ -1117,7 +1151,7 @@ mod tests {
     fn test_default_commit_template_renders_project_fragment() {
         let config = CommitGenerationConfig::default();
         let mut context = commit_context("diff content", "main", None, "myrepo");
-        context.project_template = Some("- Use conventional commits\n- Reference the issue");
+        context.project_append = Some("- Use conventional commits\n- Reference the issue");
         let prompt = build_prompt(&config, TemplateType::Commit, &context).unwrap();
         // The block lives between `<style>` and `<diffstat>`, only when guidance is set.
         assert_snapshot!(prompt, @r#"
@@ -1135,10 +1169,10 @@ mod tests {
         - Describe the change, not the intent or benefit
         </style>
 
-        <project_template>
+        <project-guidance>
         - Use conventional commits
         - Reference the issue
-        </project_template>
+        </project-guidance>
 
         <diffstat>
 
@@ -1155,6 +1189,76 @@ mod tests {
         "#);
     }
 
+    /// The user-level `template-append` (from `CommitGenerationConfig`,
+    /// no approval) renders into a `<user-guidance>` block.
+    #[test]
+    fn test_user_template_append_renders() {
+        let config = CommitGenerationConfig {
+            template_append: Some("- Personal: explain the why".to_string()),
+            ..Default::default()
+        };
+        let context = commit_context("diff content", "main", None, "myrepo");
+        let prompt = build_prompt(&config, TemplateType::Commit, &context).unwrap();
+        assert!(
+            prompt.contains("<user-guidance>\n- Personal: explain the why\n</user-guidance>"),
+            "user append should render in <user-guidance>, got:\n{prompt}"
+        );
+    }
+
+    /// User and project appends render into separate provenance-labeled
+    /// blocks, `<user-guidance>` before `<project-guidance>`.
+    #[test]
+    fn test_user_and_project_append_combined() {
+        let config = CommitGenerationConfig {
+            template_append: Some("USER LINE".to_string()),
+            ..Default::default()
+        };
+        let mut context = commit_context("d", "main", None, "repo");
+        context.project_append = Some("PROJECT LINE");
+        let prompt = build_prompt(&config, TemplateType::Commit, &context).unwrap();
+        let user_at = prompt.find("<user-guidance>\nUSER LINE\n</user-guidance>");
+        let project_at = prompt.find("<project-guidance>\nPROJECT LINE\n</project-guidance>");
+        assert!(
+            matches!((user_at, project_at), (Some(u), Some(p)) if u < p),
+            "<user-guidance> should precede <project-guidance>, got:\n{prompt}"
+        );
+    }
+
+    /// A blank user append is treated as unset — no empty block rendered.
+    #[test]
+    fn test_user_template_append_blank_is_unset() {
+        let config = CommitGenerationConfig {
+            template_append: Some("   \n\t ".to_string()),
+            ..Default::default()
+        };
+        let context = commit_context("d", "main", None, "repo");
+        let prompt = build_prompt(&config, TemplateType::Commit, &context).unwrap();
+        assert!(
+            !prompt.contains("<user-guidance>"),
+            "blank user append must not render a block, got:\n{prompt}"
+        );
+    }
+
+    /// The user append is itself a minijinja template, rendered against the
+    /// same context as the main template.
+    #[test]
+    fn test_user_template_append_expands_variables() {
+        let config = CommitGenerationConfig {
+            template_append: Some("Repo {{ repo }} on {{ branch }}".to_string()),
+            ..Default::default()
+        };
+        let context = commit_context("d", "feat/x", None, "myrepo");
+        let prompt = build_prompt(&config, TemplateType::Commit, &context).unwrap();
+        assert!(
+            prompt.contains("Repo myrepo on feat/x"),
+            "user append should expand variables, got:\n{prompt}"
+        );
+        assert!(
+            !prompt.contains("{{ repo }}"),
+            "user append was not rendered:\n{prompt}"
+        );
+    }
+
     /// The project fragment is itself a minijinja template — variables in it
     /// expand against the same context as the main template. Without this
     /// test, the pre-render pass in `build_prompt` could regress to a raw
@@ -1163,7 +1267,7 @@ mod tests {
     fn test_project_fragment_expands_template_variables() {
         let config = CommitGenerationConfig::default();
         let mut context = commit_context("diff", "feature/auth", None, "myrepo");
-        context.project_template = Some("Branch: {{ branch }} ({{ repo }})");
+        context.project_append = Some("Branch: {{ branch }} ({{ repo }})");
         let prompt = build_prompt(&config, TemplateType::Commit, &context).unwrap();
         assert!(
             prompt.contains("Branch: feature/auth (myrepo)"),
@@ -1182,7 +1286,7 @@ mod tests {
     fn test_project_fragment_render_error_propagates() {
         let config = CommitGenerationConfig::default();
         let mut context = commit_context("diff", "main", None, "repo");
-        context.project_template = Some("Unclosed {{ branch");
+        context.project_append = Some("Unclosed {{ branch");
         let err = build_prompt(&config, TemplateType::Commit, &context).unwrap_err();
         assert!(
             err.to_string().contains("syntax error")
@@ -1196,7 +1300,7 @@ mod tests {
         let config = CommitGenerationConfig::default();
         let commits = vec!["feat: A".to_string(), "fix: B".to_string()];
         let mut context = squash_context("diff content", "feature", None, "repo", &commits, "main");
-        context.project_template = Some("- Reference the related issue");
+        context.project_append = Some("- Reference the related issue");
         let prompt = build_prompt(&config, TemplateType::Squash, &context).unwrap();
         assert_snapshot!(prompt, @r#"
         <task>Write a commit message for the combined effect of these commits.</task>
@@ -1213,9 +1317,9 @@ mod tests {
         - Describe the change, not the intent or benefit
         </style>
 
-        <project_template>
+        <project-guidance>
         - Reference the related issue
-        </project_template>
+        </project-guidance>
 
         <commits branch="feature" target="main">
         - fix: B
@@ -1279,6 +1383,7 @@ mod tests {
                     .to_string(),
             ),
             squash_template_file: None,
+            template_append: None,
         };
         let commits = vec!["A".to_string(), "B".to_string()];
         let context = squash_context("diff", "feature", None, "repo", &commits, "main");
@@ -1305,6 +1410,7 @@ mod tests {
             template_file: None,
             squash_template: Some("{% for x in commits %}{{ x }".to_string()),
             squash_template_file: None,
+            template_append: None,
         };
         let commits: Vec<String> = vec![];
         let context = squash_context("diff", "feature", None, "repo", &commits, "main");
@@ -1320,6 +1426,7 @@ mod tests {
             template_file: None,
             squash_template: Some("  \n  ".to_string()),
             squash_template_file: None,
+            template_append: None,
         };
         let commits: Vec<String> = vec![];
         let context = squash_context("diff", "feature", None, "repo", &commits, "main");
@@ -1339,6 +1446,7 @@ mod tests {
                     .to_string(),
             ),
             squash_template_file: None,
+            template_append: None,
         };
         let commits = vec!["A".to_string(), "B".to_string()];
         let recent = vec!["prev1".to_string(), "prev2".to_string()];
@@ -1383,6 +1491,7 @@ Diff follows:
             template_file: None,
             squash_template: None,
             squash_template_file: None,
+            template_append: None,
         };
 
         // With commits — exercises if-branch, filters, loop.index, whitespace control
@@ -1438,6 +1547,7 @@ Single commit: {{ commits[0] }}
                     .to_string(),
             ),
             squash_template_file: None,
+            template_append: None,
         };
 
         // Multiple commits — reversed for chronological order (C, B, A)
@@ -1482,6 +1592,7 @@ Single commit: {{ commits[0] }}
             template_file: Some(template_path.to_string_lossy().to_string()),
             squash_template: None,
             squash_template_file: None,
+            template_append: None,
         };
         let context = commit_context("my diff", "feature", None, "myrepo");
         let result = build_prompt(&config, TemplateType::Commit, &context);
@@ -1503,6 +1614,7 @@ Single commit: {{ commits[0] }}
             template_file: Some("/nonexistent/path/template.txt".to_string()),
             squash_template: None,
             squash_template_file: None,
+            template_append: None,
         };
         let context = commit_context("diff", "main", None, "repo");
         let result = build_prompt(&config, TemplateType::Commit, &context);
@@ -1528,6 +1640,7 @@ Single commit: {{ commits[0] }}
             template_file: None,
             squash_template: None,
             squash_template_file: Some(template_path.to_string_lossy().to_string()),
+            template_append: None,
         };
         let commits = vec!["A".to_string(), "B".to_string()];
         let context = squash_context("diff", "feature", None, "repo", &commits, "main");
@@ -1550,6 +1663,7 @@ Single commit: {{ commits[0] }}
             template_file: Some("~/nonexistent_template_for_test.txt".to_string()),
             squash_template: None,
             squash_template_file: None,
+            template_append: None,
         };
         let context = commit_context("diff", "main", None, "repo");
         let result = build_prompt(&config, TemplateType::Commit, &context);
@@ -1573,6 +1687,7 @@ Single commit: {{ commits[0] }}
             template_file: None,
             squash_template: None,
             squash_template_file: None,
+            template_append: None,
         };
         let context = commit_context("diff", "feature", None, "repo");
         let result = build_prompt(&config, TemplateType::Commit, &context);

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -251,6 +251,9 @@ struct TemplateContext<'a> {
     commits: &'a [String],
     /// Target branch for merge (squash only)
     target_branch: Option<&'a str>,
+    /// Project-level commit guidance appended in a `<project_guidance>` block.
+    /// `None` when no project guidance is set or the user declined approval.
+    project_guidance: Option<&'a str>,
 }
 
 /// Default template for commit message prompts
@@ -269,7 +272,11 @@ const DEFAULT_TEMPLATE: &str = r#"<task>Write a commit message for the staged ch
 - Match recent commit style (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-
+{% if project_guidance %}
+<project_guidance>
+{{ project_guidance }}
+</project_guidance>
+{% endif %}
 <diffstat>
 {{ git_diff_stat }}
 </diffstat>
@@ -302,7 +309,11 @@ const DEFAULT_SQUASH_TEMPLATE: &str = r#"<task>Write a commit message for the co
 - Match the style of commits being squashed (conventional commits if used)
 - Describe the change, not the intent or benefit
 </style>
-
+{% if project_guidance %}
+<project_guidance>
+{{ project_guidance }}
+</project_guidance>
+{% endif %}
 <commits branch="{{ branch }}" target="{{ target_branch }}">
 {% for commit in commits %}- {{ commit }}
 {% endfor %}</commits>
@@ -495,6 +506,7 @@ fn build_prompt(
         repo => context.repo_name,
         commits => commits_chronological,
         target_branch => context.target_branch.unwrap_or(""),
+        project_guidance => context.project_guidance.unwrap_or(""),
     })?;
 
     Ok(rendered)
@@ -502,26 +514,34 @@ fn build_prompt(
 
 /// `index_override` is forwarded to git operations that read the staging area, so
 /// `--dry-run` can preview against a temp index without touching the user's real one.
+///
+/// `project_guidance` is the approved project-level guidance (or `None` to skip).
 pub(crate) fn generate_commit_message(
     commit_generation_config: &CommitGenerationConfig,
     index_override: Option<&Path>,
+    project_guidance: Option<&str>,
 ) -> anyhow::Result<String> {
     // Check if commit generation is configured (non-empty command)
     if commit_generation_config.is_configured() {
         let command = commit_generation_config.command.as_ref().unwrap();
         // Commit generation is explicitly configured - fail if it doesn't work
-        return try_generate_commit_message(command, commit_generation_config, index_override)
-            .map_err(|e| {
-                worktrunk::git::GitError::LlmCommandFailed {
-                    command: command.clone(),
-                    error: e.to_string(),
-                    reproduction_command: Some(format_reproduction_command(
-                        "wt step commit --show-prompt",
-                        command,
-                    )),
-                }
-                .into()
-            });
+        return try_generate_commit_message(
+            command,
+            commit_generation_config,
+            index_override,
+            project_guidance,
+        )
+        .map_err(|e| {
+            worktrunk::git::GitError::LlmCommandFailed {
+                command: command.clone(),
+                error: e.to_string(),
+                reproduction_command: Some(format_reproduction_command(
+                    "wt step commit --show-prompt",
+                    command,
+                )),
+            }
+            .into()
+        });
     }
 
     // Fallback: generate a descriptive commit message based on changed files
@@ -563,8 +583,9 @@ fn try_generate_commit_message(
     command: &str,
     config: &CommitGenerationConfig,
     index_override: Option<&Path>,
+    project_guidance: Option<&str>,
 ) -> anyhow::Result<String> {
-    let prompt = build_commit_prompt(config, index_override)?;
+    let prompt = build_commit_prompt(config, index_override, project_guidance)?;
     execute_llm_command(command, &prompt)
 }
 
@@ -596,6 +617,7 @@ fn run_git_capture(cmd: Cmd, what: &str) -> anyhow::Result<String> {
 pub(crate) fn build_commit_prompt(
     config: &CommitGenerationConfig,
     index_override: Option<&Path>,
+    project_guidance: Option<&str>,
 ) -> anyhow::Result<String> {
     let repo = Repository::current()?;
     let cwd = repo.discovery_path().to_path_buf();
@@ -645,6 +667,7 @@ pub(crate) fn build_commit_prompt(
         repo_name,
         commits: &[],
         target_branch: None,
+        project_guidance,
     };
     build_prompt(config, TemplateType::Commit, &context)
 }
@@ -656,6 +679,7 @@ pub(crate) fn generate_squash_message(
     current_branch: &str,
     repo_name: &str,
     commit_generation_config: &CommitGenerationConfig,
+    project_guidance: Option<&str>,
 ) -> anyhow::Result<String> {
     // Check if commit generation is configured (non-empty command)
     if commit_generation_config.is_configured() {
@@ -668,6 +692,7 @@ pub(crate) fn generate_squash_message(
             current_branch,
             repo_name,
             commit_generation_config,
+            project_guidance,
         )?;
 
         return execute_llm_command(command, &prompt).map_err(|e| {
@@ -704,6 +729,7 @@ pub(crate) fn build_squash_prompt(
     current_branch: &str,
     repo_name: &str,
     config: &CommitGenerationConfig,
+    project_guidance: Option<&str>,
 ) -> anyhow::Result<String> {
     let repo = Repository::current()?;
 
@@ -733,6 +759,7 @@ pub(crate) fn build_squash_prompt(
         repo_name,
         commits: subjects,
         target_branch: Some(target_branch),
+        project_guidance,
     };
     build_prompt(config, TemplateType::Squash, &context)
 }
@@ -784,6 +811,10 @@ pub(crate) fn test_commit_generation(
         repo_name: "test-repo",
         commits: &[],
         target_branch: None,
+        // The connectivity test sends a synthetic prompt — keep it independent
+        // of any project guidance so it doesn't surface team-policy text in
+        // `wt config show`.
+        project_guidance: None,
     };
     let prompt = build_prompt(commit_generation_config, TemplateType::Commit, &context)?;
 
@@ -860,6 +891,7 @@ mod tests {
             repo_name,
             commits: &[],
             target_branch: None,
+            project_guidance: None,
         }
     }
 
@@ -880,6 +912,7 @@ mod tests {
             repo_name,
             commits,
             target_branch: Some(target_branch),
+            project_guidance: None,
         }
     }
 
@@ -1053,6 +1086,89 @@ mod tests {
             prompt,
             "Repo: myrepo\nBranch: feature\nDiff: my diff\ncommit1\ncommit2\n"
         );
+    }
+
+    #[test]
+    fn test_default_commit_template_renders_project_guidance() {
+        let config = CommitGenerationConfig::default();
+        let mut context = commit_context("diff content", "main", None, "myrepo");
+        context.project_guidance = Some("- Use conventional commits\n- Reference the issue");
+        let prompt = build_prompt(&config, TemplateType::Commit, &context).unwrap();
+        // The block lives between `<style>` and `<diffstat>`, only when guidance is set.
+        assert_snapshot!(prompt, @r#"
+        <task>Write a commit message for the staged changes below.</task>
+
+        <format>
+        - Subject line under 50 chars
+        - For material changes, add a blank line then a body paragraph explaining the change
+        - Output only the commit message, no quotes or code blocks
+        </format>
+
+        <style>
+        - Imperative mood: "Add feature" not "Added feature"
+        - Match recent commit style (conventional commits if used)
+        - Describe the change, not the intent or benefit
+        </style>
+
+        <project_guidance>
+        - Use conventional commits
+        - Reference the issue
+        </project_guidance>
+
+        <diffstat>
+
+        </diffstat>
+
+        <diff>
+        diff content
+        </diff>
+
+        <context>
+        Branch: main
+
+        </context>
+        "#);
+    }
+
+    #[test]
+    fn test_default_squash_template_renders_project_guidance() {
+        let config = CommitGenerationConfig::default();
+        let commits = vec!["feat: A".to_string(), "fix: B".to_string()];
+        let mut context = squash_context("diff content", "feature", None, "repo", &commits, "main");
+        context.project_guidance = Some("- Reference the related issue");
+        let prompt = build_prompt(&config, TemplateType::Squash, &context).unwrap();
+        assert_snapshot!(prompt, @r#"
+        <task>Write a commit message for the combined effect of these commits.</task>
+
+        <format>
+        - Subject line under 50 chars
+        - For material changes, add a blank line then a body paragraph explaining the change
+        - Output only the commit message, no quotes or code blocks
+        </format>
+
+        <style>
+        - Imperative mood: "Add feature" not "Added feature"
+        - Match the style of commits being squashed (conventional commits if used)
+        - Describe the change, not the intent or benefit
+        </style>
+
+        <project_guidance>
+        - Reference the related issue
+        </project_guidance>
+
+        <commits branch="feature" target="main">
+        - fix: B
+        - feat: A
+        </commits>
+
+        <diffstat>
+
+        </diffstat>
+
+        <diff>
+        diff content
+        </diff>
+        "#);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -264,6 +264,7 @@ fn handle_step_command(action: StepCommand, yes: bool) -> anyhow::Result<()> {
                     hooks,
                     args.stage,
                     &mut announcer,
+                    commands::PreApprovedGuidance::RunOwnGate,
                 )?;
                 announcer.flush()?;
                 if format == SwitchFormat::Json {

--- a/src/main.rs
+++ b/src/main.rs
@@ -246,7 +246,7 @@ fn handle_step_command(action: StepCommand, yes: bool) -> anyhow::Result<()> {
             if args.show_prompt {
                 commands::step_show_squash_prompt(args.target.as_deref())
             } else if args.dry_run {
-                commands::step_dry_run_squash(args.target.as_deref())
+                commands::step_dry_run_squash(args.target.as_deref(), yes)
             } else {
                 // Approval is handled inside handle_squash (like step_commit).
                 let repo = Repository::current()?;

--- a/tests/integration_tests/approval_pty.rs
+++ b/tests/integration_tests/approval_pty.rs
@@ -598,14 +598,14 @@ command = "cat >/dev/null && echo 'feat: test commit message'"
 ///
 /// Accept → guidance is included in the prompt the LLM receives.
 #[rstest]
-fn test_commit_guidance_approval_accept(mut repo: TestRepo) {
+fn test_commit_template_approval_accept(mut repo: TestRepo) {
     // Remove origin so worktrunk uses directory name as project identifier.
     repo.run_git(&["remote", "remove", "origin"]);
 
     repo.write_project_config(
         r#"
 [commit.generation]
-guidance = "Use conventional commits"
+template = "Use conventional commits"
 "#,
     );
     repo.commit("Add project commit guidance");
@@ -633,7 +633,7 @@ command = "tee {prompt_capture_str} > /dev/null && echo 'feat: accept guidance'"
         "Commit should succeed when guidance approved. Output:\n{output}"
     );
     assert!(
-        output.contains("commit-guidance"),
+        output.contains("commit-template"),
         "Approval prompt should label the guidance phase. Output:\n{output}"
     );
     assert!(
@@ -643,21 +643,21 @@ command = "tee {prompt_capture_str} > /dev/null && echo 'feat: accept guidance'"
 
     let captured = std::fs::read_to_string(&prompt_capture).expect("captured prompt");
     assert!(
-        captured.contains("<project_guidance>") && captured.contains("Use conventional commits"),
-        "Guidance should be sent to the LLM inside <project_guidance>. Captured:\n{captured}"
+        captured.contains("<project_template>") && captured.contains("Use conventional commits"),
+        "Guidance should be sent to the LLM inside <project_template>. Captured:\n{captured}"
     );
 }
 
 /// Declining the guidance prompt continues without the guidance — the LLM
 /// receives the rest of the prompt as if no project guidance were configured.
 #[rstest]
-fn test_commit_guidance_approval_decline(mut repo: TestRepo) {
+fn test_commit_template_approval_decline(mut repo: TestRepo) {
     repo.run_git(&["remote", "remove", "origin"]);
 
     repo.write_project_config(
         r#"
 [commit.generation]
-guidance = "Reference the issue ID"
+template = "Reference the issue ID"
 "#,
     );
     repo.commit("Add project commit guidance");
@@ -694,8 +694,8 @@ command = "tee {prompt_capture_str} > /dev/null && echo 'feat: decline guidance'
         "Declined guidance must not reach the LLM. Captured:\n{captured}"
     );
     assert!(
-        !captured.contains("<project_guidance>"),
-        "No <project_guidance> block when guidance declined. Captured:\n{captured}"
+        !captured.contains("<project_template>"),
+        "No <project_template> block when guidance declined. Captured:\n{captured}"
     );
 }
 
@@ -710,7 +710,7 @@ fn test_merge_bundles_guidance_into_hook_approval(mut repo: TestRepo) {
 pre-commit = "echo 'pre-commit hook'"
 
 [commit.generation]
-guidance = "Reference the related issue"
+template = "Reference the related issue"
 "#,
     );
     repo.commit("Add project config with hook + guidance");
@@ -740,7 +740,7 @@ command = "tee {prompt_capture_str} > /dev/null && echo 'feat: bundled'"
         "Bundled prompt should list the pre-commit hook command. Output:\n{output}"
     );
     assert!(
-        output.contains("commit-guidance") && output.contains("Reference the related issue"),
+        output.contains("commit-template") && output.contains("Reference the related issue"),
         "Bundled prompt should list the commit guidance. Output:\n{output}"
     );
     // The downstream commit step must not present a second prompt.
@@ -752,7 +752,7 @@ command = "tee {prompt_capture_str} > /dev/null && echo 'feat: bundled'"
 
     let captured = std::fs::read_to_string(&prompt_capture).expect("captured prompt");
     assert!(
-        captured.contains("<project_guidance>") && captured.contains("Reference the related issue"),
+        captured.contains("<project_template>") && captured.contains("Reference the related issue"),
         "Approved guidance should reach the LLM. Captured:\n{captured}"
     );
 }

--- a/tests/integration_tests/approval_pty.rs
+++ b/tests/integration_tests/approval_pty.rs
@@ -594,6 +594,169 @@ command = "cat >/dev/null && echo 'feat: test commit message'"
     assert_no_spurious_no_hooks(&output);
 }
 
+/// Project commit-message guidance must be approved before the LLM sees it.
+///
+/// Accept → guidance is included in the prompt the LLM receives.
+#[rstest]
+fn test_commit_guidance_approval_accept(mut repo: TestRepo) {
+    // Remove origin so worktrunk uses directory name as project identifier.
+    repo.run_git(&["remote", "remove", "origin"]);
+
+    repo.write_project_config(
+        r#"
+[commit.generation]
+guidance = "Use conventional commits"
+"#,
+    );
+    repo.commit("Add project commit guidance");
+
+    let feature_wt = repo.add_worktree("feature-guidance-accept");
+    std::fs::write(feature_wt.join("new-file.txt"), "new content").unwrap();
+
+    // Sink the LLM prompt to a file so we can confirm the guidance reached it.
+    let prompt_capture = repo.root_path().join("captured-prompt.txt");
+    let prompt_capture_str = prompt_capture.display().to_string();
+    repo.write_test_config(&format!(
+        r#"
+[commit.generation]
+command = "tee {prompt_capture_str} > /dev/null && echo 'feat: accept guidance'"
+"#
+    ));
+
+    let env_vars = test_env_vars_with_shell(&repo);
+
+    let (output, exit_code) =
+        exec_wt_in_pty_cwd(&feature_wt, &["step", "commit"], &env_vars, "y\n");
+
+    assert_eq!(
+        exit_code, 0,
+        "Commit should succeed when guidance approved. Output:\n{output}"
+    );
+    assert!(
+        output.contains("commit-guidance"),
+        "Approval prompt should label the guidance phase. Output:\n{output}"
+    );
+    assert!(
+        output.contains("Use conventional commits"),
+        "Approval prompt should display the guidance text. Output:\n{output}"
+    );
+
+    let captured = std::fs::read_to_string(&prompt_capture).expect("captured prompt");
+    assert!(
+        captured.contains("<project_guidance>") && captured.contains("Use conventional commits"),
+        "Guidance should be sent to the LLM inside <project_guidance>. Captured:\n{captured}"
+    );
+}
+
+/// Declining the guidance prompt continues without the guidance — the LLM
+/// receives the rest of the prompt as if no project guidance were configured.
+#[rstest]
+fn test_commit_guidance_approval_decline(mut repo: TestRepo) {
+    repo.run_git(&["remote", "remove", "origin"]);
+
+    repo.write_project_config(
+        r#"
+[commit.generation]
+guidance = "Reference the issue ID"
+"#,
+    );
+    repo.commit("Add project commit guidance");
+
+    let feature_wt = repo.add_worktree("feature-guidance-decline");
+    std::fs::write(feature_wt.join("new-file.txt"), "new content").unwrap();
+
+    let prompt_capture = repo.root_path().join("captured-prompt.txt");
+    let prompt_capture_str = prompt_capture.display().to_string();
+    repo.write_test_config(&format!(
+        r#"
+[commit.generation]
+command = "tee {prompt_capture_str} > /dev/null && echo 'feat: decline guidance'"
+"#
+    ));
+
+    let env_vars = test_env_vars_with_shell(&repo);
+
+    let (output, exit_code) =
+        exec_wt_in_pty_cwd(&feature_wt, &["step", "commit"], &env_vars, "n\n");
+
+    assert_eq!(
+        exit_code, 0,
+        "Commit should succeed even when guidance declined. Output:\n{output}"
+    );
+    assert!(
+        output.contains("Project commit guidance declined"),
+        "Should announce that guidance was declined. Output:\n{output}"
+    );
+
+    let captured = std::fs::read_to_string(&prompt_capture).expect("captured prompt");
+    assert!(
+        !captured.contains("Reference the issue ID"),
+        "Declined guidance must not reach the LLM. Captured:\n{captured}"
+    );
+    assert!(
+        !captured.contains("<project_guidance>"),
+        "No <project_guidance> block when guidance declined. Captured:\n{captured}"
+    );
+}
+
+/// `wt merge` with both project hooks and commit guidance bundles the two
+/// items into the same approval prompt — the user sees one prompt covering
+/// both, not one for hooks and a second for guidance mid-merge.
+#[rstest]
+fn test_merge_bundles_guidance_into_hook_approval(mut repo: TestRepo) {
+    repo.run_git(&["remote", "remove", "origin"]);
+    repo.write_project_config(
+        r#"
+pre-commit = "echo 'pre-commit hook'"
+
+[commit.generation]
+guidance = "Reference the related issue"
+"#,
+    );
+    repo.commit("Add project config with hook + guidance");
+
+    let feature_wt = repo.add_worktree("feature-merge-bundle");
+    std::fs::write(feature_wt.join("new-file.txt"), "new content").unwrap();
+
+    let prompt_capture = repo.root_path().join("captured-prompt.txt");
+    let prompt_capture_str = prompt_capture.display().to_string();
+    repo.write_test_config(&format!(
+        r#"
+[commit.generation]
+command = "tee {prompt_capture_str} > /dev/null && echo 'feat: bundled'"
+"#
+    ));
+
+    let env_vars = test_env_vars_with_shell(&repo);
+
+    let (output, exit_code) = exec_wt_in_pty_cwd(&feature_wt, &["merge"], &env_vars, "y\n");
+
+    assert_eq!(
+        exit_code, 0,
+        "Merge should succeed when both prompts approved. Output:\n{output}"
+    );
+    assert!(
+        output.contains("pre-commit hook"),
+        "Bundled prompt should list the pre-commit hook command. Output:\n{output}"
+    );
+    assert!(
+        output.contains("commit-guidance") && output.contains("Reference the related issue"),
+        "Bundled prompt should list the commit guidance. Output:\n{output}"
+    );
+    // The downstream commit step must not present a second prompt.
+    let prompts = output.matches("Allow and remember?").count();
+    assert_eq!(
+        prompts, 1,
+        "Bundled approval should produce exactly one [y/N] prompt. Saw {prompts}. Output:\n{output}"
+    );
+
+    let captured = std::fs::read_to_string(&prompt_capture).expect("captured prompt");
+    assert!(
+        captured.contains("<project_guidance>") && captured.contains("Reference the related issue"),
+        "Approved guidance should reach the LLM. Captured:\n{captured}"
+    );
+}
+
 /// `wt config approvals add` accepts the prompt — covers the success branch of
 /// `add_approvals` after `approve_command_batch` returns Ok(true).
 #[rstest]

--- a/tests/integration_tests/approval_pty.rs
+++ b/tests/integration_tests/approval_pty.rs
@@ -8,7 +8,7 @@
 //! to simulate interactive terminals. The non-PTY tests in `approval_ui.rs` verify the
 //! error case (non-TTY environments).
 
-use crate::common::pty::{build_pty_command, exec_cmd_in_pty_prompted};
+use crate::common::pty::{build_pty_command, exec_cmd_in_pty, exec_cmd_in_pty_prompted};
 use crate::common::{TestRepo, add_pty_binary_path_filters, add_pty_filters, repo, wt_bin};
 use insta::assert_snapshot;
 use rstest::rstest;
@@ -646,6 +646,32 @@ command = "tee {prompt_capture_str} > /dev/null && echo 'feat: accept guidance'"
         captured.contains("<project-guidance>") && captured.contains("Use conventional commits"),
         "Append should be sent to the LLM inside <project-guidance>. Captured:\n{captured}"
     );
+
+    // Second run: the fragment is already approved, so it must NOT re-prompt
+    // — exercises the `is_command_approved` cache-hit path in
+    // `approve_commit_template_append`.
+    std::fs::write(feature_wt.join("second.txt"), "more content").unwrap();
+    let cmd = build_pty_command(
+        wt_bin().to_str().unwrap(),
+        &["step", "commit"],
+        &feature_wt,
+        &env_vars,
+        None,
+    );
+    let (output2, exit2) = exec_cmd_in_pty(cmd, "");
+    assert_eq!(
+        exit2, 0,
+        "Second commit should succeed without re-prompting. Output:\n{output2}"
+    );
+    assert!(
+        !output2.contains("Allow and remember?"),
+        "Already-approved append must not prompt again. Output:\n{output2}"
+    );
+    let captured2 = std::fs::read_to_string(&prompt_capture).expect("captured prompt (2)");
+    assert!(
+        captured2.contains("<project-guidance>") && captured2.contains("Use conventional commits"),
+        "Approved append should still reach the LLM on re-run. Captured:\n{captured2}"
+    );
 }
 
 /// Declining the append prompt continues without it — the LLM receives the
@@ -762,7 +788,15 @@ command = "tee {prompt_capture_str} > /dev/null && echo 'feat: bundled'"
 #[rstest]
 fn test_config_approvals_add_accept(repo: TestRepo) {
     repo.run_git(&["remote", "remove", "origin"]);
-    repo.write_project_config(r#"pre-start = "echo 'test command'""#);
+    // Include a project commit append so `add_approvals` also collects the
+    // `commit-template-append` entry (covers that branch in add_approvals).
+    repo.write_project_config(
+        r#"pre-start = "echo 'test command'"
+
+[commit.generation]
+template-append = "Use conventional commits"
+"#,
+    );
     repo.commit("Add config");
 
     let env_vars = repo.test_env_vars();
@@ -773,6 +807,10 @@ fn test_config_approvals_add_accept(repo: TestRepo) {
     assert!(
         output.contains("Commands approved"),
         "Should show approval success. Output:\n{output}"
+    );
+    assert!(
+        output.contains("commit-template-append") && output.contains("Use conventional commits"),
+        "add should list the project commit append. Output:\n{output}"
     );
 }
 

--- a/tests/integration_tests/approval_pty.rs
+++ b/tests/integration_tests/approval_pty.rs
@@ -594,21 +594,21 @@ command = "cat >/dev/null && echo 'feat: test commit message'"
     assert_no_spurious_no_hooks(&output);
 }
 
-/// Project commit-message guidance must be approved before the LLM sees it.
+/// Project commit-message append must be approved before the LLM sees it.
 ///
-/// Accept → guidance is included in the prompt the LLM receives.
+/// Accept → the fragment is included in the prompt the LLM receives.
 #[rstest]
-fn test_commit_template_approval_accept(mut repo: TestRepo) {
+fn test_commit_template_append_approval_accept(mut repo: TestRepo) {
     // Remove origin so worktrunk uses directory name as project identifier.
     repo.run_git(&["remote", "remove", "origin"]);
 
     repo.write_project_config(
         r#"
 [commit.generation]
-template = "Use conventional commits"
+template-append = "Use conventional commits"
 "#,
     );
-    repo.commit("Add project commit guidance");
+    repo.commit("Add project commit append");
 
     let feature_wt = repo.add_worktree("feature-guidance-accept");
     std::fs::write(feature_wt.join("new-file.txt"), "new content").unwrap();
@@ -633,34 +633,34 @@ command = "tee {prompt_capture_str} > /dev/null && echo 'feat: accept guidance'"
         "Commit should succeed when guidance approved. Output:\n{output}"
     );
     assert!(
-        output.contains("commit-template"),
-        "Approval prompt should label the guidance phase. Output:\n{output}"
+        output.contains("commit-template-append"),
+        "Approval prompt should label the append phase. Output:\n{output}"
     );
     assert!(
         output.contains("Use conventional commits"),
-        "Approval prompt should display the guidance text. Output:\n{output}"
+        "Approval prompt should display the append text. Output:\n{output}"
     );
 
     let captured = std::fs::read_to_string(&prompt_capture).expect("captured prompt");
     assert!(
-        captured.contains("<project_template>") && captured.contains("Use conventional commits"),
-        "Guidance should be sent to the LLM inside <project_template>. Captured:\n{captured}"
+        captured.contains("<project-guidance>") && captured.contains("Use conventional commits"),
+        "Append should be sent to the LLM inside <project-guidance>. Captured:\n{captured}"
     );
 }
 
-/// Declining the guidance prompt continues without the guidance — the LLM
-/// receives the rest of the prompt as if no project guidance were configured.
+/// Declining the append prompt continues without it — the LLM receives the
+/// rest of the prompt as if no project append were configured.
 #[rstest]
-fn test_commit_template_approval_decline(mut repo: TestRepo) {
+fn test_commit_template_append_approval_decline(mut repo: TestRepo) {
     repo.run_git(&["remote", "remove", "origin"]);
 
     repo.write_project_config(
         r#"
 [commit.generation]
-template = "Reference the issue ID"
+template-append = "Reference the issue ID"
 "#,
     );
-    repo.commit("Add project commit guidance");
+    repo.commit("Add project commit append");
 
     let feature_wt = repo.add_worktree("feature-guidance-decline");
     std::fs::write(feature_wt.join("new-file.txt"), "new content").unwrap();
@@ -684,33 +684,33 @@ command = "tee {prompt_capture_str} > /dev/null && echo 'feat: decline guidance'
         "Commit should succeed even when template declined. Output:\n{output}"
     );
     assert!(
-        output.contains("Project commit template declined"),
-        "Should announce that the template was declined. Output:\n{output}"
+        output.contains("Project commit guidance declined"),
+        "Should announce that the append was declined. Output:\n{output}"
     );
 
     let captured = std::fs::read_to_string(&prompt_capture).expect("captured prompt");
     assert!(
         !captured.contains("Reference the issue ID"),
-        "Declined guidance must not reach the LLM. Captured:\n{captured}"
+        "Declined append must not reach the LLM. Captured:\n{captured}"
     );
     assert!(
-        !captured.contains("<project_template>"),
-        "No <project_template> block when guidance declined. Captured:\n{captured}"
+        !captured.contains("<project-guidance>"),
+        "No <project-guidance> block when append declined. Captured:\n{captured}"
     );
 }
 
-/// `wt merge` with both project hooks and commit guidance bundles the two
+/// `wt merge` with both project hooks and a commit append bundles the two
 /// items into the same approval prompt — the user sees one prompt covering
-/// both, not one for hooks and a second for guidance mid-merge.
+/// both, not one for hooks and a second for the append mid-merge.
 #[rstest]
-fn test_merge_bundles_guidance_into_hook_approval(mut repo: TestRepo) {
+fn test_merge_bundles_append_into_hook_approval(mut repo: TestRepo) {
     repo.run_git(&["remote", "remove", "origin"]);
     repo.write_project_config(
         r#"
 pre-commit = "echo 'pre-commit hook'"
 
 [commit.generation]
-template = "Reference the related issue"
+template-append = "Reference the related issue"
 "#,
     );
     repo.commit("Add project config with hook + guidance");
@@ -740,8 +740,8 @@ command = "tee {prompt_capture_str} > /dev/null && echo 'feat: bundled'"
         "Bundled prompt should list the pre-commit hook command. Output:\n{output}"
     );
     assert!(
-        output.contains("commit-template") && output.contains("Reference the related issue"),
-        "Bundled prompt should list the commit guidance. Output:\n{output}"
+        output.contains("commit-template-append") && output.contains("Reference the related issue"),
+        "Bundled prompt should list the commit append. Output:\n{output}"
     );
     // The downstream commit step must not present a second prompt.
     let prompts = output.matches("Allow and remember?").count();
@@ -752,8 +752,8 @@ command = "tee {prompt_capture_str} > /dev/null && echo 'feat: bundled'"
 
     let captured = std::fs::read_to_string(&prompt_capture).expect("captured prompt");
     assert!(
-        captured.contains("<project_template>") && captured.contains("Reference the related issue"),
-        "Approved guidance should reach the LLM. Captured:\n{captured}"
+        captured.contains("<project-guidance>") && captured.contains("Reference the related issue"),
+        "Approved append should reach the LLM. Captured:\n{captured}"
     );
 }
 

--- a/tests/integration_tests/approval_pty.rs
+++ b/tests/integration_tests/approval_pty.rs
@@ -681,11 +681,11 @@ command = "tee {prompt_capture_str} > /dev/null && echo 'feat: decline guidance'
 
     assert_eq!(
         exit_code, 0,
-        "Commit should succeed even when guidance declined. Output:\n{output}"
+        "Commit should succeed even when template declined. Output:\n{output}"
     );
     assert!(
-        output.contains("Project commit guidance declined"),
-        "Should announce that guidance was declined. Output:\n{output}"
+        output.contains("Project commit template declined"),
+        "Should announce that the template was declined. Output:\n{output}"
     );
 
     let captured = std::fs::read_to_string(&prompt_capture).expect("captured prompt");

--- a/tests/integration_tests/help.rs
+++ b/tests/integration_tests/help.rs
@@ -11,7 +11,7 @@
 //! only the presentation varies.
 #![cfg(not(windows))]
 
-use crate::common::wt_command;
+use crate::common::{add_standard_env_redactions, wt_command};
 use insta::Settings;
 use insta_cmd::assert_cmd_snapshot;
 use rstest::rstest;
@@ -19,6 +19,7 @@ use rstest::rstest;
 fn snapshot_help(test_name: &str, args: &[&str]) {
     let mut settings = Settings::clone_current();
     settings.set_snapshot_path("../snapshots");
+    add_standard_env_redactions(&mut settings);
     settings.bind(|| {
         let mut cmd = wt_command();
         cmd.args(args);

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
@@ -23,6 +23,7 @@ info:
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
     MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     NO_COLOR: ""
     OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
@@ -69,7 +70,7 @@ exit_code: 0
 [107m [0m \ No newline at end of file[m
 [107m [0m [32m+[m[32m[commit.generation][m
 [107m [0m [32m+[m[32mcommand = "claude"[m
-[33m▲[39m [33mKey [1mcommit-generation[22m belongs in user config as [commit.generation][39m
+[33m▲[39m [33mUnknown key [1mcommit.generation.command[22m will be ignored[39m
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -266,10 +266,10 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# - Match recent commit style (conventional commits if used)[0m
 [107m [0m [2m# - Describe the change, not the intent or benefit[0m
 [107m [0m [2m# </style>[0m
-[107m [0m [2m# {% if project_guidance %}[0m
-[107m [0m [2m# <project_guidance>[0m
-[107m [0m [2m# {{ project_guidance }}[0m
-[107m [0m [2m# </project_guidance>[0m
+[107m [0m [2m# {% if project_template %}[0m
+[107m [0m [2m# <project_template>[0m
+[107m [0m [2m# {{ project_template }}[0m
+[107m [0m [2m# </project_template>[0m
 [107m [0m [2m# {% endif %}[0m
 [107m [0m [2m# <diffstat>[0m
 [107m [0m [2m# {{ git_diff_stat }}[0m
@@ -314,10 +314,10 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# - Match the style of commits being squashed (conventional commits if used)[0m
 [107m [0m [2m# - Describe the change, not the intent or benefit[0m
 [107m [0m [2m# </style>[0m
-[107m [0m [2m# {% if project_guidance %}[0m
-[107m [0m [2m# <project_guidance>[0m
-[107m [0m [2m# {{ project_guidance }}[0m
-[107m [0m [2m# </project_guidance>[0m
+[107m [0m [2m# {% if project_template %}[0m
+[107m [0m [2m# <project_template>[0m
+[107m [0m [2m# {{ project_template }}[0m
+[107m [0m [2m# </project_template>[0m
 [107m [0m [2m# {% endif %}[0m
 [107m [0m [2m# <commits branch="{{ branch }}" target="{{ target_branch }}">[0m
 [107m [0m [2m# {% for commit in commits %}- {{ commit }}[0m
@@ -371,19 +371,19 @@ With [2m--project[0m, creates [2m.config/wt.toml[0m in the current repositor
 [107m [0m [2m# platform = "github"  # or "gitlab", "gitea" (experimental), "azure-devops" (experimental)[0m
 [107m [0m [2m# hostname = "github.example.com"  # Example: API host (GHE / self-hosted GitLab)[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# ## Commit-message guidance[0m
+[107m [0m [2m# ## Commit-message template[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# <span class="badge-experimental"></span>[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# Project-wide commit-message style notes appended to the LLM prompt inside a `<project_guidance>` block. The first time the guidance changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.[0m
+[107m [0m [2m# Project-wide commit-message conventions appended to the LLM prompt inside a `<project_template>` block. Rendered as a minijinja (https://docs.rs/minijinja/) template with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, etc.), so the fragment can reference them directly. The first time the fragment changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# [commit.generation][0m
-[107m [0m [2m# guidance = """[0m
+[107m [0m [2m# template = """[0m
 [107m [0m [2m# - Use conventional commits (feat:, fix:, docs:, …)[0m
 [107m [0m [2m# - Reference the relevant issue ID in the body[0m
 [107m [0m [2m# """[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# Only `guidance` is honored from the project file. The LLM command and the full template stay in user config (https://worktrunk.dev/config/) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).[0m
+[107m [0m [2m# Only `template` is honored from the project file. The LLM command and the main prompt template stay in user config (https://worktrunk.dev/config/) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# ## Copy-ignored excludes[0m
 [107m [0m [2m#[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -12,14 +12,15 @@ info:
     GIT_EDITOR: ""
     LANG: C
     LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
     NO_COLOR: ""
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
-    WORKTRUNK_APPROVALS_PATH: /nonexistent/wt/approvals.toml
-    WORKTRUNK_CONFIG_PATH: /nonexistent/wt/config.toml
-    WORKTRUNK_SYSTEM_CONFIG_PATH: /etc/xdg/worktrunk/config.toml
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
@@ -265,7 +266,11 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# - Match recent commit style (conventional commits if used)[0m
 [107m [0m [2m# - Describe the change, not the intent or benefit[0m
 [107m [0m [2m# </style>[0m
-[107m [0m [2m#[0m
+[107m [0m [2m# {% if project_guidance %}[0m
+[107m [0m [2m# <project_guidance>[0m
+[107m [0m [2m# {{ project_guidance }}[0m
+[107m [0m [2m# </project_guidance>[0m
+[107m [0m [2m# {% endif %}[0m
 [107m [0m [2m# <diffstat>[0m
 [107m [0m [2m# {{ git_diff_stat }}[0m
 [107m [0m [2m# </diffstat>[0m
@@ -309,7 +314,11 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# - Match the style of commits being squashed (conventional commits if used)[0m
 [107m [0m [2m# - Describe the change, not the intent or benefit[0m
 [107m [0m [2m# </style>[0m
-[107m [0m [2m#[0m
+[107m [0m [2m# {% if project_guidance %}[0m
+[107m [0m [2m# <project_guidance>[0m
+[107m [0m [2m# {{ project_guidance }}[0m
+[107m [0m [2m# </project_guidance>[0m
+[107m [0m [2m# {% endif %}[0m
 [107m [0m [2m# <commits branch="{{ branch }}" target="{{ target_branch }}">[0m
 [107m [0m [2m# {% for commit in commits %}- {{ commit }}[0m
 [107m [0m [2m# {% endfor %}</commits>[0m
@@ -361,6 +370,20 @@ With [2m--project[0m, creates [2m.config/wt.toml[0m in the current repositor
 [107m [0m [2m# [forge][0m
 [107m [0m [2m# platform = "github"  # or "gitlab", "gitea" (experimental), "azure-devops" (experimental)[0m
 [107m [0m [2m# hostname = "github.example.com"  # Example: API host (GHE / self-hosted GitLab)[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# ## Commit-message guidance[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# <span class="badge-experimental"></span>[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Project-wide commit-message style notes appended to the LLM prompt inside a `<project_guidance>` block. The first time the guidance changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# [commit.generation][0m
+[107m [0m [2m# guidance = """[0m
+[107m [0m [2m# - Use conventional commits (feat:, fix:, docs:, …)[0m
+[107m [0m [2m# - Reference the relevant issue ID in the body[0m
+[107m [0m [2m# """[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Only `guidance` is honored from the project file. The LLM command and the full template stay in user config (https://worktrunk.dev/config/) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# ## Copy-ignored excludes[0m
 [107m [0m [2m#[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -247,6 +247,7 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# - `{{ git_diff }}`, `{{ git_diff_stat }}` — diff content[0m
 [107m [0m [2m# - `{{ branch }}`, `{{ repo }}` — context[0m
 [107m [0m [2m# - `{{ recent_commits }}` — recent commit messages[0m
+[107m [0m [2m# - `{{ user_guidance }}`, `{{ project_guidance }}` — rendered append fragments (see Appending to the prompt (#appending-to-the-prompt))[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# Default template:[0m
 [107m [0m [2m#[0m
@@ -266,10 +267,14 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# - Match recent commit style (conventional commits if used)[0m
 [107m [0m [2m# - Describe the change, not the intent or benefit[0m
 [107m [0m [2m# </style>[0m
-[107m [0m [2m# {% if project_template %}[0m
-[107m [0m [2m# <project_template>[0m
-[107m [0m [2m# {{ project_template }}[0m
-[107m [0m [2m# </project_template>[0m
+[107m [0m [2m# {% if user_guidance %}[0m
+[107m [0m [2m# <user-guidance>[0m
+[107m [0m [2m# {{ user_guidance }}[0m
+[107m [0m [2m# </user-guidance>[0m
+[107m [0m [2m# {% endif %}{% if project_guidance %}[0m
+[107m [0m [2m# <project-guidance>[0m
+[107m [0m [2m# {{ project_guidance }}[0m
+[107m [0m [2m# </project-guidance>[0m
 [107m [0m [2m# {% endif %}[0m
 [107m [0m [2m# <diffstat>[0m
 [107m [0m [2m# {{ git_diff_stat }}[0m
@@ -314,10 +319,14 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# - Match the style of commits being squashed (conventional commits if used)[0m
 [107m [0m [2m# - Describe the change, not the intent or benefit[0m
 [107m [0m [2m# </style>[0m
-[107m [0m [2m# {% if project_template %}[0m
-[107m [0m [2m# <project_template>[0m
-[107m [0m [2m# {{ project_template }}[0m
-[107m [0m [2m# </project_template>[0m
+[107m [0m [2m# {% if user_guidance %}[0m
+[107m [0m [2m# <user-guidance>[0m
+[107m [0m [2m# {{ user_guidance }}[0m
+[107m [0m [2m# </user-guidance>[0m
+[107m [0m [2m# {% endif %}{% if project_guidance %}[0m
+[107m [0m [2m# <project-guidance>[0m
+[107m [0m [2m# {{ project_guidance }}[0m
+[107m [0m [2m# </project-guidance>[0m
 [107m [0m [2m# {% endif %}[0m
 [107m [0m [2m# <commits branch="{{ branch }}" target="{{ target_branch }}">[0m
 [107m [0m [2m# {% for commit in commits %}- {{ commit }}[0m
@@ -333,6 +342,19 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m#[0m
 [107m [0m [2m# """[0m
 [107m [0m [2m# <!-- DEFAULT_SQUASH_TEMPLATE_END -->[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# #### Appending to the prompt[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# <span class="badge-experimental"></span>[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# `template-append` adds to the prompt instead of replacing it. The value is rendered as its own minijinja template (same variables) and injected into the default templates' `{{ user_guidance }}` slot — a `<user-guidance>` block right after `<style>`. It applies to both commit and squash. Use it for personal preferences without restating the whole template:[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# [commit.generation][0m
+[107m [0m [2m# template-append = """[0m
+[107m [0m [2m# - Explain the rationale in the body, not just the change[0m
+[107m [0m [2m# """[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# The project config (https://worktrunk.dev/config/#project-configuration) has a `template-append` of its own; it renders into a separate `<project-guidance>` block right after `<user-guidance>`.[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# ## Hooks[0m
 [107m [0m [2m#[0m
@@ -371,19 +393,20 @@ With [2m--project[0m, creates [2m.config/wt.toml[0m in the current repositor
 [107m [0m [2m# platform = "github"  # or "gitlab", "gitea" (experimental), "azure-devops" (experimental)[0m
 [107m [0m [2m# hostname = "github.example.com"  # Example: API host (GHE / self-hosted GitLab)[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# ## Commit-message template[0m
+[107m [0m [2m# ## Commit-message append[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# <span class="badge-experimental"></span>[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# Project-wide commit-message conventions appended to the LLM prompt inside a `<project_template>` block. Rendered as a minijinja (https://docs.rs/minijinja/) template with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, etc.), so the fragment can reference them directly. The first time the fragment changes, `wt` prompts the user to approve it — the same one-shot gate as project-defined hooks.[0m
+[107m [0m [2m# Project-wide commit-message conventions appended to the LLM commit and squash prompts inside a `<project-guidance>` block, after the main template's `<style>` section (and after any user `<user-guidance>`). Rendered as a minijinja (https://docs.rs/minijinja/) template with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, etc.), so it can reference them directly. The first time the fragment changes, `wt` prompts the user to approve it — the same one-shot gate
+[107m [0m as project-defined hooks.[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# [commit.generation][0m
-[107m [0m [2m# template = """[0m
+[107m [0m [2m# template-append = """[0m
 [107m [0m [2m# - Use conventional commits (feat:, fix:, docs:, …)[0m
 [107m [0m [2m# - Reference the relevant issue ID in the body[0m
 [107m [0m [2m# """[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# Only `template` is honored from the project file. The LLM command and the main prompt template stay in user config (https://worktrunk.dev/config/) — they describe per-developer environment (which CLI is installed, which agent the developer prefers).[0m
+[107m [0m [2m# Only `template-append` is honored from the project file. The LLM command and the main prompt template stay in user config (https://worktrunk.dev/config/) — they describe per-developer environment (which CLI is installed, which agent the developer prefers). User config has a `[commit.generation] template-append` of its own; it renders into a separate `<user-guidance>` block immediately before this one.[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# ## Copy-ignored excludes[0m
 [107m [0m [2m#[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -247,7 +247,7 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# - `{{ git_diff }}`, `{{ git_diff_stat }}` — diff content[0m
 [107m [0m [2m# - `{{ branch }}`, `{{ repo }}` — context[0m
 [107m [0m [2m# - `{{ recent_commits }}` — recent commit messages[0m
-[107m [0m [2m# - `{{ user_guidance }}`, `{{ project_guidance }}` — rendered append fragments (see Appending to the prompt (#appending-to-the-prompt))[0m
+[107m [0m [2m# - `{{ user_guidance }}`, `{{ project_guidance }}` — rendered append fragments (see Appending to the prompt (https://worktrunk.dev/config/#appending-to-the-prompt))[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# Default template:[0m
 [107m [0m [2m#[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -343,9 +343,7 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# """[0m
 [107m [0m [2m# <!-- DEFAULT_SQUASH_TEMPLATE_END -->[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# #### Appending to the prompt[0m
-[107m [0m [2m#[0m
-[107m [0m [2m# <span class="badge-experimental"></span>[0m
+[107m [0m [2m# #### Appending to the prompt [experimental][0m
 [107m [0m [2m#[0m
 [107m [0m [2m# `template-append` adds to the prompt instead of replacing it. The value is rendered as its own minijinja template (same variables) and injected into the default templates' `{{ user_guidance }}` slot — a `<user-guidance>` block right after `<style>`. It applies to both commit and squash. Use it for personal preferences without restating the whole template:[0m
 [107m [0m [2m#[0m
@@ -393,9 +391,7 @@ With [2m--project[0m, creates [2m.config/wt.toml[0m in the current repositor
 [107m [0m [2m# platform = "github"  # or "gitlab", "gitea" (experimental), "azure-devops" (experimental)[0m
 [107m [0m [2m# hostname = "github.example.com"  # Example: API host (GHE / self-hosted GitLab)[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# ## Commit-message append[0m
-[107m [0m [2m#[0m
-[107m [0m [2m# <span class="badge-experimental"></span>[0m
+[107m [0m [2m# ## Commit-message append [experimental][0m
 [107m [0m [2m#[0m
 [107m [0m [2m# Project-wide commit-message conventions appended to the LLM commit and squash prompts inside a `<project-guidance>` block, after the main template's `<style>` section (and after any user `<user-guidance>`). Rendered as a minijinja (https://docs.rs/minijinja/) template with the same variables as the main commit template (`{{ branch }}`, `{{ git_diff }}`, etc.), so it can reference them directly. The first time the fragment changes, `wt` prompts the user to approve it — the same one-shot gate
 [107m [0m as project-defined hooks.[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -295,6 +295,7 @@ Available variables:
 - [2m{{ git_diff }}[0m, [2m{{ git_diff_stat }}[0m — diff content
 - [2m{{ branch }}[0m, [2m{{ repo }}[0m — context
 - [2m{{ recent_commits }}[0m — recent commit messages
+- [2m{{ user_guidance }}[0m, [2m{{ project_guidance }}[0m — rendered append fragments (see Appending to the prompt)
 
 Default template:
 
@@ -313,10 +314,14 @@ Default template:
 [107m [0m [2m[32m- Match recent commit style (conventional commits if used)[0m
 [107m [0m [2m[32m- Describe the change, not the intent or benefit[0m
 [107m [0m [2m[32m</style>[0m
-[107m [0m [2m[32m{% if project_template %}[0m
-[107m [0m [2m[32m<project_template>[0m
-[107m [0m [2m[32m{{ project_template }}[0m
-[107m [0m [2m[32m</project_template>[0m
+[107m [0m [2m[32m{% if user_guidance %}[0m
+[107m [0m [2m[32m<user-guidance>[0m
+[107m [0m [2m[32m{{ user_guidance }}[0m
+[107m [0m [2m[32m</user-guidance>[0m
+[107m [0m [2m[32m{% endif %}{% if project_guidance %}[0m
+[107m [0m [2m[32m<project-guidance>[0m
+[107m [0m [2m[32m{{ project_guidance }}[0m
+[107m [0m [2m[32m</project-guidance>[0m
 [107m [0m [2m[32m{% endif %}[0m
 [107m [0m [2m[32m<diffstat>[0m
 [107m [0m [2m[32m{{ git_diff_stat }}[0m
@@ -359,10 +364,14 @@ Default template:
 [107m [0m [2m[32m- Match the style of commits being squashed (conventional commits if used)[0m
 [107m [0m [2m[32m- Describe the change, not the intent or benefit[0m
 [107m [0m [2m[32m</style>[0m
-[107m [0m [2m[32m{% if project_template %}[0m
-[107m [0m [2m[32m<project_template>[0m
-[107m [0m [2m[32m{{ project_template }}[0m
-[107m [0m [2m[32m</project_template>[0m
+[107m [0m [2m[32m{% if user_guidance %}[0m
+[107m [0m [2m[32m<user-guidance>[0m
+[107m [0m [2m[32m{{ user_guidance }}[0m
+[107m [0m [2m[32m</user-guidance>[0m
+[107m [0m [2m[32m{% endif %}{% if project_guidance %}[0m
+[107m [0m [2m[32m<project-guidance>[0m
+[107m [0m [2m[32m{{ project_guidance }}[0m
+[107m [0m [2m[32m</project-guidance>[0m
 [107m [0m [2m[32m{% endif %}[0m
 [107m [0m [2m[32m<commits branch="[0m[2m{{ branch }}[0m[2m[32m" target="[0m[2m{{ target_branch }}[0m[2m[32m">[0m
 [107m [0m [2m[32m{% for commit in commits %}- {{ commit }}[0m
@@ -377,6 +386,19 @@ Default template:
 [107m [0m [2m[32m</diff>[0m
 [107m [0m 
 [107m [0m [2m[32m"[0m[2m[32m""[0m
+
+[1mAppending to the prompt[0m
+
+<span class="badge-experimental"></span>
+
+[2mtemplate-append[0m adds to the prompt instead of replacing it. The value is rendered as its own minijinja template (same variables) and injected into the default templates' [2m{{ user_guidance }}[0m slot — a [2m<user-guidance>[0m block right after [2m<style>[0m. It applies to both commit and squash. Use it for personal preferences without restating the whole template:
+
+[107m [0m [2m[36m[commit.generation][0m
+[107m [0m [2mtemplate-append = [0m[2m[32m""[0m[2m[32m"[0m
+[107m [0m [2m[32m- Explain the rationale in the body, not just the change[0m
+[107m [0m [2m[32m"[0m[2m[32m""[0m
+
+The project config has a [2mtemplate-append[0m of its own; it renders into a separate [2m<project-guidance>[0m block right after [2m<user-guidance>[0m.
 
 [1m[32mHooks[0m
 
@@ -410,19 +432,19 @@ Name the forge explicitly for SSH aliases or self-hosted instances, where it can
 [107m [0m [2mplatform = [0m[2m[32m"github"[0m[2m  [0m[2m# or "gitlab", "gitea" (experimental), "azure-devops" (experimental)[0m
 [107m [0m [2mhostname = [0m[2m[32m"github.example.com"[0m[2m  [0m[2m# Example: API host (GHE / self-hosted GitLab)[0m
 
-[1m[32mCommit-message template[0m
+[1m[32mCommit-message append[0m
 
 <span class="badge-experimental"></span>
 
-Project-wide commit-message conventions appended to the LLM prompt inside a [2m<project_template>[0m block. Rendered as a minijinja template with the same variables as the main commit template ([2m{{ branch }}[0m, [2m{{ git_diff }}[0m, etc.), so the fragment can reference them directly. The first time the fragment changes, [2mwt[0m prompts the user to approve it — the same one-shot gate as project-defined hooks.
+Project-wide commit-message conventions appended to the LLM commit and squash prompts inside a [2m<project-guidance>[0m block, after the main template's [2m<style>[0m section (and after any user [2m<user-guidance>[0m). Rendered as a minijinja template with the same variables as the main commit template ([2m{{ branch }}[0m, [2m{{ git_diff }}[0m, etc.), so it can reference them directly. The first time the fragment changes, [2mwt[0m prompts the user to approve it — the same one-shot gate as project-defined hooks.
 
 [107m [0m [2m[36m[commit.generation][0m
-[107m [0m [2mtemplate = [0m[2m[32m""[0m[2m[32m"[0m
+[107m [0m [2mtemplate-append = [0m[2m[32m""[0m[2m[32m"[0m
 [107m [0m [2m[32m- Use conventional commits (feat:, fix:, docs:, …)[0m
 [107m [0m [2m[32m- Reference the relevant issue ID in the body[0m
 [107m [0m [2m[32m"[0m[2m[32m""[0m
 
-Only [2mtemplate[0m is honored from the project file. The LLM command and the main prompt template stay in user config — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
+Only [2mtemplate-append[0m is honored from the project file. The LLM command and the main prompt template stay in user config — they describe per-developer environment (which CLI is installed, which agent the developer prefers). User config has a [2m[commit.generation] template-append[0m of its own; it renders into a separate [2m<user-guidance>[0m block immediately before this one.
 
 [1m[32mCopy-ignored excludes[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -387,9 +387,7 @@ Default template:
 [107m [0m 
 [107m [0m [2m[32m"[0m[2m[32m""[0m
 
-[1mAppending to the prompt[0m
-
-<span class="badge-experimental"></span>
+[1mAppending to the prompt [experimental][0m
 
 [2mtemplate-append[0m adds to the prompt instead of replacing it. The value is rendered as its own minijinja template (same variables) and injected into the default templates' [2m{{ user_guidance }}[0m slot — a [2m<user-guidance>[0m block right after [2m<style>[0m. It applies to both commit and squash. Use it for personal preferences without restating the whole template:
 
@@ -432,9 +430,7 @@ Name the forge explicitly for SSH aliases or self-hosted instances, where it can
 [107m [0m [2mplatform = [0m[2m[32m"github"[0m[2m  [0m[2m# or "gitlab", "gitea" (experimental), "azure-devops" (experimental)[0m
 [107m [0m [2mhostname = [0m[2m[32m"github.example.com"[0m[2m  [0m[2m# Example: API host (GHE / self-hosted GitLab)[0m
 
-[1m[32mCommit-message append[0m
-
-<span class="badge-experimental"></span>
+[1m[32mCommit-message append [experimental][0m
 
 Project-wide commit-message conventions appended to the LLM commit and squash prompts inside a [2m<project-guidance>[0m block, after the main template's [2m<style>[0m section (and after any user [2m<user-guidance>[0m). Rendered as a minijinja template with the same variables as the main commit template ([2m{{ branch }}[0m, [2m{{ git_diff }}[0m, etc.), so it can reference them directly. The first time the fragment changes, [2mwt[0m prompts the user to approve it — the same one-shot gate as project-defined hooks.
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -11,14 +11,15 @@ info:
     GIT_EDITOR: ""
     LANG: C
     LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
     NO_COLOR: ""
     PSModulePath: ""
     RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
-    WORKTRUNK_APPROVALS_PATH: /nonexistent/wt/approvals.toml
-    WORKTRUNK_CONFIG_PATH: /nonexistent/wt/config.toml
-    WORKTRUNK_SYSTEM_CONFIG_PATH: /etc/xdg/worktrunk/config.toml
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
@@ -312,7 +313,11 @@ Default template:
 [107m [0m [2m[32m- Match recent commit style (conventional commits if used)[0m
 [107m [0m [2m[32m- Describe the change, not the intent or benefit[0m
 [107m [0m [2m[32m</style>[0m
-[107m [0m 
+[107m [0m [2m[32m{% if project_guidance %}[0m
+[107m [0m [2m[32m<project_guidance>[0m
+[107m [0m [2m[32m{{ project_guidance }}[0m
+[107m [0m [2m[32m</project_guidance>[0m
+[107m [0m [2m[32m{% endif %}[0m
 [107m [0m [2m[32m<diffstat>[0m
 [107m [0m [2m[32m{{ git_diff_stat }}[0m
 [107m [0m [2m[32m</diffstat>[0m
@@ -354,7 +359,11 @@ Default template:
 [107m [0m [2m[32m- Match the style of commits being squashed (conventional commits if used)[0m
 [107m [0m [2m[32m- Describe the change, not the intent or benefit[0m
 [107m [0m [2m[32m</style>[0m
-[107m [0m 
+[107m [0m [2m[32m{% if project_guidance %}[0m
+[107m [0m [2m[32m<project_guidance>[0m
+[107m [0m [2m[32m{{ project_guidance }}[0m
+[107m [0m [2m[32m</project_guidance>[0m
+[107m [0m [2m[32m{% endif %}[0m
 [107m [0m [2m[32m<commits branch="[0m[2m{{ branch }}[0m[2m[32m" target="[0m[2m{{ target_branch }}[0m[2m[32m">[0m
 [107m [0m [2m[32m{% for commit in commits %}- {{ commit }}[0m
 [107m [0m [2m[32m{% endfor %}</commits>[0m
@@ -400,6 +409,20 @@ Name the forge explicitly for SSH aliases or self-hosted instances, where it can
 [107m [0m [2m[36m[forge][0m
 [107m [0m [2mplatform = [0m[2m[32m"github"[0m[2m  [0m[2m# or "gitlab", "gitea" (experimental), "azure-devops" (experimental)[0m
 [107m [0m [2mhostname = [0m[2m[32m"github.example.com"[0m[2m  [0m[2m# Example: API host (GHE / self-hosted GitLab)[0m
+
+[1m[32mCommit-message guidance[0m
+
+<span class="badge-experimental"></span>
+
+Project-wide commit-message style notes appended to the LLM prompt inside a [2m<project_guidance>[0m block. The first time the guidance changes, [2mwt[0m prompts the user to approve it — the same one-shot gate as project-defined hooks.
+
+[107m [0m [2m[36m[commit.generation][0m
+[107m [0m [2mguidance = [0m[2m[32m""[0m[2m[32m"[0m
+[107m [0m [2m[32m- Use conventional commits (feat:, fix:, docs:, …)[0m
+[107m [0m [2m[32m- Reference the relevant issue ID in the body[0m
+[107m [0m [2m[32m"[0m[2m[32m""[0m
+
+Only [2mguidance[0m is honored from the project file. The LLM command and the full template stay in user config — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
 
 [1m[32mCopy-ignored excludes[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -313,10 +313,10 @@ Default template:
 [107m [0m [2m[32m- Match recent commit style (conventional commits if used)[0m
 [107m [0m [2m[32m- Describe the change, not the intent or benefit[0m
 [107m [0m [2m[32m</style>[0m
-[107m [0m [2m[32m{% if project_guidance %}[0m
-[107m [0m [2m[32m<project_guidance>[0m
-[107m [0m [2m[32m{{ project_guidance }}[0m
-[107m [0m [2m[32m</project_guidance>[0m
+[107m [0m [2m[32m{% if project_template %}[0m
+[107m [0m [2m[32m<project_template>[0m
+[107m [0m [2m[32m{{ project_template }}[0m
+[107m [0m [2m[32m</project_template>[0m
 [107m [0m [2m[32m{% endif %}[0m
 [107m [0m [2m[32m<diffstat>[0m
 [107m [0m [2m[32m{{ git_diff_stat }}[0m
@@ -359,10 +359,10 @@ Default template:
 [107m [0m [2m[32m- Match the style of commits being squashed (conventional commits if used)[0m
 [107m [0m [2m[32m- Describe the change, not the intent or benefit[0m
 [107m [0m [2m[32m</style>[0m
-[107m [0m [2m[32m{% if project_guidance %}[0m
-[107m [0m [2m[32m<project_guidance>[0m
-[107m [0m [2m[32m{{ project_guidance }}[0m
-[107m [0m [2m[32m</project_guidance>[0m
+[107m [0m [2m[32m{% if project_template %}[0m
+[107m [0m [2m[32m<project_template>[0m
+[107m [0m [2m[32m{{ project_template }}[0m
+[107m [0m [2m[32m</project_template>[0m
 [107m [0m [2m[32m{% endif %}[0m
 [107m [0m [2m[32m<commits branch="[0m[2m{{ branch }}[0m[2m[32m" target="[0m[2m{{ target_branch }}[0m[2m[32m">[0m
 [107m [0m [2m[32m{% for commit in commits %}- {{ commit }}[0m
@@ -410,19 +410,19 @@ Name the forge explicitly for SSH aliases or self-hosted instances, where it can
 [107m [0m [2mplatform = [0m[2m[32m"github"[0m[2m  [0m[2m# or "gitlab", "gitea" (experimental), "azure-devops" (experimental)[0m
 [107m [0m [2mhostname = [0m[2m[32m"github.example.com"[0m[2m  [0m[2m# Example: API host (GHE / self-hosted GitLab)[0m
 
-[1m[32mCommit-message guidance[0m
+[1m[32mCommit-message template[0m
 
 <span class="badge-experimental"></span>
 
-Project-wide commit-message style notes appended to the LLM prompt inside a [2m<project_guidance>[0m block. The first time the guidance changes, [2mwt[0m prompts the user to approve it — the same one-shot gate as project-defined hooks.
+Project-wide commit-message conventions appended to the LLM prompt inside a [2m<project_template>[0m block. Rendered as a minijinja template with the same variables as the main commit template ([2m{{ branch }}[0m, [2m{{ git_diff }}[0m, etc.), so the fragment can reference them directly. The first time the fragment changes, [2mwt[0m prompts the user to approve it — the same one-shot gate as project-defined hooks.
 
 [107m [0m [2m[36m[commit.generation][0m
-[107m [0m [2mguidance = [0m[2m[32m""[0m[2m[32m"[0m
+[107m [0m [2mtemplate = [0m[2m[32m""[0m[2m[32m"[0m
 [107m [0m [2m[32m- Use conventional commits (feat:, fix:, docs:, …)[0m
 [107m [0m [2m[32m- Reference the relevant issue ID in the body[0m
 [107m [0m [2m[32m"[0m[2m[32m""[0m
 
-Only [2mguidance[0m is honored from the project file. The LLM command and the full template stay in user config — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
+Only [2mtemplate[0m is honored from the project file. The LLM command and the main prompt template stay in user config — they describe per-developer environment (which CLI is installed, which agent the developer prefers).
 
 [1m[32mCopy-ignored excludes[0m
 


### PR DESCRIPTION
## Summary

- Adds `[commit.generation] template-append` to **both** user config and project config (`.config/wt.toml`). It *adds to* the commit/squash prompt rather than replacing it (`template` still replaces). One field covers both commit and squash.
- Each fragment is rendered as its own minijinja template with the same variable context as the main template, then emitted in a provenance-labeled block: `<user-guidance>` (the developer's own config — no approval) followed by `<project-guidance>` (repo-supplied — gated). Default templates render each block conditionally; `{{ user_guidance }}` / `{{ project_guidance }}` are exposed for custom user templates.
- The project fragment keeps the first-time approval gate — same one-shot gate as project hooks. `wt merge` bundles it into the existing hook-approval batch so the user sees one combined prompt. Declining is non-fatal; the LLM runs with just the user fragment (if any). Skipped automatically when no LLM command is configured.
- Marked experimental in CLI help, docs, and the user/project config docstrings.

Discussion: #2758 (comment [4454619614](https://github.com/max-sixty/worktrunk/issues/2758#issuecomment-4454619614))

## Test plan

- [x] Unit tests for `commit_template_append()` and the user-side accessor (trim / empty / unset)
- [x] `Merge` test for user `template-append`
- [x] Snapshot tests confirming the default commit and squash templates render the `<project-guidance>` block
- [x] Unit tests for user-side append: renders into `<user-guidance>`, ordered before `<project-guidance>`, blank-is-unset, minijinja variable expansion
- [x] PTY integration tests for the approval flow (accept / decline / merge bundling), asserting `<project-guidance>`
- [x] `cargo run -- hook pre-merge --yes` — 3708 tests passing, clippy + pre-commit clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
