### PR TITLE
fix(codex): ship .agents/plugins/marketplace.json so the plugin is installable

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -1,0 +1,18 @@
+{
+  "name": "worktrunk",
+  "interface": {
+    "displayName": "Worktrunk",
+    "shortDescription": "Git worktree workflows for parallel Codex sessions.",
+    "longDescription": "Use Worktrunk from Codex to manage linked worktrees, set up LLM commit workflows, configure hooks, and bundle activity markers for wt list.",
+    "developerName": "Worktrunk",
+    "category": "Productivity",
+    "websiteURL": "https://worktrunk.dev/claude-code/"
+  },
+  "plugins": [
+    {
+      "name": "worktrunk",
+      "description": "Worktrunk is a CLI for Git worktree management, designed for parallel AI agent workflows. This plugin provides configuration guidance (LLM commit messages, project hooks, worktree paths) and automatic activity tracking (🤖/💬 indicators in `wt list` showing active Codex sessions).",
+      "source": "./"
+    }
+  ]
+}

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -3543,11 +3543,13 @@ fn test_codex_plugin_metadata_is_valid_json() {
         &fs::read_to_string(project_root.join(".codex-plugin/plugin.json")).unwrap(),
     )
     .unwrap();
-    // Codex falls back to .claude-plugin/marketplace.json when
-    // .agents/plugins/marketplace.json is absent, so the existing Claude
-    // marketplace doubles as the Codex marketplace.
+    // Codex discovers a marketplace's plugin list strictly from
+    // <repo-root>/.agents/plugins/marketplace.json — there is no fallback to
+    // the Claude .claude-plugin/marketplace.json. Without this file Codex
+    // registers the marketplace but enumerates zero plugins, so the plugin is
+    // uninstallable via /plugins (verified against codex-cli 0.130.0).
     let marketplace: serde_json::Value = serde_json::from_str(
-        &fs::read_to_string(project_root.join(".claude-plugin/marketplace.json")).unwrap(),
+        &fs::read_to_string(project_root.join(".agents/plugins/marketplace.json")).unwrap(),
     )
     .unwrap();
     let hooks: serde_json::Value = serde_json::from_str(
@@ -3560,6 +3562,9 @@ fn test_codex_plugin_metadata_is_valid_json() {
     assert_eq!(plugin["hooks"], "./.codex-plugin/hooks/hooks.json");
     assert_eq!(marketplace["plugins"][0]["name"], "worktrunk");
     assert_eq!(marketplace["plugins"][0]["source"], "./");
+    // Codex validates `interface` is an object and requires `displayName`;
+    // omitting it is what made the plugin undiscoverable in /plugins.
+    assert_eq!(marketplace["interface"]["displayName"], "Worktrunk");
     assert_eq!(
         hooks["hooks"]["UserPromptSubmit"][0]["hooks"][0]["command"],
         "wt config state marker set \"🤖\" >/dev/null 2>&1 || true"


### PR DESCRIPTION
## Problem

PR #2512 (Codex support) assumed Codex falls back to `.claude-plugin/marketplace.json` when `.agents/plugins/marketplace.json` is absent — encoded in a comment in `test_codex_plugin_metadata_is_valid_json`. That assumption is false for codex-cli 0.130.0.

I verified by driving the Codex `/plugins` TUI: the `worktrunk` marketplace registers fine (`~/.codex/config.toml` gets `[marketplaces.worktrunk]`, the repo clones to `~/.codex/.tmp/marketplaces/worktrunk`), but `/plugins` enumerates **zero** plugins from it — no marketplace tab, "no matches" on search. The codex binary's own embedded plugin spec confirms it: `DEFAULT_MARKETPLACE_PATH = <repo-root>/.agents/plugins/marketplace.json`, with **no fallback** to the Claude marketplace for the plugin listing. Net: `wt config plugins codex install` looks successful but the plugin is uninstallable via the Codex TUI.

## Fix

- Add `.agents/plugins/marketplace.json` at the path codex-cli reads, with the schema its binary requires: top-level `name`, an `interface` object containing `displayName`, and a `plugins` array. `source: "./"` mirrors the working `.claude-plugin/marketplace.json` so Codex resolves the plugin from `./.codex-plugin/plugin.json` at repo root.
- Correct the false fallback comment in `test_codex_plugin_metadata_is_valid_json`, point the test at the new manifest (so its absence fails loudly), and assert `interface.displayName` — the Codex-required field whose omission caused the bug.

`docs/content/claude-code.md` needs no change: its documented flow (`wt config plugins codex install` → `/plugins`) is accurate once this manifest ships.

## Testing

`test_codex_plugin_metadata_is_valid_json` now guards the manifest path and the `interface` object. Schema conformance is derived from the codex 0.130.0 binary's embedded plugin spec; the `source: "./"` resolution is the same pattern the already-working Claude manifest uses. Not yet exercised through a live `/plugins` install — that requires the manifest on the default branch (the install flow re-clones from GitHub), which this PR provides.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
