### PR TITLE
fix(config): redirect user-only commit-generation keys in project config

### DIFF
--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -155,16 +155,37 @@ mod tests {
     }
 
     #[test]
-    fn test_warn_unknown_keys_deprecated_in_wrong_config() {
-        // commit-generation in project config should suggest user config with canonical form
-        assert_snapshot!(warn_unknown_keys::<ProjectConfig>(
-            "[commit-generation]\ncommand = \"llm\"\n"
-        ));
+    fn test_warn_unknown_keys_user_only_commit_key_redirects_to_user_config() {
+        // The LLM `command` is user-config-only. In a *project* config it must
+        // redirect the user to user config — both via the legacy flat
+        // `[commit-generation]` and the canonical `[commit.generation]`, since
+        // `[commit.generation]` is now a valid project section (for
+        // `template-append`) so the offending key surfaces nested.
+        assert_snapshot!(
+            warn_unknown_keys::<ProjectConfig>("[commit-generation]\ncommand = \"llm\"\n"),
+            @"[33m▲[39m [33mKey [1mcommit.generation.command[22m belongs in user config (will be ignored)[39m");
+        assert_snapshot!(
+            warn_unknown_keys::<ProjectConfig>("[commit.generation]\ncommand = \"llm\"\n"),
+            @"[33m▲[39m [33mKey [1mcommit.generation.command[22m belongs in user config (will be ignored)[39m");
 
-        // ci in user config should suggest project config with canonical form
-        assert_snapshot!(warn_unknown_keys::<UserConfig>(
-            "[ci]\nplatform = \"github\"\n"
-        ));
+        // The one project-valid key in the section is unaffected.
+        assert!(
+            warn_unknown_keys::<ProjectConfig>("[commit.generation]\ntemplate-append = \"x\"\n")
+                .is_empty()
+        );
+        // The same user-only key in user config is valid — no warning there.
+        assert!(
+            warn_unknown_keys::<UserConfig>("[commit.generation]\ncommand = \"llm\"\n").is_empty()
+        );
+    }
+
+    #[test]
+    fn test_warn_unknown_keys_deprecated_section_in_wrong_config() {
+        // `ci` is deprecated in favor of `[forge]`, which is project-only; in
+        // user config it redirects with the canonical form.
+        assert_snapshot!(
+            warn_unknown_keys::<UserConfig>("[ci]\nplatform = \"github\"\n"),
+            @"[33m▲[39m [33mKey [1mci[22m belongs in project config as [forge][39m");
     }
 
     #[test]

--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -643,6 +643,10 @@ fn format_show_warning(warning: &worktrunk::config::UnknownWarning) -> String {
             other_description,
             canonical_display,
         } => cformat!("Key <bold>{key}</> belongs in {other_description} as {canonical_display}"),
+        UnknownWarning::NestedWrongConfig {
+            path,
+            other_description,
+        } => cformat!("Key <bold>{path}</> belongs in {other_description} (will be ignored)"),
         UnknownWarning::NestedUnknown { path } => {
             cformat!("Unknown key <bold>{path}</> will be ignored")
         }

--- a/src/commands/config/snapshots/wt__commands__config__tests__warn_unknown_keys_deprecated_in_wrong_config-2.snap
+++ b/src/commands/config/snapshots/wt__commands__config__tests__warn_unknown_keys_deprecated_in_wrong_config-2.snap
@@ -1,5 +1,0 @@
----
-source: src/commands/config/mod.rs
-expression: "warn_unknown_keys::<UserConfig>(&unknown)"
----
-[33m▲[39m [33mKey [1mci[22m belongs in project config as [forge][39m

--- a/src/commands/config/snapshots/wt__commands__config__tests__warn_unknown_keys_deprecated_in_wrong_config.snap
+++ b/src/commands/config/snapshots/wt__commands__config__tests__warn_unknown_keys_deprecated_in_wrong_config.snap
@@ -1,5 +1,0 @@
----
-source: src/commands/config/mod.rs
-expression: "warn_unknown_keys::<ProjectConfig>(\"[commit-generation]\\ncommand = \\\"llm\\\"\\n\")"
----
-[33m▲[39m [33mUnknown key [1mcommit.generation.command[22m will be ignored[39m

--- a/src/config/deprecation.rs
+++ b/src/config/deprecation.rs
@@ -1603,6 +1603,44 @@ pub fn key_belongs_in<C: WorktrunkConfig>(key: &str) -> Option<&'static str> {
     C::Other::is_valid_key(key).then(C::Other::description)
 }
 
+/// `[commit.generation]` sub-keys (canonical/migrated form) that belong only
+/// in user config.
+///
+/// `[commit.generation]` is itself a valid *project* config section — but only
+/// for `template-append`, the project-wide commit convention shared across the
+/// team. The LLM `command` and the full prompt templates are resolved from
+/// user/system config only. Putting them in a project `.config/wt.toml` is a
+/// common, easily-missed mistake (see #2774).
+///
+/// `is_valid_key` only knows top-level keys, so misplaced *nested* keys can't
+/// be classified by [`key_belongs_in`]. Since `commit` is now a legitimate
+/// project section, the round-trip flags just these offending leaves; without
+/// this list they'd surface as a bare "unknown field" instead of a redirect.
+///
+/// These paths are schema-valid in user config, so they only ever surface as
+/// unknown-nested under *project* config; [`nested_key_belongs_in`] therefore
+/// needs no config-type gate. The list is kept in sync with
+/// `CommitGenerationConfig` by `user_only_commit_generation_paths_track_schema`.
+const USER_ONLY_COMMIT_GENERATION_PATHS: &[&str] = &[
+    "commit.generation.command",
+    "commit.generation.template",
+    "commit.generation.template-file",
+    "commit.generation.squash-template",
+    "commit.generation.squash-template-file",
+];
+
+/// Returns the config where a misplaced *nested* key belongs.
+///
+/// The nested analog of [`key_belongs_in`], for the one case that needs a
+/// redirect: user-only `[commit.generation]` keys placed in project config
+/// (see `USER_ONLY_COMMIT_GENERATION_PATHS`). Returns `None` for ordinary
+/// unknown nested paths (typos), which stay "unknown field".
+pub fn nested_key_belongs_in<C: WorktrunkConfig>(path: &str) -> Option<&'static str> {
+    USER_ONLY_COMMIT_GENERATION_PATHS
+        .contains(&path)
+        .then(C::Other::description)
+}
+
 /// Classification of an unknown config key for warning purposes.
 pub enum UnknownKeyKind {
     /// Deprecated key in its correct config type — deprecation system handles it
@@ -1693,6 +1731,12 @@ fn format_load_warning(label: &str, warning: &crate::config::UnknownWarning) -> 
         } => cformat!(
             "{label} has key <bold>{key}</> which belongs in {other_description} as {canonical_display}"
         ),
+        UnknownWarning::NestedWrongConfig {
+            path,
+            other_description,
+        } => cformat!(
+            "{label} has key <bold>{path}</> which belongs in {other_description} (will be ignored)"
+        ),
         UnknownWarning::NestedUnknown { path } => {
             cformat!("{label} has unknown field <bold>{path}</> (will be ignored)")
         }
@@ -1702,6 +1746,36 @@ fn format_load_warning(label: &str, warning: &crate::config::UnknownWarning) -> 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `USER_ONLY_COMMIT_GENERATION_PATHS` must stay in sync with
+    /// `CommitGenerationConfig`: every key except the project-valid
+    /// `template-append`. If a field is added to that struct without updating
+    /// the list, a misplaced key would silently degrade to "unknown field".
+    #[test]
+    fn user_only_commit_generation_paths_track_schema() {
+        let schema = schemars::SchemaGenerator::default()
+            .into_root_schema_for::<crate::config::CommitGenerationConfig>();
+        let mut expected: Vec<String> = schema
+            .as_object()
+            .and_then(|o| o.get("properties"))
+            .and_then(|p| p.as_object())
+            .map(|props| props.keys().cloned().collect())
+            .unwrap_or_default();
+        expected.retain(|k| k != "template-append");
+        let mut expected: Vec<String> = expected
+            .iter()
+            .map(|k| format!("commit.generation.{k}"))
+            .collect();
+        expected.sort();
+
+        let mut actual: Vec<String> = USER_ONLY_COMMIT_GENERATION_PATHS
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+        actual.sort();
+
+        assert_eq!(actual, expected);
+    }
 
     // Test helpers that parse from string and delegate to the internal functions.
     // These mirror the former pub wrappers that were inlined into
@@ -3676,19 +3750,39 @@ ff = true
 
     #[test]
     fn test_warn_unknown_fields_deprecated_key_in_wrong_config() {
-        use crate::config::{ProjectConfig, UserConfig};
+        use crate::config::{ProjectConfig, UnknownWarning, UserConfig, collect_unknown_warnings};
 
-        // commit-generation in project config → should warn "belongs in user config"
+        // User-only commit-generation key in project config → nested redirect
+        // to user config (the load path that `config show` mirrors).
+        let warnings =
+            collect_unknown_warnings::<ProjectConfig>("[commit-generation]\ncommand = \"llm\"\n");
+        assert!(
+            matches!(
+                warnings.as_slice(),
+                [UnknownWarning::NestedWrongConfig { path, other_description }]
+                    if path == "commit.generation.command" && *other_description == "user config"
+            ),
+            "expected one NestedWrongConfig → user config, got {warnings:?}"
+        );
+
+        // ci in user config → top-level deprecated-section redirect.
+        let warnings = collect_unknown_warnings::<UserConfig>("[ci]\nplatform = \"github\"\n");
+        assert!(
+            matches!(
+                warnings.as_slice(),
+                [UnknownWarning::TopLevelDeprecatedWrongConfig { other_description, .. }]
+                    if *other_description == "project config"
+            ),
+            "expected one TopLevelDeprecatedWrongConfig → project config, got {warnings:?}"
+        );
+
+        // Exercise the stderr/dedup side-effect path itself.
         let path = std::env::temp_dir().join("test-deprecated-wrong-config-project.toml");
         warn_unknown_fields::<ProjectConfig>(
             "[commit-generation]\ncommand = \"llm\"\n",
             &path,
             "Project config",
         );
-
-        // ci in user config → should warn "belongs in project config"
-        let path = std::env::temp_dir().join("test-deprecated-wrong-config-user.toml");
-        warn_unknown_fields::<UserConfig>("[ci]\nplatform = \"github\"\n", &path, "User config");
     }
 
     // ==================== pre-hook table form tests ====================

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -118,7 +118,7 @@ pub use deprecation::normalize_template_vars;
 pub use deprecation::suppress_warnings;
 pub use deprecation::{
     DEPRECATED_SECTION_KEYS, DeprecatedSection, UnknownKeyKind, classify_unknown_key,
-    key_belongs_in, warn_unknown_fields,
+    key_belongs_in, nested_key_belongs_in, warn_unknown_fields,
 };
 pub use expansion::{
     ACTIVE_VARS, ALIAS_ARGS_KEY, DEPRECATED_TEMPLATE_VARS, EXEC_BASE_VARS, REPO_VARS,

--- a/src/config/unknown_tree.rs
+++ b/src/config/unknown_tree.rs
@@ -163,8 +163,17 @@ pub enum UnknownWarning {
         other_description: &'static str,
         canonical_display: &'static str,
     },
-    /// An unknown path below a schema-valid top-level key, e.g.
-    /// `merge.squas` or `commit.generation.template`.
+    /// A nested key, valid in the *other* config type, found below a
+    /// schema-valid shared section (e.g. `commit.generation.command` in
+    /// project config — the `[commit.generation]` section is valid there for
+    /// `template-append`, but the LLM command/templates belong in user
+    /// config).
+    NestedWrongConfig {
+        path: String,
+        other_description: &'static str,
+    },
+    /// An unknown path below a schema-valid top-level key — a typo, e.g.
+    /// `merge.squas`.
     NestedUnknown { path: String },
 }
 
@@ -216,15 +225,24 @@ pub fn collect_unknown_warnings<C: WorktrunkConfig>(raw_contents: &str) -> Vec<U
         if !C::is_valid_key(key) {
             continue; // top-level unknowns were classified above against raw
         }
-        walk_nested(sub, key, &mut out);
+        walk_nested::<C>(sub, key, &mut out);
     }
     out
 }
 
-fn walk_nested(tree: &UnknownTree, prefix: &str, out: &mut Vec<UnknownWarning>) {
+fn walk_nested<C: WorktrunkConfig>(
+    tree: &UnknownTree,
+    prefix: &str,
+    out: &mut Vec<UnknownWarning>,
+) {
     for key in &tree.keys {
-        out.push(UnknownWarning::NestedUnknown {
-            path: format!("{prefix}.{key}"),
+        let path = format!("{prefix}.{key}");
+        out.push(match crate::config::nested_key_belongs_in::<C>(&path) {
+            Some(other_description) => UnknownWarning::NestedWrongConfig {
+                path,
+                other_description,
+            },
+            None => UnknownWarning::NestedUnknown { path },
         });
     }
     for (key, sub) in &tree.nested {
@@ -232,7 +250,7 @@ fn walk_nested(tree: &UnknownTree, prefix: &str, out: &mut Vec<UnknownWarning>) 
             continue;
         }
         let path = format!("{prefix}.{key}");
-        walk_nested(sub, &path, out);
+        walk_nested::<C>(sub, &path, out);
     }
 }
 

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_suggests_user_config_for_commit_generation.snap
@@ -38,6 +38,7 @@ info:
     WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
     WORKTRUNK_TEST_FISH_INSTALLED: "0"
@@ -70,7 +71,7 @@ exit_code: 0
 [107m [0m \ No newline at end of file[m
 [107m [0m [32m+[m[32m[commit.generation][m
 [107m [0m [32m+[m[32mcommand = "claude"[m
-[33m▲[39m [33mUnknown key [1mcommit.generation.command[22m will be ignored[39m
+[33m▲[39m [33mKey [1mcommit.generation.command[22m belongs in user config (will be ignored)[39m
 
 [36mSHELL INTEGRATION[39m
 [33m▲[39m [33mShell integration not configured[39m


### PR DESCRIPTION
## What

Restores the helpful "this belongs in user config" redirect for user-only commit-generation keys placed in a **project** `.config/wt.toml`.

## Why

PR #2774 made `[commit]` a valid `ProjectConfig` section (for the team-shared `template-append`). As a side effect, the user-only commit-generation keys (`command`, `template`, `template-file`, `squash-template`, `squash-template-file`) — which the LLM command/prompt templates are resolved from user/system config only — stopped being top-level unknowns and surfaced as *nested* unknowns. They lost the redirect and degraded to a bare "Unknown key `commit.generation.command` will be ignored", removing the trip-wire that catches this common mistake. This was flagged in worktrunk-bot's review of #2774 and deferred as a follow-up.

## Approach

The codebase already had a top-level redirect mechanism (`key_belongs_in` / `classify_unknown_key` → `TopLevelWrongConfig`). This adds the strictly-analogous nested case: `nested_key_belongs_in` plus a `UnknownWarning::NestedWrongConfig` variant, with `walk_nested` made generic over the config type. The wrinkle is that `commit` is *not* removed from `ProjectConfig` — it's valid there for `template-append` — so the redirect must distinguish the one valid project key from the user-only keys in the wrong file. The user-only set is a hand-maintained list (the "project-valid is only `template-append`" negative space isn't expressible in JsonSchema), guarded by `user_only_commit_generation_paths_track_schema` which derives the expected set from `CommitGenerationConfig` and fails loudly if a field is added without updating the list.

Behavior verified: user-only keys in project config (both the canonical `[commit.generation]` and the legacy flat `[commit-generation]`) now redirect to user config; `[commit.generation] template-append` in project config produces no spurious warning; the same keys in user config still validate normally.

## Testing

Well-covered: the redirect (unit + the `config show` integration snapshot), the no-spurious-warning and user-config-valid cases, the load-path structured classification, and the schema drift guard. `wt hook pre-merge --yes` is green (3737 tests, clippy/fmt/docs-sync clean).

Ref #2774

🤖 Generated with [Claude Code](https://claude.com/claude-code)
