### PR TITLE
Release v0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.52.0
+
+### Improved
+
+- **`wt step tether`**: New `[experimental]` operation that runs a command in its own process group and kills the whole group when the command exits or its worktree is removed (a 250ms portable poll — `killpg` on Unix, `taskkill /T /F` on Windows). A single `post-start` hook (`wt step tether -- npm run dev`) replaces the usual `post-start`-to-launch / `pre-remove`-to-stop pair, and unlike `pre-remove` it also cleans up after a `git worktree remove`, an `rm -rf`, or a crashed hook — the leak path that eventually saturates macOS `fseventsd`. Arguments after `--` run directly with no shell, matching `wt step for-each`. ([#2785](https://github.com/max-sixty/worktrunk/pull/2785))
+
+- **Gemini CLI extension**: Worktrunk now ships a Gemini CLI extension for `wt list` activity tracking, installable with `gemini extensions install max-sixty/worktrunk`. The extension's manifest, hooks, and skills resolve at the repo root, so the GitHub-name install path works without a local clone. ([#2803](https://github.com/max-sixty/worktrunk/pull/2803), [#2807](https://github.com/max-sixty/worktrunk/pull/2807), thanks @rafavital for the request in [#2763](https://github.com/max-sixty/worktrunk/issues/2763))
+
+### Fixed
+
+- **Project hooks are frozen at the approval gate**: A project-defined `pre-*`/`post-*` hook command was selected from `.config/wt.toml` twice — once to build the approval prompt, once at execution — and the operation itself mutates state between the two reads (a merge moves the target ref, an auto-rebase rewrites the feature config, a removal scrubs the worktree, `git worktree add` materializes a `--create` worktree). The second read could select a command the user never approved; on a freshly cloned repo that is unapproved code execution. The gate now freezes the command set into an immutable plan that the executor consumes verbatim, so post-operation hooks can never run an unapproved command. Behavior is otherwise unchanged, and `wt merge --no-hooks` (or a declined/empty plan) now returns before loading approvals, so a malformed `approvals.toml` no longer aborts a command that had nothing to authorize. ([#2806](https://github.com/max-sixty/worktrunk/pull/2806))
+
+- **Declining the `wt merge` commit-append no longer skips hooks**: When a project's `pre-merge`/`post-merge` hooks were already approved, `wt merge` bundled the commit-message append into the same prompt; declining the lone append prompt skipped every hook for that run even though the user only meant to skip the append. The append is now gated on its own path (the same one `wt step commit`/`wt step squash` use), so declining it drops only the append. On a fresh repo where both the hooks and the append are unapproved this is now two prompts instead of one bundled prompt. Decline messages are also canonicalized across `merge`, `remove`, `prune`, and `switch` (`Commands declined, … without hooks`). ([#2802](https://github.com/max-sixty/worktrunk/pull/2802))
+
+- **Windows `wt step prune` `.git/config` race**: `wt step prune` could intermittently fail on Windows with `unable to access '.git/config': Permission denied` — its parallel branch-integration checks read `.git/config` while an inline `git branch -D` rewrote it via git's lockfile rename, which on Windows briefly blocks concurrent readers. Branch-integration reads are now excluded from overlapping the `git branch -D` that rewrites config. ([#2808](https://github.com/max-sixty/worktrunk/pull/2808))
+
 ## 0.51.0
 
 ### Improved

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3171,7 +3171,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "worktrunk"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "ansi-str",
  "ansi-to-html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ default-members = [".", "tests/helpers/mock-stub", "tests/helpers/wt-perf"]
 
 [package]
 name = "worktrunk"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2024"
 rust-version = "1.94"
 build = "build.rs"


### PR DESCRIPTION
Release v0.52.0. Version bump (`Cargo.toml`, `Cargo.lock`) plus the CHANGELOG section.

Two new user-facing features since v0.51.0 — `wt step tether` (experimental: ties a command's lifetime to its worktree) and a Gemini CLI extension for `wt list` activity tracking — plus three fixes (approval-boundary TOCTOU hardening, the `wt merge` commit-append/hook decline conflation, and a Windows `wt step prune` `.git/config` race). No breaking changes; `cargo semver-checks` reports no library API breakage.

Changelog entries were verified against the diffs by a review subagent before finalizing.
