### PR TITLE
feat(plugin): detect Gemini extension; document OpenCode and Gemini install

### DIFF
--- a/docs/content/claude-code.md
+++ b/docs/content/claude-code.md
@@ -1,21 +1,22 @@
 +++
-title = "Claude Code & Codex Integration"
-description = "Worktrunk plugins for Claude Code and Codex: a shared configuration skill, plus Claude-only worktree isolation and wt list activity tracking."
+title = "Agent Integration"
+description = "Worktrunk plugins for Claude Code, Codex, OpenCode, and Gemini CLI: a configuration skill, wt list activity tracking, and Claude-only worktree isolation."
 weight = 23
 
 [extra]
 group = "Reference"
 +++
 
-Worktrunk ships plugins for Claude Code and Codex. Both bundle a **configuration skill** — documentation the agent can read, so it can help set up LLM commits, hooks, and troubleshoot issues.
+Worktrunk ships a plugin for each supported agent CLI. What a plugin provides depends on the hooks that CLI exposes:
 
-The Claude Code plugin additionally provides:
+| Capability | Claude Code | Codex | OpenCode | Gemini CLI |
+|---|:-:|:-:|:-:|:-:|
+| Configuration skill | ✓ | ✓ |  | ✓ |
+| Activity tracking (🤖/💬 in `wt list`) | ✓ |  | ✓ | ✓ |
+| Worktree isolation | ✓ |  |  |  |
+| `/wt-switch-create` command | ✓ |  |  |  |
 
-1. **Activity tracking** — Status markers in `wt list` showing which worktrees have active agent sessions (🤖 working, 💬 waiting)
-2. **Worktree isolation** — Routes agent-created isolated worktrees through `wt switch --create` / `wt remove` instead of raw `git`
-3. **`/wt-switch-create` command** — Creates a worktrunk worktree and moves the current Claude session into it
-
-Codex exposes no turn-end or worktree-lifecycle hooks, so the Codex plugin ships only the configuration skill.
+The configuration skill is documentation the agent reads to help set up LLM commits, hooks, and troubleshooting. Activity tracking shows which worktrees have running sessions. Worktree isolation and `/wt-switch-create` need worktree-lifecycle hooks that only Claude Code exposes, so Codex, OpenCode, and Gemini users invoke `wt switch --create` and `wt remove` directly. Codex omits activity tracking because its hooks have no turn-end event, so a 🤖 marker could never clear back to 💬.
 
 ## Installation
 
@@ -37,6 +38,18 @@ This configures the Worktrunk marketplace in Codex. Then run `/plugins` in Codex
 
 To remove the marketplace entry, run `wt config plugins codex uninstall`. Already-installed plugins are left unchanged.
 
+### OpenCode
+
+{{ terminal(cmd="wt config plugins opencode install") }}
+
+This writes the activity-tracking plugin to OpenCode's global plugins directory, `~/.config/opencode/plugins/worktrunk.ts` (honoring `$OPENCODE_CONFIG_DIR` and `$XDG_CONFIG_HOME`). `wt config plugins opencode uninstall` removes it.
+
+### Gemini CLI
+
+{{ terminal(cmd="gemini extensions install https://github.com/max-sixty/worktrunk") }}
+
+Gemini loads the extension natively from the repository, so there is no `wt` wrapper. `gemini extensions uninstall worktrunk` removes it.
+
 ## Configuration skill
 
 The plugin includes a skill — documentation the agent can read — covering Worktrunk's configuration system. After installation, the agent can help with:
@@ -48,9 +61,9 @@ The plugin includes a skill — documentation the agent can read — covering Wo
 
 Claude Code is designed to load the skill automatically when it detects worktrunk-related questions.
 
-## Activity tracking (Claude Code only)
+## Activity tracking
 
-The Claude Code plugin tracks Claude sessions with status markers in `wt list`:
+The Claude Code, OpenCode, and Gemini plugins track agent sessions with status markers in `wt list`:
 
 <!-- ⚠️ AUTO-GENERATED from tests/snapshots/integration__integration_tests__list__list_with_user_marker.snap — edit source to update -->
 
@@ -70,7 +83,7 @@ The Claude Code plugin tracks Claude sessions with status markers in `wt list`:
 - 🤖 — agent is working
 - 💬 — agent is waiting or idle
 
-The plugin clears the marker when a session ends. A stale marker can remain if the Claude process is killed before its stop hook runs; `wt config state marker clear` removes a marker manually.
+The plugin clears the marker when a session ends. A stale marker can remain if the agent process is killed before its session-end hook runs; `wt config state marker clear` removes a marker manually.
 
 ### Manual status markers
 
@@ -85,8 +98,6 @@ Set status markers manually for any workflow:
 ## Worktree isolation (Claude Code only)
 
 Claude Code agents can run in isolated worktrees (`isolation: "worktree"`). By default, Claude Code creates these with `git worktree add`. The plugin's `WorktreeCreate` and `WorktreeRemove` hooks route this through `wt switch --create` and `wt remove` instead, so worktrees created by agents get worktrunk's naming conventions, hooks, and lifecycle management.
-
-Codex does not currently expose equivalent hook events, so Codex users should invoke `wt switch --create` and `wt remove` directly.
 
 ## `/wt-switch-create` command (Claude Code only)
 

--- a/docs/static/llms.txt
+++ b/docs/static/llms.txt
@@ -23,6 +23,6 @@ with many parallel changes, including hooks to automate local workflows.
 
 - [Extending Worktrunk](https://worktrunk.dev/extending.md): Three ways to add custom behavior: hooks for lifecycle automation, aliases for reusable commands, and custom subcommands for standalone tools.
 - [LLM Commit Messages](https://worktrunk.dev/llm-commits.md): Generate commit messages from diffs using any LLM. Integrates with wt merge, wt step commit, and wt step squash.
-- [Claude Code & Codex Integration](https://worktrunk.dev/claude-code.md): Worktrunk plugins for Claude Code and Codex: a shared configuration skill, plus Claude-only worktree isolation and wt list activity tracking.
+- [Agent Integration](https://worktrunk.dev/claude-code.md): Worktrunk plugins for Claude Code, Codex, OpenCode, and Gemini CLI: a configuration skill, wt list activity tracking, and Claude-only worktree isolation.
 - [Tips & Patterns](https://worktrunk.dev/tips-patterns.md): Practical recipes for Worktrunk workflows: aliases, shell integration, Zellij layouts, and parallel agent patterns.
 - [FAQ](https://worktrunk.dev/faq.md): Common questions about Worktrunk: comparison to git worktree and branch switching, bare repos, TUI support, and more.

--- a/skills/worktrunk/reference/claude-code.md
+++ b/skills/worktrunk/reference/claude-code.md
@@ -1,14 +1,15 @@
-# Claude Code & Codex Integration
+# Agent Integration
 
-Worktrunk ships plugins for Claude Code and Codex. Both bundle a **configuration skill** — documentation the agent can read, so it can help set up LLM commits, hooks, and troubleshoot issues.
+Worktrunk ships a plugin for each supported agent CLI. What a plugin provides depends on the hooks that CLI exposes:
 
-The Claude Code plugin additionally provides:
+| Capability | Claude Code | Codex | OpenCode | Gemini CLI |
+|---|:-:|:-:|:-:|:-:|
+| Configuration skill | ✓ | ✓ |  | ✓ |
+| Activity tracking (🤖/💬 in `wt list`) | ✓ |  | ✓ | ✓ |
+| Worktree isolation | ✓ |  |  |  |
+| `/wt-switch-create` command | ✓ |  |  |  |
 
-1. **Activity tracking** — Status markers in `wt list` showing which worktrees have active agent sessions (🤖 working, 💬 waiting)
-2. **Worktree isolation** — Routes agent-created isolated worktrees through `wt switch --create` / `wt remove` instead of raw `git`
-3. **`/wt-switch-create` command** — Creates a worktrunk worktree and moves the current Claude session into it
-
-Codex exposes no turn-end or worktree-lifecycle hooks, so the Codex plugin ships only the configuration skill.
+The configuration skill is documentation the agent reads to help set up LLM commits, hooks, and troubleshooting. Activity tracking shows which worktrees have running sessions. Worktree isolation and `/wt-switch-create` need worktree-lifecycle hooks that only Claude Code exposes, so Codex, OpenCode, and Gemini users invoke `wt switch --create` and `wt remove` directly. Codex omits activity tracking because its hooks have no turn-end event, so a 🤖 marker could never clear back to 💬.
 
 ## Installation
 
@@ -39,6 +40,22 @@ codex plugin marketplace add max-sixty/worktrunk
 
 To remove the marketplace entry, run `wt config plugins codex uninstall`. Already-installed plugins are left unchanged.
 
+### OpenCode
+
+```bash
+wt config plugins opencode install
+```
+
+This writes the activity-tracking plugin to OpenCode's global plugins directory, `~/.config/opencode/plugins/worktrunk.ts` (honoring `$OPENCODE_CONFIG_DIR` and `$XDG_CONFIG_HOME`). `wt config plugins opencode uninstall` removes it.
+
+### Gemini CLI
+
+```bash
+gemini extensions install https://github.com/max-sixty/worktrunk
+```
+
+Gemini loads the extension natively from the repository, so there is no `wt` wrapper. `gemini extensions uninstall worktrunk` removes it.
+
 ## Configuration skill
 
 The plugin includes a skill — documentation the agent can read — covering Worktrunk's configuration system. After installation, the agent can help with:
@@ -50,9 +67,9 @@ The plugin includes a skill — documentation the agent can read — covering Wo
 
 Claude Code is designed to load the skill automatically when it detects worktrunk-related questions.
 
-## Activity tracking (Claude Code only)
+## Activity tracking
 
-The Claude Code plugin tracks Claude sessions with status markers in `wt list`:
+The Claude Code, OpenCode, and Gemini plugins track agent sessions with status markers in `wt list`:
 
 ```bash
 $ wt list
@@ -68,7 +85,7 @@ $ wt list
 - 🤖 — agent is working
 - 💬 — agent is waiting or idle
 
-The plugin clears the marker when a session ends. A stale marker can remain if the Claude process is killed before its stop hook runs; `wt config state marker clear` removes a marker manually.
+The plugin clears the marker when a session ends. A stale marker can remain if the agent process is killed before its session-end hook runs; `wt config state marker clear` removes a marker manually.
 
 ### Manual status markers
 
@@ -83,8 +100,6 @@ $ git config worktrunk.state.feature.marker '{"marker":"💬","set_at":0}'  # Di
 ## Worktree isolation (Claude Code only)
 
 Claude Code agents can run in isolated worktrees (`isolation: "worktree"`). By default, Claude Code creates these with `git worktree add`. The plugin's `WorktreeCreate` and `WorktreeRemove` hooks route this through `wt switch --create` and `wt remove` instead, so worktrees created by agents get worktrunk's naming conventions, hooks, and lifecycle management.
-
-Codex does not currently expose equivalent hook events, so Codex users should invoke `wt switch --create` and `wt remove` directly.
 
 ## `/wt-switch-create` command (Claude Code only)
 

--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -72,6 +72,12 @@ pub fn handle_config_show(full: bool, format: SwitchFormat) -> anyhow::Result<()
         render_opencode_status(&mut show_output)?;
     }
 
+    // Render Gemini status (only when gemini CLI is available)
+    if is_gemini_available() {
+        show_output.push('\n');
+        render_gemini_status(&mut show_output)?;
+    }
+
     // Run full diagnostic checks if requested (includes slow network calls)
     if full {
         show_output.push('\n');
@@ -336,6 +342,57 @@ fn render_opencode_status(out: &mut String) -> anyhow::Result<()> {
             "{}",
             hint_message(cformat!(
                 "Plugin not installed. To install, run <underline>wt config plugins opencode install</>"
+            ))
+        )?;
+    }
+
+    Ok(())
+}
+
+/// Check if Gemini CLI is available
+fn is_gemini_available() -> bool {
+    // Allow tests to override detection
+    if let Ok(val) = std::env::var("WORKTRUNK_TEST_GEMINI_INSTALLED") {
+        return val == "1";
+    }
+    which::which("gemini").is_ok()
+}
+
+/// Check if the worktrunk extension is installed in Gemini CLI.
+///
+/// `gemini extensions install` clones the extension into
+/// `~/.gemini/extensions/<name>/`, so a worktrunk install leaves a
+/// `gemini-extension.json` whose `name` is `worktrunk` at that path.
+fn is_gemini_extension_installed() -> bool {
+    let Some(home) = home_dir() else {
+        return false;
+    };
+
+    let manifest = home.join(".gemini/extensions/worktrunk/gemini-extension.json");
+    let Ok(content) = std::fs::read_to_string(&manifest) else {
+        return false;
+    };
+
+    let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+        return false;
+    };
+
+    json.get("name").and_then(|n| n.as_str()) == Some("worktrunk")
+}
+
+/// Render GEMINI CLI section (extension status).
+/// Caller must check `is_gemini_available()` first.
+fn render_gemini_status(out: &mut String) -> anyhow::Result<()> {
+    writeln!(out, "{}", format_heading("GEMINI CLI", None))?;
+
+    if is_gemini_extension_installed() {
+        writeln!(out, "{}", success_message("Extension installed"))?;
+    } else {
+        writeln!(
+            out,
+            "{}",
+            hint_message(cformat!(
+                "Extension not installed. To install, run <underline>gemini extensions install https://github.com/max-sixty/worktrunk</>"
             ))
         )?;
     }

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -539,6 +539,8 @@ pub fn configure_cli_command(cmd: &mut Command) {
     cmd.env("WORKTRUNK_TEST_CODEX_INSTALLED", "0");
     // Treat OpenCode as not installed by default (tests can override with "1")
     cmd.env("WORKTRUNK_TEST_OPENCODE_INSTALLED", "0");
+    // Treat Gemini as not installed by default (tests can override with "1")
+    cmd.env("WORKTRUNK_TEST_GEMINI_INSTALLED", "0");
 
     // Apply shared static env vars (see STATIC_TEST_ENV_VARS)
     for &(key, value) in STATIC_TEST_ENV_VARS {
@@ -784,6 +786,8 @@ pub struct TestRepo {
     codex_installed: bool,
     /// Whether OpenCode CLI should be treated as installed
     opencode_installed: bool,
+    /// Whether Gemini CLI should be treated as installed
+    gemini_installed: bool,
 }
 
 impl TestRepo {
@@ -879,6 +883,7 @@ impl TestRepo {
             claude_installed: false,
             codex_installed: false,
             opencode_installed: false,
+            gemini_installed: false,
         };
 
         // Mock gh/glab as authenticated to prevent CI hints in test output
@@ -930,6 +935,7 @@ impl TestRepo {
             claude_installed: false,
             codex_installed: false,
             opencode_installed: false,
+            gemini_installed: false,
         }
     }
 
@@ -977,6 +983,7 @@ impl TestRepo {
             claude_installed: false,
             codex_installed: false,
             opencode_installed: false,
+            gemini_installed: false,
         }
     }
 
@@ -1800,6 +1807,29 @@ impl TestRepo {
         .unwrap();
     }
 
+    /// Setup mock `gemini` CLI as installed
+    ///
+    /// Call this to simulate Gemini CLI being available on the system.
+    pub fn setup_mock_gemini_installed(&mut self) {
+        self.gemini_installed = true;
+    }
+
+    /// Setup the worktrunk extension as installed in Gemini CLI
+    ///
+    /// `gemini extensions install` clones the extension into
+    /// `~/.gemini/extensions/<name>/`; this writes the resulting
+    /// `gemini-extension.json` under the temp home directory (which must
+    /// already be set up via `set_temp_home_env` on the command).
+    pub fn setup_gemini_extension_installed(temp_home: &std::path::Path) {
+        let extension_dir = temp_home.join(".gemini/extensions/worktrunk");
+        std::fs::create_dir_all(&extension_dir).unwrap();
+        std::fs::write(
+            extension_dir.join("gemini-extension.json"),
+            include_str!("../../gemini-extension.json"),
+        )
+        .unwrap();
+    }
+
     /// Setup mock `claude` CLI with plugin subcommand support
     ///
     /// Creates a mock claude binary that handles `plugin marketplace`,
@@ -2313,6 +2343,11 @@ impl TestRepo {
         // Override OpenCode installed status if setup_mock_opencode_installed() was called
         if self.opencode_installed {
             cmd.env("WORKTRUNK_TEST_OPENCODE_INSTALLED", "1");
+        }
+
+        // Override Gemini installed status if setup_mock_gemini_installed() was called
+        if self.gemini_installed {
+            cmd.env("WORKTRUNK_TEST_GEMINI_INSTALLED", "1");
         }
     }
 

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -2341,6 +2341,39 @@ fn test_config_show_gemini_available_extension_not_installed(
 }
 
 #[rstest]
+fn test_config_show_gemini_extension_invalid_manifest(mut repo: TestRepo, temp_home: TempDir) {
+    // A malformed gemini-extension.json should fall through the JSON-parse
+    // branch and report the extension as not installed (the install hint).
+    repo.setup_mock_ci_tools_unauthenticated();
+    repo.setup_mock_gemini_installed();
+
+    let extension_dir = temp_home.path().join(".gemini/extensions/worktrunk");
+    fs::create_dir_all(&extension_dir).unwrap();
+    fs::write(extension_dir.join("gemini-extension.json"), "not json\n").unwrap();
+
+    let global_config_dir = temp_home.path().join(".config").join("worktrunk");
+    fs::create_dir_all(&global_config_dir).unwrap();
+    fs::write(
+        global_config_dir.join("config.toml"),
+        r#"worktree-path = "../{{ repo }}.{{ branch }}"
+"#,
+    )
+    .unwrap();
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        repo.configure_mock_commands(&mut cmd);
+        cmd.arg("config").arg("show").current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+        set_xdg_config_path(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
+#[rstest]
 fn test_config_show_gemini_extension_installed(mut repo: TestRepo, temp_home: TempDir) {
     // Setup mock gh/glab for deterministic output
     repo.setup_mock_ci_tools_unauthenticated();

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -2307,6 +2307,70 @@ fn test_config_show_opencode_plugin_outdated(mut repo: TestRepo, temp_home: Temp
     });
 }
 
+#[rstest]
+fn test_config_show_gemini_available_extension_not_installed(
+    mut repo: TestRepo,
+    temp_home: TempDir,
+) {
+    // Setup mock gh/glab for deterministic output
+    repo.setup_mock_ci_tools_unauthenticated();
+    // Setup mock gemini as available (but extension not installed)
+    repo.setup_mock_gemini_installed();
+
+    // Create global config
+    let global_config_dir = temp_home.path().join(".config").join("worktrunk");
+    fs::create_dir_all(&global_config_dir).unwrap();
+    fs::write(
+        global_config_dir.join("config.toml"),
+        r#"worktree-path = "../{{ repo }}.{{ branch }}"
+"#,
+    )
+    .unwrap();
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        repo.configure_mock_commands(&mut cmd);
+        cmd.arg("config").arg("show").current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+        set_xdg_config_path(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
+#[rstest]
+fn test_config_show_gemini_extension_installed(mut repo: TestRepo, temp_home: TempDir) {
+    // Setup mock gh/glab for deterministic output
+    repo.setup_mock_ci_tools_unauthenticated();
+    // Setup mock gemini CLI and extension as installed
+    repo.setup_mock_gemini_installed();
+    TestRepo::setup_gemini_extension_installed(temp_home.path());
+
+    // Create global config
+    let global_config_dir = temp_home.path().join(".config").join("worktrunk");
+    fs::create_dir_all(&global_config_dir).unwrap();
+    fs::write(
+        global_config_dir.join("config.toml"),
+        r#"worktree-path = "../{{ repo }}.{{ branch }}"
+"#,
+    )
+    .unwrap();
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        repo.configure_mock_commands(&mut cmd);
+        cmd.arg("config").arg("show").current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+        set_xdg_config_path(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
 // =============================================================================
 // OpenCode plugin install/uninstall
 // =============================================================================

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_gemini_available_extension_not_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_gemini_available_extension_not_installed.snap
@@ -1,0 +1,77 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - show
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
+    GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
+    GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "1"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
+[2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
+
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
+[2m↳[22m [2mNot found[22m
+
+[36mSHELL INTEGRATION[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
+
+[36mGEMINI CLI[39m
+[2m↳[22m [2mExtension not installed. To install, run [4mgemini extensions install https://github.com/max-sixty/worktrunk[24m[22m
+
+[36mOTHER[39m
+[2m○[22m wt: [1m[VERSION][22m
+[2m○[22m git: [1m[VERSION][22m
+[2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_gemini_extension_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_gemini_extension_installed.snap
@@ -1,0 +1,77 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - show
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
+    GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
+    GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "1"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
+[2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
+
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
+[2m↳[22m [2mNot found[22m
+
+[36mSHELL INTEGRATION[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
+
+[36mGEMINI CLI[39m
+[32m✓[39m [32mExtension installed[39m
+
+[36mOTHER[39m
+[2m○[22m wt: [1m[VERSION][22m
+[2m○[22m git: [1m[VERSION][22m
+[2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_gemini_extension_invalid_manifest.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_gemini_extension_invalid_manifest.snap
@@ -1,0 +1,77 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - show
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
+    GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
+    GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "1"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
+[2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
+
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
+[2m↳[22m [2mNot found[22m
+
+[36mSHELL INTEGRATION[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
+
+[36mGEMINI CLI[39m
+[2m↳[22m [2mExtension not installed. To install, run [4mgemini extensions install https://github.com/max-sixty/worktrunk[24m[22m
+
+[36mOTHER[39m
+[2m○[22m wt: [1m[VERSION][22m
+[2m○[22m git: [1m[VERSION][22m
+[2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----


### PR DESCRIPTION
Closing two gaps a prior plugin-implementation review surfaced: Gemini's native install path was invisible (no `wt config show` section, no user-facing docs), and OpenCode — which has the most substantial implementation of the four — was absent from the plugins page despite being the only tool that ships activity tracking via a worktrunk-written plugin.

`wt config show` now renders a `GEMINI CLI` section gated on `which::which("gemini")`. Installed state is detected by parsing `~/.gemini/extensions/worktrunk/gemini-extension.json` and checking `name == "worktrunk"` — exactly where `gemini extensions install` clones the extension. Fail-closed on a missing home, unreadable file, or invalid JSON, matching the existing claude/codex/opencode detection. Test infrastructure (`gemini_installed` field on `TestRepo`, `setup_mock_gemini_installed`, `setup_gemini_extension_installed`) and the two new snapshot tests mirror the OpenCode equivalents line-for-line.

`docs/content/claude-code.md` retitled "Agent Integration" and restructured around a four-tool capability table covering configuration skill, activity tracking, worktree isolation, and `/wt-switch-create`. OpenCode and Gemini get install subsections; the activity-tracking section is generalized from Claude-only to Claude+OpenCode+Gemini so the heading matches the table. A Codex-only sentence under "Worktree isolation" was redundant with the table and dropped.

## Verified end-to-end

After **v0.52.0** went `Latest`, `gemini extensions install https://github.com/max-sixty/worktrunk` resolves via `/releases/latest` → the v0.52.0 source tarball (which now carries the root `gemini-extension.json` from #2807) → install succeeds. `gemini extensions list` shows `Type: github-release`, `Release tag: v0.52.0`, with both skills (`wt-switch-create`, `worktrunk`) loaded via `${extensionPath}/skills/`. Live `wt config show` reports `✓ Extension installed`. The bare URL is what the docs use — `owner/repo` shorthand returns "Install source not found" against gemini-cli, so the full URL is the right form.

Per the `release` and detection paths in gemini-cli 0.42 (`bundle/chunk-CHERUG6W.js` lines 44170–44290 / 44640–44675), the URL install always tries `releases/latest` first when releases exist, and only auto-falls-back to `git clone` if there's no release data at all — so the work landed in #2807 on `main` only became user-visible once v0.52.0 was cut. This PR ships the detection and docs that have now been confirmed accurate against the live release path.

Pre-merge gate green locally (3747 tests, 0 skipped; pre-commit clean; `test_docs_are_in_sync` green so the skill reference and `llms.txt` are in sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
