### PR TITLE
docs(claude): cross-ref PTY coverage and compress list-features rubric

### DIFF
--- a/src/commands/list/CLAUDE.md
+++ b/src/commands/list/CLAUDE.md
@@ -36,18 +36,9 @@ Results update cells progressively as they complete.
 
 ## Adding New Features
 
-When adding a new column or feature, ask:
-
-1. **Does it need data before skeleton?** Usually no. The skeleton can show a
-   placeholder or omit the column until data arrives.
-
-2. **Can template expansion wait?** Yes. Expand templates post-skeleton, then
-   update the relevant cells.
-
-3. **Does it require file I/O?** If so, it belongs post-skeleton.
-
-**Default answer: defer to post-skeleton.** Only add pre-skeleton operations
-when the skeleton literally cannot render without the data.
+Default: defer to post-skeleton. Only add a pre-skeleton operation when the
+skeleton literally cannot render without the data. File I/O and template
+expansion always wait; new columns can render a placeholder until data arrives.
 
 ## Benchmarking Skeleton Time
 

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -33,6 +33,8 @@ For each uncovered function, either write a test (integration tests via `assert_
 
 **"N functions have mismatched data" warning:** `cargo llvm-cov` merges profiles from multiple compilation targets with minor codegen differences (typically 5–20 functions). Expected, harmless, no suppression flag exists ([LLVM #97574](https://github.com/llvm/llvm-project/issues/97574)).
 
+PTY tests need extra setup to be measured at all — they `env_clear()` the subprocess, so LLVM env vars must be passed through explicitly. See "Coverage in PTY Tests" below.
+
 ## Running `wt` Commands in Tests
 
 **Use the correct helper to ensure test isolation.** Tests that spawn `wt` must


### PR DESCRIPTION
Two small CLAUDE.md follow-ups surfaced while surveying the tree during #2816.

- `tests/CLAUDE.md`: one-line forward reference from "Coverage Investigation" to "Coverage in PTY Tests" — explains *why* the PTY section exists (the subprocess `env_clear()` is the link, so it reads as a real prerequisite rather than a generic "see also").
- `src/commands/list/CLAUDE.md` → "Adding New Features": three rhetorical questions all answering "defer to post-skeleton", then a restated "Default answer" line. Collapse to one declarative paragraph. Substance preserved (file I/O and template expansion wait; new columns render a placeholder until data arrives).

Docs-only, `+5 / −12`.
