### PR TITLE
test(config): cover which::which CLI detection fallback

### DIFF
--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -788,6 +788,9 @@ pub struct TestRepo {
     opencode_installed: bool,
     /// Whether Gemini CLI should be treated as installed
     gemini_installed: bool,
+    /// Whether to drop the `WORKTRUNK_TEST_*_INSTALLED` overrides so
+    /// `is_*_available()` exercises its real `which::which` PATH lookup
+    detect_clis_via_path: bool,
 }
 
 impl TestRepo {
@@ -884,6 +887,7 @@ impl TestRepo {
             codex_installed: false,
             opencode_installed: false,
             gemini_installed: false,
+            detect_clis_via_path: false,
         };
 
         // Mock gh/glab as authenticated to prevent CI hints in test output
@@ -936,6 +940,7 @@ impl TestRepo {
             codex_installed: false,
             opencode_installed: false,
             gemini_installed: false,
+            detect_clis_via_path: false,
         }
     }
 
@@ -984,6 +989,7 @@ impl TestRepo {
             codex_installed: false,
             opencode_installed: false,
             gemini_installed: false,
+            detect_clis_via_path: false,
         }
     }
 
@@ -1814,6 +1820,28 @@ impl TestRepo {
         self.gemini_installed = true;
     }
 
+    /// Make `claude`, `codex`, `opencode`, and `gemini` resolvable on `PATH`.
+    ///
+    /// The `setup_mock_*_installed` helpers force detection through the
+    /// `WORKTRUNK_TEST_*_INSTALLED` env overrides, so the `which::which`
+    /// lookup inside each `is_*_available()` never runs under test. This
+    /// helper instead drops those overrides and prepends real mock
+    /// executables, exercising the production PATH-detection path for all
+    /// four AI CLIs at once. Call `setup_mock_ci_tools_unauthenticated()`
+    /// first to create the mock bin directory.
+    pub fn setup_mock_clis_on_path(&mut self) {
+        let mock_bin = self
+            .mock_bin_path
+            .as_ref()
+            .expect("call setup_mock_ci_tools_unauthenticated() first");
+        // `wt config show` only `which`-detects these CLIs (never runs
+        // them), so the mocks need no command behavior.
+        for cli in ["claude", "codex", "opencode", "gemini"] {
+            MockConfig::new(cli).write(mock_bin);
+        }
+        self.detect_clis_via_path = true;
+    }
+
     /// Setup the worktrunk extension as installed in Gemini CLI
     ///
     /// `gemini extensions install` clones the extension into
@@ -2330,24 +2358,33 @@ impl TestRepo {
             cmd.env(&path_var_name, new_path);
         }
 
-        // Override Claude installed status if setup_mock_claude_installed() was called
-        if self.claude_installed {
-            cmd.env("WORKTRUNK_TEST_CLAUDE_INSTALLED", "1");
-        }
-
-        // Override Codex installed status if setup_mock_codex_installed() was called
-        if self.codex_installed {
-            cmd.env("WORKTRUNK_TEST_CODEX_INSTALLED", "1");
-        }
-
-        // Override OpenCode installed status if setup_mock_opencode_installed() was called
-        if self.opencode_installed {
-            cmd.env("WORKTRUNK_TEST_OPENCODE_INSTALLED", "1");
-        }
-
-        // Override Gemini installed status if setup_mock_gemini_installed() was called
-        if self.gemini_installed {
-            cmd.env("WORKTRUNK_TEST_GEMINI_INSTALLED", "1");
+        // AI CLI detection. `setup_mock_clis_on_path()` drops the
+        // `WORKTRUNK_TEST_*_INSTALLED` overrides so `is_*_available()`
+        // exercises its real `which::which` PATH lookup against the mock
+        // executables prepended above. Otherwise each override forces
+        // detection on for the CLIs whose `setup_mock_*_installed()` ran.
+        if self.detect_clis_via_path {
+            for var in [
+                "WORKTRUNK_TEST_CLAUDE_INSTALLED",
+                "WORKTRUNK_TEST_CODEX_INSTALLED",
+                "WORKTRUNK_TEST_OPENCODE_INSTALLED",
+                "WORKTRUNK_TEST_GEMINI_INSTALLED",
+            ] {
+                cmd.env_remove(var);
+            }
+        } else {
+            if self.claude_installed {
+                cmd.env("WORKTRUNK_TEST_CLAUDE_INSTALLED", "1");
+            }
+            if self.codex_installed {
+                cmd.env("WORKTRUNK_TEST_CODEX_INSTALLED", "1");
+            }
+            if self.opencode_installed {
+                cmd.env("WORKTRUNK_TEST_OPENCODE_INSTALLED", "1");
+            }
+            if self.gemini_installed {
+                cmd.env("WORKTRUNK_TEST_GEMINI_INSTALLED", "1");
+            }
         }
     }
 

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -2404,6 +2404,38 @@ fn test_config_show_gemini_extension_installed(mut repo: TestRepo, temp_home: Te
     });
 }
 
+/// Each `is_*_available()` short-circuits on the `WORKTRUNK_TEST_*_INSTALLED`
+/// override the harness sets, so the production `which::which` PATH lookup is
+/// otherwise never exercised. `setup_mock_clis_on_path()` drops the overrides
+/// and prepends real mock executables, so this single run covers the
+/// PATH-detection path for all four AI CLIs at once.
+#[rstest]
+fn test_config_show_clis_detected_via_path(mut repo: TestRepo, temp_home: TempDir) {
+    repo.setup_mock_ci_tools_unauthenticated();
+    repo.setup_mock_clis_on_path();
+
+    let global_config_dir = temp_home.path().join(".config").join("worktrunk");
+    fs::create_dir_all(&global_config_dir).unwrap();
+    fs::write(
+        global_config_dir.join("config.toml"),
+        r#"worktree-path = "../{{ repo }}.{{ branch }}"
+"#,
+    )
+    .unwrap();
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        repo.configure_mock_commands(&mut cmd);
+        cmd.arg("config").arg("show").current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+        set_xdg_config_path(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+    });
+}
+
 // =============================================================================
 // OpenCode plugin install/uninstall
 // =============================================================================

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_clis_detected_via_path.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_clis_detected_via_path.snap
@@ -1,0 +1,88 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - show
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
+    GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
+    GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    RUST_LOG: warn
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: ""
+    WORKTRUNK_TEST_CODEX_INSTALLED: ""
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: ""
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: ""
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"
+[2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
+
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
+[2m↳[22m [2mNot found[22m
+
+[36mSHELL INTEGRATION[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
+
+[36mCLAUDE CODE[39m
+[2m↳[22m [2mPlugin not installed. To install, run [4mwt config plugins claude install[24m[22m
+[2m↳[22m [2mStatusline not configured. To configure, run [4mwt config plugins claude install-statusline[24m[22m
+
+[36mCODEX[39m
+[32m✓[39m [32mCodex CLI available[39m
+[2m↳[22m [2mIf Worktrunk is not installed in /plugins yet, run [4mwt config plugins codex install[24m[22m
+
+[36mOPENCODE[39m
+[2m↳[22m [2mPlugin not installed. To install, run [4mwt config plugins opencode install[24m[22m
+
+[36mGEMINI CLI[39m
+[2m↳[22m [2mExtension not installed. To install, run [4mgemini extensions install https://github.com/max-sixty/worktrunk[24m[22m
+
+[36mOTHER[39m
+[2m○[22m wt: [1m[VERSION][22m
+[2m○[22m git: [1m[VERSION][22m
+[2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----


### PR DESCRIPTION
Closes a latent test-coverage gap surfaced by PR #2819. The four `is_<tool>_available()` helpers in `src/commands/config/show.rs` (Claude, Codex, OpenCode, Gemini) each short-circuit on a `WORKTRUNK_TEST_<TOOL>_INSTALLED` env var that the test harness always sets, so the trailing `which::which(<cli>).is_ok()` real-detection line is never executed under any test. `codecov/patch` flagged this when the Gemini helper was added; the identical Claude/Codex/OpenCode lines have been silently uncovered all along and would re-trigger the failure on any future PR touching a detection helper.

`TestRepo::setup_mock_clis_on_path()` writes real mock `claude`/`codex`/`opencode`/`gemini` executables into the mock-bin directory (already prepended to `PATH`) and sets a `detect_clis_via_path` flag. When the flag is set, `configure_mock_commands` drops the `WORKTRUNK_TEST_*_INSTALLED` overrides via `env_remove` instead of setting them, so `is_*_available()` falls through to `which::which`, which resolves the mocks deterministically. The `else` branch is the original code verbatim — no behavior change for existing tests.

One new integration test, `test_config_show_clis_detected_via_path`, runs `wt config show` once and snapshots all four AI-tool sections. The coverage is structural: each section only renders when its helper returns `true`, and with the overrides removed the only path to `true` is `which::which` resolving the mock — so the rendered sections confirm all four detection lines executed.

Pre-merge gate green locally (3779 tests, 0 skipped; clippy and pre-commit clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
