### PR TITLE
fix(skills): correct codecov LineType mapping in running-tend coverage query

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -53,8 +53,9 @@ curl -sL "https://api.codecov.io/api/v2/gh/${REPO%/*}/repos/${REPO#*/}/compare/?
 # Patch-level summary per file:
 jq '.files[] | {name: .name.head, patch: .totals.patch}' /tmp/codecov.json
 
-# Uncovered added lines in a specific changed file:
-jq '.files[] | select(.name.head == "<path>") | .lines[] | select(.is_diff and .added and .coverage.head == 0) | {line: .number.head, code: (.value | .[0:80])}' /tmp/codecov.json
+# Uncovered added lines in a specific changed file
+# (coverage.head is a LineType enum: 0=hit, 1=miss, 2=partial — filter on 1=miss):
+jq '.files[] | select(.name.head == "<path>") | .lines[] | select(.is_diff and .added and .coverage.head == 1) | {line: .number.head, code: .value}' /tmp/codecov.json
 ```
 
 If the Codecov API markers aren't enough, download the `code-coverage-report`


### PR DESCRIPTION
The `running-tend` skill's "Investigating codecov failures in CI" jq snippet filtered `coverage.head == 0` to find uncovered added lines — but codecov's `LineType` enum is `0=hit, 1=miss, 2=partial`, so `== 0` selected *covered* lines and missed the genuinely uncovered ones. On #2815 this sent the author chasing the wrong lines for a commit before `worktrunk-bot` self-corrected.

Filter on `1` (miss) instead, and add an inline enum legend so the values can't be misremembered. The mapping is the one already documented in `tests/CLAUDE.md`.

`2=partial` can't occur for worktrunk in practice — CI uploads line-coverage-only cobertura from `cargo llvm-cov --cobertura` (no branch coverage), so codecov reports `branches: 0, partials: 0` repo-wide. `== 1` is therefore both correct and complete here.

Also drops the `0:80` preview truncation on the displayed line text so the full line shows.

Reviewed by `/reviewing-code` and Codex; the partials question was checked empirically against the live codecov compare API.
