### PR TITLE
ci(affected): don't fail Windows job on empty test selection

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -400,6 +400,15 @@ jobs:
     - name: 🎯 Run affected tests
       env:
         NEXTEST_NO_INPUT_HANDLER: 1
+        # An empty affected selection is a valid outcome — a diff can touch
+        # nothing with recorded coverage. nextest's default exits 4 ("no
+        # tests to run"), which fails this advisory job spuriously. Windows
+        # hits this every run: the `#[cfg_attr(windows, ignore)]` tests never
+        # execute during `collect` (nextest skips ignored tests), so they get
+        # no coverage rows and cargo-affected keeps re-flagging them as `new`
+        # and selecting them — then `nextest run` skips them as ignored too,
+        # so zero run. `warn` exits 0 and leaves the breadcrumb in the log.
+        NEXTEST_NO_TESTS: warn
       run: cargo affected run --report-json target/affected/report.json -- --features shell-integration-tests
 
     # Report writes BEFORE nextest runs, so it survives test failures —


### PR DESCRIPTION
## Problem

The advisory `affected tests (windows, advisory)` job in `ci` failed on every recent PR — Linux and macOS passed on the same runs. Two distinct Windows-only failure modes.

**Mode 1 — `os error 206` (`The filename or extension is too long`).** `cargo-affected` passed its `cargo nextest` test-filter list as inline `-E` arguments; with a large affected set the command line overflowed Windows' ~32 KB `CreateProcess` cap. **Already fixed upstream** in cargo-affected ([#37](https://github.com/max-sixty/cargo-affected/pull/37) — selection now travels via a `--config-file`). This job installs cargo-affected unpinned from the default branch, so it self-healed once that landed — no change needed here.

**Mode 2 — `error: no tests to run` → exit 1.** This is what this PR fixes. The repo has tests attributed `#[cfg_attr(windows, ignore)]`. On Windows they compile into the test binary but are skipped at run time. `cargo affected collect` gathers coverage via `cargo nextest run`, which skips ignored tests — so those tests never earn coverage rows. cargo-affected's "new test" detection diffs `cargo nextest list` (lists ignored tests) against the coverage DB, so it re-flags them as `new` and selects them on **every Windows run**. `cargo nextest run` then skips them as ignored too — zero tests execute, and nextest's default `--no-tests` behavior (`auto` → `fail`) makes that exit 4. When a PR's diff overlaps no recorded coverage, the whole selection collapses to just these phantom tests and the job fails.

## Fix

Set `NEXTEST_NO_TESTS=warn` on the `🎯 Run affected tests` step. An empty affected selection is a legitimate outcome — a diff genuinely can touch nothing with recorded coverage — so it should pass, not fail. `warn` exits 0 while leaving a breadcrumb in the log, keeping the calibration signal honest. It governs only the zero-selection outcome: a real test failure still exits non-zero and still fails the job.

The env-var form (vs. a CLI passthrough) doesn't depend on cargo-affected forwarding trailing args, and `cargo nextest list` — which has no `--no-tests` arg — silently ignores it.

## Follow-up (not in this PR)

Two cargo-affected bugs worth filing upstream: (1) tests that `nextest run` always skips can never earn coverage and are flagged `new` forever; (2) `nextest list` runs without the build features that `nextest run` uses, so new-test detection enumerates a different test set than the run.
