### PR TITLE
docs: make the Network Access inventory activity-based

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,10 +97,11 @@ Why: silent "lookup" paths that walk to the wire (alias dispatch, hook context b
 
 Before adding an accessor that could reach the wire (`gh`, `glab`, `git fetch`, `git ls-remote`, HTTP), confirm the command that calls it is not intended to be fast. A foreground command the user runs and waits on absorbs the latency; a command in a synchronous hot path like a shell prompt cannot, and must not reach the wire. `wt list statusline` is not a fast command despite running on every prompt: Claude Code consumes its output asynchronously.
 
-Commands that currently reach the wire:
+What currently reaches the wire:
 
-- `wt list --full`, `wt list statusline` — CI status, LLM summaries
-- `wt step commit` — commit message via a configured LLM command
+- `wt list --full`, `wt list statusline` — CI status
+- generating a branch summary with a `commit.generation` command
+- generating a commit message with a `commit.generation` command
 - `wt switch pr:<n>`, `wt switch mr:<n>` — host API to resolve the PR/MR, then `git fetch` of its branch
 - `wt config show --full` — version check against GitHub
 - the first `Repository::default_branch()` per repo — `git ls-remote` (above)


### PR DESCRIPTION
A command-keyed list of wire-reaching commands missed entry points. The interactive `wt switch` picker generates LLM branch summaries (`preview_orchestrator.rs` `spawn_summary`), and `wt merge` runs an intermediate commit through the same `commit.generation` path as `wt step commit`.

This replaces the two command-attributed LLM rows ("`wt list` — LLM summaries", "`wt step commit`") with activity-based entries: "generating a branch summary" and "generating a commit message" with a `commit.generation` command. Activities cover every entry point without enumerating commands. The header becomes "What currently reaches the wire" since two entries are now activities rather than commands.
