### PR TITLE
test(hook-plan): isolate approval test from the real user config dir

### DIFF
--- a/src/commands/hook_plan.rs
+++ b/src/commands/hook_plan.rs
@@ -453,9 +453,17 @@ mod tests {
         );
 
         // With the project command approved, it survives the read-only gate.
+        // A tempdir-backed approvals path keeps the write off the real user
+        // config dir, which the nix build sandbox makes unwritable.
+        let temp_dir = tempfile::tempdir().unwrap();
+        let approvals_path = temp_dir.path().join("approvals.toml");
         let mut approvals = Approvals::default();
         approvals
-            .approve_command("proj".to_string(), "echo project-hook".to_string(), None)
+            .approve_command(
+                "proj".to_string(),
+                "echo project-hook".to_string(),
+                Some(&approvals_path),
+            )
             .unwrap();
         let mut builder = HookPlanBuilder::new();
         builder.add(


### PR DESCRIPTION
The `nix-flake` CI job was red on `main`: the unit test `commands::hook_plan::tests::approve_readonly_drops_unapproved_project_keeps_user` panicked with `Failed to create config directory: Permission denied`.

The test called `approve_command(.., None)`. The `None` for `approvals_path` makes `Approvals` resolve the path through `approvals_path()`, which — in the lib crate compiled in non-test mode — points at the real `~/.config/worktrunk/` directory. `approve_command` then `create_dir_all`s it. Outside a sandbox `$HOME` is writable, so the test silently passed while writing a stray `[projects.proj]` entry into the user's `approvals.toml`. The nix build sandbox has no writable config dir, so it panicked instead.

This was latent on `main` since #2806 (which added the test). It only started tripping the gate now because the `nix-flake` job runs when a PR touches `Cargo.{toml,lock}`, and #2849 was the first to do so — so `nix-flake` failed there for a reason unrelated to that PR's change.

The fix points `approve_command` at a `tempfile::tempdir()`-backed approvals path via the `Some(&path)` parameter it already accepts — no process-env mutation (`tests/CLAUDE.md` bans it), matching the in-file pattern in `src/config/approvals.rs`'s own tests. Same class of fix as #2615 and #2624.

The two sibling tests in `hook_plan.rs` only *read* via `Approvals::load()`, which returns the default when no file exists — never creating a directory or writing — so they pass in the sandbox unchanged and were left as-is.

Verified by reproducing the sandbox condition locally (test binary run with `HOME` / `XDG_CONFIG_HOME` pointed at a non-writable dir): the target test fails before the fix and passes after, and all three `hook_plan` tests still pass under a plain `cargo test`.
