### PR TITLE
feat(switch): add a feedback link to the --execute deprecation warning

### DIFF
--- a/src/commands/worktree/switch.rs
+++ b/src/commands/worktree/switch.rs
@@ -1991,12 +1991,14 @@ fn is_clean_program_token(value: &str) -> bool {
 /// here without the user's shell, so it is left to fail loudly at the cutover
 /// rather than guessed at. Informational only — it never blocks the switch.
 ///
-/// The migration hint reconstructs the command line that runs today — the
-/// `-x` value with its trailing args appended, the way `run_switch` joins
-/// them — and wraps it for whichever shell the active wrapper evaluates the
-/// payload with (`sh` / `fish` / `pwsh`). That keeps the suggestion
-/// behavior-preserving on fish/PowerShell, not just POSIX sh, and complete
-/// when trailing args are present.
+/// The hint reconstructs the command line that runs today — the `-x` value
+/// with its trailing args appended, the way `run_switch` joins them — and
+/// wraps it for whichever shell the active wrapper evaluates the payload
+/// with (`sh` / `fish` / `pwsh`), so the suggestion is behavior-preserving
+/// on fish/PowerShell, not just POSIX sh, and complete when trailing args
+/// are present. It also links the tracking issue (#2860) so anyone whose
+/// workflow the argv model would regress can report the case before the
+/// cutover.
 fn warn_if_execute_form_deprecated(cmd: &str, execute_args: &[String]) {
     if is_clean_program_token(cmd) {
         return;
@@ -2026,7 +2028,7 @@ fn warn_if_execute_form_deprecated(cmd: &str, execute_args: &[String]) {
     eprintln!(
         "{}",
         hint_message(cformat!(
-            "To run this command line unchanged, pass it to a shell: <underline>--execute {shell} -- {flag} {suggested}</>"
+            "Comment at <underline>https://github.com/max-sixty/worktrunk/issues/2860</> if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: <underline>--execute {shell} -- {flag} {suggested}</>"
         ))
     );
 }

--- a/tests/snapshots/integration__integration_tests__directives__switch_exec_scrubbed_warns.snap
+++ b/tests/snapshots/integration__integration_tests__directives__switch_exec_scrubbed_warns.snap
@@ -61,7 +61,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo should-not-run'[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo should-not-run'[24m[22m
 [32m✓[39m [32mCreated branch [1mscrub-test[22m from [1mmain[22m and worktree @ [1m_REPO_.scrub-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33m[1m--execute[22m disabled inside project alias / hook bodies for safety; skipping [1mecho should-not-run[22m[39m

--- a/tests/snapshots/integration__integration_tests__directives__switch_legacy_directive_file_with_execute.snap
+++ b/tests/snapshots/integration__integration_tests__directives__switch_legacy_directive_file_with_execute.snap
@@ -61,7 +61,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo hello'[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo hello'[24m[22m
 [32m✓[39m [32mCreated branch [1mexec-legacy[22m from [1mmain[22m and worktree @ [1m_REPO_.exec-legacy[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [36m◎[39m [36mExecuting (--execute):[39m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__execute_with_post_start.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__execute_with_post_start.snap
@@ -60,7 +60,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''Execute flag'\'' > execute.txt'[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''Execute flag'\'' > execute.txt'[24m[22m
 [32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__fish_multiline_command_execution.snap
+++ b/tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__fish_multiline_command_execution.snap
@@ -4,7 +4,7 @@ expression: "&output.combined"
 ---
 
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute fish -- -c 'echo \'line 1\'; echo \'line 2\'; echo \'line 3\''[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute fish -- -c 'echo \'line 1\'; echo \'line 2\'; echo \'line 3\''[24m[22m
 [32m✓[39m [32mCreated branch [1mfish-multiline[22m from [1mmain[22m and worktree @ [1m_REPO_.fish-multiline[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [36m◎[39m [36mExecuting (--execute):[39m

--- a/tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__switch_with_execute_through_wrapper.snap
+++ b/tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__switch_with_execute_through_wrapper.snap
@@ -4,7 +4,7 @@ expression: "&output.combined"
 ---
 
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo executed'[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo executed'[24m[22m
 [32m✓[39m [32mCreated branch [1mtest-exec[22m from [1mmain[22m and worktree @ [1m_REPO_.test-exec[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [36m◎[39m [36mExecuting (--execute):[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_creates_file.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_creates_file.snap
@@ -60,7 +60,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''test content'\'' > test.txt'[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''test content'\'' > test.txt'[24m[22m
 [32m✓[39m [32mCreated branch [1mfile-test[22m from [1mmain[22m and worktree @ [1m_REPO_.file-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_deprecation_fish_wrapper.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_deprecation_fish_wrapper.snap
@@ -63,7 +63,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute fish -- -c 'set -lx FOO bar; echo $FOO'[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute fish -- -c 'set -lx FOO bar; echo $FOO'[24m[22m
 [32m✓[39m [32mCreated branch [1mdep-fish[22m from [1mmain[22m and worktree @ [1m_REPO_.dep-fish[22m[39m
 [36m◎[39m [36mExecuting (--execute):[39m
 [107m [0m [2m[0m[2m[34mset[0m[2m [0m[2m[36m-lx[0m[2m FOO bar; [0m[2m[34mecho[0m[2m [0m[2m[36m$[0m[2mFOO

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_deprecation_shell_syntax.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_deprecation_shell_syntax.snap
@@ -62,7 +62,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo hi && ls'[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo hi && ls'[24m[22m
 [32m✓[39m [32mCreated branch [1mdep-shell[22m from [1mmain[22m and worktree @ [1m_REPO_.dep-shell[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [36m◎[39m [36mExecuting (--execute):[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_deprecation_trailing_args.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_deprecation_trailing_args.snap
@@ -64,7 +64,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'npm run test'[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'npm run test'[24m[22m
 [32m✓[39m [32mCreated branch [1mdep-args[22m from [1mmain[22m and worktree @ [1m_REPO_.dep-args[22m[39m
 [36m◎[39m [36mExecuting (--execute):[39m
 [107m [0m [2m[0m[2m[34mnpm[0m[2m run test

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_existing.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_existing.snap
@@ -59,7 +59,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''existing worktree'\'' > existing.txt'[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''existing worktree'\'' > existing.txt'[24m[22m
 [33m▲[39m [33mWorktree for [1mexisting-exec[22m @ [1m_REPO_.existing-exec[22m, but cannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
 [36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.existing-exec[22m:[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_failure.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_failure.snap
@@ -60,7 +60,7 @@ exit_code: 1
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'exit 1'[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'exit 1'[24m[22m
 [32m✓[39m [32mCreated branch [1mfail-test[22m from [1mmain[22m and worktree @ [1m_REPO_.fail-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_multiline.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_multiline.snap
@@ -63,7 +63,7 @@ line3
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''line1'\''
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''line1'\''
 echo '\''line2'\''
 echo '\''line3'\'''[24m[22m
 [32m✓[39m [32mCreated branch [1mmultiline-test[22m from [1mmain[22m and worktree @ [1m_REPO_.multiline-test[22m[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_success.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_success.snap
@@ -61,7 +61,7 @@ test output
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''test output'\'''[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''test output'\'''[24m[22m
 [32m✓[39m [32mCreated branch [1mexec-test[22m from [1mmain[22m and worktree @ [1m_REPO_.exec-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_template_base.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_template_base.snap
@@ -63,7 +63,7 @@ base=main
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''base={{ base }}'\'''[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''base={{ base }}'\'''[24m[22m
 [32m✓[39m [32mCreated branch [1mfrom-main[22m from [1mmain[22m and worktree @ [1m_REPO_.from-main[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_template_base_without_create.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_template_base_without_create.snap
@@ -60,7 +60,7 @@ base=main
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''base={{ base }}'\'''[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''base={{ base }}'\'''[24m[22m
 [33m▲[39m [33mWorktree for [1mexisting[22m @ [1m_REPO_.existing[22m, but cannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
 [36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.existing[22m:[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_template_branch.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_template_branch.snap
@@ -61,7 +61,7 @@ branch=template-test
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''branch={{ branch }}'\'''[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''branch={{ branch }}'\'''[24m[22m
 [32m✓[39m [32mCreated branch [1mtemplate-test[22m from [1mmain[22m and worktree @ [1m_REPO_.template-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_template_shell_escape.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_template_shell_escape.snap
@@ -61,7 +61,7 @@ feat;id
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo {{ branch }}'[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo {{ branch }}'[24m[22m
 [32m✓[39m [32mCreated branch [1mfeat;id[22m from [1mmain[22m and worktree @ [1m'_REPO_.feat;id'[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_template_with_filter.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_template_with_filter.snap
@@ -61,7 +61,7 @@ sanitized=feature-with-slash
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''sanitized={{ branch | sanitize }}'\'''[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''sanitized={{ branch | sanitize }}'\'''[24m[22m
 [32m✓[39m [32mCreated branch [1mfeature/with-slash[22m from [1mmain[22m and worktree @ [1m_REPO_.feature-with-slash[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_template_worktree_path.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_template_worktree_path.snap
@@ -61,7 +61,7 @@ path=_REPO_.path-test
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''path={{ worktree_path }}'\'''[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''path={{ worktree_path }}'\'''[24m[22m
 [32m✓[39m [32mCreated branch [1mpath-test[22m from [1mmain[22m and worktree @ [1m_REPO_.path-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_verbose_multiline_template.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_verbose_multiline_template.snap
@@ -67,7 +67,7 @@ repo=repo
 [107m [0m [2m→[22m
 [107m [0m [2m[0m[2m[34m_REPO_/../repo.multiline-test[0m[2m
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c '{% if branch %}
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c '{% if branch %}
 echo '\''branch={{ branch }}'\''
 echo '\''repo={{ repo }}'\''
 {% endif %}'[24m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_verbose_template.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_verbose_template.snap
@@ -66,7 +66,7 @@ branch=verbose-test
 [107m [0m [2m→[22m
 [107m [0m [2m[0m[2m[34m_REPO_/../repo.verbose-test[0m[2m
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''branch={{ branch }}'\'''[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''branch={{ branch }}'\'''[24m[22m
 [32m✓[39m [32mCreated branch [1mverbose-test[22m from [1mmain[22m and worktree @ [1m_REPO_.verbose-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_internal_execute_exit_code.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_internal_execute_exit_code.snap
@@ -62,7 +62,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'exit 42'[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'exit 42'[24m[22m
 [32m✓[39m [32mCreated branch [1mexit-code-test[22m from [1mmain[22m and worktree @ [1m_REPO_.exit-code-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [36m◎[39m [36mExecuting (--execute):[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_internal_execute_output_then_exit.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_internal_execute_output_then_exit.snap
@@ -62,7 +62,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''doing work'\''
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''doing work'\''
 exit 7'[24m[22m
 [32m✓[39m [32mCreated branch [1moutput-exit-test[22m from [1mmain[22m and worktree @ [1m_REPO_.output-exit-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_internal_with_execute.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_internal_with_execute.snap
@@ -62,7 +62,7 @@ exit_code: 0
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''line1'\''
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''line1'\''
 echo '\''line2'\'''[24m[22m
 [32m✓[39m [32mCreated branch [1mexec-internal[22m from [1mmain[22m and worktree @ [1m_REPO_.exec-internal[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_execute_still_runs.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_execute_still_runs.snap
@@ -62,7 +62,7 @@ execute command runs
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''execute command runs'\'''[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''execute command runs'\'''[24m[22m
 [32m✓[39m [32mCreated branch [1mno-hooks-test[22m from [1mmain[22m and worktree @ [1m_REPO_.no-hooks-test[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_existing.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_no_hooks_existing.snap
@@ -61,7 +61,7 @@ execute still runs
 
 ----- stderr -----
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
-[2m↳[22m [2mTo run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''execute still runs'\'''[24m[22m
+[2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''execute still runs'\'''[24m[22m
 [33m▲[39m [33mWorktree for [1mexisting-no-hooks[22m @ [1m_REPO_.existing-no-hooks[22m, but cannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
 [36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.existing-no-hooks[22m:[39m


### PR DESCRIPTION
Follow-up to #2852. The `--execute` deprecation warning tells users how to migrate a shell command line to the upcoming argv form, but gave no channel for users whose workflow the argv cutover would genuinely regress to push back before it lands.

This adds the B2 tracking issue (#2860) to the migration hint. To keep the deprecation at one warning + one hint, the issue link is merged into the single existing hint line rather than added as a second `↳`:

```
▲ --execute will change in a future release: it will run a single program, with arguments after --, not a shell command line
↳ Comment at https://github.com/max-sixty/worktrunk/issues/2860 if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: --execute sh -- -c 'echo hi && ls'
```

The two suggestions are semicolon-joined per the writing-user-outputs "multiple suggestions in one hint" pattern; the migration command stays last so it remains the easy copy target, and the URL stays clickable mid-line. The 26 `--execute` snapshots gained the URL mechanically.

Ref #2860.

> _This was written by Claude Code on behalf of Maximilian Roos_
