### PR TITLE
fix(picker): identify worktree rows by path, not branch name

### DIFF
--- a/src/commands/picker/items.rs
+++ b/src/commands/picker/items.rs
@@ -28,6 +28,11 @@ pub(super) type PreviewCacheKey = (String, PreviewMode);
 /// Shared across all WorktreeSkimItems for background pre-computation.
 pub(super) type PreviewCache = Arc<DashMap<PreviewCacheKey, String>>;
 
+/// Prefix on a worktree-backed item's `output()` token. Detached worktrees
+/// all share the `(detached)` branch label, so `output()` returns the
+/// worktree path (which is unique) behind this prefix instead.
+pub(super) const WORKTREE_OUTPUT_PREFIX: &str = "worktree-path:";
+
 /// Header item for column names (non-selectable)
 pub(super) struct HeaderSkimItem {
     pub display_text: String,
@@ -101,8 +106,7 @@ pub(super) struct WorktreeSkimItem {
     /// Current ANSI-colored display line. Starts as the skeleton render;
     /// replaced in place as data arrives.
     pub rendered: Arc<Mutex<String>>,
-    /// Branch name — also what `output()` returns when this item is
-    /// selected.
+    /// Branch name used by switch selection and preview cache keys.
     pub branch_name: String,
     /// Skeleton-snapshot of the underlying ListItem. Preview computation
     /// reads only skeleton-time fields (`branch_name`, `head`,
@@ -130,7 +134,13 @@ impl SkimItem for WorktreeSkimItem {
     }
 
     fn output(&self) -> Cow<'_, str> {
-        Cow::Borrowed(&self.branch_name)
+        match self.item.worktree_path() {
+            Some(path) => Cow::Owned(format!(
+                "{WORKTREE_OUTPUT_PREFIX}{}",
+                path.to_string_lossy()
+            )),
+            None => Cow::Borrowed(&self.branch_name),
+        }
     }
 
     fn preview(&self, context: PreviewContext<'_>) -> ItemPreview {

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -1022,16 +1022,14 @@ pub mod tests {
         assert!(PickerRemovalTarget::from_signal("   ").is_none());
         assert!(PickerRemovalTarget::from_signal("worktree-path:").is_none());
 
-        match PickerRemovalTarget::from_signal("feature/foo") {
-            Some(PickerRemovalTarget::Branch(branch)) => assert_eq!(branch, "feature/foo"),
-            _ => panic!("expected a branch target"),
-        }
-        match PickerRemovalTarget::from_signal("worktree-path:/tmp/wt") {
-            Some(PickerRemovalTarget::WorktreePath(path)) => {
-                assert_eq!(path, std::path::PathBuf::from("/tmp/wt"));
-            }
-            _ => panic!("expected a worktree-path target"),
-        }
+        assert!(matches!(
+            PickerRemovalTarget::from_signal("feature/foo"),
+            Some(PickerRemovalTarget::Branch(branch)) if branch == "feature/foo"
+        ));
+        assert!(matches!(
+            PickerRemovalTarget::from_signal("worktree-path:/tmp/wt"),
+            Some(PickerRemovalTarget::WorktreePath(path)) if path == std::path::Path::new("/tmp/wt")
+        ));
     }
 
     /// A `SkimItem` that is not a `WorktreeSkimItem`, used to drive
@@ -1059,6 +1057,7 @@ pub mod tests {
         let worktree_row = FakeSkimItem {
             output: "worktree-path:/tmp/detached".to_string(),
         };
+        assert_eq!(worktree_row.text(), "worktree-path:/tmp/detached");
         assert_eq!(picker_item_identifier(&worktree_row), "/tmp/detached");
 
         let branch_row = FakeSkimItem {

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -120,7 +120,7 @@ use crate::cli::SwitchFormat;
 use crate::output::handle_remove_output;
 use worktrunk::git::{BranchDeletionMode, delete_branch_if_safe};
 
-use items::{PreviewCache, WorktreeSkimItem};
+use items::{PreviewCache, WORKTREE_OUTPUT_PREFIX, WorktreeSkimItem};
 use preview::{PreviewLayout, PreviewMode, PreviewState};
 use preview_orchestrator::PreviewOrchestrator;
 
@@ -140,6 +140,55 @@ enum PickerAction {
     Switch,
     /// Create a new worktree from the search query (alt-c).
     Create,
+}
+
+/// The alt-r removal target parsed back out of a row's `output()` token.
+///
+/// A worktree-backed row's token is `worktree-path:<path>` (paths are
+/// unique — detached worktrees would otherwise collide on the shared
+/// `(detached)` label); a branch-only row's token is the bare branch name.
+enum PickerRemovalTarget {
+    WorktreePath(PathBuf),
+    Branch(String),
+}
+
+impl PickerRemovalTarget {
+    fn from_signal(signal: &str) -> Option<Self> {
+        let signal = signal.trim();
+        if signal.is_empty() {
+            return None;
+        }
+        if let Some(path) = signal.strip_prefix(WORKTREE_OUTPUT_PREFIX) {
+            if path.is_empty() {
+                return None;
+            }
+            return Some(Self::WorktreePath(PathBuf::from(path)));
+        }
+        Some(Self::Branch(signal.to_string()))
+    }
+}
+
+/// Resolve the switch identifier for a selected picker row: the worktree
+/// path for a detached worktree (so `wt switch` addresses it the same way
+/// `wt switch /path` does), the branch name otherwise.
+fn picker_item_identifier(item: &dyn SkimItem) -> String {
+    if let Some(item) = item.as_any().downcast_ref::<WorktreeSkimItem>() {
+        if let Some(data) = item.item.worktree_data()
+            && data.detached
+        {
+            return data.path.to_string_lossy().into_owned();
+        }
+        return item.branch_name.clone();
+    }
+
+    // `as_any().downcast_ref` fails across skim's reader-thread / main-thread
+    // compilation units (TypeId mismatch, skim 0.20). Fall back to the
+    // `output()` token, decoding a `worktree-path:` prefix to the bare path.
+    let output = item.output().to_string();
+    match PickerRemovalTarget::from_signal(&output) {
+        Some(PickerRemovalTarget::WorktreePath(path)) => path.to_string_lossy().into_owned(),
+        _ => output,
+    }
 }
 
 /// Custom command collector for skim's `reload` action.
@@ -170,7 +219,14 @@ struct PickerCollector {
 impl PickerCollector {
     /// Build removal state from a fresh `Repository` so picker reloads after a
     /// background removal do not reuse the startup worktree inventory cache.
-    fn prepare_removal(&self, selected_output: &str) -> anyhow::Result<(Repository, RemoveResult)> {
+    ///
+    /// `target` carries the exact worktree path or branch name decoded from
+    /// the row's `output()` token — no `git worktree list` lookup, so a
+    /// detached row can't be confused with another detached row.
+    fn prepare_removal(
+        &self,
+        target: &PickerRemovalTarget,
+    ) -> anyhow::Result<(Repository, RemoveResult)> {
         let repo = Repository::at(self.repo.discovery_path())?;
 
         // Validate removal before touching the list. prepare_worktree_removal
@@ -178,26 +234,14 @@ impl PickerCollector {
         // Only remove the item and spawn background deletion if this succeeds.
         let caller_path = repo.current_worktree().root().ok();
 
-        // Resolve removal target by path when possible (handles both
-        // branched and detached worktrees). Branch-only items won't match any
-        // worktree path, so they fall through to Branch.
-        let worktree_path = repo.list_worktrees().ok().and_then(|wts| {
-            // Match by branch first, then fall back to detached (branch: None).
-            let by_branch = wts
-                .iter()
-                .find(|wt| wt.branch.as_deref() == Some(selected_output));
-            let matched = by_branch.or_else(|| wts.iter().find(|wt| wt.branch.is_none()));
-            matched.map(|wt| wt.path.clone())
-        });
-
         let result = {
             let config = repo.user_config();
-            let target = match &worktree_path {
-                Some(path) => RemoveTarget::Path(path),
-                None => RemoveTarget::Branch(selected_output),
+            let remove_target = match target {
+                PickerRemovalTarget::WorktreePath(path) => RemoveTarget::Path(path),
+                PickerRemovalTarget::Branch(branch) => RemoveTarget::Branch(branch),
             };
             repo.prepare_worktree_removal(
-                target,
+                remove_target,
                 BranchDeletionMode::SafeDelete,
                 false,
                 config,
@@ -286,15 +330,19 @@ impl CommandCollector for PickerCollector {
         _cmd: &str,
         components_to_stop: Arc<AtomicUsize>,
     ) -> (SkimItemReceiver, Sender<i32>) {
-        // Read the removal signal (item output text written by execute-silent)
+        // Read the removal signal (item output token written by execute-silent)
         if let Ok(signal) = std::fs::read_to_string(&self.signal_path) {
             let selected_output = signal.trim().to_string();
-            if !selected_output.is_empty() {
-                let preparation = self.prepare_removal(&selected_output);
+            if let Some(removal_target) = PickerRemovalTarget::from_signal(&selected_output) {
+                let preparation = self.prepare_removal(&removal_target);
 
                 match preparation {
                     Ok((planning_repo, result)) => {
-                        // Removal validated — remove item from the picker list.
+                        // Removal validated — remove the selected item from the
+                        // picker list. The `output()` token is unique per row
+                        // (a `worktree-path:` path for worktrees), so this
+                        // drops exactly the selected row even when several
+                        // detached rows share the `(detached)` branch label.
                         //
                         // Note: skim's `as_any().downcast_ref::<WorktreeSkimItem>()` fails
                         // at runtime (TypeId mismatch between reader thread and main thread
@@ -778,21 +826,12 @@ pub fn handle_picker(
 
         let should_create = matches!(action, PickerAction::Create);
 
-        // Get branch name: from query if creating new, from selected item if switching.
-        // For detached worktrees, use the path (same as `wt switch /path` from CLI).
+        // Get branch name: from query if creating new, from selected item if
+        // switching. `picker_item_identifier` yields the branch name for a
+        // branched worktree and the path for a detached one (same as
+        // `wt switch /path` from CLI) — never the raw `worktree-path:` token.
         let selected = out.selected_items.first();
-        let selected_name = selected.map(|item| {
-            if !should_create
-                && let Some(data) = item
-                    .as_any()
-                    .downcast_ref::<WorktreeSkimItem>()
-                    .and_then(|s| s.item.worktree_data())
-                    .filter(|d| d.detached)
-            {
-                return data.path.to_string_lossy().into_owned();
-            }
-            item.output().to_string()
-        });
+        let selected_name = selected.map(|item| picker_item_identifier(item.as_ref()));
         let query = out.query.trim().to_string();
         let identifier = resolve_identifier(&action, query, selected_name)?;
 
@@ -869,11 +908,21 @@ fn resolve_identifier(
 
 #[cfg(test)]
 pub mod tests {
+    use super::items::{PreviewCache, WorktreeSkimItem};
     use super::preview::{PreviewLayout, PreviewMode, PreviewStateData};
-    use super::{PickerAction, PickerCollector, drain_stashed_warnings, resolve_identifier};
+    use super::{
+        PickerAction, PickerCollector, PickerRemovalTarget, drain_stashed_warnings,
+        picker_item_identifier, resolve_identifier,
+    };
+    use crate::commands::list::model::{ItemKind, ListItem, WorktreeData};
     use crate::commands::worktree::RemoveResult;
+    use skim::prelude::SkimItem;
+    use skim::reader::CommandCollector;
     use std::fs;
+    use std::path::Path;
+    use std::sync::atomic::AtomicUsize;
     use std::sync::{Arc, Mutex};
+    use std::time::{Duration, Instant};
     use worktrunk::config::Approvals;
     use worktrunk::git::BranchDeletionMode;
 
@@ -1094,88 +1143,15 @@ pub mod tests {
         assert!(!wt_path.exists(), "detached worktree should be removed");
     }
 
-    #[test]
-    fn test_prepare_removal_refreshes_stale_detached_worktree_cache() {
-        let test = worktrunk::testing::TestRepo::with_initial_commit();
-        let repo = worktrunk::git::Repository::at(test.path()).unwrap();
-        let wt_dir = tempfile::tempdir().unwrap();
-        let first_path = wt_dir.path().join("detached-one");
-        let second_path = wt_dir.path().join("detached-two");
-
-        for (branch, path) in [
-            ("to-detach-one", first_path.as_path()),
-            ("to-detach-two", second_path.as_path()),
-        ] {
-            repo.run_command(&["worktree", "add", "-b", branch, path.to_str().unwrap()])
-                .unwrap();
-            worktrunk::shell_exec::Cmd::new("git")
-                .args(["checkout", "--detach", "HEAD"])
-                .current_dir(path)
-                .run()
-                .unwrap();
-        }
-
-        let stale_repo = worktrunk::git::Repository::at(test.path()).unwrap();
-        let detached_count = stale_repo
-            .list_worktrees()
-            .unwrap()
-            .iter()
-            .filter(|wt| wt.branch.is_none())
-            .count();
-        assert_eq!(detached_count, 2);
-
-        let first_result = RemoveResult::RemovedWorktree {
-            main_path: test.path().to_path_buf(),
-            worktree_path: first_path.clone(),
-            changed_directory: false,
-            branch_name: None,
-            deletion_mode: BranchDeletionMode::SafeDelete,
-            target_branch: Some("main".to_string()),
-            integration_reason: None,
-            force_worktree: false,
-            expected_path: None,
-            removed_commit: None,
-        };
-        PickerCollector::do_removal(&stale_repo, &first_result, &Approvals::default()).unwrap();
-        assert!(
-            !first_path.exists(),
-            "first detached worktree should be removed"
-        );
-        assert!(
-            second_path.exists(),
-            "second detached worktree should remain"
-        );
-
-        let state_dir = tempfile::tempdir().unwrap();
-        let collector = PickerCollector {
-            items: Arc::new(Mutex::new(Vec::new())),
-            signal_path: state_dir.path().join("remove"),
-            repo: stale_repo,
-            approvals: Arc::new(Approvals::default()),
-        };
-
-        let (_planning_repo, result) = collector.prepare_removal("(detached)").unwrap();
-        let canonical_second = dunce::canonicalize(&second_path).unwrap();
-        assert!(
-            matches!(
-                &result,
-                RemoveResult::RemovedWorktree { worktree_path, branch_name: None, .. }
-                    if dunce::canonicalize(worktree_path).unwrap() == canonical_second
-            ),
-            "detached picker removal should resolve to the surviving detached worktree"
-        );
-    }
-
-    /// A branch with no worktree resolves to `RemoveTarget::Branch` — it
-    /// matches no worktree path, so `prepare_removal` falls through to the
-    /// branch-only disposition rather than a worktree removal.
+    /// A branch-only row's signal carries the bare branch name, which
+    /// `PickerRemovalTarget::from_signal` decodes to `Branch`; `prepare_removal`
+    /// then resolves it to the branch-only disposition.
     #[test]
     fn test_prepare_removal_resolves_branch_only_item() {
         let test = worktrunk::testing::TestRepo::with_initial_commit();
         let repo = worktrunk::git::Repository::at(test.path()).unwrap();
 
-        // A branch at the same commit as main, with no worktree. There are no
-        // detached worktrees, so the detached fallback can't capture it.
+        // A branch at the same commit as main, with no worktree.
         repo.run_command(&["branch", "branch-only-feature"])
             .unwrap();
 
@@ -1187,7 +1163,8 @@ pub mod tests {
             approvals: Arc::new(Approvals::default()),
         };
 
-        let (_planning_repo, result) = collector.prepare_removal("branch-only-feature").unwrap();
+        let target = PickerRemovalTarget::from_signal("branch-only-feature").unwrap();
+        let (_planning_repo, result) = collector.prepare_removal(&target).unwrap();
         assert!(
             matches!(&result, RemoveResult::BranchOnly { branch_name, .. } if branch_name == "branch-only-feature"),
             "a branch with no worktree should resolve to BranchOnly"
@@ -1212,8 +1189,9 @@ pub mod tests {
 
         // `RemoveResult` isn't `Debug`; drop the Ok payload so `unwrap_err`
         // (which needs `T: Debug`) can report a failure cleanly.
+        let target = PickerRemovalTarget::from_signal("no-such-branch").unwrap();
         let err = collector
-            .prepare_removal("no-such-branch")
+            .prepare_removal(&target)
             .map(|_| ())
             .expect_err("unknown removal target should fail validation");
         assert!(
@@ -1271,4 +1249,118 @@ pub mod tests {
         assert!(!wt_path.exists(), "worktree should be removed");
         assert!(!marker.exists(), "unapproved pre-remove hook must not run");
     }
+
+    /// Build a `WorktreeSkimItem` standing in for a detached-worktree row.
+    fn detached_picker_item(path: &Path) -> Arc<dyn SkimItem> {
+        let mut item = ListItem::new_branch("abc123".to_string(), "(detached)".to_string());
+        item.branch = None;
+        item.kind = ItemKind::Worktree(Box::new(WorktreeData {
+            path: path.to_path_buf(),
+            detached: true,
+            ..Default::default()
+        }));
+        let item = Arc::new(item);
+        let preview_cache: PreviewCache = Arc::new(dashmap::DashMap::new());
+
+        Arc::new(WorktreeSkimItem {
+            search_text: format!("(detached) {}", path.display()),
+            rendered: Arc::new(Mutex::new(String::new())),
+            branch_name: "(detached)".to_string(),
+            item,
+            preview_cache,
+        }) as Arc<dyn SkimItem>
+    }
+
+    /// Two detached worktrees both render the branch label `(detached)`, but
+    /// each row's `output()` token carries its unique path. alt-r on the
+    /// second row must remove exactly that worktree — not the first detached
+    /// one a branch-name match would resolve to — and drop only its row.
+    #[test]
+    fn test_invoke_removes_selected_detached_worktree_by_path_token() {
+        let test = worktrunk::testing::TestRepo::with_initial_commit();
+        let repo = worktrunk::git::Repository::at(test.path()).unwrap();
+        let wt_dir = tempfile::tempdir().unwrap();
+        let first_path = wt_dir.path().join("detached-one");
+        let second_path = wt_dir.path().join("detached-two");
+
+        for (branch, path) in [
+            ("to-detach-one", first_path.as_path()),
+            ("to-detach-two", second_path.as_path()),
+        ] {
+            repo.run_command(&["worktree", "add", "-b", branch, path.to_str().unwrap()])
+                .unwrap();
+            worktrunk::shell_exec::Cmd::new("git")
+                .args(["checkout", "--detach", "HEAD"])
+                .current_dir(path)
+                .run()
+                .unwrap();
+        }
+
+        let reported_paths: Vec<_> = repo
+            .list_worktrees()
+            .unwrap()
+            .iter()
+            .filter(|wt| wt.branch.is_none())
+            .map(|wt| wt.path.clone())
+            .collect();
+        let first_reported = reported_paths
+            .iter()
+            .find(|path| path.file_name().is_some_and(|name| name == "detached-one"))
+            .unwrap();
+        let second_reported = reported_paths
+            .iter()
+            .find(|path| path.file_name().is_some_and(|name| name == "detached-two"))
+            .unwrap();
+
+        let first_item = detached_picker_item(first_reported);
+        let second_item = detached_picker_item(second_reported);
+        let first_output = first_item.output().to_string();
+        let second_output = second_item.output().to_string();
+        assert_ne!(first_output, second_output);
+        assert_eq!(
+            picker_item_identifier(second_item.as_ref()),
+            second_reported.to_string_lossy()
+        );
+
+        let signal_dir = tempfile::tempdir().unwrap();
+        let signal_path = signal_dir.path().join("remove-signal");
+        fs::write(&signal_path, &second_output).unwrap();
+
+        let items = Arc::new(Mutex::new(vec![
+            Arc::clone(&first_item),
+            Arc::clone(&second_item),
+        ]));
+        let mut collector = PickerCollector {
+            items: Arc::clone(&items),
+            signal_path,
+            repo: repo.clone(),
+            approvals: Arc::new(Approvals::default()),
+        };
+
+        let (_rx, _interrupt) = collector.invoke("remove", Arc::new(AtomicUsize::new(0)));
+
+        let remaining: Vec<_> = items
+            .lock()
+            .unwrap()
+            .iter()
+            .map(|item| item.output().to_string())
+            .collect();
+        assert_eq!(remaining, vec![first_output]);
+
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while second_path.exists() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        assert!(first_path.exists(), "first detached worktree should remain");
+        assert!(
+            !second_path.exists(),
+            "selected detached worktree should be removed"
+        );
+    }
+
+    // Note: skim's `as_any().downcast_ref::<WorktreeSkimItem>()` fails at
+    // runtime due to TypeId mismatch between skim's reader thread and the main
+    // compilation unit (skim 0.20 bug). The invoke() code path uses output()
+    // matching instead. Full TUI tests require interactive skim — verified
+    // via tmux-cli during development.
 }

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -1013,6 +1013,60 @@ pub mod tests {
         assert!(result.unwrap_err().to_string().contains("no branch name"));
     }
 
+    /// `from_signal` rejects tokens that carry no usable target: a blank or
+    /// whitespace-only signal, and a bare `worktree-path:` prefix with no path
+    /// after it. A non-empty branch token and a prefixed path both parse.
+    #[test]
+    fn test_picker_removal_target_from_signal() {
+        assert!(PickerRemovalTarget::from_signal("").is_none());
+        assert!(PickerRemovalTarget::from_signal("   ").is_none());
+        assert!(PickerRemovalTarget::from_signal("worktree-path:").is_none());
+
+        match PickerRemovalTarget::from_signal("feature/foo") {
+            Some(PickerRemovalTarget::Branch(branch)) => assert_eq!(branch, "feature/foo"),
+            _ => panic!("expected a branch target"),
+        }
+        match PickerRemovalTarget::from_signal("worktree-path:/tmp/wt") {
+            Some(PickerRemovalTarget::WorktreePath(path)) => {
+                assert_eq!(path, std::path::PathBuf::from("/tmp/wt"));
+            }
+            _ => panic!("expected a worktree-path target"),
+        }
+    }
+
+    /// A `SkimItem` that is not a `WorktreeSkimItem`, used to drive
+    /// `picker_item_identifier`'s `output()`-token fallback — the path skim's
+    /// cross-thread `downcast_ref` failure (skim 0.20) takes in production.
+    struct FakeSkimItem {
+        output: String,
+    }
+
+    impl SkimItem for FakeSkimItem {
+        fn text(&self) -> std::borrow::Cow<'_, str> {
+            std::borrow::Cow::Borrowed(&self.output)
+        }
+
+        fn output(&self) -> std::borrow::Cow<'_, str> {
+            std::borrow::Cow::Borrowed(&self.output)
+        }
+    }
+
+    /// When `downcast_ref::<WorktreeSkimItem>` fails, `picker_item_identifier`
+    /// falls back to the `output()` token: a `worktree-path:` token decodes to
+    /// the bare path, anything else is returned verbatim.
+    #[test]
+    fn test_picker_item_identifier_output_fallback() {
+        let worktree_row = FakeSkimItem {
+            output: "worktree-path:/tmp/detached".to_string(),
+        };
+        assert_eq!(picker_item_identifier(&worktree_row), "/tmp/detached");
+
+        let branch_row = FakeSkimItem {
+            output: "feature/foo".to_string(),
+        };
+        assert_eq!(picker_item_identifier(&branch_row), "feature/foo");
+    }
+
     #[test]
     fn test_do_removal_removes_worktree_and_branch() {
         let test = worktrunk::testing::TestRepo::with_initial_commit();

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -120,7 +120,7 @@ use crate::cli::SwitchFormat;
 use crate::output::handle_remove_output;
 use worktrunk::git::{BranchDeletionMode, delete_branch_if_safe};
 
-use items::{PreviewCache, WORKTREE_OUTPUT_PREFIX, WorktreeSkimItem};
+use items::{PreviewCache, WORKTREE_OUTPUT_PREFIX};
 use preview::{PreviewLayout, PreviewMode, PreviewState};
 use preview_orchestrator::PreviewOrchestrator;
 
@@ -168,22 +168,19 @@ impl PickerRemovalTarget {
     }
 }
 
-/// Resolve the switch identifier for a selected picker row: the worktree
-/// path for a detached worktree (so `wt switch` addresses it the same way
-/// `wt switch /path` does), the branch name otherwise.
+/// Resolve the switch identifier for a selected picker row, decoded from its
+/// `output()` token: the worktree path for any worktree-backed row, the branch
+/// name for a branch-only row.
+///
+/// `wt switch` accepts a worktree path for any existing worktree (`plan_switch`
+/// phase 2b), so a worktree-backed row always switches by its unique path —
+/// detached *and* branched alike. A branch-only row has no worktree, so its
+/// branch name is the only handle.
+///
+/// Decoding `output()` rather than `downcast_ref::<WorktreeSkimItem>()` also
+/// sidesteps skim 0.20's cross-thread `TypeId` mismatch, which makes the
+/// downcast fail when the item originates on the reader thread.
 fn picker_item_identifier(item: &dyn SkimItem) -> String {
-    if let Some(item) = item.as_any().downcast_ref::<WorktreeSkimItem>() {
-        if let Some(data) = item.item.worktree_data()
-            && data.detached
-        {
-            return data.path.to_string_lossy().into_owned();
-        }
-        return item.branch_name.clone();
-    }
-
-    // `as_any().downcast_ref` fails across skim's reader-thread / main-thread
-    // compilation units (TypeId mismatch, skim 0.20). Fall back to the
-    // `output()` token, decoding a `worktree-path:` prefix to the bare path.
     let output = item.output().to_string();
     match PickerRemovalTarget::from_signal(&output) {
         Some(PickerRemovalTarget::WorktreePath(path)) => path.to_string_lossy().into_owned(),
@@ -826,10 +823,10 @@ pub fn handle_picker(
 
         let should_create = matches!(action, PickerAction::Create);
 
-        // Get branch name: from query if creating new, from selected item if
-        // switching. `picker_item_identifier` yields the branch name for a
-        // branched worktree and the path for a detached one (same as
-        // `wt switch /path` from CLI) — never the raw `worktree-path:` token.
+        // Get the switch identifier: the query if creating new, otherwise the
+        // selected item. `picker_item_identifier` yields a worktree path for
+        // any worktree-backed row and the branch name for a branch-only row
+        // (same as `wt switch` from CLI) — never the raw `worktree-path:` token.
         let selected = out.selected_items.first();
         let selected_name = selected.map(|item| picker_item_identifier(item.as_ref()));
         let query = out.query.trim().to_string();
@@ -908,7 +905,7 @@ fn resolve_identifier(
 
 #[cfg(test)]
 pub mod tests {
-    use super::items::{PreviewCache, WorktreeSkimItem};
+    use super::items::WorktreeSkimItem;
     use super::preview::{PreviewLayout, PreviewMode, PreviewStateData};
     use super::{
         PickerAction, PickerCollector, PickerRemovalTarget, drain_stashed_warnings,
@@ -1032,38 +1029,25 @@ pub mod tests {
         ));
     }
 
-    /// A `SkimItem` that is not a `WorktreeSkimItem`, used to drive
-    /// `picker_item_identifier`'s `output()`-token fallback — the path skim's
-    /// cross-thread `downcast_ref` failure (skim 0.20) takes in production.
-    struct FakeSkimItem {
-        output: String,
-    }
-
-    impl SkimItem for FakeSkimItem {
-        fn text(&self) -> std::borrow::Cow<'_, str> {
-            std::borrow::Cow::Borrowed(&self.output)
-        }
-
-        fn output(&self) -> std::borrow::Cow<'_, str> {
-            std::borrow::Cow::Borrowed(&self.output)
-        }
-    }
-
-    /// When `downcast_ref::<WorktreeSkimItem>` fails, `picker_item_identifier`
-    /// falls back to the `output()` token: a `worktree-path:` token decodes to
-    /// the bare path, anything else is returned verbatim.
+    /// `picker_item_identifier` yields the worktree path for every
+    /// worktree-backed row — branched as well as detached — and the branch name
+    /// for a branch-only row, matching what each row's `output()` token carries.
     #[test]
-    fn test_picker_item_identifier_output_fallback() {
-        let worktree_row = FakeSkimItem {
-            output: "worktree-path:/tmp/detached".to_string(),
-        };
-        assert_eq!(worktree_row.text(), "worktree-path:/tmp/detached");
-        assert_eq!(picker_item_identifier(&worktree_row), "/tmp/detached");
+    fn test_picker_item_identifier() {
+        let branched = branched_picker_item("feature/foo", Path::new("/tmp/wt-branched"));
+        assert_eq!(
+            picker_item_identifier(branched.as_ref()),
+            "/tmp/wt-branched"
+        );
 
-        let branch_row = FakeSkimItem {
-            output: "feature/foo".to_string(),
-        };
-        assert_eq!(picker_item_identifier(&branch_row), "feature/foo");
+        let detached = detached_picker_item(Path::new("/tmp/wt-detached"));
+        assert_eq!(
+            picker_item_identifier(detached.as_ref()),
+            "/tmp/wt-detached"
+        );
+
+        let branch_only = branch_only_picker_item("feature/bar");
+        assert_eq!(picker_item_identifier(branch_only.as_ref()), "feature/bar");
     }
 
     #[test]
@@ -1303,6 +1287,17 @@ pub mod tests {
         assert!(!marker.exists(), "unapproved pre-remove hook must not run");
     }
 
+    /// Build a `WorktreeSkimItem` from a snapshot `ListItem`.
+    fn picker_item(branch_name: &str, item: ListItem) -> Arc<dyn SkimItem> {
+        Arc::new(WorktreeSkimItem {
+            search_text: branch_name.to_string(),
+            rendered: Arc::new(Mutex::new(String::new())),
+            branch_name: branch_name.to_string(),
+            item: Arc::new(item),
+            preview_cache: Arc::new(dashmap::DashMap::new()),
+        }) as Arc<dyn SkimItem>
+    }
+
     /// Build a `WorktreeSkimItem` standing in for a detached-worktree row.
     fn detached_picker_item(path: &Path) -> Arc<dyn SkimItem> {
         let mut item = ListItem::new_branch("abc123".to_string(), "(detached)".to_string());
@@ -1312,16 +1307,25 @@ pub mod tests {
             detached: true,
             ..Default::default()
         }));
-        let item = Arc::new(item);
-        let preview_cache: PreviewCache = Arc::new(dashmap::DashMap::new());
+        picker_item("(detached)", item)
+    }
 
-        Arc::new(WorktreeSkimItem {
-            search_text: format!("(detached) {}", path.display()),
-            rendered: Arc::new(Mutex::new(String::new())),
-            branch_name: "(detached)".to_string(),
-            item,
-            preview_cache,
-        }) as Arc<dyn SkimItem>
+    /// Build a `WorktreeSkimItem` standing in for a branched-worktree row.
+    fn branched_picker_item(branch: &str, path: &Path) -> Arc<dyn SkimItem> {
+        let mut item = ListItem::new_branch("abc123".to_string(), branch.to_string());
+        item.kind = ItemKind::Worktree(Box::new(WorktreeData {
+            path: path.to_path_buf(),
+            ..Default::default()
+        }));
+        picker_item(branch, item)
+    }
+
+    /// Build a `WorktreeSkimItem` standing in for a branch-only row (no worktree).
+    fn branch_only_picker_item(branch: &str) -> Arc<dyn SkimItem> {
+        picker_item(
+            branch,
+            ListItem::new_branch("abc123".to_string(), branch.to_string()),
+        )
     }
 
     /// Two detached worktrees both render the branch label `(detached)`, but


### PR DESCRIPTION
The interactive picker's alt-r removal signal carried each row's branch name. Detached worktrees all report `(detached)`, so two detached rows produced the same signal — the collector matched by branch, fell back to the *first* detached worktree in `git worktree list`, and could prepare removal for the wrong one. The `items.retain` call also dropped every row sharing that text.

Worktree-backed rows now return a unique `worktree-path:<path>` token from `output()`; `PickerRemovalTarget::from_signal` decodes it back into an exact `RemoveTarget::Path` / `Branch`, replacing the branch-match-then-first-detached fallback. A `picker_item_identifier` helper resolves the switch identifier off the same token (the switch path can no longer read it raw, since `output()` now returns the token for every worktree row).

Includes a regression test — two detached worktrees, alt-r on the second removes exactly that one — verified to fail without the fix.

> _This was written by Claude Code on behalf of Maximilian Roos_
