### PR TITLE
fix(output): correct user-output consistency defects

### DIFF
--- a/src/commands/command_approval.rs
+++ b/src/commands/command_approval.rs
@@ -84,7 +84,7 @@ pub fn approve_command_batch(
             );
             eprintln!(
                 "{}",
-                hint_message("Approval will be requested again next time.")
+                hint_message("Approval will be requested again next time")
             );
         }
     }

--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -17,8 +17,8 @@ use worktrunk::path::format_path_for_display;
 use worktrunk::shell::{FileDetectionResult, Shell, scan_for_detection_details};
 use worktrunk::shell_exec::Cmd;
 use worktrunk::styling::{
-    error_message, format_bash_with_gutter, format_heading, format_toml, format_with_gutter,
-    hint_message, info_message, success_message, warning_message,
+    FormattedMessage, error_message, format_bash_with_gutter, format_heading, format_toml,
+    format_with_gutter, hint_message, info_message, success_message, warning_message,
 };
 
 use super::state::require_user_config_path;
@@ -1390,28 +1390,26 @@ pub(super) fn render_ci_tool_status(
     Ok(())
 }
 
+/// Format the version-check line given the latest release version.
+///
+/// Pure over `latest` so both arms are unit-testable without injecting a
+/// version through the environment; `render_version_check` supplies the value
+/// from `fetch_latest_version`.
+fn format_version_status(latest: &str) -> FormattedMessage {
+    let current = crate::cli::version_str();
+    if is_newer_version(latest, env!("CARGO_PKG_VERSION")) {
+        info_message(cformat!(
+            "Update available: <bold>{latest}</> (current: {current})"
+        ))
+    } else {
+        info_message(cformat!("Up to date (<bold>{current}</>)"))
+    }
+}
+
 /// Render version update check (fetches from GitHub)
 fn render_version_check(out: &mut String) -> anyhow::Result<()> {
     match fetch_latest_version() {
-        Ok(latest) => {
-            let current = crate::cli::version_str();
-            let current_semver = env!("CARGO_PKG_VERSION");
-            if is_newer_version(&latest, current_semver) {
-                writeln!(
-                    out,
-                    "{}",
-                    info_message(cformat!(
-                        "Update available: <bold>{latest}</> (current: {current})"
-                    ))
-                )?;
-            } else {
-                writeln!(
-                    out,
-                    "{}",
-                    info_message(cformat!("Up to date (<bold>{current}</>)"))
-                )?;
-            }
-        }
+        Ok(latest) => writeln!(out, "{}", format_version_status(&latest))?,
         Err(e) => {
             log::debug!("Version check failed: {e}");
             writeln!(out, "{}", hint_message("Version check unavailable"))?;
@@ -1509,5 +1507,22 @@ mod tests {
         // Invalid input
         assert!(!is_newer_version("invalid", "0.23.2"));
         assert!(!is_newer_version("0.23.2", "invalid"));
+    }
+
+    #[test]
+    fn test_format_version_status() {
+        // A version far above the current crate version is "newer".
+        let update = format_version_status("999.0.0").to_string();
+        assert!(
+            update.contains("Update available"),
+            "expected update message, got: {update}"
+        );
+
+        // The current crate version is not newer than itself.
+        let up_to_date = format_version_status(env!("CARGO_PKG_VERSION")).to_string();
+        assert!(
+            up_to_date.contains("Up to date"),
+            "expected up-to-date message, got: {up_to_date}"
+        );
     }
 }

--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -1408,7 +1408,7 @@ fn render_version_check(out: &mut String) -> anyhow::Result<()> {
                 writeln!(
                     out,
                     "{}",
-                    success_message(cformat!("Up to date (<bold>{current}</>)"))
+                    info_message(cformat!("Up to date (<bold>{current}</>)"))
                 )?;
             }
         }

--- a/src/commands/relocate.rs
+++ b/src/commands/relocate.rs
@@ -709,10 +709,10 @@ pub fn show_dry_run_preview(candidates: &[RelocationCandidate]) {
 }
 
 /// Show summary of relocations performed.
+///
+/// Only called after validation produced at least one candidate, so
+/// `relocated + skipped >= 1` always — each candidate either moves or is skipped.
 pub fn show_summary(relocated: usize, skipped: usize) {
-    if relocated == 0 && skipped == 0 {
-        return;
-    }
     eprintln!();
     let plural = |n: usize| if n == 1 { "worktree" } else { "worktrees" };
     let msg = if skipped == 0 {

--- a/src/commands/relocate.rs
+++ b/src/commands/relocate.rs
@@ -749,15 +749,16 @@ pub fn show_no_relocations_needed(template_errors: usize) {
 }
 
 /// Show message when all candidates were skipped during validation.
+///
+/// Only called when validation skipped every candidate, and at least one
+/// candidate exists by then, so `skipped >= 1` always.
 pub fn show_all_skipped(skipped: usize) {
-    if skipped > 0 {
-        eprintln!();
-        eprintln!(
-            "{}",
-            info_message(format!(
-                "Skipped {skipped} worktree{}",
-                if skipped == 1 { "" } else { "s" }
-            ))
-        );
-    }
+    eprintln!();
+    eprintln!(
+        "{}",
+        info_message(format!(
+            "Skipped {skipped} worktree{}",
+            if skipped == 1 { "" } else { "s" }
+        ))
+    );
 }

--- a/src/commands/relocate.rs
+++ b/src/commands/relocate.rs
@@ -710,20 +710,25 @@ pub fn show_dry_run_preview(candidates: &[RelocationCandidate]) {
 
 /// Show summary of relocations performed.
 pub fn show_summary(relocated: usize, skipped: usize) {
-    if relocated > 0 || skipped > 0 {
-        eprintln!();
-        let plural = |n: usize| if n == 1 { "worktree" } else { "worktrees" };
-        if skipped == 0 {
-            let msg = format!("Relocated {relocated} {}", plural(relocated));
-            eprintln!("{}", success_message(msg));
-        } else {
-            let msg = format!(
-                "Relocated {relocated} {}, skipped {skipped} {}",
-                plural(relocated),
-                plural(skipped)
-            );
-            eprintln!("{}", info_message(msg));
-        }
+    if relocated == 0 && skipped == 0 {
+        return;
+    }
+    eprintln!();
+    let plural = |n: usize| if n == 1 { "worktree" } else { "worktrees" };
+    let msg = if skipped == 0 {
+        format!("Relocated {relocated} {}", plural(relocated))
+    } else {
+        format!(
+            "Relocated {relocated} {}, skipped {skipped} {}",
+            plural(relocated),
+            plural(skipped)
+        )
+    };
+    // Success when worktrees moved; info when only skips (no change made).
+    if relocated > 0 {
+        eprintln!("{}", success_message(msg));
+    } else {
+        eprintln!("{}", info_message(msg));
     }
 }
 

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -51,7 +51,7 @@ use minijinja::{Environment, context};
 use worktrunk::git::Repository;
 use worktrunk::path::format_path_for_display;
 use worktrunk::shell_exec::Cmd;
-use worktrunk::styling::{eprintln, hint_message, info_message, warning_message};
+use worktrunk::styling::{eprintln, hint_message, success_message, warning_message};
 
 use crate::cli::version_str;
 use crate::output;
@@ -254,7 +254,7 @@ pub(crate) fn write_if_verbose(verbose: u8, command_line: &str, error_msg: Optio
             let path_display = format_path_for_display(&path);
             eprintln!(
                 "{}",
-                info_message(format!("Diagnostic saved: {path_display}"))
+                success_message(format!("Diagnostic saved @ {path_display}"))
             );
 
             // Only show gh command if gh is installed

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -1220,7 +1220,7 @@ impl GitError {
                         "Cannot create branch for <bold>{syntax}{number}</> — {name} already has branch <bold>{branch}</>"
                     )),
                     hint_message(cformat!(
-                        "To switch to it: <underline>wt switch {syntax}{number}</>"
+                        "To switch to the existing branch, run <underline>wt switch {syntax}{number}</>"
                     ))
                 )
             }

--- a/src/output/shell_integration.rs
+++ b/src/output/shell_integration.rs
@@ -347,7 +347,7 @@ pub fn print_shell_install_result(scan_result: &crate::commands::configure_shell
             ))
         );
     } else {
-        eprintln!("{}", success_message("All shells already configured"));
+        eprintln!("{}", info_message("All shells already configured"));
     }
 
     // Zsh compinit advisory

--- a/tests/integration_tests/configure_shell.rs
+++ b/tests/integration_tests/configure_shell.rs
@@ -118,7 +118,7 @@ fn test_configure_shell_already_exists(repo: TestRepo, temp_home: TempDir) {
 
         ----- stderr -----
         [2m○[22m Already configured shell extension & completions for [1mzsh[22m @ [1m~/.zshrc[22m
-        [32m✓[39m [32mAll shells already configured[39m
+        [2m○[22m All shells already configured
         ");
     });
 
@@ -1356,7 +1356,7 @@ fn test_configure_shell_no_warning_when_already_configured(repo: TestRepo, temp_
 
         ----- stderr -----
         [2m○[22m Already configured shell extension & completions for [1mzsh[22m @ [1m~/.zshrc[22m
-        [32m✓[39m [32mAll shells already configured[39m
+        [2m○[22m All shells already configured
         ");
     });
 }

--- a/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_permission_error.snap
+++ b/tests/snapshots/integration__integration_tests__approval_pty__approval_prompt_permission_error.snap
@@ -8,7 +8,7 @@ expression: "&output"
 
 [36m❯[39m [36mAllow and remember? [1m[y/N][22m[39m y
 [33m▲[39m [33mFailed to save command approval: Failed to open lock file: Permission denied (os error 13)[39m
-[2m↳[22m [2mApproval will be requested again next time.[22m
+[2m↳[22m [2mApproval will be requested again next time[22m
 [36m◎[39m [36mRunning pre-start project hook @ [1m_REPO_.test-permission[22m[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m
 test command

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_command_not_found.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_command_not_found.snap
@@ -74,7 +74,7 @@ exit_code: 0
 
 [36mDIAGNOSTICS[39m
 [2m↳[22m [2mCI status requires GitHub, GitLab, Gitea, or Azure DevOps remote[22m
-[32m✓[39m [32mUp to date ([1m[VERSION][22m)[39m
+[2m○[22m Up to date ([1m[VERSION][22m)
 [31m✗[39m [31mCommit generation failed ([1mnonexistent-llm-command-12345 -m test-model[22m)[39m
 [107m [0m [31m✗[39m [31mCommit generation command failed[39m
 [107m [0m [107m [0m sh: nonexistent-llm-command-12345: command not found

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_gitea_remote.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_gitea_remote.snap
@@ -71,7 +71,7 @@ exit_code: 0
 
 [36mDIAGNOSTICS[39m
 [33m▲[39m [33m[1mtea[22m installed but not authenticated; run [1mtea login add[22m[39m
-[32m✓[39m [32mUp to date ([1m[VERSION][22m)[39m
+[2m○[22m Up to date ([1m[VERSION][22m)
 [2m↳[22m [2mCommit generation not configured[22m
 
 [36mOTHER[39m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_not_configured.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_not_configured.snap
@@ -71,7 +71,7 @@ exit_code: 0
 
 [36mDIAGNOSTICS[39m
 [2m↳[22m [2mCI status requires GitHub, GitLab, Gitea, or Azure DevOps remote[22m
-[32m✓[39m [32mUp to date ([1m[VERSION][22m)[39m
+[2m○[22m Up to date ([1m[VERSION][22m)
 [2m↳[22m [2mCommit generation not configured[22m
 
 [36mOTHER[39m

--- a/tests/snapshots/integration__integration_tests__step_relocate__relocate_mixed_success_and_skip.snap
+++ b/tests/snapshots/integration__integration_tests__step_relocate__relocate_mixed_success_and_skip.snap
@@ -47,4 +47,4 @@ exit_code: 0
 [33m▲[39m [33mSkipping [1mfeature2[22m (locked)[39m
 [32m✓[39m [32mRelocated [1mfeature1[22m: _PARENT_/wrong-location-1 → _REPO_.feature1[39m
 
-[2m○[22m Relocated 1 worktree, skipped 1 worktree
+[32m✓[39m [32mRelocated 1 worktree, skipped 1 worktree[39m

--- a/tests/snapshots/integration__integration_tests__step_relocate__relocate_same_target_no_panic.snap
+++ b/tests/snapshots/integration__integration_tests__step_relocate__relocate_same_target_no_panic.snap
@@ -49,4 +49,4 @@ exit_code: 0
 [32m✓[39m [32mRelocated [1malpha[22m: _PARENT_/wrong-location-1 → _REPO_/repo.shared[39m
 [33m▲[39m [33mSkipping [1mbeta[22m (target occupied: _REPO_/repo.shared)[39m
 
-[2m○[22m Relocated 1 worktree, skipped 1 worktree
+[32m✓[39m [32mRelocated 1 worktree, skipped 1 worktree[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_mr_create_conflict.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_mr_create_conflict.snap
@@ -49,4 +49,4 @@ exit_code: 1
 [107m [0m [1mFix authentication bug in login flow[22m (!101)
 [107m [0m by @alice · opened · feature-auth · [90mhttps://gitlab.com/owner/test-repo/-/merge_requests/101[39m
 [31m✗[39m [31mCannot create branch for [1mmr:101[22m — MR already has branch [1mfeature-auth[22m[39m
-[2m↳[22m [2mTo switch to it: [4mwt switch mr:101[24m[22m
+[2m↳[22m [2mTo switch to the existing branch, run [4mwt switch mr:101[24m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_azure_create_conflict.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_azure_create_conflict.snap
@@ -58,4 +58,4 @@ exit_code: 1
 [107m [0m [1mFix authentication bug in login flow[22m (#101)
 [107m [0m by @alice@example.com · active · feature-auth · [90mhttps://dev.azure.com/myorg/myproject/_git/test-repo/pullrequest/101[39m
 [31m✗[39m [31mCannot create branch for [1mpr:101[22m — PR already has branch [1mfeature-auth[22m[39m
-[2m↳[22m [2mTo switch to it: [4mwt switch pr:101[24m[22m
+[2m↳[22m [2mTo switch to the existing branch, run [4mwt switch pr:101[24m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_azure_forge_platform.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_azure_forge_platform.snap
@@ -58,4 +58,4 @@ exit_code: 1
 [107m [0m [1mOverride test[22m (#101)
 [107m [0m by @alice@example.com · active · feature-auth · [90mhttps://dev.azure.com/myorg/myproject/_git/test-repo/pullrequest/101[39m
 [31m✗[39m [31mCannot create branch for [1mpr:101[22m — PR already has branch [1mfeature-auth[22m[39m
-[2m↳[22m [2mTo switch to it: [4mwt switch pr:101[24m[22m
+[2m↳[22m [2mTo switch to the existing branch, run [4mwt switch pr:101[24m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_create_conflict.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_create_conflict.snap
@@ -49,4 +49,4 @@ exit_code: 1
 [107m [0m [1mFix authentication bug in login flow[22m (#101)
 [107m [0m by @alice · open · feature-auth · [90mhttps://github.com/owner/test-repo/pull/101[39m
 [31m✗[39m [31mCannot create branch for [1mpr:101[22m — PR already has branch [1mfeature-auth[22m[39m
-[2m↳[22m [2mTo switch to it: [4mwt switch pr:101[24m[22m
+[2m↳[22m [2mTo switch to the existing branch, run [4mwt switch pr:101[24m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_create_conflict.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_create_conflict.snap
@@ -49,4 +49,4 @@ exit_code: 1
 [107m [0m [1mFix authentication bug in login flow[22m (#101)
 [107m [0m by @alice · open · feature-auth · [90mhttps://gitea.example.com/owner/test-repo/pulls/101[39m
 [31m✗[39m [31mCannot create branch for [1mpr:101[22m — PR already has branch [1mfeature-auth[22m[39m
-[2m↳[22m [2mTo switch to it: [4mwt switch pr:101[24m[22m
+[2m↳[22m [2mTo switch to the existing branch, run [4mwt switch pr:101[24m[22m

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_forge_platform.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_forge_platform.snap
@@ -49,4 +49,4 @@ exit_code: 1
 [107m [0m [1mOverride test[22m (#101)
 [107m [0m by @alice · open · feature-auth · [90mhttps://git.internal.example.com/owner/test-repo/pulls/101[39m
 [31m✗[39m [31mCannot create branch for [1mpr:101[22m — PR already has branch [1mfeature-auth[22m[39m
-[2m↳[22m [2mTo switch to it: [4mwt switch pr:101[24m[22m
+[2m↳[22m [2mTo switch to the existing branch, run [4mwt switch pr:101[24m[22m


### PR DESCRIPTION
An audit of `wt`'s user-visible strings against the repo's `writing-user-outputs` skill. Six consistency corrections, each matching a rule the skill states — and, in most cases, a sibling message that already follows it:

- `RefCreateConflict` hint: dropped the cross-message pronoun ("it") and switched to the skill's `"To X, run Y"` command-hint form.
- `"All shells already configured"` and the version-check `"Up to date"`: `success ✓` → `info ○` — both acknowledge existing state without changing anything.
- `relocate` summary: keyed the message type on whether anything was *relocated*, not on whether anything was *skipped* (the same outcome was rendered two ways).
- `"Diagnostic saved"`: → `success` (a file was created) and the `@`-before-path convention.
- Removed a stray trailing period — the only single-line message in the codebase that had one.

`--no-verify` is deliberately untouched (handled in the `canonical-paths` PR). Snapshot tests updated.

> _This was written by Claude Code on behalf of Maximilian Roos_
