### PR TITLE
refactor(config): fold require_user_config_path into require_config_path

### DIFF
--- a/src/commands/config/create.rs
+++ b/src/commands/config/create.rs
@@ -5,11 +5,10 @@
 use anyhow::Context;
 use color_print::cformat;
 use std::path::PathBuf;
+use worktrunk::config::require_config_path;
 use worktrunk::git::Repository;
 use worktrunk::path::format_path_for_display;
 use worktrunk::styling::{eprintln, hint_message, info_message, success_message};
-
-use super::state::require_user_config_path;
 
 /// Example user configuration file content (displayed in help with values uncommented)
 const USER_CONFIG_EXAMPLE: &str = include_str!("../../../dev/config.example.toml");
@@ -47,9 +46,7 @@ pub fn handle_config_create(project: bool) -> anyhow::Result<()> {
         let config_path = repo
             .project_config_path()?
             .context("Cannot determine project config location — no worktree found")?;
-        let user_config_exists = require_user_config_path()
-            .map(|p| p.exists())
-            .unwrap_or(false);
+        let user_config_exists = require_config_path().map(|p| p.exists()).unwrap_or(false);
         create_config_file(
             config_path,
             PROJECT_CONFIG_EXAMPLE,
@@ -69,7 +66,7 @@ pub fn handle_config_create(project: bool) -> anyhow::Result<()> {
             .map(|path| path.exists())
             .unwrap_or(false);
         create_config_file(
-            require_user_config_path()?,
+            require_config_path()?,
             USER_CONFIG_EXAMPLE,
             "User config",
             &["Edit this file to customize worktree paths and LLM settings"],

--- a/src/commands/config/mod.rs
+++ b/src/commands/config/mod.rs
@@ -38,7 +38,6 @@ mod tests {
 
     use super::create::comment_out_config;
     use super::show::{render_ci_tool_status, warn_unknown_keys};
-    use super::state::require_user_config_path;
 
     // ==================== comment_out_config tests ====================
 
@@ -232,30 +231,5 @@ mod tests {
         let mut out = String::new();
         render_ci_tool_status(&mut out, "glab", "GitLab", true, true).unwrap();
         assert_snapshot!(out, @"[32m✓[39m [32m[1mglab[22m installed & authenticated[39m");
-    }
-
-    // ==================== require_user_config_path tests ====================
-
-    #[test]
-    fn test_require_user_config_path_returns_ok() {
-        // In a normal environment, require_user_config_path should succeed
-        let result = require_user_config_path();
-        assert!(result.is_ok());
-        let path = result.unwrap();
-        assert!(path.ends_with("worktrunk/config.toml"));
-    }
-
-    #[test]
-    fn test_require_user_config_path_matches_config_path() {
-        // Verify that config create/show path matches config loading path.
-        // This was the root cause of #1134: the two paths diverged on Windows
-        // when XDG_CONFIG_HOME was set because config create had its own
-        // XDG/HOME resolution that differed from config loading.
-        let create_path = require_user_config_path().unwrap();
-        let load_path = worktrunk::config::config_path().unwrap();
-        assert_eq!(
-            create_path, load_path,
-            "config create path and config loading path must be identical"
-        );
     }
 }

--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -10,7 +10,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Context;
 use color_print::cformat;
 use worktrunk::config::{
-    ProjectConfig, UserConfig, default_system_config_path, system_config_path,
+    ProjectConfig, UserConfig, default_system_config_path, require_config_path, system_config_path,
 };
 use worktrunk::git::{CiPlatform, ErrorExt, Repository};
 use worktrunk::path::format_path_for_display;
@@ -21,7 +21,6 @@ use worktrunk::styling::{
     hint_message, info_message, success_message, warning_message,
 };
 
-use super::state::require_user_config_path;
 use crate::cli::{SwitchFormat, version_str};
 use crate::commands::configure_shell::{ConfigAction, ConfigureResult, scan_shell_configs};
 use crate::commands::list::ci_status::CiToolsStatus;
@@ -96,7 +95,7 @@ pub fn handle_config_show(full: bool, format: SwitchFormat) -> anyhow::Result<()
 
 /// JSON output for config show: paths, existence, and parsed config contents.
 fn handle_config_show_json() -> anyhow::Result<()> {
-    let user_path = require_user_config_path()?;
+    let user_path = require_config_path()?;
     let user_exists = user_path.exists();
     let user_config = if user_exists {
         Some(serde_json::to_value(&UserConfig::load()?)?)
@@ -583,7 +582,7 @@ fn render_system_config(out: &mut String) -> anyhow::Result<bool> {
 }
 
 fn render_user_config(out: &mut String, has_system_config: bool) -> anyhow::Result<()> {
-    let config_path = require_user_config_path()?;
+    let config_path = require_config_path()?;
 
     writeln!(
         out,

--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -42,12 +42,11 @@
 //! under a single reserved subdirectory rather than adding sibling top-level dirs.
 
 use std::fmt::Write as _;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 
 use anyhow::Context;
 use color_print::cformat;
 use path_slash::PathExt as _;
-use worktrunk::config::config_path;
 use worktrunk::git::{BranchRef, Repository, sha_cache};
 use worktrunk::path::format_path_for_display;
 use worktrunk::styling::{
@@ -93,17 +92,6 @@ fn picker_preview_clear(repo: &Repository) -> anyhow::Result<usize> {
         let _ = repo;
         Ok(0)
     }
-}
-
-// ==================== Path Helpers ====================
-
-/// Get the user config path, or error if it cannot be determined.
-///
-/// Delegates to `config_path()` so that `config create` and `config show`
-/// resolve the same path that config loading uses — including any CLI
-/// (`--config`) or environment variable (`WORKTRUNK_CONFIG_PATH`) overrides.
-pub fn require_user_config_path() -> anyhow::Result<PathBuf> {
-    config_path().context("Cannot determine config directory")
 }
 
 // ==================== Log Management ====================


### PR DESCRIPTION
`require_config_path()` (added in #2862) and the older `require_user_config_path()` in `src/commands/config/state.rs` both just wrapped `config_path()` with a `Result`. Two functions, two slightly different error messages, one purpose.

This deletes `require_user_config_path()` and points its four callers — `config create` (×2) and `config show` (×2) — at the lib-crate `require_config_path()`.

The two wrapper tests in `config/mod.rs` are removed with it. `test_require_user_config_path_returns_ok` tested a trivial wrapper. `test_require_user_config_path_matches_config_path` guarded issue #1134 (config-create resolving a *different* path than config-loading) — that regression is now structurally impossible: `config create` / `show` resolve through `require_config_path()`, which is `config_path()` itself, so there is no separate resolver left to diverge.

One behavior delta: when no config directory can be resolved, `config create` / `config show` now error `Cannot determine config directory. Set $HOME or $XDG_CONFIG_HOME` instead of `Cannot determine config directory`. No snapshot test references either string.

Follow-up to #2862.
