### PR TITLE
fix(log): honor RUST_LOG at -v and -vv, not just -v 0

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1246,15 +1246,25 @@ fn thread_label() -> char {
 }
 
 fn init_logging(verbose_level: u8) {
-    // Configure logging based on --verbose flag or RUST_LOG env var.
-    // Level map: -v → Info on stderr (no file), -vv+ → Debug routed to
-    // `.git/wt/logs/trace.log` instead of stderr, plus uncapped subprocess
-    // bodies in `.git/wt/logs/output.log` (via `SUBPROCESS_FULL_TARGET`).
+    // Configure logging based on --verbose flag, with `RUST_LOG` layered on
+    // top. The flag sets the baseline filter level (`-v 0` → Off, `-v` →
+    // Info, `-vv+` → Debug); `RUST_LOG`, when set, refines or overrides that
+    // baseline via `env_logger`'s standard directive grammar. Examples:
     //
-    // At -vv the `log::*` pipeline is silent on stderr — user-facing
+    //   - bare `wt`                        → Off (silent)
+    //   - `RUST_LOG=debug wt`              → Debug (env raises baseline)
+    //   - `wt -v`                          → Info
+    //   - `RUST_LOG=trace wt -vv`          → Trace globally
+    //   - `RUST_LOG=worktrunk=trace wt -v` → Info + Trace for `worktrunk`
+    //
+    // All three flag levels go through the same builder shape — set the
+    // baseline, then `parse_default_env()` — so `RUST_LOG` is honored
+    // uniformly and never silently dropped. The flag still controls the
+    // file-sink side effects: `-vv+` opens `.git/wt/logs/trace.log` and
+    // `output.log`, and the `log::*` pipeline becomes silent on stderr
+    // (the bounded preview lands in `trace.log` instead). User-facing
     // `eprintln!` output (template expansions, status, hints) is
-    // unaffected. A one-line pointer below tells the user where the
-    // trace went.
+    // unaffected at any level.
     output::set_verbosity(verbose_level);
 
     // Prime `GIT_COMMON_DIR_CACHE` BEFORE env_logger registers, so any
@@ -1280,19 +1290,13 @@ fn init_logging(verbose_level: u8) {
         let _ = worktrunk::git::Repository::current();
     }
 
-    let mut builder = match verbose_level {
-        0 => env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("off")),
-        1 => {
-            let mut b = env_logger::Builder::new();
-            b.filter_level(log::LevelFilter::Info);
-            b
-        }
-        _ => {
-            let mut b = env_logger::Builder::new();
-            b.filter_level(log::LevelFilter::Debug);
-            b
-        }
+    let baseline = match verbose_level {
+        0 => log::LevelFilter::Off,
+        1 => log::LevelFilter::Info,
+        _ => log::LevelFilter::Debug,
     };
+    let mut builder = env_logger::Builder::new();
+    builder.filter_level(baseline).parse_default_env();
 
     builder
         .format(|buf, record| {

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -519,7 +519,6 @@ pub fn configure_completion_invocation_for_shell(cmd: &mut Command, words: &[&st
 /// - This function uses COLUMNS=500 (wider for long macOS paths in error messages)
 /// - `test_env_vars()` uses COLUMNS=150 (narrower for PTY snapshot consistency)
 /// - This function sets TERM=alacritty; PTY tests don't (skim needs valid terminfo)
-/// - This function enables RUST_LOG=warn; PTY tests don't (too noisy in combined output)
 /// - This function clears host GIT_*/WORKTRUNK_* vars; PTY tests start with clean env
 pub fn configure_cli_command(cmd: &mut Command) {
     // Strip host context and set baseline `WORKTRUNK_*_PATH` defaults
@@ -531,8 +530,12 @@ pub fn configure_cli_command(cmd: &mut Command) {
     // by the env-strip above.
     isolate_subprocess_env(cmd, None);
     cmd.env("WORKTRUNK_TEST_EPOCH", TEST_EPOCH.to_string());
-    // Enable warn-level logging so diagnostics show up in test failures
-    cmd.env("RUST_LOG", "warn");
+    // RUST_LOG intentionally NOT set: now that the flag baseline and
+    // `RUST_LOG` merge via `env_logger::Builder::parse_default_env`
+    // (env wins when set), a blanket `RUST_LOG=warn` default would cap
+    // `-vv` tests at Warn and starve `trace.log` of debug-level
+    // `[wt-trace]` records. Tests that need warn-level output should
+    // opt in per-invocation.
     // Treat Claude as not installed by default (tests can override with "1")
     cmd.env("WORKTRUNK_TEST_CLAUDE_INSTALLED", "0");
     // Treat Codex as not installed by default (tests can override with "1")

--- a/tests/integration_tests/ci_status.rs
+++ b/tests/integration_tests/ci_status.rs
@@ -479,6 +479,12 @@ platform = "invalid_platform"
     settings.bind(|| {
         let mut cmd = make_snapshot_cmd(&repo, "list", &["--full"], None);
         repo.configure_mock_commands(&mut cmd);
+        // The snapshot asserts on the `log::warn!` diagnostic for the
+        // invalid platform value, which is suppressed at the default
+        // baseline filter (`-v 0` → Off). Opt this test into Warn-level
+        // logging via `RUST_LOG`, which the verbose flag now merges with
+        // through `env_logger::Builder::parse_default_env` (`init_logging`).
+        cmd.env("RUST_LOG", "warn");
         // Invalid platform should fall back to URL detection (GitHub)
         assert_cmd_snapshot!(cmd);
     });

--- a/tests/integration_tests/diagnostic.rs
+++ b/tests/integration_tests/diagnostic.rs
@@ -446,6 +446,52 @@ fn test_vv_log_pipeline_silent_on_stderr(repo: TestRepo) {
     );
 }
 
+/// `RUST_LOG` is honored at every verbosity level — including `-v` — and
+/// can raise the filter above the flag's baseline. A user who runs
+/// `RUST_LOG=debug wt -v` gets Debug, not Info: the flag sets a baseline,
+/// and `RUST_LOG` refines it on top via `env_logger`'s standard directive
+/// grammar. Guards against the regression where `-v`/`-vv` hardcoded
+/// `filter_level(...)` without `parse_default_env()` and silently dropped
+/// `RUST_LOG`.
+///
+/// The probe is the `[wt-trace]` grammar — those records are emitted at
+/// `log::debug!`, so they're suppressed at the Info baseline `-v` selects
+/// and surface when `RUST_LOG=debug` raises it. (At `-v 0` the same
+/// `RUST_LOG=debug` path is already covered by
+/// `test_rust_log_debug_fallback_without_vv`; at `-vv` the baseline is
+/// already Debug so there's no flag/env conflict to assert.)
+#[rstest]
+fn test_rust_log_overrides_verbose_flag(repo: TestRepo) {
+    // Baseline: -v alone caps at Info, so debug-level [wt-trace] records
+    // are dropped from stderr.
+    let info_only = repo
+        .wt_command()
+        .args(["list", "-v"])
+        .env_remove("RUST_LOG")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("wt list -v");
+    let info_stderr = String::from_utf8_lossy(&info_only.stderr);
+    assert!(
+        !info_stderr.contains("[wt-trace]"),
+        "-v alone (Info baseline) should not surface [wt-trace] records: {info_stderr}"
+    );
+
+    // RUST_LOG=debug + -v raises the level: [wt-trace] records appear.
+    let with_env = repo
+        .wt_command()
+        .args(["list", "-v"])
+        .env("RUST_LOG", "debug")
+        .env("NO_COLOR", "1")
+        .output()
+        .expect("wt list -v");
+    let env_stderr = String::from_utf8_lossy(&with_env.stderr);
+    assert!(
+        env_stderr.contains("[wt-trace]"),
+        "RUST_LOG=debug at -v should surface [wt-trace] records on stderr: {env_stderr}"
+    );
+}
+
 /// `RUST_LOG=debug` at `-v 0` activates Debug logging without creating the
 /// on-disk log files. Stderr receives the **bounded** preview
 /// (`SUBPROCESS_BOUNDED_TARGET`); the uncapped `SUBPROCESS_FULL_TARGET`


### PR DESCRIPTION
## Summary

`wt`'s `-v 0` (no flag) honors `RUST_LOG` — `RUST_LOG=debug wt list` shows debug records. `-v` and `-vv` silently ignored it: they hardcoded `filter_level(Info)` / `filter_level(Debug)` and dropped any `RUST_LOG` directives on the floor.

Now all three verbosity levels flow through the same builder shape: the flag sets a baseline (`Off` / `Info` / `Debug`), and `env_logger::Builder::parse_default_env()` layers `RUST_LOG` on top. When `RUST_LOG` is set it wins (raising or lowering the level, and supporting per-target directives like `worktrunk=trace`). When it's unset the flag baseline stands.

Examples:

- bare `wt` → Off (silent, unchanged)
- `RUST_LOG=debug wt` → Debug (unchanged)
- `wt -v` → Info (unchanged)
- `RUST_LOG=trace wt -vv` → Trace globally (was silently capped at Debug)
- `RUST_LOG=worktrunk=trace wt -v` → Info + Trace for `worktrunk` (was silently ignored)

The flag still owns the file-sink side effects (`-vv+` opens `trace.log` / `output.log`); only the level filter is now `RUST_LOG`-aware.

## Design choice

Three patterns are common in Rust CLIs:

1. **env wins when set, flag is the default** (`env_logger` convention; e.g. cargo via `CARGO_LOG`)
2. **flag wins when both are set** (e.g. ripgrep, which doesn't honor `RUST_LOG` at all and uses its own `--debug` / `--trace`)
3. **max(flag, env)** with per-target additions

I picked (1). The task framing makes the case directly — `RUST_LOG` users are debugging and know exactly what they want; the flag-only user wants a level; the two shouldn't fight silently. (1) is also the documented `env_logger` pattern (`builder.filter_level(...); builder.parse_default_env();`) and gives the smallest implementation. (3) was tempting for "the verbose user always wins", but it's not natively supported by `env_logger` — extracting just the env's global-wildcard level (not its per-target ceilings) has no clean API, and any hand-rolled merge complicates an otherwise five-line function for the small win of "`RUST_LOG=warn` doesn't downgrade `wt -vv`".

## Adjacent fix

`src/testing/mod.rs::configure_cli_command` was setting `RUST_LOG=warn` as a blanket default for every CLI test. That was harmless under the old behavior (the flag overrode it at `-vv`); under the new behavior it would silently cap all `-vv` tests at Warn, starving `trace.log` of the debug-level `[wt-trace]` records the diagnostic tests assert on. Dropped the default; the one test that genuinely needed the warn-level diagnostic (`test_list_full_with_invalid_configured_platform`, asserting on the `log::warn!` for invalid CI platform) opts in via `cmd.env("RUST_LOG", "warn")` per-invocation.

## Test plan

- New `test_rust_log_overrides_verbose_flag` in `tests/integration_tests/diagnostic.rs` — asserts `-v` alone suppresses `[wt-trace]` records (Info baseline) and `RUST_LOG=debug wt -v` surfaces them (env raises).
- Existing `test_rust_log_debug_fallback_without_vv` still covers `RUST_LOG=debug` at `-v 0`.
- All 3835 tests in `cargo run -- hook pre-merge --yes` pass.
