### PR TITLE
refactor(log): drop OUTPUT_LOG_ACTIVE static; query tracing dispatcher

### DIFF
--- a/src/log_files.rs
+++ b/src/log_files.rs
@@ -108,9 +108,6 @@ pub(crate) static OUTPUT: LogSink = LogSink {
 pub(crate) fn init() {
     TRACE.init();
     OUTPUT.init();
-    // Let shell_exec phrase the elision marker to match reality — points at
-    // output.log when it exists, else suggests rerunning with -vv.
-    worktrunk::shell_exec::set_output_log_active(OUTPUT.is_active());
 }
 
 /// Per-event writer: collects formatted bytes, then forwards them to the

--- a/src/shell_exec.rs
+++ b/src/shell_exec.rs
@@ -474,28 +474,6 @@ pub const SUBPROCESS_FULL_TARGET: &str = "worktrunk::subprocess_full";
 /// uncapped version is captured via [`SUBPROCESS_FULL_TARGET`].
 pub const SUBPROCESS_BOUNDED_TARGET: &str = "worktrunk::subprocess_bounded";
 
-/// Whether the full subprocess output is being captured to `output.log` at
-/// `-vv`. Gates the phrasing of the elision marker so it doesn't promise a
-/// file that wasn't created.
-///
-/// The two-state split (active / not) intentionally collapses two
-/// situations: (a) the user didn't run with `-vv` at all, and (b) the user
-/// did but `output.log` failed to open (rare: path-type mismatch, FD
-/// exhaustion). In (b), `announce_trace_destination` already warns at
-/// startup; the elision marker text is allowed to lag — saying "rerun with
-/// -vv" is harmless because the user's startup warning is the
-/// authoritative signal.
-///
-/// Set by the binary's log-file init; stays `false` under `RUST_LOG=debug`
-/// without `-vv`, where the full records are dropped by design.
-static OUTPUT_LOG_ACTIVE: std::sync::atomic::AtomicBool = std::sync::atomic::AtomicBool::new(false);
-
-/// Called from the binary once `log_files::init` has attempted to open
-/// `output.log` — `yes` reflects whether that attempt succeeded.
-pub fn set_output_log_active(yes: bool) {
-    OUTPUT_LOG_ACTIVE.store(yes, std::sync::atomic::Ordering::Relaxed);
-}
-
 /// Log captured stdout/stderr of a finished command.
 ///
 /// At `tracing::DEBUG` (`-vv`) each stream is emitted twice via separate
@@ -538,7 +516,10 @@ fn format_stream_full(bytes: &[u8], prefix: &str) -> Vec<String> {
 /// Split captured bytes into prefixed lines with at most [`LOG_OUTPUT_MAX_LINES`]
 /// and [`LOG_OUTPUT_MAX_BYTES`] emitted; remainder replaced by a single
 /// `… (N more lines, M bytes elided — <hint>)` marker. The hint text tracks
-/// whether `output.log` was opened (see [`set_output_log_active`]).
+/// whether `output.log` is collecting the full bodies, asked through
+/// `tracing::enabled!` against [`SUBPROCESS_FULL_TARGET`] — true iff the
+/// `output.log` layer is registered and accepting that target (`-vv` opened
+/// the file successfully).
 fn format_stream_bounded(bytes: &[u8], prefix: &str) -> Vec<String> {
     if bytes.is_empty() {
         return Vec::new();
@@ -553,7 +534,7 @@ fn format_stream_bounded(bytes: &[u8], prefix: &str) -> Vec<String> {
         if lines_emitted >= LOG_OUTPUT_MAX_LINES || bytes_emitted >= LOG_OUTPUT_MAX_BYTES {
             let remaining_lines = 1 + lines.count();
             let remaining_bytes = total_bytes.saturating_sub(bytes_emitted);
-            let hint = if OUTPUT_LOG_ACTIVE.load(std::sync::atomic::Ordering::Relaxed) {
+            let hint = if tracing::enabled!(target: SUBPROCESS_FULL_TARGET, tracing::Level::DEBUG) {
                 "full output in output.log"
             } else {
                 "rerun with -vv for full output"
@@ -2124,8 +2105,9 @@ mod tests {
             marker.starts_with("  … (5 more lines, "),
             "marker should count the 5 lines past the cap: {marker}"
         );
-        // OUTPUT_LOG_ACTIVE defaults to false (only the binary's
-        // log_files::init sets it true), so the marker here suggests `-vv`.
+        // No tracing subscriber is installed in unit tests, so
+        // `tracing::enabled!(SUBPROCESS_FULL_TARGET, DEBUG)` is false and the
+        // marker suggests `-vv`.
         assert!(marker.contains("rerun with -vv"));
     }
 


### PR DESCRIPTION
## Why

The tracing migration in #2902 preserved a relic of the env_logger design: a static `AtomicBool` (`shell_exec::OUTPUT_LOG_ACTIVE`) populated through a cross-module setter (`set_output_log_active`) called from `log_files::init`. Its job is to gate the wording of the elision marker in `format_stream_bounded` — "full output in output.log" vs. "rerun with -vv for full output" — so we don't promise a file that wasn't actually opened.

The dispatcher already knows the answer. The `output.log` layer is the *only* registered layer that accepts `SUBPROCESS_FULL_TARGET` (the other two layers explicitly filter it out), and that layer is registered iff `verbose_level >= 2 && log_files::OUTPUT.is_active()` — exactly the condition the static encoded.

`tracing::enabled!(target: SUBPROCESS_FULL_TARGET, Level::DEBUG)` asks the dispatcher whether any layer would consume an event at that target/level. Under our subscriber, that's true iff the `output.log` layer is registered. Same answer, no static, no setter, no cross-module coupling.

## What changed

- Deleted `shell_exec::OUTPUT_LOG_ACTIVE` (the static).
- Deleted `shell_exec::set_output_log_active` (the setter).
- Removed the call site in `log_files::init`.
- Replaced the one read site in `format_stream_bounded` with `tracing::enabled!(...)`.
- Updated docstrings and the unit-test comment.

## Test plan

- [x] `cargo run -- hook pre-merge --yes` — all tests + lints pass locally.
- [x] Existing `format_stream_bounded` unit tests cover the inactive branch; under `cargo test` no subscriber is installed, so `tracing::enabled!` returns false (matches prior behavior where the setter was never called).
- [ ] Active branch (`-vv`) phrasing is exercised end-to-end via the existing diagnostic integration tests; coverage that asserts the literal "full output in output.log" string was already absent before this change.