### PR TITLE
refactor(verbose): -vv pointer names diagnostic.md; finish output_log rename

### DIFF
--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -105,12 +105,12 @@ Shell integration: {{ shell_integration }}
 ```
 </details>
 {%- endif %}
-{%- if output_log_path %}
+{%- if subprocess_log_path %}
 
 <details>
 <summary>Raw subprocess output</summary>
 
-Full captured stdout/stderr is in `{{ output_log_path }}` — not inlined because it can be multi-MB.
+Full captured stdout/stderr is in `{{ subprocess_log_path }}`.
 </details>
 {%- endif %}
 "#;
@@ -167,7 +167,7 @@ impl DiagnosticReport {
             .filter(|s| !s.is_empty());
         // Forward slashes on both platforms so the rendered markdown reads the
         // same in bug reports regardless of where it was produced.
-        let output_log_path = crate::log_files::SUBPROCESS
+        let subprocess_log_path = crate::log_files::SUBPROCESS
             .path()
             .map(|p| path_slash::PathExt::to_slash_lossy(p.as_path()).into_owned());
 
@@ -186,7 +186,7 @@ impl DiagnosticReport {
             worktree_list,
             config_show,
             trace_log,
-            output_log_path,
+            subprocess_log_path,
         })
         .unwrap()
     }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -492,19 +492,23 @@ fn announce_trace_destination() {
     // file. The (Some, None) case (trace.log open, subprocess.log failed) is
     // rare but real (path-type mismatch, fs quota); the reverse is
     // possible too but `subprocess.log` alone has no `$ cmd` context, so we
-    // stay silent there.
+    // stay silent there. `diagnostic.md` is named even though it's written
+    // at exit (not init) — by the time the user reads the pointer and looks
+    // for files, all three will be there.
     let Some(trace_path) = log_files::TRACE.path() else {
         return;
     };
-    let trace_display = worktrunk::path::format_path_for_display(&trace_path);
+    let Some(dir) = trace_path.parent() else {
+        return;
+    };
+    let dir_display = worktrunk::path::format_path_for_display(dir);
     let msg = match log_files::SUBPROCESS.path() {
-        Some(output_path) => {
-            let output_display = worktrunk::path::format_path_for_display(&output_path);
-            cformat!(
-                "Tracing to <underline>{trace_display}</> (raw subprocess output @ <underline>{output_display}</>)"
-            )
-        }
-        None => cformat!("Tracing to <underline>{trace_display}</> (subprocess.log unavailable)"),
+        Some(_) => cformat!(
+            "Writing to <underline>{dir_display}/</> — trace.log, subprocess.log, diagnostic.md"
+        ),
+        None => cformat!(
+            "Writing to <underline>{dir_display}/</> — trace.log, diagnostic.md (subprocess.log unavailable)"
+        ),
     };
     eprintln!("{}", info_message(msg));
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -498,9 +498,9 @@ fn announce_trace_destination() {
     let Some(trace_path) = log_files::TRACE.path() else {
         return;
     };
-    let Some(dir) = trace_path.parent() else {
-        return;
-    };
+    // trace.log is always at `<git>/wt/logs/trace.log` (see `log_files::try_create`),
+    // so the parent is structurally guaranteed.
+    let dir = trace_path.parent().expect("trace.log path has a parent");
     let dir_display = worktrunk::path::format_path_for_display(dir);
     let msg = match log_files::SUBPROCESS.path() {
         Some(_) => cformat!(

--- a/tests/integration_tests/diagnostic.rs
+++ b/tests/integration_tests/diagnostic.rs
@@ -312,10 +312,10 @@ fn test_log_files_created(mut repo: TestRepo) {
 
     let logs_dir = repo.root_path().join(".git").join("wt/logs");
     let trace_log = logs_dir.join("trace.log");
-    let output_log = logs_dir.join("subprocess.log");
+    let subprocess_log = logs_dir.join("subprocess.log");
     assert!(trace_log.exists(), "trace.log should be created with -vv");
     assert!(
-        output_log.exists(),
+        subprocess_log.exists(),
         "subprocess.log should be created with -vv"
     );
 
@@ -444,7 +444,7 @@ fn test_vv_debug_pipeline_silent_on_stderr(repo: TestRepo) {
     // Stderr at -vv should contain the new pointer line (and the existing
     // diagnostic line), so the user knows where the trace went.
     assert!(
-        stderr.contains("Tracing to") && stderr.contains("trace.log"),
+        stderr.contains("Writing to") && stderr.contains("trace.log"),
         "stderr should announce the trace destination at -vv: {stderr}"
     );
 }
@@ -605,7 +605,7 @@ fn test_vv_writes_diagnostic_on_error(mut repo: TestRepo) {
 }
 
 /// If one of the `-vv` log files can't be opened (here: pre-existing path
-/// of the wrong type), the user still gets a "Tracing to ..." pointer for
+/// of the wrong type), the user still gets a "Writing to ..." pointer for
 /// the one that opened, and the elision marker reflects the asymmetric
 /// state instead of telling a `-vv` user to "rerun with -vv".
 #[rstest]
@@ -624,7 +624,7 @@ fn test_vv_pointer_handles_split_init(repo: TestRepo) {
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     assert!(
-        stderr.contains("Tracing to") && stderr.contains("trace.log"),
+        stderr.contains("Writing to") && stderr.contains("trace.log"),
         "stderr should point at trace.log even when subprocess.log can't open: {stderr}"
     );
     assert!(
@@ -697,7 +697,7 @@ fn test_vv_outside_repo_no_crash() {
     // announce_trace_destination took its early-return path.
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        !stderr.contains("Tracing to"),
+        !stderr.contains("Writing to"),
         "no startup pointer when trace.log can't open: {stderr}"
     );
 }

--- a/tests/snapshots/integration__integration_tests__diagnostic__diagnostic_file_format.snap
+++ b/tests/snapshots/integration__integration_tests__diagnostic__diagnostic_file_format.snap
@@ -64,5 +64,5 @@ Project config: _REPO_/.config/wt.toml
 <details>
 <summary>Raw subprocess output</summary>
 
-Full captured stdout/stderr is in `_REPO_/.git/wt/logs/subprocess.log` — not inlined because it can be multi-MB.
+Full captured stdout/stderr is in `_REPO_/.git/wt/logs/subprocess.log`.
 </details>


### PR DESCRIPTION
## Motivation

Follow-up cleanup surfaced after #2913 landed:

1. The `-vv` startup pointer listed `trace.log` and `subprocess.log` but never mentioned `diagnostic.md`, even though the gist-creation hint at exit points specifically at `diagnostic.md`. Users had no idea the bundle existed until exit.
2. The Jinja template field `output_log_path` and a test local `output_log` lagged behind the file rename in #2913 — values were correct but names disagreed.
3. While reshaping the pointer, the "Tracing to ..." verb read awkwardly ("Writing to ..." is more natural for "files are being written here").

## Change

- `src/logging.rs:490` — `announce_trace_destination` now prints the shared log directory once and lists all three files:

  ```
  ○ Writing to ~/.../wt/logs/ — trace.log, subprocess.log, diagnostic.md
  ```

  (When `subprocess.log` failed to open: `… — trace.log, diagnostic.md (subprocess.log unavailable)`.) `diagnostic.md` is named at startup even though it's written at exit — by the time a user reads the pointer and looks for files, all three are there.

- `src/diagnostic.rs` — `output_log_path` Jinja field + Rust local renamed to `subprocess_log_path`. Dropped the trailing `— not inlined because it can be multi-MB` clause from the template (matches the principle from #2913's review: describe what's there, not what isn't).

- `tests/integration_tests/diagnostic.rs:315` — local `output_log` → `subprocess_log`.

- Diagnostic snapshot re-accepted for the template wording change.

## Tests

3875 tests pass + lints + doctests. Pointer wording change is covered by `test_vv_debug_pipeline_silent_on_stderr` and `test_vv_pointer_handles_split_init`, both updated to assert "Writing to".

> _This was written by Claude Code on behalf of max-sixty_
