### PR TITLE
fix(clippy): fold nested if into match guard

### DIFF
--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -1159,7 +1159,7 @@ fn render_shell_status(out: &mut String) -> anyhow::Result<()> {
             ConfigAction::AlreadyExists => {
                 render_already_configured(out, result, &detection_results, &cmd, shell_active)?;
             }
-            ConfigAction::WouldAdd | ConfigAction::WouldCreate => {
+            ConfigAction::WouldAdd | ConfigAction::WouldCreate
                 if render_would_add_or_create(
                     out,
                     result,
@@ -1167,9 +1167,9 @@ fn render_shell_status(out: &mut String) -> anyhow::Result<()> {
                     legacy_fish_has_integration,
                     &cmd,
                     shell_active,
-                )? {
-                    any_not_configured = true;
-                }
+                )? =>
+            {
+                any_not_configured = true;
             }
             _ => {} // Added/Created won't appear in dry_run mode
         }


### PR DESCRIPTION
clippy 1.95.0 enables `collapsible_match` under `-D warnings`, breaking lint on the `WouldAdd | WouldCreate` arm in `render_shell_config_status`. The fix moves the `render_would_add_or_create(...)?` call into the arm guard. Behavior is unchanged: the call's output side effects still run during guard evaluation, and `any_not_configured` is set only when it returns true (a false result now falls through to the `_` arm, exactly as the old skipped `if` body did).

> _This was written by Claude Code on behalf of max_