### PR TITLE
ci: add lockfile pre-merge hook to catch a stale Cargo.lock

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -11,6 +11,12 @@ install = "cargo install --path ."
 sync = 'if [ "{{ target }}" = "main" ]; then git pull && git push; fi'
 
 [[pre-merge]]
+# Assert Cargo.lock is in sync with Cargo.toml before anything builds. Must be
+# first: a preceding unlocked cargo command (the insta hook's test runner, or a
+# pre-commit hook) would silently regenerate a stale lock and mask this check.
+# `--workspace` reconciles the lock against the manifests only; plain
+# `cargo update --locked` would also fail on dependencies merely behind latest.
+lockfile = "cargo update --workspace --locked"
 pre-commit = 'if [ -n "$MSYSTEM" ]; then SKIP=lychee-system pre-commit run --all-files; else pre-commit run --all-files; fi'
 insta = """RUSTFLAGS='-D warnings' NEXTEST_NO_INPUT_HANDLER=1 cargo insta test --test-runner nextest --dnd --check $([ "$(uname)" = 'Linux' ] && echo '--unreferenced reject') --features shell-integration-tests"""
 doctest = "RUSTDOCFLAGS='-Dwarnings' cargo test --doc"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -103,7 +103,7 @@ jobs:
         echo "TMP=D:\tmp" >> $env:GITHUB_ENV
 
     - name: 🧪 Pre-merge hooks
-      run: wt hook pre-merge --yes insta doctest doc
+      run: wt hook pre-merge --yes lockfile insta doctest doc
 
     # Anything tests leave behind in the working tree is a leak we want to see
     # before it lands. `target/` is gitignored, so a normal run is clean —


### PR DESCRIPTION
The pre-merge hooks run cargo unlocked, so a stale `Cargo.lock` gets silently regenerated instead of flagged. The existing "Verify clean working tree" step catches it only indirectly, after the regeneration, with a misleading `tests left files behind` error.

This adds a `lockfile` pre-merge hook (`cargo update --workspace --locked`) that runs first, before any unlocked cargo command can mask a stale lock, so CI fails fast with a clear message. `--workspace` reconciles the lock against the manifests; plain `cargo update --locked` would also fail on dependencies merely behind latest.

> _This was written by Claude Code on behalf of max_
