### PR TITLE
fix(statusline): space the context gauge emoji from its percent

### DIFF
--- a/.claude/skills/writing-user-outputs/SKILL.md
+++ b/.claude/skills/writing-user-outputs/SKILL.md
@@ -648,6 +648,28 @@ perform_squash()?;
 eprintln!("{}", success_message("Squashed @ a1b2c3d"));
 ```
 
+## Section and Glyph Spacing
+
+When composing tightly-packed output where adjacent pieces carry distinct
+meaning (the statusline segments, prefix-char indicators like `@+1`, `↓1`,
+`?^|`), pack sections flush — no separating space. The marker and its value
+read as one unit, and visual density keeps the line short.
+
+The one exception is **emoji**: leave a trailing space after an emoji glyph.
+Most terminals render emoji as double-width and bleed the glyph into the cell
+to its right, so a flush `🌔65%` collides the moon with the digits. A space
+(`🌔 65%`) keeps them legible. ASCII and narrow Unicode markers (`@`, `↓`, `●`,
+`⊂`) don't have this problem and stay flush.
+
+```rust
+// GOOD - ASCII marker flush with its value
+format!("@{added}");          // @+1
+// GOOD - emoji gets a trailing space to clear the next cell
+format!("{moon} {pct:.0}%");  // 🌔 65%
+// BAD - emoji runs into the digits; terminals overlap the glyph
+format!("{moon}{pct:.0}%");   // 🌔65%
+```
+
 ## Style Constants
 
 Only three `anstyle` constants exist for table rendering (`src/styling/constants.rs`):

--- a/docs/content/claude-code.md
+++ b/docs/content/claude-code.md
@@ -109,7 +109,7 @@ On session exit the worktree is offered for removal via the `WorktreeRemove` hoo
 
 `wt list statusline --format=claude-code` outputs a single-line status for the Claude Code statusline. When the CI status cache is stale, this fetches from the network — typically 1–2 seconds — making it suitable for async statuslines but too slow for synchronous shell prompts. If a faster version would be helpful, please [open an issue](https://github.com/max-sixty/worktrunk/issues).
 
-<code>~/w/myproject.feature-auth  !🤖  @<span style='color:#0a0'>+42</span> <span style='color:#a00'>-8</span>  <span style='color:#0a0'>↑3</span>  <span style='color:#0a0'>⇡1</span>  <span style='color:#0a0'>●</span>  Opus  🌔65%  <span style='color:#a70'>1.4×pace(10am–3pm)</span></code>
+<code>~/w/myproject.feature-auth  !🤖  @<span style='color:#0a0'>+42</span> <span style='color:#a00'>-8</span>  <span style='color:#0a0'>↑3</span>  <span style='color:#0a0'>⇡1</span>  <span style='color:#0a0'>●</span>  Opus  🌔 65%  <span style='color:#a70'>1.4×pace(10am–3pm)</span></code>
 
 When Claude Code provides context window usage via stdin JSON, a moon phase gauge appears (🌕→🌑 as context fills). A yellow `<n>×pace(<window>)` segment appears when Claude's 5-hour or weekly rate limit is on track to be hit before reset — `1.4×pace(10am–3pm)` reads as 1.4× the pace that would exactly fill that window.
 

--- a/skills/worktrunk/reference/claude-code.md
+++ b/skills/worktrunk/reference/claude-code.md
@@ -111,7 +111,7 @@ On session exit the worktree is offered for removal via the `WorktreeRemove` hoo
 
 `wt list statusline --format=claude-code` outputs a single-line status for the Claude Code statusline. When the CI status cache is stale, this fetches from the network — typically 1–2 seconds — making it suitable for async statuslines but too slow for synchronous shell prompts. If a faster version would be helpful, please [open an issue](https://github.com/max-sixty/worktrunk/issues).
 
-<code>~/w/myproject.feature-auth  !🤖  @<span style='color:#0a0'>+42</span> <span style='color:#a00'>-8</span>  <span style='color:#0a0'>↑3</span>  <span style='color:#0a0'>⇡1</span>  <span style='color:#0a0'>●</span>  Opus  🌔65%  <span style='color:#a70'>1.4×pace(10am–3pm)</span></code>
+<code>~/w/myproject.feature-auth  !🤖  @<span style='color:#0a0'>+42</span> <span style='color:#a00'>-8</span>  <span style='color:#0a0'>↑3</span>  <span style='color:#0a0'>⇡1</span>  <span style='color:#0a0'>●</span>  Opus  🌔 65%  <span style='color:#a70'>1.4×pace(10am–3pm)</span></code>
 
 When Claude Code provides context window usage via stdin JSON, a moon phase gauge appears (🌕→🌑 as context fills). A yellow `<n>×pace(<window>)` segment appears when Claude's 5-hour or weekly rate limit is on track to be hit before reset — `1.4×pace(10am–3pm)` reads as 1.4× the pace that would exactly fill that window.
 

--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -516,10 +516,12 @@ fn format_context_gauge(percentage: f64) -> String {
         91..=97 => '🌒',
         _ => '🌑',
     };
-    // Display the original percentage (not clamped) for transparency
-    // Emoji + percent runs together (no separator) to match the other
-    // prefix-char segments in the statusline: `@+1`, `↓1`, `?^|`.
-    format!("{symbol}{:.0}%", percentage)
+    // Display the original percentage (not clamped) for transparency.
+    // A space separates the moon emoji from the percent: unlike the ASCII
+    // prefix-char segments (`@+1`, `↓1`, `?^|`) that run flush, emoji glyphs
+    // are double-width and bleed into the next cell on most terminals, so they
+    // need a trailing space to keep from colliding with the digits.
+    format!("{symbol} {:.0}%", percentage)
 }
 
 /// Run the statusline command.
@@ -1002,38 +1004,38 @@ mod tests {
     fn test_context_gauge_formatting() {
         // Test boundary values for each moon phase symbol (waning - darker as context fills)
         // Thresholds use exponential halving: ratio 16:8:4:2:1, normalized to 100%
-        assert_eq!(format_context_gauge(0.0), "🌕0%");
-        assert_eq!(format_context_gauge(51.0), "🌕51%");
-        assert_eq!(format_context_gauge(52.0), "🌔52%");
-        assert_eq!(format_context_gauge(77.0), "🌔77%");
-        assert_eq!(format_context_gauge(78.0), "🌓78%");
-        assert_eq!(format_context_gauge(90.0), "🌓90%");
-        assert_eq!(format_context_gauge(91.0), "🌒91%");
-        assert_eq!(format_context_gauge(97.0), "🌒97%");
-        assert_eq!(format_context_gauge(98.0), "🌑98%");
-        assert_eq!(format_context_gauge(100.0), "🌑100%");
+        assert_eq!(format_context_gauge(0.0), "🌕 0%");
+        assert_eq!(format_context_gauge(51.0), "🌕 51%");
+        assert_eq!(format_context_gauge(52.0), "🌔 52%");
+        assert_eq!(format_context_gauge(77.0), "🌔 77%");
+        assert_eq!(format_context_gauge(78.0), "🌓 78%");
+        assert_eq!(format_context_gauge(90.0), "🌓 90%");
+        assert_eq!(format_context_gauge(91.0), "🌒 91%");
+        assert_eq!(format_context_gauge(97.0), "🌒 97%");
+        assert_eq!(format_context_gauge(98.0), "🌑 98%");
+        assert_eq!(format_context_gauge(100.0), "🌑 100%");
     }
 
     #[test]
     fn test_context_gauge_fractional_percentages() {
         // Fractional values are rounded (per {:.0} format specifier)
         // Rust uses banker's rounding (round half to even)
-        assert_eq!(format_context_gauge(42.7), "🌕43%"); // 43% is in 0-51% range
-        assert_eq!(format_context_gauge(0.4), "🌕0%");
-        assert_eq!(format_context_gauge(0.5), "🌕0%"); // banker's rounding: 0.5 rounds to even (0)
-        assert_eq!(format_context_gauge(1.5), "🌕2%"); // banker's rounding: 1.5 rounds to even (2)
-        assert_eq!(format_context_gauge(99.9), "🌑100%");
+        assert_eq!(format_context_gauge(42.7), "🌕 43%"); // 43% is in 0-51% range
+        assert_eq!(format_context_gauge(0.4), "🌕 0%");
+        assert_eq!(format_context_gauge(0.5), "🌕 0%"); // banker's rounding: 0.5 rounds to even (0)
+        assert_eq!(format_context_gauge(1.5), "🌕 2%"); // banker's rounding: 1.5 rounds to even (2)
+        assert_eq!(format_context_gauge(99.9), "🌑 100%");
     }
 
     #[test]
     fn test_context_gauge_edge_cases() {
         // Negative values: symbol clamps to bright (low usage), but display shows original value
-        assert_eq!(format_context_gauge(-5.0), "🌕-5%");
-        assert_eq!(format_context_gauge(-0.1), "🌕-0%"); // rounds to -0%
+        assert_eq!(format_context_gauge(-5.0), "🌕 -5%");
+        assert_eq!(format_context_gauge(-0.1), "🌕 -0%"); // rounds to -0%
 
         // Values over 100%: symbol clamps to dark (high usage), but display shows original value
-        assert_eq!(format_context_gauge(105.0), "🌑105%");
-        assert_eq!(format_context_gauge(150.0), "🌑150%");
+        assert_eq!(format_context_gauge(105.0), "🌑 105%");
+        assert_eq!(format_context_gauge(150.0), "🌑 150%");
     }
 
     #[test]

--- a/tests/integration_tests/statusline.rs
+++ b/tests/integration_tests/statusline.rs
@@ -247,7 +247,7 @@ fn test_statusline_claude_code_with_context_gauge(repo: TestRepo) {
 
     let output = run_statusline(&repo, &["--format=claude-code"], Some(&json));
     claude_code_snapshot_settings().bind(|| {
-        assert_snapshot!(output, @"[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕42%");
+        assert_snapshot!(output, @"[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕 42%");
     });
 }
 
@@ -264,7 +264,7 @@ fn test_statusline_claude_code_context_gauge_low(repo: TestRepo) {
 
     let output = run_statusline(&repo, &["--format=claude-code"], Some(&json));
     claude_code_snapshot_settings().bind(|| {
-        assert_snapshot!(output, @"[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕5%");
+        assert_snapshot!(output, @"[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕 5%");
     });
 }
 
@@ -281,7 +281,7 @@ fn test_statusline_claude_code_context_gauge_high(repo: TestRepo) {
 
     let output = run_statusline(&repo, &["--format=claude-code"], Some(&json));
     claude_code_snapshot_settings().bind(|| {
-        assert_snapshot!(output, @"[PATH]  main  [2m^[22m[2m|[22m  Opus  🌑98%");
+        assert_snapshot!(output, @"[PATH]  main  [2m^[22m[2m|[22m  Opus  🌑 98%");
     });
 }
 

--- a/tests/snapshots/integration__integration_tests__statusline__rate_limit_5h_24h_locale.snap
+++ b/tests/snapshots/integration__integration_tests__statusline__rate_limit_5h_24h_locale.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/statusline.rs
 expression: out
 ---
-[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕42%  [33m1.3×pace(10:00–15:00)[39m
+[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕 42%  [33m1.3×pace(10:00–15:00)[39m

--- a/tests/snapshots/integration__integration_tests__statusline__rate_limit_5h_at_limit.snap
+++ b/tests/snapshots/integration__integration_tests__statusline__rate_limit_5h_at_limit.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/statusline.rs
 expression: out
 ---
-[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕42%  [33m1.7×pace(10am–3pm)[39m
+[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕 42%  [33m1.7×pace(10am–3pm)[39m

--- a/tests/snapshots/integration__integration_tests__statusline__rate_limit_5h_clock_time.snap
+++ b/tests/snapshots/integration__integration_tests__statusline__rate_limit_5h_clock_time.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/statusline.rs
 expression: out
 ---
-[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕42%  [33m1.3×pace(10am–3pm)[39m
+[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕 42%  [33m1.3×pace(10am–3pm)[39m

--- a/tests/snapshots/integration__integration_tests__statusline__rate_limit_5h_with_minutes.snap
+++ b/tests/snapshots/integration__integration_tests__statusline__rate_limit_5h_with_minutes.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/statusline.rs
 expression: out
 ---
-[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕42%  [33m1.1×pace(8:30am–1:30pm)[39m
+[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕 42%  [33m1.1×pace(8:30am–1:30pm)[39m

--- a/tests/snapshots/integration__integration_tests__statusline__rate_limit_7d_with_day_and_time.snap
+++ b/tests/snapshots/integration__integration_tests__statusline__rate_limit_7d_with_day_and_time.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/statusline.rs
 expression: out
 ---
-[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕42%  [33m1.9×pace(Mon–Mon 3pm)[39m
+[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕 42%  [33m1.9×pace(Mon–Mon 3pm)[39m

--- a/tests/snapshots/integration__integration_tests__statusline__rate_limit_both_picks_worse.snap
+++ b/tests/snapshots/integration__integration_tests__statusline__rate_limit_both_picks_worse.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/statusline.rs
 expression: out
 ---
-[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕42%  [33m1.9×pace(Mon–Mon 3pm)[39m
+[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕 42%  [33m1.9×pace(Mon–Mon 3pm)[39m

--- a/tests/snapshots/integration__integration_tests__statusline__rate_limit_drops_at_narrow_width.snap
+++ b/tests/snapshots/integration__integration_tests__statusline__rate_limit_drops_at_narrow_width.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/statusline.rs
 expression: out
 ---
-[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕42%
+[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕 42%

--- a/tests/snapshots/integration__integration_tests__statusline__rate_limit_hidden_when_safe.snap
+++ b/tests/snapshots/integration__integration_tests__statusline__rate_limit_hidden_when_safe.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/statusline.rs
 expression: out
 ---
-[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕42%
+[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕 42%

--- a/tests/snapshots/integration__integration_tests__statusline__rate_limit_with_dirty_worktree_and_context.snap
+++ b/tests/snapshots/integration__integration_tests__statusline__rate_limit_with_dirty_worktree_and_context.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/statusline.rs
 expression: out
 ---
-[PATH]  main  [36m?[0m[2m^[22m[2m|[22m  @[32m+1[0m  Opus  🌒95%  [33m1.3×pace(10am–3pm)[39m
+[PATH]  main  [36m?[0m[2m^[22m[2m|[22m  @[32m+1[0m  Opus  🌒 95%  [33m1.3×pace(10am–3pm)[39m


### PR DESCRIPTION
The context gauge in the Claude Code statusline rendered the moon-phase emoji flush against the percent (`🌕42%`). Most terminals draw emoji as double-width and bleed the glyph into the cell to its right, so the moon visually collided with the digits. This adds a trailing space — `🌕 42%`.

The flush-packing convention still holds for ASCII and narrow markers (`@+1`, `↓1`, `●`); emoji are the exception. That distinction is now documented in the `writing-user-outputs` skill so future output keeps it consistent.

Tests, the three inline statusline snapshots, nine rate-limit `.snap` files, and the hand-authored docs example (auto-synced to the skill reference) are all updated.

> _This was written by Claude Code on behalf of max_
