### PR TITLE
fix(bare-repo): UX fixes for worktree-path prompt and `wt config create --project` in bare repos

### DIFF
--- a/docs/content/tips-patterns.md
+++ b/docs/content/tips-patterns.md
@@ -439,14 +439,14 @@ myproject/
 
 ### Configure the worktree path
 
-When you run `wt switch` for the first time in a bare repo at a hidden path (`.git`, `.bare`), worktrunk detects that the default template would produce broken paths like `myproject/.git.main` and offers to fix it automatically:
+On first `wt switch` in a bare repo at a hidden path (`.git`, `.bare`), worktrunk detects that the default template would produce broken paths like `myproject/.git.main` and offers a fix:
 
 ```
 ▲ Bare repo at myproject/.git — worktrees will be at myproject/.git.main
 ◎ Configure worktree-path to place worktrees at myproject/main? [y/N/?]
 ```
 
-Accepting writes a project-scoped entry to your user config:
+Accepting writes a project-scoped entry to user config:
 
 ```toml
 # ~/.config/worktrunk/config.toml

--- a/docs/content/tips-patterns.md
+++ b/docs/content/tips-patterns.md
@@ -432,20 +432,42 @@ With `worktree-path = "{{ repo_path }}/../{{ branch | sanitize }}"`, worktrees b
 ```
 myproject/
 ├── .git/       # bare repository
-├── main/       # default branch
-├── feature/    # feature branch
-└── bugfix/     # bugfix branch
+├── main/       # default branch worktree
+├── feature/    # feature branch worktree
+└── bugfix/     # bugfix branch worktree
 ```
 
-Configure worktrunk:
+### Configure the worktree path
+
+When you run `wt switch` for the first time in a bare repo at a hidden path (`.git`, `.bare`), worktrunk detects that the default template would produce broken paths like `myproject/.git.main` and offers to fix it automatically:
+
+```
+▲ Bare repo at myproject/.git — worktrees will be at myproject/.git.main
+◎ Configure worktree-path to place worktrees at myproject/main? [y/N/?]
+```
+
+Accepting writes a project-scoped entry to your user config:
 
 ```toml
 # ~/.config/worktrunk/config.toml
+[projects."github.com/myorg/myrepo"]
 worktree-path = "{{ repo_path }}/../{{ branch | sanitize }}"
 ```
 
-Create the first worktree:
+Run `wt config show` from inside any worktree to find the project identifier (`Identifier: …` in the PROJECT CONFIG section). Set it globally with `worktree-path = "..."` at the top level if this layout is preferred for all bare repos.
 
-{{ terminal(cmd="wt switch --create main") }}
+### Create the first worktree
+
+{{ terminal(cmd="wt switch main") }}
+
+For a freshly cloned bare repo the default branch already exists, so `wt switch main` (without `--create`) is enough. Use `wt switch --create <branch>` for new branches.
 
 Now `wt switch --create feature` creates `myproject/feature/`.
+
+### Set up the project config
+
+The project config (`.config/wt.toml`) must live inside a worktree — the bare `.git` directory has no tracked files. Once the first worktree exists, create it from there:
+
+{{ terminal(cmd="cd myproject/main|||wt config create --project") }}
+
+Commit the file and it will appear in every worktree automatically.

--- a/skills/worktrunk/reference/tips-patterns.md
+++ b/skills/worktrunk/reference/tips-patterns.md
@@ -463,14 +463,14 @@ myproject/
 
 ### Configure the worktree path
 
-When you run `wt switch` for the first time in a bare repo at a hidden path (`.git`, `.bare`), worktrunk detects that the default template would produce broken paths like `myproject/.git.main` and offers to fix it automatically:
+On first `wt switch` in a bare repo at a hidden path (`.git`, `.bare`), worktrunk detects that the default template would produce broken paths like `myproject/.git.main` and offers a fix:
 
 ```
 ▲ Bare repo at myproject/.git — worktrees will be at myproject/.git.main
 ◎ Configure worktree-path to place worktrees at myproject/main? [y/N/?]
 ```
 
-Accepting writes a project-scoped entry to your user config:
+Accepting writes a project-scoped entry to user config:
 
 ```toml
 # ~/.config/worktrunk/config.toml

--- a/skills/worktrunk/reference/tips-patterns.md
+++ b/skills/worktrunk/reference/tips-patterns.md
@@ -456,22 +456,47 @@ With `worktree-path = "{{ repo_path }}/../{{ branch | sanitize }}"`, worktrees b
 ```
 myproject/
 ├── .git/       # bare repository
-├── main/       # default branch
-├── feature/    # feature branch
-└── bugfix/     # bugfix branch
+├── main/       # default branch worktree
+├── feature/    # feature branch worktree
+└── bugfix/     # bugfix branch worktree
 ```
 
-Configure worktrunk:
+### Configure the worktree path
+
+When you run `wt switch` for the first time in a bare repo at a hidden path (`.git`, `.bare`), worktrunk detects that the default template would produce broken paths like `myproject/.git.main` and offers to fix it automatically:
+
+```
+▲ Bare repo at myproject/.git — worktrees will be at myproject/.git.main
+◎ Configure worktree-path to place worktrees at myproject/main? [y/N/?]
+```
+
+Accepting writes a project-scoped entry to your user config:
 
 ```toml
 # ~/.config/worktrunk/config.toml
+[projects."github.com/myorg/myrepo"]
 worktree-path = "{{ repo_path }}/../{{ branch | sanitize }}"
 ```
 
-Create the first worktree:
+Run `wt config show` from inside any worktree to find the project identifier (`Identifier: …` in the PROJECT CONFIG section). Set it globally with `worktree-path = "..."` at the top level if this layout is preferred for all bare repos.
+
+### Create the first worktree
 
 ```bash
-wt switch --create main
+wt switch main
 ```
 
+For a freshly cloned bare repo the default branch already exists, so `wt switch main` (without `--create`) is enough. Use `wt switch --create <branch>` for new branches.
+
 Now `wt switch --create feature` creates `myproject/feature/`.
+
+### Set up the project config
+
+The project config (`.config/wt.toml`) must live inside a worktree — the bare `.git` directory has no tracked files. Once the first worktree exists, create it from there:
+
+```bash
+cd myproject/main
+wt config create --project
+```
+
+Commit the file and it will appear in every worktree automatically.

--- a/src/commands/config/create.rs
+++ b/src/commands/config/create.rs
@@ -43,9 +43,16 @@ pub(super) fn comment_out_config(content: &str) -> String {
 pub fn handle_config_create(project: bool) -> anyhow::Result<()> {
     if project {
         let repo = Repository::current()?;
-        let config_path = repo
-            .project_config_path()?
-            .context("Cannot determine project config location — no worktree found")?;
+        let config_path = repo.project_config_path()?.ok_or_else(|| {
+            if repo.is_bare().unwrap_or(false) {
+                anyhow::anyhow!(
+                    "Bare repository has no linked worktrees yet.\n\
+                     Run `wt switch <branch>` to create a worktree first, then run `wt config create --project` from inside it."
+                )
+            } else {
+                anyhow::anyhow!("Cannot determine project config location — no worktree found")
+            }
+        })?;
         let user_config_exists = require_config_path().map(|p| p.exists()).unwrap_or(false);
         create_config_file(
             config_path,

--- a/src/commands/worktree/resolve.rs
+++ b/src/commands/worktree/resolve.rs
@@ -199,8 +199,16 @@ fn template_references_repo_name(template: &str) -> bool {
 pub fn offer_bare_repo_worktree_path_fix(
     repo: &Repository,
     config: &mut UserConfig,
+    branch: &str,
 ) -> anyhow::Result<bool> {
     if !repo.is_bare()? {
+        return Ok(false);
+    }
+
+    // Symbolic identifiers (-, @, ^, pr:N, mr:N) haven't been resolved to a real
+    // branch name yet, so the example paths would be misleading. Skip the prompt;
+    // it will surface on the next switch with a concrete branch name.
+    if branch == "-" || branch == "@" || branch == "^" || branch.contains(':') {
         return Ok(false);
     }
 
@@ -235,9 +243,12 @@ pub fn offer_bare_repo_worktree_path_fix(
         .and_then(|n| n.to_str())
         .unwrap_or("project");
 
-    // Example paths to show the user what changes
-    let example_bad = format!("{parent_name}/{repo_name}.feature-auth");
-    let example_good = format!("{parent_name}/feature-auth");
+    // Use the actual branch being switched to in example paths. Calling
+    // `sanitize_branch_name` keeps the displayed example aligned with what
+    // the `sanitize` Jinja filter applies inside `BARE_REPO_WORKTREE_PATH`.
+    let sanitized = worktrunk::config::sanitize_branch_name(branch);
+    let example_bad = format!("{parent_name}/{repo_name}.{sanitized}");
+    let example_good = format!("{parent_name}/{sanitized}");
 
     let config_path_display = worktrunk::config::config_path()
         .map(|p| format_path_for_display(&p).to_string())

--- a/src/commands/worktree/switch.rs
+++ b/src/commands/worktree/switch.rs
@@ -1573,7 +1573,7 @@ impl SwitchPipeline<'_> {
 
         // Offer to fix worktree-path for bare repos with hidden directory names
         // (.git, .bare) before anything reads worktree-path config.
-        offer_bare_repo_worktree_path_fix(repo, config)?;
+        offer_bare_repo_worktree_path_fix(repo, config, identifier)?;
 
         // Run pre-switch hooks before branch resolution or worktree creation.
         // {{ branch }} receives the raw user input (before resolution). Skip

--- a/tests/integration_tests/bare_repository.rs
+++ b/tests/integration_tests/bare_repository.rs
@@ -1554,6 +1554,32 @@ fn test_bare_repo_worktree_path_prompt_non_interactive_warning() {
     });
 }
 
+/// Symbolic identifiers (-, @, pr:N) are passed before branch resolution, so
+/// the example paths in the prompt would show the raw symbol. The function
+/// must return early without prompting.
+#[test]
+fn test_bare_repo_worktree_path_prompt_skipped_for_symbolic_identifier() {
+    let test = setup_unconfigured_nested_bare_repo();
+    let main_worktree = test.project_path().join("main");
+
+    // `@` means HEAD — resolves to `main`, which already exists. The prompt
+    // must not appear because `@` is a symbolic form.
+    let mut cmd = wt_command();
+    test.configure_wt_cmd(&mut cmd);
+    cmd.args(["switch", "@"]).current_dir(&main_worktree);
+    let output = cmd.output().unwrap();
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Configure worktree-path"),
+        "Prompt should not appear for symbolic identifier '@', got: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Bare repo at"),
+        "Warning should not appear for symbolic identifier '@', got: {stderr}"
+    );
+}
+
 // =============================================================================
 // PTY-based interactive prompt tests
 // =============================================================================

--- a/tests/integration_tests/config_init.rs
+++ b/tests/integration_tests/config_init.rs
@@ -119,3 +119,16 @@ run = "echo hello"
         ");
     });
 }
+
+/// Running `wt config create --project` from inside a repo's `.git` directory
+/// (not inside a worktree, not a bare repo) must fail with the generic
+/// "no worktree found" error rather than the bare-repo-specific message.
+#[rstest]
+fn test_config_create_project_from_git_dir_errors(repo: TestRepo) {
+    let git_dir = repo.path().join(".git");
+    let settings = setup_snapshot_settings(&repo);
+    settings.bind(|| {
+        let mut cmd = make_snapshot_cmd(&repo, "config", &["create", "--project"], Some(&git_dir));
+        assert_cmd_snapshot!(cmd);
+    });
+}

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_prompt_pty__bare_repo_prompt_accept.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_prompt_pty__bare_repo_prompt_accept.snap
@@ -2,9 +2,9 @@
 source: tests/integration_tests/bare_repository.rs
 expression: "&output"
 ---
-[33m▲[39m [33mBare repo at [1mproject/.git[22m — worktrees will be at [1mproject/.git.feature-auth[22m[39m
+[33m▲[39m [33mBare repo at [1mproject/.git[22m — worktrees will be at [1mproject/.git.feature[22m[39m
 
-[36m❯[39m Configure worktree-path to place worktrees at [1mproject/feature-auth[22m? [1m[y/N/?][22m y
+[36m❯[39m Configure worktree-path to place worktrees at [1mproject/feature[22m? [1m[y/N/?][22m y
 [32m✓[39m [32mSet [1mworktree-path[22m for [1m[TEMP]/project[22m:[39m
 [107m [0m [2mworktree-path = [0m[2m[32m"{{ repo_path }}/../{{ branch | sanitize }}"[0m
 [2m↳[22m [2mTo set globally, add to [4m[TEMP]/test-config.toml[24m[22m

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_prompt_pty__bare_repo_prompt_decline.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_prompt_pty__bare_repo_prompt_decline.snap
@@ -2,9 +2,9 @@
 source: tests/integration_tests/bare_repository.rs
 expression: "&output"
 ---
-[33m▲[39m [33mBare repo at [1mproject/.git[22m — worktrees will be at [1mproject/.git.feature-auth[22m[39m
+[33m▲[39m [33mBare repo at [1mproject/.git[22m — worktrees will be at [1mproject/.git.feature[22m[39m
 
-[36m❯[39m Configure worktree-path to place worktrees at [1mproject/feature-auth[22m? [1m[y/N/?][22m n
+[36m❯[39m Configure worktree-path to place worktrees at [1mproject/feature[22m? [1m[y/N/?][22m n
 [32m✓[39m [32mCreated branch [1mfeature[22m and worktree @ [1m[TEMP]/project/.git.feature[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_prompt_pty__bare_repo_prompt_preview.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_prompt_pty__bare_repo_prompt_preview.snap
@@ -2,14 +2,14 @@
 source: tests/integration_tests/bare_repository.rs
 expression: "&output"
 ---
-[33m▲[39m [33mBare repo at [1mproject/.git[22m — worktrees will be at [1mproject/.git.feature-auth[22m[39m
+[33m▲[39m [33mBare repo at [1mproject/.git[22m — worktrees will be at [1mproject/.git.feature[22m[39m
 
-[36m❯[39m Configure worktree-path to place worktrees at [1mproject/feature-auth[22m? [1m[y/N/?][22m ?
+[36m❯[39m Configure worktree-path to place worktrees at [1mproject/feature[22m? [1m[y/N/?][22m ?
 [2m○[22m Would add to [1m[TEMP]/test-config.toml[22m:
 [107m [0m [2m[36m[projects."[TEMP]/project/.git"][0m
 [107m [0m [2mworktree-path = [0m[2m[32m"{{ repo_path }}/../{{ branch | sanitize }}"[0m
 
-[36m❯[39m Configure worktree-path to place worktrees at [1mproject/feature-auth[22m? [1m[y/N/?][22m n
+[36m❯[39m Configure worktree-path to place worktrees at [1mproject/feature[22m? [1m[y/N/?][22m n
 [32m✓[39m [32mCreated branch [1mfeature[22m and worktree @ [1m[TEMP]/project/.git.feature[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_worktree_path_prompt_non_interactive_warning.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_worktree_path_prompt_non_interactive_warning.snap
@@ -11,15 +11,20 @@ info:
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
     GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
     GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
     GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
     LANG: C
     LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
     NO_COLOR: ""
     PSModulePath: ""
-    RUST_LOG: warn
     SHELL: ""
     TERM: alacritty
     WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
@@ -27,21 +32,27 @@ info:
     WORKTRUNK_DIRECTIVE_CD_FILE: "[DIRECTIVE_CD_FILE]"
     WORKTRUNK_DIRECTIVE_EXEC_FILE: "[DIRECTIVE_EXEC_FILE]"
     WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
     WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
     WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
 ---
 success: true
 exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-▲ Bare repo at project/.git — worktrees will be at project/.git.feature-auth
-↳ To place worktrees at project/feature-auth, add to [TEMP]/test-config.toml:
+▲ Bare repo at project/.git — worktrees will be at project/.git.feature
+↳ To place worktrees at project/feature, add to [TEMP]/test-config.toml:
   [projects."[TEMP]/project/.git"]
   worktree-path = "{{ repo_path }}/../{{ branch | sanitize }}"
 ✓ Created branch feature and worktree @ [TEMP]/project/.git.feature

--- a/tests/snapshots/integration__integration_tests__config_init__config_create_project_from_git_dir_errors.snap
+++ b/tests/snapshots/integration__integration_tests__config_init__config_create_project_from_git_dir_errors.snap
@@ -1,14 +1,14 @@
 ---
-source: tests/integration_tests/bare_repository.rs
+source: tests/integration_tests/config_init.rs
 info:
   program: wt
   args:
-    - switch
-    - "--create"
-    - feature
-    - "--yes"
+    - config
+    - create
+    - "--project"
   env:
-    CLICOLOR_FORCE: ""
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
@@ -21,17 +21,20 @@ info:
     GIT_OBJECT_DIRECTORY: ""
     GIT_TERMINAL_PROMPT: "0"
     GIT_WORK_TREE: ""
+    HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
     LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
     PSModulePath: ""
     SHELL: ""
     TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
     WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
     WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
-    WORKTRUNK_DIRECTIVE_CD_FILE: "[DIRECTIVE_CD_FILE]"
-    WORKTRUNK_DIRECTIVE_EXEC_FILE: "[DIRECTIVE_EXEC_FILE]"
     WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
     WORKTRUNK_TEST_BASH_INSTALLED: "0"
     WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
@@ -46,16 +49,11 @@ info:
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
-success: true
-exit_code: 0
+success: false
+exit_code: 1
 ----- stdout -----
 
 ----- stderr -----
-▲ Bare repo at project/.git — worktrees will be at project/.git.feature
-↳ To place worktrees at project/feature, add to [TEMP]/test-config.toml:
-  [projects."[TEMP]/project/.git"]
-  worktree-path = "{{ repo_path }}/../{{ branch | sanitize }}"
-✓ Created branch feature and worktree @ [TEMP]/project/.git.feature
-↳ To customize worktree locations, run wt config create
-[0m
+[31m✗[39m [31mCannot determine project config location — no worktree found[39m


### PR DESCRIPTION
## Problem

Three UX issues in the bare-repository workflow documented in [Tips & Patterns](https://worktrunk.dev/tips-patterns/#bare-repository-layout).

### Bug 1: Example paths use a hardcoded placeholder branch

When `wt switch` detects a bare repo at a hidden path (`.git`, `.bare`), the warning and prompt previously showed:

```
▲ Bare repo at camel/.git — worktrees will be at camel/.git.feature-auth
```

The `feature-auth` placeholder was hardcoded regardless of the branch being switched to. Switching to `main` produced a confusing mismatch between what was shown and what would actually happen.

### Bug 2: Symbolic identifiers showed unresolved input in the prompt

Switching with `wt switch @`, `wt switch -`, `wt switch ^`, or `wt switch pr:123` triggered the prompt with the literal symbol in the example path (`camel/.git.@`, etc.), which is meaningless. The symbol isn't a branch name — it gets resolved later. Skip the prompt for those; it surfaces on the next switch with a concrete branch.

### Bug 3: `wt config create --project` gives an unhelpful error in bare repos with no worktrees

Running `wt config create --project` from a bare repo root with no linked worktrees yet failed with:

```
Cannot determine project config location — no worktree found
```

No indication of why this happened or what to do next.

### Bug 4: Docs are vague about the bare-repo setup order

The Tips & Patterns bare-repo section told users to set `worktree-path` globally in user config, affecting all repos. It didn't mention the per-project `[projects."..."]` override, didn't clarify that `wt switch main` (without `--create`) works for existing branches on a freshly cloned bare repo, and didn't explain that the project config must be created from inside a worktree.

---

## Solution

1. **Pass the actual branch into `offer_bare_repo_worktree_path_fix`** and use it (with `/` and `\` sanitized to `-`) in the warning and preview messages.
2. **Skip the prompt for symbolic identifiers** (`-`, `@`, `^`, `pr:N`, `mr:N`).
3. **Bare-repo-aware error for `wt config create --project`** — points the user at `wt switch <branch>` as the next step.
4. **Restructure the Tips & Patterns bare-repo section** into three subsections (Configure the worktree path / Create the first worktree / Set up the project config) explaining the per-project `[projects."..."]` scope, when `--create` is needed, and the chicken-and-egg constraint on `.config/wt.toml`.

---

## Out of scope

The original PR also added a per-clone `worktrunk.worktree-path` git-config key as a third scope alongside per-remote and global user-config. That's a more invasive change (new exception in the config-resolution chain) and is split out into a follow-up PR — see #2953.

---

## Testing

- `test_bare_repo_worktree_path_prompt_auto_accept` / `..._non_interactive_warning` — snapshots now show the actual branch name (`feature`) instead of hardcoded `feature-auth`.
- `test_bare_repo_worktree_path_prompt_skipped_for_symbolic_identifier` — new test confirming `wt switch @` skips the prompt in an unconfigured bare repo.
- `test_config_create_project_from_git_dir_errors` — new test confirming the generic error fires from a non-bare repo's `.git` directory (the bare-repo-specific message only fires for bare repos).
- `test_docs_are_in_sync` passes.

Co-authored with @ammachado from the original PR.
