### PR TITLE
fix: prevent console storm on windows

### DIFF
--- a/src/commands/process.rs
+++ b/src/commands/process.rs
@@ -283,9 +283,9 @@ fn spawn_detached_windows(
     use worktrunk::shell_exec::ShellConfig;
 
     // CREATE_NEW_PROCESS_GROUP: Creates new process group (0x00000200)
-    // DETACHED_PROCESS: Creates process without console (0x00000008)
+    // CREATE_NO_WINDOW: Creates process without console window (0x08000000)
     const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
-    const DETACHED_PROCESS: u32 = 0x00000008;
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
 
     let shell = ShellConfig::get()?;
 
@@ -320,12 +320,12 @@ fn spawn_detached_windows(
                 .context("Failed to clone log file handle")?,
         ))
         .stderr(Stdio::from(log_file))
-        .creation_flags(CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS);
+        .creation_flags(CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
     // Prevent hooks from writing to the directive file
     worktrunk::shell_exec::scrub_directive_env_vars(&mut cmd);
     cmd.spawn().context("Failed to spawn detached process")?;
 
-    // Windows: Process is fully detached via DETACHED_PROCESS flag,
+    // Windows: Process is fully detached with a hidden window via CREATE_NO_WINDOW flag,
     // no need to wait (unlike Unix which waits for the outer shell)
 
     Ok(())
@@ -455,7 +455,7 @@ fn spawn_detached_exec_windows(
     use std::os::windows::process::CommandExt;
 
     const CREATE_NEW_PROCESS_GROUP: u32 = 0x00000200;
-    const DETACHED_PROCESS: u32 = 0x00000008;
+    const CREATE_NO_WINDOW: u32 = 0x08000000;
 
     let mut cmd = Command::new(program);
     cmd.args(args)
@@ -467,7 +467,7 @@ fn spawn_detached_exec_windows(
                 .context("Failed to clone log file handle")?,
         ))
         .stderr(Stdio::from(log_file))
-        .creation_flags(CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS);
+        .creation_flags(CREATE_NEW_PROCESS_GROUP | CREATE_NO_WINDOW);
     worktrunk::shell_exec::scrub_directive_env_vars(&mut cmd);
     set_background_hook_env(&mut cmd, is_background_hook);
     let mut child = cmd.spawn().context("Failed to spawn detached process")?;


### PR DESCRIPTION
**Tl;dr:** Background steps during hooks like `[post-start]` briefly spawn visible consoles on Windows. The fix is to use `CREATE_NO_WINDOW`. Apart from suppressing the console windows, it functions identically.

---

From [**Process Creation Flags** (Microsoft Learn)](https://learn.microsoft.com/en-us/windows/win32/procthread/process-creation-flags):

`DETACHED_PROCESS` — `0x00000008`

> For console processes, the new process does not inherit its parent's console (the default). The new process can call the [`AllocConsole`](https://learn.microsoft.com/en-us/windows/console/allocconsole) function at a later time to create a console. For more information, see [Creation of a Console](https://learn.microsoft.com/en-us/windows/console/creation-of-a-console). This value cannot be used with `CREATE_NEW_CONSOLE`.

`CREATE_NO_WINDOW` — `0x08000000`

> The process is a console application that is being run without a console window. Therefore, the console handle for the application is not set. This flag is ignored if the application is not a console application, or if it is used with either `CREATE_NEW_CONSOLE` or `DETACHED_PROCESS`.

---

Verified locally on a `wt.toml` that had 4 pre-start hooks (some semi long-running like a `pnpm install`)

<table><thead><tr><th>Before</th><th>After</th></tr></thead>
<tbody><tr><td>

[worktrunk-console-storm-before.webm](https://github.com/user-attachments/assets/4e88b798-e2d0-43a1-a750-da1eb41ece76)

</td><td>

[worktrunk-console-storm-after.webm](https://github.com/user-attachments/assets/d572cc6d-7d39-40ff-a851-afb5ff733972)

</td></tr></tbody></table>