### PR TITLE
Fix Claude hooks for Fish shell users.

### DIFF
--- a/plugins/worktrunk/CLAUDE.md
+++ b/plugins/worktrunk/CLAUDE.md
@@ -21,7 +21,7 @@ worktrunk/                          ← repo root = marketplace root
     ├── .codex-plugin/plugin.json   ← Codex manifest (Codex's required wrapper)
     ├── hooks/hooks.json            ← Claude activity + WorktreeCreate/Remove hooks
     ├── hooks/wt.sh                 ← canonical hook shim; Claude/Codex reach it via
-    │                                  ${CLAUDE_PLUGIN_ROOT}, Gemini via
+    │                                  $CLAUDE_PLUGIN_ROOT, Gemini via
     │                                  ${extensionPath}/plugins/worktrunk/hooks/wt.sh
     ├── skills -> ../../skills       ← symlink; single-sources skills across all
     │                                  tools and the docs auto-sync
@@ -35,7 +35,7 @@ Path resolution differs by tool, all verified end-to-end against the real CLIs:
   Claude reads `plugins/worktrunk/plugin.json` (at the plugin root, *not* a
   `.claude-plugin/` subdir). `hooks` and `skills` paths in `plugin.json` resolve
   from the plugin root, so `./skills/worktrunk` follows the `skills` symlink to
-  the repo-root `skills/worktrunk`. `${CLAUDE_PLUGIN_ROOT}` is the plugin root.
+  the repo-root `skills/worktrunk`. `$CLAUDE_PLUGIN_ROOT` is the plugin root.
 - **Codex**: `.agents/plugins/marketplace.json` `source` object
   `{ "source": "local", "path": "./plugins/worktrunk" }`. Codex reads
   `plugins/worktrunk/.codex-plugin/plugin.json`. `skills: "./skills/"` resolves

--- a/plugins/worktrunk/hooks/hooks.json
+++ b/plugins/worktrunk/hooks/hooks.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/wt.sh\" config state marker set 🤖 || true"
+            "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/wt.sh\" config state marker set 🤖 || true"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/wt.sh\" config state marker set 💬 || true"
+            "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/wt.sh\" config state marker set 💬 || true"
           }
         ]
       }
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/wt.sh\" config state marker clear || true"
+            "command": "bash \"$CLAUDE_PLUGIN_ROOT/hooks/wt.sh\" config state marker clear || true"
           }
         ]
       }
@@ -37,7 +37,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.name' | xargs -I{} bash \"${CLAUDE_PLUGIN_ROOT}/hooks/wt.sh\" switch --create {} --no-cd --format=json | jq -r '.path'"
+            "command": "jq -r '.name' | xargs -I{} bash \"$CLAUDE_PLUGIN_ROOT/hooks/wt.sh\" switch --create {} --no-cd --format=json | jq -r '.path'"
           }
         ]
       }
@@ -47,7 +47,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "jq -r '.worktree_path' | xargs bash \"${CLAUDE_PLUGIN_ROOT}/hooks/wt.sh\" remove --foreground"
+            "command": "jq -r '.worktree_path' | xargs bash \"$CLAUDE_PLUGIN_ROOT/hooks/wt.sh\" remove --foreground"
           }
         ]
       }

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -3909,7 +3909,7 @@ fn test_plugin_layout_is_consolidated() {
     );
     assert!(
         !read("plugins/worktrunk/hooks/hooks.json").contains(".claude-plugin/hooks/"),
-        "hooks.json must reference ${{CLAUDE_PLUGIN_ROOT}}/hooks/wt.sh, not the old wrapper path"
+        "hooks.json must reference $CLAUDE_PLUGIN_ROOT/hooks/wt.sh, not the old wrapper path"
     );
 
     // The description is duplicated across the Claude marketplace pointer and
@@ -3987,6 +3987,35 @@ fn test_plugin_layout_is_consolidated() {
     // and prints a `wt remove -D <branch>` hint for the user to act on.
     let hooks = read("plugins/worktrunk/hooks/hooks.json");
     let hooks_json = json("plugins/worktrunk/hooks/hooks.json");
+
+    // Claude hands each hook command to the user's LOGIN shell before `bash`
+    // launches, so the outer command line must parse under fish/zsh/bash. fish
+    // rejects bash brace syntax ("Variables cannot be bracketed"), so the plugin
+    // root must be referenced as `$CLAUDE_PLUGIN_ROOT`, never `${CLAUDE_PLUGIN_ROOT}`.
+    let all_commands: Vec<&str> = hooks_json["hooks"]
+        .as_object()
+        .expect("hooks.json must have a `hooks` object")
+        .values()
+        .flat_map(|event| event.as_array().expect("each hook event must be an array"))
+        .flat_map(|group| {
+            group["hooks"]
+                .as_array()
+                .expect("each hook group must have a `hooks` array")
+        })
+        .map(|hook| {
+            hook["command"]
+                .as_str()
+                .expect("each hook must define a command")
+        })
+        .collect();
+    for cmd in &all_commands {
+        assert!(
+            cmd.contains("$CLAUDE_PLUGIN_ROOT") && !cmd.contains("${CLAUDE_PLUGIN_ROOT}"),
+            "hook command must use unbraced $CLAUDE_PLUGIN_ROOT (braces break fish \
+             login-shell parsing: \"fish: Variables cannot be bracketed\"). command:\n{cmd}"
+        );
+    }
+
     let worktree_remove_cmd = hooks_json["hooks"]["WorktreeRemove"][0]["hooks"][0]["command"]
         .as_str()
         .expect("WorktreeRemove hook must define a command");
@@ -4020,6 +4049,60 @@ fn test_plugin_layout_is_consolidated() {
             val.starts_with(STEM),
             "{label} description must start with the canonical product sentence; got: {val}"
         );
+    }
+}
+
+/// Claude hands each hook `command` to the user's LOGIN shell, which parses the
+/// whole line before the leading `bash …` ever launches. The command must
+/// therefore parse cleanly under fish, zsh, and bash — fish in particular
+/// rejects bash brace syntax (`${VAR}` → "Variables cannot be bracketed"). This
+/// syntax-checks every Claude hook command under all three shells with their
+/// no-execute flags, so a reintroduced brace (or any other non-portable
+/// construct) fails here instead of silently breaking fish users at runtime.
+#[cfg(feature = "shell-integration-tests")]
+#[test]
+fn test_claude_hook_commands_parse_in_all_shells() {
+    let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let hooks_json: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(root.join("plugins/worktrunk/hooks/hooks.json")).unwrap(),
+    )
+    .unwrap();
+
+    let commands: Vec<&str> = hooks_json["hooks"]
+        .as_object()
+        .expect("hooks.json must have a `hooks` object")
+        .values()
+        .flat_map(|event| event.as_array().expect("each hook event must be an array"))
+        .flat_map(|group| {
+            group["hooks"]
+                .as_array()
+                .expect("each hook group must have a `hooks` array")
+        })
+        .map(|hook| {
+            hook["command"]
+                .as_str()
+                .expect("each hook must define a command")
+        })
+        .collect();
+    assert!(
+        !commands.is_empty(),
+        "expected at least one hook command to syntax-check"
+    );
+
+    // Each shell's no-execute flag: parse and report syntax errors without
+    // running the command. fish/zsh/bash all spell this `-n`.
+    for command in &commands {
+        for shell in ["fish", "bash", "zsh"] {
+            let output = std::process::Command::new(shell)
+                .args(["-n", "-c", command])
+                .output()
+                .unwrap_or_else(|e| panic!("failed to spawn {shell}: {e}"));
+            assert!(
+                output.status.success(),
+                "{shell} failed to parse hook command:\n  {command}\nstderr:\n{}",
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
     }
 }
 

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -4059,7 +4059,7 @@ fn test_plugin_layout_is_consolidated() {
 /// syntax-checks every Claude hook command under all three shells with their
 /// no-execute flags, so a reintroduced brace (or any other non-portable
 /// construct) fails here instead of silently breaking fish users at runtime.
-#[cfg(feature = "shell-integration-tests")]
+#[cfg(all(unix, feature = "shell-integration-tests"))]
 #[test]
 fn test_claude_hook_commands_parse_in_all_shells() {
     let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));


### PR DESCRIPTION
Fixing hook commands for Fish which doesn't allow bracketed variables:


```
SessionEnd hook [...] failed: fish: Variables cannot be bracketed. In fish, please use "$CLAUDE_PLUGIN_R…".
  bash "${CLAUDE_PLUGIN_ROOT}/hooks/wt.sh" config state marker clear || true
```

The unbracketed version works in all shells.