### PR TITLE
test(switch): cover Azure DevOps PR URLs end-to-end

### DIFF
--- a/src/git/remote_ref/mod.rs
+++ b/src/git/remote_ref/mod.rs
@@ -466,6 +466,13 @@ mod tests {
             parse_ref_url("https://dev.azure.com/org/project/_git/repo/pullrequest/9").as_deref(),
             Some("pr:9")
         );
+        // Legacy `*.visualstudio.com` host: org in the hostname, one fewer path
+        // segment than `dev.azure.com`. Still resolves to the same shortcut.
+        assert_eq!(
+            parse_ref_url("https://myorg.visualstudio.com/myproject/_git/repo/pullrequest/9")
+                .as_deref(),
+            Some("pr:9")
+        );
     }
 
     #[test]

--- a/tests/integration_tests/switch.rs
+++ b/tests/integration_tests/switch.rs
@@ -5026,6 +5026,50 @@ fn test_switch_pr_azure_same_repo(#[from(repo_with_remote)] mut repo: TestRepo) 
     });
 }
 
+/// A full Azure DevOps PR web URL passed to `wt switch` resolves the same as the
+/// `pr:N` shortcut: the URL normalises to `pr:101` (shape-based `parse_ref_url`),
+/// dispatch selects `AzureDevOpsProvider`, and the worktree is created. The
+/// snapshot should match `switch_pr_azure_same_repo`, since both forms converge
+/// on the same shortcut.
+#[rstest]
+fn test_switch_pr_azure_web_url(#[from(repo_with_remote)] mut repo: TestRepo) {
+    repo.add_worktree("feature-auth");
+    repo.run_git(&["push", "origin", "feature-auth"]);
+
+    set_azure_remote_url(
+        &repo,
+        "https://dev.azure.com/myorg/myproject/_git/test-repo",
+    );
+
+    let az_response = r#"{
+        "title": "Fix authentication bug in login flow",
+        "createdBy": {"uniqueName": "alice@example.com"},
+        "status": "active",
+        "isDraft": false,
+        "sourceRefName": "refs/heads/feature-auth",
+        "repository": {
+            "name": "test-repo",
+            "project": {"name": "myproject"},
+            "webUrl": "https://dev.azure.com/myorg/myproject/_git/test-repo"
+        },
+        "forkSource": null
+    }"#;
+
+    let mock_bin = setup_mock_az(&repo, Some(az_response));
+
+    let settings = setup_snapshot_settings(&repo);
+    settings.bind(|| {
+        let mut cmd = make_snapshot_cmd(
+            &repo,
+            "switch",
+            &["https://dev.azure.com/myorg/myproject/_git/test-repo/pullrequest/101"],
+            None,
+        );
+        configure_mock_cli_env(&mut cmd, &mock_bin);
+        assert_cmd_snapshot!("switch_pr_azure_web_url", cmd);
+    });
+}
+
 /// Regression: an Azure PR whose `sourceRefName` is just `refs/heads/`
 /// (empty branch after stripping) must fail at the provider boundary with a
 /// clear message — matching GitHub/GitLab/Gitea — not produce a confusing

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_azure_web_url.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_azure_web_url.snap
@@ -1,0 +1,65 @@
+---
+source: tests/integration_tests/switch.rs
+info:
+  program: wt
+  args:
+    - switch
+    - "https://dev.azure.com/myorg/myproject/_git/test-repo/pullrequest/101"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
+    GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
+    GIT_SSH_COMMAND: ""
+    GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    WORKTRUNK_WORKTREE_PATH: ""
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mFetching PR #101...[39m
+[107m [0m [1mFix authentication bug in login flow[22m (#101)
+[107m [0m by @alice@example.com · active · feature-auth · [90mhttps://dev.azure.com/myorg/myproject/_git/test-repo/pullrequest/101[39m
+[36m◎[39m [36mFetching [1mfeature-auth[22m from origin...[39m
+[33m▲[39m [33mWorktree for [1mfeature-auth[22m @ [1m_REPO_.feature-auth[22m, but cannot change directory — shell integration not installed[39m
+[2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m


### PR DESCRIPTION
Adds test coverage for passing an Azure DevOps PR web URL to `wt switch`. No behavior change.

This follows up on a question from [#2941](https://github.com/max-sixty/worktrunk/pull/2941#issuecomment-4599678110):

> Was going to follow up with accepting URL on `switch` only to find #2898 🙌🏻
>
> (though would it need a change for the Azure format?)

The Azure format already works. URL detection in #2898 is shape-based, not host-based: `parse_ref_url_parts` scans path segments for a `pull` / `pulls` / `pullrequest` / `merge_requests` marker followed by a number, ignoring the host. Azure URLs reduce to `pr:N` and dispatch to `AzureDevOpsProvider` through the normal path. The gap was test coverage, not behavior.

## Changes

- Adds `test_switch_pr_azure_web_url`, the first end-to-end test that passes a real web URL to `wt switch`. Every prior switch PR/MR test used the `pr:N` / `mr:N` shortcut directly, so the URL → `pr:N` → `AzureDevOpsProvider` path had only been exercised as two separate halves. The new snapshot is byte-identical to `switch_pr_azure_same_repo` apart from the recorded `args`, confirming the URL and shortcut forms converge.
- Pins the legacy `*.visualstudio.com` host shape in the `parse_ref_url_azure_devops` unit test, which previously only covered `dev.azure.com`.

This is low importance, since the behavior was already correct and covered indirectly. Happy to trim it to just the unit-test assertion, or close it altogether.

## References

- #2898 added URL acceptance on `switch`
- #2941 is where the question came up
