### PR TITLE
fix(shell): tag zsh init script with #compdef so it works from $fpath

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -31,6 +31,8 @@ Zsh (~/.zshrc):
 eval "$(wt config shell init zsh)"
 ```
 
+The zsh script starts with a `#compdef` tag, so it also works as an fpath completion file: save it as `_wt` in a directory on `$fpath` before compinit runs, and completions load on first use. Completion managers that cache generated completion files can consume it this way.
+
 Nushell [experimental] — save to vendor autoload directory:
 ```console
 $ wt config shell init nu | save -f ($nu.default-config-dir | path join vendor/autoload/wt.nu)

--- a/src/shell/snapshots/worktrunk__shell__tests__init_zsh.snap
+++ b/src/shell/snapshots/worktrunk__shell__tests__init_zsh.snap
@@ -2,7 +2,13 @@
 source: src/shell/mod.rs
 expression: output
 ---
+#compdef wt
 # worktrunk shell integration for zsh
+#
+# Loads two ways:
+#   eval "$(wt config shell init zsh)" in .zshrc, or saved as a
+#   completion file (e.g. _wt in a $fpath directory) — the #compdef tag
+#   above lets compinit autoload it on the first completion.
 #
 # Completions require zsh's completion system (compinit). If completions don't work:
 #   autoload -Uz compinit && compinit  # add before this line in .zshrc
@@ -98,5 +104,14 @@ if command -v wt >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
         # Prevent grouping branches with identical descriptions (same timestamp) on one line.
         # Without this, "release  main  -- + 12m" instead of separate lines per branch.
         zstyle ':completion:*:*:wt:*' list-grouped false
+    fi
+
+    # When compinit autoloads this file from $fpath (first TAB), the body runs
+    # as the completion function itself. compdef above re-registered
+    # _wt_lazy_complete for subsequent completions, but this first
+    # invocation must produce candidates too. Never true when eval'd from
+    # .zshrc — funcstack is empty at the top level.
+    if [[ "${funcstack[1]}" == "_wt" ]]; then
+        _wt_lazy_complete "$@"
     fi
 fi

--- a/templates/zsh.zsh
+++ b/templates/zsh.zsh
@@ -1,4 +1,10 @@
+#compdef {{ cmd }}
 # worktrunk shell integration for zsh
+#
+# Loads two ways:
+#   eval "$({{ cmd }} config shell init zsh)" in .zshrc, or saved as a
+#   completion file (e.g. _{{ cmd }} in a $fpath directory) — the #compdef tag
+#   above lets compinit autoload it on the first completion.
 #
 # Completions require zsh's completion system (compinit). If completions don't work:
 #   autoload -Uz compinit && compinit  # add before this line in .zshrc
@@ -94,5 +100,14 @@ if command -v {{ cmd }} >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
         # Prevent grouping branches with identical descriptions (same timestamp) on one line.
         # Without this, "release  main  -- + 12m" instead of separate lines per branch.
         zstyle ':completion:*:*:{{ cmd }}:*' list-grouped false
+    fi
+
+    # When compinit autoloads this file from $fpath (first TAB), the body runs
+    # as the completion function itself. compdef above re-registered
+    # _{{ cmd }}_lazy_complete for subsequent completions, but this first
+    # invocation must produce candidates too. Never true when eval'd from
+    # .zshrc — funcstack is empty at the top level.
+    if [[ "${funcstack[1]}" == "_{{ cmd }}" ]]; then
+        _{{ cmd }}_lazy_complete "$@"
     fi
 fi

--- a/tests/integration_tests/shell_wrapper.rs
+++ b/tests/integration_tests/shell_wrapper.rs
@@ -3068,6 +3068,58 @@ _wt_lazy_complete
         assert_snapshot!(String::from_utf8_lossy(&output.stdout));
     }
 
+    /// Black-box test: the zsh init script works as an fpath completion file.
+    ///
+    /// Completion managers (zinit, zsh-completion-generators, oh-my-zsh custom
+    /// completions) save `wt config shell init zsh` output as `_wt` in a
+    /// directory on `$fpath` instead of eval-ing it from .zshrc. compinit only
+    /// registers files whose first line is a `#compdef` tag, and the first TAB
+    /// runs the file body as the completion function — so the body must
+    /// produce candidates for that invocation itself, not just rebind compdef
+    /// for the next one.
+    #[test]
+    fn test_zsh_completion_fpath_autoload() {
+        let wt_bin = wt_bin();
+        let init = std::process::Command::new(&wt_bin)
+            .args(["config", "shell", "init", "zsh"])
+            .output()
+            .unwrap();
+        let shell_integration = String::from_utf8_lossy(&init.stdout);
+
+        // Save the init script as an fpath completion file, the way
+        // completion managers consume it.
+        let fpath_dir = tempfile::tempdir().unwrap();
+        std::fs::write(fpath_dir.path().join("_wt"), shell_integration.as_bytes()).unwrap();
+
+        // Same _describe override as test_zsh_completion_subcommands; the
+        // first `"${_comps[wt]}"` call is the first TAB — it must print
+        // candidates immediately. `compinit -d` keeps the dump file out of
+        // the real $HOME.
+        let script = format!(
+            r#"
+fpath=({fpath_dir} $fpath)
+autoload -Uz compinit && compinit -u -i -d {fpath_dir}/zcompdump 2>/dev/null
+echo "completer: ${{_comps[wt]:-NONE}}"
+_describe() {{
+    while [[ "$1" == -* ]]; do shift; done; shift
+    for arr in "$@"; do for item in "${{(@P)arr}}"; do echo "${{item%%:*}}"; done; done
+}}
+words=(wt "") CURRENT=2
+"${{_comps[wt]}}"
+"#,
+            fpath_dir = fpath_dir.path().display()
+        );
+
+        let (_dir, clean_path) = completion_test_path(&wt_bin);
+
+        let mut cmd = std::process::Command::new("zsh");
+        cmd.args(["-f", "-c"]).arg(&script).env("PATH", &clean_path);
+        set_empty_configs(&mut cmd);
+        let output = cmd.output().unwrap();
+
+        assert_snapshot!(String::from_utf8_lossy(&output.stdout));
+    }
+
     /// Black-box test: bash completion produces correct subcommands.
     ///
     /// Sources actual `wt config shell init bash`, triggers completion, snapshots result.

--- a/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__zsh_completion_fpath_autoload.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__shell_wrapper__unix_tests__zsh_completion_fpath_autoload.snap
@@ -1,0 +1,12 @@
+---
+source: tests/integration_tests/shell_wrapper.rs
+expression: "String::from_utf8_lossy(&output.stdout)"
+---
+completer: _wt
+switch
+list
+remove
+merge
+step
+hook
+config

--- a/tests/snapshots/integration__integration_tests__init__init_zsh.snap
+++ b/tests/snapshots/integration__integration_tests__init__init_zsh.snap
@@ -53,7 +53,13 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
+#compdef wt
 # worktrunk shell integration for zsh
+#
+# Loads two ways:
+#   eval "$(wt config shell init zsh)" in .zshrc, or saved as a
+#   completion file (e.g. _wt in a $fpath directory) — the #compdef tag
+#   above lets compinit autoload it on the first completion.
 #
 # Completions require zsh's completion system (compinit). If completions don't work:
 #   autoload -Uz compinit && compinit  # add before this line in .zshrc
@@ -149,6 +155,15 @@ if command -v wt >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
         # Prevent grouping branches with identical descriptions (same timestamp) on one line.
         # Without this, "release  main  -- + 12m" instead of separate lines per branch.
         zstyle ':completion:*:*:wt:*' list-grouped false
+    fi
+
+    # When compinit autoloads this file from $fpath (first TAB), the body runs
+    # as the completion function itself. compdef above re-registered
+    # _wt_lazy_complete for subsequent completions, but this first
+    # invocation must produce candidates too. Never true when eval'd from
+    # .zshrc — funcstack is empty at the top level.
+    if [[ "${funcstack[1]}" == "_wt" ]]; then
+        _wt_lazy_complete "$@"
     fi
 fi
 


### PR DESCRIPTION
## Problem

The zsh integration script only works via `eval "$(wt config shell init zsh)"` in `.zshrc`. Completion managers that cache generated completion files (zinit, [zsh-completion-generators](https://github.com/zetlen/zsh-completion-generators), oh-my-zsh custom completions) instead save the output as `_wt` in a directory on `$fpath` — and compinit only registers files whose **first line** is a `#compdef` tag, so completions never load from there.

There's also a second-order issue: even with the tag added, the first TAB is a dud. compinit autoloads the file body as the completion function `_wt`; the body registers `compdef _wt_lazy_complete wt` for *future* completions but produces no candidates for the in-flight one.

## Fix

Two changes to `templates/zsh.zsh`, both inert in the existing `eval` flow:

- **`#compdef {{ cmd }}` as line 1** — an ordinary comment when eval'd; a registration tag when scanned by compinit. Same dual-use convention as clap_complete's own `COMPLETE=zsh wt` registration script and kubectl/docker completion files.
- **funcstack-guarded dispatch at the end** — when the body runs as the autoloaded completion function, complete the current word immediately:

  ```zsh
  if [[ "${funcstack[1]}" == "_wt" ]]; then
      _wt_lazy_complete "$@"
  fi
  ```

  At eval time `funcstack` is empty at the top level, so this never fires (verified — sourcing/eval'ing the script produces no spurious output).

## Verification

- New black-box test `test_zsh_completion_fpath_autoload` (gated on `shell-integration-tests`, alongside `test_zsh_completion_subcommands`): saves `wt config shell init zsh` output as `_wt` in a temp fpath dir, runs real compinit, asserts the completer is registered and the **first** invocation yields subcommands. Before the fix it snapshots `completer: NONE`; after, `completer: _wt` plus the subcommand list.
- `wt config shell init --help` documents the fpath usage.
- Snapshots refreshed (`init_zsh`, unit `init_zsh`); docs-sync test passes; fmt/clippy clean; full integration failure set is identical to `main` on my machine (remaining failures are local-env only: missing fish/nu, host shell-detection leaks).