### PR TITLE
chore(demos): drop the obsolete CLAUDECODE= env from the shared tape

### DIFF
--- a/docs/demos/tapes/shared-commands.tape
+++ b/docs/demos/tapes/shared-commands.tape
@@ -2,7 +2,6 @@
 Require wt
 Require git
 
-Env CLAUDECODE ""
 Env IS_DEMO "1"
 Env GIT_TERMINAL_PROMPT "0"
 Env GIT_PAGER "{{GIT_PAGER}}"


### PR DESCRIPTION
Follow-up to #2979. The shared demo tape set `Env CLAUDECODE ""` so that a `claude` invoked while recording would not be rejected as a nested session. Claude Code no longer blocks nested `claude -p`, and #2979 dropped the matching workaround in commit generation, so the override is unneeded. It is not part of the recorded output, so the GIFs are unchanged; no re-record.

> _This was written by Claude Code on behalf of max_
