### PR TITLE
Expose commit bodies to squash templates

### DIFF
--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -250,7 +250,7 @@
 # Available variables (in addition to commit template variables):
 #
 # - `{{ commits }}` — list of commit subjects being squashed
-# - `{{ commit_details }}` — list of commits being squashed as `{ subject, body }` objects
+# - `{{ commit_details }}` — [experimental] list of commits being squashed as `{ subject, body }` objects
 # - `{{ target_branch }}` — merge target branch
 #
 # Default template:

--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -249,7 +249,8 @@
 #
 # Available variables (in addition to commit template variables):
 #
-# - `{{ commits }}` — list of commits being squashed
+# - `{{ commits }}` — list of commit subjects being squashed
+# - `{{ commit_details }}` — list of commits being squashed as `{ subject, body }` objects
 # - `{{ target_branch }}` — merge target branch
 #
 # Default template:

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -355,7 +355,8 @@ Branch: {{ branch }}
 
 Available variables (in addition to commit template variables):
 
-- `{{ commits }}` — list of commits being squashed
+- `{{ commits }}` — list of commit subjects being squashed
+- `{{ commit_details }}` — list of commits being squashed as `{ subject, body }` objects
 - `{{ target_branch }}` — merge target branch
 
 Default template:

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -356,7 +356,7 @@ Branch: {{ branch }}
 Available variables (in addition to commit template variables):
 
 - `{{ commits }}` — list of commit subjects being squashed
-- `{{ commit_details }}` — list of commits being squashed as `{ subject, body }` objects
+- `{{ commit_details }}` — <span class="badge-experimental"></span> list of commits being squashed as `{ subject, body }` objects
 - `{{ target_branch }}` — merge target branch
 
 Default template:

--- a/docs/content/llm-commits.md
+++ b/docs/content/llm-commits.md
@@ -181,7 +181,8 @@ Diff:
 | `{{ branch }}` | Current branch name |
 | `{{ repo }}` | Repository name |
 | `{{ recent_commits }}` | Recent commit subjects (for style reference) |
-| `{{ commits }}` | Commits being squashed (squash template only) |
+| `{{ commits }}` | Commit subjects being squashed (squash template only) |
+| `{{ commit_details }}` | Commits being squashed as `{ subject, body }` (squash template only) |
 | `{{ target_branch }}` | Merge target branch (squash template only) |
 | `{{ user_guidance }}` | Rendered user `template-append` fragment (see below) |
 | `{{ project_guidance }}` | Rendered project `template-append` fragment (see below) |

--- a/docs/content/llm-commits.md
+++ b/docs/content/llm-commits.md
@@ -182,7 +182,7 @@ Diff:
 | `{{ repo }}` | Repository name |
 | `{{ recent_commits }}` | Recent commit subjects (for style reference) |
 | `{{ commits }}` | Commit subjects being squashed (squash template only) |
-| `{{ commit_details }}` | Commits being squashed as `{ subject, body }` (squash template only) |
+| `{{ commit_details }}` | Commits being squashed as `{ subject, body }` (squash template only) <span class="badge-experimental"></span> |
 | `{{ target_branch }}` | Merge target branch (squash template only) |
 | `{{ user_guidance }}` | Rendered user `template-append` fragment (see below) |
 | `{{ project_guidance }}` | Rendered project `template-append` fragment (see below) |

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -354,7 +354,8 @@ Branch: {{ branch }}
 
 Available variables (in addition to commit template variables):
 
-- `{{ commits }}` — list of commits being squashed
+- `{{ commits }}` — list of commit subjects being squashed
+- `{{ commit_details }}` — list of commits being squashed as `{ subject, body }` objects
 - `{{ target_branch }}` — merge target branch
 
 Default template:

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -355,7 +355,7 @@ Branch: {{ branch }}
 Available variables (in addition to commit template variables):
 
 - `{{ commits }}` — list of commit subjects being squashed
-- `{{ commit_details }}` — list of commits being squashed as `{ subject, body }` objects
+- `{{ commit_details }}` — [experimental] list of commits being squashed as `{ subject, body }` objects
 - `{{ target_branch }}` — merge target branch
 
 Default template:

--- a/skills/worktrunk/reference/llm-commits.md
+++ b/skills/worktrunk/reference/llm-commits.md
@@ -155,7 +155,8 @@ Diff:
 | `{{ branch }}` | Current branch name |
 | `{{ repo }}` | Repository name |
 | `{{ recent_commits }}` | Recent commit subjects (for style reference) |
-| `{{ commits }}` | Commits being squashed (squash template only) |
+| `{{ commits }}` | Commit subjects being squashed (squash template only) |
+| `{{ commit_details }}` | Commits being squashed as `{ subject, body }` (squash template only) |
 | `{{ target_branch }}` | Merge target branch (squash template only) |
 | `{{ user_guidance }}` | Rendered user `template-append` fragment (see below) |
 | `{{ project_guidance }}` | Rendered project `template-append` fragment (see below) |

--- a/skills/worktrunk/reference/llm-commits.md
+++ b/skills/worktrunk/reference/llm-commits.md
@@ -156,7 +156,7 @@ Diff:
 | `{{ repo }}` | Repository name |
 | `{{ recent_commits }}` | Recent commit subjects (for style reference) |
 | `{{ commits }}` | Commit subjects being squashed (squash template only) |
-| `{{ commit_details }}` | Commits being squashed as `{ subject, body }` (squash template only) |
+| `{{ commit_details }}` | Commits being squashed as `{ subject, body }` (squash template only) [experimental] |
 | `{{ target_branch }}` | Merge target branch (squash template only) |
 | `{{ user_guidance }}` | Rendered user `template-append` fragment (see below) |
 | `{{ project_guidance }}` | Rendered project `template-append` fragment (see below) |

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1928,7 +1928,7 @@ Branch: {{ branch }}
 Available variables (in addition to commit template variables):
 
 - `{{ commits }}` — list of commit subjects being squashed
-- `{{ commit_details }}` — list of commits being squashed as `{ subject, body }` objects
+- `{{ commit_details }}` — [experimental] list of commits being squashed as `{ subject, body }` objects
 - `{{ target_branch }}` — merge target branch
 
 Default template:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1927,7 +1927,8 @@ Branch: {{ branch }}
 
 Available variables (in addition to commit template variables):
 
-- `{{ commits }}` — list of commits being squashed
+- `{{ commits }}` — list of commit subjects being squashed
+- `{{ commit_details }}` — list of commits being squashed as `{ subject, body }` objects
 - `{{ target_branch }}` — merge target branch
 
 Default template:

--- a/src/commands/step/squash.rs
+++ b/src/commands/step/squash.rs
@@ -256,8 +256,8 @@ pub fn handle_squash(
         eprintln!("{}", hint_message(format!("Backup created @ {sha}")));
     }
 
-    // Get commit subjects for the squash message
-    let subjects = repo.commit_subjects(&range)?;
+    // Get commit subjects and bodies for the squash message
+    let commit_details = repo.commit_message_details(&range)?;
 
     // Generate squash commit message
     eprintln!(
@@ -277,7 +277,7 @@ pub fn handle_squash(
     let commit_message = crate::llm::generate_squash_message(
         &integration_target,
         &merge_base,
-        &subjects,
+        &commit_details,
         &current_branch,
         repo_name,
         &resolved.commit_generation,
@@ -372,7 +372,7 @@ fn preview_squash(target: Option<&str>, dry_run: bool, yes: bool) -> anyhow::Res
         .context("Cannot generate squash message: no common ancestor with target branch")?;
 
     let range = format!("{}..HEAD", merge_base);
-    let subjects = repo.commit_subjects(&range)?;
+    let commit_details = repo.commit_message_details(&range)?;
 
     let repo_root = wt.root()?;
     let repo_name = repo_root
@@ -387,7 +387,7 @@ fn preview_squash(target: Option<&str>, dry_run: bool, yes: bool) -> anyhow::Res
     let prompt = crate::llm::build_squash_prompt(
         &integration_target,
         &merge_base,
-        &subjects,
+        &commit_details,
         &current_branch,
         repo_name,
         &commit_config,
@@ -400,7 +400,7 @@ fn preview_squash(target: Option<&str>, dry_run: bool, yes: bool) -> anyhow::Res
     let message = crate::llm::generate_squash_message(
         &integration_target,
         &merge_base,
-        &subjects,
+        &commit_details,
         &current_branch,
         repo_name,
         &commit_config,

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -76,8 +76,8 @@ pub use remove::{
 };
 pub use repository::sha_cache;
 pub use repository::{
-    Branch, IntegrationTargets, RefSnapshot, Repository, ResolvedWorktree, TempIndex, WorkingTree,
-    set_base_path,
+    Branch, CommitMessageDetail, IntegrationTargets, RefSnapshot, Repository, ResolvedWorktree,
+    TempIndex, WorkingTree, set_base_path,
 };
 pub use url::GitRemoteUrl;
 pub use url::parse_owner_repo;

--- a/src/git/repository/diff.rs
+++ b/src/git/repository/diff.rs
@@ -7,6 +7,37 @@ use dashmap::mapref::entry::Entry;
 
 use super::{DiffStats, LineDiff, Repository};
 
+/// Subject and body for one commit in a range.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct CommitMessageDetail {
+    /// Commit subject from git's `%s` pretty format.
+    pub subject: String,
+    /// Commit body from git's `%b` pretty format, including trailer-like lines.
+    pub body: String,
+}
+
+fn parse_commit_message_details_output(output: &str) -> anyhow::Result<Vec<CommitMessageDetail>> {
+    if output.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let parts = output.split('\0').collect::<Vec<_>>();
+    if parts.len() % 2 != 0 {
+        bail!(
+            "Malformed git log output: expected NUL-separated subject/body pairs, got {} field(s)",
+            parts.len()
+        );
+    }
+
+    Ok(parts
+        .chunks_exact(2)
+        .map(|pair| CommitMessageDetail {
+            subject: pair[0].to_string(),
+            body: pair[1].to_string(),
+        })
+        .collect())
+}
+
 impl Repository {
     /// Count commits between base and head.
     pub fn count_commits(&self, base: &str, head: &str) -> anyhow::Result<usize> {
@@ -112,16 +143,21 @@ impl Repository {
         Ok(result)
     }
 
-    /// Get commit subjects (first line of commit message) from a range.
-    pub fn commit_subjects(&self, range: &str) -> anyhow::Result<Vec<String>> {
+    /// Get commit subjects and bodies from a range.
+    pub fn commit_message_details(&self, range: &str) -> anyhow::Result<Vec<CommitMessageDetail>> {
+        // Git pretty-format placeholders:
+        // - `%s`: subject
+        // - `%x00`: literal NUL delimiter
+        // - `%b`: body as Git reports it; trailer-like lines remain part of this text
         let output = self.run_command(&[
             "log",
+            "-z",
             "--no-show-signature",
-            "--format=%s",
+            "--pretty=format:%s%x00%b",
             "--end-of-options",
             range,
         ])?;
-        Ok(output.lines().map(String::from).collect())
+        parse_commit_message_details_output(&output)
     }
 
     /// Get recent commit subjects for style reference.
@@ -367,5 +403,18 @@ impl Repository {
             .ok()
             .map(|output| DiffStats::from_shortstat(&output).format_summary())
             .unwrap_or_default()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn parse_commit_message_details_output_rejects_odd_field_count() {
+        let err =
+            super::parse_commit_message_details_output("subject\0body\0dangling").unwrap_err();
+        assert!(
+            err.to_string().contains("subject/body pairs"),
+            "unexpected error: {err}"
+        );
     }
 }

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -124,6 +124,7 @@ mod worktrees;
 
 // Re-export WorkingTree, Branch, IntegrationTargets, and RefSnapshot
 pub use branch::Branch;
+pub use diff::CommitMessageDetail;
 pub use integration::IntegrationTargets;
 pub use ref_snapshot::RefSnapshot;
 pub(super) use working_tree::path_to_logging_context;

--- a/src/git/repository/tests.rs
+++ b/src/git/repository/tests.rs
@@ -785,6 +785,45 @@ fn commit_details_many_deduplicates_repeated_sha() {
 }
 
 #[test]
+fn commit_message_details_returns_subjects_and_bodies_in_git_order() {
+    use super::CommitMessageDetail;
+    use crate::testing::TestRepo;
+
+    let test = TestRepo::new();
+    test.commit_with_message("base");
+
+    test.commit_in_worktree(
+        test.root_path(),
+        "first.txt",
+        "first content",
+        "first subject\n\nline 1\nline 2\n\nTrailer: value",
+    );
+    test.commit_in_worktree(
+        test.root_path(),
+        "second.txt",
+        "second content",
+        "second subject",
+    );
+
+    let range = "HEAD~2..HEAD";
+    let result = test.repo.commit_message_details(range).unwrap();
+
+    assert_eq!(
+        result,
+        vec![
+            CommitMessageDetail {
+                subject: "second subject".to_string(),
+                body: String::new(),
+            },
+            CommitMessageDetail {
+                subject: "first subject".to_string(),
+                body: "line 1\nline 2\n\nTrailer: value\n".to_string(),
+            },
+        ]
+    );
+}
+
+#[test]
 #[cfg(unix)]
 fn worktree_at_path_resolves_symlinked_path() {
     // Reproduction for issue #2460: `wt switch` fails to resolve existing

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -5,7 +5,7 @@ use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use worktrunk::config::CommitGenerationConfig;
-use worktrunk::git::Repository;
+use worktrunk::git::{CommitMessageDetail, Repository};
 use worktrunk::path::format_path_for_display;
 use worktrunk::shell_exec::{Cmd, SUBPROCESS_FULL_TARGET, ShellConfig};
 use worktrunk::styling::{eprintln, warning_message};
@@ -235,7 +235,7 @@ pub(crate) fn prepare_diff(diff: String, stat: String) -> PreparedDiff {
 /// Context data for building LLM prompts
 ///
 /// All fields are available to both commit and squash templates.
-/// Squash-specific fields (`commits`, `target_branch`) are empty/None for regular commits.
+/// Squash-specific fields (`commit_details`, `target_branch`) are empty/None for regular commits.
 struct TemplateContext<'a> {
     /// The diff to describe (staged changes for commit, combined diff for squash)
     git_diff: &'a str,
@@ -247,8 +247,8 @@ struct TemplateContext<'a> {
     recent_commits: Option<&'a Vec<String>>,
     /// Repository name
     repo_name: &'a str,
-    /// Commits being squashed (squash only)
-    commits: &'a [String],
+    /// Subject/body details for commits being squashed (squash only)
+    commit_details: &'a [CommitMessageDetail],
     /// Target branch for merge (squash only)
     target_branch: Option<&'a str>,
     /// Approved project-level append fragment. `None` when no project
@@ -461,7 +461,8 @@ fn load_template(
 /// - `repo`: Repository directory name
 ///
 /// Squash-specific variables (empty for regular commits):
-/// - `commits`: Commits being squashed
+/// - `commits`: Commit subjects being squashed
+/// - `commit_details`: Subject/body details for commits being squashed
 /// - `target_branch`: Target branch for merge
 fn build_prompt(
     config: &CommitGenerationConfig,
@@ -503,7 +504,14 @@ fn build_prompt(
     let tmpl = env.template_from_str(&template)?;
 
     // Reverse commits so they're in chronological order (oldest first)
-    let commits_chronological: Vec<&String> = context.commits.iter().rev().collect();
+    let commits_chronological: Vec<&String> = context
+        .commit_details
+        .iter()
+        .rev()
+        .map(|detail| &detail.subject)
+        .collect();
+    let commit_details_chronological: Vec<&CommitMessageDetail> =
+        context.commit_details.iter().rev().collect();
     let empty_commits: Vec<String> = vec![];
 
     // The append fragments are themselves minijinja templates. Render each
@@ -524,6 +532,7 @@ fn build_prompt(
             recent_commits => context.recent_commits.unwrap_or(&empty_commits),
             repo => context.repo_name,
             commits => &commits_chronological,
+            commit_details => &commit_details_chronological,
             target_branch => context.target_branch.unwrap_or(""),
         })?)
     };
@@ -548,6 +557,7 @@ fn build_prompt(
         recent_commits => context.recent_commits.unwrap_or(&empty_commits),
         repo => context.repo_name,
         commits => commits_chronological,
+        commit_details => commit_details_chronological,
         target_branch => context.target_branch.unwrap_or(""),
         user_guidance => user_guidance,
         project_guidance => project_guidance,
@@ -713,7 +723,7 @@ pub(crate) fn build_commit_prompt(
         branch: &current_branch,
         recent_commits: recent_commits.as_ref(),
         repo_name,
-        commits: &[],
+        commit_details: &[],
         target_branch: None,
         project_append,
     };
@@ -723,7 +733,7 @@ pub(crate) fn build_commit_prompt(
 pub(crate) fn generate_squash_message(
     target_branch: &str,
     merge_base: &str,
-    subjects: &[String],
+    commit_details: &[CommitMessageDetail],
     current_branch: &str,
     repo_name: &str,
     commit_generation_config: &CommitGenerationConfig,
@@ -736,7 +746,7 @@ pub(crate) fn generate_squash_message(
         let prompt = build_squash_prompt(
             target_branch,
             merge_base,
-            subjects,
+            commit_details,
             current_branch,
             repo_name,
             commit_generation_config,
@@ -759,21 +769,21 @@ pub(crate) fn generate_squash_message(
     // Fallback: deterministic commit message (only when not configured)
     let mut commit_message = format!("Squash commits from {}\n\n", current_branch);
     commit_message.push_str("Combined commits:\n");
-    for subject in subjects.iter().rev() {
+    for detail in commit_details.iter().rev() {
         // Reverse so they're in chronological order
-        commit_message.push_str(&format!("- {}\n", subject));
+        commit_message.push_str(&format!("- {}\n", detail.subject));
     }
     Ok(commit_message)
 }
 
 /// Build the squash prompt from commits being squashed.
 ///
-/// Gathers the combined diff, commit subjects, branch names, and recent commits, then
+/// Gathers the combined diff, commit message details, branch names, and recent commits, then
 /// renders the prompt template. Used by both normal squash generation and `--show-prompt`.
 pub(crate) fn build_squash_prompt(
     target_branch: &str,
     merge_base: &str,
-    subjects: &[String],
+    commit_details: &[CommitMessageDetail],
     current_branch: &str,
     repo_name: &str,
     config: &CommitGenerationConfig,
@@ -805,7 +815,7 @@ pub(crate) fn build_squash_prompt(
         branch: current_branch,
         recent_commits: recent_commits.as_ref(),
         repo_name,
-        commits: subjects,
+        commit_details,
         target_branch: Some(target_branch),
         project_append,
     };
@@ -857,7 +867,7 @@ pub(crate) fn test_commit_generation(
         branch: "feature/example",
         recent_commits: Some(&recent_commits),
         repo_name: "test-repo",
-        commits: &[],
+        commit_details: &[],
         target_branch: None,
         // The connectivity test sends a synthetic prompt — keep it independent
         // of any project guidance so it doesn't surface team-policy text in
@@ -937,7 +947,7 @@ mod tests {
             branch,
             recent_commits,
             repo_name,
-            commits: &[],
+            commit_details: &[],
             target_branch: None,
             project_append: None,
         }
@@ -949,7 +959,7 @@ mod tests {
         branch: &'a str,
         recent_commits: Option<&'a Vec<String>>,
         repo_name: &'a str,
-        commits: &'a [String],
+        commit_details: &'a [CommitMessageDetail],
         target_branch: &'a str,
     ) -> TemplateContext<'a> {
         TemplateContext {
@@ -958,7 +968,7 @@ mod tests {
             branch,
             recent_commits,
             repo_name,
-            commits,
+            commit_details,
             target_branch: Some(target_branch),
             project_append: None,
         }
@@ -1291,8 +1301,24 @@ mod tests {
     #[test]
     fn test_default_squash_template_renders_project_fragment() {
         let config = CommitGenerationConfig::default();
-        let commits = vec!["feat: A".to_string(), "fix: B".to_string()];
-        let mut context = squash_context("diff content", "feature", None, "repo", &commits, "main");
+        let commit_details = vec![
+            CommitMessageDetail {
+                subject: "feat: A".to_string(),
+                body: String::new(),
+            },
+            CommitMessageDetail {
+                subject: "fix: B".to_string(),
+                body: String::new(),
+            },
+        ];
+        let mut context = squash_context(
+            "diff content",
+            "feature",
+            None,
+            "repo",
+            &commit_details,
+            "main",
+        );
         context.project_append = Some("- Reference the related issue");
         let prompt = build_prompt(&config, TemplateType::Squash, &context).unwrap();
         assert_snapshot!(prompt, @r#"
@@ -1332,8 +1358,24 @@ mod tests {
     #[test]
     fn test_build_squash_prompt_with_default_template() {
         let config = CommitGenerationConfig::default();
-        let commits = vec!["feat: A".to_string(), "fix: B".to_string()];
-        let context = squash_context("diff content", "feature", None, "repo", &commits, "main");
+        let commit_details = vec![
+            CommitMessageDetail {
+                subject: "feat: A".to_string(),
+                body: String::new(),
+            },
+            CommitMessageDetail {
+                subject: "fix: B".to_string(),
+                body: String::new(),
+            },
+        ];
+        let context = squash_context(
+            "diff content",
+            "feature",
+            None,
+            "repo",
+            &commit_details,
+            "main",
+        );
         let prompt = build_prompt(&config, TemplateType::Squash, &context).unwrap();
         assert_snapshot!(prompt, @r#"
         <task>Write a commit message for the combined effect of these commits.</task>
@@ -1378,8 +1420,17 @@ mod tests {
             squash_template_file: None,
             template_append: None,
         };
-        let commits = vec!["A".to_string(), "B".to_string()];
-        let context = squash_context("diff", "feature", None, "repo", &commits, "main");
+        let commit_details = vec![
+            CommitMessageDetail {
+                subject: "A".to_string(),
+                body: "body A".to_string(),
+            },
+            CommitMessageDetail {
+                subject: "B".to_string(),
+                body: "body B".to_string(),
+            },
+        ];
+        let context = squash_context("diff", "feature", None, "repo", &commit_details, "main");
         let result = build_prompt(&config, TemplateType::Squash, &context);
         assert!(result.is_ok());
         // Commits are reversed, so chronological order is B, A
@@ -1387,10 +1438,45 @@ mod tests {
     }
 
     #[test]
+    fn test_build_squash_prompt_with_commit_details() {
+        let config = CommitGenerationConfig {
+            command: None,
+            template: None,
+            template_file: None,
+            squash_template: Some(
+                r#"{% for detail in commit_details %}{{ loop.index }}. {{ detail.subject }}
+{{ detail.body }}
+{% endfor %}"#
+                    .to_string(),
+            ),
+            squash_template_file: None,
+            template_append: None,
+        };
+        let commit_details = vec![
+            CommitMessageDetail {
+                subject: "newer subject".to_string(),
+                body: "newer body".to_string(),
+            },
+            CommitMessageDetail {
+                subject: "older subject".to_string(),
+                body: "older body line 1\nolder body line 2".to_string(),
+            },
+        ];
+        let context = squash_context("diff", "feature", None, "repo", &commit_details, "main");
+
+        let prompt = build_prompt(&config, TemplateType::Squash, &context).unwrap();
+
+        assert_eq!(
+            prompt,
+            "1. older subject\nolder body line 1\nolder body line 2\n2. newer subject\nnewer body\n"
+        );
+    }
+
+    #[test]
     fn test_build_squash_prompt_empty_commits() {
         let config = CommitGenerationConfig::default();
-        let commits: Vec<String> = vec![];
-        let context = squash_context("diff", "feature", None, "repo", &commits, "main");
+        let commit_details = vec![];
+        let context = squash_context("diff", "feature", None, "repo", &commit_details, "main");
         let result = build_prompt(&config, TemplateType::Squash, &context);
         assert!(result.is_ok());
     }
@@ -1405,8 +1491,8 @@ mod tests {
             squash_template_file: None,
             template_append: None,
         };
-        let commits: Vec<String> = vec![];
-        let context = squash_context("diff", "feature", None, "repo", &commits, "main");
+        let commit_details = vec![];
+        let context = squash_context("diff", "feature", None, "repo", &commit_details, "main");
         let result = build_prompt(&config, TemplateType::Squash, &context);
         assert!(result.is_err());
     }
@@ -1421,8 +1507,8 @@ mod tests {
             squash_template_file: None,
             template_append: None,
         };
-        let commits: Vec<String> = vec![];
-        let context = squash_context("diff", "feature", None, "repo", &commits, "main");
+        let commit_details = vec![];
+        let context = squash_context("diff", "feature", None, "repo", &commit_details, "main");
         let result = build_prompt(&config, TemplateType::Squash, &context);
         assert_snapshot!(result.unwrap_err().to_string(), @"Squash template is empty");
     }
@@ -1441,14 +1527,23 @@ mod tests {
             squash_template_file: None,
             template_append: None,
         };
-        let commits = vec!["A".to_string(), "B".to_string()];
+        let commit_details = vec![
+            CommitMessageDetail {
+                subject: "A".to_string(),
+                body: String::new(),
+            },
+            CommitMessageDetail {
+                subject: "B".to_string(),
+                body: String::new(),
+            },
+        ];
         let recent = vec!["prev1".to_string(), "prev2".to_string()];
         let context = squash_context(
             "the diff",
             "feature",
             Some(&recent),
             "myrepo",
-            &commits,
+            &commit_details,
             "main",
         );
         let result = build_prompt(&config, TemplateType::Squash, &context);
@@ -1544,12 +1639,21 @@ Single commit: {{ commits[0] }}
         };
 
         // Multiple commits — reversed for chronological order (C, B, A)
-        let commits = vec![
-            "commit A".to_string(),
-            "commit B".to_string(),
-            "commit C".to_string(),
+        let commit_details = vec![
+            CommitMessageDetail {
+                subject: "commit A".to_string(),
+                body: String::new(),
+            },
+            CommitMessageDetail {
+                subject: "commit B".to_string(),
+                body: String::new(),
+            },
+            CommitMessageDetail {
+                subject: "commit C".to_string(),
+                body: String::new(),
+            },
         ];
-        let context = squash_context("diff", "feature", None, "repo", &commits, "main");
+        let context = squash_context("diff", "feature", None, "repo", &commit_details, "main");
         let prompt = build_prompt(&config, TemplateType::Squash, &context).unwrap();
         assert_snapshot!(prompt, @"
         Squashing 3 commit(s) from feature to main
@@ -1560,7 +1664,10 @@ Single commit: {{ commits[0] }}
         ");
 
         // Single commit — exercises else-branch
-        let single_commit = vec!["solo commit".to_string()];
+        let single_commit = vec![CommitMessageDetail {
+            subject: "solo commit".to_string(),
+            body: String::new(),
+        }];
         let context = squash_context("diff", "feature", None, "repo", &single_commit, "main");
         let prompt = build_prompt(&config, TemplateType::Squash, &context).unwrap();
         assert_snapshot!(prompt, @"
@@ -1635,8 +1742,17 @@ Single commit: {{ commits[0] }}
             squash_template_file: Some(template_path.to_string_lossy().to_string()),
             template_append: None,
         };
-        let commits = vec!["A".to_string(), "B".to_string()];
-        let context = squash_context("diff", "feature", None, "repo", &commits, "main");
+        let commit_details = vec![
+            CommitMessageDetail {
+                subject: "A".to_string(),
+                body: String::new(),
+            },
+            CommitMessageDetail {
+                subject: "B".to_string(),
+                body: String::new(),
+            },
+        ];
+        let context = squash_context("diff", "feature", None, "repo", &commit_details, "main");
         let result = build_prompt(&config, TemplateType::Squash, &context);
         assert!(result.is_ok());
         // Commits are reversed for chronological order
@@ -1674,7 +1790,7 @@ Single commit: {{ commits[0] }}
         let config = CommitGenerationConfig {
             command: None,
             template: Some(
-                "Branch: {{ branch }}\nTarget: {{ target_branch }}\nCommits: {{ commits | length }}"
+                "Branch: {{ branch }}\nTarget: {{ target_branch }}\nCommit subjects: {{ commits | length }}\nCommit details: {{ commit_details | length }}"
                     .to_string(),
             ),
             template_file: None,
@@ -1687,7 +1803,10 @@ Single commit: {{ commits[0] }}
         assert!(result.is_ok());
         let prompt = result.unwrap();
         // Squash-specific variables are empty for regular commits
-        assert_eq!(prompt, "Branch: feature\nTarget: \nCommits: 0");
+        assert_eq!(
+            prompt,
+            "Branch: feature\nTarget: \nCommit subjects: 0\nCommit details: 0"
+        );
     }
 
     // Tests for diff filtering

--- a/tests/integration_tests/merge.rs
+++ b/tests/integration_tests/merge.rs
@@ -2488,6 +2488,71 @@ fn test_step_squash_show_prompt(repo_with_multi_commit_feature: TestRepo) {
     ));
 }
 
+#[rstest]
+fn test_step_squash_show_prompt_custom_template_renders_commit_details(mut repo: TestRepo) {
+    let feature_wt = repo.add_worktree("feature");
+
+    repo.commit_in_worktree(
+        &feature_wt,
+        "empty_body.txt",
+        "empty body change\n",
+        "Add empty-body change",
+    );
+
+    let commit_with_body = |file: &str, content: &str, subject: &str, body: &str| {
+        let message = format!("{subject}\n\n{body}");
+        repo.commit_in_worktree(&feature_wt, file, content, &message);
+    };
+    commit_with_body(
+        "with_body.txt",
+        "body change\n",
+        "Describe body",
+        "Body line",
+    );
+    commit_with_body(
+        "multiline_body.txt",
+        "multiline body change\n",
+        "Describe multiline body",
+        "First body line\nSecond body line\n\nThird body line",
+    );
+    commit_with_body(
+        "multiline_body.txt",
+        "multiline body next change\n",
+        "Describe multiline body",
+        "- First line\n- Second line",
+    );
+    commit_with_body(
+        "trailer_body.txt",
+        "trailer body change\n",
+        "Keep trailer-like text",
+        "Implements the workflow.\n\nRefs: #123",
+    );
+
+    let worktrunk_config = r#"
+[commit.generation]
+squash-template = """
+Combine these {{ commit_details | length }} commits into one message:
+{% for c in commit_details -%}
+- {{ c.subject }}
+{% if c.body -%}
+{{ c.body | trim | indent(2, true) }}
+{% endif -%}
+{% endfor %}
+<diff>
+{{ git_diff_stat -}}
+</diff>
+"""
+"#;
+    fs::write(repo.test_config_path(), worktrunk_config).unwrap();
+
+    assert_cmd_snapshot!(make_snapshot_cmd(
+        &repo,
+        "step",
+        &["squash", "--show-prompt"],
+        Some(&feature_wt),
+    ));
+}
+
 // =============================================================================
 // --dry-run tests
 // =============================================================================

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -317,7 +317,7 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# Available variables (in addition to commit template variables):[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# - `{{ commits }}` — list of commit subjects being squashed[0m
-[107m [0m [2m# - `{{ commit_details }}` — list of commits being squashed as `{ subject, body }` objects[0m
+[107m [0m [2m# - `{{ commit_details }}` — [experimental] list of commits being squashed as `{ subject, body }` objects[0m
 [107m [0m [2m# - `{{ target_branch }}` — merge target branch[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# Default template:[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -316,7 +316,8 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m#[0m
 [107m [0m [2m# Available variables (in addition to commit template variables):[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# - `{{ commits }}` — list of commits being squashed[0m
+[107m [0m [2m# - `{{ commits }}` — list of commit subjects being squashed[0m
+[107m [0m [2m# - `{{ commit_details }}` — list of commits being squashed as `{ subject, body }` objects[0m
 [107m [0m [2m# - `{{ target_branch }}` — merge target branch[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# Default template:[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -362,7 +362,8 @@ Default template:
 
 Available variables (in addition to commit template variables):
 
-- [2m{{ commits }}[0m — list of commits being squashed
+- [2m{{ commits }}[0m — list of commit subjects being squashed
+- [2m{{ commit_details }}[0m — list of commits being squashed as [2m{ subject, body }[0m objects
 - [2m{{ target_branch }}[0m — merge target branch
 
 Default template:

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -363,7 +363,7 @@ Default template:
 Available variables (in addition to commit template variables):
 
 - [2m{{ commits }}[0m — list of commit subjects being squashed
-- [2m{{ commit_details }}[0m — list of commits being squashed as [2m{ subject, body }[0m objects
+- [2m{{ commit_details }}[0m — [experimental] list of commits being squashed as [2m{ subject, body }[0m objects
 - [2m{{ target_branch }}[0m — merge target branch
 
 Default template:

--- a/tests/snapshots/integration__integration_tests__merge__step_squash_show_prompt_custom_template_renders_commit_details.snap
+++ b/tests/snapshots/integration__integration_tests__merge__step_squash_show_prompt_custom_template_renders_commit_details.snap
@@ -1,0 +1,81 @@
+---
+source: tests/integration_tests/merge.rs
+info:
+  program: wt
+  args:
+    - step
+    - squash
+    - "--show-prompt"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
+    GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+Combine these 5 commits into one message:
+- Add empty-body change
+- Describe body
+  Body line
+- Describe multiline body
+  First body line
+  Second body line
+
+  Third body line
+- Describe multiline body
+  - First line
+  - Second line
+- Keep trailer-like text
+  Implements the workflow.
+
+  Refs: #123
+
+<diff>
+ empty_body.txt     | 1 +
+ multiline_body.txt | 1 +
+ trailer_body.txt   | 1 +
+ with_body.txt      | 1 +
+ 4 files changed, 4 insertions(+)
+</diff>
+
+----- stderr -----


### PR DESCRIPTION
Closes #2982

This addresses the issue with an additive template variable, leaving `commits` unchanged.

- Adds `commit_details` to squash prompt templates as a list of `{ subject, body }`.
- Derives the existing subject-only `commits` value from `commit_details`.
- Uses the existing repository command to collect bodies with `git log` `%b` and NUL delimiters to preserve multiline bodies.
- Documents the variable and adds unit/integration coverage.

## Example

After this change, squash templates can include commit bodies:

```jinja
{% for c in commit_details -%}
- {{ c.subject }}
{% if c.body -%}
{{ c.body | trim | indent(2, true) }}
{% endif -%}
{% endfor %}
```

## Verification

```bash
cargo test -p worktrunk commit_message_details
cargo test -p worktrunk llm::tests
cargo test --test integration test_step_squash_show_prompt_custom_template_renders_commit_details
```