### PR TITLE
ci: retry codecov upload to ride out transient GPG-verification blips

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -465,10 +465,16 @@ jobs:
         path: cobertura.xml
 
     - name: Upload to codecov.io
-      uses: codecov/codecov-action@v6.0.1
+      # Retry to ride out transient Codecov uploader GPG-verification blips
+      # (the installer's public-key fetch intermittently returns empty).
+      uses: Wandalen/wretry.action@v3
       with:
-        files: cobertura.xml
+        action: codecov/codecov-action@v6.0.1
+        attempt_limit: 3
+        attempt_delay: 15000
         # Soft-fail on fork PRs: secrets aren't available there, so we rely on
         # tokenless upload, which can hiccup. Keep hard-fail on the main repo.
-        fail_ci_if_error: ${{ github.repository_owner == 'max-sixty' }}
-        token: ${{ secrets.CODECOV_TOKEN }}
+        with: |
+          files: cobertura.xml
+          fail_ci_if_error: ${{ github.repository_owner == 'max-sixty' }}
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
The `Upload to codecov.io` step has failed on three consecutive main pushes (issues #2993, #2996, plus the nushell push). Each time it's the same shape: the codecov installer fetches its GPG public key from Codecov's own infra, that fetch returns empty, and verifying the uploader's signature then fails with `Can't check signature: No public key`, exiting 1. Nothing in this repo controls that fetch, and it's intermittent — other codecov uploads in the same run succeed.

Issue #2996 flagged this third occurrence as the point to add a durable mitigation. Bumping the action isn't available (`codecov/codecov-action` is already at the latest, v6.0.1), so this wraps the upload in `Wandalen/wretry.action` (3 attempts, 15s apart). The wrapped action still runs its full GPG verification on each attempt, so the retry rides out the blip without weakening the signature check (unlike `skip_validation`, which would disable it).

Only the coverage upload is wrapped. It sets `fail_ci_if_error: true` on the main repo, so it's the one step that hard-fails CI. The test-results upload defaults to soft-fail (exit 0), so `wretry` would never see a failure to retry there.

Verified with `actionlint` and `pre-commit`. The real test is a future run where Codecov's GPG fetch flakes again.

> _This was written by Claude Code on behalf of max_
