### PR TITLE
refactor(config): store bare-repo prompt opt-out as a hint

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -850,6 +850,7 @@ as `worktrunk.hints.<name>`, a count of times the hint has been shown.
 | Name | Trigger | Message |
 |------|---------|---------|
 | `worktree-path` | First `wt switch --create` | Customize worktree locations: wt config create |
+| `skip-bare-repo-prompt` | Declining the bare-repo worktree-path prompt | Records the opt-out (no message shown) |
 
 ## Examples
 

--- a/src/commands/worktree/resolve.rs
+++ b/src/commands/worktree/resolve.rs
@@ -304,9 +304,9 @@ pub fn offer_bare_repo_worktree_path_fix(
             Ok(true)
         }
         PromptResponse::Declined => {
-            if let Err(e) = repo.mark_hint_shown("skip-bare-repo-prompt") {
-                log::warn!("Failed to save skip-bare-repo-prompt hint to git config: {e}");
-            }
+            // Best-effort, like every other hint write: a failed persist just
+            // means the prompt may reappear on the next switch.
+            let _ = repo.mark_hint_shown("skip-bare-repo-prompt");
             Ok(false)
         }
     }

--- a/src/commands/worktree/resolve.rs
+++ b/src/commands/worktree/resolve.rs
@@ -218,11 +218,7 @@ pub fn offer_bare_repo_worktree_path_fix(
         return Ok(false);
     }
 
-    if repo
-        .config_value("worktrunk.skip-bare-repo-prompt")
-        .unwrap_or(None)
-        .is_some()
-    {
+    if repo.has_shown_hint("skip-bare-repo-prompt") {
         return Ok(false);
     }
 
@@ -308,8 +304,8 @@ pub fn offer_bare_repo_worktree_path_fix(
             Ok(true)
         }
         PromptResponse::Declined => {
-            if let Err(e) = repo.set_config("worktrunk.skip-bare-repo-prompt", "true") {
-                log::warn!("Failed to save skip-bare-repo-prompt to git config: {e}");
+            if let Err(e) = repo.mark_hint_shown("skip-bare-repo-prompt") {
+                log::warn!("Failed to save skip-bare-repo-prompt hint to git config: {e}");
             }
             Ok(false)
         }

--- a/tests/integration_tests/bare_repository.rs
+++ b/tests/integration_tests/bare_repository.rs
@@ -1646,18 +1646,64 @@ mod bare_repo_prompt_pty {
             assert_snapshot!("bare_repo_prompt_decline", &output);
         });
 
-        // Verify skip flag was saved in git config
-        let git_config_output = Cmd::new("git")
+        // Declining records the opt-out as a hint (count 1), not under the legacy
+        // top-level key — so it participates in `wt config state`.
+        let hint_value = Cmd::new("git")
+            .args(["config", "worktrunk.hints.skip-bare-repo-prompt"])
+            .current_dir(&main_worktree)
+            .env("GIT_CONFIG_GLOBAL", test.git_config_path())
+            .run()
+            .unwrap();
+        assert_eq!(
+            String::from_utf8_lossy(&hint_value.stdout).trim(),
+            "1",
+            "Declining should record the opt-out as a hint"
+        );
+
+        // The legacy top-level key must not be written anymore.
+        let legacy_key = Cmd::new("git")
             .args(["config", "worktrunk.skip-bare-repo-prompt"])
             .current_dir(&main_worktree)
             .env("GIT_CONFIG_GLOBAL", test.git_config_path())
             .run()
             .unwrap();
-        let value = String::from_utf8_lossy(&git_config_output.stdout);
-        assert_eq!(
-            value.trim(),
-            "true",
-            "Skip flag should be saved in git config"
+        assert!(
+            !legacy_key.status.success(),
+            "Legacy top-level skip key should no longer be written"
+        );
+
+        // Round-trip through `wt config state`: the opt-out is listed by
+        // `state hints` and removed by the aggregate `state clear`.
+        let mut hints_cmd = wt_command();
+        test.configure_wt_cmd(&mut hints_cmd);
+        hints_cmd
+            .args(["config", "state", "hints"])
+            .current_dir(&main_worktree);
+        let hints_listed = String::from_utf8(hints_cmd.output().unwrap().stdout).unwrap();
+        assert!(
+            hints_listed.contains("skip-bare-repo-prompt"),
+            "state hints should list the opt-out.\nstdout: {hints_listed}"
+        );
+
+        let mut clear_cmd = wt_command();
+        test.configure_wt_cmd(&mut clear_cmd);
+        clear_cmd
+            .args(["config", "state", "clear"])
+            .current_dir(&main_worktree);
+        assert!(
+            clear_cmd.output().unwrap().status.success(),
+            "state clear should succeed"
+        );
+
+        let mut hints_after = wt_command();
+        test.configure_wt_cmd(&mut hints_after);
+        hints_after
+            .args(["config", "state", "hints"])
+            .current_dir(&main_worktree);
+        let hints_remaining = String::from_utf8(hints_after.output().unwrap().stdout).unwrap();
+        assert!(
+            !hints_remaining.contains("skip-bare-repo-prompt"),
+            "state clear should remove the opt-out hint.\nstdout: {hints_remaining}"
         );
     }
 

--- a/tests/integration_tests/bare_repository.rs
+++ b/tests/integration_tests/bare_repository.rs
@@ -1580,6 +1580,31 @@ fn test_bare_repo_worktree_path_prompt_skipped_for_symbolic_identifier() {
     );
 }
 
+/// Once the opt-out is recorded (the `skip-bare-repo-prompt` hint is set), the
+/// bare-repo warning/prompt is suppressed on later switches — the read path
+/// early-returns via `has_shown_hint`.
+#[test]
+fn test_bare_repo_prompt_suppressed_when_opted_out() {
+    let test = setup_unconfigured_nested_bare_repo();
+    let main_worktree = test.project_path().join("main");
+
+    // Record the opt-out the way a decline does: `worktrunk.hints.<name> = <count>`.
+    test.run_git_in(
+        &main_worktree,
+        &["config", "worktrunk.hints.skip-bare-repo-prompt", "1"],
+    );
+
+    let mut cmd = wt_command();
+    test.configure_wt_cmd(&mut cmd);
+    cmd.args(["switch", "--create", "feature"])
+        .current_dir(&main_worktree);
+    let stderr = String::from_utf8(cmd.output().unwrap().stderr).unwrap();
+    assert!(
+        !stderr.contains("Bare repo at"),
+        "Opted-out repo should not re-show the bare-repo warning.\nstderr: {stderr}"
+    );
+}
+
 // =============================================================================
 // PTY-based interactive prompt tests
 // =============================================================================


### PR DESCRIPTION
`worktrunk.skip-bare-repo-prompt` was stored as a top-level git-config key, which made it the only piece of persistent `worktrunk.*` state escaping the `state get`↔`state clear` parity invariant (documented at `src/commands/config/state.rs:6-31`). The `hints` subcommand globs the `worktrunk.hints.` prefix and the aggregate get/clear walk the same namespace, so a top-level key fell through both nets.

It's semantically a hint — a per-repo sticky "don't ask me this again" flag — so this stores it under `worktrunk.hints.skip-bare-repo-prompt` and reads/writes it via `has_shown_hint` / `mark_hint_shown`. It now lists under `wt config state hints` and clears with `wt config state clear`, with no new state category or docstring entry. The boolean opt-out maps onto the count-based hint API cleanly: `has_shown_hint` is `count >= 1`, and a single `mark_hint_shown` on decline sets the count to 1.

**Migration:** clean cutover, no migration. Existing users who already opted out get re-prompted once on their next `wt switch --create` in a dotted-name bare repo, after which the opt-out is recorded as a hint. Their orphaned legacy key is left in git config, unread. This is internal git-config state (flexible per project conventions), and the prompt only fires for bare repos with dotted names, so a single re-prompt is low-stakes.

**Testing:** the PTY decline test now asserts the hint key is written (and the legacy key is not), then round-trips the opt-out through `wt config state hints` → `wt config state clear`. Existing accept/preview/non-interactive prompt tests cover the unchanged paths.

> _This was written by Claude Code on behalf of max_
