### PR TITLE
docs(faq): add entry on moving uncommitted changes to a new worktree

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -62,6 +62,20 @@ Git TUIs operate on a single repository. Worktrunk manages multiple worktrees, r
 
 Not natively — stacked-branch workflows are a large design space, so Worktrunk treats them as an extension rather than a built-in. [`worktrunk-sync`](https://github.com/pablospe/worktrunk-sync) is a community tool that auto-detects the branch dependency tree from git history and rebases each branch onto its parent in topological order. Install with `cargo install worktrunk-sync` and run as `wt sync` (via [custom subcommands](@/extending.md#custom-subcommands)).
 
+## How do I move uncommitted changes to a new worktree?
+
+Stash the changes, create the worktree, then pop:
+
+{% terminal() %}
+<span class="cmd">git stash push -u           # -u also stashes untracked files</span>
+<span class="cmd">wt switch --create feature  # new branch off the default branch</span>
+<span class="cmd">git stash pop               # changes reappear in the new worktree</span>
+{% end %}
+
+The stash lives in the shared `.git` directory, so it's reachable from the new worktree. The original branch is left clean.
+
+`wt switch --create` bases the new branch on the default branch. To base it on the current commit instead, pass `--base=@` (needed when the current branch has commits beyond the default branch).
+
 ## There's an issue with my shell setup
 
 If shell integration isn't working (auto-cd not happening, completions missing, `wt` not found as a function), the fastest path to a fix is using Claude Code with the Worktrunk plugin:

--- a/skills/worktrunk/reference/faq.md
+++ b/skills/worktrunk/reference/faq.md
@@ -55,6 +55,20 @@ Git TUIs operate on a single repository. Worktrunk manages multiple worktrees, r
 
 Not natively — stacked-branch workflows are a large design space, so Worktrunk treats them as an extension rather than a built-in. [`worktrunk-sync`](https://github.com/pablospe/worktrunk-sync) is a community tool that auto-detects the branch dependency tree from git history and rebases each branch onto its parent in topological order. Install with `cargo install worktrunk-sync` and run as `wt sync` (via [custom subcommands](https://worktrunk.dev/extending/#custom-subcommands)).
 
+## How do I move uncommitted changes to a new worktree?
+
+Stash the changes, create the worktree, then pop:
+
+```bash
+$ git stash push -u           # -u also stashes untracked files
+$ wt switch --create feature  # new branch off the default branch
+$ git stash pop               # changes reappear in the new worktree
+```
+
+The stash lives in the shared `.git` directory, so it's reachable from the new worktree. The original branch is left clean.
+
+`wt switch --create` bases the new branch on the default branch. To base it on the current commit instead, pass `--base=@` (needed when the current branch has commits beyond the default branch).
+
 ## There's an issue with my shell setup
 
 If shell integration isn't working (auto-cd not happening, completions missing, `wt` not found as a function), the fastest path to a fix is using Claude Code with the Worktrunk plugin:


### PR DESCRIPTION
Adds an FAQ entry for moving uncommitted changes from the current branch onto a new worktree: the `git stash -u` → `wt switch --create` → `git stash pop` relay, plus `--base=@` for branching off the current commit instead of the default branch. Placed next to the stacked-branches how-to.

The entry exists because the worktree model collides with `git switch -c` muscle memory — reaching for the in-place flow either retargets the main worktree or silently leaves the changes behind. The gap is discoverability, not capability (the two-line stash relay already covers it), so a doc fits better than a new flag.

> _This was written by Claude Code on behalf of max_
