### PR TITLE
fix(help): render inline code in --help section headings

### DIFF
--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -100,7 +100,7 @@ See [LLM-generated commit messages](@/llm-commits.md) for configuration and prom
 
 ### Options
 
-#### `--stage`
+#### Staging
 
 Controls what to stage before committing:
 
@@ -119,7 +119,7 @@ Configure the default in user config:
 stage = "tracked"
 ```
 
-#### `--dry-run`
+#### Dry run
 
 Render the prompt, print the LLM command, generate the message, and exit without staging, running hooks, or committing:
 
@@ -190,7 +190,7 @@ See [LLM-generated commit messages](@/llm-commits.md) for configuration and prom
 
 ### Options
 
-#### `--stage`
+#### Staging
 
 Controls what to stage before squashing:
 
@@ -209,7 +209,7 @@ Configure the default in user config:
 stage = "tracked"
 ```
 
-#### `--dry-run`
+#### Dry run
 
 Render the prompt, print the LLM command, generate the squash message, and exit without resetting, running hooks, or committing:
 

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -91,7 +91,7 @@ See [LLM-generated commit messages](https://worktrunk.dev/llm-commits/) for conf
 
 ### Options
 
-#### `--stage`
+#### Staging
 
 Controls what to stage before committing:
 
@@ -112,7 +112,7 @@ Configure the default in user config:
 stage = "tracked"
 ```
 
-#### `--dry-run`
+#### Dry run
 
 Render the prompt, print the LLM command, generate the message, and exit without staging, running hooks, or committing:
 
@@ -185,7 +185,7 @@ See [LLM-generated commit messages](https://worktrunk.dev/llm-commits/) for conf
 
 ### Options
 
-#### `--stage`
+#### Staging
 
 Controls what to stage before squashing:
 
@@ -206,7 +206,7 @@ Configure the default in user config:
 stage = "tracked"
 ```
 
-#### `--dry-run`
+#### Dry run
 
 Render the prompt, print the LLM command, generate the squash message, and exit without resetting, running hooks, or committing:
 

--- a/src/cli/step.rs
+++ b/src/cli/step.rs
@@ -73,7 +73,7 @@ pub enum StepCommand {
 
 ## Options
 
-### `--stage`
+### Staging
 
 Controls what to stage before committing:
 
@@ -94,7 +94,7 @@ Configure the default in user config:
 stage = "tracked"
 ```
 
-### `--dry-run`
+### Dry run
 
 Render the prompt, print the LLM command, generate the message, and exit without staging, running hooks, or committing:
 
@@ -115,7 +115,7 @@ Three sections are printed: the rendered prompt, the shell command that would in
 
 ## Options
 
-### `--stage`
+### Staging
 
 Controls what to stage before squashing:
 
@@ -136,7 +136,7 @@ Configure the default in user config:
 stage = "tracked"
 ```
 
-### `--dry-run`
+### Dry run
 
 Render the prompt, print the LLM command, generate the squash message, and exit without resetting, running hooks, or committing:
 

--- a/src/md_help.rs
+++ b/src/md_help.rs
@@ -158,16 +158,20 @@ pub(crate) fn render_markdown_in_help_with_width(help: &str, width: Option<usize
         // - H4: Bold (nested subsections like "Commit template")
         if let Some(header_text) = trimmed.strip_prefix("#### ") {
             let bold = Style::new().bold();
+            let header_text = render_header_text(header_text);
             result.push_str(&format!("{bold}{header_text}{bold:#}\n"));
         } else if let Some(header_text) = trimmed.strip_prefix("### ") {
+            let header_text = render_header_text(header_text);
             result.push_str(&format!("{green}{header_text}{green:#}\n"));
         } else if let Some(header_text) = trimmed.strip_prefix("## ") {
             let bold_green = Style::new()
                 .bold()
                 .fg_color(Some(Color::Ansi(AnsiColor::Green)));
+            let header_text = render_header_text(header_text);
             result.push_str(&format!("{bold_green}{header_text}{bold_green:#}\n"));
         } else if let Some(header_text) = trimmed.strip_prefix("# ") {
-            result.push_str(&format!("{green}{}{green:#}\n", header_text.to_uppercase()));
+            let header_text = render_header_text(header_text).to_uppercase();
+            result.push_str(&format!("{green}{header_text}{green:#}\n"));
         } else {
             // Prose text - wrap if width is specified
             let formatted = render_inline_formatting(line);
@@ -324,6 +328,17 @@ fn strip_markdown_links(line: &str) -> String {
     }
 
     result
+}
+
+/// Strip inline markdown markers from header text.
+///
+/// Headers render with a single uniform style (color and/or weight), so inline
+/// `code` can't carry its own styling — the dim style's ANSI reset would
+/// terminate the header's color partway through the line. We drop the backticks
+/// and let the header style cover the whole heading; links are reduced to their
+/// text, matching prose rendering.
+fn render_header_text(text: &str) -> String {
+    strip_markdown_links(text).replace('`', "")
 }
 
 /// Render inline markdown formatting (bold, inline code, links)
@@ -571,6 +586,21 @@ mod tests {
         [1m[32mSection[0m
         [32mSubsection[0m
         [1mNested[0m
+        ");
+    }
+
+    #[test]
+    fn test_render_markdown_in_help_header_inline_code() {
+        // Inline `code` and links in headers are reduced to plain text so the
+        // header's own style covers the whole line (no literal backticks, no
+        // mid-line ANSI reset). Real case: `### Command log (`commands.jsonl`)`
+        // on the `wt config state logs` page.
+        let md = "### `--stage`\n#### Run `wt merge`\n## See [the docs](@/x.md)";
+        let result = render_markdown_in_help(md);
+        assert_snapshot!(result, @"
+        [32m--stage[0m
+        [1mRun wt merge[0m
+        [1m[32mSee the docs[0m
         ");
     }
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
@@ -73,7 +73,7 @@ View and manage log files — hook output, command audit trail, and debug diagno
 
 Three kinds of logs live in [2m.git/wt/logs/[0m:
 
-[32mCommand log (`commands.jsonl`)[0m
+[32mCommand log (commands.jsonl)[0m
 
 All hook executions and LLM commands are recorded automatically — one JSON object per line. Rotates to [2mcommands.jsonl.old[0m at 1MB (~2MB total). Fields:
 


### PR DESCRIPTION
Terminal `--help` applied heading styling to the raw header text without stripping inline-code markers, so a heading authored as `` ### `--stage` `` rendered with literal backticks. Header rendering now reduces inline `code` and links to plain text, letting the heading's single uniform style (color/weight) cover the whole line. A dim ANSI reset inside a colored heading would otherwise terminate the heading color partway through — visible on the `wt config state logs` heading `Command log (`commands.jsonl`)`, where the trailing `)` follows the code span. That heading is now fixed too.

Separately, renamed the `--stage` / `--dry-run` subsection headings in `wt step commit` and `wt step squash` to sentence case ("Staging", "Dry run"). They were the only flag-literal, inline-code headings in the entire help system; every other heading uses sentence-case topic wording, which the `writing-user-outputs` skill also prescribes. The flag name is still surfaced by the clap `Options:` block and each section's usage example.

The markdown source feeds three render contexts (terminal `--help`, web docs, skill mirrors); only the terminal path was wrong. Doc mirrors regenerated via `test_docs_are_in_sync`.

> _This was written by Claude Code on behalf of max_
