### PR TITLE
fix(state): don't repopulate default-branch cache on state get

### DIFF
--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -1081,8 +1081,9 @@ pub fn handle_state_show(format: OutputFormat) -> anyhow::Result<()> {
 
 /// Output state as JSON
 fn handle_state_show_json(repo: &Repository) -> anyhow::Result<()> {
-    // Get default branch
-    let default_branch = repo.default_branch();
+    // Read-only: report the cached default branch without detecting/persisting
+    // (see handle_state_show_table).
+    let default_branch = repo.cached_default_branch();
 
     // Get previous branch
     let previous_branch = repo.switch_previous();
@@ -1190,11 +1191,12 @@ fn handle_state_show_table(repo: &Repository) -> anyhow::Result<()> {
     // Build complete output as a string
     let mut out = String::new();
 
-    // Show default branch cache
+    // Show default branch cache. Read-only: this inspection must not detect
+    // or persist, or it would silently repopulate a just-cleared cache.
     writeln!(out, "{}", format_heading("DEFAULT BRANCH", None))?;
-    match repo.default_branch() {
+    match repo.cached_default_branch() {
         Some(branch) => writeln!(out, "{}", format_with_gutter(&branch, None))?,
-        None => writeln!(out, "{}", format_with_gutter("(not available)", None))?,
+        None => writeln!(out, "{}", format_with_gutter("(none)", None))?,
     }
     writeln!(out)?;
 

--- a/src/git/repository/config.rs
+++ b/src/git/repository/config.rs
@@ -529,6 +529,24 @@ impl Repository {
         self.unset_config_value("worktrunk.default-branch")
     }
 
+    /// Read the persisted default-branch cache without detecting or writing.
+    ///
+    /// Unlike `default_branch()`, this never falls through to detection
+    /// (`origin/HEAD`, `git ls-remote`, local inference) and never persists a
+    /// result. It reports only what is currently stored in
+    /// `worktrunk.default-branch`, so state-inspection commands
+    /// (`wt config state`) can display the cache without the act of inspecting
+    /// it repopulating the very value being cleared.
+    ///
+    /// Returns `None` when nothing is cached.
+    pub fn cached_default_branch(&self) -> Option<String> {
+        self.config_value("worktrunk.default-branch")
+            .ok()
+            .flatten()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+    }
+
     // =========================================================================
     // Project config
     // =========================================================================

--- a/tests/integration_tests/config_state.rs
+++ b/tests/integration_tests/config_state.rs
@@ -1040,7 +1040,7 @@ fn test_state_get_empty(repo: TestRepo) {
     state_get_settings().bind(|| {
         assert_snapshot!(String::from_utf8_lossy(&output.stdout), @"
         [36mDEFAULT BRANCH[39m
-        [107m [0m main
+        [107m [0m (none)
 
         [36mPREVIOUS BRANCH[39m
         [107m [0m (none)
@@ -1114,6 +1114,12 @@ fn test_state_get_with_ci_entries(repo: TestRepo) {
 
 #[rstest]
 fn test_state_get_comprehensive(repo: TestRepo) {
+    // Populate the default-branch cache (the dump reads it, never detects)
+    repo.git_command()
+        .args(["config", "worktrunk.default-branch", "main"])
+        .run()
+        .unwrap();
+
     // Set up previous branch
     repo.git_command()
         .args(["config", "worktrunk.history", "feature"])
@@ -1207,7 +1213,7 @@ fn test_state_get_json_empty(repo: TestRepo) {
     {
       "ci_status": [],
       "command_log": [],
-      "default_branch": "main",
+      "default_branch": null,
       "diagnostic": [],
       "git_commands_cache": 0,
       "hints": [],
@@ -1223,6 +1229,12 @@ fn test_state_get_json_empty(repo: TestRepo) {
 
 #[rstest]
 fn test_state_get_json_comprehensive(repo: TestRepo) {
+    // Populate the default-branch cache (the dump reads it, never detects)
+    repo.git_command()
+        .args(["config", "worktrunk.default-branch", "main"])
+        .run()
+        .unwrap();
+
     // Set up previous branch
     repo.git_command()
         .args(["config", "worktrunk.history", "feature"])
@@ -1375,7 +1387,7 @@ fn test_state_get_json_with_logs(repo: TestRepo) {
               "size": "<SIZE>"
             }
           ],
-          "default_branch": "main",
+          "default_branch": null,
           "diagnostic": [],
           "git_commands_cache": 0,
           "hints": [],

--- a/tests/snapshots/integration__integration_tests__config_state__state_get_with_ci_entries.snap
+++ b/tests/snapshots/integration__integration_tests__config_state__state_get_with_ci_entries.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/config_state.rs
 expression: "String::from_utf8_lossy(&output.stdout)"
 ---
 [36mDEFAULT BRANCH[39m
-[107m [0m main
+[107m [0m (none)
 
 [36mPREVIOUS BRANCH[39m
 [107m [0m (none)


### PR DESCRIPTION
`wt config state get` rendered its DEFAULT BRANCH section through `default_branch()`, the detect-and-cache resolver. On an empty cache that resolver re-detects and persists, so running `wt config state get` right after `wt config state clear` silently rewrote the `worktrunk.default-branch` value the clear had just removed. The cleared state was real but invisible: inspecting it re-created it. On a cold clone the same path could fire `git ls-remote` from a command that's meant to be pure inspection.

The aggregate dump now reads the cache read-only through a new `cached_default_branch()` accessor, in both the text and JSON paths. This matches how the dump's CI section already reads `CachedCiStatus` without fetching, so every section of `state get` is now a faithful, side-effect-free readout. An empty cache shows `(none)` (text) / `null` (JSON), consistent with the sibling sections.

`wt config state default-branch get` is unchanged: it still resolves and caches, because that command's job is to determine the default branch (e.g. `git rebase $(wt config state default-branch)`), not to report stored state.

The two comprehensive `state get` tests now seed `worktrunk.default-branch` so they exercise the populated path; the empty/CI/logs tests exercise the `(none)`/`null` path.

> _This was written by Claude Code on behalf of max_
