### PR TITLE
docs(state): distinguish reading the cache from resolving it

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -838,6 +838,8 @@ In a hook or alias template, prefer the `{{ default_branch }}` [template variabl
 
 Without a subcommand, runs `get`. Use `set` to override, or `clear` then `get` to re-detect.
 
+`default-branch get` resolves the value and caches it on a miss; the aggregate `wt config state get` only reports the cache (read-only), so it can show `(none)` until something populates it.
+
 ### Detection
 
 Worktrunk detects the default branch automatically:

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -868,6 +868,8 @@ In a hook or alias template, prefer the `{{ default_branch }}` [template variabl
 
 Without a subcommand, runs `get`. Use `set` to override, or `clear` then `get` to re-detect.
 
+`default-branch get` resolves the value and caches it on a miss; the aggregate `wt config state get` only reports the cache (read-only), so it can show `(none)` until something populates it.
+
 ### Detection
 
 Worktrunk detects the default branch automatically:

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -709,6 +709,8 @@ In a hook or alias template, prefer the `{{ default_branch }}` [template variabl
 
 Without a subcommand, runs `get`. Use `set` to override, or `clear` then `get` to re-detect.
 
+`default-branch get` resolves the value and caches it on a miss; the aggregate `wt config state get` only reports the cache (read-only), so it can show `(none)` until something populates it.
+
 ## Detection
 
 Worktrunk detects the default branch automatically:

--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -30,6 +30,17 @@
 //! `handle_state_clear_all`, plus the `after_long_help` blocks for `state get`
 //! and `state clear` in `src/cli/config.rs`, in the same change.
 //!
+//! # Reading vs resolving
+//!
+//! The aggregate `state get` is pure inspection: it reports stored values
+//! read-only and never detects, fetches, or persists (`default-branch` via
+//! `cached_default_branch()`, CI via `CachedCiStatus::list_all`). A per-key
+//! `get` for a *derived* value resolves it and caches the result
+//! (`default-branch get` -> `default_branch()`, `ci-status get` ->
+//! `PrStatus::detect`); for stored-only values (`previous-branch`, `marker`)
+//! it is a plain read. So a `clear` followed by the aggregate `get` shows the
+//! value gone, while the per-key `get` would re-resolve it.
+//!
 //! # Log layout invariant
 //!
 //! Inside `wt_logs_dir()`, top-level *files* are shared logs (`commands.jsonl*`,

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_default_branch.snap
@@ -72,6 +72,8 @@ In a hook or alias template, prefer the [2m{{ default_branch }}[0m template va
 
 Without a subcommand, runs [2mget[0m. Use [2mset[0m to override, or [2mclear[0m then [2mget[0m to re-detect.
 
+[2mdefault-branch get[0m resolves the value and caches it on a miss; the aggregate [2mwt config state get[0m only reports the cache (read-only), so it can show [2m(none)[0m until something populates it.
+
 [1m[32mDetection[0m
 
 Worktrunk detects the default branch automatically:


### PR DESCRIPTION
Documentation follow-up to #3024 (which made `wt config state get` read the default-branch cache read-only).

After that change the dump shows `DEFAULT BRANCH (none)` right after a `clear`, while `wt config state default-branch get` still returns the resolved branch. That contrast can read as inconsistent. Two small additions make the model explicit:

- The `default-branch` `--help` gains one line: `default-branch get` resolves and caches; the aggregate `wt config state get` only reports the cache, so it can show `(none)` until something populates it.
- The `state` module spec gains a "Reading vs resolving" section recording the invariant for future developers: the aggregate `get` inspects read-only (`cached_default_branch()`, `CachedCiStatus::list_all`), while a per-key `get` for a derived value resolves it (`default_branch()`, `PrStatus::detect`).

No behavior change. The `docs/` and `skills/` mirrors and the `--help` snapshot are regenerated from the source.

> _This was written by Claude Code on behalf of max_
