### PR TITLE
feat(statusline): log rate-limit window selection at -vv

### DIFF
--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -10,17 +10,24 @@ pub enum ListSubcommand {
 
 - `table` (default): `branch  status  ±working  commits  upstream  ci`
 - `json`: Same structure as `wt list --format=json` but for the current worktree only
-- `claude-code`: Reads context from stdin, adds directory and model segments
+- `claude-code`: Reads context from stdin, adds directory, model, context, and rate-limit segments
 
 ## Claude Code mode
 
 With `--format=claude-code`, reads JSON context from stdin:
-`dir  branch  status  ±working  commits  upstream  ci  | model  context`
+`dir  branch  status  ±working  commits  upstream  ci  model  context  pace`
 
-Input fields (all optional):
+Input fields (`.workspace.current_dir` is required; the rest are optional):
 - `.workspace.current_dir` — working directory
 - `.model.display_name` — model name
 - `.context_window.used_percentage` — context usage (0-100)
+- `.rate_limits.{five_hour,seven_day}.used_percentage` — rate-limit window usage (0-100)
+- `.rate_limits.{five_hour,seven_day}.resets_at` — window reset time (Unix epoch seconds)
+
+The pace segment (e.g. `2.9×pace(Tue–Tue 5pm)`) appears only when usage is
+likely to hit a rate limit before its window resets, and shows the
+higher-risk window. With `-vv`, each window's inputs and projection are
+logged to `.git/wt/logs/trace.log`.
 "#)]
     Statusline {
         /// Output format (table, json, claude-code)

--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -39,6 +39,8 @@ struct ClaudeCodeContext {
 /// A single rate-limit window reading parsed from Claude Code's JSON.
 #[derive(Clone, Debug)]
 struct RateLimitReading {
+    /// Window key in Claude Code's JSON: `five_hour` or `seven_day`.
+    name: &'static str,
     /// 0–100 from `.rate_limits.<window>.used_percentage`.
     used_percentage: f64,
     /// Unix epoch seconds from `.rate_limits.<window>.resets_at`.
@@ -230,6 +232,14 @@ const RATE_LIMIT_P_THRESHOLD: f64 = 0.50;
 /// Both windows are independently optional: subscribers see `rate_limits`
 /// only after the first API response, and each window may be missing.
 fn parse_rate_limits(v: &serde_json::Value) -> Vec<RateLimitReading> {
+    // Ground truth for debugging window selection: which windows Claude Code
+    // actually sent, before any parsing or clamping. The explicit absent case
+    // distinguishes "no rate_limits key" from "stdin context never parsed"
+    // (which logs nothing at all).
+    match v.get("rate_limits") {
+        Some(rl) => log::debug!("rate_limits input: {rl}"),
+        None => log::debug!("rate_limits input: absent"),
+    }
     let mut out = Vec::new();
     for (key, window_secs, priors) in [
         ("five_hour", FIVE_HOUR_SECS, &FIVE_HOUR_PRIORS),
@@ -243,6 +253,7 @@ fn parse_rate_limits(v: &serde_json::Value) -> Vec<RateLimitReading> {
             .and_then(|x| x.as_i64());
         if let (Some(u), Some(r)) = (used, resets) {
             out.push(RateLimitReading {
+                name: key,
                 used_percentage: u,
                 resets_at: r,
                 window_secs,
@@ -395,8 +406,8 @@ where
 }
 
 /// Format the rate-limit window's start and end as a short label that
-/// goes inside the parenthetical: `10am-3pm` (12h) / `10:00–15:00` (24h) for
-/// the 5-hour window, `Mon-Mon 3pm` / `Mon-Mon 15:00` for the 7-day window.
+/// goes inside the parenthetical: `10am–3pm` (12h) / `10:00–15:00` (24h) for
+/// the 5-hour window, `Mon–Mon 3pm` / `Mon–Mon 15:00` for the 7-day window.
 ///
 /// The 5h variant uses clock times on both endpoints. The longer window
 /// uses the weekday on both ends (they're equal for a true 7-day rolling
@@ -459,6 +470,13 @@ fn select_binding_window(
             let elapsed = (now_unix - (r.resets_at - r.window_secs)) as f64 / r.window_secs as f64;
             let t = elapsed.clamp(0.0, 1.0);
             let p = p_over(u, t, r.priors);
+            log::debug!(
+                "rate-limit {} window: used={:.1}% elapsed={:.1}% pace={:.2}× P(over)={p:.3} (show threshold {RATE_LIMIT_P_THRESHOLD})",
+                r.name,
+                u * 100.0,
+                t * 100.0,
+                u / t.max(0.001),
+            );
             (p >= RATE_LIMIT_P_THRESHOLD).then_some((p, r))
         })
         .max_by(|(a, _), (b, _)| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal))
@@ -467,8 +485,8 @@ fn select_binding_window(
 
 /// Build the rate-limit segment, or `None` to hide.
 ///
-/// Shape: `<pace>×pace(<window_bounds>)` — e.g. `1.4×pace(10am-3pm)` or
-/// `1.9×pace(Mon-Mon 3pm)`. `pace` is the **naive `u/t` ratio**: what the
+/// Shape: `<pace>×pace(<window_bounds>)` — e.g. `1.4×pace(10am–3pm)` or
+/// `1.9×pace(Mon–Mon 3pm)`. `pace` is the **naive `u/t` ratio**: what the
 /// user has actually consumed per unit elapsed window. `1.0×` is on pace
 /// to exactly fill the window; `>1.0×` is over-pace. The Bayesian
 /// posterior `m₁` is only used by [`p_over`] to decide whether to show —
@@ -1283,6 +1301,11 @@ mod tests {
     ) -> RateLimitReading {
         let resets_at = now + ((1.0 - t_elapsed) * window_secs as f64).round() as i64;
         RateLimitReading {
+            name: if window_secs == FIVE_HOUR_SECS {
+                "five_hour"
+            } else {
+                "seven_day"
+            },
             used_percentage: used_pct,
             resets_at,
             window_secs,

--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -1337,6 +1337,23 @@ mod tests {
     }
 
     #[test]
+    fn test_select_binding_window_logs_at_debug() {
+        // The per-window debug line's format args are lazily skipped at
+        // default verbosity; enabling Debug evaluates them. The
+        // not-yet-started window (negative elapsed, clamped to 0) is the
+        // case the `t.max(0.001)` division guard exists for.
+        log::set_max_level(log::LevelFilter::Debug);
+        let now = 1_700_000_000_i64;
+        let readings = [
+            make_reading(80.0, 0.60, &FIVE_HOUR_PRIORS, now, FIVE_HOUR_SECS),
+            make_reading(5.0, -0.10, &SEVEN_DAY_PRIORS, now, SEVEN_DAY_SECS),
+        ];
+        let sel = select_binding_window(&readings, now);
+        log::set_max_level(log::LevelFilter::Off);
+        assert_eq!(sel.unwrap().used_percentage, 80.0);
+    }
+
+    #[test]
     fn test_select_binding_window_picks_worse_of_two() {
         let now = 1_700_000_000_i64;
         let readings = [


### PR DESCRIPTION
The statusline's rate-limit pace segment surfaces only the "binding" window (highest P(over)), which made questions like "why does it show the weekly window instead of the session?" unanswerable: the inputs arrive on stdin per redraw and are never persisted. With `-vv`, the statusline now logs the raw `rate_limits` payload and each window's used/elapsed/pace/P(over) to `.git/wt/logs/trace.log`, so pointing the Claude Code statusline at `wt -vv list statusline --format=claude-code` makes the selection reconstructable from the latest redraw.

The `wt list statusline` help text also catches up with claude-code mode: it now documents the context and pace segments and the `.rate_limits.*` input fields, drops the literal `|` from the segment diagram (segments join with two spaces), and marks `.workspace.current_dir` as required (the parser discards the whole stdin context without it). `RateLimitReading` carries the window key so log lines say `five_hour`/`seven_day` like the payload does.

Tested with synthetic payloads piped through `wt -vv list statusline --format=claude-code` and against a live Claude Code session; the docs-sync test confirms no generated mirrors needed updating.

> _This was written by Claude Code on behalf of max_
