### PR TITLE
refactor: strip ANSI via ansi_strip() directly, dropping local helpers

### DIFF
--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -2003,35 +2003,14 @@ pub fn populate_item(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    /// Strip ANSI escape sequences so snapshots read as plain text.
-    fn strip_ansi(s: &str) -> String {
-        let mut out = String::with_capacity(s.len());
-        let mut chars = s.chars().peekable();
-        while let Some(c) = chars.next() {
-            if c != '\x1b' {
-                out.push(c);
-                continue;
-            }
-            // CSI: ESC [ ... (letter terminator)
-            if chars.peek() == Some(&'[') {
-                chars.next();
-                for next in chars.by_ref() {
-                    if next.is_ascii_alphabetic() {
-                        break;
-                    }
-                }
-            }
-        }
-        out
-    }
+    use ansi_str::AnsiStr;
 
     #[test]
     fn test_format_stall_footer_single_pending() {
         let rendered =
             format_stall_footer("Showing 3 worktrees", 5, 12, 1, TaskKind::CiStatus, "feat");
         insta::assert_snapshot!(
-            strip_ansi(&rendered),
+            rendered.ansi_strip(),
             @"○ Showing 3 worktrees (5/12 loaded, no recent progress; waiting on ci-status for feat)"
         );
     }
@@ -2041,7 +2020,7 @@ mod tests {
         let rendered =
             format_stall_footer("Showing 3 worktrees", 5, 12, 3, TaskKind::CiStatus, "feat");
         insta::assert_snapshot!(
-            strip_ansi(&rendered),
+            rendered.ansi_strip(),
             @"○ Showing 3 worktrees (5/12 loaded, no recent progress; waiting on 3 tasks, including ci-status for feat)"
         );
     }
@@ -2052,7 +2031,7 @@ mod tests {
     fn test_format_drain_timeout_diag_no_items() {
         let rendered = format_drain_timeout_diag(7, &[]);
         insta::assert_snapshot!(
-            strip_ansi(&rendered),
+            rendered.ansi_strip(),
             @"Listing worktrees timed out after 120s (7 results received)"
         );
     }
@@ -2073,12 +2052,14 @@ mod tests {
         let lines = captured.lock().unwrap();
         assert_eq!(lines.len(), 2, "expected warning + hint, got: {lines:?}");
         assert!(
-            strip_ansi(&lines[0]).contains("Listing worktrees timed out after"),
+            lines[0]
+                .ansi_strip()
+                .contains("Listing worktrees timed out after"),
             "warning line: {}",
             lines[0]
         );
         assert!(
-            strip_ansi(&lines[1]).contains("re-run with -v"),
+            lines[1].ansi_strip().contains("re-run with -v"),
             "hint line: {}",
             lines[1]
         );
@@ -2134,7 +2115,7 @@ mod tests {
         ];
         let rendered = format_drain_timeout_diag(3, &items);
         insta::assert_snapshot!(
-            strip_ansi(&rendered),
+            rendered.ansi_strip(),
             @r"
         Listing worktrees timed out after 120s (3 results received); blocked tasks:
           feature-a: ci-status, branch-diff
@@ -2156,7 +2137,7 @@ mod tests {
             .collect();
         let rendered = format_drain_timeout_diag(2, &items);
         insta::assert_snapshot!(
-            strip_ansi(&rendered),
+            rendered.ansi_strip(),
             @r"
         Listing worktrees timed out after 120s (2 results received); blocked tasks:
           feature-0: ahead-behind

--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -136,7 +136,7 @@ impl DiagnosticReport {
     /// Format the complete diagnostic report as markdown using minijinja template.
     fn format_report(repo: &Repository, command: &str, context: &str) -> String {
         // Strip ANSI codes from context - the diagnostic is a markdown file for GitHub
-        let context = strip_ansi_codes(context);
+        let context = context.ansi_strip();
 
         // Collect data for template
         let timestamp = worktrunk::utils::now_iso8601();
@@ -298,13 +298,6 @@ fn is_gh_installed() -> bool {
         .unwrap_or(false)
 }
 
-/// Strip ANSI escape codes from a string.
-///
-/// Used to clean terminal-formatted text for markdown output.
-fn strip_ansi_codes(s: &str) -> String {
-    s.ansi_strip().into_owned()
-}
-
 /// Truncate log content to ~50KB if it's too large.
 ///
 /// Keeps the last ~50KB of the log, cutting at a line boundary.
@@ -447,15 +440,6 @@ mod tests {
         let result = format_config_section(&path, "Test");
         assert!(result.contains("(truncated)"));
         assert!(result.len() < 5000);
-    }
-
-    #[test]
-    fn test_strip_ansi_codes() {
-        // Build ANSI codes programmatically to avoid lint
-        let esc = '\x1b';
-        let input = format!("{esc}[31mred{esc}[0m and {esc}[32mgreen{esc}[0m");
-        let result = strip_ansi_codes(&input);
-        assert_eq!(result, "red and green");
     }
 
     #[test]

--- a/src/help.rs
+++ b/src/help.rs
@@ -348,7 +348,7 @@ fn find_after_help_start(help: &str) -> Option<usize> {
 
     for line in help.lines() {
         // Strip ANSI codes for pattern matching
-        let plain_line = strip_ansi_codes(line);
+        let plain_line = line.ansi_strip();
 
         if plain_line.starts_with("Global Options:") {
             past_global_options = true;
@@ -371,11 +371,6 @@ fn find_after_help_start(help: &str) -> Option<usize> {
         offset += line.len() + 1;
     }
     None
-}
-
-/// Strip ANSI escape codes from a string for pattern matching.
-fn strip_ansi_codes(s: &str) -> String {
-    s.ansi_strip().into_owned()
 }
 
 /// Extract the `about` (definition) and subtitle from a command's metadata.


### PR DESCRIPTION
A simplification review found three local ANSI-stripping implementations: identical `strip_ansi_codes` wrappers in `help.rs` and `diagnostic.rs`, and a hand-rolled CSI-only escape parser in the `list/collect` test module. All three call sites now use `ansi_str::AnsiStr::ansi_strip()` directly, the idiom already used at the ~45 other stripping sites in the codebase. Net +12/−52, no new API.

The hand-rolled parser handled only CSI sequences; `ansi_strip` covers the full escape grammar. The unchanged inline snapshots in the collect tests confirm identical output for the strings those tests produce. In `help.rs`, keeping the returned `Cow` borrowed also drops a per-line `String` allocation in the help-text scanning loop.

An earlier iteration added a shared `styling::strip_ansi_codes` helper instead; it was cut in favor of the trait method since the crate already is the canonical implementation, and a wrapper would have left the codebase with two spellings of the same operation.

> _This was written by Claude Code on behalf of max_
