### PR TITLE
docs(CLAUDE): codecov posts check runs on PR heads, not commit statuses

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -131,7 +131,7 @@ Why: wt installs a `signal_hook` SIGINT/SIGTERM handler so it can forward signal
 
 ## Coverage
 
-**NEVER merge a PR with failing `codecov/patch` without explicit user approval.** It is marked "not required" in GitHub but still gates merge. On failure, investigate and fix the gap — write tests, or remove unused code (including specialized error handlers for rare cases where falling through to a general handler suffices). If you believe it's a false positive, ask the user before merging. Coverage runs include `--features shell-integration-tests` (CI `code-coverage` and local `task coverage`) — don't dismiss failures by claiming the feature is off. Investigation commands, rename false-positives, and the "N functions mismatched" warning: `tests/CLAUDE.md`.
+**NEVER merge a PR with failing `codecov/patch` without explicit user approval.** It is marked "not required" in GitHub but still gates merge. On PR heads codecov posts **check runs** (codecov GitHub App), not commit statuses: poll with `gh pr checks <number>` or the check-runs API; the combined-status API (`/commits/<sha>/status`) never shows them, and the check run lands a few minutes after the `code-coverage` job finishes. On failure, investigate and fix the gap — write tests, or remove unused code (including specialized error handlers for rare cases where falling through to a general handler suffices). If you believe it's a false positive, ask the user before merging. Coverage runs include `--features shell-integration-tests` (CI `code-coverage` and local `task coverage`) — don't dismiss failures by claiming the feature is off. Investigation commands, rename false-positives, and the "N functions mismatched" warning: `tests/CLAUDE.md`.
 
 ## Benchmarks & Traces
 


### PR DESCRIPTION
A CI monitor watching PR #3035 polled the combined-status API (`gh api .../commits/<sha>/status`) for `codecov/patch` and concluded codecov had stopped posting on PR heads. Investigation showed nothing is broken: codecov's GitHub App posts **check runs** on PR head commits (commit statuses appear only on main pushes), and check runs never show up in the legacy status API. This has been the case since at least April (oldest surviving PR head, #1743). The check run also lands several minutes after the `code-coverage` job finishes (~9 min on #3035).

This adds one sentence to the Coverage section so merge gating polls `gh pr checks` rather than the status API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> _This was written by Claude Code on behalf of max_
