### PR TITLE
Add PR/MR review state to wt list CI status

### DIFF
--- a/docs/CLAUDE.md
+++ b/docs/CLAUDE.md
@@ -256,6 +256,8 @@ The `--help-page` generator in `src/help.rs` applies post-processing to transfor
 | `` `●` green `` | `<span style='color:#0a0'>●</span> green` |
 | `` `●` blue `` | `<span style='color:#00a'>●</span> blue` |
 | `` `●` red `` | `<span style='color:#a00'>●</span> red` |
+| `` `●` magenta `` | `<span style='color:#a0a'>●</span> magenta` |
+| `` `●` cyan `` | `<span style='color:#0aa'>●</span> cyan` |
 | `` `●` yellow `` | `<span style='color:#a60'>●</span> yellow` |
 | `` `●` gray `` | `<span style='color:#888'>●</span> gray` |
 | `[experimental]` | `<span class="badge-experimental"></span>` (text via CSS `::after`) |

--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -99,10 +99,14 @@ The CI column shows GitHub/GitLab pipeline status:
 | <span style='color:#0a0'>●</span> green | All checks passed |
 | <span style='color:#00a'>●</span> blue | Checks running |
 | <span style='color:#a00'>●</span> red | Checks failed |
+| <span style='color:#a0a'>●</span> magenta | Reviewer requested changes |
+| <span style='color:#0aa'>●</span> cyan | Review required, not yet given |
 | <span style='color:#a60'>●</span> yellow | Merge conflicts with base |
 | <span style='color:#888'>●</span> gray | No checks configured |
 | <span style='color:#a60'>⚠</span> yellow | Fetch error (rate limit, network) |
 | (blank) | No upstream or no PR/MR |
+
+Review state merges into the same dot where its required action ranks: changes-requested (magenta) outranks running checks — waiting can't clear it — while an outstanding required review (cyan) only recolors an otherwise green or quiet branch. Cool colors mean waiting, warm colors mean act. A PR with no review signal (no required reviewers and no reviews) keeps its plain CI color, and draft PRs appear dimmed.
 
 CI indicators are clickable links to the PR or pipeline page. Any CI dot appears dimmed when unpushed local changes make the status stale. PRs/MRs are checked first, then branch workflows/pipelines for branches with an upstream. Local-only branches show blank; remote-only branches — visible with `--remotes` — get CI status detection. Results are cached for 30-60 seconds; use `wt config state` to view or clear.
 
@@ -239,6 +243,8 @@ Query structured data with `--format=json`:
 | `source` | string | `"pr"` (PR/MR) or `"branch"` (branch workflow) |
 | `stale` | boolean | Local HEAD differs from remote (unpushed changes) |
 | `url` | string | URL to the PR/MR page |
+| `repo_url` | string | Web URL of the repo the PR/MR targets (the upstream for fork PRs); absent when `url` is absent or unrecognized |
+| `review_state` | string | Review state (see below); absent when the forge reports no review signal |
 
 ### main_state values
 
@@ -253,6 +259,12 @@ When `main_state == "integrated"`: `"ancestor"` `"trees-match"` `"no-added-chang
 ### ci.status values
 
 `"passed"` `"running"` `"failed"` `"conflicts"` `"no-ci"` `"error"`
+
+### ci.review_state values
+
+`"approved"` `"changes_requested"` `"pending"` `"draft"`
+
+The vocabulary matches Claude Code's statusline `pr.review_state` field. `"pending"` means a review is required (e.g. branch protection) but not yet given; a PR with no review signal at all has no `review_state`. GitLab reports only `"pending"` and `"draft"` — MR list data carries no approved or changes-requested signal.
 
 Missing a field that would be generally useful? [Open an issue](https://github.com/max-sixty/worktrunk/issues).
 

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -88,10 +88,14 @@ The CI column shows GitHub/GitLab pipeline status:
 | `●` green | All checks passed |
 | `●` blue | Checks running |
 | `●` red | Checks failed |
+| `●` magenta | Reviewer requested changes |
+| `●` cyan | Review required, not yet given |
 | `●` yellow | Merge conflicts with base |
 | `●` gray | No checks configured |
 | `⚠` yellow | Fetch error (rate limit, network) |
 | (blank) | No upstream or no PR/MR |
+
+Review state merges into the same dot where its required action ranks: changes-requested (magenta) outranks running checks — waiting can't clear it — while an outstanding required review (cyan) only recolors an otherwise green or quiet branch. Cool colors mean waiting, warm colors mean act. A PR with no review signal (no required reviewers and no reviews) keeps its plain CI color, and draft PRs appear dimmed.
 
 CI indicators are clickable links to the PR or pipeline page. Any CI dot appears dimmed when unpushed local changes make the status stale. PRs/MRs are checked first, then branch workflows/pipelines for branches with an upstream. Local-only branches show blank; remote-only branches — visible with `--remotes` — get CI status detection. Results are cached for 30-60 seconds; use `wt config state` to view or clear.
 
@@ -250,6 +254,8 @@ $ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 | `source` | string | `"pr"` (PR/MR) or `"branch"` (branch workflow) |
 | `stale` | boolean | Local HEAD differs from remote (unpushed changes) |
 | `url` | string | URL to the PR/MR page |
+| `repo_url` | string | Web URL of the repo the PR/MR targets (the upstream for fork PRs); absent when `url` is absent or unrecognized |
+| `review_state` | string | Review state (see below); absent when the forge reports no review signal |
 
 ### main_state values
 
@@ -264,6 +270,12 @@ When `main_state == "integrated"`: `"ancestor"` `"trees-match"` `"no-added-chang
 ### ci.status values
 
 `"passed"` `"running"` `"failed"` `"conflicts"` `"no-ci"` `"error"`
+
+### ci.review_state values
+
+`"approved"` `"changes_requested"` `"pending"` `"draft"`
+
+The vocabulary matches Claude Code's statusline `pr.review_state` field. `"pending"` means a review is required (e.g. branch protection) but not yet given; a PR with no review signal at all has no `review_state`. GitLab reports only `"pending"` and `"draft"` — MR list data carries no approved or changes-requested signal.
 
 Missing a field that would be generally useful? Open an issue at https://github.com/max-sixty/worktrunk.
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -771,10 +771,14 @@ The CI column shows GitHub/GitLab pipeline status:
 | `●` green | All checks passed |
 | `●` blue | Checks running |
 | `●` red | Checks failed |
+| `●` magenta | Reviewer requested changes |
+| `●` cyan | Review required, not yet given |
 | `●` yellow | Merge conflicts with base |
 | `●` gray | No checks configured |
 | `⚠` yellow | Fetch error (rate limit, network) |
 | (blank) | No upstream or no PR/MR |
+
+Review state merges into the same dot where its required action ranks: changes-requested (magenta) outranks running checks — waiting can't clear it — while an outstanding required review (cyan) only recolors an otherwise green or quiet branch. Cool colors mean waiting, warm colors mean act. A PR with no review signal (no required reviewers and no reviews) keeps its plain CI color, and draft PRs appear dimmed.
 
 CI indicators are clickable links to the PR or pipeline page. Any CI dot appears dimmed when unpushed local changes make the status stale. PRs/MRs are checked first, then branch workflows/pipelines for branches with an upstream. Local-only branches show blank; remote-only branches — visible with `--remotes` — get CI status detection. Results are cached for 30-60 seconds; use `wt config state` to view or clear.
 
@@ -933,6 +937,8 @@ $ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 | `source` | string | `"pr"` (PR/MR) or `"branch"` (branch workflow) |
 | `stale` | boolean | Local HEAD differs from remote (unpushed changes) |
 | `url` | string | URL to the PR/MR page |
+| `repo_url` | string | Web URL of the repo the PR/MR targets (the upstream for fork PRs); absent when `url` is absent or unrecognized |
+| `review_state` | string | Review state (see below); absent when the forge reports no review signal |
 
 ### main_state values
 
@@ -947,6 +953,12 @@ When `main_state == "integrated"`: `"ancestor"` `"trees-match"` `"no-added-chang
 ### ci.status values
 
 `"passed"` `"running"` `"failed"` `"conflicts"` `"no-ci"` `"error"`
+
+### ci.review_state values
+
+`"approved"` `"changes_requested"` `"pending"` `"draft"`
+
+The vocabulary matches Claude Code's statusline `pr.review_state` field. `"pending"` means a review is required (e.g. branch protection) but not yet given; a PR with no review signal at all has no `review_state`. GitLab reports only `"pending"` and `"draft"` — MR list data carries no approved or changes-requested signal.
 
 Missing a field that would be generally useful? Open an issue at https://github.com/max-sixty/worktrunk.
 

--- a/src/commands/list/ci_status/azure.rs
+++ b/src/commands/list/ci_status/azure.rs
@@ -133,6 +133,7 @@ pub(super) fn detect_azure_pr(
         source: CiSource::PullRequest,
         is_stale,
         url,
+        review_state: None,
     })
 }
 
@@ -211,6 +212,7 @@ pub(super) fn detect_azure_pipeline(
         source: CiSource::Branch,
         is_stale,
         url: web_url,
+        review_state: None,
     })
 }
 

--- a/src/commands/list/ci_status/gitea.rs
+++ b/src/commands/list/ci_status/gitea.rs
@@ -119,6 +119,7 @@ pub(super) fn detect_gitea_pr(
         source: CiSource::PullRequest,
         is_stale,
         url: Some(pr.html_url.clone()),
+        review_state: None,
     })
 }
 
@@ -138,6 +139,7 @@ pub(super) fn detect_gitea_commit_status(
         source: CiSource::Branch,
         is_stale: false,
         url: None,
+        review_state: None,
     })
 }
 

--- a/src/commands/list/ci_status/github.rs
+++ b/src/commands/list/ci_status/github.rs
@@ -6,7 +6,7 @@ use serde::Deserialize;
 use worktrunk::git::Repository;
 
 use super::{
-    CiBranchName, CiSource, CiStatus, MAX_PRS_TO_FETCH, PrStatus, branch_owner_repo,
+    CiBranchName, CiSource, CiStatus, MAX_PRS_TO_FETCH, PrStatus, ReviewState, branch_owner_repo,
     non_interactive_cmd, parse_json, retriable_pr_error,
 };
 
@@ -68,7 +68,7 @@ pub(super) fn detect_github(
             "--limit",
             &MAX_PRS_TO_FETCH.to_string(),
             "--json",
-            "headRefOid,mergeStateStatus,statusCheckRollup,url,headRepositoryOwner",
+            "headRefOid,mergeStateStatus,statusCheckRollup,url,headRepositoryOwner,reviewDecision,isDraft",
         ])
         .current_dir(&repo_root)
         .run()
@@ -128,6 +128,7 @@ pub(super) fn detect_github(
         source: CiSource::PullRequest,
         is_stale,
         url: pr_info.url.clone(),
+        review_state: pr_info.review_state(),
     })
 }
 
@@ -193,6 +194,7 @@ pub(super) fn detect_github_commit_checks(
         source: CiSource::Branch,
         is_stale: false, // We're querying by SHA, so always current
         url: None,
+        review_state: None,
     })
 }
 
@@ -215,6 +217,12 @@ pub(super) struct GitHubPrInfo {
     /// Used to filter PRs by source fork (see `parse_owner_repo()`).
     #[serde(rename = "headRepositoryOwner")]
     pub head_repository_owner: Option<HeadRepositoryOwner>,
+    /// GraphQL review decision: "APPROVED", "CHANGES_REQUESTED",
+    /// "REVIEW_REQUIRED", or empty when no reviews exist and none are required.
+    #[serde(rename = "reviewDecision")]
+    pub review_decision: Option<String>,
+    #[serde(rename = "isDraft")]
+    pub is_draft: Option<bool>,
 }
 
 /// Owner info for the head repository of a PR.
@@ -248,6 +256,23 @@ pub(super) struct GitHubCheck {
 }
 
 impl GitHubPrInfo {
+    /// Map `isDraft` + `reviewDecision` to a [`ReviewState`].
+    ///
+    /// Draft wins over the review decision: a draft is intentionally parked,
+    /// so its review verdict shouldn't demand attention. An empty
+    /// `reviewDecision` means no review signal and maps to `None`.
+    pub fn review_state(&self) -> Option<ReviewState> {
+        if self.is_draft == Some(true) {
+            return Some(ReviewState::Draft);
+        }
+        match self.review_decision.as_deref() {
+            Some("APPROVED") => Some(ReviewState::Approved),
+            Some("CHANGES_REQUESTED") => Some(ReviewState::ChangesRequested),
+            Some("REVIEW_REQUIRED") => Some(ReviewState::Pending),
+            _ => None,
+        }
+    }
+
     pub fn ci_status(&self) -> CiStatus {
         match &self.status_check_rollup {
             None => CiStatus::NoCI,
@@ -331,6 +356,8 @@ mod tests {
             status_check_rollup: None,
             url: None,
             head_repository_owner: None,
+            review_decision: None,
+            is_draft: None,
         };
         assert_eq!(pr.ci_status(), CiStatus::NoCI);
 
@@ -341,6 +368,8 @@ mod tests {
             status_check_rollup: Some(vec![]),
             url: None,
             head_repository_owner: None,
+            review_decision: None,
+            is_draft: None,
         };
         assert_eq!(pr.ci_status(), CiStatus::NoCI);
 
@@ -356,6 +385,8 @@ mod tests {
                 }]),
                 url: None,
                 head_repository_owner: None,
+                review_decision: None,
+                is_draft: None,
             };
             assert_eq!(pr.ci_status(), CiStatus::Running, "status={status}");
         }
@@ -371,6 +402,8 @@ mod tests {
             }]),
             url: None,
             head_repository_owner: None,
+            review_decision: None,
+            is_draft: None,
         };
         assert_eq!(pr.ci_status(), CiStatus::Running);
 
@@ -386,6 +419,8 @@ mod tests {
                 }]),
                 url: None,
                 head_repository_owner: None,
+                review_decision: None,
+                is_draft: None,
             };
             assert_eq!(pr.ci_status(), CiStatus::Failed, "conclusion={conclusion}");
         }
@@ -402,6 +437,8 @@ mod tests {
                 }]),
                 url: None,
                 head_repository_owner: None,
+                review_decision: None,
+                is_draft: None,
             };
             assert_eq!(pr.ci_status(), CiStatus::Failed, "state={state}");
         }
@@ -417,8 +454,44 @@ mod tests {
             }]),
             url: None,
             head_repository_owner: None,
+            review_decision: None,
+            is_draft: None,
         };
         assert_eq!(pr.ci_status(), CiStatus::Passed);
+    }
+
+    #[test]
+    fn test_github_pr_info_review_state() {
+        let pr = |review_decision: Option<&str>, is_draft: Option<bool>| GitHubPrInfo {
+            head_ref_oid: None,
+            merge_state_status: None,
+            status_check_rollup: None,
+            url: None,
+            head_repository_owner: None,
+            review_decision: review_decision.map(Into::into),
+            is_draft,
+        };
+
+        assert_eq!(
+            pr(Some("APPROVED"), None).review_state(),
+            Some(ReviewState::Approved)
+        );
+        assert_eq!(
+            pr(Some("CHANGES_REQUESTED"), Some(false)).review_state(),
+            Some(ReviewState::ChangesRequested)
+        );
+        assert_eq!(
+            pr(Some("REVIEW_REQUIRED"), None).review_state(),
+            Some(ReviewState::Pending)
+        );
+        // Empty decision = no review signal, not pending
+        assert_eq!(pr(Some(""), None).review_state(), None);
+        assert_eq!(pr(None, None).review_state(), None);
+        // Draft wins over the decision
+        assert_eq!(
+            pr(Some("APPROVED"), Some(true)).review_state(),
+            Some(ReviewState::Draft)
+        );
     }
 
     #[test]

--- a/src/commands/list/ci_status/gitlab.rs
+++ b/src/commands/list/ci_status/gitlab.rs
@@ -19,7 +19,7 @@ use std::path::Path;
 use worktrunk::git::Repository;
 
 use super::{
-    CiBranchName, CiSource, CiStatus, MAX_PRS_TO_FETCH, PrStatus, is_retriable_error,
+    CiBranchName, CiSource, CiStatus, MAX_PRS_TO_FETCH, PrStatus, ReviewState, is_retriable_error,
     non_interactive_cmd, parse_json,
 };
 
@@ -187,6 +187,7 @@ pub(super) fn detect_gitlab(
         source: CiSource::PullRequest,
         is_stale,
         url: mr_entry.web_url.clone(),
+        review_state: mr_entry.review_state(),
     })
 }
 
@@ -253,6 +254,7 @@ pub(super) fn detect_gitlab_pipeline(
         source: CiSource::Branch,
         is_stale,
         url: pipeline.web_url.clone(),
+        review_state: None,
     })
 }
 
@@ -274,6 +276,26 @@ struct GitLabMrListEntry {
     pub source_project_id: Option<u64>,
     /// URL to the MR page for clickable links
     pub web_url: Option<String>,
+    /// Draft/WIP flag (absent in older glab versions)
+    pub draft: Option<bool>,
+}
+
+impl GitLabMrListEntry {
+    /// Map draft + `detailed_merge_status` to a [`ReviewState`].
+    ///
+    /// GitLab has no changes-requested equivalent in MR list data; draft and
+    /// "not_approved" (approvals required but missing) are the available
+    /// signals. Draft wins: a draft is intentionally parked, so its approval
+    /// gap shouldn't demand attention.
+    fn review_state(&self) -> Option<ReviewState> {
+        if self.draft == Some(true) {
+            return Some(ReviewState::Draft);
+        }
+        if self.detailed_merge_status.as_deref() == Some("not_approved") {
+            return Some(ReviewState::Pending);
+        }
+        None
+    }
 }
 
 /// Full MR info from `glab mr view <iid> --output json`.
@@ -355,6 +377,32 @@ impl GitLabPipeline {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_mr_list_entry_review_state() {
+        let entry = |draft: Option<bool>, status: Option<&str>| GitLabMrListEntry {
+            iid: 1,
+            sha: "abc".into(),
+            has_conflicts: false,
+            detailed_merge_status: status.map(Into::into),
+            source_project_id: None,
+            web_url: None,
+            draft,
+        };
+
+        // Draft wins over the approval gap
+        assert_eq!(
+            entry(Some(true), Some("not_approved")).review_state(),
+            Some(ReviewState::Draft)
+        );
+        assert_eq!(
+            entry(Some(false), Some("not_approved")).review_state(),
+            Some(ReviewState::Pending)
+        );
+        // Other merge statuses carry no review signal
+        assert_eq!(entry(Some(false), Some("mergeable")).review_state(), None);
+        assert_eq!(entry(None, None).review_state(), None);
+    }
 
     #[test]
     fn test_parse_gitlab_status() {

--- a/src/commands/list/ci_status/mod.rs
+++ b/src/commands/list/ci_status/mod.rs
@@ -302,6 +302,23 @@ pub enum CiSource {
     Branch,
 }
 
+/// Review state of a PR/MR.
+///
+/// The vocabulary matches Claude Code's statusline `pr.review_state` field so
+/// the two surfaces never disagree on names. A PR with no review signal at all
+/// (e.g. GitHub's `reviewDecision` is empty on repos without required
+/// reviewers and no reviews) carries `None` on [`PrStatus`], not `Pending`,
+/// so unreviewed branches keep their plain CI colors.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewState {
+    Approved,
+    ChangesRequested,
+    /// Review is required before merge (e.g. branch protection) but not given yet
+    Pending,
+    Draft,
+}
+
 /// CI status from PR/MR or branch workflow
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PrStatus {
@@ -313,6 +330,9 @@ pub struct PrStatus {
     /// URL to the PR/MR (if available)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub url: Option<String>,
+    /// Review state of the PR/MR (absent when the forge reports no review signal)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_state: Option<ReviewState>,
 }
 
 impl CiStatus {
@@ -336,10 +356,31 @@ impl CiStatus {
 }
 
 impl PrStatus {
-    /// Get the style for this PR status (color + optional dimming for stale)
+    /// Display color merging CI status with review state.
+    ///
+    /// Review states slot in where their required action ranks: conflicts and
+    /// fetch errors still lead; changes-requested outranks a running build
+    /// because waiting can't clear it; an outstanding required review only
+    /// recolors an otherwise green or quiet branch. Cool colors mean waiting
+    /// (blue: on CI, cyan: on a reviewer), warm colors mean act.
+    pub fn color(&self) -> AnsiColor {
+        match (self.ci_status, self.review_state) {
+            (CiStatus::Conflicts | CiStatus::Error, _) => self.ci_status.color(),
+            (_, Some(ReviewState::ChangesRequested)) => AnsiColor::Magenta,
+            (CiStatus::Running | CiStatus::Failed, _) => self.ci_status.color(),
+            (_, Some(ReviewState::Pending)) => AnsiColor::Cyan,
+            _ => self.ci_status.color(),
+        }
+    }
+
+    /// Get the style for this PR status (color + dimming for stale/draft)
     pub fn style(&self) -> Style {
-        let style = Style::new().fg_color(Some(Color::Ansi(self.ci_status.color())));
-        if self.is_stale { style.dimmed() } else { style }
+        let style = Style::new().fg_color(Some(Color::Ansi(self.color())));
+        if self.is_stale || self.review_state == Some(ReviewState::Draft) {
+            style.dimmed()
+        } else {
+            style
+        }
     }
 
     /// Get the indicator symbol for this status
@@ -383,6 +424,7 @@ impl PrStatus {
             source: CiSource::Branch,
             is_stale: false,
             url: None,
+            review_state: None,
         }
     }
 
@@ -521,6 +563,7 @@ mod tests {
             source: CiSource::PullRequest,
             is_stale: false,
             url: None,
+            review_state: None,
         };
         assert_eq!(pr_passed.indicator(), "●");
 
@@ -529,6 +572,7 @@ mod tests {
             source: CiSource::Branch,
             is_stale: false,
             url: None,
+            review_state: None,
         };
         assert_eq!(branch_running.indicator(), "●");
 
@@ -537,6 +581,7 @@ mod tests {
             source: CiSource::PullRequest,
             is_stale: false,
             url: None,
+            review_state: None,
         };
         assert_eq!(error_status.indicator(), "⚠");
     }
@@ -550,12 +595,14 @@ mod tests {
             source: CiSource::PullRequest,
             is_stale: false,
             url: Some("https://github.com/owner/repo/pull/123".to_string()),
+            review_state: None,
         };
         let no_url = PrStatus {
             ci_status: CiStatus::Passed,
             source: CiSource::PullRequest,
             is_stale: false,
             url: None,
+            review_state: None,
         };
 
         // With URL + include_link=true → has OSC 8 hyperlink
@@ -613,10 +660,74 @@ mod tests {
             source: CiSource::Branch,
             is_stale: true,
             url: None,
+            review_state: None,
         };
         let style = stale.style();
         // Just verify it doesn't panic and returns a style
         let _ = format!("{style}test{style:#}");
+    }
+
+    #[test]
+    fn test_pr_status_color_merges_review_state() {
+        let pr = |ci_status, review_state| PrStatus {
+            ci_status,
+            source: CiSource::PullRequest,
+            is_stale: false,
+            url: None,
+            review_state,
+        };
+
+        // Changes-requested outranks running and passed — waiting can't clear it
+        assert_eq!(
+            pr(CiStatus::Running, Some(ReviewState::ChangesRequested)).color(),
+            AnsiColor::Magenta
+        );
+        assert_eq!(
+            pr(CiStatus::Passed, Some(ReviewState::ChangesRequested)).color(),
+            AnsiColor::Magenta
+        );
+        // Conflicts and fetch errors still lead
+        assert_eq!(
+            pr(CiStatus::Conflicts, Some(ReviewState::ChangesRequested)).color(),
+            AnsiColor::Yellow
+        );
+        assert_eq!(
+            pr(CiStatus::Error, Some(ReviewState::ChangesRequested)).color(),
+            AnsiColor::Yellow
+        );
+        // An outstanding required review only recolors a green or quiet branch
+        assert_eq!(
+            pr(CiStatus::Passed, Some(ReviewState::Pending)).color(),
+            AnsiColor::Cyan
+        );
+        assert_eq!(
+            pr(CiStatus::NoCI, Some(ReviewState::Pending)).color(),
+            AnsiColor::Cyan
+        );
+        assert_eq!(
+            pr(CiStatus::Failed, Some(ReviewState::Pending)).color(),
+            AnsiColor::Red
+        );
+        assert_eq!(
+            pr(CiStatus::Running, Some(ReviewState::Pending)).color(),
+            AnsiColor::Blue
+        );
+        // Approved and absent review keep plain CI colors
+        assert_eq!(
+            pr(CiStatus::Passed, Some(ReviewState::Approved)).color(),
+            AnsiColor::Green
+        );
+        assert_eq!(pr(CiStatus::Passed, None).color(), AnsiColor::Green);
+
+        // Draft dims rather than recoloring
+        let draft = pr(CiStatus::Passed, Some(ReviewState::Draft));
+        assert_eq!(draft.color(), AnsiColor::Green);
+        assert_eq!(
+            draft.style(),
+            Style::new()
+                .fg_color(Some(Color::Ansi(AnsiColor::Green)))
+                .dimmed()
+        );
     }
 
     /// Build a synthetic non-success `Output` with the given stderr/stdout

--- a/src/commands/list/json_output.rs
+++ b/src/commands/list/json_output.rs
@@ -22,7 +22,7 @@ use schemars::JsonSchema;
 use serde::Serialize;
 use worktrunk::git::{LineDiff, Repository};
 
-use super::ci_status::{CiSource, PrStatus};
+use super::ci_status::{CiSource, PrStatus, ReviewState};
 use super::model::{ItemKind, ListItem, UpstreamStatus};
 
 /// JSON output for a single list item
@@ -237,6 +237,11 @@ pub struct JsonCi {
     /// is absent or not a recognized PR/MR link.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub repo_url: Option<String>,
+
+    /// Review state: "approved", "changes_requested", "pending", "draft"
+    /// (absent when the forge reports no review signal)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_state: Option<ReviewState>,
 }
 
 impl JsonItem {
@@ -453,6 +458,7 @@ impl From<&PrStatus> for JsonCi {
                 .as_deref()
                 .and_then(worktrunk::git::remote_ref::repo_url_from_ref_url),
             url: pr.url.clone(),
+            review_state: pr.review_state,
         }
     }
 }
@@ -567,6 +573,7 @@ mod tests {
             source: CiSource::PullRequest,
             is_stale: false,
             url: Some("https://github.com/org/repo/pull/123".to_string()),
+            review_state: None,
         });
         assert_eq!(passed.status, "passed");
         assert_eq!(passed.source, CiSource::PullRequest);
@@ -587,6 +594,7 @@ mod tests {
             source: CiSource::Branch,
             is_stale: true,
             url: None,
+            review_state: None,
         });
         assert_eq!(failed.status, "failed");
         assert_eq!(failed.source, CiSource::Branch);
@@ -608,6 +616,7 @@ mod tests {
                 source: CiSource::Branch,
                 is_stale: false,
                 url: None,
+                review_state: None,
             });
             assert_eq!(json.status, expected);
         }
@@ -982,16 +991,19 @@ mod tests {
             source: CiSource::PullRequest,
             stale: false,
             url: Some("https://github.com/org/repo/pull/7".to_string()),
+            review_state: Some(ReviewState::ChangesRequested),
             repo_url: Some("https://github.com/org/repo".to_string()),
         })
         .unwrap();
+        // review_state vocabulary matches Claude Code's statusline `pr.review_state`
         assert_snapshot!(json, @r#"
         {
           "status": "passed",
           "source": "pr",
           "stale": false,
           "url": "https://github.com/org/repo/pull/7",
-          "repo_url": "https://github.com/org/repo"
+          "repo_url": "https://github.com/org/repo",
+          "review_state": "changes_requested"
         }
         "#);
     }

--- a/src/help.rs
+++ b/src/help.rs
@@ -549,6 +549,8 @@ fn post_process_for_html(text: &str) -> String {
         .replace("`●` green", "<span style='color:#0a0'>●</span> green")
         .replace("`●` blue", "<span style='color:#00a'>●</span> blue")
         .replace("`●` red", "<span style='color:#a00'>●</span> red")
+        .replace("`●` magenta", "<span style='color:#a0a'>●</span> magenta")
+        .replace("`●` cyan", "<span style='color:#0aa'>●</span> cyan")
         .replace("`●` yellow", "<span style='color:#a60'>●</span> yellow")
         .replace("`⚠` yellow", "<span style='color:#a60'>⚠</span> yellow")
         .replace("`●` gray", "<span style='color:#888'>●</span> gray")

--- a/src/md_help.rs
+++ b/src/md_help.rs
@@ -394,6 +394,8 @@ fn colorize_status_symbols(text: &str) -> String {
     let progress = Style::new().fg_color(Some(AnsiStyleColor::Ansi(AnsiColor::Blue)));
     let disabled = Style::new().fg_color(Some(AnsiStyleColor::Ansi(AnsiColor::BrightBlack)));
     let working_tree = Style::new().fg_color(Some(AnsiStyleColor::Ansi(AnsiColor::Cyan)));
+    let changes_requested = Style::new().fg_color(Some(AnsiStyleColor::Ansi(AnsiColor::Magenta)));
+    let pending_review = Style::new().fg_color(Some(AnsiStyleColor::Ansi(AnsiColor::Cyan)));
 
     // Pattern for dimmed text (from inline `code` rendering)
     // render_inline_formatting wraps backticked text in dimmed style
@@ -440,6 +442,14 @@ fn colorize_status_symbols(text: &str) -> String {
         .replace(
             &format!("{dimmed_bullet} red"),
             &format!("{error}●{error:#} red"),
+        )
+        .replace(
+            &format!("{dimmed_bullet} magenta"),
+            &format!("{changes_requested}●{changes_requested:#} magenta"),
+        )
+        .replace(
+            &format!("{dimmed_bullet} cyan"),
+            &format!("{pending_review}●{pending_review:#} cyan"),
         )
         .replace(
             &format!("{dimmed_bullet} yellow"),

--- a/tests/integration_tests/ci_status.rs
+++ b/tests/integration_tests/ci_status.rs
@@ -160,6 +160,41 @@ fn test_list_full_with_github_pr_status(
 }
 
 // =============================================================================
+// Review state tests (reviewDecision / isDraft from gh pr list)
+// =============================================================================
+
+#[rstest]
+#[case::changes_requested("\"CHANGES_REQUESTED\"", "false", "github_pr_changes_requested")]
+#[case::review_required("\"REVIEW_REQUIRED\"", "false", "github_pr_review_required")]
+#[case::approved("\"APPROVED\"", "false", "github_pr_approved")]
+#[case::draft("\"APPROVED\"", "true", "github_pr_draft")]
+fn test_list_full_with_github_review_state(
+    mut repo: TestRepo,
+    #[case] review_decision: &str,
+    #[case] is_draft: &str,
+    #[case] snapshot_name: &str,
+) {
+    let head_sha = setup_github_repo_with_feature(&mut repo);
+
+    let pr_json = format!(
+        r#"[{{
+        "headRefOid": "{}",
+        "mergeStateStatus": "CLEAN",
+        "statusCheckRollup": [
+            {{"status": "COMPLETED", "conclusion": "SUCCESS"}}
+        ],
+        "url": "https://github.com/test-owner/test-repo/pull/1",
+        "headRepositoryOwner": {{"login": "test-owner"}},
+        "reviewDecision": {},
+        "isDraft": {}
+    }}]"#,
+        head_sha, review_decision, is_draft
+    );
+
+    run_ci_status_test(&mut repo, snapshot_name, &pr_json, "[]");
+}
+
+// =============================================================================
 // StatusContext tests (external CI systems like Jenkins)
 // =============================================================================
 

--- a/tests/snapshots/integration__integration_tests__ci_status__github_pr_approved.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__github_pr_approved.snap
@@ -1,0 +1,65 @@
+---
+source: tests/integration_tests/ci_status.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
+    GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
+    GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCI[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     [32m●[0m   .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
++ [2mfeature[0m        [2m_[22m[2m|[22m                                      [2m|[0m     [32m●[0m   [2m../repo.feature[0m    [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
++ feature-a      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m●[0m   ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
++ feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m●[0m   ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file
++ feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m●[0m   ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__ci_status__github_pr_changes_requested.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__github_pr_changes_requested.snap
@@ -1,0 +1,65 @@
+---
+source: tests/integration_tests/ci_status.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
+    GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
+    GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCI[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     [35m●[0m   .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
++ [2mfeature[0m        [2m_[22m[2m|[22m                                      [2m|[0m     [35m●[0m   [2m../repo.feature[0m    [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
++ feature-a      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[35m●[0m   ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
++ feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[35m●[0m   ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file
++ feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[35m●[0m   ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__ci_status__github_pr_draft.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__github_pr_draft.snap
@@ -1,0 +1,65 @@
+---
+source: tests/integration_tests/ci_status.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
+    GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
+    GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCI[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     [2m[32m●[0m   .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
++ [2mfeature[0m        [2m_[22m[2m|[22m                                      [2m|[0m     [2m[32m●[0m   [2m../repo.feature[0m    [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
++ feature-a      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m●[0m   ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
++ feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m●[0m   ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file
++ feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m●[0m   ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__ci_status__github_pr_review_required.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__github_pr_review_required.snap
@@ -1,0 +1,65 @@
+---
+source: tests/integration_tests/ci_status.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMON_DIR: ""
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_DIR: ""
+    GIT_EDITOR: ""
+    GIT_INDEX_FILE: ""
+    GIT_OBJECT_DIRECTORY: ""
+    GIT_TERMINAL_PROMPT: "0"
+    GIT_WORK_TREE: ""
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    NO_COLOR: ""
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    PSModulePath: ""
+    SHELL: ""
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCI[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     [36m●[0m   .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
++ [2mfeature[0m        [2m_[22m[2m|[22m                                      [2m|[0m     [36m●[0m   [2m../repo.feature[0m    [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit
++ feature-a      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[36m●[0m   ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file
++ feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[36m●[0m   ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file
++ feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[36m●[0m   ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -158,10 +158,14 @@ The CI column shows GitHub/GitLab pipeline status:
  [32m●[0m green   All checks passed                 
  [34m●[0m blue    Checks running                    
  [31m●[0m red     Checks failed                     
+ [35m●[0m magenta Reviewer requested changes        
+ [36m●[0m cyan    Review required, not yet given    
  [33m●[0m yellow  Merge conflicts with base         
  [90m●[0m gray    No checks configured              
  [33m⚠[0m yellow  Fetch error (rate limit, network) 
  (blank)   No upstream or no PR/MR           
+
+Review state merges into the same dot where its required action ranks: changes-requested (magenta) outranks running checks — waiting can't clear it — while an outstanding required review (cyan) only recolors an otherwise green or quiet branch. Cool colors mean waiting, warm colors mean act. A PR with no review signal (no required reviewers and no reviews) keeps its plain CI color, and draft PRs appear dimmed.
 
 CI indicators are clickable links to the PR or pipeline page. Any CI dot appears dimmed when unpushed local changes make the status stale. PRs/MRs are checked first, then branch workflows/pipelines for branches with an upstream. Local-only branches show blank; remote-only branches — visible with [2m--remotes[0m — get CI status detection. Results are cached for 30-60 seconds; use [2mwt config state[0m to view or clear.
 
@@ -312,12 +316,14 @@ Query structured data with [2m--format=json[0m:
 
 [32mci object[0m
 
- Field   Type                      Description                    
- ────── ─────── ───────────────────────────────────────────────── 
- [2mstatus[0m string  CI status (see below)                             
- [2msource[0m string  [2m"pr"[0m (PR/MR) or [2m"branch"[0m (branch workflow)        
- [2mstale[0m  boolean Local HEAD differs from remote (unpushed changes) 
- [2murl[0m    string  URL to the PR/MR page                             
+    Field      Type                                                   Description                                                  
+ ──────────── ─────── ──────────────────────────────────────────────────────────────────────────────────────────────────────────── 
+ [2mstatus[0m       string  CI status (see below)                                                                                        
+ [2msource[0m       string  [2m"pr"[0m (PR/MR) or [2m"branch"[0m (branch workflow)                                                                   
+ [2mstale[0m        boolean Local HEAD differs from remote (unpushed changes)                                                            
+ [2murl[0m          string  URL to the PR/MR page                                                                                        
+ [2mrepo_url[0m     string  Web URL of the repo the PR/MR targets (the upstream for fork PRs); absent when [2murl[0m is absent or unrecognized 
+ [2mreview_state[0m string  Review state (see below); absent when the forge reports no review signal                                     
 
 [32mmain_state values[0m
 
@@ -332,6 +338,12 @@ When [2mmain_state == "integrated"[0m: [2m"ancestor"[0m [2m"trees-match"[0
 [32mci.status values[0m
 
 [2m"passed"[0m [2m"running"[0m [2m"failed"[0m [2m"conflicts"[0m [2m"no-ci"[0m [2m"error"[0m
+
+[32mci.review_state values[0m
+
+[2m"approved"[0m [2m"changes_requested"[0m [2m"pending"[0m [2m"draft"[0m
+
+The vocabulary matches Claude Code's statusline [2mpr.review_state[0m field. [2m"pending"[0m means a review is required (e.g. branch protection) but not yet given; a PR with no review signal at all has no [2mreview_state[0m. GitLab reports only [2m"pending"[0m and [2m"draft"[0m — MR list data carries no approved or changes-requested signal.
 
 Missing a field that would be generally useful? Open an issue at https://github.com/max-sixty/worktrunk.
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -185,10 +185,19 @@ The CI column shows GitHub/GitLab pipeline status:
  [32m●[0m green   All checks passed                 
  [34m●[0m blue    Checks running                    
  [31m●[0m red     Checks failed                     
+ [35m●[0m magenta Reviewer requested changes        
+ [36m●[0m cyan    Review required, not yet given    
  [33m●[0m yellow  Merge conflicts with base         
  [90m●[0m gray    No checks configured              
  [33m⚠[0m yellow  Fetch error (rate limit, network) 
  (blank)   No upstream or no PR/MR           
+
+Review state merges into the same dot where its required action ranks: 
+changes-requested (magenta) outranks running checks — waiting can't clear it — 
+while an outstanding required review (cyan) only recolors an otherwise green or 
+quiet branch. Cool colors mean waiting, warm colors mean act. A PR with no 
+review signal (no required reviewers and no reviews) keeps its plain CI color, 
+and draft PRs appear dimmed.
 
 CI indicators are clickable links to the PR or pipeline page. Any CI dot appears
  dimmed when unpushed local changes make the status stale. PRs/MRs are checked 
@@ -364,12 +373,16 @@ Query structured data with [2m--format=json[0m:
 
 [32mci object[0m
 
- Field   Type                      Description                    
- ────── ─────── ───────────────────────────────────────────────── 
- [2mstatus[0m string  CI status (see below)                             
- [2msource[0m string  [2m"pr"[0m (PR/MR) or [2m"branch"[0m (branch workflow)        
- [2mstale[0m  boolean Local HEAD differs from remote (unpushed changes) 
- [2murl[0m    string  URL to the PR/MR page                             
+    Field      Type                          Description                        
+ ──────────── ─────── ───────────────────────────────────────────────────────── 
+ [2mstatus[0m       string  CI status (see below)                                     
+ [2msource[0m       string  [2m"pr"[0m (PR/MR) or [2m"branch"[0m (branch workflow)                
+ [2mstale[0m        boolean Local HEAD differs from remote (unpushed changes)         
+ [2murl[0m          string  URL to the PR/MR page                                     
+ [2mrepo_url[0m     string  Web URL of the repo the PR/MR targets (the upstream for   
+                      fork PRs); absent when [2murl[0m is absent or unrecognized      
+ [2mreview_state[0m string  Review state (see below); absent when the forge reports   
+                      no review signal                                          
 
 [32mmain_state values[0m
 
@@ -386,6 +399,15 @@ When [2mmain_state == "integrated"[0m: [2m"ancestor"[0m [2m"trees-match"[0
 [32mci.status values[0m
 
 [2m"passed"[0m [2m"running"[0m [2m"failed"[0m [2m"conflicts"[0m [2m"no-ci"[0m [2m"error"[0m
+
+[32mci.review_state values[0m
+
+[2m"approved"[0m [2m"changes_requested"[0m [2m"pending"[0m [2m"draft"[0m
+
+The vocabulary matches Claude Code's statusline [2mpr.review_state[0m field. [2m"pending"[0m
+ means a review is required (e.g. branch protection) but not yet given; a PR 
+with no review signal at all has no [2mreview_state[0m. GitLab reports only [2m"pending"[0m 
+and [2m"draft"[0m — MR list data carries no approved or changes-requested signal.
 
 Missing a field that would be generally useful? Open an issue at 
 https://github.com/max-sixty/worktrunk.


### PR DESCRIPTION
Adds PR/MR review state to `wt list`'s CI status, merged into the existing CI dot color.

## What

- New `ReviewState` (`approved` / `changes_requested` / `pending` / `draft`) on `PrStatus`, absent when the forge reports no review signal — branches with no review activity render exactly as before.
- **GitHub**: `reviewDecision,isDraft` join the existing single `gh pr list --json` call (no extra API cost). Draft wins over the decision; an empty `reviewDecision` (no required reviewers, no reviews) maps to absent rather than `pending`, so solo repos don't show a perpetual waiting state.
- **GitLab**: `draft` + `detailed_merge_status == "not_approved"` → `draft`/`pending`; MR list data carries no approved/changes-requested signal. Gitea/Azure: none.
- **Display**: review state merges into the CI dot in `PrStatus::color()` — conflicts (yellow) > changes-requested (**magenta**) > running (blue) > failed (red) > review-required (**cyan**) > base CI color; draft dims like staleness. Cool colors mean waiting (blue: on CI, cyan: on a human), warm mean act; changes-requested outranks running because waiting can't clear it. Magenta was the one color not already carrying a meaning in the list row; cyan is reused from the working-tree symbols column, where the differing glyph disambiguates.
- **JSON**: `ci.review_state` in `wt list --format=json`, vocabulary matching Claude Code's statusline `pr.review_state` so the two surfaces agree on names.

## Notes for review

- The merge lives in `PrStatus::color()`/`style()` — `CiStatus` stays pure CI (cache values and JSON `status` strings unchanged). Both the table and the statusline render through `format_indicator` → `style()`, so there's a single chokepoint.
- Old CI cache files deserialize unchanged (the new field is an `Option`).
- `docs/content/list.md` and `skills/worktrunk/reference/list.md` are regenerated from `src/cli/mod.rs`. The HTML and terminal help colorizers learned magenta/cyan (they previously mapped only the five existing colors). Also fixed a pre-existing missing `repo_url` row in the ci-object doc table.
- Testing: unit tables for the color merge and both forge mappings; integration snapshots (mocked `gh`) for changes-requested / review-required / approved / draft verifying the exact ANSI codes; the JSON field name is pinned by an inline snapshot.

If this change is bad, it's most likely because the dot now encodes two axes (CI health and review attention) in one color — a consumer who reads green as "CI passed" still gets that, but red-vs-magenta now distinguishes who rejected the branch, which is more vocabulary to learn. The `--format=json` output keeps the axes separate for anyone who wants their own logic.

Ref #2950

> _This was written by Claude Code on behalf of max_
