### PR TITLE
refactor: stale-doc and dedup cleanups from simplification review

### DIFF
--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -163,12 +163,13 @@ pub(super) fn is_codex_available() -> bool {
 
 /// Get the home directory for Claude Code config detection
 pub(super) fn home_dir() -> Option<PathBuf> {
-    // Try HOME/USERPROFILE env vars first (for tests and explicit overrides), then fall back to dirs
+    // Try HOME/USERPROFILE env vars first (for tests and explicit overrides),
+    // then fall back to the OS lookup
     std::env::var("HOME")
         .or_else(|_| std::env::var("USERPROFILE"))
         .ok()
         .map(PathBuf::from)
-        .or_else(dirs::home_dir)
+        .or_else(worktrunk::path::home_dir)
 }
 
 /// Check if the worktrunk plugin is installed in Claude Code

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -1218,9 +1218,8 @@ pub fn collect(
         // plus — when default_branch is known and the per-base
         // ahead-behind cache doesn't already cover the branches — one
         // `for-each-ref %(ahead-behind:BASE)` walk (scoped to the cold
-        // subset; warm runs do neither). The snapshot replaces the prior
-        // `commit_shas` priming + `batch_ahead_behind` pair: tasks consume
-        // it by SHA, dodging ref→SHA cache staleness.
+        // subset; warm runs do neither). Tasks consume the snapshot by
+        // SHA, dodging ref→SHA cache staleness.
         //
         // After the snapshot is built, an inner spawn primes the
         // `Remote⇅` cache off its already-scanned inventories — see the

--- a/src/git/remote_ref/gitea.rs
+++ b/src/git/remote_ref/gitea.rs
@@ -319,7 +319,7 @@ fn content_has_any_login(content: &str) -> bool {
 /// `~/.tea/tea.yml` fallback. Returns None if neither file is readable.
 fn read_tea_config() -> Option<String> {
     let xdg = std::env::var_os("XDG_CONFIG_HOME").map(std::path::PathBuf::from);
-    let home = dirs::home_dir();
+    let home = crate::path::home_dir();
 
     let primary = xdg
         .clone()

--- a/src/git/repository/ref_snapshot.rs
+++ b/src/git/repository/ref_snapshot.rs
@@ -1,17 +1,12 @@
 //! `RefSnapshot` — a captured, immutable view of repository ref state.
 //!
-//! The snapshot is the structural answer to ref-name cache staleness. Today's
-//! `RepoCache` ambient ref-name → SHA fields (`commit_shas`, `tree_shas`,
-//! `effective_integration_targets`, `integration_reasons`, `ahead_behind`)
-//! become stale the moment wt updates a ref mid-command — `wt merge`'s
-//! `git update-ref refs/heads/main` is the canonical example. Any code that
-//! reads through those caches afterwards gets pre-write SHAs.
-//!
-//! A `RefSnapshot` replaces that ambient cache with an explicit, named,
-//! point-in-time value. Callers thread it through. After a ref-mutating
-//! write, the caller captures a new snapshot and uses it for downstream
-//! reads — the old snapshot remains valid as a pre-write view, but cannot
-//! masquerade as current state.
+//! A `RefSnapshot` is an explicit, named, point-in-time value: callers
+//! capture it once and thread it through. Unlike an ambient ref-name → SHA
+//! cache, it cannot go stale invisibly when wt updates a ref mid-command —
+//! `wt merge`'s `git update-ref refs/heads/main` is the canonical example.
+//! After a ref-mutating write, the caller captures a new snapshot and uses
+//! it for downstream reads — the old snapshot remains valid as a pre-write
+//! view, but cannot masquerade as current state.
 //!
 //! # Construction
 //!

--- a/src/output/shell_integration.rs
+++ b/src/output/shell_integration.rs
@@ -64,7 +64,7 @@ use color_print::cformat;
 use worktrunk::config::{UserConfig, require_config_path};
 use worktrunk::git::Repository;
 use worktrunk::path::format_path_for_display;
-use worktrunk::shell::{Shell, current_shell, extract_filename_from_path};
+use worktrunk::shell::{Shell, current_shell, current_shell_name, extract_filename_from_path};
 use worktrunk::styling::{
     eprintln, format_bash_with_gutter, hint_message, info_message, success_message, warning_message,
 };
@@ -365,9 +365,7 @@ pub fn print_shell_install_result(scan_result: &crate::commands::configure_shell
 
     // Restart hint for current shell
     if shells_configured_count > 0 {
-        let current_shell = std::env::var("SHELL")
-            .ok()
-            .and_then(|s| extract_filename_from_path(&s).map(String::from));
+        let current_shell = current_shell_name();
 
         let current_shell_result = current_shell.as_ref().and_then(|shell_name| {
             scan_result
@@ -587,9 +585,7 @@ pub fn print_shell_uninstall_result(scan_result: &UninstallScanResult, explicit_
     );
 
     // Hint about restarting shell (only if current shell was affected)
-    let current_shell = std::env::var("SHELL")
-        .ok()
-        .and_then(|s| extract_filename_from_path(&s).map(String::from));
+    let current_shell = current_shell_name();
 
     let current_shell_affected = current_shell.as_ref().is_some_and(|shell_name| {
         scan_result

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -19,7 +19,9 @@ pub use detection::{
     is_shell_integration_line_for_uninstall, scan_for_detection_details,
 };
 pub use paths::{completion_path, config_paths, legacy_fish_conf_d_path};
-pub use utils::{current_shell, detect_zsh_compinit, extract_filename_from_path};
+pub use utils::{
+    current_shell, current_shell_name, detect_zsh_compinit, extract_filename_from_path,
+};
 
 /// Supported shells
 ///

--- a/src/shell/utils.rs
+++ b/src/shell/utils.rs
@@ -58,6 +58,14 @@ pub fn shell_from_name(shell_name: &str) -> Option<Shell> {
     }
 }
 
+/// Read `$SHELL` and extract the executable name (e.g. `/usr/bin/zsh` -> "zsh").
+///
+/// Returns `None` when `$SHELL` is unset or has no extractable filename.
+pub fn current_shell_name() -> Option<String> {
+    let shell_path = std::env::var("SHELL").ok()?;
+    extract_filename_from_path(&shell_path).map(String::from)
+}
+
 /// Detect the current shell from the environment.
 ///
 /// Uses two strategies:
@@ -72,10 +80,8 @@ pub fn shell_from_name(shell_name: &str) -> Option<Shell> {
 /// - Windows PowerShell: `PSModulePath` set -> PowerShell
 pub fn current_shell() -> Option<Shell> {
     // Primary: $SHELL (Unix standard, also set by Git Bash on Windows)
-    if let Ok(shell_path) = std::env::var("SHELL")
-        && let Some(name) = extract_filename_from_path(&shell_path)
-    {
-        return shell_from_name(name);
+    if let Some(name) = current_shell_name() {
+        return shell_from_name(&name);
     }
 
     // Fallback: PSModulePath indicates PowerShell (set on all platforms when


### PR DESCRIPTION
Bundle of small, independent cleanups recorded during a simplification review. No behavior changes; the full gate passes with no snapshot churn.

- **RefSnapshot docstring**: the module header motivated the type against `RepoCache` ref-name fields (`commit_shas`, `tree_shas`, …) that were removed when that migration completed. Rewritten to describe what the snapshot is and guarantees today; a comment in `list/collect/mod.rs` referencing the same dead names is cut too. Those names now have zero hits in the repo.
- **`$SHELL` reading**: three sites read `$SHELL` and extracted the executable name with identical logic (`current_shell()` plus two copies in `output/shell_integration.rs`). They now share `shell::current_shell_name()`. The other three `$SHELL` readers are deliberately untouched since their semantics differ: a `var_os().is_none()` absence check, and two raw-path-for-display reads.
- **Home-dir crate**: `dirs::home_dir` leaked in at `git/remote_ref/gitea.rs` and `commands/config/show.rs`; both now use the project-canonical `home::home_dir` re-export. `dirs` stays in Cargo.toml for `data_dir`/`document_dir` in `shell/paths.rs`. One Windows nuance in `gitea.rs`: an explicitly-set `USERPROFILE` now wins over the known-folder API, matching the documented contract of `path::home_dir` and what the test harness relies on.

Two reviewed-and-skipped items, for the record: `strip_markdown_links` stays in `md_help.rs` (no second consumer; `help.rs` strips OSC 8 ANSI hyperlinks, a different representation), and the statusline already derives git-segment priorities from `ColumnKind::priority()` (the four local constants are Claude-Code-only segments with no column equivalent).

> _This was written by Claude Code on behalf of max_
