### PR TITLE
refactor(progress): Progress owns file/byte counting

### DIFF
--- a/src/commands/step/copy_ignored.rs
+++ b/src/commands/step/copy_ignored.rs
@@ -205,8 +205,6 @@ pub fn step_copy_ignored(
         Progress::start("Copying")
     };
 
-    let mut copied_count = 0usize;
-    let mut copied_bytes = 0u64;
     for (src_entry, is_dir) in &entries_to_copy {
         let relative = src_entry
             .strip_prefix(&source_path)
@@ -214,13 +212,10 @@ pub fn step_copy_ignored(
         let dest_entry = dest_path.join(relative);
 
         if *is_dir {
-            let (n, b) =
-                copy_dir_recursive(src_entry, &dest_entry, Some(&dest_path), force, &progress)
-                    .with_context(|| {
-                        format!("copying directory {}", format_path_for_display(relative))
-                    })?;
-            copied_count += n;
-            copied_bytes += b;
+            copy_dir_recursive(src_entry, &dest_entry, Some(&dest_path), force, &progress)
+                .with_context(|| {
+                    format!("copying directory {}", format_path_for_display(relative))
+                })?;
         } else {
             if let Some(parent) = dest_entry.parent() {
                 fs::create_dir_all(parent).with_context(|| {
@@ -231,12 +226,11 @@ pub fn step_copy_ignored(
                 })?;
             }
             if let Some(bytes) = copy_leaf(src_entry, &dest_entry, Some(&dest_path), force)? {
-                copied_count += 1;
-                copied_bytes += bytes;
                 progress.record(bytes);
             }
         }
     }
+    let (copied_count, copied_bytes) = progress.totals();
     progress.finish();
 
     if json_mode {

--- a/src/copy.rs
+++ b/src/copy.rs
@@ -12,15 +12,16 @@
 //! Callers that want low-priority I/O (e.g. `step_copy_ignored`) should call
 //! [`crate::priority::lower_current_process`] before starting work.
 //!
-//! Callers that want a TTY progress spinner pass a [`Progress`] — every
-//! successful leaf copy calls `progress.record(bytes)`. Non-interactive
-//! callers pass [`Progress::disabled`] for a zero-overhead no-op.
+//! Every successful leaf copy calls `progress.record(bytes)` on the caller's
+//! [`Progress`], which both feeds the TTY spinner (when enabled) and
+//! accumulates the `(files, bytes)` totals the caller reads back via
+//! [`Progress::totals`]. Non-interactive callers pass [`Progress::disabled`]
+//! to skip the spinner; counting still happens.
 
 use std::fs;
 use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 use anyhow::Context;
 use rayon::prelude::*;
@@ -130,21 +131,21 @@ struct CopyLeaf {
 /// are skipped for idempotent usage.
 ///
 /// When `force` is true, existing files and symlinks at the destination are
-/// removed before copying. `progress` receives per-file callbacks; pass
-/// [`Progress::disabled`] for a zero-overhead no-op.
+/// removed before copying. Each copied leaf is recorded on `progress` —
+/// skipped entries are not counted — so a `progress` dedicated to this call
+/// reports `(files_copied, bytes_copied)` in `totals()` afterwards; a shared
+/// one accumulates across calls.
 ///
 /// When `root` is `Some`, refuses destination directory ancestry that resolves
 /// outside `root`. Leaves inherit the guarantee because `entry.file_name()` is
 /// a single basename and cannot escape the validated parent directory.
-///
-/// Returns `(files_copied, bytes_copied)` — counts exclude skipped entries.
 pub fn copy_dir_recursive(
     src: &Path,
     dest: &Path,
     root: Option<&Path>,
     force: bool,
     progress: &Progress,
-) -> anyhow::Result<(usize, u64)> {
+) -> anyhow::Result<()> {
     // Phase 1: Walk directories iteratively, creating dest dirs and collecting leaves.
     let mut leaves = Vec::new();
     let mut dir_stack = vec![(src.to_path_buf(), dest.to_path_buf())];
@@ -180,15 +181,11 @@ pub fn copy_dir_recursive(
     }
 
     // Phase 2: Copy all leaves in parallel.
-    let copied_files = AtomicUsize::new(0);
-    let copied_bytes = AtomicU64::new(0);
     COPY_POOL.install(|| {
         leaves
             .par_iter()
             .try_for_each(|leaf| -> anyhow::Result<()> {
                 if let Some(bytes) = copy_leaf(&leaf.src, &leaf.dest, None, force)? {
-                    copied_files.fetch_add(1, Ordering::Relaxed);
-                    copied_bytes.fetch_add(bytes, Ordering::Relaxed);
                     progress.record(bytes);
                 }
                 Ok(())
@@ -207,7 +204,7 @@ pub fn copy_dir_recursive(
             .with_context(|| format!("setting permissions on {}", dest_dir.display()))?;
     }
 
-    Ok((copied_files.into_inner(), copied_bytes.into_inner()))
+    Ok(())
 }
 
 /// Remove a file, ignoring "not found" errors.

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -64,9 +64,10 @@ fn cleanup_staged_with_progress(staged: &Path) -> (usize, u64) {
     } else {
         Progress::start("Removing")
     };
-    let result = remove_dir_with_progress(staged, &progress);
+    remove_dir_with_progress(staged, &progress);
+    let totals = progress.totals();
     progress.finish();
-    result
+    totals
 }
 
 // ============================================================================

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,9 +1,16 @@
-//! TTY spinner for long-running file-walk operations.
+//! TTY spinner and file/byte counters for long-running file-walk operations.
 //!
 //! Shows a single-line stderr spinner (`⠋ Copying 1,234 files · 312 MiB`,
 //! `⠋ Removing 7,272 files · 64.5 MiB`) that updates in place while the work
 //! runs. Workers bump atomic counters via [`Progress::record`]; a background
 //! thread renders at ~10Hz using crossterm cursor control.
+//!
+//! `Progress` is the single owner of operation counts: every state (spinner
+//! enabled, disabled, and the no-`cli` stub) accumulates files/bytes, and
+//! [`Progress::totals`] reads the running totals from `&self` mid-operation.
+//! Callers report from `totals()` rather than keeping their own counters.
+//! Counts accumulate for the lifetime of the reporter, so each counted
+//! operation (or batch reported as one) gets its own `Progress`.
 //!
 //! `start` is named deliberately (not `new`) because it spawns a ticker thread
 //! as a side effect — `Default`-style semantics would be misleading. The verb
@@ -12,11 +19,11 @@
 //! The progress line is cleared on [`Progress::finish`] or on drop, so the
 //! caller can print a summary message immediately afterward without overlap.
 //!
-//! The full spinner machinery (crossterm, the ticker thread, the render loop)
-//! is gated on the `cli` feature. Without `cli`, [`Progress`] is a zero-cost
-//! stub: `start` always returns a no-op reporter and `record` does nothing.
-//! Pure formatting helpers ([`format_bytes`], [`format_stats_paren`]) are
-//! always available since callers in both modes want them.
+//! The spinner machinery (crossterm, the ticker thread, the render loop) is
+//! gated on the `cli` feature. Without `cli`, [`Progress`] keeps the counters
+//! but never renders. Pure formatting helpers ([`format_bytes`],
+//! [`format_stats_paren`]) are always available since callers in both modes
+//! want them.
 
 use color_print::cformat;
 
@@ -48,26 +55,35 @@ mod imp {
         files: AtomicUsize,
         bytes: AtomicU64,
         done: AtomicBool,
-        verb: &'static str,
     }
 
-    struct Inner {
-        shared: Arc<Shared>,
-        ticker: JoinHandle<()>,
+    impl Shared {
+        fn new() -> Self {
+            Self {
+                files: AtomicUsize::new(0),
+                bytes: AtomicU64::new(0),
+                done: AtomicBool::new(false),
+            }
+        }
     }
 
     /// Live spinner displaying file and byte counters for a single operation.
     ///
+    /// Counters accumulate in every state; only the rendering is conditional.
     /// See [module docs](super) for the output format and lifecycle.
-    pub struct Progress(Option<Inner>);
+    pub struct Progress {
+        shared: Arc<Shared>,
+        /// Render thread; present only when the spinner is enabled (stderr TTY).
+        ticker: Option<JoinHandle<()>>,
+    }
 
     impl Progress {
         /// Start a progress reporter, enabling the spinner iff stderr is a TTY.
         ///
         /// `verb` is the present-participle label shown to the user (e.g.
         /// `"Copying"`, `"Removing"`). Spawns a background ticker thread when a
-        /// TTY is detected. When stderr is not a TTY, returns a disabled reporter
-        /// and does no work.
+        /// TTY is detected. When stderr is not a TTY, returns a disabled
+        /// reporter that still counts but renders nothing.
         pub fn start(verb: &'static str) -> Self {
             Self::start_with(verb, std::io::stderr().is_terminal())
         }
@@ -86,9 +102,13 @@ mod imp {
             }
         }
 
-        /// A reporter that does nothing — for benchmarks, tests, and internal moves.
+        /// A reporter that renders nothing but still counts — for non-TTY
+        /// contexts, benchmarks, tests, and internal moves.
         pub fn disabled() -> Self {
-            Self(None)
+            Self {
+                shared: Arc::new(Shared::new()),
+                ticker: None,
+            }
         }
 
         /// Constructor for the enabled state, separated so the TTY-gated branch in
@@ -96,25 +116,32 @@ mod imp {
         /// implementation. Spawns the ticker thread; safe to call from any
         /// context that genuinely wants live output.
         fn enabled(verb: &'static str) -> Self {
-            let shared = Arc::new(Shared {
-                files: AtomicUsize::new(0),
-                bytes: AtomicU64::new(0),
-                done: AtomicBool::new(false),
-                verb,
-            });
+            let shared = Arc::new(Shared::new());
             let ticker = {
                 let shared = Arc::clone(&shared);
-                thread::spawn(move || ticker_loop(&shared))
+                thread::spawn(move || ticker_loop(&shared, verb))
             };
-            Self(Some(Inner { shared, ticker }))
+            Self {
+                shared,
+                ticker: Some(ticker),
+            }
         }
 
         /// Record that a file (or symlink) was processed. Safe to call from any thread.
         pub fn record(&self, bytes: u64) {
-            if let Some(inner) = &self.0 {
-                inner.shared.files.fetch_add(1, Ordering::Relaxed);
-                inner.shared.bytes.fetch_add(bytes, Ordering::Relaxed);
-            }
+            self.shared.files.fetch_add(1, Ordering::Relaxed);
+            self.shared.bytes.fetch_add(bytes, Ordering::Relaxed);
+        }
+
+        /// Running `(files, bytes)` totals recorded so far.
+        ///
+        /// Relaxed loads — exact only once the recording threads have finished
+        /// (e.g. after the rayon pool call returns).
+        pub fn totals(&self) -> (usize, u64) {
+            (
+                self.shared.files.load(Ordering::Relaxed),
+                self.shared.bytes.load(Ordering::Relaxed),
+            )
         }
 
         /// Stop the spinner and clear the progress line.
@@ -126,18 +153,16 @@ mod imp {
 
     impl Drop for Progress {
         fn drop(&mut self) {
-            // `Inner` is Drop-free, so we can take ownership of its fields and
-            // run shutdown without partial-move conflicts.
-            if let Some(inner) = self.0.take() {
-                inner.shared.done.store(true, Ordering::Relaxed);
-                inner.ticker.thread().unpark();
-                let _ = inner.ticker.join();
+            if let Some(ticker) = self.ticker.take() {
+                self.shared.done.store(true, Ordering::Relaxed);
+                ticker.thread().unpark();
+                let _ = ticker.join();
                 let _ = clear_line(&mut std::io::stderr().lock());
             }
         }
     }
 
-    fn ticker_loop(shared: &Shared) {
+    fn ticker_loop(shared: &Shared, verb: &str) {
         let start = Instant::now();
         // Sub-300ms operations render nothing — the line never gets drawn.
         // park_timeout returns immediately on `unpark` from drop, so short
@@ -153,7 +178,7 @@ mod imp {
                 % SPINNER_FRAMES.len();
             let files = shared.files.load(Ordering::Relaxed);
             let bytes = shared.bytes.load(Ordering::Relaxed);
-            let line = format_line(shared.verb, files, bytes, SPINNER_FRAMES[frame_idx]);
+            let line = format_line(verb, files, bytes, SPINNER_FRAMES[frame_idx]);
             let _ = render_line(&mut std::io::stderr().lock(), &line);
             thread::park_timeout(TICK_INTERVAL);
         }
@@ -229,13 +254,13 @@ mod imp {
 
         #[test]
         fn test_start_with_non_tty_is_disabled() {
-            assert!(Progress::start_with("Copying", false).0.is_none());
+            assert!(Progress::start_with("Copying", false).ticker.is_none());
         }
 
         #[test]
         fn test_start_with_tty_is_enabled() {
             let p = Progress::start_with("Copying", true);
-            assert!(p.0.is_some());
+            assert!(p.ticker.is_some());
             p.finish();
         }
 
@@ -244,9 +269,7 @@ mod imp {
             let p = Progress::enabled("Copying");
             p.record(1024);
             p.record(2048);
-            let inner = p.0.as_ref().expect("expected enabled");
-            assert_eq!(inner.shared.files.load(Ordering::Relaxed), 2);
-            assert_eq!(inner.shared.bytes.load(Ordering::Relaxed), 3072);
+            assert_eq!(p.totals(), (2, 3072));
             p.finish();
         }
 
@@ -264,22 +287,41 @@ mod imp {
 
 #[cfg(not(feature = "cli"))]
 mod imp {
-    /// Zero-cost stub when the `cli` feature is off. The spinner depends on
+    use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+
+    /// Spinner-less stub when the `cli` feature is off. The spinner depends on
     /// `crossterm`, which is only pulled in by `cli`; library consumers that
-    /// disable default features get this no-op type instead. Counters are
-    /// dropped on the floor — no allocation, no thread, no rendering.
-    pub struct Progress;
+    /// disable default features get this thread-free, render-free type. The
+    /// counters still accumulate so [`Progress::totals`] reports the same
+    /// numbers in both builds.
+    pub struct Progress {
+        files: AtomicUsize,
+        bytes: AtomicU64,
+    }
 
     impl Progress {
         pub fn start(_verb: &'static str) -> Self {
-            Self
+            Self::disabled()
         }
 
         pub fn disabled() -> Self {
-            Self
+            Self {
+                files: AtomicUsize::new(0),
+                bytes: AtomicU64::new(0),
+            }
         }
 
-        pub fn record(&self, _bytes: u64) {}
+        pub fn record(&self, bytes: u64) {
+            self.files.fetch_add(1, Ordering::Relaxed);
+            self.bytes.fetch_add(bytes, Ordering::Relaxed);
+        }
+
+        pub fn totals(&self) -> (usize, u64) {
+            (
+                self.files.load(Ordering::Relaxed),
+                self.bytes.load(Ordering::Relaxed),
+            )
+        }
 
         pub fn finish(self) {}
     }
@@ -382,13 +424,14 @@ mod tests {
         assert!(s.contains("5.0 MiB"));
     }
 
+    // Not cfg-gated: covers the disabled-state counting contract in both the
+    // `cli` implementation and the no-`cli` stub.
     #[test]
-    fn test_disabled_record_is_noop() {
+    fn test_disabled_still_counts() {
         let p = Progress::disabled();
         p.record(1_000_000);
         p.record(2_000_000);
-        // No counters to inspect — Disabled has no fields. The assertion is
-        // simply that the call doesn't panic and finish() returns cleanly.
+        assert_eq!(p.totals(), (2, 3_000_000));
         p.finish();
     }
 }

--- a/src/remove_dir.rs
+++ b/src/remove_dir.rs
@@ -3,7 +3,7 @@
 //! Walks the tree iteratively (no recursion), unlinks files in parallel, then
 //! removes the now-empty directories deepest-first. Each unlinked leaf bumps
 //! a [`Progress`] counter so a TTY spinner can render live updates; the
-//! returned `(files, bytes)` tuple drives the matching post-op summary.
+//! caller reads `progress.totals()` to drive the matching post-op summary.
 //!
 //! Best-effort by design: this is the trash-cleanup phase that runs *after*
 //! the worktree has already been pruned from git's metadata, so a partial
@@ -18,7 +18,6 @@
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
 
 use rayon::prelude::*;
 
@@ -35,10 +34,12 @@ static REMOVE_POOL: LazyLock<rayon::ThreadPool> = LazyLock::new(|| {
 
 /// Remove a directory tree, reporting per-file progress.
 ///
-/// Returns `(files_removed, bytes_removed)`. Bytes use `symlink_metadata`, so
-/// symlinks count as their own size, not the target's. Any I/O errors are
-/// silently skipped — a leaf that can't be unlinked is simply not counted.
-pub fn remove_dir_with_progress(path: &Path, progress: &Progress) -> (usize, u64) {
+/// Each successful unlink is recorded on `progress`, so a `progress` dedicated
+/// to this call reports `(files_removed, bytes_removed)` in `totals()`
+/// afterwards. Bytes use `symlink_metadata`, so symlinks count as their own
+/// size, not the target's. Any I/O errors are silently skipped — a leaf that
+/// can't be unlinked is simply not counted.
+pub fn remove_dir_with_progress(path: &Path, progress: &Progress) {
     let mut leaves: Vec<PathBuf> = Vec::new();
     let mut dirs: Vec<PathBuf> = Vec::new();
     let mut stack = vec![path.to_path_buf()];
@@ -68,8 +69,6 @@ pub fn remove_dir_with_progress(path: &Path, progress: &Progress) -> (usize, u64
         }
     }
 
-    let removed_files = AtomicUsize::new(0);
-    let removed_bytes = AtomicU64::new(0);
     REMOVE_POOL.install(|| {
         leaves.par_iter().for_each(|leaf| {
             // Capture size before unlinking. Best-effort: symlink_metadata may
@@ -77,8 +76,6 @@ pub fn remove_dir_with_progress(path: &Path, progress: &Progress) -> (usize, u64
             // count the leaf with zero bytes.
             let bytes = leaf.symlink_metadata().map(|m| m.len()).unwrap_or(0);
             if fs::remove_file(leaf).is_ok() {
-                removed_files.fetch_add(1, Ordering::Relaxed);
-                removed_bytes.fetch_add(bytes, Ordering::Relaxed);
                 progress.record(bytes);
             }
         });
@@ -89,8 +86,6 @@ pub fn remove_dir_with_progress(path: &Path, progress: &Progress) -> (usize, u64
     for dir in dirs.iter().rev() {
         let _ = fs::remove_dir(dir);
     }
-
-    (removed_files.into_inner(), removed_bytes.into_inner())
 }
 
 #[cfg(test)]
@@ -103,10 +98,10 @@ mod tests {
         let dir = temp.path().join("empty");
         std::fs::create_dir(&dir).unwrap();
 
-        let (files, bytes) = remove_dir_with_progress(&dir, &Progress::disabled());
+        let progress = Progress::disabled();
+        remove_dir_with_progress(&dir, &progress);
 
-        assert_eq!(files, 0);
-        assert_eq!(bytes, 0);
+        assert_eq!(progress.totals(), (0, 0));
         assert!(!dir.exists());
     }
 
@@ -119,10 +114,10 @@ mod tests {
         std::fs::write(root.join("a/b/file2.txt"), b"world!").unwrap(); // 6 bytes
         std::fs::write(root.join("top.txt"), b"x").unwrap(); // 1 byte
 
-        let (files, bytes) = remove_dir_with_progress(&root, &Progress::disabled());
+        let progress = Progress::disabled();
+        remove_dir_with_progress(&root, &progress);
 
-        assert_eq!(files, 3);
-        assert_eq!(bytes, 12);
+        assert_eq!(progress.totals(), (3, 12));
         assert!(!root.exists());
     }
 
@@ -131,10 +126,10 @@ mod tests {
         let temp = tempfile::tempdir().unwrap();
         let missing = temp.path().join("does-not-exist");
 
-        let (files, bytes) = remove_dir_with_progress(&missing, &Progress::disabled());
+        let progress = Progress::disabled();
+        remove_dir_with_progress(&missing, &progress);
 
-        assert_eq!(files, 0);
-        assert_eq!(bytes, 0);
+        assert_eq!(progress.totals(), (0, 0));
     }
 
     #[cfg(unix)]
@@ -146,10 +141,12 @@ mod tests {
         std::fs::write(root.join("real.txt"), b"abc").unwrap();
         std::os::unix::fs::symlink(root.join("real.txt"), root.join("link")).unwrap();
 
-        let (files, _bytes) = remove_dir_with_progress(&root, &Progress::disabled());
+        let progress = Progress::disabled();
+        remove_dir_with_progress(&root, &progress);
 
         // 1 file + 1 symlink = 2 leaves removed; the symlink is unlinked
         // without following.
+        let (files, _bytes) = progress.totals();
         assert_eq!(files, 2);
         assert!(!root.exists());
     }
@@ -182,12 +179,16 @@ mod tests {
             return;
         }
 
-        let (files, bytes) = remove_dir_with_progress(&root, &Progress::disabled());
+        let progress = Progress::disabled();
+        remove_dir_with_progress(&root, &progress);
 
         // Restore so the tempdir's Drop can clean up.
         std::fs::set_permissions(&blocked, std::fs::Permissions::from_mode(0o755)).ok();
 
-        assert_eq!(files, 0, "no leaves should be unlinked when blocked");
-        assert_eq!(bytes, 0);
+        assert_eq!(
+            progress.totals(),
+            (0, 0),
+            "no leaves should be unlinked when blocked"
+        );
     }
 }

--- a/src/styling/mod.rs
+++ b/src/styling/mod.rs
@@ -628,6 +628,7 @@ command = "npm install"
         }
     }
 
+    #[cfg(feature = "syntax-highlighting")]
     #[test]
     fn test_format_bash_with_gutter_template_command() {
         // Test that format_bash_with_gutter produces consistent dim styling
@@ -643,6 +644,7 @@ command = "npm install"
         assert_snapshot!(result);
     }
 
+    #[cfg(feature = "syntax-highlighting")]
     #[test]
     fn test_format_bash_multiline_command_consistent_styling() {
         // This test simulates the REAL user scenario: a multi-line command

--- a/tests/integration_tests/step_copy_ignored.rs
+++ b/tests/integration_tests/step_copy_ignored.rs
@@ -1107,7 +1107,7 @@ fn test_copy_ignored_directory_with_symlinks(mut repo: TestRepo) {
 
 /// Test that copy errors include file paths in the message (GitHub issue #1084)
 ///
-/// Tests both the directory recursive copy error path (copy_dir_recursive_fallback)
+/// Tests both the directory recursive copy error path (copy_dir_recursive)
 /// and the top-level file copy error path (step_copy_ignored main loop).
 #[cfg(unix)]
 #[rstest]
@@ -1149,7 +1149,7 @@ fn test_copy_ignored_error_includes_path_directory(mut repo: TestRepo) {
 
 /// Test that top-level file copy errors include file paths (GitHub issue #1084)
 ///
-/// This exercises the error path in the main copy loop (not copy_dir_recursive_fallback).
+/// This exercises the error path in the main copy loop (not copy_dir_recursive).
 #[cfg(unix)]
 #[rstest]
 fn test_copy_ignored_error_includes_path_file(mut repo: TestRepo) {
@@ -1435,7 +1435,7 @@ fn test_copy_ignored_preserves_file_executable_permissions(mut repo: TestRepo) {
     );
 
     // Verify executable file inside directory was copied with permissions preserved
-    // (exercises copy.rs copy_dir_recursive_inner path)
+    // (exercises copy.rs copy_dir_recursive path)
     let dest_exec = feature_path.join("node_modules/.bin/playwright");
     assert!(dest_exec.exists(), "executable file should be copied");
     let dest_mode = fs::metadata(&dest_exec).unwrap().permissions().mode() & 0o777;


### PR DESCRIPTION
`Progress::record` only counted in the enabled (TTY) state, so both file-walk helpers kept duplicate atomic counters next to each `record()` call, and `wt step copy-ignored` kept a third pair summing their returns. This makes `Progress` the single owner of counting: every state (enabled, disabled, and the no-`cli` stub) counts, and a new `totals()` accessor reads `(files, bytes)` from `&self` mid-operation.

`copy_dir_recursive` and `remove_dir_with_progress` lose their local counters and their `(files, bytes)` returns. A cumulative-totals return would have silently double-counted in `step_copy_ignored`, which reuses one `Progress` across several calls and summed the per-call returns. Callers read `progress.totals()` once instead. Counting semantics are unchanged (copy counts only leaves actually copied, remove only successful unlinks), and the no-cli stub trades "zero-cost" for two atomics so `totals()` reports the same numbers in both builds.

Adjacent fixes: two tests in `src/styling/mod.rs` called a function imported only under `syntax-highlighting`, which broke compilation of `cargo test --lib --no-default-features`; they're now gated on the feature. Six pre-existing snapshot failures remain under that combo (their snapshots bake in highlighted output); a separate branch is adding feature-combo test CI and will gate those. Three comments in the copy-ignored integration tests referenced function names that no longer exist.

No user-visible changes and no snapshot churn.

> _This was written by Claude Code on behalf of max_
