### PR TITLE
feat(statusline): show used % instead of pace above 90% of the rate limit

### DIFF
--- a/docs/content/claude-code.md
+++ b/docs/content/claude-code.md
@@ -111,7 +111,7 @@ On session exit the worktree is offered for removal via the `WorktreeRemove` hoo
 
 <code>~/w/myproject.feature-auth  !🤖  @<span style='color:#0a0'>+42</span> <span style='color:#a00'>-8</span>  <span style='color:#0a0'>↑3</span>  <span style='color:#0a0'>⇡1</span>  <span style='color:#0a0'>#3035</span>  Opus  🌔 65%  <span style='color:#a70'>1.4×(10am–3pm)</span></code>
 
-When Claude Code provides context window usage via stdin JSON, a moon phase gauge appears (🌕→🌑 as context fills). A yellow `<n>×(<window>)` segment appears when Claude's 5-hour or weekly rate limit is on track to be hit before reset — `1.4×(10am–3pm)` reads as 1.4× the pace that would exactly fill that window.
+When Claude Code provides context window usage via stdin JSON, a moon phase gauge appears (🌕→🌑 as context fills). A yellow `<n>×(<window>)` segment appears when Claude's 5-hour or weekly rate limit is on track to be hit before reset — `1.4×(10am–3pm)` reads as 1.4× the pace that would exactly fill that window. Above 90% used it shows usage instead of pace — `93%(10am–3pm)` — near the cap, how much is left matters more than how fast it's going.
 
 <figure class="demo">
 <picture>

--- a/skills/worktrunk/reference/claude-code.md
+++ b/skills/worktrunk/reference/claude-code.md
@@ -113,7 +113,7 @@ On session exit the worktree is offered for removal via the `WorktreeRemove` hoo
 
 <code>~/w/myproject.feature-auth  !🤖  @<span style='color:#0a0'>+42</span> <span style='color:#a00'>-8</span>  <span style='color:#0a0'>↑3</span>  <span style='color:#0a0'>⇡1</span>  <span style='color:#0a0'>#3035</span>  Opus  🌔 65%  <span style='color:#a70'>1.4×(10am–3pm)</span></code>
 
-When Claude Code provides context window usage via stdin JSON, a moon phase gauge appears (🌕→🌑 as context fills). A yellow `<n>×(<window>)` segment appears when Claude's 5-hour or weekly rate limit is on track to be hit before reset — `1.4×(10am–3pm)` reads as 1.4× the pace that would exactly fill that window.
+When Claude Code provides context window usage via stdin JSON, a moon phase gauge appears (🌕→🌑 as context fills). A yellow `<n>×(<window>)` segment appears when Claude's 5-hour or weekly rate limit is on track to be hit before reset — `1.4×(10am–3pm)` reads as 1.4× the pace that would exactly fill that window. Above 90% used it shows usage instead of pace — `93%(10am–3pm)` — near the cap, how much is left matters more than how fast it's going.
 
 Add to `~/.claude/settings.json`:
 

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -22,7 +22,7 @@ pub enum ListSubcommand {
 - `.rate_limits.{five_hour,seven_day}.used_percentage` — rate-limit window usage (0–100)
 - `.rate_limits.{five_hour,seven_day}.resets_at` — window reset time (Unix epoch seconds)
 
-The pace segment appears only when usage is likely to hit a rate limit before its window resets, and shows the higher-risk window: `2.9×(Tue–Tue 5pm)` reads as 2.9× the pace that would exactly fill that window. "Likely" is a Bayesian forecast; early-window bursts don't trigger it. With `-vv`, each window's inputs and projection are logged to `.git/wt/logs/trace.log`.
+The pace segment appears only when usage is likely to hit a rate limit before its window resets, and shows the higher-risk window: `2.9×(Tue–Tue 5pm)` reads as 2.9× the pace that would exactly fill that window. Above 90% used it shows usage instead of pace — `93%(Tue–Tue 5pm)` — near the cap, how much is left matters more than how fast it's going. "Likely" is a Bayesian forecast; early-window bursts don't trigger it. With `-vv`, each window's inputs and projection are logged to `.git/wt/logs/trace.log`.
 "#)]
     Statusline {
         /// Output format (table, json, claude-code)

--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -227,6 +227,13 @@ const SEVEN_DAY_SECS: i64 = 7 * 86400;
 /// Show the rate-limit segment when P(over) crosses this threshold.
 const RATE_LIMIT_P_THRESHOLD: f64 = 0.50;
 
+/// Above this usage (in percent), display used % instead of pace.
+///
+/// Close to the cap, proximity beats velocity: pace answers "will the limit
+/// be hit?", but once usage is nearly there that's all but settled, and "how
+/// much is left?" becomes the actionable number.
+const RATE_LIMIT_NEAR_CAP_PCT: f64 = 90.0;
+
 /// Extract any present rate-limit windows from the Claude Code JSON.
 ///
 /// Both windows are independently optional: subscribers see `rate_limits`
@@ -492,6 +499,10 @@ fn select_binding_window(
 /// posterior `m₁` is only used by [`p_over`] to decide whether to show —
 /// for the *displayed* number, the raw measurement is more honest, more
 /// transparent, and tracks bursts naturally.
+///
+/// Above [`RATE_LIMIT_NEAR_CAP_PCT`] used, the shape becomes
+/// `<used>%(<window_bounds>)` — e.g. `93%(10am–3pm)` — showing how close
+/// the limit is rather than how fast it's being approached.
 fn format_rate_limit_segment(readings: &[RateLimitReading], now_unix: i64) -> Option<String> {
     let r = select_binding_window(readings, now_unix)?;
     let u = r.used_percentage / 100.0;
@@ -500,7 +511,11 @@ fn format_rate_limit_segment(readings: &[RateLimitReading], now_unix: i64) -> Op
     // returns a reading whose `P(over) ≥ 0.5`, which requires `t > 0`.
     let elapsed = (now_unix - (r.resets_at - r.window_secs)) as f64 / r.window_secs as f64;
     let t = elapsed.clamp(0.001, 1.0);
-    let pace = u / t;
+    let reading = if r.used_percentage > RATE_LIMIT_NEAR_CAP_PCT {
+        format!("{:.0}%", r.used_percentage)
+    } else {
+        format!("{:.1}×", u / t)
+    };
     let bounds = format_window_bounds(
         r.resets_at,
         r.window_secs,
@@ -511,7 +526,7 @@ fn format_rate_limit_segment(readings: &[RateLimitReading], now_unix: i64) -> Op
     // the warning. Unlike informational segments where color picks out one
     // sub-glyph (`@+1` green, `?` cyan), here the entire string is the
     // "you should look at this" signal.
-    Some(color_print::cformat!("<yellow>{pace:.1}×({bounds})</>"))
+    Some(color_print::cformat!("<yellow>{reading}({bounds})</>"))
 }
 
 /// Format context usage as a moon phase gauge.
@@ -1391,6 +1406,30 @@ mod tests {
         let visible = out.ansi_strip();
         assert!(
             visible.starts_with("1.3×(") && visible.ends_with(')'),
+            "unexpected format: {visible:?}"
+        );
+    }
+
+    #[test]
+    fn test_format_rate_limit_segment_near_cap_shows_used_pct() {
+        let now = 1_700_000_000_i64;
+        // Above 90% used the displayed number switches from pace to used %:
+        // remaining headroom, not speed, is the actionable quantity there.
+        let r = make_reading(95.0, 0.60, &FIVE_HOUR_PRIORS, now, FIVE_HOUR_SECS);
+        let out =
+            format_rate_limit_segment(std::slice::from_ref(&r), now).expect("should be visible");
+        let visible = out.ansi_strip();
+        assert!(
+            visible.starts_with("95%(") && visible.ends_with(')'),
+            "unexpected format: {visible:?}"
+        );
+        // Exactly 90% stays on the pace form — the switch is strictly above.
+        let r = make_reading(90.0, 0.60, &FIVE_HOUR_PRIORS, now, FIVE_HOUR_SECS);
+        let out =
+            format_rate_limit_segment(std::slice::from_ref(&r), now).expect("should be visible");
+        let visible = out.ansi_strip();
+        assert!(
+            visible.starts_with("1.5×("),
             "unexpected format: {visible:?}"
         );
     }

--- a/tests/snapshots/integration__integration_tests__statusline__rate_limit_5h_at_limit.snap
+++ b/tests/snapshots/integration__integration_tests__statusline__rate_limit_5h_at_limit.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/statusline.rs
 expression: out
 ---
-[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕 42%  [33m1.7×(10am–3pm)[39m
+[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕 42%  [33m100%(10am–3pm)[39m

--- a/tests/snapshots/integration__integration_tests__statusline__rate_limit_5h_with_minutes.snap
+++ b/tests/snapshots/integration__integration_tests__statusline__rate_limit_5h_with_minutes.snap
@@ -2,4 +2,4 @@
 source: tests/integration_tests/statusline.rs
 expression: out
 ---
-[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕 42%  [33m1.1×(8:30am–1:30pm)[39m
+[PATH]  main  [2m^[22m[2m|[22m  Opus  🌕 42%  [33m95%(8:30am–1:30pm)[39m


### PR DESCRIPTION
When the statusline rate-limit segment shows and the binding window is above 90% used, it now displays the used percentage instead of the pace ratio — `95%(8:30am–1:30pm)` rather than `1.1×(8:30am–1:30pm)`. Near the cap, how much is left matters more than how fast it's going; the pace form is unchanged below 90%.

The show condition is untouched (P(over) ≥ 0.5 via the existing Bayesian gate), so this only changes which number renders once the segment is already visible. Strictly greater-than 90: a window at exactly 90% still shows pace. Unit test pins the switch and the boundary; the 95%- and 100%-used integration snapshots now render the percent form, and the help text and claude-code docs describe it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> _This was written by Claude Code on behalf of max_
