### PR TITLE
ci: run lib tests across the feature powerset in nightly

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,7 +1,7 @@
 name: nightly
 # Slower checks that aren't worth running on every PR but should run before a
 # release. Jobs:
-#   - feature-powerset: feature-flag unification (motivated by #2442)
+#   - feature-powerset: feature-flag unification, check + lib tests (motivated by #2442)
 #   - release-target: PTY+shell suite on the release triples ci.yaml doesn't cover
 #   - benchmarks: full criterion suite + time-series gist append (cron only)
 #   - check-unused-dependencies: cargo-udeps on nightly toolchain
@@ -89,6 +89,15 @@ jobs:
     # Workspace members must use `default-features = false` when depending on
     # worktrunk, or feature unification will mask gating bugs by silently
     # enabling `cli` in the lib build (see tests/helpers/wt-perf/Cargo.toml).
+    #
+    # The test step runs the unit tests per combination — the check step
+    # strips dev-deps, so `#[cfg(test)]` code is invisible to it, and a test
+    # importing a feature-gated symbol without its own gate, or a snapshot
+    # baking feature-dependent output, only surfaces when tests are built and
+    # run per combo. Bounded to `--lib`: the integration suite snapshots `wt`
+    # output, which bakes in syntax-highlighted command rendering, so it only
+    # passes with syntax-highlighting on; ci.yaml's `test` matrix already
+    # runs it (with shell-integration-tests) on every PR.
     needs: gate
     if: needs.gate.outputs.run == 'true'
     runs-on: ubuntu-24.04
@@ -104,8 +113,9 @@ jobs:
       with:
         tool: cargo-hack
 
-    - name: cargo hack check --feature-powerset --no-dev-deps
-      run: cargo hack check --feature-powerset --no-dev-deps
+    - run: cargo hack check --feature-powerset --no-dev-deps
+
+    - run: cargo hack test --feature-powerset --lib
 
   release-target:
     # Build and run the test suite on the release triples that ci.yaml's

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -115,6 +115,12 @@ jobs:
 
     - run: cargo hack check --feature-powerset --no-dev-deps
 
+    # The lib suite shells out to the mock-stub helper bin, which `--lib`
+    # doesn't build (tests/CLAUDE.md documents the fresh-target panic).
+    # mock-stub doesn't depend on worktrunk features, so one build serves
+    # every combo.
+    - run: cargo build -p mock-stub
+
     - run: cargo hack test --feature-powerset --lib
 
   release-target:

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -1980,6 +1980,9 @@ mod tests {
         );
     }
 
+    // The third snapshot renders a failed command through `format_bash_with_gutter`,
+    // whose output is highlighted only with the feature on.
+    #[cfg(feature = "syntax-highlighting")]
     #[test]
     fn snapshot_worktree_creation_failed() {
         let err = GitError::WorktreeCreationFailed {

--- a/src/styling/mod.rs
+++ b/src/styling/mod.rs
@@ -424,6 +424,7 @@ command = "npm install"
         ");
     }
 
+    #[cfg(feature = "syntax-highlighting")]
     #[test]
     fn test_bash_gutter_formatting_ends_with_reset() {
         // Test that bash gutter formatting properly resets colors at the end of each line
@@ -628,6 +629,7 @@ command = "npm install"
         }
     }
 
+    #[cfg(feature = "syntax-highlighting")]
     #[test]
     fn test_format_bash_with_gutter_template_command() {
         // Test that format_bash_with_gutter produces consistent dim styling
@@ -643,6 +645,7 @@ command = "npm install"
         assert_snapshot!(result);
     }
 
+    #[cfg(feature = "syntax-highlighting")]
     #[test]
     fn test_format_bash_multiline_command_consistent_styling() {
         // This test simulates the REAL user scenario: a multi-line command
@@ -673,17 +676,20 @@ cp -cR {{ repo_root }}/target/debug/.fingerprint {{ repo_root }}/target/debug/bu
         assert_snapshot!(result);
     }
 
+    #[cfg(feature = "syntax-highlighting")]
     #[test]
     fn test_unhighlighted_text_has_consistent_dim_across_lines() {
         assert_snapshot!(format_bash_with_gutter("echo {{ worktree\n}}/path"));
     }
 
+    #[cfg(feature = "syntax-highlighting")]
     #[test]
     fn test_syntax_highlighting_produces_multiple_colors() {
         let command = "echo 'hello' | grep hello > output.txt && cat output.txt";
         assert_snapshot!(format_bash_with_gutter(command));
     }
 
+    #[cfg(feature = "syntax-highlighting")]
     #[test]
     fn test_no_color_discontinuity_in_template_variables() {
         // Regression test: wrap_ansi injects [39m (reset foreground color) at line ends
@@ -737,6 +743,7 @@ cp -cR {{ repo_root }}/target/debug/.fingerprint {{ repo_root }}/target/debug/bu
         );
     }
 
+    #[cfg(feature = "syntax-highlighting")]
     #[test]
     fn test_no_bold_dim_conflict() {
         // Regression test: We must never mix bold (SGR 1) and dim (SGR 2) in the same
@@ -761,6 +768,7 @@ cp -cR {{ repo_root }}/target/debug/.fingerprint {{ repo_root }}/target/debug/bu
         );
     }
 
+    #[cfg(feature = "syntax-highlighting")]
     #[test]
     fn test_all_tokens_are_dimmed() {
         // Regression test: All highlighted tokens should be dimmed to match the base text.


### PR DESCRIPTION
The nightly `feature-powerset` job only ran `cargo hack check --no-dev-deps`, which never compiles `#[cfg(test)]` code, so test-gating breaks were invisible. Two existed on main: `cargo test --lib --no-default-features` didn't compile (two styling tests call `format_bash_with_gutter_at_width`, which is imported only under `syntax-highlighting`), and once compiling, six tests failed because their assertions/snapshots bake in syntax-highlighted output.

This adds `cargo hack test --feature-powerset --lib` as a second step on the job and gates the affected tests on `syntax-highlighting`. It also gates `test_no_bold_dim_conflict`, which has only negative `!contains` assertions and so passed vacuously without the feature. The fix to the two compile-broken styling tests is line-identical to the one on `progress-owns-counters`, so the branches merge cleanly in either order. A follow-up commit builds the `mock-stub` helper bin before the sweep: `--lib` is a target filter, which skips the default-members helper-bin build, so one lib test panicked on the fresh CI runner (it passed locally only because the binary already existed in `target/`).

The test step is bounded to `--lib`: the integration suite snapshots `wt` output, which bakes in highlighted command rendering (verified: 11 snapshot failures in the first 51 tests without the feature), and ci.yaml's `test` matrix already runs it with full features on every PR.

Verified locally: all 20 powerset combos pass, and the full pre-merge gate is green (3926 tests).

> _This was written by Claude Code on behalf of max_

