### PR TITLE
feat(picker): free digit keys for typing; preview tabs to Alt + Tab/Shift-Tab

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -249,7 +249,7 @@ inherits = "release"
 lto = "thin"
 
 [patch.crates-io]
-# Local fork of skim-tuikit 0.6.6 carrying three small fixes. Run
+# Local fork of skim-tuikit 0.6.6 carrying four small fixes. Run
 # `task vendor-diff` to see the full diff against the upstream tarball.
 #
 # Upstream status: skim-tuikit is effectively abandoned. Upstream skim
@@ -285,4 +285,13 @@ lto = "thin"
 #    which clamps `cursor_row` to 0 — matching the full-screen fallback
 #    `ensure_height` already uses. See vendor/skim-tuikit/src/term.rs. No
 #    known upstream tracking issue; moot post-ratatui.
+#
+# 4. `from_keyname` did not parse `alt-<digit>` tokens — it had `alt-a`..
+#    `alt-z` but no `alt-0`..`alt-9`, so a keymap like `alt-1:...` silently
+#    failed to bind (Input::bind early-returns on an unparseable key). The
+#    input reader already decodes ESC-<digit> to `Alt(ch)`, so this was a
+#    pure config-parser gap. The picker binds alt-1..alt-5 to jump directly
+#    to preview tabs (bare digits are reserved for the query). Added the ten
+#    missing arms, matching fzf's alt-1..alt-9. See
+#    vendor/skim-tuikit/src/key.rs. Clean upstream PR candidate.
 skim-tuikit = { path = "vendor/skim-tuikit" }

--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -74,12 +74,15 @@ When called without arguments, `wt switch` opens an interactive picker to browse
 | `Enter` | Switch to selected worktree |
 | `Alt-c` | Create new worktree named as entered text |
 | `Esc` | Cancel |
-| `1`–`5` | Switch preview tab |
+| `Alt-1`–`Alt-5` | Jump to a preview tab |
+| `Tab`/`Shift-Tab` | Cycle preview tabs forward/backward |
 | `Alt-p` | Toggle preview panel |
 | `Ctrl-u`/`Ctrl-d` | Scroll preview up/down |
 <!-- Alt-r (remove worktree) works but is omitted: cursor resets after skim reload (#1695). Add once fixed. See #1881. -->
 
-**Preview tabs** — toggle with number keys:
+Plain digits go to the filter, so a branch name containing a number can be typed directly; the preview tabs move to `Alt`.
+
+**Preview tabs** — jump with `Alt-1`–`Alt-5`, or cycle with `Tab`/`Shift-Tab`:
 
 1. **HEAD±** — Diff of uncommitted changes
 2. **log** — Recent commits; commits already on the default branch have dimmed hashes

--- a/skills/worktrunk/reference/switch.md
+++ b/skills/worktrunk/reference/switch.md
@@ -70,12 +70,15 @@ When called without arguments, `wt switch` opens an interactive picker to browse
 | `Enter` | Switch to selected worktree |
 | `Alt-c` | Create new worktree named as entered text |
 | `Esc` | Cancel |
-| `1`–`5` | Switch preview tab |
+| `Alt-1`–`Alt-5` | Jump to a preview tab |
+| `Tab`/`Shift-Tab` | Cycle preview tabs forward/backward |
 | `Alt-p` | Toggle preview panel |
 | `Ctrl-u`/`Ctrl-d` | Scroll preview up/down |
 <!-- Alt-r (remove worktree) works but is omitted: cursor resets after skim reload (#1695). Add once fixed. See #1881. -->
 
-**Preview tabs** — toggle with number keys:
+Plain digits go to the filter, so a branch name containing a number can be typed directly; the preview tabs move to `Alt`.
+
+**Preview tabs** — jump with `Alt-1`–`Alt-5`, or cycle with `Tab`/`Shift-Tab`:
 
 1. **HEAD±** — Diff of uncommitted changes
 2. **log** — Recent commits; commits already on the default branch have dimmed hashes

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -620,12 +620,15 @@ When called without arguments, `wt switch` opens an interactive picker to browse
 | `Enter` | Switch to selected worktree |
 | `Alt-c` | Create new worktree named as entered text |
 | `Esc` | Cancel |
-| `1`–`5` | Switch preview tab |
+| `Alt-1`–`Alt-5` | Jump to a preview tab |
+| `Tab`/`Shift-Tab` | Cycle preview tabs forward/backward |
 | `Alt-p` | Toggle preview panel |
 | `Ctrl-u`/`Ctrl-d` | Scroll preview up/down |
 <!-- Alt-r (remove worktree) works but is omitted: cursor resets after skim reload (#1695). Add once fixed. See #1881. -->
 
-**Preview tabs** — toggle with number keys:
+Plain digits go to the filter, so a branch name containing a number can be typed directly; the preview tabs move to `Alt`.
+
+**Preview tabs** — jump with `Alt-1`–`Alt-5`, or cycle with `Tab`/`Shift-Tab`:
 
 1. **HEAD±** — Diff of uncommitted changes
 2. **log** — Recent commits; commits already on the default branch have dimmed hashes

--- a/src/commands/picker/items.rs
+++ b/src/commands/picker/items.rs
@@ -190,9 +190,11 @@ impl WorktreeSkimItem {
         let tab4 = format_tab("4: remote⇅", mode == PreviewMode::UpstreamDiff);
         let tab5 = format_tab("5: summary", mode == PreviewMode::Summary);
 
-        // Controls use dim yellow to distinguish from dimmed (white) tabs
+        // Controls use dim yellow to distinguish from dimmed (white) tabs.
+        // The tab numbers above are the alt-N accelerators (bare digits type
+        // into the query); Tab/shift-tab cycle the same tabs.
         let controls = cformat!(
-            "<dim,yellow>Enter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle</>"
+            "<dim,yellow>Enter: switch | Tab/alt-1…5: preview | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle</>"
         );
 
         // End each tab and controls with full reset to prevent style bleeding
@@ -230,7 +232,9 @@ impl WorktreeSkimItem {
     /// preview for this mode. Skim has no API to re-query preview from
     /// outside user interaction (see `skim::previewer::on_item_change` bail
     /// at `previewer.rs:187`), so the hint tells the user to press the mode
-    /// key again to refresh once the background fill lands.
+    /// key again to refresh once the background fill lands. `alt-N`
+    /// re-runs the same `echo N + refresh-preview` chain, re-reading the
+    /// now-populated cache.
     pub(super) fn loading_placeholder(mode: PreviewMode) -> String {
         let (verb, label) = match mode {
             PreviewMode::WorkingTree => ("Loading", "working-tree diff"),
@@ -240,7 +244,7 @@ impl WorktreeSkimItem {
             PreviewMode::Summary => ("Generating", "summary"),
         };
         let key = mode as u8;
-        format!("○ {verb} {label}. Press {key} again to refresh.\n")
+        format!("○ {verb} {label}. Press alt-{key} again to refresh.\n")
     }
 
     /// Compute preview and apply pager for diff modes. Returns the

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -675,25 +675,57 @@ pub fn handle_picker(
         ))
         .cmd_collector(Rc::new(RefCell::new(collector)) as Rc<RefCell<dyn CommandCollector>>)
         .bind(vec![
-            // Mode switching (1/2/3/4/5 keys change preview content)
+            // Preview-tab switching. Bare digits 1-5 are intentionally NOT
+            // bound — they flow to the query input so a number can be typed
+            // (a PR number, or digits within a branch name). Two ways to
+            // switch tabs remain:
+            //   * alt-1..alt-5 jump straight to a tab. `from_keyname` only
+            //     learns the alt-<digit> tokens via the vendor patch in
+            //     vendor/skim-tuikit/src/key.rs; without it these silently
+            //     no-op (Input::bind drops unparsable keys).
+            //   * tab / shift-tab cycle forward / backward (below).
             format!(
-                "1:execute-silent(echo 1 > {0})+refresh-preview",
+                "alt-1:execute-silent(echo 1 > {0})+refresh-preview",
                 state_path_str
             ),
             format!(
-                "2:execute-silent(echo 2 > {0})+refresh-preview",
+                "alt-2:execute-silent(echo 2 > {0})+refresh-preview",
                 state_path_str
             ),
             format!(
-                "3:execute-silent(echo 3 > {0})+refresh-preview",
+                "alt-3:execute-silent(echo 3 > {0})+refresh-preview",
                 state_path_str
             ),
             format!(
-                "4:execute-silent(echo 4 > {0})+refresh-preview",
+                "alt-4:execute-silent(echo 4 > {0})+refresh-preview",
                 state_path_str
             ),
             format!(
-                "5:execute-silent(echo 5 > {0})+refresh-preview",
+                "alt-5:execute-silent(echo 5 > {0})+refresh-preview",
+                state_path_str
+            ),
+            // Cycle tabs with tab / shift-tab. The state file holds the current
+            // digit; `tr` rotates it (1→2→3→4→5→1 forward, the reverse for
+            // btab) with wraparound, via a temp file + rename so the read and
+            // write don't race on one path. Two hard constraints shape this:
+            //   * Paren-free — skim parses the execute-silent argument up to
+            //     the first `)` (a naive `\([^\)]*?\)` regex), so `$(...)` /
+            //     `$(( ))` would truncate the command. The embedded `{0}` temp
+            //     path must stay `)`-free too (it does: `std::env::temp_dir()`
+            //     paths don't contain parens) — the alt-r/alt-N bindings share
+            //     this assumption.
+            //   * Shell-agnostic — skim runs it under the user's $SHELL
+            //     (fish/zsh/sh), so no shell-specific syntax: `tr` + `mv` are
+            //     external and behave identically everywhere.
+            // This overrides skim's default Tab (toggle-select + cursor down)
+            // and Shift-Tab (toggle-select + cursor up); `bind` replaces the
+            // chain wholesale, and both are inert in this single-select picker.
+            format!(
+                "tab:execute-silent(tr 12345 23451 < {0} > {0}.tmp; mv {0}.tmp {0})+refresh-preview",
+                state_path_str
+            ),
+            format!(
+                "btab:execute-silent(tr 12345 51234 < {0} > {0}.tmp; mv {0}.tmp {0})+refresh-preview",
                 state_path_str
             ),
             // Create new worktree with query as branch name (alt-c for "create")

--- a/src/commands/picker/preview.rs
+++ b/src/commands/picker/preview.rs
@@ -162,7 +162,11 @@ pub(super) struct PreviewStateData;
 
 impl PreviewStateData {
     pub(super) fn state_path() -> PathBuf {
-        // Use per-process temp file to avoid race conditions when running multiple instances
+        // Use per-process temp file to avoid race conditions when running multiple instances.
+        // The leaf stays dot-free (the pid is numeric), so the sibling files
+        // derived via `with_extension(...)` — `.remove` (alt-r signal) and
+        // `.tmp` (tab/btab rotate scratch) — append rather than replace an
+        // extension, matching the shell `{0}.tmp` the keybindings write.
         std::env::temp_dir().join(format!("wt-picker-state-{}", std::process::id()))
     }
 
@@ -204,6 +208,10 @@ impl Drop for PreviewState {
         let _ = fs::remove_file(&self.path);
         // Clean up the removal signal file used by alt-r (see PickerCollector)
         let _ = fs::remove_file(self.path.with_extension("remove"));
+        // Clean up the rotate scratch file used by tab/shift-tab cycling
+        // (`tr … > {path}.tmp; mv …` in the keybindings); normally already
+        // renamed away, but a failed `mv` could leave it behind.
+        let _ = fs::remove_file(self.path.with_extension("tmp"));
     }
 }
 

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__branch_diff.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__branch_diff.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::render_preview_tabs(mode)"
 ---
 [2m1: HEAD±[22m[0m | [2m2: log[22m[0m | [1m3: main…±[22m[0m | [2m4: remote⇅[22m[0m | [2m5: summary[22m[0m
-[33m[2mEnter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m
+[33m[2mEnter: switch | Tab/alt-1…5: preview | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__cache_miss.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__cache_miss.snap
@@ -2,4 +2,4 @@
 source: src/commands/picker/items.rs
 expression: "cache_miss.preview_for_mode(PreviewMode::Summary, 80, 40)"
 ---
-[1m○ Generating summary. Press 5 again to refresh.[0m
+[1m○ Generating summary. Press alt-5 again to refresh.[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_branch_diff.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_branch_diff.snap
@@ -2,4 +2,4 @@
 source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::loading_placeholder(mode)"
 ---
-○ Loading branch diff. Press 3 again to refresh.
+○ Loading branch diff. Press alt-3 again to refresh.

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_log.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_log.snap
@@ -2,4 +2,4 @@
 source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::loading_placeholder(mode)"
 ---
-○ Loading log. Press 2 again to refresh.
+○ Loading log. Press alt-2 again to refresh.

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_summary.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_summary.snap
@@ -2,4 +2,4 @@
 source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::loading_placeholder(mode)"
 ---
-○ Generating summary. Press 5 again to refresh.
+○ Generating summary. Press alt-5 again to refresh.

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_upstream_diff.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_upstream_diff.snap
@@ -2,4 +2,4 @@
 source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::loading_placeholder(mode)"
 ---
-○ Loading upstream diff. Press 4 again to refresh.
+○ Loading upstream diff. Press alt-4 again to refresh.

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_working_tree.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_working_tree.snap
@@ -2,4 +2,4 @@
 source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::loading_placeholder(mode)"
 ---
-○ Loading working-tree diff. Press 1 again to refresh.
+○ Loading working-tree diff. Press alt-1 again to refresh.

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__log.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__log.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::render_preview_tabs(mode)"
 ---
 [2m1: HEAD±[22m[0m | [1m2: log[22m[0m | [2m3: main…±[22m[0m | [2m4: remote⇅[22m[0m | [2m5: summary[22m[0m
-[33m[2mEnter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m
+[33m[2mEnter: switch | Tab/alt-1…5: preview | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__summary.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__summary.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::render_preview_tabs(mode)"
 ---
 [2m1: HEAD±[22m[0m | [2m2: log[22m[0m | [2m3: main…±[22m[0m | [2m4: remote⇅[22m[0m | [1m5: summary[22m[0m
-[33m[2mEnter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m
+[33m[2mEnter: switch | Tab/alt-1…5: preview | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__upstream_diff.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__upstream_diff.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::render_preview_tabs(mode)"
 ---
 [2m1: HEAD±[22m[0m | [2m2: log[22m[0m | [2m3: main…±[22m[0m | [1m4: remote⇅[22m[0m | [2m5: summary[22m[0m
-[33m[2mEnter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m
+[33m[2mEnter: switch | Tab/alt-1…5: preview | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__working_tree.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__working_tree.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::render_preview_tabs(mode)"
 ---
 [1m1: HEAD±[22m[0m | [2m2: log[22m[0m | [2m3: main…±[22m[0m | [2m4: remote⇅[22m[0m | [2m5: summary[22m[0m
-[33m[2mEnter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m
+[33m[2mEnter: switch | Tab/alt-1…5: preview | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -146,9 +146,9 @@ fn exec_in_pty_with_input(
 /// - `expected_content`: a substring that must appear on screen before the input is considered
 ///   processed. Required for async preview content that lands later than the prompt update.
 ///
-/// Example: `[("\x1b[B", None), ("3", Some("diff --git"))]`
+/// Example: `[("\x1b[B", None), ("\x1b3", Some("diff --git"))]`
 /// - After Down (move cursor to the next worktree): just wait for the screen to settle.
-/// - After pressing "3" (switch to diff panel): wait until "diff --git" appears.
+/// - After Alt-3 (switch to the main…± diff panel): wait until "diff --git" appears.
 fn exec_in_pty_with_input_expectations(
     command: &str,
     args: &[&str],
@@ -647,8 +647,9 @@ fn test_switch_picker_preview_panel_uncommitted(mut repo: TestRepo) {
     .unwrap();
 
     let env_vars = repo.test_env_vars();
-    // Type "feature" to filter to just the feature worktree, press 1 for HEAD± panel
-    // Wait for "diff --git" to appear after pressing 1 - the async preview can be slow under congestion
+    // Select `feature`, then Alt-1 for the HEAD± panel (bare digits filter; the
+    // preview tabs moved to Alt). Wait for "diff --git" — the async preview can
+    // be slow under congestion.
     let result = exec_in_pty_capture_before_abort(
         wt_bin().to_str().unwrap(),
         &["switch"],
@@ -663,8 +664,8 @@ fn test_switch_picker_preview_panel_uncommitted(mut repo: TestRepo) {
             // The list now shows both worktrees with the cursor on `feature`; the
             // panel-content gate below still fails loudly if the wrong row is
             // selected (the snapshot would not match `feature`'s preview).
-            ("\x1b[B", None),          // Down: move cursor to `feature`
-            ("1", Some("diff --git")), // Wait for diff to load
+            ("\x1b[B", None),              // Down: move cursor to `feature`
+            ("\x1b1", Some("diff --git")), // Alt-1: HEAD± panel; wait for diff
         ],
     );
 
@@ -713,8 +714,8 @@ fn test_switch_picker_preview_panel_log(mut repo: TestRepo) {
     }
 
     let env_vars = repo.test_env_vars();
-    // Type "feature" to filter, press 2 for log panel
-    // Wait for commit log format "* [hash]" to appear - the async preview can be slow under congestion
+    // Select `feature`, then Alt-2 for the log panel. Wait for commit log
+    // format "* [hash]" — the async preview can be slow under congestion.
     let result = exec_in_pty_capture_before_abort(
         wt_bin().to_str().unwrap(),
         &["switch"],
@@ -723,8 +724,8 @@ fn test_switch_picker_preview_panel_log(mut repo: TestRepo) {
         &[
             // Cursor-navigation select: see test_switch_picker_preview_panel_uncommitted
             // for the matcher-lag rationale.
-            ("\x1b[B", None),  // Down: move cursor to `feature`
-            ("2", Some("* ")), // Wait for git log output
+            ("\x1b[B", None),      // Down: move cursor to `feature`
+            ("\x1b2", Some("* ")), // Alt-2: log panel; wait for git log output
         ],
     );
 
@@ -806,8 +807,8 @@ fn test_new_feature() {
     assert!(output.status.success(), "Failed to commit");
 
     let env_vars = repo.test_env_vars();
-    // Type "feature" to filter, press 3 for main…± panel
-    // Wait for "diff --git" to appear after pressing 3 - the async preview can be slow under congestion
+    // Select `feature`, then Alt-3 for the main…± panel. Wait for "diff --git"
+    // — the async preview can be slow under congestion.
     let result = exec_in_pty_capture_before_abort(
         wt_bin().to_str().unwrap(),
         &["switch"],
@@ -816,8 +817,8 @@ fn test_new_feature() {
         &[
             // Cursor-navigation select: see test_switch_picker_preview_panel_uncommitted
             // for the matcher-lag rationale.
-            ("\x1b[B", None),          // Down: move cursor to `feature`
-            ("3", Some("diff --git")), // Wait for diff to load
+            ("\x1b[B", None),              // Down: move cursor to `feature`
+            ("\x1b3", Some("diff --git")), // Alt-3: main…± panel; wait for diff
         ],
     );
 
@@ -860,8 +861,8 @@ fn test_switch_picker_preview_panel_summary(mut repo: TestRepo) {
     assert!(output.status.success(), "Failed to commit");
 
     let env_vars = repo.test_env_vars();
-    // Type "feature" to filter, press 5 for summary panel
-    // Wait for "commit.generation" hint since no LLM is configured
+    // Select `feature`, then Alt-5 for the summary panel. Wait for the
+    // "commit.generation" config hint since no LLM is configured.
     let result = exec_in_pty_capture_before_abort(
         wt_bin().to_str().unwrap(),
         &["switch"],
@@ -870,8 +871,8 @@ fn test_switch_picker_preview_panel_summary(mut repo: TestRepo) {
         &[
             // Cursor-navigation select: see test_switch_picker_preview_panel_uncommitted
             // for the matcher-lag rationale.
-            ("\x1b[B", None),         // Down: move cursor to `feature`
-            ("5", Some("Configure")), // Wait for config hint
+            ("\x1b[B", None),             // Down: move cursor to `feature`
+            ("\x1b5", Some("Configure")), // Alt-5: summary panel; wait for hint
         ],
     );
 
@@ -883,6 +884,169 @@ fn test_switch_picker_preview_panel_summary(mut repo: TestRepo) {
         assert_snapshot!("switch_picker_preview_summary_list", list);
         assert_snapshot!("switch_picker_preview_summary_preview", preview);
     });
+}
+
+#[rstest]
+fn test_switch_picker_preview_cycle_tab_forward(mut repo: TestRepo) {
+    // Tab cycles the preview tab forward. From the default HEAD± tab (1), one
+    // Tab lands on the log tab (2), proving the `tr 12345 23451` rotation in the
+    // keybinding runs under the real shell. (alt-1..alt-5 jump directly; the
+    // panel tests above cover those — this covers the cycle path.)
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["remote", "remove", "origin"]);
+    let feature_path = repo.add_worktree("feature");
+
+    // Commit a file so the log tab has content; the worktree stays clean, so the
+    // HEAD± tab shows no diff and the "* " log-graph marker is unambiguous.
+    std::fs::write(feature_path.join("file.txt"), "content\n").unwrap();
+    let add = repo
+        .git_command()
+        .args(["-C", feature_path.to_str().unwrap(), "add", "."])
+        .run()
+        .unwrap();
+    assert!(add.status.success(), "Failed to add file");
+    let commit = repo
+        .git_command()
+        .args([
+            "-C",
+            feature_path.to_str().unwrap(),
+            "commit",
+            "-m",
+            "Commit for tab cycle",
+        ])
+        .run()
+        .unwrap();
+    assert!(commit.status.success(), "Failed to commit");
+
+    let env_vars = repo.test_env_vars();
+    let result = exec_in_pty_capture_before_abort(
+        wt_bin().to_str().unwrap(),
+        &["switch"],
+        repo.root_path(),
+        &env_vars,
+        &[
+            // Cursor-navigation select: see test_switch_picker_preview_panel_uncommitted
+            // for the matcher-lag rationale.
+            ("\x1b[B", None),   // Down: move cursor to `feature`
+            ("\t", Some("* ")), // Tab: HEAD± → log; wait for git log output
+        ],
+    );
+
+    assert_valid_abort_exit_code(result.exit_code);
+
+    let (_list, preview) = result.panels();
+    assert!(
+        preview.contains("* "),
+        "Tab should advance the preview to the log tab; preview was:\n{preview}"
+    );
+}
+
+#[rstest]
+fn test_switch_picker_preview_cycle_tab_forward_wraps(mut repo: TestRepo) {
+    // Forward cycling wraps 5 → 1: from the summary tab (reached via Alt-5),
+    // one Tab returns to the HEAD± tab. This covers the `5 → 1` end of the
+    // `tr 12345 23451` map, the half most easily typo'd away.
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["remote", "remove", "origin"]);
+    let feature_path = repo.add_worktree("feature");
+
+    // Commit so the worktree is clean: the HEAD± tab then reads "no uncommitted
+    // changes", a message unique to tab 1 — so seeing it proves the wrap landed
+    // there and not on some other tab.
+    std::fs::write(feature_path.join("file.txt"), "content\n").unwrap();
+    let add = repo
+        .git_command()
+        .args(["-C", feature_path.to_str().unwrap(), "add", "."])
+        .run()
+        .unwrap();
+    assert!(add.status.success(), "Failed to add file");
+    let commit = repo
+        .git_command()
+        .args([
+            "-C",
+            feature_path.to_str().unwrap(),
+            "commit",
+            "-m",
+            "Commit for forward-wrap cycle",
+        ])
+        .run()
+        .unwrap();
+    assert!(commit.status.success(), "Failed to commit");
+
+    let env_vars = repo.test_env_vars();
+    let result = exec_in_pty_capture_before_abort(
+        wt_bin().to_str().unwrap(),
+        &["switch"],
+        repo.root_path(),
+        &env_vars,
+        &[
+            // Cursor-navigation select: see test_switch_picker_preview_panel_uncommitted
+            // for the matcher-lag rationale.
+            ("\x1b[B", None),                       // Down: move cursor to `feature`
+            ("\x1b5", Some("Configure")),           // Alt-5: jump to summary (5)
+            ("\t", Some("no uncommitted changes")), // Tab: wrap 5 → HEAD± (1)
+        ],
+    );
+
+    assert_valid_abort_exit_code(result.exit_code);
+
+    let (_list, preview) = result.panels();
+    assert!(
+        preview.contains("no uncommitted changes"),
+        "Tab from the summary tab should wrap to the HEAD± tab; preview was:\n{preview}"
+    );
+}
+
+#[rstest]
+fn test_switch_picker_preview_cycle_shift_tab_wraps(mut repo: TestRepo) {
+    // Shift-Tab cycles backward and wraps: from the default HEAD± tab (1), one
+    // Shift-Tab lands on the summary tab (5), exercising the reverse rotation
+    // `tr 12345 51234` including the 1 → 5 wraparound.
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["remote", "remove", "origin"]);
+    let feature_path = repo.add_worktree("feature");
+
+    std::fs::write(feature_path.join("new.txt"), "content\n").unwrap();
+    let add = repo
+        .git_command()
+        .args(["-C", feature_path.to_str().unwrap(), "add", "."])
+        .run()
+        .unwrap();
+    assert!(add.status.success(), "Failed to add file");
+    let commit = repo
+        .git_command()
+        .args([
+            "-C",
+            feature_path.to_str().unwrap(),
+            "commit",
+            "-m",
+            "Add new file",
+        ])
+        .run()
+        .unwrap();
+    assert!(commit.status.success(), "Failed to commit");
+
+    let env_vars = repo.test_env_vars();
+    let result = exec_in_pty_capture_before_abort(
+        wt_bin().to_str().unwrap(),
+        &["switch"],
+        repo.root_path(),
+        &env_vars,
+        &[
+            // Cursor-navigation select: see test_switch_picker_preview_panel_uncommitted
+            // for the matcher-lag rationale.
+            ("\x1b[B", None),              // Down: move cursor to `feature`
+            ("\x1b[Z", Some("Configure")), // Shift-Tab: HEAD± → summary (wrap)
+        ],
+    );
+
+    assert_valid_abort_exit_code(result.exit_code);
+
+    let (_list, preview) = result.panels();
+    assert!(
+        preview.contains("Configure"),
+        "Shift-Tab should wrap to the summary tab; preview was:\n{preview}"
+    );
 }
 
 #[rstest]

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -180,11 +180,14 @@ When called without arguments, [2mwt switch[0m opens an interactive picker to 
  [2mEnter[0m         Switch to selected worktree               
  [2mAlt-c[0m         Create new worktree named as entered text 
  [2mEsc[0m           Cancel                                    
- [2m1[0m–[2m5[0m           Switch preview tab                        
+ [2mAlt-1[0m–[2mAlt-5[0m   Jump to a preview tab                     
+ [2mTab[0m/[2mShift-Tab[0m Cycle preview tabs forward/backward       
  [2mAlt-p[0m         Toggle preview panel                      
  [2mCtrl-u[0m/[2mCtrl-d[0m Scroll preview up/down                    
 
-[1mPreview tabs[0m — toggle with number keys:
+Plain digits go to the filter, so a branch name containing a number can be typed directly; the preview tabs move to [2mAlt[0m.
+
+[1mPreview tabs[0m — jump with [2mAlt-1[0m–[2mAlt-5[0m, or cycle with [2mTab[0m/[2mShift-Tab[0m:
 
 1. [1mHEAD±[0m — Diff of uncommitted changes
 2. [1mlog[0m — Recent commits; commits already on the default branch have dimmed hashes

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_abort_escape_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_abort_escape_preview.snap
@@ -3,6 +3,6 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± | 2: log | 3: main…± | 4: remote⇅ | 5: summary [N/M]
-Enter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scr
+Enter: switch | Tab/alt-1…5: preview | alt-c: create | Esc:
 
 ○ main has no uncommitted changes

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_multiple_worktrees_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_multiple_worktrees_preview.snap
@@ -3,6 +3,6 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± | 2: log | 3: main…± | 4: remote⇅ | 5: summary [N/M]
-Enter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scr
+Enter: switch | Tab/alt-1…5: preview | alt-c: create | Esc:
 
 ○ main has no uncommitted changes

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_log_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_log_preview.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± | 2: log | 3: main…± | 4: remote⇅ | 5: summary [N/M]
-Enter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scr
+Enter: switch | Tab/alt-1…5: preview | alt-c: create | Esc:
 
 * [HASH]   +1        [TIME] (feature) Add file 5 with content
 * [HASH]   +1        [TIME] Add file 4 with content

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_main_diff_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_main_diff_preview.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± | 2: log | 3: main…± | 4: remote⇅ | 5: summary [N/M]
-Enter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scr
+Enter: switch | Tab/alt-1…5: preview | alt-c: create | Esc:
 
  feature_code.rs | 6 ++++++
  tests.rs        | 4 ++++

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_summary_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_summary_preview.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± | 2: log | 3: main…± | 4: remote⇅ | 5: summary [N/M]
-Enter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scr
+Enter: switch | Tab/alt-1…5: preview | alt-c: create | Esc:
 
 Configure [commit.generation] command to enable LLM summari
 

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_uncommitted_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_uncommitted_preview.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± | 2: log | 3: main…± | 4: remote⇅ | 5: summary [N/M]
-Enter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scr
+Enter: switch | Tab/alt-1…5: preview | alt-c: create | Esc:
 
  tracked.txt | 4 +++-
  1 file changed, 3 insertions(+), 1 deletion(-)

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_with_branches_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_with_branches_preview.snap
@@ -3,6 +3,6 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± | 2: log | 3: main…± | 4: remote⇅ | 5: summary [N/M]
-Enter: switch | alt-c: create | Esc: cancel | ctrl-u/d: scr
+Enter: switch | Tab/alt-1…5: preview | alt-c: create | Esc:
 
 ○ main has no uncommitted changes

--- a/vendor/NOTES.md
+++ b/vendor/NOTES.md
@@ -10,9 +10,11 @@ Landed:
 
 1. **`Output::flush` uses `write_all`** (`src/output.rs`) — fixes dropped bytes on partial writes under PTY pressure. Upstream PR: [skim-rs/skim#1056](https://github.com/skim-rs/skim/pull/1056). Drop this patch once #1056 ships in a tagged release.
 
+2. **`from_keyname` parses `alt-<digit>`** (`src/key.rs`) — adds the missing `alt-0`..`alt-9` arms (it had `alt-a`..`alt-z`), so `alt-1:…` keymaps bind. The input reader already decodes ESC-digit to `Alt(ch)`; this was a pure config-parser gap. The `wt switch` picker uses it for alt-1..alt-5 direct preview-tab jumps while leaving bare digits for the query. Matches fzf's alt-1..alt-9; clean upstream PR candidate to skim-rs/skim.
+
 In flight (dispatched 2026-04-14):
 
-2. **Symmetric smcup/rmcup in partial-height mode** — currently worked around with `SkimOptionsBuilder::no_clear_start(true)` in `src/commands/picker/mod.rs:454-457`. See [skim-rs/skim#880](https://github.com/skim-rs/skim/issues/880). Branch: `tuikit-clear-start-fix`.
+3. **Symmetric smcup/rmcup in partial-height mode** — currently worked around with `SkimOptionsBuilder::no_clear_start(true)` in `src/commands/picker/mod.rs:454-457`. See [skim-rs/skim#880](https://github.com/skim-rs/skim/issues/880). Branch: `tuikit-clear-start-fix`.
 
 ## Candidate future patches
 

--- a/vendor/skim-tuikit/src/key.rs
+++ b/vendor/skim-tuikit/src/key.rs
@@ -186,6 +186,21 @@ pub fn from_keyname(keyname: &str) -> Option<Key> {
         "alt-z" => Some(Alt('z')),
         "alt-/" => Some(Alt('/')),
 
+        // Alt-digit. The input reader already decodes ESC-<digit> to Alt(ch)
+        // via the generic `ch => Alt(ch)` arm in `parse_alt` (input.rs); these
+        // arms make the keymap-config parser accept the same tokens, matching
+        // fzf's alt-1..alt-9 bindings. (worktrunk vendor patch.)
+        "alt-0" => Some(Alt('0')),
+        "alt-1" => Some(Alt('1')),
+        "alt-2" => Some(Alt('2')),
+        "alt-3" => Some(Alt('3')),
+        "alt-4" => Some(Alt('4')),
+        "alt-5" => Some(Alt('5')),
+        "alt-6" => Some(Alt('6')),
+        "alt-7" => Some(Alt('7')),
+        "alt-8" => Some(Alt('8')),
+        "alt-9" => Some(Alt('9')),
+
         "shift-a" => Some(Char('A')),
         "shift-b" => Some(Char('B')),
         "shift-c" => Some(Char('C')),
@@ -279,5 +294,14 @@ mod test {
 
         // A correct way to refer to an uppercase char.
         assert_eq!(from_keyname("shift-a").unwrap(), Char('A'));
+    }
+
+    #[test]
+    fn bind_alt_digit() {
+        // Alt-digit tokens resolve to the same Alt(ch) the input reader emits
+        // for ESC-<digit>, so `alt-1:...` keymaps bind (worktrunk vendor patch).
+        assert_eq!(from_keyname("alt-0").unwrap(), Alt('0'));
+        assert_eq!(from_keyname("alt-5").unwrap(), Alt('5'));
+        assert_eq!(from_keyname("alt-9").unwrap(), Alt('9'));
     }
 }


### PR DESCRIPTION
The interactive `wt switch` picker bound the bare digit keys `1`–`5` to preview-mode switching, so skim consumed them before they could reach the fuzzy query — a number could never be typed to filter. This frees the bare digits (they now go to the query — useful for digits in branch names, and for the PR/MR numbers the `--prs` work will add) and moves preview-tab switching onto modifiers.

## Behavior

| Keys | Action |
|------|--------|
| bare `1`–`5` | filter the list (previously switched tabs) |
| `Alt-1`–`Alt-5` | jump directly to a preview tab |
| `Tab` / `Shift-Tab` | cycle preview tabs forward / backward, wrapping |

`Alt-1`–`Alt-5` carries the same Meta-key requirement the existing `alt-c`/`alt-r`/`alt-p` bindings already rely on; `Tab`/`Shift-Tab` works regardless, so the cycle is the universal path and Alt-digit is the accelerator.

## Navigating the diff

- **`vendor/skim-tuikit/src/key.rs`** — the load-bearing enabler. `from_keyname` had `alt-a`..`alt-z` but no `alt-0`..`alt-9`, so an `alt-1:…` keymap silently failed to bind (`Input::bind` drops keys it can't parse), even though the terminal reader already decodes ESC+digit to `Alt(digit)` (`input.rs:333`). Added the ten arms, matching fzf's `alt-1`..`alt-9`; documented in the `Cargo.toml` `[patch.crates-io]` block and `vendor/NOTES.md` as a clean upstream-PR candidate.
- **`src/commands/picker/mod.rs`** — the `.bind(vec![…])` block: `alt-1`..`alt-5` jumps plus the `tab`/`btab` cycle. The cycle rotates the mode digit in the state file with `tr 12345 23451 < {0} > {0}.tmp; mv {0}.tmp {0}`. That command shape is forced by two constraints, both documented inline: skim parses the `execute-silent(…)` argument only up to the first `)` (so no `$(( ))`), and runs it under the user's `$SHELL` (so `tr`+`mv`, no shell-specific syntax).
- **`src/commands/picker/items.rs`** / **`preview.rs`** — legend controls line, loading-placeholder hint, and a `Drop` that cleans up the rotate scratch file.
- **`src/cli/mod.rs`** + regenerated `docs/content/switch.md` and `skills/worktrunk/reference/switch.md` (`test_docs_are_in_sync` passes).

## Testing

The four `preview_panel` tests now drive `Alt-N`. Three new PTY tests cover the cycle end-to-end under the real shell: forward (`1→2`), forward wraparound (`5→1`), and backward wraparound (`1→5`). The full gate (`cargo run -- hook pre-merge --yes`, including `--features shell-integration-tests`) is green: 3943 tests, clippy/fmt/typos clean. Bare-digit-to-query is structurally guaranteed (the bindings are simply removed) and intentionally not given a filter-query test, since the suite documents skim matcher-lag flakiness for query-driven tests.

This branch is based on `main`; reconciling with the sibling `--prs` branch that motivated it is left to that branch.

> _This was written by Claude Code on behalf of max_
