### PR TITLE
refactor(output): route --dry-run previews to stdout

### DIFF
--- a/.claude/skills/writing-user-outputs/SKILL.md
+++ b/.claude/skills/writing-user-outputs/SKILL.md
@@ -93,14 +93,17 @@ format_heading("USER CONFIG", Some("@ ~/.config/wt.toml"))
 
 ## stdout vs stderr
 
-**Decision principle:** If this command is piped, what should the receiving program get?
+**Decision principle:** stdout carries the command's *answer*; stderr carries *narration* about producing it.
 
-- **stdout** → Data for pipes, scripts, `eval` (tables, JSON, shell code)
-- **stderr** → Status for the human watching (progress, success, errors, hints)
-- **directive file** → Shell commands executed after wt exits (cd, exec)
+- **stdout** → the answer, in whatever format the user selected. Data (tables, JSON, shell code, an expanded template) and `--dry-run` previews both qualify: a preview is the whole answer when nothing mutates. Human-formatted output belongs here too. Color strips automatically on a pipe (anstream), so `wt list | grep` stays safe.
+- **stderr** → narration about doing it: progress, success/warning/error messages, hints, interactive prompts, and `-v`/`-vv` diagnostics.
+- **directive file** → shell commands executed after wt exits (cd, exec).
+
+A `--dry-run` answers "what would this do?", so its preview goes to stdout. It pages like any long answer (`wt step commit --dry-run`) and shares the stream with the command's `--format=json` form: `wt step prune --dry-run` prints the same removal plan as human text or as json, both to stdout. One case stays on stderr: a preview shown *inside* an interactive prompt, such as the `?` re-preview during `wt config shell install`, is mid-prompt narration.
 
 Examples:
-- `wt list` → table/JSON to stdout (for grep, jq, scripts)
+- `wt list`, `wt config show` → human table/dump or `--format=json`, both to stdout
+- `wt step prune --dry-run` → the removal plan to stdout (human or json); "nothing to remove" and skipped-young caveats to stderr
 - `wt config shell init` → shell code to stdout (for `eval`)
 - `wt switch` → status messages only (nothing to pipe)
 

--- a/.claude/skills/writing-user-outputs/SKILL.md
+++ b/.claude/skills/writing-user-outputs/SKILL.md
@@ -93,13 +93,15 @@ format_heading("USER CONFIG", Some("@ ~/.config/wt.toml"))
 
 ## stdout vs stderr
 
-**Decision principle:** stdout carries the command's *answer*; stderr carries *narration* about producing it.
+**Decision principle:** stdout carries the command's *answer*; stderr carries *narration* about producing it. The discriminating question is answer-vs-narration, not audience — `wt list` is "for the user" yet belongs on stdout because it *is* the answer. "Is this a message to the user?" doesn't discriminate, because nearly all output is.
 
 - **stdout** → the answer, in whatever format the user selected. Data (tables, JSON, shell code, an expanded template) and `--dry-run` previews both qualify: a preview is the whole answer when nothing mutates. Human-formatted output belongs here too. Color strips automatically on a pipe (anstream), so `wt list | grep` stays safe.
 - **stderr** → narration about doing it: progress, success/warning/error messages, hints, interactive prompts, and `-v`/`-vv` diagnostics.
 - **directive file** → shell commands executed after wt exits (cd, exec).
 
-A `--dry-run` answers "what would this do?", so its preview goes to stdout. It pages like any long answer (`wt step commit --dry-run`) and shares the stream with the command's `--format=json` form: `wt step prune --dry-run` prints the same removal plan as human text or as json, both to stdout. One case stays on stderr: a preview shown *inside* an interactive prompt, such as the `?` re-preview during `wt config shell install`, is mid-prompt narration.
+The same line can flip streams between modes. `wt config shell uninstall` deletes the file, so `✓ Removed … @ ~/.zshrc` only narrates a side effect that already happened → stderr (the edited file is the answer; stdout is empty). `wt config shell uninstall --dry-run` mutates nothing, so `○ Will remove … @ ~/.zshrc` is the only answer there is → stdout. What flips isn't the wording, it's whether a side effect exists to be the answer.
+
+For a split preview, the `--format=json` payload is the arbiter: a line json would carry goes to stdout, narration json omits stays on stderr. `wt step prune --dry-run` puts the removal plan on stdout (the same plan json emits) but keeps "Skipped young-branch (younger than 1d)" and "nothing to remove" on stderr. One case ignores all this: a preview shown *inside* an interactive prompt, such as the `?` re-preview during `wt config shell install`, is mid-prompt narration → stderr.
 
 Examples:
 - `wt list`, `wt config show` → human table/dump or `--format=json`, both to stdout

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -122,7 +122,7 @@ The help text should be scannable. Users reading `wt switch --help` need to quic
 
 The flags answer different questions: `--dry-run` is "what would this change?", `-v` is "what is this doing?" (template variables, expansion, echoed `$ git …` subprocesses).
 
-Both render in the gutter house style: `format_heading` for sections, `format_with_gutter` / `format_bash_with_gutter` for quoted blocks, `info_message` / `hint_message` for status lines. The `/writing-user-outputs` skill covers the helpers, the stdout/stderr split, and when to page.
+A `--dry-run` preview is the command's answer, so it prints to stdout (pageable when long), on the same stream as the command's `--format=json` form; progress and status stay on stderr. Both flags render in the gutter house style: `format_heading` for sections, `format_with_gutter` / `format_bash_with_gutter` for quoted blocks, `info_message` / `hint_message` for status lines. The `/writing-user-outputs` skill covers the helpers, the full stdout/stderr split, and when to page.
 
 ## CLI Help Text Placement
 

--- a/src/commands/configure_shell.rs
+++ b/src/commands/configure_shell.rs
@@ -8,7 +8,7 @@ use worktrunk::path::format_path_for_display;
 use worktrunk::shell::{self, Shell};
 use worktrunk::styling::{
     INFO_SYMBOL, SUCCESS_SYMBOL, eprint, eprintln, format_bash_with_gutter, format_toml,
-    format_with_gutter, hint_message, prompt_message, warning_message,
+    format_with_gutter, hint_message, println, prompt_message, warning_message,
 };
 
 use crate::output::prompt::{PromptResponse, prompt_yes_no_preview};
@@ -280,7 +280,10 @@ pub fn handle_configure_shell(
 
     // For --dry-run, show preview and return without modifying anything
     if dry_run {
-        show_install_preview(&preview.configured, &completion_preview, &cmd);
+        let preview_text = show_install_preview(&preview.configured, &completion_preview, &cmd);
+        if !preview_text.is_empty() {
+            println!("{preview_text}");
+        }
         return Ok(ScanResult {
             configured: preview.configured,
             completion_results: completion_preview,
@@ -725,10 +728,12 @@ fn configure_wrapper_file(
     }))
 }
 
-/// Display what will be installed (shell extensions and completions)
+/// Format what will be installed (shell extensions and completions).
 ///
-/// Shows the config lines that will be added without prompting.
-/// Used both for install preview and when user types `?` at prompt.
+/// Returns the preview as a string (no trailing newline); the caller picks the
+/// sink. `--dry-run` is the command's answer, so it prints to stdout; the
+/// interactive `?` re-preview during the install prompt is mid-prompt narration,
+/// so it prints to stderr. See /writing-user-outputs.
 ///
 /// Note: I/O errors are intentionally ignored - preview is best-effort
 /// and shouldn't block the prompt flow.
@@ -736,8 +741,9 @@ pub fn show_install_preview(
     results: &[ConfigureResult],
     completion_results: &[CompletionResult],
     cmd: &str,
-) {
+) -> String {
     let bold = Style::new().bold();
+    let mut blocks: Vec<String> = Vec::new();
 
     // Show shell extension changes
     for result in results {
@@ -750,12 +756,6 @@ pub fn show_install_preview(
         let path = format_path_for_display(&result.path);
         let what = shell_extension_label(shell);
 
-        eprintln!(
-            "{} {} {what} for {bold}{shell}{bold:#} @ {bold}{path}{bold:#}",
-            result.action.symbol(),
-            result.action.description(),
-        );
-
         // Show the config content that will be added with gutter
         // Fish: show the wrapper (it's a complete file that sources the full function)
         // Other shells: show the one-liner that gets appended
@@ -766,13 +766,18 @@ pub fn show_install_preview(
         } else {
             result.config_line.clone()
         };
-        eprintln!("{}", format_bash_with_gutter(&content));
+        let nushell_note = if matches!(shell, Shell::Nushell) {
+            format!("\n{}", hint_message("Nushell support is experimental"))
+        } else {
+            String::new()
+        };
 
-        if matches!(shell, Shell::Nushell) {
-            eprintln!("{}", hint_message("Nushell support is experimental"));
-        }
-
-        eprintln!(); // Blank line after each shell block
+        blocks.push(format!(
+            "{} {} {what} for {bold}{shell}{bold:#} @ {bold}{path}{bold:#}\n{}{nushell_note}",
+            result.action.symbol(),
+            result.action.description(),
+            format_bash_with_gutter(&content),
+        ));
     }
 
     // Show completion changes (only fish has separate completion files)
@@ -784,31 +789,33 @@ pub fn show_install_preview(
         let shell = result.shell;
         let path = format_path_for_display(&result.path);
 
-        eprintln!(
-            "{} {} completions for {bold}{shell}{bold:#} @ {bold}{path}{bold:#}",
-            result.action.symbol(),
-            result.action.description(),
-        );
-
         // Show the completion content that will be written
         let fish_completion = fish_completion_content(cmd);
-        eprintln!("{}", format_bash_with_gutter(fish_completion.trim()));
-        eprintln!(); // Blank line after
+        blocks.push(format!(
+            "{} {} completions for {bold}{shell}{bold:#} @ {bold}{path}{bold:#}\n{}",
+            result.action.symbol(),
+            result.action.description(),
+            format_bash_with_gutter(fish_completion.trim()),
+        ));
     }
+
+    blocks.join("\n\n")
 }
 
-/// Display what will be uninstalled (shell extensions and completions)
+/// Format what will be uninstalled (shell extensions and completions).
 ///
-/// Shows the files that will be modified without prompting.
-/// Used for --dry-run mode.
+/// Returns the preview as a string (no trailing newline). Used only for
+/// `--dry-run`, which is the command's answer, so the caller prints it to
+/// stdout. See /writing-user-outputs.
 ///
 /// Note: I/O errors are intentionally ignored - preview is best-effort
 /// and shouldn't block the flow.
 pub fn show_uninstall_preview(
     results: &[UninstallResult],
     completion_results: &[CompletionUninstallResult],
-) {
+) -> String {
     let bold = Style::new().bold();
+    let mut lines: Vec<String> = Vec::new();
 
     for result in results {
         let shell = result.shell;
@@ -817,18 +824,18 @@ pub fn show_uninstall_preview(
         // Deprecated files get a different message format
         if let Some(canonical) = &result.superseded_by {
             let canonical_path = format_path_for_display(canonical);
-            eprintln!(
+            lines.push(format!(
                 "{INFO_SYMBOL} {} {bold}{path}{bold:#} (deprecated; now using {bold}{canonical_path}{bold:#})",
                 result.action.description(),
-            );
+            ));
         } else {
             let what = shell_extension_label(shell);
 
-            eprintln!(
+            lines.push(format!(
                 "{} {} {what} for {bold}{shell}{bold:#} @ {bold}{path}{bold:#}",
                 result.action.symbol(),
                 result.action.description(),
-            );
+            ));
         }
     }
 
@@ -836,12 +843,14 @@ pub fn show_uninstall_preview(
         let shell = result.shell;
         let path = format_path_for_display(&result.path);
 
-        eprintln!(
+        lines.push(format!(
             "{} {} completions for {bold}{shell}{bold:#} @ {bold}{path}{bold:#}",
             result.action.symbol(),
             result.action.description(),
-        );
+        ));
     }
+
+    lines.join("\n")
 }
 
 /// Prompt for install with [y/N/?] options
@@ -856,7 +865,12 @@ pub fn prompt_for_install(
     prompt_text: &str,
 ) -> Result<bool, String> {
     let response = prompt_yes_no_preview(prompt_text, || {
-        show_install_preview(results, completion_results, cmd);
+        // Mid-prompt re-preview is narration, so it goes to stderr (the trailing
+        // blank separates it from the re-prompt). See /writing-user-outputs.
+        eprintln!(
+            "{}\n",
+            show_install_preview(results, completion_results, cmd)
+        );
     })
     .map_err(|e| e.to_string())?;
 
@@ -985,7 +999,10 @@ pub fn handle_unconfigure_shell(
 
     // For --dry-run, show preview and return without prompting or applying
     if dry_run {
-        show_uninstall_preview(&preview.results, &preview.completion_results);
+        let preview_text = show_uninstall_preview(&preview.results, &preview.completion_results);
+        if !preview_text.is_empty() {
+            println!("{preview_text}");
+        }
         return Ok(preview);
     }
 

--- a/src/commands/configure_shell.rs
+++ b/src/commands/configure_shell.rs
@@ -997,12 +997,17 @@ pub fn handle_unconfigure_shell(
         return Ok(preview);
     }
 
-    // For --dry-run, show preview and return without prompting or applying
+    // For --dry-run, show preview and return without prompting or applying. The
+    // early-return above guarantees at least one result, and
+    // show_uninstall_preview emits a line per result, so the preview is never
+    // empty here (unlike the install path, where AlreadyExists entries are
+    // skipped and the preview can be empty). The preview is the command's
+    // answer, so it goes to stdout. See /writing-user-outputs.
     if dry_run {
-        let preview_text = show_uninstall_preview(&preview.results, &preview.completion_results);
-        if !preview_text.is_empty() {
-            println!("{preview_text}");
-        }
+        println!(
+            "{}",
+            show_uninstall_preview(&preview.results, &preview.completion_results)
+        );
         return Ok(preview);
     }
 

--- a/src/commands/hook_commands.rs
+++ b/src/commands/hook_commands.rs
@@ -18,7 +18,7 @@ use worktrunk::git::Repository;
 use worktrunk::path::format_path_for_display;
 use worktrunk::styling::{
     INFO_SYMBOL, PROMPT_SYMBOL, eprintln, format_bash_with_gutter, format_heading, hint_message,
-    info_message, warning_message,
+    info_message, println, warning_message,
 };
 
 use super::command_approval::approve_hooks_filtered;
@@ -304,7 +304,9 @@ pub fn run_hook(
                 } else {
                     cformat!("{hook_type} <bold>{}</> hook would run:", cmd.label)
                 };
-                eprintln!(
+                // Dry-run preview is the command's answer (the hook that would
+                // run), so it goes to stdout — see /writing-user-outputs.
+                println!(
                     "{}",
                     info_message(cformat!("{label}\n{}", format_bash_with_gutter(&preview)))
                 );

--- a/src/commands/relocate.rs
+++ b/src/commands/relocate.rs
@@ -29,8 +29,8 @@ use worktrunk::config::UserConfig;
 use worktrunk::git::{ErrorExt, Repository, WorktreeInfo};
 use worktrunk::path::{format_path_for_display, paths_match};
 use worktrunk::styling::{
-    eprintln, format_with_gutter, hint_message, info_message, progress_message, success_message,
-    warning_message,
+    eprintln, format_with_gutter, hint_message, info_message, println, progress_message,
+    success_message, warning_message,
 };
 
 use super::backup;
@@ -662,7 +662,9 @@ impl<'a> RelocationExecutor<'a> {
 
 /// Show dry-run preview of relocations.
 pub fn show_dry_run_preview(candidates: &[RelocationCandidate]) {
-    eprintln!(
+    // Dry-run preview is the command's answer (the relocations that would
+    // happen), so it goes to stdout — see /writing-user-outputs.
+    println!(
         "{}",
         info_message(format!(
             "{} worktree{} would be relocated:",
@@ -680,7 +682,7 @@ pub fn show_dry_run_preview(candidates: &[RelocationCandidate]) {
             cformat!("<bold>{branch}</>: {src_display} → {dest_display}")
         })
         .collect();
-    eprintln!("{}", format_with_gutter(&preview_lines.join("\n"), None));
+    println!("{}", format_with_gutter(&preview_lines.join("\n"), None));
 }
 
 /// Show summary of relocations performed.

--- a/src/commands/step/copy_ignored.rs
+++ b/src/commands/step/copy_ignored.rs
@@ -162,7 +162,9 @@ pub fn step_copy_ignored(
             })
             .collect();
         let entry_word = if items.len() == 1 { "entry" } else { "entries" };
-        eprintln!(
+        // The human preview mirrors the `--format=json` plan (the entries that
+        // would be copied), so it goes to stdout — see /writing-user-outputs.
+        println!(
             "{}",
             info_message(format!(
                 "Would copy {} {}:\n{}",

--- a/src/commands/step/prune.rs
+++ b/src/commands/step/prune.rs
@@ -547,9 +547,13 @@ fn render_dry_run(
         return Ok(());
     }
 
+    // The human preview mirrors the `--format=json` plan above (the worktrees
+    // that would be removed), so it goes to stdout. The skipped-young caveat and
+    // the "nothing to remove" no-op below are narration the json omits — they
+    // stay on stderr. See /writing-user-outputs.
     let mut dry_candidates = Vec::new();
     for (candidate, info) in dry_run_info {
-        eprintln!(
+        println!(
             "{}",
             info_message(cformat!(
                 "<bold>{}</>{} — {} {}",
@@ -583,7 +587,7 @@ fn render_dry_run(
         }
         return Ok(());
     }
-    eprintln!(
+    println!(
         "{}",
         hint_message(format!(
             "{} would be removed (dry run)",

--- a/tests/integration_tests/configure_shell.rs
+++ b/tests/integration_tests/configure_shell.rs
@@ -1823,6 +1823,31 @@ mod pty_tests {
         );
     }
 
+    /// Typing `?` at the install prompt re-shows the preview (the interactive
+    /// re-preview path), then declining with `n` leaves the rcfile untouched.
+    #[rstest]
+    fn test_install_preview_question_mark(repo: TestRepo, temp_home: TempDir) {
+        let zshrc_path = temp_home.path().join(".zshrc");
+        fs::write(&zshrc_path, "# Existing config\n").unwrap();
+
+        // `?` re-shows the preview, then `n` declines (both lines are buffered
+        // and consumed across the two prompt cycles).
+        let (output, exit_code) = exec_install_in_pty(&temp_home, &repo, "?\nn\n");
+
+        assert_eq!(exit_code, 1, "declining returns exit 1:\n{output}");
+        assert!(
+            output.contains("wt config shell init"),
+            "Typing ? should re-show the install preview:\n{output}"
+        );
+
+        // Declined, so the file is untouched.
+        let content = fs::read_to_string(&zshrc_path).unwrap();
+        assert!(
+            !content.contains("wt config shell init"),
+            "File should not be modified when user declines"
+        );
+    }
+
     /// Declining the interactive `wt config shell uninstall` prompt
     /// exercises `prompt_for_uninstall_confirmation` — the one render
     /// path that neither `--yes` nor `--dry-run` reaches. Verifies the
@@ -1918,6 +1943,52 @@ fn test_configure_shell_nushell(repo: TestRepo, temp_home: TempDir) {
         content.contains("def --env --wrapped wt"),
         "Should contain nushell function definition: {}",
         content
+    );
+}
+
+/// Dry-run install for nushell previews what would be added, on stdout (the
+/// command's answer), including the experimental note, without writing the file.
+#[rstest]
+fn test_configure_shell_nushell_dry_run(repo: TestRepo, temp_home: TempDir) {
+    let home = canonical_temp_home(&temp_home);
+    let autoload = home.join(".local/share/nushell/vendor/autoload");
+    let nu_config = autoload.join("wt.nu");
+
+    let mut cmd = wt_command();
+    repo.configure_wt_cmd(&mut cmd);
+    set_temp_home_env(&mut cmd, temp_home.path());
+    cmd.env("WORKTRUNK_TEST_NU_VENDOR_AUTOLOAD_DIR", &autoload);
+    cmd.env("SHELL", "/bin/nu");
+    cmd.arg("config")
+        .arg("shell")
+        .arg("install")
+        .arg("nu")
+        .arg("--dry-run")
+        .current_dir(repo.root_path());
+
+    let output = cmd.output().expect("Failed to execute command");
+    assert!(
+        output.status.success(),
+        "Dry-run install should succeed:\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // The dry-run preview is the command's answer, so it lands on stdout, and
+    // for nushell it carries the experimental note.
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("shell extension & completions for") && stdout.contains("nu"),
+        "Dry-run preview should show nushell would be added:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Nushell support is experimental"),
+        "Dry-run preview should include the nushell experimental note:\n{stdout}"
+    );
+
+    // Nothing should be written in dry-run mode.
+    assert!(
+        !nu_config.exists(),
+        "wt.nu should NOT be created with --dry-run: {nu_config:?}"
     );
 }
 

--- a/tests/integration_tests/configure_shell.rs
+++ b/tests/integration_tests/configure_shell.rs
@@ -1712,10 +1712,11 @@ fn test_uninstall_shell_dry_run_nushell(repo: TestRepo, temp_home: TempDir) {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let stderr = String::from_utf8_lossy(&output.stderr);
+    // The dry-run preview is the command's answer, so it lands on stdout.
+    let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stderr.contains("shell extension & completions for") && stderr.contains("nu"),
-        "Dry-run output should label nushell as 'shell extension & completions':\n{stderr}"
+        stdout.contains("shell extension & completions for") && stdout.contains("nu"),
+        "Dry-run output should label nushell as 'shell extension & completions':\n{stdout}"
     );
 }
 

--- a/tests/integration_tests/output_system_guard.rs
+++ b/tests/integration_tests/output_system_guard.rs
@@ -1,10 +1,11 @@
 //! Guard test to prevent stdout leaks in command code
 //!
-//! stdout carries content the user may want to pipe, redirect, or capture:
-//! data (JSON, tables), rendered views (`wt config show`, `wt hook show`),
-//! and shell integration output. Interactive status, progress, and errors
-//! go to stderr. When shell integration is active (directive env vars set),
-//! directives are written to files, not stdout.
+//! stdout carries the command's answer — content the user may want to pipe,
+//! redirect, or capture: data (JSON, tables), rendered views (`wt config show`,
+//! `wt hook show`), `--dry-run` previews (the whole answer when nothing
+//! mutates), and shell integration output. Interactive status, progress, and
+//! errors go to stderr. When shell integration is active (directive env vars
+//! set), directives are written to files, not stdout.
 //!
 //! This test enforces: **No accidental stdout writes in command code**
 //!
@@ -45,12 +46,17 @@ const STDOUT_ALLOWED_PATHS: &[&str] = &[
     // LLM prompt output for wt step commit --show-prompt and squash --show-prompt
     "step/commit.rs",
     "step/squash.rs",
-    // JSON output for wt step copy-ignored --format=json
+    // wt step copy-ignored dry-run plan (human preview + --format=json)
     "step/copy_ignored.rs",
-    // JSON output for wt step prune --format=json
+    // wt step prune dry-run plan (human preview + --format=json)
     "step/prune.rs",
     // JSON output for wt step relocate --format=json
     "step/relocate.rs",
+    // wt step relocate dry-run human preview (show_dry_run_preview)
+    "relocate.rs",
+    // wt config shell install/uninstall --dry-run preview (the interactive
+    // `?` re-preview still goes to stderr)
+    "configure_shell.rs",
     // Dry-run cache inventory dump (WORKTRUNK_PICKER_DRY_RUN)
     "picker/mod.rs",
     // JSON output for wt switch --format=json
@@ -65,7 +71,7 @@ const STDOUT_ALLOWED_PATHS: &[&str] = &[
     "merge.rs",
     // JSON output for wt remove --format=json
     "remove.rs",
-    // Hook listing output for wt hook show (paged)
+    // Hook listing for wt hook show (paged), and the wt hook --dry-run preview
     "hook_commands.rs",
 ];
 

--- a/tests/snapshots/integration__integration_tests__configure_shell__configure_shell_dry_run.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__configure_shell_dry_run.snap
@@ -48,7 +48,7 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [2m○[22m Will add shell extension & completions for [1mzsh[0m @ [1m~/.zshrc[0m
 [107m [0m [2m[0m[2m[35mif[0m[2m [0m[2m[34mcommand[0m[2m [0m[2m[36m-v[0m[2m wt [0m[2m[36m>[0m[2m/dev/null [0m[2m[33m2[0m[2m>&1; [0m[2m[35mthen[0m[2m [0m[2m[34meval[0m[2m [0m[2m[32m"$([0m[2m[34mcommand[0m[2m wt config shell init zsh)"[0m[2m; [0m[2m[35mfi[0m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__configure_shell__configure_shell_dry_run_multiple.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__configure_shell_dry_run_multiple.snap
@@ -47,10 +47,10 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [2m○[22m Will add shell extension & completions for [1mbash[0m @ [1m~/.bashrc[0m
 [107m [0m [2m[0m[2m[35mif[0m[2m [0m[2m[34mcommand[0m[2m [0m[2m[36m-v[0m[2m wt [0m[2m[36m>[0m[2m/dev/null [0m[2m[33m2[0m[2m>&1; [0m[2m[35mthen[0m[2m [0m[2m[34meval[0m[2m [0m[2m[32m"$([0m[2m[34mcommand[0m[2m wt config shell init bash)"[0m[2m; [0m[2m[35mfi[0m
 
 [2m○[22m Will add shell extension & completions for [1mzsh[0m @ [1m~/.zshrc[0m
 [107m [0m [2m[0m[2m[35mif[0m[2m [0m[2m[34mcommand[0m[2m [0m[2m[36m-v[0m[2m wt [0m[2m[36m>[0m[2m/dev/null [0m[2m[33m2[0m[2m>&1; [0m[2m[35mthen[0m[2m [0m[2m[34meval[0m[2m [0m[2m[32m"$([0m[2m[34mcommand[0m[2m wt config shell init zsh)"[0m[2m; [0m[2m[35mfi[0m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__configure_shell__configure_shell_fish_dry_run.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__configure_shell_fish_dry_run.snap
@@ -48,8 +48,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [2m○[22m Will create shell extension for [1mfish[0m @ [1m~/.config/fish/functions/wt.fish[0m
 [107m [0m [2m# worktrunk shell integration for fish[0m
 [107m [0m [2m# Sources full integration from binary on first use.[0m
@@ -70,3 +68,5 @@ exit_code: 0
 [2m○[22m Will create completions for [1mfish[0m @ [1m~/.config/fish/completions/wt.fish[0m
 [107m [0m [2m# worktrunk completions for fish[0m
 [107m [0m [2m[0m[2m[34mcomplete[0m[2m [0m[2m[36m--keep-order[0m[2m [0m[2m[36m--exclusive[0m[2m [0m[2m[36m--command[0m[2m wt [0m[2m[36m--arguments[0m[2m [0m[2m[32m"(test -n /"/$WORKTRUNK_BIN/"; or set -l WORKTRUNK_BIN (type -P wt 2>/dev/null); and COMPLETE=fish /$WORKTRUNK_BIN -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"[0m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__configure_shell__configure_shell_fish_dry_run_does_not_delete_legacy.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__configure_shell_fish_dry_run_does_not_delete_legacy.snap
@@ -48,8 +48,8 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [2m○[22m Will add completions for [1mfish[0m @ [1m~/.config/fish/completions/wt.fish[0m
 [107m [0m [2m# worktrunk completions for fish[0m
 [107m [0m [2m[0m[2m[34mcomplete[0m[2m [0m[2m[36m--keep-order[0m[2m [0m[2m[36m--exclusive[0m[2m [0m[2m[36m--command[0m[2m wt [0m[2m[36m--arguments[0m[2m [0m[2m[32m"(test -n /"/$WORKTRUNK_BIN/"; or set -l WORKTRUNK_BIN (type -P wt 2>/dev/null); and COMPLETE=fish /$WORKTRUNK_BIN -- (commandline --current-process --tokenize --cut-at-cursor) (commandline --current-token))"[0m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__configure_shell__uninstall_shell_dry_run.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__uninstall_shell_dry_run.snap
@@ -48,6 +48,6 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
+[2m○[22m Will remove shell extension & completions for [1mzsh[0m @ [1m~/.zshrc[0m
 
 ----- stderr -----
-[2m○[22m Will remove shell extension & completions for [1mzsh[0m @ [1m~/.zshrc[0m

--- a/tests/snapshots/integration__integration_tests__configure_shell__uninstall_shell_dry_run_fish.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__uninstall_shell_dry_run_fish.snap
@@ -48,7 +48,7 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [2m○[22m Will remove [1m~/.config/fish/conf.d/wt.fish[0m (deprecated; now using [1m~/.config/fish/functions/wt.fish[0m)
 [2m○[22m Will remove completions for [1mfish[0m @ [1m~/.config/fish/completions/wt.fish[0m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__configure_shell__uninstall_shell_dry_run_fish_canonical.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__uninstall_shell_dry_run_fish_canonical.snap
@@ -48,7 +48,7 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [2m○[22m Will remove shell extension for [1mfish[0m @ [1m~/.config/fish/functions/wt.fish[0m
 [2m○[22m Will remove completions for [1mfish[0m @ [1m~/.config/fish/completions/wt.fish[0m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__configure_shell__uninstall_shell_dry_run_multiple.snap
+++ b/tests/snapshots/integration__integration_tests__configure_shell__uninstall_shell_dry_run_multiple.snap
@@ -47,7 +47,7 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [2m○[22m Will remove shell extension & completions for [1mbash[0m @ [1m~/.bashrc[0m
 [2m○[22m Will remove shell extension & completions for [1mzsh[0m @ [1m~/.zshrc[0m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_copy_ignored__copy_ignored_dry_run.snap
+++ b/tests/snapshots/integration__integration_tests__step_copy_ignored__copy_ignored_dry_run.snap
@@ -45,7 +45,7 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [2m○[22m Would copy 1 entry:
 [107m [0m .env (file)
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_prune__prune_dry_run.snap
+++ b/tests/snapshots/integration__integration_tests__step_prune__prune_dry_run.snap
@@ -46,8 +46,8 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [2m○[22m [1mmerged-a[22m — same commit as main
 [2m○[22m [1mmerged-b[22m — same commit as main
 [2m↳[22m [2m2 worktrees & branches would be removed (dry run)[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_prune__prune_dry_run_mixed_worktrees_and_branches.snap
+++ b/tests/snapshots/integration__integration_tests__step_prune__prune_dry_run_mixed_worktrees_and_branches.snap
@@ -45,9 +45,9 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [2m○[22m [1mmerged-a[22m — same commit as main
 [2m○[22m [1mmerged-b[22m — same commit as main
 [2m○[22m [1morphan-integrated[22m (branch only) — same commit as main
 [2m↳[22m [2m2 worktrees & branches, 1 branch would be removed (dry run)[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_prune__prune_min_age_passes.snap
+++ b/tests/snapshots/integration__integration_tests__step_prune__prune_min_age_passes.snap
@@ -45,7 +45,7 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [2m○[22m [1mold-merged[22m — same commit as main
 [2m↳[22m [2m1 worktree & branch would be removed (dry run)[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_prune__prune_skips_unmerged_detached.snap
+++ b/tests/snapshots/integration__integration_tests__step_prune__prune_skips_unmerged_detached.snap
@@ -46,7 +46,7 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [2m○[22m [1mmerged-branch[22m — same commit as main
 [2m↳[22m [2m1 worktree & branch would be removed (dry run)[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_prune__prune_squash_merged_same_files_modified.snap
+++ b/tests/snapshots/integration__integration_tests__step_prune__prune_squash_merged_same_files_modified.snap
@@ -46,7 +46,7 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [2m○[22m [1mfeature-squash[22m — all changes in main
 [2m↳[22m [2m1 worktree & branch would be removed (dry run)[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_prune__prune_stale_plus_young.snap
+++ b/tests/snapshots/integration__integration_tests__step_prune__prune_stale_plus_young.snap
@@ -45,8 +45,8 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
+[2m○[22m [1mstale-branch[22m (stale) — same commit as main
+[2m↳[22m [2m1 branch would be removed (dry run)[22m
 
 ----- stderr -----
-[2m○[22m [1mstale-branch[22m (stale) — same commit as main
 [2m○[22m Skipped [1myoung-branch[22m, [1myoung-orphan[22m (younger than 1d)
-[2m↳[22m [2m1 branch would be removed (dry run)[22m

--- a/tests/snapshots/integration__integration_tests__step_relocate__relocate_dry_run.snap
+++ b/tests/snapshots/integration__integration_tests__step_relocate__relocate_dry_run.snap
@@ -45,7 +45,7 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [2m○[22m 1 worktree would be relocated:
 [107m [0m [1mfeature[22m: _PARENT_/wrong-location → _REPO_.feature
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__user_hooks__hook_dry_run_named_hooks.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__hook_dry_run_named_hooks.snap
@@ -45,9 +45,9 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [2m○[22m pre-merge [1mproject:lint[22m would run:
 [107m [0m [2m[0m[2m[34mpre-commit[0m[2m run [0m[2m[36m--all-files[0m
 [2m○[22m pre-merge [1mproject:test[22m would run:
 [107m [0m [2m[0m[2m[34mcargo[0m[2m test[0m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__user_hooks__hook_dry_run_shows_expanded_command.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__hook_dry_run_shows_expanded_command.snap
@@ -45,7 +45,7 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-
------ stderr -----
 [2m○[22m pre-merge [1mproject[22m hook would run:
 [107m [0m [2m[0m[2m[34mecho[0m[2m branch=main[0m
+
+----- stderr -----


### PR DESCRIPTION
## Summary

The codebase had two conflicting stdout/stderr conventions. `wt list` and `wt config show` put their human output on stdout (human default or `--format=json`), but several `--dry-run` previews went to stderr while their `--format=json` form went to stdout, and `hook` / `relocate` / `shell install` previews went to stderr with no json form at all. So `wt list` printed a table to stdout while `wt step prune --dry-run` printed its plan to stderr: the same kind of output on opposite streams.

This adopts one rule: **stdout carries the command's answer in whatever format the user selected (human or `--format=json`), including `--dry-run` previews; stderr carries narration** (progress, success/warning/error, hints, interactive prompts, `-v`/`-vv`). A `--dry-run` is the answer when nothing mutates, so the preview goes to stdout. This matches `wt list` / `wt config show`, the wider ecosystem (`git clean -n`, `rsync -n`, `terraform plan`), and keeps paging working (the pager writes stdout, so `wt step commit --dry-run` stays pageable). Color strips automatically on a pipe via anstream, so human-on-stdout is still pipe-safe.

## What changed

Five commands had their `--dry-run` human preview moved from stderr to stdout: `wt hook <type> --dry-run`, `wt step relocate --dry-run`, `wt step prune --dry-run`, `wt step copy-ignored --dry-run`, and `wt config shell install/uninstall --dry-run`.

The rule for the partial cases: the human preview on stdout mirrors exactly what `--format=json` already puts there (the plan); narration the json omits stays on stderr. So `wt step prune --dry-run` prints its candidates and "would be removed" summary to stdout, but its "Skipped … younger than" caveat and "No merged worktrees to remove" no-op to stderr.

The shell preview renderers (`show_install_preview`, `show_uninstall_preview`) now return a `String` so the caller picks the sink: `--dry-run` prints to stdout, while the interactive `?` re-preview during the `wt config shell install` prompt stays on stderr (mid-prompt narration, not the command's final answer).

The policy is documented in the `writing-user-outputs` skill and the `--dry-run` section of `src/commands/CLAUDE.md`. The output-system guard allowlist gained `relocate.rs` (the human preview lives in the top-level file, distinct from `step/relocate.rs`'s json) and `configure_shell.rs`.

## Testing

`cargo run -- hook pre-merge --yes` passes (3940 tests, `cargo fmt` and `cargo clippy` clean). 18 dry-run snapshots regenerated; `output_system_guard::check_no_stdout_in_commands` passes. One test that asserted the old stderr stream (`test_uninstall_shell_dry_run_nushell`) was updated to assert stdout.

> _This was written by Claude Code on behalf of max_
