### PR TITLE
chore(ci): add cargo-affected input rules for snapshots and doc sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,43 @@ members = ["tests/helpers/wt-perf", "tests/helpers/mock-stub"]
 # Include mock-stub and wt-perf so `cargo test` builds their binaries
 default-members = [".", "tests/helpers/mock-stub", "tests/helpers/wt-perf"]
 
+# cargo-affected input→test rules. cargo-affected selects tests by Rust-line
+# coverage overlap, so a file a test reads at *runtime* (never recorded in
+# coverage) maps to no test and would slip through `cargo affected run`. Each
+# rule force-selects the owning tests when a matching path changes. `[*.metadata]`
+# is excluded from cargo-affected's fingerprint, so editing a rule is
+# cache-neutral. See https://github.com/max-sixty/cargo-affected#input-rules.
+
+# insta `.snap` snapshots are read at test time and never appear in coverage, so
+# a snapshot edit maps to no test. Route each snapshot to the binary that owns
+# it — the finest granularity available without a snapshot→test map. Integration
+# snapshots live under tests/; unit-test snapshots under src/, split across the
+# lib (`worktrunk`) and the `wt` binary (`worktrunk::bin/wt`).
+[[workspace.metadata.affected.rule]]
+globs = ["tests/**/*.snap"]
+filterset = "binary_id(=worktrunk::integration)"
+
+[[workspace.metadata.affected.rule]]
+globs = ["src/**/*.snap"]
+filterset = "binary_id(=worktrunk) | binary_id(=worktrunk::bin/wt)"
+
+# tests/integration_tests/readme_sync.rs reads these inputs at runtime (via
+# fs::read_to_string) and asserts the committed copies stay in sync: README.md,
+# docs/content markdown, the dev/*.example.toml files generated from src/llm.rs
+# and src/cli/mod.rs, the skill references, and Taskfile.yaml. A change to any of
+# them must rerun that module, which coverage cannot link to the changed file.
+[[workspace.metadata.affected.rule]]
+globs = [
+    "README.md",
+    "docs/**/*.md",
+    "dev/*.toml",
+    "src/cli/mod.rs",
+    "src/llm.rs",
+    "Taskfile.yaml",
+    "skills/**/*.md",
+]
+filterset = "test(/readme_sync/)"
+
 [package]
 name = "worktrunk"
 version = "0.58.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,15 +23,21 @@ filterset = "binary_id(=worktrunk::integration)"
 globs = ["src/**/*.snap"]
 filterset = "binary_id(=worktrunk) | binary_id(=worktrunk::bin/wt)"
 
-# tests/integration_tests/readme_sync.rs reads these inputs at runtime (via
-# fs::read_to_string) and asserts the committed copies stay in sync: README.md,
-# docs/content markdown, the dev/*.example.toml files generated from src/llm.rs
-# and src/cli/mod.rs, the skill references, and Taskfile.yaml. A change to any of
-# them must rerun that module, which coverage cannot link to the changed file.
+# tests/integration_tests/readme_sync.rs reads each of these at runtime (via
+# fs::read_to_string) and asserts the committed copies stay in sync — both the
+# sources (README.md, docs/content markdown, docs/config.toml's site title and
+# description, src/cli/mod.rs, src/llm.rs, the skill references, Taskfile.yaml)
+# and the generated artifacts it regenerates and compares against (the
+# dev/*.example.toml files, docs/static/llms.txt, the agent-skills index.json).
+# Editing any of them flips the test, but coverage can't link a runtime-read
+# file to it.
 [[workspace.metadata.affected.rule]]
 globs = [
     "README.md",
     "docs/**/*.md",
+    "docs/config.toml",
+    "docs/static/llms.txt",
+    "docs/static/.well-known/agent-skills/index.json",
     "dev/*.toml",
     "src/cli/mod.rs",
     "src/llm.rs",


### PR DESCRIPTION
`cargo affected run` selects tests by Rust-line coverage overlap, so a file a test reads at runtime (never recorded in coverage) maps to no test and slips through. This adds `[workspace.metadata.affected]` rules so those inputs still select their guarding tests.

## Rules

- **`tests/**/*.snap` → `binary_id(=worktrunk::integration)`**. insta snapshots are read at test time and never appear in coverage.
- **`src/**/*.snap` → `binary_id(=worktrunk) | binary_id(=worktrunk::bin/wt)`**. The ~57 snapshots under `src/` belong to the lib and `wt`-binary unit tests (split 35 `worktrunk__*` / 19 `wt__*`). Routing by snapshot location is the finest granularity available without a snapshot→test map.
- **README.md, `docs/**/*.md`, `dev/*.toml`, `src/cli/mod.rs`, `src/llm.rs`, `Taskfile.yaml`, `skills/**/*.md` → `test(/readme_sync/)`**. `tests/integration_tests/readme_sync.rs` reads each of these at runtime via `fs::read_to_string` and asserts the committed copies stay in sync; a change to any of them must rerun that module.

`docs/demos/*.snap` are hyphen-named demo recordings, not insta test inputs, so the snapshot globs are scoped to `tests/` and `src/` to leave them out.

## Notes

The rules are read by cargo-affected's input-rules feature ([max-sixty/cargo-affected#53](https://github.com/max-sixty/cargo-affected/pull/53), released in 0.3.0); worktrunk's CI installs cargo-affected from its default branch, so this takes effect immediately. The `[*.metadata]` block is excluded from cargo-affected's fingerprint, so editing a rule is cache-neutral (no coverage re-collect). Each filterset was verified to resolve against the current suite via `cargo nextest list -E`.

> _This was written by Claude Code on behalf of max_
