### PR TITLE
fix(picker): stop first-keystroke freeze

### DIFF
--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -337,12 +337,11 @@ pub(crate) static COLLECT_POOL: LazyLock<rayon::ThreadPool> = LazyLock::new(|| {
         .expect("failed to build collect thread pool")
 });
 
-/// The `num_threads` argument for [`COLLECT_POOL`]. Mirrors `main.rs`'s
-/// global-pool sizing: when `RAYON_NUM_THREADS` is set, return 0 so Rayon
-/// reads and validates the env var itself; otherwise return
-/// [`crate::rayon_thread_count`] (`2× CPU`), since Rayon's own default is
-/// `1× CPU`. Takes the env presence as a parameter so both branches are
-/// unit-testable without mutating process-global environment.
+/// The `num_threads` argument for [`COLLECT_POOL`]. When `RAYON_NUM_THREADS`
+/// is set, return 0 so Rayon reads and validates the env var itself.
+/// Otherwise return [`crate::rayon_thread_count`] (`2× CPU`), since Rayon's
+/// own default is `1× CPU`. Takes the env presence as a parameter so both
+/// branches are unit-testable without mutating process-global environment.
 fn collect_pool_num_threads(rayon_num_threads_set: bool) -> usize {
     if rayon_num_threads_set {
         0

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -326,20 +326,30 @@ use types::{MissingResult, TaskError, TaskResult};
 /// Routing collection and preview work through this pool leaves the global pool
 /// free for skim. Same isolation pattern as `copy::COPY_POOL` and
 /// `remove_dir::REMOVE_POOL`, but sized like the global pool
-/// ([`crate::rayon_thread_count`], i.e. `2× CPU`, honoring `RAYON_NUM_THREADS`)
+/// ([`collect_pool_num_threads`], i.e. `2× CPU`, honoring `RAYON_NUM_THREADS`)
 /// so collection throughput is unchanged. The goal is separation, not a
 /// smaller pool.
 pub(crate) static COLLECT_POOL: LazyLock<rayon::ThreadPool> = LazyLock::new(|| {
-    let num_threads = if std::env::var_os("RAYON_NUM_THREADS").is_some() {
-        0 // Let Rayon handle the env var (includes validation)
-    } else {
-        crate::rayon_thread_count()
-    };
+    let num_threads = collect_pool_num_threads(std::env::var_os("RAYON_NUM_THREADS").is_some());
     rayon::ThreadPoolBuilder::new()
         .num_threads(num_threads)
         .build()
         .expect("failed to build collect thread pool")
 });
+
+/// The `num_threads` argument for [`COLLECT_POOL`]. Mirrors `main.rs`'s
+/// global-pool sizing: when `RAYON_NUM_THREADS` is set, return 0 so Rayon
+/// reads and validates the env var itself; otherwise return
+/// [`crate::rayon_thread_count`] (`2× CPU`), since Rayon's own default is
+/// `1× CPU`. Takes the env presence as a parameter so both branches are
+/// unit-testable without mutating process-global environment.
+fn collect_pool_num_threads(rayon_num_threads_set: bool) -> usize {
+    if rayon_num_threads_set {
+        0
+    } else {
+        crate::rayon_thread_count()
+    }
+}
 
 struct TableRenderPlan {
     progressive_table: Option<ProgressiveTable>,
@@ -2056,6 +2066,14 @@ pub fn populate_item(
 mod tests {
     use super::*;
     use ansi_str::AnsiStr;
+
+    #[test]
+    fn test_collect_pool_num_threads_honors_env() {
+        // Env var set: defer to Rayon (0 means "read RAYON_NUM_THREADS").
+        assert_eq!(collect_pool_num_threads(true), 0);
+        // Env var unset: explicit 2× CPU, since Rayon's own default is 1×.
+        assert_eq!(collect_pool_num_threads(false), crate::rayon_thread_count());
+    }
 
     #[test]
     fn test_format_stall_footer_single_pending() {

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -282,6 +282,7 @@ mod types;
 use anyhow::Context;
 use std::collections::HashSet;
 use std::sync::Arc;
+use std::sync::LazyLock;
 
 use anstyle::Style;
 use color_print::cformat;
@@ -310,6 +311,35 @@ use execution::{work_items_for_branch, work_items_for_worktree};
 use results::drain_results;
 use types::DrainOutcome;
 use types::{MissingResult, TaskError, TaskResult};
+
+/// Dedicated rayon pool for git-heavy worktree collection and preview
+/// pre-compute, kept off the global pool.
+///
+/// The picker (skim) runs its per-keystroke fuzzy matcher and result sort on
+/// the **global** rayon pool. Worktrunk's collection floods that same pool with
+/// blocking git subprocess tasks (status, diff, rev-list, merge-base…), one
+/// batch per worktree, plus the preview orchestrator's per-mode `git diff` /
+/// `git log` tasks. With only `2× CPU` global workers, all blocked on
+/// subprocesses, skim's matcher queues behind the flood and the picker freezes
+/// for seconds on the first keystroke, scaling with worktree count.
+///
+/// Routing collection and preview work through this pool leaves the global pool
+/// free for skim. Same isolation pattern as `copy::COPY_POOL` and
+/// `remove_dir::REMOVE_POOL`, but sized like the global pool
+/// ([`crate::rayon_thread_count`], i.e. `2× CPU`, honoring `RAYON_NUM_THREADS`)
+/// so collection throughput is unchanged. The goal is separation, not a
+/// smaller pool.
+pub(crate) static COLLECT_POOL: LazyLock<rayon::ThreadPool> = LazyLock::new(|| {
+    let num_threads = if std::env::var_os("RAYON_NUM_THREADS").is_some() {
+        0 // Let Rayon handle the env var (includes validation)
+    } else {
+        crate::rayon_thread_count()
+    };
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(num_threads)
+        .build()
+        .expect("failed to build collect thread pool")
+});
 
 struct TableRenderPlan {
     progressive_table: Option<ProgressiveTable>,
@@ -455,8 +485,8 @@ pub trait PickerProgressHandler: Send + Sync {
 
     /// Fired once before `collect` returns `Ok(Some(_))`. Lets the picker
     /// kick off the deferred tier of background work — secondary preview
-    /// modes for items 1..N, and LLM summaries for items 1..N. The
-    /// global rayon pool serves both pipelines; deferring this tier
+    /// modes for items 1..N, and LLM summaries for items 1..N.
+    /// `COLLECT_POOL` serves both pipelines. Deferring this tier
     /// until drain-end keeps low-priority preview submissions out of
     /// the injector while row tasks dominate worker deques.
     ///
@@ -1455,10 +1485,15 @@ pub fn collect(
     worktrunk::trace::instant("Spawning worker thread");
     std::thread::spawn(move || {
         worktrunk::trace::instant("Parallel execution started");
-        all_work_items.into_par_iter().for_each(|item| {
-            worktrunk::shell_exec::set_command_timeout(command_timeout);
-            let result = item.execute();
-            let _ = tx_worker.send(result);
+        // Run on the dedicated `COLLECT_POOL` so the blocking git subprocess
+        // tasks leave the global pool free for skim's per-keystroke matcher
+        // when the picker is open. See `COLLECT_POOL`.
+        COLLECT_POOL.install(|| {
+            all_work_items.into_par_iter().for_each(|item| {
+                worktrunk::shell_exec::set_command_timeout(command_timeout);
+                let result = item.execute();
+                let _ = tx_worker.send(result);
+            });
         });
     });
 
@@ -1950,11 +1985,15 @@ pub fn populate_item(
     // Sort: network tasks last
     work_items.sort_by_key(|w| w.kind.is_network());
 
-    // Spawn collection in background thread (executes only)
+    // Spawn collection in background thread (executes only). Route through
+    // `COLLECT_POOL` for consistency with the multi-item path, though a single
+    // item never floods the global pool.
     std::thread::spawn(move || {
-        work_items.into_par_iter().for_each(|w| {
-            let result = w.execute();
-            let _ = tx.send(result);
+        COLLECT_POOL.install(|| {
+            work_items.into_par_iter().for_each(|w| {
+                let result = w.execute();
+                let _ = tx.send(result);
+            });
         });
     });
 

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -23,7 +23,7 @@
 //! 1. `current_or_recover` + config resolution.
 //! 2. `PreviewState::new` — auto-detects Right vs Down layout.
 //! 3. Allocates the `PreviewOrchestrator` and kicks off a *speculative*
-//!    `git diff HEAD` for the current worktree on the global rayon pool.
+//!    `git diff HEAD` for the current worktree on `COLLECT_POOL`.
 //!    That bg work overlaps with everything below.
 //! 4. Computes `num_items_estimate` — `list_worktrees` plus (conditionally)
 //!    `local_branches` / `remote_branches`, capped at
@@ -486,7 +486,7 @@ pub fn handle_picker(
 
     // Preview cache is created up-front so the speculative first-item
     // preview can run in parallel with `collect::collect` below. Tasks
-    // route to the global rayon pool (shared with the row pipeline).
+    // route to `COLLECT_POOL` (shared with the row pipeline).
     // Wrapped in `Arc` because the progressive handler (running on the
     // collect background thread) also calls `spawn_preview`.
     //
@@ -805,7 +805,7 @@ pub fn handle_picker(
 
     // Dry-run / preview-bench: skim is bypassed. Wait for collect (which
     // spawns previews via the handler) to finish, then for the orchestrator's
-    // pending tasks to drain on the global rayon pool. Dry-run additionally
+    // pending tasks to drain on `COLLECT_POOL`. Dry-run additionally
     // drains stashed warnings and dumps the cache inventory; preview-bench
     // returns immediately so the measured wall clock is just "spawn → all
     // preview tasks drained", with no JSON serialization or stderr I/O in

--- a/src/commands/picker/preview_cache.rs
+++ b/src/commands/picker/preview_cache.rs
@@ -56,7 +56,7 @@ const KIND: &str = "picker-preview";
 /// commonly: a squash merge landing `main` at the cached SHA) would
 /// leave the decoration text stale even though the cache key is still
 /// valid. The orchestrator mitigates this by enqueuing a background
-/// refresh task on the global rayon pool whenever a Log preview hit
+/// refresh task on `COLLECT_POOL` whenever a Log preview hit
 /// the disk cache; the refresh re-runs `compute_log_raw_and_stats`,
 /// overwrites this entry, and updates the in-memory `PreviewCache`.
 /// The cached entry served on the *current* render is still potentially

--- a/src/commands/picker/preview_orchestrator.rs
+++ b/src/commands/picker/preview_orchestrator.rs
@@ -1,10 +1,15 @@
 //! Background preview pre-compute orchestration.
 //!
-//! Routes preview tasks to the global rayon pool (shared with the row
-//! pipeline) and tracks the in-memory cache. A single pool lets workers
+//! Routes preview tasks to the dedicated [`COLLECT_POOL`] (shared with the
+//! row pipeline) and tracks the in-memory cache. A single pool lets workers
 //! prefer whichever workload has dominant pressure: row tasks land on
 //! workers' local deques and take priority during drain; preview tasks
-//! sit in the global injector and pick up workers as they free.
+//! sit in the pool's injector and pick up workers as they free.
+//!
+//! `COLLECT_POOL` is deliberately *not* the global pool: skim runs its
+//! per-keystroke fuzzy matcher on the global pool, so keeping these blocking
+//! git tasks off it is what prevents the picker from freezing on the first
+//! keystroke. See [`COLLECT_POOL`] for the full reasoning.
 //!
 //! Provides a pending-task counter for the dry-run path
 //! (`WORKTRUNK_PICKER_DRY_RUN`) and tests, both of which want to wait for
@@ -21,6 +26,7 @@ use worktrunk::git::Repository;
 use super::items::{PreviewCache, WorktreeSkimItem};
 use super::preview::PreviewMode;
 use super::summary;
+use crate::commands::list::collect::COLLECT_POOL;
 use crate::commands::list::model::ListItem;
 
 /// The picker's initial preview tab — `WorkingTree`, shown when the
@@ -82,8 +88,9 @@ impl PreviewOrchestrator {
     ///
     /// Log mode that hits the disk cache also enqueues a refresh task
     /// (via `rayon::spawn_fifo`, so it lands behind in-flight foreground
-    /// precompute submitted with `rayon::spawn`) to recompute the
-    /// embedded ref decorations before the next visit. See the
+    /// precompute) to recompute the embedded ref decorations before the
+    /// next visit. The `spawn_fifo` runs from inside a `COLLECT_POOL`
+    /// worker, so it inherits that pool rather than the global one. See the
     /// `LogCacheEntry` docstring for why the disk cache itself is
     /// SHA-keyed but decoration text drifts.
     pub(super) fn spawn_preview(
@@ -170,10 +177,10 @@ impl PreviewOrchestrator {
     /// Spawn the deferred pre-compute tier for items 1..N.
     ///
     /// Fires from the picker handler's `on_collect_complete` hook — i.e.
-    /// after `collect::collect`'s drain ends. The global rayon pool
-    /// serves both the row pipeline and the preview pipeline; deferring
-    /// this tier keeps these submissions out of the global injector
-    /// while row tasks are still landing on workers' local deques. The
+    /// after `collect::collect`'s drain ends. `COLLECT_POOL` serves
+    /// both the row pipeline and the preview pipeline. Deferring this
+    /// tier keeps these submissions out of that pool's injector while
+    /// row tasks are still landing on workers' local deques. The
     /// default tab for these rows already fired at skeleton time via
     /// [`Self::spawn_initial_precompute`]; what's left is
     /// [`SECONDARY_MODES`] plus summaries.
@@ -227,10 +234,10 @@ impl PreviewOrchestrator {
             task();
         };
         // The `pending` counter is independent of which pool the task
-        // lands on, so routing through `rayon::spawn` (global pool, shared
-        // with the row pipeline) doesn't change `wait_for_idle` semantics
-        // in tests or the dry-run path.
-        rayon::spawn(wrapped);
+        // lands on, so routing through `COLLECT_POOL` (shared with the row
+        // pipeline, off the global pool skim's matcher uses) doesn't change
+        // `wait_for_idle` semantics in tests or the dry-run path.
+        COLLECT_POOL.spawn(wrapped);
     }
 
     /// Block until all spawned tasks complete.

--- a/src/commands/picker/progressive_handler.rs
+++ b/src/commands/picker/progressive_handler.rs
@@ -12,9 +12,9 @@
 //!   every row when summaries are disabled.
 //! - `on_collect_complete` fires the secondary modes (Log / BranchDiff /
 //!   UpstreamDiff) and summaries for items 1..N once the row pipeline
-//!   has torn down. Preview tasks share the global rayon pool with the
-//!   row pipeline; staging keeps low-priority preview submissions out
-//!   of the global injector while row tasks are still landing on
+//!   has torn down. Preview tasks share `COLLECT_POOL` with the row
+//!   pipeline. Staging keeps low-priority preview submissions out of
+//!   that pool's injector while row tasks are still landing on
 //!   workers' local deques during drain.
 
 use std::sync::{Arc, Mutex, OnceLock};
@@ -120,7 +120,7 @@ impl PickerProgressHandler for PickerHandler {
         // other row's default tab. Tier 2 (secondary modes + summaries
         // for items 1..N) fires from `on_collect_complete` after the row
         // pipeline tears down — spawning that bulk now would queue ahead
-        // of row tasks in the global injector while workers are still
+        // of row tasks in `COLLECT_POOL`'s injector while workers are still
         // grinding through the row work.
         self.orchestrator.spawn_initial_precompute(
             &list_items,


### PR DESCRIPTION
Fixes a multi-second freeze in the `wt switch` picker: with many accumulated worktrees, typing the first character locks the UI for seconds, then it recovers. The freeze scales with worktree count.

The picker (skim) runs its per-keystroke fuzzy matcher and result sort on rayon's **global** thread pool. Worktrunk's collection floods that same global pool with blocking git subprocess tasks (status, diff, rev-list, merge-base, plus the preview orchestrator's per-mode `git diff` / `git log`), one batch per worktree. The global pool has only `2× CPU` workers, and each git call blocks its worker for the subprocess lifetime. When the user types, skim's matcher queues behind that flood and can't run until workers drain. `wt list` never froze because nothing else contends for the pool there.

The fix moves the git-heavy collection and preview work onto a dedicated `COLLECT_POOL`, leaving the global pool free for skim. This is the same isolation pattern already used by `copy::COPY_POOL` and `remove_dir::REMOVE_POOL`. The new pool is sized like the global pool (`2× CPU`, honoring `RAYON_NUM_THREADS`), so collection throughput is unchanged. Its only job is to keep the git work off the pool skim's matcher uses.

## Decisions

- Collection's row pipeline and the preview orchestrator stay on the same dedicated pool, preserving the orchestrator's intentional "one shared pool, let workers prefer dominant pressure" design. They just move off the pool skim needs.
- The bounded pre- and post-skeleton `rayon::scope` calls stay on the global pool. They are O(1) in worktree count (~7 spawns), so they are not the scaling flood.
- The single-item statusline path (`populate_item`) routes through `COLLECT_POOL` too, purely for consistency. A single item never floods the pool, so this path was never the problem.
- The nested log-refresh `rayon::spawn_fifo` needs no change. The free `rayon::spawn_fifo` resolves its target via the current worker's registry, so when called from inside a `COLLECT_POOL` worker it inherits `COLLECT_POOL` rather than falling back to the global pool. Confirmed against the rayon-core source.

## Testing

Ran locally, before and after below, depicting the freeze/fix

### Before


https://github.com/user-attachments/assets/55c12cec-4466-487a-b480-fd2ff03ad111

### After


https://github.com/user-attachments/assets/71a5499a-5521-4727-a6b4-ab6a12f317d5

