### PR TITLE
refactor(expand): label -v template expansion as source/result blocks

### DIFF
--- a/.claude/skills/writing-user-outputs/SKILL.md
+++ b/.claude/skills/writing-user-outputs/SKILL.md
@@ -925,20 +925,26 @@ See `src/git/error.rs` for examples of this pattern in `GitError` Display impls.
 **`-v` (verbose):** User-facing diagnostic output. Must follow these guidelines.
 Shows template expansions and other details users might need for debugging config.
 
-Format for template expansion:
+Template expansion shows the source template and the rendered result as two
+labeled blocks. Each block is a bash gutter (dim + syntax highlighting via
+`format_bash_with_gutter`) under its own info header (`○` symbol, bold name,
+then `source` or `result`):
 ```
-○ Expanding name
- ┃ template (bash-highlighted)
- ┃ → (dim)
- ┃ result (bash-highlighted)
+○ name source
+ ┃ template
+○ name result
+ ┃ result
 ```
 
-- **Info message** for header (`○` symbol, "Expanding" + bold name)
-- **Bash gutter** for template and result (dim + syntax highlighting via
-  `format_bash_with_gutter`)
-- **Plain gutter** for dim `→` separator (bypasses syntax highlighter)
-- Template and result are always on separate gutter blocks from the arrow,
-  because the `→` can't go through the bash syntax highlighter
+The two headers carry the input/output distinction, so both blocks share the
+same gutter and the content always starts at the gutter's column 2 (no marker
+glyph or extra indent inside the gutter). Multi-line templates and results
+follow the same shape, one gutter line per source line.
+
+`expand_template` emits no trailing blank, so a standalone caller adds one to
+separate the block from what follows (`wt step eval` does this after the view).
+In a command pipeline the executor already separates the block from the next
+output, so the expansion adds nothing.
 
 **`-vv` (debug):** Developer-facing logging output. MAY violate these guidelines.
 Uses `log::debug!()` with structured format for deep debugging. Not intended for

--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -540,10 +540,11 @@ List the available template variables with `-v` (alongside the expansion, on std
 ○ Available template variables
   branch        = feature/auth-oauth2
   worktree_path = /home/user/projects/myapp-feature-auth-oauth2
-○ Expanding eval
+○ eval source
   {{ branch }}
-  →
+○ eval result
   feature/auth-oauth2
+
 feature/auth-oauth2
 {% end %}
 

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -557,10 +557,11 @@ $ wt step eval -v '{{ branch }}'
 ○ Available template variables
   branch        = feature/auth-oauth2
   worktree_path = /home/user/projects/myapp-feature-auth-oauth2
-○ Expanding eval
+○ eval source
   {{ branch }}
-  →
+○ eval result
   feature/auth-oauth2
+
 feature/auth-oauth2
 ```
 

--- a/src/cli/step.rs
+++ b/src/cli/step.rs
@@ -438,10 +438,11 @@ $ wt step eval -v '{{ branch }}'
 ○ Available template variables
   branch        = feature/auth-oauth2
   worktree_path = /home/user/projects/myapp-feature-auth-oauth2
-○ Expanding eval
+○ eval source
   {{ branch }}
-  →
+○ eval result
   feature/auth-oauth2
+
 feature/auth-oauth2
 ```
 

--- a/src/commands/eval.rs
+++ b/src/commands/eval.rs
@@ -20,7 +20,7 @@ use crate::commands::command_executor::{CommandContext, build_hook_context};
 ///
 /// `eval` mutates nothing, so it has no `--dry-run`. Variable discovery lives
 /// in the verbose lane instead: `-v` lists the available template variables on
-/// stderr, above the `{{ template }} → result` expansion view that
+/// stderr, above the labeled `source` / `result` expansion view that
 /// `expand_template` renders at `-v`.
 pub fn step_eval(template: &str) -> anyhow::Result<()> {
     let repo = Repository::current()?;
@@ -55,6 +55,11 @@ pub fn step_eval(template: &str) -> anyhow::Result<()> {
         .collect();
 
     let result = expand_template(template, &vars, ShellEscapeMode::Literal, &repo, "eval")?;
+    // `expand_template` emitted the `source` / `result` view to stderr under
+    // `-v`; a trailing blank separates it from the result printed below.
+    if verbosity() >= 1 {
+        eprintln!();
+    }
     println!("{result}");
     Ok(())
 }

--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -1038,17 +1038,19 @@ pub fn expand_template(
         log::debug!("[template:{name}] result={:?}", redact_credentials(&result));
     }
 
-    // -v: Nice styled output showing template expansion
-    // Info message for header, gutter for quoted content (template → result)
+    // -v: Nice styled output showing template expansion. The source template
+    // and the rendered result each get a labeled info header above a bash gutter
+    // block, so the eye separates input from output. Callers that emit several
+    // expansions in a row (or a single standalone one, like `wt step eval`) add
+    // a trailing blank to separate them; in a command pipeline the executor
+    // already provides that separation.
     // Single atomic write to avoid interleaving in multi-threaded execution
     if verbose == 1 {
-        let header = info_message(cformat!("Expanding <bold>{name}</>"));
-        // Format template and result as bash (dim + syntax highlighting),
-        // with a dim → separator that bypasses the syntax highlighter
-        let template_gutter = format_bash_with_gutter(template);
-        let arrow = format_with_gutter(&cformat!("<dim>→</>"), None);
+        let source_header = info_message(cformat!("<bold>{name}</> source"));
+        let source_gutter = format_bash_with_gutter(template);
+        let result_header = info_message(cformat!("<bold>{name}</> result"));
         let result_gutter = format_bash_with_gutter(&result);
-        eprintln!("{header}\n{template_gutter}\n{arrow}\n{result_gutter}");
+        eprintln!("{source_header}\n{source_gutter}\n{result_header}\n{result_gutter}");
     }
     Ok(result)
 }

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_verbose_shows_content.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_verbose_shows_content.snap
@@ -57,15 +57,15 @@ exit_code: 0
 [33m▲[39m [33mUser config: template variable [1mworktree[22m is deprecated in favor of [1mworktree_path[22m[39m
 [33m▲[39m [33mUser config: template variable [1mmain_worktree[22m is deprecated in favor of [1mrepo[22m[39m
 [2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
-[2m○[22m Expanding [1mworktree-path[22m
+[2m○[22m [1mworktree-path[22m source
 [107m [0m [2m[0m[2m[34m../[0m[2m[32m{{[0m[2m[34m[0m[2m main_worktree [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[32m}}[0m
-[107m [0m [2m→[22m
+[2m○[22m [1mworktree-path[22m result
 [107m [0m [2m[0m[2m[34m../repo.feature-a[0m
-[2m○[22m Expanding [1mworktree-path[22m
+[2m○[22m [1mworktree-path[22m source
 [107m [0m [2m[0m[2m[34m../[0m[2m[32m{{[0m[2m[34m[0m[2m main_worktree [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[32m}}[0m
-[107m [0m [2m→[22m
+[2m○[22m [1mworktree-path[22m result
 [107m [0m [2m[0m[2m[34m../repo.feature-b[0m
-[2m○[22m Expanding [1mworktree-path[22m
+[2m○[22m [1mworktree-path[22m source
 [107m [0m [2m[0m[2m[34m../[0m[2m[32m{{[0m[2m[34m[0m[2m main_worktree [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[32m}}[0m
-[107m [0m [2m→[22m
+[2m○[22m [1mworktree-path[22m result
 [107m [0m [2m[0m[2m[34m../repo.feature-c[0m

--- a/tests/snapshots/integration__integration_tests__eval__eval_verbose.snap
+++ b/tests/snapshots/integration__integration_tests__eval__eval_verbose.snap
@@ -67,7 +67,7 @@ exit_code: 0
 [107m [0m [1mworktree[22m              = _REPO_
 [107m [0m [1mworktree_name[22m         = repo
 [107m [0m [1mworktree_path[22m         = _REPO_
-[2m○[22m Expanding [1meval[22m
+[2m○[22m [1meval[22m source
 [107m [0m [2m[0m[2m[32m{{[0m[2m[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34mhash_port[0m[2m [0m[2m[32m}}[0m
-[107m [0m [2m→[22m
+[2m○[22m [1meval[22m result
 [107m [0m [2m[0m[2m[34m12107[0m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_verbose_output.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_verbose_output.snap
@@ -48,9 +48,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m Expanding [1mworktree-path[22m
+[2m○[22m [1mworktree-path[22m source
 [107m [0m [2m[0m[2m[32m{{[0m[2m[0m[2m repo_path [0m[2m[32m}}[0m[2m/../[0m[2m[32m{{[0m[2m repo [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34msanitize[0m[2m [0m[2m[32m}}[0m
-[107m [0m [2m→[22m
+[2m○[22m [1mworktree-path[22m result
 [107m [0m [2m[0m[2m[34m_REPO_/../repo.feature[0m
 [32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_verbose_template_expansion.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_verbose_template_expansion.snap
@@ -48,13 +48,13 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m Expanding [1mworktree-path[22m
+[2m○[22m [1mworktree-path[22m source
 [107m [0m [2m[0m[2m[34m../[0m[2m[32m{{[0m[2m[34m[0m[2m repo [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34msanitize[0m[2m [0m[2m[32m}}[0m
-[107m [0m [2m→[22m
+[2m○[22m [1mworktree-path[22m result
 [107m [0m [2m[0m[2m[34m../repo.verbose-hooks[0m
-[2m○[22m Expanding [1mproject:setup[22m
+[2m○[22m [1mproject:setup[22m source
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setting up {{ branch | sanitize }} in {{ worktree_path }}'[0m
-[107m [0m [2m→[22m
+[2m○[22m [1mproject:setup[22m result
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setting up verbose-hooks in _REPO_.verbose-hooks'[0m
 [2m○[22m template variables:
 [107m [0m branch                = verbose-hooks

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_verbose_args_shell_escaped.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_verbose_args_shell_escaped.snap
@@ -66,8 +66,8 @@ hello foo bar baz
 [107m [0m cwd                   = _REPO_.feature
 [107m [0m args                  = foo 'bar baz'
 [36m◎[39m [36mRunning alias [1mgreet[22m[39m
-[2m○[22m Expanding [1mgreet[22m
+[2m○[22m [1mgreet[22m source
 [107m [0m [2m[0m[2m[34mecho[0m[2m hello [0m[2m[32m{{[0m[2m args [0m[2m[32m}}[0m
-[107m [0m [2m→[22m
+[2m○[22m [1mgreet[22m result
 [107m [0m [2m[0m[2m[34mecho[0m[2m hello foo [0m[2m[32m'bar baz'[0m
 [0m

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_verbose_variable_table.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_verbose_variable_table.snap
@@ -65,8 +65,8 @@ hello world
 [107m [0m cwd                   = _REPO_.feature
 [107m [0m args                  = world
 [36m◎[39m [36mRunning alias [1mgreet[22m[39m
-[2m○[22m Expanding [1mgreet[22m
+[2m○[22m [1mgreet[22m source
 [107m [0m [2m[0m[2m[34mecho[0m[2m hello [0m[2m[32m{{[0m[2m args [0m[2m[32m}}[0m
-[107m [0m [2m→[22m
+[2m○[22m [1mgreet[22m result
 [107m [0m [2m[0m[2m[34mecho[0m[2m hello world[0m
 [0m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_verbose_multiline_template.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_verbose_multiline_template.snap
@@ -52,9 +52,9 @@ branch=multiline-test
 repo=repo
 
 ----- stderr -----
-[2m○[22m Expanding [1mworktree-path[22m
+[2m○[22m [1mworktree-path[22m source
 [107m [0m [2m[0m[2m[32m{{[0m[2m[0m[2m repo_path [0m[2m[32m}}[0m[2m/../[0m[2m[32m{{[0m[2m repo [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34msanitize[0m[2m [0m[2m[32m}}[0m
-[107m [0m [2m→[22m
+[2m○[22m [1mworktree-path[22m result
 [107m [0m [2m[0m[2m[34m_REPO_/../repo.multiline-test[0m
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
 [2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c '{% if branch %}
@@ -65,12 +65,12 @@ echo '\''repo={{ repo }}'\''
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
-[2m○[22m Expanding [1m--execute command[22m
+[2m○[22m [1m--execute command[22m source
 [107m [0m [2m{[0m[2m[34m%[0m[2m if branch %}[0m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'branch={{ branch }}'[0m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'repo={{ repo }}'[0m
 [107m [0m [2m{[0m[2m[34m%[0m[2m endif %}[0m
-[107m [0m [2m→[22m
+[2m○[22m [1m--execute command[22m result
 [107m [0m [0m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'branch=multiline-test'[0m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'repo=repo'[0m

--- a/tests/snapshots/integration__integration_tests__switch__switch_execute_verbose_template.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_execute_verbose_template.snap
@@ -51,9 +51,9 @@ exit_code: 0
 branch=verbose-test
 
 ----- stderr -----
-[2m○[22m Expanding [1mworktree-path[22m
+[2m○[22m [1mworktree-path[22m source
 [107m [0m [2m[0m[2m[32m{{[0m[2m[0m[2m repo_path [0m[2m[32m}}[0m[2m/../[0m[2m[32m{{[0m[2m repo [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34msanitize[0m[2m [0m[2m[32m}}[0m
-[107m [0m [2m→[22m
+[2m○[22m [1mworktree-path[22m result
 [107m [0m [2m[0m[2m[34m_REPO_/../repo.verbose-test[0m
 [33m▲[39m [33m[1m--execute[22m will change in a future release: it will run a single program, with arguments after [1m--[22m, not a shell command line[39m
 [2m↳[22m [2mComment at [4mhttps://github.com/max-sixty/worktrunk/issues/2860[24m if the new single-program form would make a workflow worse; to run this command line unchanged, pass it to a shell: [4m--execute sh -- -c 'echo '\''branch={{ branch }}'\'''[24m[22m
@@ -61,9 +61,9 @@ branch=verbose-test
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
-[2m○[22m Expanding [1m--execute command[22m
+[2m○[22m [1m--execute command[22m source
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'branch={{ branch }}'[0m
-[107m [0m [2m→[22m
+[2m○[22m [1m--execute command[22m result
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'branch=verbose-test'[0m
 [36m◎[39m [36mExecuting (--execute) @ [1m_REPO_.verbose-test[22m:[39m
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'branch=verbose-test'[0m

--- a/tests/snapshots/integration__integration_tests__user_hooks__combined_post_remove_and_post_switch_verbose.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__combined_post_remove_and_post_switch_verbose.snap
@@ -48,9 +48,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m Expanding [1mworktree-path[22m
+[2m○[22m [1mworktree-path[22m source
 [107m [0m [2m[0m[2m[32m{{[0m[2m[0m[2m repo_path [0m[2m[32m}}[0m[2m/../[0m[2m[32m{{[0m[2m repo [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34msanitize[0m[2m [0m[2m[32m}}[0m
-[107m [0m [2m→[22m
+[2m○[22m [1mworktree-path[22m result
 [107m [0m [2m[0m[2m[34m_REPO_/../repo.feature[0m
 [36m◎[39m [36mRemoving [1mfeature[22m worktree & branch in background (--force-delete)[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__user_hooks__hook_verbose_background_dedup.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__hook_verbose_background_dedup.snap
@@ -48,9 +48,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m Expanding [1mworktree-path[22m
+[2m○[22m [1mworktree-path[22m source
 [107m [0m [2m[0m[2m[32m{{[0m[2m[0m[2m repo_path [0m[2m[32m}}[0m[2m/../[0m[2m[32m{{[0m[2m repo [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34msanitize[0m[2m [0m[2m[32m}}[0m
-[107m [0m [2m→[22m
+[2m○[22m [1mworktree-path[22m result
 [107m [0m [2m[0m[2m[34m_REPO_/../repo.feature[0m
 [32m✓[39m [32mCreated branch [1mfeature[22m from [1mmain[22m and worktree @ [1m_REPO_.feature[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m

--- a/tests/snapshots/integration__integration_tests__user_hooks__hook_verbose_variable_table.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__hook_verbose_variable_table.snap
@@ -47,9 +47,9 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[2m○[22m Expanding [1muser:noop[22m
+[2m○[22m [1muser:noop[22m source
 [107m [0m [2m[0m[2m[34mtrue[0m
-[107m [0m [2m→[22m
+[2m○[22m [1muser:noop[22m result
 [107m [0m [2m[0m[2m[34mtrue[0m
 [2m○[22m template variables:
 [107m [0m branch                = feature
@@ -76,9 +76,9 @@ exit_code: 0
 [107m [0m hook_name             = noop
 [36m◎[39m [36mRunning pre-switch [1muser:noop[22m[39m
 [107m [0m [2m[0m[2m[34mtrue[0m
-[0m[2m○[22m Expanding [1mworktree-path[22m
+[0m[2m○[22m [1mworktree-path[22m source
 [107m [0m [2m[0m[2m[32m{{[0m[2m[0m[2m repo_path [0m[2m[32m}}[0m[2m/../[0m[2m[32m{{[0m[2m repo [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34msanitize[0m[2m [0m[2m[32m}}[0m
-[107m [0m [2m→[22m
+[2m○[22m [1mworktree-path[22m result
 [107m [0m [2m[0m[2m[34m_REPO_/../repo.feature[0m
 [33m▲[39m [33mWorktree for [1mfeature[22m @ [1m_REPO_.feature[22m, but cannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m


### PR DESCRIPTION
Reworks the `-v` template-expansion view. It used to stack the template, a lone `→`, and the result in one shared gutter; the arrow on its own line read awkwardly and the shared gutter blurred input vs output.

Now each side is its own labeled block — an info header above a bash gutter:

```
○ eval source
  {{ branch | hash_port }}
○ eval result
  12107
```

The two headers carry the input/output distinction, so both blocks keep the same gutter with content at column 2 (no marker glyph, no in-gutter indent). Multi-line templates and results follow the same shape, one gutter line per source line.

`expand_template` emits no trailing blank. The standalone `wt step eval` adds one after the view; in a command pipeline the executor already separates the block from the next output (an unconditional trailing blank there would trip the no-double-blank guard).

This view also surfaces in `wt switch -v`, hooks, aliases, and `wt -v list`'s deprecation preview — all snapshots regenerated. Known rough edge: `wt -v list` previews a deprecated `worktree-path` once per worktree, and those previews now sit back-to-back without a separating blank.

> _This was written by Claude Code on behalf of max_
