### PR TITLE
Release v0.59.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## 0.59.0
+
+### Improved
+
+- **Picker frees digit keys for filtering; preview tabs move to `Alt`**: In the `wt switch` picker, plain digits now go to the filter, so a branch name with a number in it can be typed directly. Preview tabs jump with `Alt-1`–`Alt-5` or cycle with `Tab`/`Shift-Tab`. (Breaking: `1`–`5` no longer switch preview tabs) ([#3079](https://github.com/max-sixty/worktrunk/pull/3079))
+
+- **Squash templates use `commit_details` instead of `commits`**: The squash commit-message template's `{{ commits }}` variable (commit subjects) is deprecated in favor of `{{ commit_details }}`, which renders as the bare subject when printed directly and also exposes `.subject` and `.body`. `wt config update` migrates `commits` to `commit_details` as a plain rename. ([#2985](https://github.com/max-sixty/worktrunk/pull/2985))
+
+- **`wt step eval -v` lists template variables**: `wt step eval -v` now prints the available template variables on stderr in the gutter style, above the `{{ template }} → result` expansion it already showed. The result still goes to stdout, so `$(wt step eval …)` is unchanged. Since `eval` mutates nothing and is experimental, its `--dry-run` flag (which dumped the raw variable context) is removed rather than deprecated. ([#3078](https://github.com/max-sixty/worktrunk/pull/3078))
+
+### Fixed
+
+- **Picker no longer freezes on the first keystroke**: With many worktrees, typing the first character in the `wt switch` picker locked the UI for several seconds. The fuzzy matcher shares rayon's global thread pool with worktrunk's git collection, which floods it with blocking subprocess calls, so the matcher queued behind them. Collection and preview work now run on a dedicated pool, keeping the matcher responsive. ([#3087](https://github.com/max-sixty/worktrunk/pull/3087), thanks @bendrucker; fixes [#2926](https://github.com/max-sixty/worktrunk/issues/2926), thanks @mahume for reporting)
+
+- **Tab-completion covers all hook types**: `wt hook <type> <Tab>` completed configured command names for only seven of the ten hook types; `pre-switch`, `post-switch`, and `post-remove` returned nothing. Completion now derives the type from the canonical hook list, so every type completes its command names. ([#3070](https://github.com/max-sixty/worktrunk/pull/3070))
+
+- **Ctrl-C on a concurrent alias reports the right exit code**: Interrupting `wt step <concurrent-alias>` could report exit 143 (SIGTERM) instead of 130 (SIGINT), because a per-child SIGINT → SIGTERM → SIGKILL escalation could land a SIGTERM on a child during the grace window; the escalation also serialized across process groups, so repeated Ctrl-C could wait. wt now forwards the user's signal once per process group, so a cooperative child dies from the signal actually sent (130 on Ctrl-C); a second signal kills any survivor immediately. ([#3075](https://github.com/max-sixty/worktrunk/pull/3075))
+
+### Documentation
+
+- **Per-worktree env vars**: A Tips & Patterns section shows how to give each worktree its own environment variables with direnv or mise. ([#3074](https://github.com/max-sixty/worktrunk/pull/3074))
+
+### Internal
+
+- The commit-generation command is not rewritten to disk when its value is unchanged. ([#3084](https://github.com/max-sixty/worktrunk/pull/3084))
+
 ## 0.58.0
 
 ### Improved

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3309,7 +3309,7 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
 name = "worktrunk"
-version = "0.58.0"
+version = "0.59.0"
 dependencies = [
  "ansi-str",
  "ansi-to-html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ filterset = "test(/readme_sync/)"
 
 [package]
 name = "worktrunk"
-version = "0.58.0"
+version = "0.59.0"
 edition = "2024"
 rust-version = "1.95"
 build = "build.rs"

--- a/tests/integration_tests/ci_status.rs
+++ b/tests/integration_tests/ci_status.rs
@@ -519,8 +519,11 @@ platform = "invalid_platform"
     repo.setup_mock_gh_with_ci_data(&pr_json, "[]");
 
     let mut settings = setup_snapshot_settings(&repo);
-    // Normalize worker thread ID prefix in log output (e.g., [n], [z], [A] -> [W])
-    settings.add_filter(r"\[[a-zA-Z]\]", "[W]");
+    // Normalize worker thread ID prefix in log output (e.g., [n], [z], [A] -> [W]).
+    // `label_for_thread_index` emits `0`, `a`-`z`, `A`-`Z`, and `?` (the latter
+    // for thread IDs above 52, which appear on high-core machines where the
+    // rayon pools span enough threads); the filter covers the whole alphabet.
+    settings.add_filter(r"\[[a-zA-Z0-9?]\]", "[W]");
     settings.bind(|| {
         let mut cmd = make_snapshot_cmd(&repo, "list", &["--full"], None);
         repo.configure_mock_commands(&mut cmd);


### PR DESCRIPTION
Release v0.59.0 (minor). The bump is minor because two backward-incompatible behavior changes ship: in the `wt switch` picker, `1`–`5` no longer switch preview tabs (digits now filter; tabs move to `Alt-1`–`Alt-5` / `Tab`); and `wt step eval --dry-run` is removed in favor of `-v`. `cargo semver-checks` reports no library API breakage.

### Highlights

- **Improved**: picker frees digit keys for filtering (preview tabs to `Alt`); squash templates use `commit_details` instead of the deprecated `commits`; `wt step eval -v` lists template variables.
- **Fixed**: picker no longer freezes on the first keystroke with many worktrees (#3087, thanks @bendrucker; fixes #2926, thanks @mahume for reporting); tab-completion covers all hook types; Ctrl-C on a concurrent alias reports the right exit code.

See `CHANGELOG.md` for the full set.

### Bundled test fix

This PR also carries one non-release commit: `test(ci_status): cover '?' worker-thread label in snapshot filter`. The `test_list_full_with_invalid_configured_platform` snapshot filter only normalized `[a-zA-Z]` worker-thread labels, but `label_for_thread_index` emits `?` for thread IDs above 52. On high-core machines the rayon pools span enough threads to hit that, so the gate failed locally (CI's low core count never triggers it). The filter now covers the full label alphabet. Test-only; not in the changelog.

> _This was written by Claude Code on behalf of max_
