### PR TITLE
chore: roll back to the default claude harness

### DIFF
--- a/.config/tend.yaml
+++ b/.config/tend.yaml
@@ -1,5 +1,4 @@
 bot_name: worktrunk-bot
-harness: claude-interactive
 setup:
 - uses: ./.github/actions/claude-setup
 secrets:

--- a/.github/workflows/tend-ci-fix.yaml
+++ b/.github/workflows/tend-ci-fix.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: ./.github/actions/claude-setup
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -209,7 +209,7 @@ jobs:
         env:
           EVENT_TS: ${{ github.event.comment.updated_at || github.event.review.submitted_at || github.event.issue.updated_at }}
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-nightly.yaml
+++ b/.github/workflows/tend-nightly.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: ./.github/actions/claude-setup
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-notifications.yaml
+++ b/.github/workflows/tend-notifications.yaml
@@ -99,7 +99,7 @@ jobs:
 
       - uses: ./.github/actions/claude-setup
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         if: steps.check.outputs.count != '0' || github.event_name == 'workflow_dispatch'
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}

--- a/.github/workflows/tend-review-runs.yaml
+++ b/.github/workflows/tend-review-runs.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: ./.github/actions/claude-setup
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-review.yaml
+++ b/.github/workflows/tend-review.yaml
@@ -50,7 +50,7 @@ jobs:
 
       - uses: ./.github/actions/claude-setup
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-triage.yaml
+++ b/.github/workflows/tend-triage.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - uses: ./.github/actions/claude-setup
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}

--- a/.github/workflows/tend-weekly.yaml
+++ b/.github/workflows/tend-weekly.yaml
@@ -32,7 +32,7 @@ jobs:
 
       - uses: ./.github/actions/claude-setup
 
-      - uses: max-sixty/tend/interactive@0.1.4
+      - uses: max-sixty/tend@0.1.4
         with:
           github_token: ${{ secrets.TEND_BOT_TOKEN }}
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}


### PR DESCRIPTION
Anthropic [paused](https://support.claude.com/en/articles/15036540-use-the-claude-agent-sdk-with-your-claude-plan) the 2026-06-15 Agent SDK credit metering (the `-p` billing change), so subscription `claude-code-action` runs again draw from the plan's usage limits. That removes the reason this repo was on the `claude-interactive` harness.

- `.config/tend.yaml`: drop `harness: claude-interactive` (the default is `claude`).
- Regenerate `tend-*.yaml` via `uvx tend@latest init`: the action ref goes from `max-sixty/tend/interactive@0.1.4` to `max-sixty/tend@0.1.4` across all eight workflows.

Auth is unchanged: both harnesses use the same secrets.

> _This was written by Claude Code on behalf of max_
