### PR TITLE
docs(cli): drop redundant --format value parenthetical where clap lists them

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -629,7 +629,7 @@ Usage: <b><span class=c>wt config show</span></b> <span class=c>[OPTIONS]</span>
 
 <b><span class=g>Output:</span></b>
       <b><span class=c>--format</span></b><span class=c> &lt;FORMAT&gt;</span>
-          Output format (text, json)
+          Output format
 
           [default: text]
           [possible values: text, json]

--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -564,11 +564,8 @@ Usage: <b><span class=c>wt step eval</span></b> <span class=c>[OPTIONS]</span> <
 
           JSON prints <b>{name, template, result}</b> to stdout instead of the bare result.
 
-          Possible values:
-          - <b><span class=c>text</span></b>: Human-readable text output
-          - <b><span class=c>json</span></b>: JSON output
-
           [default: text]
+          [possible values: text, json]
 
 <b><span class=g>Global Options:</span></b>
   <b><span class=c>-C</span></b><span class=c> &lt;path&gt;</span>
@@ -634,7 +631,7 @@ Usage: <b><span class=c>wt step for-each</span></b> <span class=c>[OPTIONS]</spa
 
 <b><span class=g>Options:</span></b>
       <b><span class=c>--format</span></b><span class=c> &lt;FORMAT&gt;</span>
-          Output format (text, json)
+          Output format
 
           [default: text]
           [possible values: text, json]
@@ -782,7 +779,7 @@ Usage: <b><span class=c>wt step prune</span></b> <span class=c>[OPTIONS]</span>
           Run removal in foreground (block until complete)
 
       <b><span class=c>--format</span></b><span class=c> &lt;FORMAT&gt;</span>
-          Output format (text, json)
+          Output format
 
           [default: text]
           [possible values: text, json]

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -630,7 +630,7 @@ Options:
 
 Output:
       --format <FORMAT>
-          Output format (text, json)
+          Output format
 
           [default: text]
           [possible values: text, json]

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -581,11 +581,8 @@ Automation:
 
           JSON prints {name, template, result} to stdout instead of the bare result.
 
-          Possible values:
-          - text: Human-readable text output
-          - json: JSON output
-
           [default: text]
+          [possible values: text, json]
 
 Global Options:
   -C <path>
@@ -661,7 +658,7 @@ Arguments:
 
 Options:
       --format <FORMAT>
-          Output format (text, json)
+          Output format
 
           [default: text]
           [possible values: text, json]
@@ -819,7 +816,7 @@ Options:
           Run removal in foreground (block until complete)
 
       --format <FORMAT>
-          Output format (text, json)
+          Output format
 
           [default: text]
           [possible values: text, json]

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -489,7 +489,7 @@ This tests:
         #[arg(long)]
         full: bool,
 
-        /// Output format (text, json)
+        /// Output format
         #[arg(long, default_value = "text", help_heading = "Output")]
         format: SwitchFormat,
     },
@@ -1447,7 +1447,7 @@ $ wt config state vars list --branch=feature
         #[arg(long, add = crate::completion::branch_value_completer())]
         branch: Option<String>,
 
-        /// Output format (text, json)
+        /// Output format
         #[arg(long, default_value = "text", help_heading = "Output")]
         format: SwitchFormat,
     },

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -25,7 +25,7 @@ pub enum ListSubcommand {
 The pace segment appears only when usage is likely to hit a rate limit before its window resets, and shows the higher-risk window: `2.9×(Tue–Tue 5pm)` reads as 2.9× the pace that would exactly fill that window. Above 90% used it shows usage instead of pace — `93%(Tue–Tue 5pm)` — near the cap, how much is left matters more than how fast it's going. "Likely" is a Bayesian forecast; early-window bursts don't trigger it. With `-vv`, each window's inputs and projection are logged to `.git/wt/logs/trace.log`.
 "#)]
     Statusline {
-        /// Output format (table, json, claude-code)
+        /// Output format
         #[arg(long, value_enum, default_value = "table")]
         format: OutputFormat,
 

--- a/src/cli/step.rs
+++ b/src/cli/step.rs
@@ -504,7 +504,7 @@ Note: This command is experimental and may change in future versions.
 "#
     )]
     ForEach {
-        /// Output format (text, json)
+        /// Output format
         #[arg(long, default_value = "text")]
         format: crate::cli::SwitchFormat,
 
@@ -611,7 +611,7 @@ $ wt step prune
         #[arg(long)]
         foreground: bool,
 
-        /// Output format (text, json)
+        /// Output format
         #[arg(long, default_value = "text")]
         format: crate::cli::SwitchFormat,
     },

--- a/tests/snapshots/integration__integration_tests__help__help_config_show.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_show.snap
@@ -46,7 +46,7 @@ Usage: [1m[36mwt config show[0m [36m[OPTIONS][0m
 
 [1m[32mOutput:[0m
       [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m
-          Output format (text, json)
+          Output format
           
           [default: text]
           [possible values: text, json]


### PR DESCRIPTION
Follow-up to #3108. That PR made clap render `--format`'s values inline as `[possible values: …]`, but five flags still carried a hand-written value parenthetical in their doc comment, so the list rendered twice — three times in `wt list statusline -h`:

```
--format <FORMAT>  Output format (table, json, claude-code) [default: table] [possible values: table, json, claude-code]
```

This drops the parenthetical (→ bare `/// Output format`) from every `--format` flag that does **not** hide possible-values, leaving clap's inline list as the single source: `wt list statusline`, `wt step for-each`, `wt step prune`, `wt config show`, `wt config state vars list`.

The deliberate hiders are left untouched — they set `hide_possible_values = true`, so their parenthetical is the *only* value list: `wt list`, `wt config state get` (both suppress the `claude-code` value, which is meaningless for them), and the shared `GlobalFormatFlag` for `config state cache`/`logs`/`hints`/`ci-status`/`marker`. The rule: if clap prints the list, drop the hand-written one; if clap's list is suppressed, keep it.

For `wt list statusline`, `claude-code`'s non-obvious behavior stays visible in the long-help possible-values block (`- claude-code: Claude Code statusline mode (reads context from stdin)`) and the dedicated "Claude Code mode" section.

This also regenerates a stale mirror: `wt step eval --format`'s `step.md` section was out of sync with the binary (expanded block vs. terse) because #3106 added that flag with the old `SwitchFormat` while #3108 trimmed it — their merge order left `test_docs_are_in_sync` failing on `main`. This PR fixes that.

> _This was written by Claude Code on behalf of max_
