### PR TITLE
feat(list): gutter sigils for local (/) and remote (|) branches

### DIFF
--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -60,8 +60,8 @@ Include branches that don't have worktrees:
 ^ main             <span class=d>^</span><span class=d>⇅</span>                                                                                           <span class=g>⇡1</span>  <span class=d><span class=r>⇣1</span></span>  <span class=g>#</span>     <span class=d>41ee0834</span>
 + fix-auth         <span class=d>↕</span><span class=d>|</span>                <span class=g>↑2</span>  <span class=d><span class=r>↓1</span></span>   <span class=g>+25</span>  <span class=r>-11</span>  Harden auth with constant-time token validation           <span class=d>|</span>     <span class=g>#408</span>  <span class=d>b772e68b</span>
 + <span class=d>fix-typos</span>        <span class=d>_</span><span class=d>|</span>                                                                                             <span class=d>|</span>     <span class=g>#410</span>  <span class=d>41ee0834</span>
-  exp             <span class=d>/</span><span class=d>↕</span>                 <span class=g>↑2</span>  <span class=d><span class=r>↓1</span></span>  <span class=g>+137</span>       Explore GraphQL schema and resolvers                                  <span class=d>96379229</span>
-  wip             <span class=d>/</span><span class=d>↕</span>                 <span class=g>↑1</span>  <span class=d><span class=r>↓1</span></span>   <span class=g>+33</span>       Start API documentation                                               <span class=d>b40716dc</span>
+<span class=d>/ </span>exp             <span class=d>/</span><span class=d>↕</span>                 <span class=g>↑2</span>  <span class=d><span class=r>↓1</span></span>  <span class=g>+137</span>       Explore GraphQL schema and resolvers                                  <span class=d>96379229</span>
+<span class=d>/ </span>wip             <span class=d>/</span><span class=d>↕</span>                 <span class=g>↑1</span>  <span class=d><span class=r>↓1</span></span>   <span class=g>+33</span>       Start API documentation                                               <span class=d>b40716dc</span>
 
 <span class=d>○</span> <span class=d>Showing 4 worktrees, 2 branches, 1 with changes, 4 ahead, 3 columns hidden</span>
 {% end %}
@@ -89,6 +89,18 @@ Output as JSON for scripting:
 | Message | Last commit message (truncated) |
 
 The `main` header label is used regardless of the default branch's actual name.
+
+### Gutter
+
+The leftmost column marks each row by physical presence, from most present to least:
+
+| Symbol | Meaning |
+|--------|---------|
+| `@` | Current worktree |
+| `^` | Primary worktree (the repo's home worktree) |
+| `+` | Other worktree |
+| `/` | Local branch without a worktree (`--branches`) |
+| `\|` | Remote branch, not present locally until fetched (`--remotes`) |
 
 ### CI status
 

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -47,8 +47,8 @@ $ wt list --branches --full
 ^ main             ^⇅                                                                                           ⇡1  ⇣1  #     41ee0834
 + fix-auth         ↕|                ↑2  ↓1   +25  -11  Harden auth with constant-time token validation           |     #408  b772e68b
 + fix-typos        _|                                                                                             |     #410  41ee0834
-  exp             /↕                 ↑2  ↓1  +137       Explore GraphQL schema and resolvers                                  96379229
-  wip             /↕                 ↑1  ↓1   +33       Start API documentation                                               b40716dc
+/ exp             /↕                 ↑2  ↓1  +137       Explore GraphQL schema and resolvers                                  96379229
+/ wip             /↕                 ↑1  ↓1   +33       Start API documentation                                               b40716dc
 
 ○ Showing 4 worktrees, 2 branches, 1 with changes, 4 ahead, 3 columns hidden
 ```
@@ -78,6 +78,18 @@ $ wt list --format=json
 | Message | Last commit message (truncated) |
 
 The `main` header label is used regardless of the default branch's actual name.
+
+### Gutter
+
+The leftmost column marks each row by physical presence, from most present to least:
+
+| Symbol | Meaning |
+|--------|---------|
+| `@` | Current worktree |
+| `^` | Primary worktree (the repo's home worktree) |
+| `+` | Other worktree |
+| `/` | Local branch without a worktree (`--branches`) |
+| `\|` | Remote branch, not present locally until fetched (`--remotes`) |
 
 ### CI status
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -734,8 +734,8 @@ $ wt list --branches --full
 ^ main             ^⇅                                                                                           ⇡1  ⇣1  #     41ee0834
 + fix-auth         ↕|                ↑2  ↓1   +25  -11  Harden auth with constant-time token validation           |     #408  b772e68b
 + fix-typos        _|                                                                                             |     #410  41ee0834
-  exp             /↕                 ↑2  ↓1  +137       Explore GraphQL schema and resolvers                                  96379229
-  wip             /↕                 ↑1  ↓1   +33       Start API documentation                                               b40716dc
+/ exp             /↕                 ↑2  ↓1  +137       Explore GraphQL schema and resolvers                                  96379229
+/ wip             /↕                 ↑1  ↓1   +33       Start API documentation                                               b40716dc
 
 ○ Showing 4 worktrees, 2 branches, 1 with changes, 4 ahead, 3 columns hidden
 ```
@@ -765,6 +765,18 @@ $ wt list --format=json
 | Message | Last commit message (truncated) |
 
 The `main` header label is used regardless of the default branch's actual name.
+
+### Gutter
+
+The leftmost column marks each row by physical presence, from most present to least:
+
+| Symbol | Meaning |
+|--------|---------|
+| `@` | Current worktree |
+| `^` | Primary worktree (the repo's home worktree) |
+| `+` | Other worktree |
+| `/` | Local branch without a worktree (`--branches`) |
+| `\|` | Remote branch, not present locally until fetched (`--remotes`) |
 
 ### CI status
 

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -1075,7 +1075,7 @@ pub fn collect(
     all_items.extend(
         remote_branches
             .iter()
-            .map(|(name, sha)| ListItem::new_branch(sha.clone(), name.clone())),
+            .map(|(name, sha)| ListItem::new_remote_branch(sha.clone(), name.clone())),
     );
 
     // If no URL template configured, add UrlStatus to skip_tasks

--- a/src/commands/list/json_output.rs
+++ b/src/commands/list/json_output.rs
@@ -263,7 +263,10 @@ impl JsonItem {
     ) -> Self {
         let (kind_str, worktree_data) = match &item.kind {
             ItemKind::Worktree(data) => ("worktree", Some(data.as_ref())),
-            ItemKind::Branch => ("branch", None),
+            // Local and remote branch rows both serialize as "branch" — the
+            // remote-qualified `branch` name (e.g. "origin/feature") already
+            // carries the local/remote distinction for JSON consumers.
+            ItemKind::Branch(_) => ("branch", None),
         };
 
         let is_main = worktree_data.is_some_and(|d| d.is_main);

--- a/src/commands/list/model/item.rs
+++ b/src/commands/list/model/item.rs
@@ -726,9 +726,10 @@ mod tests {
 
     #[test]
     fn test_list_item_worktree_data() {
-        // Branch item has no worktree data
-        let item = ListItem::new_branch("abc123".to_string(), "feature".to_string());
+        // Branch items have no worktree data, via either accessor.
+        let mut item = ListItem::new_branch("abc123".to_string(), "feature".to_string());
         assert!(item.worktree_data().is_none());
+        assert!(item.worktree_data_mut().is_none());
         assert!(item.worktree_path().is_none());
     }
 

--- a/src/commands/list/model/item.rs
+++ b/src/commands/list/model/item.rs
@@ -100,7 +100,40 @@ impl WorktreeData {
 #[derive(Clone)]
 pub enum ItemKind {
     Worktree(Box<WorktreeData>),
-    Branch,
+    Branch(BranchScope),
+}
+
+/// Whether a branch-without-worktree row is a local branch
+/// (`refs/heads/…`, checked out nowhere) or a remote-tracking branch
+/// (`refs/remotes/<remote>/…`, not present locally until fetched).
+///
+/// Recorded structurally at construction (the `RemoteBranch` vs
+/// `LocalBranch` inventory is known then) rather than inferred from the
+/// branch name — a local branch may legitimately be named `origin/foo`,
+/// so a name-prefix heuristic would misclassify it.
+///
+/// Drives the gutter sigil: local branches render `/`, remote branches
+/// render `|` — the two branch rungs past the worktree glyphs (`@`/`^`/`+`)
+/// on the gutter's presence/location axis. See `ColumnKind::Gutter` in
+/// `render.rs`.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum BranchScope {
+    /// Local branch with no worktree.
+    Local,
+    /// Remote-tracking branch (needs a fetch to materialize locally).
+    Remote,
+}
+
+impl BranchScope {
+    /// The two-cell gutter sigil (`glyph` + trailing space) for a branch
+    /// row of this scope. ASCII single-width by design — the gutter must
+    /// dodge skim's `width_cjk` clipping (see `vendor/NOTES.md`).
+    pub const fn gutter_sigil(self) -> &'static str {
+        match self {
+            BranchScope::Local => "/ ",
+            BranchScope::Remote => "| ",
+        }
+    }
 }
 
 /// Unified item for displaying worktrees and branches in the same table.
@@ -194,8 +227,17 @@ pub struct ListData {
 }
 
 impl ListItem {
-    /// Create a ListItem for a branch (not a worktree)
+    /// Create a ListItem for a local branch without a worktree.
     pub(crate) fn new_branch(head: String, branch: String) -> Self {
+        Self::new_branch_with_scope(head, branch, BranchScope::Local)
+    }
+
+    /// Create a ListItem for a remote-tracking branch (no local worktree).
+    pub(crate) fn new_remote_branch(head: String, branch: String) -> Self {
+        Self::new_branch_with_scope(head, branch, BranchScope::Remote)
+    }
+
+    fn new_branch_with_scope(head: String, branch: String, scope: BranchScope) -> Self {
         Self {
             head,
             short_sha: String::new(),
@@ -218,7 +260,7 @@ impl ListItem {
             user_marker: None,
             status_symbols: StatusSymbols::default(),
             statusline: None,
-            kind: ItemKind::Branch,
+            kind: ItemKind::Branch(scope),
         }
     }
 
@@ -249,14 +291,14 @@ impl ListItem {
     pub fn worktree_data(&self) -> Option<&WorktreeData> {
         match &self.kind {
             ItemKind::Worktree(data) => Some(data),
-            ItemKind::Branch => None,
+            ItemKind::Branch(_) => None,
         }
     }
 
     pub fn worktree_data_mut(&mut self) -> Option<&mut WorktreeData> {
         match &mut self.kind {
             ItemKind::Worktree(data) => Some(data),
-            ItemKind::Branch => None,
+            ItemKind::Branch(_) => None,
         }
     }
 
@@ -433,7 +475,7 @@ impl ListItem {
         // `worktree_state = Some(Prunable)` by the time this runs.)
         let metadata_state = match &self.kind {
             ItemKind::Worktree(data) => metadata_worktree_state(data),
-            ItemKind::Branch => WorktreeState::Branch,
+            ItemKind::Branch(_) => WorktreeState::Branch,
         };
         if self.status_symbols.worktree_state.is_none() {
             self.status_symbols.worktree_state = Some(metadata_state);
@@ -487,7 +529,7 @@ impl ListItem {
         match &self.kind {
             ItemKind::Worktree(data) => data.working_tree_status,
             // Branches have no working tree; treat as permanently clean.
-            ItemKind::Branch => Some(WorkingTreeStatus::default()),
+            ItemKind::Branch(_) => Some(WorkingTreeStatus::default()),
         }
     }
 
@@ -509,7 +551,7 @@ impl ListItem {
                 }
             }
             // Branches have no operation state; trivially resolved to None.
-            ItemKind::Branch => Some(OperationState::None),
+            ItemKind::Branch(_) => Some(OperationState::None),
         }
     }
 
@@ -541,7 +583,7 @@ impl ListItem {
         // but working tree is clean / N/A" sentinel).
         let has_working_tree_conflicts = match &self.kind {
             ItemKind::Worktree(data) => data.has_working_tree_conflicts,
-            ItemKind::Branch => Some(None),
+            ItemKind::Branch(_) => Some(None),
         };
         match tier_would_conflict(self.has_merge_tree_conflicts, has_working_tree_conflicts) {
             Tier::Fired(s) => return Some(s),
@@ -560,13 +602,13 @@ impl ListItem {
                 Some(diff.is_empty() && !status.untracked)
             }
             // Branches have no working tree; trivially clean.
-            ItemKind::Branch => Some(true),
+            ItemKind::Branch(_) => Some(true),
         };
         let integration = match &self.kind {
             ItemKind::Worktree(data) => {
                 self.check_integration_state(data.is_main, default_branch, is_clean?)
             }
-            ItemKind::Branch => self.check_integration_state(false, default_branch, true),
+            ItemKind::Branch(_) => self.check_integration_state(false, default_branch, true),
         };
 
         match tier_integration_or_counts(self.counts, is_clean, integration) {

--- a/src/commands/list/model/mod.rs
+++ b/src/commands/list/model/mod.rs
@@ -22,7 +22,7 @@ pub mod statusline_segment;
 // via `crate::commands::list::model::...` paths. The allow is needed because
 // rustc doesn't track re-export usage across module boundaries.
 #[allow(unused_imports)]
-pub use item::{ItemKind, ListData, ListItem, WorktreeData};
+pub use item::{BranchScope, ItemKind, ListData, ListItem, WorktreeData};
 #[allow(unused_imports)]
 pub use state::{ActiveGitOperation, Divergence, MainState, OperationState, WorktreeState};
 #[allow(unused_imports)]

--- a/src/commands/list/render.rs
+++ b/src/commands/list/render.rs
@@ -7,7 +7,7 @@ use worktrunk::styling::{Stream, StyledLine, hyperlink_stdout, supports_hyperlin
 use super::collect::parse_port_from_url;
 use super::columns::{ColumnKind, DiffVariant};
 use super::layout::{ColumnFormat, ColumnLayout, DiffColumnConfig, LayoutConfig};
-use super::model::{ListItem, PositionMask};
+use super::model::{ItemKind, ListItem, PositionMask};
 
 /// Placeholder glyph for unresolved Status positions — both "still loading" and
 /// "drain deadline fired, won't arrive."
@@ -275,7 +275,6 @@ impl LayoutConfig {
     /// and a blank gutter placeholder. See [`Self::render_list_item_line`] for `placeholder` semantics.
     pub fn render_skeleton_row(&self, item: &ListItem, placeholder: &str) -> StyledLine {
         let branch = item.branch_name();
-        let wt_data = item.worktree_data();
         let shortened_path = item
             .worktree_path()
             .map(|p| shorten_path(p, &self.main_worktree_path))
@@ -289,16 +288,17 @@ impl LayoutConfig {
 
             match col.kind {
                 ColumnKind::Gutter => {
-                    // Skeleton shows placeholder gutter - actual symbols (including is_previous)
-                    // appear when WorktreeData is populated post-skeleton.
-                    // Uses the current placeholder so the 200ms blank-reveal flow
-                    // keeps the gutter in lockstep with the data columns.
-                    let symbol = if wt_data.is_some() {
-                        format!("{spinner} ") // Placeholder for worktrees
-                    } else {
-                        "  ".to_string() // Branch without worktree (two spaces to match width)
-                    };
-                    cell.push_styled(symbol, dim);
+                    // Worktree gutter symbols (@/^/+, including is_previous)
+                    // resolve when WorktreeData is populated post-skeleton, so
+                    // show the dimmed placeholder — it keeps the 200ms
+                    // blank-reveal flow in lockstep with the data columns.
+                    // Branch scope is known at construction, so its sigil
+                    // (`/`/`|`) renders immediately, dimmed to match the final
+                    // render (and its Status-column twin) — no flash or flicker.
+                    match &item.kind {
+                        ItemKind::Worktree(_) => cell.push_styled(format!("{spinner} "), dim),
+                        ItemKind::Branch(scope) => cell.push_styled(scope.gutter_sigil(), dim),
+                    }
                 }
                 ColumnKind::Branch => {
                     // Show actual branch name (no dim - start normal, gray out later if removable)
@@ -378,20 +378,38 @@ impl ColumnLayout {
 
         match self.kind {
             ColumnKind::Gutter => {
+                // The gutter is a 2-cell presence/location axis. Worktree rows
+                // (`@`/`^`/`+`) are materialized on disk and render bright;
+                // branch rows are refs with no working copy, split by scope
+                // (`/` local, `|` remote) and rendered dim to match those same
+                // glyphs in the Status column (WORKTREE_STATE `/`, upstream `|`
+                // are both dim) — bright worktree vs dim ref reinforces the
+                // presence gradient, glyph still primary. All single-width
+                // ASCII — the gutter must dodge skim's `width_cjk` clipping
+                // (see `vendor/NOTES.md`).
+                //
+                // TODO(pr-rows): PR rows (open PRs with no local branch) land
+                // on a separate branch; add a `#` arm here (and a matching `#`
+                // in the Status upstream column). Not done here — PR rows don't
+                // exist in this branch, and the picker skips CI/PR detection (a
+                // network call), so a `#` driven by PR status would never
+                // render in the picker.
                 let mut cell = StyledLine::new();
-                let symbol = if let Some(data) = worktree_data {
-                    // Priority: @ (current) > ^ (main) > + (regular, including previous)
-                    if data.is_current {
-                        "@ " // Current worktree
-                    } else if data.is_main {
-                        "^ " // Main worktree
-                    } else {
-                        "+ " // Regular worktree (including previous)
+                match &item.kind {
+                    ItemKind::Worktree(data) => {
+                        let symbol = if data.is_current {
+                            "@ " // Current worktree
+                        } else if data.is_main {
+                            "^ " // Main worktree
+                        } else {
+                            "+ " // Regular worktree (including previous)
+                        };
+                        cell.push_raw(symbol);
                     }
-                } else {
-                    "  " // Branch without worktree (two spaces to match width)
-                };
-                cell.push_raw(symbol.to_string());
+                    ItemKind::Branch(scope) => {
+                        cell.push_styled(scope.gutter_sigil(), Style::new().dimmed());
+                    }
+                }
                 cell
             }
             ColumnKind::Branch => {

--- a/tests/snapshots/integration__integration_tests__ci_status__gitea_remote_branch_uses_branch_remote.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitea_remote_branch_uses_branch_remote.snap
@@ -50,7 +50,7 @@ exit_code: 0
 + feature-a                [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
 + feature-b                [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c                [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-  fork/feature-remote     [2m/[22m[2m↑[22m                 [32m↑1[0m        [32m+1[0m                [32m#[0m                         [2m86db681a[0m  [2m1d[0m    [2mfeat: fork feature[0m
+[2m| [0mfork/feature-remote     [2m/[22m[2m↑[22m                 [32m↑1[0m        [32m+1[0m                [32m#[0m                         [2m86db681a[0m  [2m1d[0m    [2mfeat: fork feature[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 remote branches, 4 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -116,8 +116,8 @@ Include branches that don't have worktrees:
 [107m [0m [2m[0m[2m[34m^[0m[2m main             ^⇅                                                                                           ⇡1  ⇣1  #     41ee0834[0m
 [107m [0m [2m[0m[2m[34m+[0m[2m fix-auth         ↕[0m[2m[36m|[0m[2m                [0m[2m[34m↑2[0m[2m  ↓1   +25  [0m[2m[36m-11[0m[2m  Harden auth with constant-time token validation           [0m[2m[36m|[0m[2m     #408  b772e68b[0m
 [107m [0m [2m[0m[2m[34m+[0m[2m fix-typos        _[0m[2m[36m|[0m[2m                                                                                             [0m[2m[36m|[0m[2m     #410  41ee0834[0m
-[107m [0m [2m  [0m[2m[34mexp[0m[2m             /↕                 ↑2  ↓1  +137       Explore GraphQL schema and resolvers                                  96379229[0m
-[107m [0m [2m  [0m[2m[34mwip[0m[2m             /↕                 ↑1  ↓1   +33       Start API documentation                                               b40716dc[0m
+[107m [0m [2m[0m[2m[34m/[0m[2m exp             /↕                 ↑2  ↓1  +137       Explore GraphQL schema and resolvers                                  96379229[0m
+[107m [0m [2m[0m[2m[34m/[0m[2m wip             /↕                 ↑1  ↓1   +33       Start API documentation                                               b40716dc[0m
 [107m [0m [0m
 [107m [0m [2m[0m[2m[34m○[0m[2m Showing 4 worktrees, 2 branches, 1 with changes, 4 ahead, 3 columns hidden[0m
 
@@ -144,6 +144,18 @@ Output as JSON for scripting:
  Message Last commit message (truncated)                                                                     
 
 The [2mmain[0m header label is used regardless of the default branch's actual name.
+
+[32mGutter[0m
+
+The leftmost column marks each row by physical presence, from most present to least:
+
+ Symbol                           Meaning                            
+ ────── ──────────────────────────────────────────────────────────── 
+ [2m@[0m      Current worktree                                             
+ [2m^[0m      Primary worktree (the repo's home worktree)                  
+ [36m+[0m      Other worktree                                               
+ [2m/[0m      Local branch without a worktree ([2m--branches[0m)                 
+ [2m|[0m      Remote branch, not present locally until fetched ([2m--remotes[0m) 
 
 [32mCI status[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -139,9 +139,9 @@ Include branches that don't have worktrees:
 [107m [0m [2mconstant-time token validation           [0m[2m[36m|[0m[2m     #408  b772e68b[0m
 [107m [0m [2m[0m[2m[34m+[0m[2m fix-typos        _[0m[2m[36m|[0m[2m                                                         [0m
 [107m [0m [2m                                    [0m[2m[36m|[0m[2m     #410  41ee0834[0m
-[107m [0m [2m  [0m[2m[34mexp[0m[2m             /↕                 ↑2  ↓1  +137       Explore GraphQL schema[0m
+[107m [0m [2m[0m[2m[34m/[0m[2m exp             /↕                 ↑2  ↓1  +137       Explore GraphQL schema[0m
 [107m [0m [2m and resolvers                                  96379229[0m
-[107m [0m [2m  [0m[2m[34mwip[0m[2m             /↕                 ↑1  ↓1   +33       Start API [0m
+[107m [0m [2m[0m[2m[34m/[0m[2m wip             /↕                 ↑1  ↓1   +33       Start API [0m
 [107m [0m [2mdocumentation                                               b40716dc[0m
 [107m [0m [0m
 [107m [0m [2m[0m[2m[34m○[0m[2m Showing 4 worktrees, 2 branches, 1 with changes, 4 ahead, 3 columns hidden[0m
@@ -171,6 +171,19 @@ Output as JSON for scripting:
  Message Last commit message (truncated)                                        
 
 The [2mmain[0m header label is used regardless of the default branch's actual name.
+
+[32mGutter[0m
+
+The leftmost column marks each row by physical presence, from most present to 
+least:
+
+ Symbol                           Meaning                            
+ ────── ──────────────────────────────────────────────────────────── 
+ [2m@[0m      Current worktree                                             
+ [2m^[0m      Primary worktree (the repo's home worktree)                  
+ [36m+[0m      Other worktree                                               
+ [2m/[0m      Local branch without a worktree ([2m--branches[0m)                 
+ [2m|[0m      Remote branch, not present locally until fetched ([2m--remotes[0m) 
 
 [32mCI status[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_branch_only_with_status.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_branch_only_with_status.snap
@@ -49,7 +49,7 @@ exit_code: 0
 + feature-a        [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
 + feature-b        [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c        [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-  [2mbranch-only[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2mbranch-only[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_handles_orphan_branch.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_handles_orphan_branch.snap
@@ -49,7 +49,7 @@ exit_code: 0
 + feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
 + feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-  assets        [2m/[22m[2m∅[22m                                                     [2m50209039[0m  [2m1d[0m    [2mAdd asset[0m
+[2m/ [0massets        [2m/[22m[2m∅[22m                                                     [2m50209039[0m  [2m1d[0m    [2mAdd asset[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_progressive_with_branches.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_progressive_with_branches.snap
@@ -50,8 +50,8 @@ exit_code: 0
 + feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
 + feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-  [2morphan-1[0m      [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-  [2morphan-2[0m      [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2morphan-1[0m      [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2morphan-2[0m      [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 2 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_with_branches_flag.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_branches_flag.snap
@@ -50,9 +50,9 @@ exit_code: 0
 + feature-b                     [2m↑[22m                 [32m↑1[0m               ../repo.feature-b              [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c                     [2m↑[22m                 [32m↑1[0m               ../repo.feature-c              [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + [2mfeature-with-worktree[0m         [2m_[22m                                  [2m../repo.feature-with-worktree[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-  [2manother-branch[0m               [2m/[22m[2m_[22m                                                                 [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-  [2mfeature-without-worktree[0m     [2m/[22m[2m_[22m                                                                 [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-  [2mfix-bug[0m                      [2m/[22m[2m_[22m                                                                 [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2manother-branch[0m               [2m/[22m[2m_[22m                                                                 [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2mfeature-without-worktree[0m     [2m/[22m[2m_[22m                                                                 [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2mfix-bug[0m                      [2m/[22m[2m_[22m                                                                 [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 5 worktrees, 3 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_with_branches_flag_only_branches.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_branches_flag_only_branches.snap
@@ -49,9 +49,9 @@ exit_code: 0
 + feature-a         [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
 + feature-b         [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c         [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-  [2mbranch-alpha[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-  [2mbranch-beta[0m      [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-  [2mbranch-gamma[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2mbranch-alpha[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2mbranch-beta[0m      [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2mbranch-gamma[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_with_remotes_and_branches.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_remotes_and_branches.snap
@@ -50,10 +50,10 @@ exit_code: 0
 + feature-a                 [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
 + feature-b                 [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c                 [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-  [2mlocal-only-1[0m             [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-  [2mlocal-only-2[0m             [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-  [2morigin/remote-only-1[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-  [2morigin/remote-only-2[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2mlocal-only-1[0m             [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2mlocal-only-2[0m             [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m| [0m[2morigin/remote-only-1[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m| [0m[2morigin/remote-only-2[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 2 branches, 2 remote branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_with_remotes_and_full.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_remotes_and_full.snap
@@ -50,7 +50,7 @@ exit_code: 0
 + feature-a                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
 + feature-b                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-  [2morigin/feature-remote[0m     [2m/[22m[2m_[22m                                                                       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m| [0m[2morigin/feature-remote[0m     [2m/[22m[2m_[22m                                                                       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 remote branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_with_remotes_filters_tracked_branches.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_remotes_filters_tracked_branches.snap
@@ -49,7 +49,7 @@ exit_code: 0
 + feature-a               [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
 + feature-b               [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c               [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-  [2morigin/remote-only[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m| [0m[2morigin/remote-only[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 remote branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_with_remotes_filters_tracked_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_remotes_filters_tracked_worktrees.snap
@@ -50,7 +50,7 @@ exit_code: 0
 + feature-b                  [2m↑[22m                 [32m↑1[0m               ../repo.feature-b              [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c                  [2m↑[22m                 [32m↑1[0m               ../repo.feature-c              [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + [2mfeature-with-worktree[0m      [2m_[22m[2m|[22m                           [2m|[0m     [2m../repo.feature-with-worktree[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-  [2morigin/remote-only[0m        [2m/[22m[2m_[22m                                                                 [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m| [0m[2morigin/remote-only[0m        [2m/[22m[2m_[22m                                                                 [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 5 worktrees, 1 remote branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_with_remotes_flag.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_remotes_flag.snap
@@ -49,8 +49,8 @@ exit_code: 0
 + feature-a                    [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
 + feature-b                    [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c                    [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-  [2morigin/remote-feature-1[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-  [2morigin/remote-feature-2[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m| [0m[2morigin/remote-feature-1[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m| [0m[2morigin/remote-feature-2[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 2 remote branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__readme_example_list_branches.snap
+++ b/tests/snapshots/integration__integration_tests__list__readme_example_list_branches.snap
@@ -50,8 +50,8 @@ exit_code: 0
 ^ main             [2m^[22m[2m⇅[22m                                                                                           [32m⇡1[0m  [2m[31m⇣1[0m  [32m#[0m     [2m41ee0834[0m
 + fix-auth         [2m↕[22m[2m|[22m                [32m↑2[0m  [2m[31m↓1[0m   [32m+25[0m  [31m-11[0m  Harden auth with constant-time token validation           [2m|[0m     [32m#408[0m  [2mb772e68b[0m
 + [2mfix-typos[0m        [2m_[22m[2m|[22m                                                                                             [2m|[0m     [32m#410[0m  [2m41ee0834[0m
-  exp             [2m/[22m[2m↕[22m                 [32m↑2[0m  [2m[31m↓1[0m  [32m+137[0m       Explore GraphQL schema and resolvers                                  [2m96379229[0m
-  wip             [2m/[22m[2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m   [32m+33[0m       Start API documentation                                               [2mb40716dc[0m
+[2m/ [0mexp             [2m/[22m[2m↕[22m                 [32m↑2[0m  [2m[31m↓1[0m  [32m+137[0m       Explore GraphQL schema and resolvers                                  [2m96379229[0m
+[2m/ [0mwip             [2m/[22m[2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m   [32m+33[0m       Start API documentation                                               [2mb40716dc[0m
 
 [2m○[22m [2mShowing 4 worktrees, 2 branches, 1 with changes, 4 ahead, 3 columns hidden[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_branches_enabled.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_branches_enabled.snap
@@ -48,7 +48,7 @@ exit_code: 0
 + feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
 + feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-  [2mfeature[0m       [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_cli_override.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_cli_override.snap
@@ -49,7 +49,7 @@ exit_code: 0
 + feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
 + feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-  [2mfeature[0m       [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_bad_value_preserves_file_config.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_bad_value_preserves_file_config.snap
@@ -49,7 +49,7 @@ exit_code: 0
 + feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
 + feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-  [2mfeature[0m       [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_preserves_file_fields.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_preserves_file_fields.snap
@@ -49,7 +49,7 @@ exit_code: 0
 + feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
 + feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-  [2mfeature[0m       [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_full_and_branches.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_full_and_branches.snap
@@ -48,7 +48,7 @@ exit_code: 0
 + feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-  [2mfeature[0m       [2m/[22m[2m_[22m                                                                       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                                       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__security__literal_escape_like_branch_names_displayed_safely.snap
+++ b/tests/snapshots/integration__integration_tests__security__literal_escape_like_branch_names_displayed_safely.snap
@@ -49,7 +49,7 @@ exit_code: 0
 + feature-a                   [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
 + feature-b                   [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c                   [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-  [2mfix-backslash-x1b-test[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2mfix-backslash-x1b-test[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_with_branches_list.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_with_branches_list.snap
@@ -6,4 +6,4 @@ expression: list
     Branch           Status        HEAD±    main↕  Remote⇅
 > @ main                 ^
   + active-worktree      _
-    orphan-branch       /_
+  / orphan-branch       /_


### PR DESCRIPTION
The interactive `wt switch` picker widens its candidate list with `--branches` (local branches without a worktree) and `--remotes` (remote branches), but the shared list/picker gutter rendered a blank cell for every row without a worktree — so a local-branch-without-worktree and a remote branch looked identical. This adds gutter sigils that distinguish the three row kinds.

## Scheme

The gutter marks each row by physical presence:

```
@ main                 worktree — current     (bright)
^ main-repo            worktree — primary     (bright)
+ feature-x            worktree — other       (bright)
/ local-feature        local branch, no worktree   (dim)
| origin/remote-feat   remote branch               (dim)
```

`@`/`^`/`+` are unchanged. The two new glyphs echo their Status-column twins — `/` is the WORKTREE_STATE "branch" glyph and `|` the in-sync upstream glyph, both already rendered dim — so the gutter reads as a left-edge summary of the row's kind, and bright-worktree / dim-ref reinforces the presence gradient. The glyph is the primary signal (survives `NO_COLOR`); dim is reinforcement only. All glyphs are single-width ASCII, deliberately, to dodge skim's `width_cjk` clipping (see `vendor/NOTES.md`) — the gutter is the worst place for a clipped row.

## Key decisions

Local vs remote is recorded structurally as `ItemKind::Branch(BranchScope)` at construction (`new_branch` / `new_remote_branch`), not inferred from the branch name — a local branch may legitimately be named `origin/foo`, so a name-prefix heuristic would misclassify it. The gutter renders in both the final and skeleton paths with matching dim, so there's no flash or flicker on progressive reveal.

A `#` sigil for PR rows (open PRs with no local branch) is intentionally **not** built here — see `TODO(pr-rows)` in `render.rs`. That row kind lives on a separate branch, and the picker skips CI/PR detection (a network call), so a PR-driven `#` would never render in the picker regardless. The scheme leaves `#` free for it.

## Files

- `src/commands/list/model/item.rs` — `BranchScope` enum, `gutter_sigil()`, `new_remote_branch`.
- `src/commands/list/render.rs` — gutter rendering (final + skeleton).
- `src/commands/list/collect/mod.rs` — remote rows use `new_remote_branch`.
- `src/cli/mod.rs` — new gutter legend in `wt list --help` (the gutter glyphs were previously undocumented); docs/skill mirrors regenerated.

## Testing

Covered by the existing `wt list` / `wt switch` snapshot suite (regenerated under nextest); the rendered-table diffs are confined to the gutter cell. JSON output is unchanged (both branch scopes still serialize as `"branch"`; the remote-qualified name already carries the distinction for scripts).

> _This was written by Claude Code on behalf of max_
