### PR TITLE
refactor(cli): split StatuslineFormat from OutputFormat

### DIFF
--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -286,9 +286,10 @@ Usage: <b><span class=c>wt list</span></b> <span class=c>[OPTIONS]</span>
 
 <b><span class=g>Options:</span></b>
       <b><span class=c>--format</span></b><span class=c> &lt;FORMAT&gt;</span>
-          Output format (table, json)
+          Output format
 
           [default: table]
+          [possible values: table, json]
 
       <b><span class=c>--branches</span></b>
           Include branches without worktrees

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -293,9 +293,10 @@ Commands:
 
 Options:
       --format <FORMAT>
-          Output format (table, json)
+          Output format
 
           [default: table]
+          [possible values: table, json]
 
       --branches
           Include branches without worktrees

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -696,8 +696,8 @@ Every category that `wt config state clear` sweeps is shown here.
 
 CI cache entries show status, age, and the commit SHA they were fetched for."#)]
     Get {
-        /// Output format (table, json)
-        #[arg(long, value_enum, default_value = "table", hide_possible_values = true)]
+        /// Output format
+        #[arg(long, value_enum, default_value = "table")]
         format: super::OutputFormat,
     },
 

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -1,6 +1,6 @@
 use clap::Subcommand;
 
-use super::OutputFormat;
+use super::StatuslineFormat;
 
 /// Subcommands for `wt list`
 #[derive(Subcommand)]
@@ -27,7 +27,7 @@ The pace segment appears only when usage is likely to hit a rate limit before it
     Statusline {
         /// Output format
         #[arg(long, value_enum, default_value = "table")]
-        format: OutputFormat,
+        format: StatuslineFormat,
 
         /// Deprecated: use --format=claude-code
         #[arg(long, hide = true)]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -183,10 +183,16 @@ pub(crate) enum SwitchFormat {
     Json,
 }
 
-// TODO: ClaudeCode is statusline-specific but lives in this shared enum, forcing
-// unrelated codepaths to handle it. Consider a dedicated StatuslineFormat enum.
+/// Output format for `wt list` and `wt config state get` (table or JSON).
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]
 pub(crate) enum OutputFormat {
+    Table,
+    Json,
+}
+
+/// Output format for `wt list statusline`, including the Claude Code mode.
+#[derive(Debug, Clone, Copy, clap::ValueEnum)]
+pub(crate) enum StatuslineFormat {
     Table,
     Json,
     /// Claude Code statusline mode (reads context from stdin)
@@ -390,8 +396,8 @@ pub(crate) struct ListArgs {
     #[command(subcommand)]
     pub(crate) subcommand: Option<ListSubcommand>,
 
-    /// Output format (table, json)
-    #[arg(long, value_enum, default_value = "table", hide_possible_values = true)]
+    /// Output format
+    #[arg(long, value_enum, default_value = "table")]
     pub(crate) format: OutputFormat,
 
     /// Include branches without worktrees

--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -1178,7 +1178,7 @@ pub fn handle_state_show(format: OutputFormat) -> anyhow::Result<()> {
 
     match format {
         OutputFormat::Json => handle_state_show_json(&repo),
-        OutputFormat::Table | OutputFormat::ClaudeCode => handle_state_show_table(&repo),
+        OutputFormat::Table => handle_state_show_table(&repo),
     }
 }
 

--- a/src/commands/list/progressive.rs
+++ b/src/commands/list/progressive.rs
@@ -24,7 +24,7 @@ impl RenderTarget {
     pub fn detect(format: OutputFormat, progressive_flag: Option<bool>) -> Self {
         match format {
             OutputFormat::Json => RenderTarget::Json,
-            OutputFormat::Table | OutputFormat::ClaudeCode => {
+            OutputFormat::Table => {
                 let is_tty = std::io::stdout().is_terminal();
                 let progressive = match progressive_flag {
                     Some(p) => p && is_tty,

--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -21,7 +21,7 @@ use worktrunk::styling::{
 };
 
 use super::list::{self, CollectOptions, StatuslineSegment, json_output};
-use crate::cli::OutputFormat;
+use crate::cli::StatuslineFormat;
 
 /// Claude Code context parsed from stdin JSON
 struct ClaudeCodeContext {
@@ -561,17 +561,17 @@ fn format_context_gauge(percentage: f64) -> String {
 ///
 /// Output uses `println!` for raw stdout (bypasses anstream color detection).
 /// Shell prompts (PS1) and Claude Code always expect ANSI codes.
-pub fn run(format: OutputFormat) -> Result<()> {
+pub fn run(format: StatuslineFormat) -> Result<()> {
     // Statusline runs on every prompt redraw — deprecation warnings on stderr
     // would appear above each prompt.
     worktrunk::config::suppress_warnings();
 
     // JSON format: output current worktree as JSON
-    if matches!(format, OutputFormat::Json) {
+    if matches!(format, StatuslineFormat::Json) {
         return run_json();
     }
 
-    let claude_code = matches!(format, OutputFormat::ClaudeCode);
+    let claude_code = matches!(format, StatuslineFormat::ClaudeCode);
 
     // Get context - either from stdin (claude-code mode) or current directory
     let (cwd, model_name, context_used_percentage, rate_limits) = if claude_code {

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,7 +33,7 @@ pub(crate) use invocation::{
     binary_name, invocation_path, is_git_subcommand, was_invoked_with_explicit_path,
 };
 
-pub(crate) use crate::cli::OutputFormat;
+pub(crate) use crate::cli::{OutputFormat, StatuslineFormat};
 
 use commands::commit::HookGate;
 #[cfg(unix)]
@@ -646,8 +646,8 @@ fn handle_list_command(args: ListArgs) -> anyhow::Result<()> {
             }
             // Hidden --claude-code flag only applies when format is default (Table)
             // Explicit --format=json takes precedence over --claude-code
-            let effective_format = if claude_code && matches!(format, OutputFormat::Table) {
-                OutputFormat::ClaudeCode
+            let effective_format = if claude_code && matches!(format, StatuslineFormat::Table) {
+                StatuslineFormat::ClaudeCode
             } else {
                 format
             };

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_get.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_get.snap
@@ -40,9 +40,10 @@ Usage: [1m[36mwt config state get[0m [36m[OPTIONS][0m
 
 [1m[32mOptions:[0m
       [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m
-          Output format (table, json)
+          Output format
           
           [default: table]
+          [possible values: table, json]
 
   [1m[36m-h[0m, [1m[36m--help[0m
           Print help (see a summary with '-h')

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -42,9 +42,10 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
 
 [1m[32mOptions:[0m
       [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m
-          Output format (table, json)
+          Output format
           
           [default: table]
+          [possible values: table, json]
 
       [1m[36m--branches[0m
           Include branches without worktrees

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -42,9 +42,10 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
 
 [1m[32mOptions:[0m
       [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m
-          Output format (table, json)
+          Output format
           
           [default: table]
+          [possible values: table, json]
 
       [1m[36m--branches[0m
           Include branches without worktrees

--- a/tests/snapshots/integration__integration_tests__help__help_list_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_short.snap
@@ -41,7 +41,7 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
   [1m[36mstatusline[0m  Single-line status for shell prompts
 
 [1m[32mOptions:[0m
-      [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m  Output format (table, json) [default: table]
+      [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m  Output format [default: table] [possible values: table, json]
       [1m[36m--branches[0m         Include branches without worktrees
       [1m[36m--remotes[0m          Include remote branches
       [1m[36m--full[0m             Show CI, diff analysis, and LLM summaries


### PR DESCRIPTION
## Summary

`OutputFormat` carried a `claude-code` variant that only `wt list statusline` uses. That forced two unrelated commands to work around it: `wt list` and `wt config state get` set `hide_possible_values = true` and hand-maintained an `Output format (table, json)` doc string to keep `claude-code` out of their help, and their match arms carried a dead `ClaudeCode` branch.

This splits the shared enum (removing the long-standing TODO that called for it):

- **`OutputFormat { Table, Json }`** — `wt list`, `wt config state get`
- **`StatuslineFormat { Table, Json, ClaudeCode }`** — `wt list statusline` only

With `claude-code` gone from `OutputFormat`, both commands drop `hide_possible_values` and the parenthetical, and clap renders the value list itself:

```
--format <FORMAT>  Output format [default: table] [possible values: table, json]
```

`wt list statusline` is unchanged (`[possible values: table, json, claude-code]`; `--help` keeps the expanded block with the `claude-code` description).

## Behavior change (CLI flag)

This tightens parsing on two flags. Previously `wt list --format=claude-code` and `wt config state get --format=claude-code` were silently accepted and treated as `table`; they now fail fast:

```
error: invalid value 'claude-code' for '--format <FORMAT>'
  [possible values: table, json]
```

The value was hidden, undocumented, and meaningless on those commands (only `statusline` ever used it), so this is a fail-fast improvement rather than a meaningful break.

## Testing

- `cargo run -- hook pre-merge --yes` — clippy, all pre-commit hooks, 3951 tests, doctests: green
- `test_docs_are_in_sync` regenerated `list.md` mirrors; 4 help snapshots updated

> _This was written by Claude Code on behalf of max_
