### PR TITLE
fix(switch): show correct worktree path in bare repo hidden-dir warning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /target
+.idea/
 docs/static/assets/
 docs/demos/out/
 

--- a/src/commands/worktree/resolve.rs
+++ b/src/commands/worktree/resolve.rs
@@ -228,23 +228,29 @@ pub fn offer_bare_repo_worktree_path_fix(
         return Ok(false);
     }
 
-    // Display names for messages
+    // Display names for messages. `display_path` is the parent directory shown
+    // in the "Set worktree-path for …" success message. `bare_repo_display` is
+    // the repo itself, used in the warning ("Bare repo at …").
     let display_path = repo_path
         .parent()
         .map(|p| format_path_for_display(p).to_string())
         .unwrap_or_else(|| format_path_for_display(repo_path).to_string());
-    let parent_name = repo_path
-        .parent()
-        .and_then(|p| p.file_name())
-        .and_then(|n| n.to_str())
-        .unwrap_or("project");
+    let bare_repo_display = format!("{display_path}/{repo_name}");
 
     // Use the actual branch being switched to in example paths. Calling
     // `sanitize_branch_name` keeps the displayed example aligned with what
     // the `sanitize` Jinja filter applies inside `BARE_REPO_WORKTREE_PATH`.
     let sanitized = worktrunk::config::sanitize_branch_name(branch);
-    let example_bad = format!("{parent_name}/{repo_name}.{sanitized}");
-    let example_good = format!("{parent_name}/{sanitized}");
+
+    // The correct path is repo_path/../<sanitized-branch>: one level up from
+    // the bare-repo directory so worktrees sit as siblings (e.g. project/main
+    // rather than project/.git.main). This is both shown in the warning and
+    // offered as the destination in the prompt.
+    let good_path = repo_path
+        .parent()
+        .map(|p| p.join(&sanitized))
+        .unwrap_or_else(|| repo_path.join(&sanitized));
+    let example_good = format_path_for_display(&good_path).to_string();
 
     let config_path_display = worktrunk::config::config_path()
         .map(|p| format_path_for_display(&p).to_string())
@@ -255,7 +261,7 @@ pub fn offer_bare_repo_worktree_path_fix(
         eprintln!(
             "{}",
             warning_message(cformat!(
-                "Bare repo at <bold>{parent_name}/{repo_name}</> — worktrees will be at <bold>{example_bad}</>"
+                "Bare repo at <bold>{bare_repo_display}</> — worktrees will be at <bold>{example_good}</>"
             ))
         );
         eprintln!(
@@ -274,7 +280,7 @@ pub fn offer_bare_repo_worktree_path_fix(
     eprintln!(
         "{}",
         warning_message(cformat!(
-            "Bare repo at <bold>{parent_name}/{repo_name}</> — worktrees will be at <bold>{example_bad}</>"
+            "Bare repo at <bold>{bare_repo_display}</> — worktrees will be at <bold>{example_good}</>"
         ))
     );
 

--- a/src/commands/worktree/resolve.rs
+++ b/src/commands/worktree/resolve.rs
@@ -242,15 +242,23 @@ pub fn offer_bare_repo_worktree_path_fix(
     // the `sanitize` Jinja filter applies inside `BARE_REPO_WORKTREE_PATH`.
     let sanitized = worktrunk::config::sanitize_branch_name(branch);
 
-    // The correct path is repo_path/../<sanitized-branch>: one level up from
-    // the bare-repo directory so worktrees sit as siblings (e.g. project/main
-    // rather than project/.git.main). This is both shown in the warning and
-    // offered as the destination in the prompt.
+    // The fixed destination — repo_path/../<sanitized-branch>, one level up
+    // from the bare-repo dir so worktrees sit as siblings (project/feature
+    // rather than project/.git.feature). Offered in the hint and prompt.
     let good_path = repo_path
         .parent()
         .map(|p| p.join(&sanitized))
         .unwrap_or_else(|| repo_path.join(&sanitized));
     let example_good = format_path_for_display(&good_path).to_string();
+
+    // Where worktrees actually land *without* the fix, under the default
+    // `{{ repo }}.{{ branch }}` template — shown in the warning so it matches
+    // the "Created … @ …" line below instead of contradicting it.
+    let bad_path = repo_path
+        .parent()
+        .map(|p| p.join(format!("{repo_name}.{sanitized}")))
+        .unwrap_or_else(|| repo_path.join(format!("{repo_name}.{sanitized}")));
+    let example_bad = format_path_for_display(&bad_path).to_string();
 
     let config_path_display = worktrunk::config::config_path()
         .map(|p| format_path_for_display(&p).to_string())
@@ -261,7 +269,7 @@ pub fn offer_bare_repo_worktree_path_fix(
         eprintln!(
             "{}",
             warning_message(cformat!(
-                "Bare repo at <bold>{bare_repo_display}</> — worktrees will be at <bold>{example_good}</>"
+                "Bare repo at <bold>{bare_repo_display}</> — worktrees will be at <bold>{example_bad}</>"
             ))
         );
         eprintln!(
@@ -280,7 +288,7 @@ pub fn offer_bare_repo_worktree_path_fix(
     eprintln!(
         "{}",
         warning_message(cformat!(
-            "Bare repo at <bold>{bare_repo_display}</> — worktrees will be at <bold>{example_good}</>"
+            "Bare repo at <bold>{bare_repo_display}</> — worktrees will be at <bold>{example_bad}</>"
         ))
     );
 

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_prompt_pty__bare_repo_prompt_accept.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_prompt_pty__bare_repo_prompt_accept.snap
@@ -2,7 +2,7 @@
 source: tests/integration_tests/bare_repository.rs
 expression: "&output"
 ---
-[33m▲[39m [33mBare repo at [1m[TEMP]/project/.git[22m — worktrees will be at [1m[TEMP]/project/feature[22m[39m
+[33m▲[39m [33mBare repo at [1m[TEMP]/project/.git[22m — worktrees will be at [1m[TEMP]/project/.git.feature[22m[39m
 
 [36m❯[39m Configure worktree-path to place worktrees at [1m[TEMP]/project/feature[22m? [1m[y/N/?][22m y
 [32m✓[39m [32mSet [1mworktree-path[22m for [1m[TEMP]/project[22m:[39m

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_prompt_pty__bare_repo_prompt_accept.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_prompt_pty__bare_repo_prompt_accept.snap
@@ -2,9 +2,9 @@
 source: tests/integration_tests/bare_repository.rs
 expression: "&output"
 ---
-[33m▲[39m [33mBare repo at [1mproject/.git[22m — worktrees will be at [1mproject/.git.feature[22m[39m
+[33m▲[39m [33mBare repo at [1m[TEMP]/project/.git[22m — worktrees will be at [1m[TEMP]/project/feature[22m[39m
 
-[36m❯[39m Configure worktree-path to place worktrees at [1mproject/feature[22m? [1m[y/N/?][22m y
+[36m❯[39m Configure worktree-path to place worktrees at [1m[TEMP]/project/feature[22m? [1m[y/N/?][22m y
 [32m✓[39m [32mSet [1mworktree-path[22m for [1m[TEMP]/project[22m:[39m
 [107m [0m [2mworktree-path = [0m[2m[32m"{{ repo_path }}/../{{ branch | sanitize }}"[0m
 [2m↳[22m [2mTo set globally, add to [4m[TEMP]/test-config.toml[24m[22m

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_prompt_pty__bare_repo_prompt_decline.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_prompt_pty__bare_repo_prompt_decline.snap
@@ -2,7 +2,7 @@
 source: tests/integration_tests/bare_repository.rs
 expression: "&output"
 ---
-[33m▲[39m [33mBare repo at [1m[TEMP]/project/.git[22m — worktrees will be at [1m[TEMP]/project/feature[22m[39m
+[33m▲[39m [33mBare repo at [1m[TEMP]/project/.git[22m — worktrees will be at [1m[TEMP]/project/.git.feature[22m[39m
 
 [36m❯[39m Configure worktree-path to place worktrees at [1m[TEMP]/project/feature[22m? [1m[y/N/?][22m n
 [32m✓[39m [32mCreated branch [1mfeature[22m and worktree @ [1m[TEMP]/project/.git.feature[22m[39m

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_prompt_pty__bare_repo_prompt_decline.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_prompt_pty__bare_repo_prompt_decline.snap
@@ -2,9 +2,9 @@
 source: tests/integration_tests/bare_repository.rs
 expression: "&output"
 ---
-[33m▲[39m [33mBare repo at [1mproject/.git[22m — worktrees will be at [1mproject/.git.feature[22m[39m
+[33m▲[39m [33mBare repo at [1m[TEMP]/project/.git[22m — worktrees will be at [1m[TEMP]/project/feature[22m[39m
 
-[36m❯[39m Configure worktree-path to place worktrees at [1mproject/feature[22m? [1m[y/N/?][22m n
+[36m❯[39m Configure worktree-path to place worktrees at [1m[TEMP]/project/feature[22m? [1m[y/N/?][22m n
 [32m✓[39m [32mCreated branch [1mfeature[22m and worktree @ [1m[TEMP]/project/.git.feature[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_prompt_pty__bare_repo_prompt_preview.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_prompt_pty__bare_repo_prompt_preview.snap
@@ -2,7 +2,7 @@
 source: tests/integration_tests/bare_repository.rs
 expression: "&output"
 ---
-[33m▲[39m [33mBare repo at [1m[TEMP]/project/.git[22m — worktrees will be at [1m[TEMP]/project/feature[22m[39m
+[33m▲[39m [33mBare repo at [1m[TEMP]/project/.git[22m — worktrees will be at [1m[TEMP]/project/.git.feature[22m[39m
 
 [36m❯[39m Configure worktree-path to place worktrees at [1m[TEMP]/project/feature[22m? [1m[y/N/?][22m ?
 [2m○[22m Would add to [1m[TEMP]/test-config.toml[22m:

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_prompt_pty__bare_repo_prompt_preview.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_prompt_pty__bare_repo_prompt_preview.snap
@@ -2,14 +2,14 @@
 source: tests/integration_tests/bare_repository.rs
 expression: "&output"
 ---
-[33m▲[39m [33mBare repo at [1mproject/.git[22m — worktrees will be at [1mproject/.git.feature[22m[39m
+[33m▲[39m [33mBare repo at [1m[TEMP]/project/.git[22m — worktrees will be at [1m[TEMP]/project/feature[22m[39m
 
-[36m❯[39m Configure worktree-path to place worktrees at [1mproject/feature[22m? [1m[y/N/?][22m ?
+[36m❯[39m Configure worktree-path to place worktrees at [1m[TEMP]/project/feature[22m? [1m[y/N/?][22m ?
 [2m○[22m Would add to [1m[TEMP]/test-config.toml[22m:
 [107m [0m [2m[36m[projects."[TEMP]/project/.git"][0m
 [107m [0m [2mworktree-path = [0m[2m[32m"{{ repo_path }}/../{{ branch | sanitize }}"[0m
 
-[36m❯[39m Configure worktree-path to place worktrees at [1mproject/feature[22m? [1m[y/N/?][22m n
+[36m❯[39m Configure worktree-path to place worktrees at [1m[TEMP]/project/feature[22m? [1m[y/N/?][22m n
 [32m✓[39m [32mCreated branch [1mfeature[22m and worktree @ [1m[TEMP]/project/.git.feature[22m[39m
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_worktree_path_prompt_auto_accept.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_worktree_path_prompt_auto_accept.snap
@@ -42,7 +42,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-▲ Bare repo at [TEMP]/project/.git — worktrees will be at [TEMP]/project/feature
+▲ Bare repo at [TEMP]/project/.git — worktrees will be at [TEMP]/project/.git.feature
 ↳ To place worktrees at [TEMP]/project/feature, add to [TEMP]/test-config.toml:
   [projects."[TEMP]/project/.git"]
   worktree-path = "{{ repo_path }}/../{{ branch | sanitize }}"

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_worktree_path_prompt_auto_accept.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_worktree_path_prompt_auto_accept.snap
@@ -42,8 +42,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-▲ Bare repo at project/.git — worktrees will be at project/.git.feature
-↳ To place worktrees at project/feature, add to [TEMP]/test-config.toml:
+▲ Bare repo at [TEMP]/project/.git — worktrees will be at [TEMP]/project/feature
+↳ To place worktrees at [TEMP]/project/feature, add to [TEMP]/test-config.toml:
   [projects."[TEMP]/project/.git"]
   worktree-path = "{{ repo_path }}/../{{ branch | sanitize }}"
 ✓ Created branch feature and worktree @ [TEMP]/project/.git.feature

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_worktree_path_prompt_non_interactive_warning.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_worktree_path_prompt_non_interactive_warning.snap
@@ -41,7 +41,7 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-▲ Bare repo at [TEMP]/project/.git — worktrees will be at [TEMP]/project/feature
+▲ Bare repo at [TEMP]/project/.git — worktrees will be at [TEMP]/project/.git.feature
 ↳ To place worktrees at [TEMP]/project/feature, add to [TEMP]/test-config.toml:
   [projects."[TEMP]/project/.git"]
   worktree-path = "{{ repo_path }}/../{{ branch | sanitize }}"

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_worktree_path_prompt_non_interactive_warning.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_worktree_path_prompt_non_interactive_warning.snap
@@ -41,8 +41,8 @@ exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-▲ Bare repo at project/.git — worktrees will be at project/.git.feature
-↳ To place worktrees at project/feature, add to [TEMP]/test-config.toml:
+▲ Bare repo at [TEMP]/project/.git — worktrees will be at [TEMP]/project/feature
+↳ To place worktrees at [TEMP]/project/feature, add to [TEMP]/test-config.toml:
   [projects."[TEMP]/project/.git"]
   worktree-path = "{{ repo_path }}/../{{ branch | sanitize }}"
 ✓ Created branch feature and worktree @ [TEMP]/project/.git.feature


### PR DESCRIPTION
## Summary

The net change over `main` is that the warning's paths now render in **full `~/…` form** instead of just their last two components — so the warning matches the `Created … @ …` success line below it. The which-path-goes-where semantics are unchanged from `main`:

- **Warning** (`worktrees will be at …`) shows the **hidden-dir destination** (`~/…/project/.git.feature`) — where worktrees actually land *without* the fix, matching the `Created @ …` line.
- **Hint / prompt** (`To place worktrees at …`) shows the **fixed sibling path** (`~/…/project/feature`) the config override would produce.
- Both lines, and "Bare repo at", now route through `format_path_for_display` for consistent full-path rendering.
- `example_bad` (the hidden-dir destination) and `example_good` (the sibling path) are both still computed — `example_bad` feeds the warning, `example_good` the hint/prompt.
- Also adds `.idea/` to `.gitignore` for RustRover (unrelated to the fix).

> Note: an earlier commit briefly flipped "worktrees will be at" to the *good* sibling path, but it was reverted in review (`fix(switch): warning shows current bad path, prompt shows fixed good path`) because it contradicted the `Created @ …/.git.feature` line on the decline / `--yes` / non-interactive paths. Net-zero on that axis; only the full-path rendering survives.

## Before / After

**Before (`main`):**
```
▲ Bare repo at project/.git — worktrees will be at project/.git.feature
↳ To place worktrees at project/feature, add to test-config.toml:
✓ Created branch feature and worktree @ [TEMP]/project/.git.feature
```

**After (this PR):**
```
▲ Bare repo at [TEMP]/project/.git — worktrees will be at [TEMP]/project/.git.feature
↳ To place worktrees at [TEMP]/project/feature, add to [TEMP]/test-config.toml:
✓ Created branch feature and worktree @ [TEMP]/project/.git.feature
```

(`[TEMP]` is the test harness substituting `$TMPDIR`; for a real user this renders as `~/…`. The warning and the `Created @ …` line now show the same full path.)

## Test plan

- [x] `cargo insta test --accept --test integration --features shell-integration-tests` — regenerates all five snapshots, including the three `shell-integration-tests` PTY ones
- [x] `cargo test --test integration bare_repo` — all bare-repo tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
