### PR TITLE
docs: wrap command-only terminal blocks; fix blank-line prompts

### DIFF
--- a/docs/sass/custom.scss
+++ b/docs/sass/custom.scss
@@ -574,6 +574,14 @@ main {
     }
 }
 
+// Command-only terminals (recipe lists with no fixed-width output) wrap long
+// pipelines at spaces instead of scrolling them out of view; a single
+// unbreakable token still falls back to the inherited horizontal scroll.
+// Fixed-width output (tables, ASCII art) keeps the default no-wrap.
+.terminal--commands code {
+    white-space: pre-wrap;
+}
+
 // ============================================================================
 // Blockquotes / Callouts
 // ============================================================================

--- a/docs/templates/shortcodes/terminal.html
+++ b/docs/templates/shortcodes/terminal.html
@@ -3,12 +3,18 @@
 {% set cmd_lines = cmd | split(pat="|||") %}
 {% if body is defined %}
 {% set clean_body = body | regex_replace(pattern='<span class="cmd">[^<]*</span>\n?', rep="") %}
+{% set extra_class = "" %}
 {% else %}
 {% set clean_body = "" %}
+{% set extra_class = " terminal--commands" %}
 {% endif %}
-<pre class="terminal"><code>
+<pre class="terminal{{ extra_class }}"><code>
 {%- for cmd_line in cmd_lines -%}
 {%- set cmd_line = cmd_line | replace(from="__WT_OPEN__", to="{{") | replace(from="__WT_CLOSE__", to="}}") | replace(from="__WT_QUOT__", to='"') -%}
+{%- if cmd_line | trim == "" -%}
+{{ "
+" }}
+{%- else -%}
 {%- set md = fence ~ "bash
 " ~ cmd_line ~ "
 " ~ fence -%}
@@ -19,6 +25,7 @@
 {% else -%}
 <span class="cmd">{{ hl | safe }}</span>
 {% endif -%}
+{%- endif -%}
 {%- endfor -%}
 {{ clean_body | safe }}</code></pre>
 {% else %}


### PR DESCRIPTION
The `wt list` JSON-output section (and every command-recipe block on the docs site) rendered badly: the blank lines between recipes showed as stray bare `$` prompts, and long `jq` pipelines overflowed the block's right edge — scrolling out of view behind macOS's hidden overlay scrollbar, so the tail of a command was simply invisible.

The recipe content in `src/cli/mod.rs` is clean Markdown; the defects were entirely in the docs rendering layer, so the fix lives there and leaves the auto-generated pages and the CLI source untouched.

- `docs/templates/shortcodes/terminal.html` — empty `|||` segments now emit a real blank line instead of a `$ ` prompt, and command-only blocks (no fixed-width output body) get a `terminal--commands` class.
- `docs/sass/custom.scss` — `.terminal--commands code { white-space: pre-wrap }` wraps long pipelines at spaces, falling back to horizontal scroll only for a single unbreakable token. Fixed-width tables and ASCII output are untagged and keep their existing no-wrap + horizontal-scroll behavior.

Verified against a local Zola build on `/list/` and `/tips-patterns/`: command blocks wrap with 0px overflow, show no stray prompts, and keep their group spacing; the three `wt list` tables are unaffected. No `white-space` override exists in the narrow-width media queries, so wrapping holds on mobile.

> _This was written by Claude Code on behalf of max_
