### PR TITLE
test(fsmonitor): reap orphaned sleep grandchild in SIGKILL escalation test

### DIFF
--- a/src/git/fsmonitor.rs
+++ b/src/git/fsmonitor.rs
@@ -734,6 +734,7 @@ mod tests {
     #[cfg(unix)]
     #[test]
     fn nix_signaller_escalates_to_sigkill_when_sigterm_ignored() {
+        use std::os::unix::process::CommandExt;
         use std::process::Command;
         use std::time::Duration;
 
@@ -741,6 +742,12 @@ mod tests {
         // child touches `ready` *after* the trap is installed; the test waits
         // for that file so the first SIGTERM can't race trap installation
         // (which would let the child die on SIGTERM and report signal 15).
+        //
+        // The trap also forces the shell to fork a separate `sleep` child
+        // rather than exec it, so the tree is sh → sleep. `process_group(0)`
+        // makes sh a group leader (the `sleep` inherits its group) so the
+        // orphaned grandchild can be reaped after sh is killed — see the group
+        // SIGKILL below.
         let tmp = tempfile::tempdir().unwrap();
         let ready = tmp.path().join("ready");
         let mut child = Command::new("sh")
@@ -749,6 +756,7 @@ mod tests {
                 "trap '' TERM; : > {}; sleep 30",
                 ready.to_str().unwrap()
             ))
+            .process_group(0)
             .spawn()
             .unwrap();
         let pid = child.id();
@@ -766,6 +774,17 @@ mod tests {
         // tests already cover that the production `REAP_KILL_DEADLINE` value
         // flows through unchanged.
         escalate_terminate(&NixSignaller, &[pid], Duration::from_millis(200));
+
+        // `escalate_terminate` SIGKILLs only sh's pid, orphaning the forked
+        // `sleep` grandchild — reparented to init, it would linger ~30s holding
+        // this test's inherited stdout/stderr, which nextest reports as a leak.
+        // sh leads its own process group, so SIGKILL the whole group (negative
+        // pid) to reap the grandchild before the test returns. sh is already a
+        // zombie here, so this only reaches the `sleep`.
+        let _ = nix::sys::signal::kill(
+            nix::unistd::Pid::from_raw(-(pid as i32)),
+            nix::sys::signal::Signal::SIGKILL,
+        );
 
         // Must have been SIGKILLed despite ignoring SIGTERM.
         use std::os::unix::process::ExitStatusExt;


### PR DESCRIPTION
`nix_signaller_escalates_to_sigkill_when_sigterm_ignored` is the one test nextest flagged as leaky in the suite (`4002 passed (1 leaky)`).

It spawns `sh -c "trap '' TERM; ...; sleep 30"` to model a process that ignores SIGTERM. The `TERM` trap stops the shell from exec-replacing itself with the final command, so it forks a separate `sleep` child. The test SIGKILL'd only the `sh` pid, orphaning that `sleep` grandchild (reparented to init), which kept the test's inherited stdout/stderr open for ~30s, past nextest's 100ms `leak-timeout`. It's a test-only artifact: production `escalate_terminate` targets a real `git fsmonitor--daemon`, which has no forked grandchild.

The fix spawns `sh` as its own process-group leader (`process_group(0)`) and SIGKILLs the whole group after killing it, reaping the grandchild before the test returns.

After the change the suite reports `4002 passed, 0 leaky`, the test leaves no stray `sleep` across repeated runs, and it runs faster (0.23s vs 0.44s) since it no longer waits out the leak window.

> _This was written by Claude Code on behalf of max_
