### PR TITLE
test(step_alias): reap orphaned sleep in external-signal alias tests

### DIFF
--- a/tests/integration_tests/step_alias.rs
+++ b/tests/integration_tests/step_alias.rs
@@ -1288,6 +1288,13 @@ trapped = "trap 'echo got-term >> trap.log; exit 143' TERM; echo started >> star
 
     let status = child.wait().expect("failed to wait for wt");
 
+    // wt forwarded SIGTERM to the wrapper sh by PID (the contract this test
+    // pins), so the trap's `exit` orphaned the backgrounded `sleep 30` in wt's
+    // process group. wt led that group (`process_group(0)` above) and is now
+    // reaped, so SIGKILL the whole group (negative pgid) to reap the sleep
+    // before returning — otherwise it lingers ~30s as a stray process.
+    let _ = kill(Pid::from_raw(-wt_pid.as_raw()), Signal::SIGKILL);
+
     // The trap marker proves the alias shell received SIGTERM. Without the
     // PID-targeted forwarding, this file would never appear and wt would
     // block on the 30s sleep.
@@ -1351,6 +1358,13 @@ trapped = "trap 'echo got-int >> trap.log; exit 130' INT; echo started >> start.
     kill(wt_pid, Signal::SIGINT).expect("failed to send SIGINT to wt");
 
     let status = child.wait().expect("failed to wait for wt");
+
+    // wt forwarded SIGINT to the wrapper sh by PID (the contract this test
+    // pins), so the trap's `exit` orphaned the backgrounded `sleep 30` in wt's
+    // process group. wt led that group (`process_group(0)` above) and is now
+    // reaped, so SIGKILL the whole group (negative pgid) to reap the sleep
+    // before returning — otherwise it lingers ~30s as a stray process.
+    let _ = kill(Pid::from_raw(-wt_pid.as_raw()), Signal::SIGKILL);
 
     let trap_marker = repo.root_path().join("trap.log");
     let recorded = std::fs::read_to_string(&trap_marker).unwrap_or_else(|e| {


### PR DESCRIPTION
The two `#[cfg(unix)]` external-signal alias tests (`test_alias_external_sigterm_reaches_child`, `test_alias_external_sigint_reaches_child`) run an alias body of `... sleep 30 & wait $!` and deliver a PID-targeted signal to wt. wt forwards it to the wrapper `sh` by PID — the contract these tests pin — so the trap's `exit` tears down the shell and leaves the backgrounded `sleep 30` orphaned in wt's process group, lingering ~30s. Two tests, one orphan each, accounted for the two stray `sleep 30` processes a full suite run left behind (invisible to nextest's leak detector because their stdio is redirected to null).

This is a test artifact, not a product bug: wt faithfully reproduces plain-shell semantics, where a trap that `exit`s without `kill $!` orphans its background job. The fix reaps the orphan after `child.wait()` with a negative-pgid SIGKILL — wt ran in its own process group (`process_group(0)`) and is reaped before the kill, so the SIGKILL reaches only the leftover sleep. Same pattern as the fsmonitor SIGKILL-escalation test fix in #3135.

Verified: targeted runs 5/5 leave 0 strays (was 2/2); full suite (`--features shell-integration-tests`) 4002 passed with 0 strays at +0s and +5s; clippy and pre-commit clean.

> _This was written by Claude Code on behalf of max_
