### PR TITLE
perf(copy): skip redundant chmod after reflink on macOS

### DIFF
--- a/src/copy.rs
+++ b/src/copy.rs
@@ -80,15 +80,20 @@ pub fn copy_leaf(
     } else {
         match reflink_copy::reflink_or_copy(src, dest) {
             Ok(_) => {
-                // Preserve file permissions (especially the execute bit).
+                // Preserve file permissions (especially the execute bit) —
+                // needed on Linux, skipped on macOS.
                 //
                 // On btrfs/XFS, reflink (FICLONE ioctl) clones data extents
                 // only — the destination gets umask-based permissions, losing
                 // execute bits. std::fs::copy's fallback preserves permissions
                 // via fchmod, creating an asymmetry in reflink_or_copy.
                 //
+                // On macOS/APFS, clonefile() already preserves the source's
+                // mode bits, so this chmod is redundant — skip it to save a
+                // syscall per file.
+                //
                 // Refs: ioctl_ficlonerange(2), LWN Articles/331808
-                #[cfg(unix)]
+                #[cfg(all(unix, not(target_os = "macos")))]
                 {
                     fs::set_permissions(dest, src_meta.permissions())
                         .context("setting destination file permissions")?;


### PR DESCRIPTION
On macOS/APFS, `clonefile()` already preserves the source's mode bits, so the `set_permissions` call right after a successful `reflink_or_copy` in `copy_leaf` is redundant. This gates that chmod to non-macOS unix (`#[cfg(all(unix, not(target_os = "macos")))]`), matching the idiom already used in `src/priority.rs`.

Linux still needs it: on btrfs/XFS, `FICLONE` clones data extents only and drops the execute bit, while `std::fs::copy`'s fallback preserves permissions via `fchmod` — so the chmod restores the asymmetry. The fallback path is unchanged and still preserves permissions on every platform. The change drops one chmod syscall per file on macOS for the `copy-ignored` step and every other `copy.rs` caller; the `symlink_metadata` read stays (it feeds symlink detection and the byte count).

Verified on macOS/APFS: the exec-bit preservation test from #1936 (`test_copy_ignored_preserves_file_executable_permissions`) still passes with the chmod skipped, empirically confirming `clonefile` preserves `0o755` and `0o644`. The full `step_copy_ignored` suite (50 tests) and `copy` unit tests pass; `cargo clippy --all-targets` is clean.

> _This was written by Claude Code on behalf of max_
