### PR TITLE
fix(test): run --source error test non-interactively to prevent a PTY wedge

### DIFF
--- a/tests/common/pty.rs
+++ b/tests/common/pty.rs
@@ -19,28 +19,9 @@ use std::path::Path;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 
-/// Exit code returned when a PTY child is killed for overrunning its wedge
-/// timeout (see [`wait_for_child_or_kill`]). Nonzero, mirroring coreutils
-/// `timeout`. Callers that re-run on a wedge key off this value.
-pub const PTY_WEDGE_EXIT_CODE: i32 = 124;
-
 /// Read output from PTY and wait for child exit.
 ///
-/// On Unix, completion is detected **causally** by polling the child shell for
-/// exit, *not* by reading the master to EOF. The naive "read to EOF, then
-/// `wait()`" shape deadlocks the run when the session-leader shell fails to
-/// terminate — e.g. a job-control SIGTTOU race under parallel load can leave it
-/// stopped (`T`). Because that shell owns the slave's controlling terminal, the
-/// kernel never revokes the tty, the master never sees EOF, and *both*
-/// `read_to_string` and `wait()` block until the test harness's 180s timeout
-/// kills the run. (Conversely, once the shell *does* exit, BSD/macOS revokes the
-/// tty and the master EOFs even if an orphaned grandchild still holds a slave
-/// fd — so a lingering child can't starve the read.)
-///
-/// So: drain the master on a background thread, treat the shell's exit as the
-/// done signal (bounded by a generous fallback that kills a wedged shell so the
-/// run ends in seconds, not minutes), then drain any trailing in-flight output.
-///
+/// On Unix, this simply reads to EOF then waits for child.
 /// On Windows ConPTY, special handling is required because:
 /// - The output pipe doesn't close when child exits (owned by pseudoconsole)
 /// - ConPTY may send cursor position requests (ESC[6n) that must be answered
@@ -52,14 +33,17 @@ pub fn read_pty_output(
     writer: Box<dyn Write + Send>,
     master: Box<dyn MasterPty + Send>,
     child: &mut Box<dyn portable_pty::Child + Send + Sync>,
-    wedge_timeout: std::time::Duration,
 ) -> (String, i32) {
     #[cfg(unix)]
     {
         let _ = master; // Not needed on Unix
         // Drop writer to signal EOF to child's stdin (important for Unix PTYs)
         drop(writer);
-        drain_pty_until_child_exit(reader, child, wedge_timeout)
+        let mut reader = reader;
+        let mut buf = String::new();
+        reader.read_to_string(&mut buf).unwrap();
+        let exit_status = child.wait().unwrap();
+        (buf, exit_status.exit_code() as i32)
     }
 
     #[cfg(windows)]
@@ -68,10 +52,6 @@ pub fn read_pty_output(
         use std::sync::{Arc, mpsc};
         use std::thread;
         use std::time::Duration;
-
-        // ConPTY drains differently (the output pipe outlives the child), so the
-        // Unix wedge bound doesn't apply here.
-        let _ = wedge_timeout;
 
         // Flag to signal the reader to stop
         let should_stop = Arc::new(AtomicBool::new(false));
@@ -184,111 +164,6 @@ pub fn read_pty_output(
 
         (buf, exit_code)
     }
-}
-
-/// Wait for a PTY child to exit, using its exit as the completion signal and
-/// bounding the wait so a wedged shell can't hang the run.
-///
-/// The normal path resolves in milliseconds. `wedge_timeout` only bounds a shell
-/// that never exits on its own — a job-control race under parallel load can
-/// leave the session-leader shell stopped (`T`), which `try_wait()` reports as
-/// not-yet-exited forever. On overrun the child is killed (`portable_pty`'s
-/// `kill` escalates to `SIGKILL`, which reaps even a stopped process) and `124`
-/// is returned, mirroring coreutils `timeout`. A read error yields `-1`.
-///
-/// Shared by both PTY readers ([`read_pty_output`] via [`drain_pty_until_child_exit`]
-/// and [`prompted_pty_interaction`]) and by interactive helpers that drive the
-/// shell directly, so none can block on a non-terminating child.
-pub fn wait_for_child_or_kill(
-    child: &mut Box<dyn portable_pty::Child + Send + Sync>,
-    wedge_timeout: std::time::Duration,
-) -> i32 {
-    let deadline = std::time::Instant::now() + wedge_timeout;
-    loop {
-        match child.try_wait() {
-            Ok(Some(status)) => return status.exit_code() as i32,
-            Ok(None) => {}
-            Err(_) => return -1,
-        }
-        if std::time::Instant::now() >= deadline {
-            let _ = child.kill();
-            let _ = child.wait();
-            return PTY_WEDGE_EXIT_CODE;
-        }
-        std::thread::sleep(std::time::Duration::from_millis(5));
-    }
-}
-
-/// Drain remaining PTY output from `rx` after the child has exited, bounded so a
-/// lingering slave-holder can't block us.
-///
-/// The reader thread drops its `tx` when it hits EOF, surfacing as
-/// `Disconnected` once all output is delivered — the common case on BSD/macOS,
-/// where the kernel revokes the tty when the session leader exits (so the master
-/// EOFs even if an orphaned grandchild still holds a slave fd). On Linux the tty
-/// isn't revoked, so a grandchild holding the slave keeps the reader blocked
-/// past EOF; the command's own output is already buffered and collected here in
-/// milliseconds, and `ceiling` caps the wait for the EOF that won't come (the
-/// reader thread is then left to exit when the process does).
-fn drain_remaining(rx: &mpsc::Receiver<Vec<u8>>, out: &mut Vec<u8>, ceiling: std::time::Duration) {
-    let deadline = std::time::Instant::now() + ceiling;
-    loop {
-        match rx.recv_timeout(std::time::Duration::from_millis(50)) {
-            Ok(data) => out.extend_from_slice(&data),
-            // Reader hit EOF and dropped `tx`: all output captured.
-            Err(mpsc::RecvTimeoutError::Disconnected) => break,
-            Err(mpsc::RecvTimeoutError::Timeout) => {
-                if std::time::Instant::now() >= deadline {
-                    break;
-                }
-            }
-        }
-    }
-}
-
-/// Drain a Unix PTY master, using the child shell's exit — not master EOF — as
-/// the completion signal.
-///
-/// `reader` is the master read end; `child` is the session-leader shell. The
-/// reader runs on a background thread accumulating output into a channel;
-/// completion is detected causally via [`wait_for_child_or_kill`], then
-/// [`drain_remaining`] collects any trailing in-flight output.
-///
-/// See [`read_pty_output`] for the full rationale. Exposed (rather than inlined)
-/// so the wedge-recovery path can be exercised with a short timeout in tests
-/// without waiting out the production safety net.
-#[cfg(unix)]
-pub fn drain_pty_until_child_exit(
-    reader: Box<dyn Read + Send>,
-    child: &mut Box<dyn portable_pty::Child + Send + Sync>,
-    wedge_timeout: std::time::Duration,
-) -> (String, i32) {
-    // Drain the master on a background thread. Dropping `tx` when the reader
-    // hits EOF/error signals that all output has been delivered.
-    let (tx, rx) = mpsc::channel::<Vec<u8>>();
-    std::thread::spawn(move || {
-        let mut reader = reader;
-        let mut chunk = [0u8; 4096];
-        loop {
-            match reader.read(&mut chunk) {
-                Ok(0) => break,
-                Ok(n) => {
-                    if tx.send(chunk[..n].to_vec()).is_err() {
-                        break;
-                    }
-                }
-                Err(_) => break,
-            }
-        }
-    });
-
-    let exit_code = wait_for_child_or_kill(child, wedge_timeout);
-
-    let mut output = Vec::new();
-    drain_remaining(&rx, &mut output, std::time::Duration::from_secs(5));
-
-    let buf = String::from_utf8_lossy(&output).to_string();
-    (buf, exit_code)
 }
 
 /// Find cursor position request (ESC[6n) in a byte slice.
@@ -415,15 +290,7 @@ pub fn exec_cmd_in_pty(cmd: CommandBuilder, input: &str) -> (String, i32) {
         writer.flush().unwrap();
     }
 
-    // Non-interactive command (no `-i` job control), so it doesn't hit the
-    // interactive-shell startup wedge; a generous bound is fine.
-    let (buf, exit_code) = read_pty_output(
-        reader,
-        writer,
-        pair.master,
-        &mut child,
-        std::time::Duration::from_secs(60),
-    );
+    let (buf, exit_code) = read_pty_output(reader, writer, pair.master, &mut child);
     let normalized = buf.replace("\r\n", "\n");
 
     (normalized, exit_code)
@@ -468,7 +335,7 @@ fn prompted_pty_interaction(
     let (tx, rx) = mpsc::channel::<Vec<u8>>();
 
     // Read PTY output in background, sending chunks via channel
-    let _reader_thread = std::thread::spawn(move || {
+    let reader_thread = std::thread::spawn(move || {
         let mut reader = reader;
         let mut buf = [0u8; 4096];
         loop {
@@ -552,18 +419,21 @@ fn prompted_pty_interaction(
     // By waiting for the child first, the slave side closes and the echo
     // from the Drop's \n goes to a dead PTY — no artifact.
     //
-    // The child won't hang on stdin: after read_line() returns for all prompts,
-    // it continues executing without reading. The wait is bounded so a
-    // job-control-wedged shell that never exits can't hang the run either (see
-    // wait_for_child_or_kill / read_pty_output).
-    let exit_code = wait_for_child_or_kill(child, Duration::from_secs(60));
+    // The child won't hang: after read_line() returns for all prompts, it
+    // continues executing without reading stdin. EOF isn't needed.
+    let exit_status = child.wait().unwrap();
+    let exit_code = exit_status.exit_code() as i32;
 
     // Now safe to drop writer (child already exited, slave side closed)
     drop(writer);
 
-    // Collect any remaining output (the reader EOFs now that the child is gone),
-    // bounded so we can't block here even if the master never EOFs.
-    drain_remaining(&rx, &mut accumulated, Duration::from_secs(5));
+    // Wait for reader thread to finish
+    let _ = reader_thread.join();
+
+    // Drain any remaining chunks
+    while let Ok(chunk) = rx.try_recv() {
+        accumulated.extend_from_slice(&chunk);
+    }
 
     let buf = String::from_utf8_lossy(&accumulated).to_string();
     let normalized = buf.replace("\r\n", "\n");

--- a/tests/common/pty.rs
+++ b/tests/common/pty.rs
@@ -21,7 +21,21 @@ use std::sync::{Arc, Mutex};
 
 /// Read output from PTY and wait for child exit.
 ///
-/// On Unix, this simply reads to EOF then waits for child.
+/// On Unix, completion is detected **causally** by polling the child shell for
+/// exit, *not* by reading the master to EOF. The naive "read to EOF, then
+/// `wait()`" shape deadlocks the run when the session-leader shell fails to
+/// terminate — e.g. a job-control SIGTTOU race under parallel load can leave it
+/// stopped (`T`). Because that shell owns the slave's controlling terminal, the
+/// kernel never revokes the tty, the master never sees EOF, and *both*
+/// `read_to_string` and `wait()` block until the test harness's 180s timeout
+/// kills the run. (Conversely, once the shell *does* exit, BSD/macOS revokes the
+/// tty and the master EOFs even if an orphaned grandchild still holds a slave
+/// fd — so a lingering child can't starve the read.)
+///
+/// So: drain the master on a background thread, treat the shell's exit as the
+/// done signal (bounded by a generous fallback that kills a wedged shell so the
+/// run ends in seconds, not minutes), then drain any trailing in-flight output.
+///
 /// On Windows ConPTY, special handling is required because:
 /// - The output pipe doesn't close when child exits (owned by pseudoconsole)
 /// - ConPTY may send cursor position requests (ESC[6n) that must be answered
@@ -39,11 +53,10 @@ pub fn read_pty_output(
         let _ = master; // Not needed on Unix
         // Drop writer to signal EOF to child's stdin (important for Unix PTYs)
         drop(writer);
-        let mut reader = reader;
-        let mut buf = String::new();
-        reader.read_to_string(&mut buf).unwrap();
-        let exit_status = child.wait().unwrap();
-        (buf, exit_status.exit_code() as i32)
+        // 60s is a generous safety net: the causal path (child exit) resolves in
+        // milliseconds, so this only bounds a genuinely wedged shell, and stays
+        // well under the test harness's 180s slow-timeout.
+        drain_pty_until_child_exit(reader, child, std::time::Duration::from_secs(60))
     }
 
     #[cfg(windows)]
@@ -164,6 +177,111 @@ pub fn read_pty_output(
 
         (buf, exit_code)
     }
+}
+
+/// Wait for a PTY child to exit, using its exit as the completion signal and
+/// bounding the wait so a wedged shell can't hang the run.
+///
+/// The normal path resolves in milliseconds. `wedge_timeout` only bounds a shell
+/// that never exits on its own — a job-control race under parallel load can
+/// leave the session-leader shell stopped (`T`), which `try_wait()` reports as
+/// not-yet-exited forever. On overrun the child is killed (`portable_pty`'s
+/// `kill` escalates to `SIGKILL`, which reaps even a stopped process) and `124`
+/// is returned, mirroring coreutils `timeout`. A read error yields `-1`.
+///
+/// Shared by both PTY readers ([`read_pty_output`] via [`drain_pty_until_child_exit`]
+/// and [`prompted_pty_interaction`]) so neither can block on a non-terminating
+/// child.
+fn wait_for_child_or_kill(
+    child: &mut Box<dyn portable_pty::Child + Send + Sync>,
+    wedge_timeout: std::time::Duration,
+) -> i32 {
+    let deadline = std::time::Instant::now() + wedge_timeout;
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => return status.exit_code() as i32,
+            Ok(None) => {}
+            Err(_) => return -1,
+        }
+        if std::time::Instant::now() >= deadline {
+            let _ = child.kill();
+            let _ = child.wait();
+            return 124; // timeout marker (nonzero, like coreutils `timeout`)
+        }
+        std::thread::sleep(std::time::Duration::from_millis(5));
+    }
+}
+
+/// Drain remaining PTY output from `rx` after the child has exited, bounded so a
+/// lingering slave-holder can't block us.
+///
+/// The reader thread drops its `tx` when it hits EOF, surfacing as
+/// `Disconnected` once all output is delivered — the common case on BSD/macOS,
+/// where the kernel revokes the tty when the session leader exits (so the master
+/// EOFs even if an orphaned grandchild still holds a slave fd). On Linux the tty
+/// isn't revoked, so a grandchild holding the slave keeps the reader blocked
+/// past EOF; the command's own output is already buffered and collected here in
+/// milliseconds, and `ceiling` caps the wait for the EOF that won't come (the
+/// reader thread is then left to exit when the process does).
+fn drain_remaining(rx: &mpsc::Receiver<Vec<u8>>, out: &mut Vec<u8>, ceiling: std::time::Duration) {
+    let deadline = std::time::Instant::now() + ceiling;
+    loop {
+        match rx.recv_timeout(std::time::Duration::from_millis(50)) {
+            Ok(data) => out.extend_from_slice(&data),
+            // Reader hit EOF and dropped `tx`: all output captured.
+            Err(mpsc::RecvTimeoutError::Disconnected) => break,
+            Err(mpsc::RecvTimeoutError::Timeout) => {
+                if std::time::Instant::now() >= deadline {
+                    break;
+                }
+            }
+        }
+    }
+}
+
+/// Drain a Unix PTY master, using the child shell's exit — not master EOF — as
+/// the completion signal.
+///
+/// `reader` is the master read end; `child` is the session-leader shell. The
+/// reader runs on a background thread accumulating output into a channel;
+/// completion is detected causally via [`wait_for_child_or_kill`], then
+/// [`drain_remaining`] collects any trailing in-flight output.
+///
+/// See [`read_pty_output`] for the full rationale. Exposed (rather than inlined)
+/// so the wedge-recovery path can be exercised with a short timeout in tests
+/// without waiting out the production safety net.
+#[cfg(unix)]
+pub fn drain_pty_until_child_exit(
+    reader: Box<dyn Read + Send>,
+    child: &mut Box<dyn portable_pty::Child + Send + Sync>,
+    wedge_timeout: std::time::Duration,
+) -> (String, i32) {
+    // Drain the master on a background thread. Dropping `tx` when the reader
+    // hits EOF/error signals that all output has been delivered.
+    let (tx, rx) = mpsc::channel::<Vec<u8>>();
+    std::thread::spawn(move || {
+        let mut reader = reader;
+        let mut chunk = [0u8; 4096];
+        loop {
+            match reader.read(&mut chunk) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if tx.send(chunk[..n].to_vec()).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
+
+    let exit_code = wait_for_child_or_kill(child, wedge_timeout);
+
+    let mut output = Vec::new();
+    drain_remaining(&rx, &mut output, std::time::Duration::from_secs(5));
+
+    let buf = String::from_utf8_lossy(&output).to_string();
+    (buf, exit_code)
 }
 
 /// Find cursor position request (ESC[6n) in a byte slice.
@@ -335,7 +453,7 @@ fn prompted_pty_interaction(
     let (tx, rx) = mpsc::channel::<Vec<u8>>();
 
     // Read PTY output in background, sending chunks via channel
-    let reader_thread = std::thread::spawn(move || {
+    let _reader_thread = std::thread::spawn(move || {
         let mut reader = reader;
         let mut buf = [0u8; 4096];
         loop {
@@ -419,21 +537,18 @@ fn prompted_pty_interaction(
     // By waiting for the child first, the slave side closes and the echo
     // from the Drop's \n goes to a dead PTY — no artifact.
     //
-    // The child won't hang: after read_line() returns for all prompts, it
-    // continues executing without reading stdin. EOF isn't needed.
-    let exit_status = child.wait().unwrap();
-    let exit_code = exit_status.exit_code() as i32;
+    // The child won't hang on stdin: after read_line() returns for all prompts,
+    // it continues executing without reading. The wait is bounded so a
+    // job-control-wedged shell that never exits can't hang the run either (see
+    // wait_for_child_or_kill / read_pty_output).
+    let exit_code = wait_for_child_or_kill(child, Duration::from_secs(60));
 
     // Now safe to drop writer (child already exited, slave side closed)
     drop(writer);
 
-    // Wait for reader thread to finish
-    let _ = reader_thread.join();
-
-    // Drain any remaining chunks
-    while let Ok(chunk) = rx.try_recv() {
-        accumulated.extend_from_slice(&chunk);
-    }
+    // Collect any remaining output (the reader EOFs now that the child is gone),
+    // bounded so we can't block here even if the master never EOFs.
+    drain_remaining(&rx, &mut accumulated, Duration::from_secs(5));
 
     let buf = String::from_utf8_lossy(&accumulated).to_string();
     let normalized = buf.replace("\r\n", "\n");

--- a/tests/common/pty.rs
+++ b/tests/common/pty.rs
@@ -19,6 +19,11 @@ use std::path::Path;
 use std::sync::mpsc;
 use std::sync::{Arc, Mutex};
 
+/// Exit code returned when a PTY child is killed for overrunning its wedge
+/// timeout (see [`wait_for_child_or_kill`]). Nonzero, mirroring coreutils
+/// `timeout`. Callers that re-run on a wedge key off this value.
+pub const PTY_WEDGE_EXIT_CODE: i32 = 124;
+
 /// Read output from PTY and wait for child exit.
 ///
 /// On Unix, completion is detected **causally** by polling the child shell for
@@ -47,16 +52,14 @@ pub fn read_pty_output(
     writer: Box<dyn Write + Send>,
     master: Box<dyn MasterPty + Send>,
     child: &mut Box<dyn portable_pty::Child + Send + Sync>,
+    wedge_timeout: std::time::Duration,
 ) -> (String, i32) {
     #[cfg(unix)]
     {
         let _ = master; // Not needed on Unix
         // Drop writer to signal EOF to child's stdin (important for Unix PTYs)
         drop(writer);
-        // 60s is a generous safety net: the causal path (child exit) resolves in
-        // milliseconds, so this only bounds a genuinely wedged shell, and stays
-        // well under the test harness's 180s slow-timeout.
-        drain_pty_until_child_exit(reader, child, std::time::Duration::from_secs(60))
+        drain_pty_until_child_exit(reader, child, wedge_timeout)
     }
 
     #[cfg(windows)]
@@ -65,6 +68,10 @@ pub fn read_pty_output(
         use std::sync::{Arc, mpsc};
         use std::thread;
         use std::time::Duration;
+
+        // ConPTY drains differently (the output pipe outlives the child), so the
+        // Unix wedge bound doesn't apply here.
+        let _ = wedge_timeout;
 
         // Flag to signal the reader to stop
         let should_stop = Arc::new(AtomicBool::new(false));
@@ -206,7 +213,7 @@ fn wait_for_child_or_kill(
         if std::time::Instant::now() >= deadline {
             let _ = child.kill();
             let _ = child.wait();
-            return 124; // timeout marker (nonzero, like coreutils `timeout`)
+            return PTY_WEDGE_EXIT_CODE;
         }
         std::thread::sleep(std::time::Duration::from_millis(5));
     }
@@ -408,7 +415,15 @@ pub fn exec_cmd_in_pty(cmd: CommandBuilder, input: &str) -> (String, i32) {
         writer.flush().unwrap();
     }
 
-    let (buf, exit_code) = read_pty_output(reader, writer, pair.master, &mut child);
+    // Non-interactive command (no `-i` job control), so it doesn't hit the
+    // interactive-shell startup wedge; a generous bound is fine.
+    let (buf, exit_code) = read_pty_output(
+        reader,
+        writer,
+        pair.master,
+        &mut child,
+        std::time::Duration::from_secs(60),
+    );
     let normalized = buf.replace("\r\n", "\n");
 
     (normalized, exit_code)

--- a/tests/common/pty.rs
+++ b/tests/common/pty.rs
@@ -197,9 +197,9 @@ pub fn read_pty_output(
 /// is returned, mirroring coreutils `timeout`. A read error yields `-1`.
 ///
 /// Shared by both PTY readers ([`read_pty_output`] via [`drain_pty_until_child_exit`]
-/// and [`prompted_pty_interaction`]) so neither can block on a non-terminating
-/// child.
-fn wait_for_child_or_kill(
+/// and [`prompted_pty_interaction`]) and by interactive helpers that drive the
+/// shell directly, so none can block on a non-terminating child.
+pub fn wait_for_child_or_kill(
     child: &mut Box<dyn portable_pty::Child + Send + Sync>,
     wedge_timeout: std::time::Duration,
 ) -> i32 {

--- a/tests/integration_tests/shell_wrapper.rs
+++ b/tests/integration_tests/shell_wrapper.rs
@@ -640,8 +640,11 @@ fn exec_bash_truly_interactive(
         buf
     });
 
-    // Wait for bash to exit
-    let status = child.wait().unwrap();
+    // Wait for bash to exit, bounded so a job-control-wedged shell can't hang
+    // the run (see wait_for_child_or_kill / read_pty_output). Once the child is
+    // gone the tty is revoked and the reader thread EOFs, so the join below
+    // completes without blocking.
+    let exit_code = crate::common::pty::wait_for_child_or_kill(&mut child, Duration::from_secs(60));
 
     // Get the captured output
     let buf = reader_thread.join().unwrap();
@@ -649,7 +652,7 @@ fn exec_bash_truly_interactive(
     // Normalize CRLF to LF (same as exec_in_pty_interactive)
     let normalized = buf.replace("\r\n", "\n");
 
-    (normalized, status.exit_code() as i32)
+    (normalized, exit_code)
 }
 
 /// Execute a command through a shell wrapper

--- a/tests/integration_tests/shell_wrapper.rs
+++ b/tests/integration_tests/shell_wrapper.rs
@@ -332,6 +332,16 @@ fn build_shell_script(shell: &str, repo: &TestRepo, subcommand: &str, args: &[&s
 /// );
 /// // The output will show: "Allow? [y/N] y"
 /// ```
+///
+/// Retries on a startup wedge: a `bash -i`/`zsh -i` interactive shell can lose a
+/// job-control race at startup under heavy parallel load and never run the
+/// script — it wedges (stopped `T`) producing no output and never exiting, which
+/// `read_pty_output` bounds with a kill and reports as exit `124`. That was the
+/// flake behind `test_source_flag_forwards_errors` (it timed out at 180s before
+/// the read was bounded, and would still fail on empty output after). Because
+/// nothing ran, re-running is safe; a fresh attempt almost always starts
+/// cleanly. This is the feedback path the harness was missing — detect the wedge
+/// (the bounded kill) and recover (re-run), rather than hang or fail.
 #[cfg(test)]
 fn exec_in_pty_interactive(
     shell: &str,
@@ -340,8 +350,52 @@ fn exec_in_pty_interactive(
     env_vars: &[(&str, &str)],
     inputs: &[&str],
 ) -> (String, i32) {
+    // A wedge is rare; 3 attempts make a run that wedges every time astronomically
+    // unlikely, and each attempt is bounded (the 30s in `_once`), so the worst
+    // case stays well under the harness's 180s slow-timeout.
+    retry_pty_on_wedge(3, || {
+        exec_in_pty_interactive_once(shell, script, working_dir, env_vars, inputs)
+    })
+}
+
+/// Re-run a PTY interaction while it reports a startup wedge — exit code
+/// `PTY_WEDGE_EXIT_CODE`, which `read_pty_output` returns after killing a shell
+/// that never exited — up to `max_attempts` times. None of these interactive
+/// tests legitimately run long enough to hit the wedge bound, so that exit code
+/// means the shell never ran (a job-control startup race), and re-running is
+/// safe. Returns the first non-wedged result, or the last wedged one if every
+/// attempt wedges.
+#[cfg(test)]
+fn retry_pty_on_wedge(
+    max_attempts: usize,
+    mut attempt: impl FnMut() -> (String, i32),
+) -> (String, i32) {
+    let mut result = (String::new(), 0);
+    for n in 1..=max_attempts {
+        result = attempt();
+        if result.1 != crate::common::pty::PTY_WEDGE_EXIT_CODE {
+            return result;
+        }
+        eprintln!("pty interactive shell wedged at startup (attempt {n}/{max_attempts})");
+    }
+    result
+}
+
+#[cfg(test)]
+fn exec_in_pty_interactive_once(
+    shell: &str,
+    script: &str,
+    working_dir: &std::path::Path,
+    env_vars: &[(&str, &str)],
+    inputs: &[&str],
+) -> (String, i32) {
     use portable_pty::CommandBuilder;
     use std::io::Write;
+
+    // Bound each attempt's wait for the shell to exit. The normal path resolves
+    // in milliseconds; this only fires on a wedge, and is short enough that the
+    // 3-attempt retry above stays under the harness timeout.
+    let wedge_timeout = std::time::Duration::from_secs(30);
 
     let pair = crate::common::open_pty();
 
@@ -419,6 +473,13 @@ fn exec_in_pty_interactive(
             cmd.arg(script);
         }
         "bash" => {
+            // Isolate from user rc files (parallels the zsh arm). Besides
+            // hermeticity, sourcing the host ~/.bashrc under an interactive
+            // shell is a plausible startup-hang source — and bash is the arm
+            // that flakes, since it was the only interactive shell here NOT
+            // isolating its rc files.
+            cmd.arg("--norc");
+            cmd.arg("--noprofile");
             cmd.arg("-i");
             cmd.arg("-c");
             cmd.arg(script);
@@ -473,7 +534,7 @@ fn exec_in_pty_interactive(
     // Read output and wait for exit using platform-aware handling
     // On Windows ConPTY, this handles cursor queries and proper pipe closure
     let (buf, exit_code) =
-        crate::common::pty::read_pty_output(reader, writer, pair.master, &mut child);
+        crate::common::pty::read_pty_output(reader, writer, pair.master, &mut child, wedge_timeout);
 
     // Normalize CRLF to LF (PTYs use CRLF on some platforms)
     let normalized = buf.replace("\r\n", "\n");
@@ -1712,9 +1773,49 @@ approved-commands = ["echo 'fish background task'"]
             "output emitted before the wedge should be captured.\nOutput:\n{output}"
         );
         assert_eq!(
-            exit_code, 124,
-            "a killed wedged shell should report the timeout exit code"
+            exit_code,
+            crate::common::pty::PTY_WEDGE_EXIT_CODE,
+            "a killed wedged shell should report the wedge exit code"
         );
+    }
+
+    /// `exec_in_pty_interactive` recovers from a startup wedge by re-running.
+    /// `test_pty_read_recovers_from_wedged_shell` covers the building block (a
+    /// wedged shell is bounded and reported as `PTY_WEDGE_EXIT_CODE`); this pins
+    /// the retry contract on top of it without paying a real 30s wedge: succeed
+    /// immediately on a clean result, retry past a wedge, and give up after the
+    /// cap returning the last result.
+    #[test]
+    fn test_retry_pty_on_wedge() {
+        let wedge = crate::common::pty::PTY_WEDGE_EXIT_CODE;
+
+        // Clean result on the first try → no retry.
+        let mut calls = 0;
+        let r = retry_pty_on_wedge(3, || {
+            calls += 1;
+            ("ok".to_string(), 0)
+        });
+        assert_eq!((r, calls), (("ok".to_string(), 0), 1));
+
+        // Wedge once, then recover → returns the recovered result.
+        let mut calls = 0;
+        let r = retry_pty_on_wedge(3, || {
+            calls += 1;
+            if calls == 1 {
+                (String::new(), wedge)
+            } else {
+                ("recovered".to_string(), 0)
+            }
+        });
+        assert_eq!((r, calls), (("recovered".to_string(), 0), 2));
+
+        // Wedge every time → gives up after the cap, returning the last result.
+        let mut calls = 0;
+        let r = retry_pty_on_wedge(3, || {
+            calls += 1;
+            (format!("try{calls}"), wedge)
+        });
+        assert_eq!((r, calls), (("try3".to_string(), wedge), 3));
     }
 
     // ========================================================================
@@ -3773,8 +3874,13 @@ mod windows_tests {
         let reader = pair.master.try_clone_reader().unwrap();
         let writer = pair.master.take_writer().unwrap();
 
-        let (output, exit_code) =
-            crate::common::pty::read_pty_output(reader, writer, pair.master, &mut child);
+        let (output, exit_code) = crate::common::pty::read_pty_output(
+            reader,
+            writer,
+            pair.master,
+            &mut child,
+            std::time::Duration::from_secs(60),
+        );
 
         let normalized = output.replace("\r\n", "\n");
 

--- a/tests/integration_tests/shell_wrapper.rs
+++ b/tests/integration_tests/shell_wrapper.rs
@@ -332,16 +332,6 @@ fn build_shell_script(shell: &str, repo: &TestRepo, subcommand: &str, args: &[&s
 /// );
 /// // The output will show: "Allow? [y/N] y"
 /// ```
-///
-/// Retries on a startup wedge: a `bash -i`/`zsh -i` interactive shell can lose a
-/// job-control race at startup under heavy parallel load and never run the
-/// script — it wedges (stopped `T`) producing no output and never exiting, which
-/// `read_pty_output` bounds with a kill and reports as exit `124`. That was the
-/// flake behind `test_source_flag_forwards_errors` (it timed out at 180s before
-/// the read was bounded, and would still fail on empty output after). Because
-/// nothing ran, re-running is safe; a fresh attempt almost always starts
-/// cleanly. This is the feedback path the harness was missing — detect the wedge
-/// (the bounded kill) and recover (re-run), rather than hang or fail.
 #[cfg(test)]
 fn exec_in_pty_interactive(
     shell: &str,
@@ -350,52 +340,31 @@ fn exec_in_pty_interactive(
     env_vars: &[(&str, &str)],
     inputs: &[&str],
 ) -> (String, i32) {
-    // A wedge is rare; 3 attempts make a run that wedges every time astronomically
-    // unlikely, and each attempt is bounded (the 30s in `_once`), so the worst
-    // case stays well under the harness's 180s slow-timeout.
-    retry_pty_on_wedge(3, || {
-        exec_in_pty_interactive_once(shell, script, working_dir, env_vars, inputs)
-    })
+    exec_in_pty_shell(shell, script, working_dir, env_vars, inputs, true)
 }
 
-/// Re-run a PTY interaction while it reports a startup wedge — exit code
-/// `PTY_WEDGE_EXIT_CODE`, which `read_pty_output` returns after killing a shell
-/// that never exited — up to `max_attempts` times. None of these interactive
-/// tests legitimately run long enough to hit the wedge bound, so that exit code
-/// means the shell never ran (a job-control startup race), and re-running is
-/// safe. Returns the first non-wedged result, or the last wedged one if every
-/// attempt wedges.
+/// Like [`exec_in_pty_interactive`] but lets the caller choose whether `bash` /
+/// `zsh` run interactively (`-i`).
+///
+/// An interactive shell does job-control initialization at startup: if it
+/// decides it isn't the PTY's foreground process group it sends its own process
+/// group `SIGTTIN` and stops — producing no output and never exiting. Under
+/// parallel load that occasionally wedged `test_source_flag_forwards_errors`
+/// until the 180s harness timeout. A non-interactive shell skips job control
+/// entirely, so the wedge can't happen; pass `interactive = false` for tests
+/// that don't assert on job-control output. Tests that *do* (e.g.
+/// `test_zsh_no_job_control`) pass `interactive = true`.
 #[cfg(test)]
-fn retry_pty_on_wedge(
-    max_attempts: usize,
-    mut attempt: impl FnMut() -> (String, i32),
-) -> (String, i32) {
-    let mut result = (String::new(), 0);
-    for n in 1..=max_attempts {
-        result = attempt();
-        if result.1 != crate::common::pty::PTY_WEDGE_EXIT_CODE {
-            return result;
-        }
-        eprintln!("pty interactive shell wedged at startup (attempt {n}/{max_attempts})");
-    }
-    result
-}
-
-#[cfg(test)]
-fn exec_in_pty_interactive_once(
+fn exec_in_pty_shell(
     shell: &str,
     script: &str,
     working_dir: &std::path::Path,
     env_vars: &[(&str, &str)],
     inputs: &[&str],
+    interactive: bool,
 ) -> (String, i32) {
     use portable_pty::CommandBuilder;
     use std::io::Write;
-
-    // Bound each attempt's wait for the shell to exit. The normal path resolves
-    // in milliseconds; this only fires on a wedge, and is short enough that the
-    // 3-attempt retry above stays under the harness timeout.
-    let wedge_timeout = std::time::Duration::from_secs(30);
 
     let pair = crate::common::open_pty();
 
@@ -456,14 +425,17 @@ fn exec_in_pty_interactive_once(
     cmd.env("USER", "testuser");
     cmd.env("SHELL", shell_binary);
 
-    // Run in interactive mode to simulate real user environment.
-    // This ensures tests catch job control message leaks like "[1] 12345" and "[1]+ Done".
-    // Interactive shells have job control enabled by default.
+    // Interactive shells (`-i`) enable job control, so tests can catch
+    // job-control message leaks like "[1] 12345" and "[1]+ Done". Callers that
+    // don't assert on job control pass `interactive = false` to skip `-i` and
+    // avoid the startup job-control wedge (see `exec_in_pty_shell`).
     match shell {
         "zsh" => {
             // Isolate from user rc files
             cmd.env("ZDOTDIR", "/dev/null");
-            cmd.arg("-i");
+            if interactive {
+                cmd.arg("-i");
+            }
             cmd.arg("--no-rcs");
             cmd.arg("-o");
             cmd.arg("NO_GLOBAL_RCS");
@@ -473,14 +445,9 @@ fn exec_in_pty_interactive_once(
             cmd.arg(script);
         }
         "bash" => {
-            // Isolate from user rc files (parallels the zsh arm). Besides
-            // hermeticity, sourcing the host ~/.bashrc under an interactive
-            // shell is a plausible startup-hang source — and bash is the arm
-            // that flakes, since it was the only interactive shell here NOT
-            // isolating its rc files.
-            cmd.arg("--norc");
-            cmd.arg("--noprofile");
-            cmd.arg("-i");
+            if interactive {
+                cmd.arg("-i");
+            }
             cmd.arg("-c");
             cmd.arg(script);
         }
@@ -534,7 +501,7 @@ fn exec_in_pty_interactive_once(
     // Read output and wait for exit using platform-aware handling
     // On Windows ConPTY, this handles cursor queries and proper pipe closure
     let (buf, exit_code) =
-        crate::common::pty::read_pty_output(reader, writer, pair.master, &mut child, wedge_timeout);
+        crate::common::pty::read_pty_output(reader, writer, pair.master, &mut child);
 
     // Normalize CRLF to LF (PTYs use CRLF on some platforms)
     let normalized = buf.replace("\r\n", "\n");
@@ -640,11 +607,8 @@ fn exec_bash_truly_interactive(
         buf
     });
 
-    // Wait for bash to exit, bounded so a job-control-wedged shell can't hang
-    // the run (see wait_for_child_or_kill / read_pty_output). Once the child is
-    // gone the tty is revoked and the reader thread EOFs, so the join below
-    // completes without blocking.
-    let exit_code = crate::common::pty::wait_for_child_or_kill(&mut child, Duration::from_secs(60));
+    // Wait for bash to exit
+    let status = child.wait().unwrap();
 
     // Get the captured output
     let buf = reader_thread.join().unwrap();
@@ -652,7 +616,7 @@ fn exec_bash_truly_interactive(
     // Normalize CRLF to LF (same as exec_in_pty_interactive)
     let normalized = buf.replace("\r\n", "\n");
 
-    (normalized, exit_code)
+    (normalized, status.exit_code() as i32)
 }
 
 /// Execute a command through a shell wrapper
@@ -1686,8 +1650,17 @@ approved-commands = ["echo 'fish background task'"]
             ("WORKTRUNK_TEST_EPOCH", "1735776000"),
         ];
 
-        let (combined, exit_code) =
-            exec_in_pty_interactive(shell, &final_script, &worktrunk_source, &env_vars, &[]);
+        // Run non-interactively: this test only checks that the `--source`
+        // branch forwards wt's error, never job-control output. Skipping `-i`
+        // avoids the interactive-shell startup wedge that flaked this test.
+        let (combined, exit_code) = exec_in_pty_shell(
+            shell,
+            &final_script,
+            &worktrunk_source,
+            &env_vars,
+            &[],
+            false,
+        );
         let output = ShellOutput {
             combined,
             exit_code,
@@ -1718,107 +1691,6 @@ approved-commands = ["echo 'fish background task'"]
                 assert_snapshot!("source_flag_error_passthrough", &output.combined);
             }
         });
-    }
-
-    /// The PTY harness must not hang when the session-leader shell fails to
-    /// terminate. The drain previously read the master to EOF and then
-    /// `wait()`ed, so a shell wedged by a job-control race (stopped, never
-    /// exiting) starved both — the master never EOFs while the shell still owns
-    /// the controlling tty — and the run blocked until the 180s harness
-    /// timeout. That was the flake behind `test_source_flag_forwards_errors`:
-    /// the read now treats child exit as the completion signal and kills a shell
-    /// that overruns a bounded fallback, returning with the output already
-    /// captured.
-    ///
-    /// This drives that recovery directly with a short timeout: a shell that
-    /// prints its output and then stops itself (`SIGSTOP`, reproducing the
-    /// job-control stop) is bounded and killed in ~2s, the marker is still
-    /// captured, and the exit code signals the timeout. Under the old drain this
-    /// call would block forever (the stopped shell never EOFs the master nor
-    /// returns from `wait()`).
-    #[test]
-    fn test_pty_read_recovers_from_wedged_shell() {
-        use portable_pty::CommandBuilder;
-        use std::time::{Duration, Instant};
-
-        let pair = crate::common::open_pty();
-
-        // Emit output, then stop the shell itself with SIGSTOP — the same
-        // `T` (stopped) state a job-control SIGTTOU race produces. `printf` and
-        // `kill` are bash builtins, so this needs nothing on PATH, and the
-        // stopped session leader never exits on its own.
-        let mut cmd = CommandBuilder::new(shell_binary("bash"));
-        cmd.arg("-c");
-        cmd.arg(r#"printf '__WEDGE_MARKER__\n'; kill -STOP "$$"; exit 0"#);
-
-        let mut child = pair.slave.spawn_command(cmd).unwrap();
-        drop(pair.slave);
-
-        let reader = pair.master.try_clone_reader().unwrap();
-        let writer = pair.master.take_writer().unwrap();
-        drop(writer); // EOF to child stdin, matching read_pty_output
-        let _ = pair.master;
-
-        let start = Instant::now();
-        let (output, exit_code) = crate::common::pty::drain_pty_until_child_exit(
-            reader,
-            &mut child,
-            Duration::from_secs(2),
-        );
-        let elapsed = start.elapsed();
-
-        assert!(
-            elapsed < Duration::from_secs(30),
-            "drain should bound a wedged shell; took {elapsed:?}"
-        );
-        assert!(
-            output.contains("__WEDGE_MARKER__"),
-            "output emitted before the wedge should be captured.\nOutput:\n{output}"
-        );
-        assert_eq!(
-            exit_code,
-            crate::common::pty::PTY_WEDGE_EXIT_CODE,
-            "a killed wedged shell should report the wedge exit code"
-        );
-    }
-
-    /// `exec_in_pty_interactive` recovers from a startup wedge by re-running.
-    /// `test_pty_read_recovers_from_wedged_shell` covers the building block (a
-    /// wedged shell is bounded and reported as `PTY_WEDGE_EXIT_CODE`); this pins
-    /// the retry contract on top of it without paying a real 30s wedge: succeed
-    /// immediately on a clean result, retry past a wedge, and give up after the
-    /// cap returning the last result.
-    #[test]
-    fn test_retry_pty_on_wedge() {
-        let wedge = crate::common::pty::PTY_WEDGE_EXIT_CODE;
-
-        // Clean result on the first try → no retry.
-        let mut calls = 0;
-        let r = retry_pty_on_wedge(3, || {
-            calls += 1;
-            ("ok".to_string(), 0)
-        });
-        assert_eq!((r, calls), (("ok".to_string(), 0), 1));
-
-        // Wedge once, then recover → returns the recovered result.
-        let mut calls = 0;
-        let r = retry_pty_on_wedge(3, || {
-            calls += 1;
-            if calls == 1 {
-                (String::new(), wedge)
-            } else {
-                ("recovered".to_string(), 0)
-            }
-        });
-        assert_eq!((r, calls), (("recovered".to_string(), 0), 2));
-
-        // Wedge every time → gives up after the cap, returning the last result.
-        let mut calls = 0;
-        let r = retry_pty_on_wedge(3, || {
-            calls += 1;
-            (format!("try{calls}"), wedge)
-        });
-        assert_eq!((r, calls), (("try3".to_string(), wedge), 3));
     }
 
     // ========================================================================
@@ -3877,13 +3749,8 @@ mod windows_tests {
         let reader = pair.master.try_clone_reader().unwrap();
         let writer = pair.master.take_writer().unwrap();
 
-        let (output, exit_code) = crate::common::pty::read_pty_output(
-            reader,
-            writer,
-            pair.master,
-            &mut child,
-            std::time::Duration::from_secs(60),
-        );
+        let (output, exit_code) =
+            crate::common::pty::read_pty_output(reader, writer, pair.master, &mut child);
 
         let normalized = output.replace("\r\n", "\n");
 

--- a/tests/integration_tests/shell_wrapper.rs
+++ b/tests/integration_tests/shell_wrapper.rs
@@ -1656,6 +1656,67 @@ approved-commands = ["echo 'fish background task'"]
         });
     }
 
+    /// The PTY harness must not hang when the session-leader shell fails to
+    /// terminate. The drain previously read the master to EOF and then
+    /// `wait()`ed, so a shell wedged by a job-control race (stopped, never
+    /// exiting) starved both — the master never EOFs while the shell still owns
+    /// the controlling tty — and the run blocked until the 180s harness
+    /// timeout. That was the flake behind `test_source_flag_forwards_errors`:
+    /// the read now treats child exit as the completion signal and kills a shell
+    /// that overruns a bounded fallback, returning with the output already
+    /// captured.
+    ///
+    /// This drives that recovery directly with a short timeout: a shell that
+    /// prints its output and then stops itself (`SIGSTOP`, reproducing the
+    /// job-control stop) is bounded and killed in ~2s, the marker is still
+    /// captured, and the exit code signals the timeout. Under the old drain this
+    /// call would block forever (the stopped shell never EOFs the master nor
+    /// returns from `wait()`).
+    #[test]
+    fn test_pty_read_recovers_from_wedged_shell() {
+        use portable_pty::CommandBuilder;
+        use std::time::{Duration, Instant};
+
+        let pair = crate::common::open_pty();
+
+        // Emit output, then stop the shell itself with SIGSTOP — the same
+        // `T` (stopped) state a job-control SIGTTOU race produces. `printf` and
+        // `kill` are bash builtins, so this needs nothing on PATH, and the
+        // stopped session leader never exits on its own.
+        let mut cmd = CommandBuilder::new(shell_binary("bash"));
+        cmd.arg("-c");
+        cmd.arg(r#"printf '__WEDGE_MARKER__\n'; kill -STOP "$$"; exit 0"#);
+
+        let mut child = pair.slave.spawn_command(cmd).unwrap();
+        drop(pair.slave);
+
+        let reader = pair.master.try_clone_reader().unwrap();
+        let writer = pair.master.take_writer().unwrap();
+        drop(writer); // EOF to child stdin, matching read_pty_output
+        let _ = pair.master;
+
+        let start = Instant::now();
+        let (output, exit_code) = crate::common::pty::drain_pty_until_child_exit(
+            reader,
+            &mut child,
+            Duration::from_secs(2),
+        );
+        let elapsed = start.elapsed();
+
+        assert!(
+            elapsed < Duration::from_secs(30),
+            "drain should bound a wedged shell; took {elapsed:?}"
+        );
+        assert!(
+            output.contains("__WEDGE_MARKER__"),
+            "output emitted before the wedge should be captured.\nOutput:\n{output}"
+        );
+        assert_eq!(
+            exit_code, 124,
+            "a killed wedged shell should report the timeout exit code"
+        );
+    }
+
     // ========================================================================
     // Job Control Notification Tests
     // ========================================================================


### PR DESCRIPTION
## Problem

`unix_tests::test_source_flag_forwards_errors` (rstest over bash/zsh/fish in `tests/integration_tests/shell_wrapper.rs`) flaked in CI by **timing out** at the 180s nextest slow-timeout — a hang, not an assertion failure.

## Root cause

The test ran `bash -i` / `zsh -i` inside a PTY. An interactive shell does job-control initialization at startup: it checks whether it owns the terminal's foreground process group, and if it decides it doesn't, it sends its own process group `SIGTTIN` and **stops** — waiting to be brought to the foreground, which the test harness never does. A stopped shell produces no output and never exits, so the PTY read blocks until the harness kills the run.

The evidence fits this and little else: the hang was **macOS-only**, the shell **never exited**, and the captured output was **empty** — so it stopped at job-control init, before running the `-c` script at all. The trigger is a rare startup race under heavy parallel load; it never reproduced locally across thousands of runs, but CI hit it.

## Fix

`test_source_flag_forwards_errors` asserts exactly one thing: that the `--source` branch forwards wt's `unrecognized subcommand` error. It never backgrounds a job and never checks for job-control messages, so it doesn't need an interactive shell. Running it **non-interactively** (no `-i`) removes the job-control path — and the wedge — structurally, not probabilistically.

`exec_in_pty_interactive` gains a sibling `exec_in_pty_shell(.., interactive: bool)`; the interactive wrapper is unchanged for the tests that genuinely verify job-control suppression (e.g. `test_zsh_no_job_control`), which still pass `interactive = true`. The error-passthrough assertions and the shared snapshot are unchanged.

The net diff is ~40 lines in one file. (An earlier revision of this PR bounded the PTY read and retried the wedged shell — recovering from the timeout rather than preventing it; that was reverted in favor of this structural fix.)

## Tests

All three cases (bash/zsh/fish) pass — verified 15× consecutively, plus the full pre-merge gate (4044 tests, all lints and doctests).

> _This was written by Claude Code on behalf of max_
