### PR TITLE
docs(skill): clarify wt-switch-create rejection cases, document --no-cd

### DIFF
--- a/skills/wt-switch-create/SKILL.md
+++ b/skills/wt-switch-create/SKILL.md
@@ -63,13 +63,19 @@ design choices behind this — read it before re-adding guards or routes. -->
 
    - **Accepted** → the session is re-rooted in the worktree. Do the task (or,
      with no task text, confirm it's ready and wait).
-   - **Rejected** → the worktree is in another repo (`EnterWorktree` re-roots
-     only within the repo your cwd is in; the rejection is graceful and creates
-     nothing). You can still `cd` into the worktree and work there if it's
-     inside an allowed directory — an entry in `permissions.additionalDirectories`,
-     such as `~/workspace`. So `cd <path>` and read the result:
+   - **Rejected** → graceful, and nothing is created. Two cases land here: the
+     worktree is in another repo (`EnterWorktree` re-roots only within the repo
+     your cwd is in), or this session is already rooted in a worktree (or is a
+     pinned agent), which limits entry to that repo's `.claude/worktrees/` and
+     refuses even a same-repo `wt` sibling. Both reduce to the same test:
+     whether you can `cd` into the worktree, which works when it's inside an
+     allowed directory (a `permissions.additionalDirectories` entry such as
+     `~/workspace`). So `cd <path>` and read the result:
      - no `Shell cwd was reset` notice → it stuck; the worktree is reachable.
-       Work there and do the task.
+       Work there, but a bare `cd` is not a tracked re-root, so the cwd can
+       revert to the session's launch worktree across turns (and in spawned
+       subagents); pin commands with `git -C <path>` / `wt -C <path>` rather
+       than trusting the `cd` to persist.
      - `Shell cwd was reset` → not reachable. Stop and ask the user to make it
        reachable: add the repo, or a parent like `~/workspace`, to
        `permissions.additionalDirectories` (durable, every session), or run

--- a/skills/wt-switch-create/rationale.md
+++ b/skills/wt-switch-create/rationale.md
@@ -1,8 +1,8 @@
 # wt-switch-create design rationale
 
 Why the skill is create-then-reach: create the worktree with `wt`, enter it with
-`EnterWorktree`, and when entry is rejected (the worktree is in another repo),
-work in it if it's reachable or escalate to the user to make it reachable. Not
+`EnterWorktree`, and when entry is rejected, work in it if it's reachable or
+escalate to the user to make it reachable. Not
 the guard-heavy multi-route flow it replaced, and not the silent absolute-paths
 fallback that read as a failure.
 
@@ -24,8 +24,8 @@ deliberately omitted — they re-minify every build.
    constrained.
 2. Enter it with `EnterWorktree({path})` — the only way to re-root a Claude Code
    session, and it accepts only a worktree of the session's own repo.
-3. On rejection (the worktree is in another repo), the session can still work
-   there iff the path sits inside a directory it's allowed in (an
+3. On rejection, the session can still work there iff the path sits inside a
+   directory it's allowed in (an
    `additionalDirectories` entry). A single `cd <path>` discovers which: it
    sticks when reachable, resets when not. Reachable → work in place.
    Unreachable → escalate, because the agent can't enlarge that set itself: ask
@@ -125,6 +125,19 @@ plain session re-roots into the sibling `wt` creates. The agent **cannot**
 enlarge that set itself (`/add-dir` is user-typed; the only automatic add is a
 narrow symlink-resolving-to-the-same-cwd fixup), so a repo reachable by neither
 the cwd nor config is a genuine handback to the user.
+
+### Why `--no-cd`
+
+The Bash tool is not a bare shell: Claude Code replays the user's shell startup
+from a snapshot, so a user who installed wt shell integration runs the `wt`
+wrapper function inside the tool. wt then runs with integration active, and a
+plain `wt switch` hands the wrapper a cd directive that moves the tool's cwd — a
+second, untracked re-root racing `EnterWorktree`. `--no-cd` skips the directive,
+so `EnterWorktree` stays the single re-root. Verified: without `--no-cd`,
+`wt switch <branch>` moved the session and the new cwd persisted to the next
+Bash call. Where the user never installed integration (a fresh shell, CI) the
+wrapper is absent and wt cannot cd regardless, so `--no-cd` is load-bearing on an
+integrated machine and a no-op elsewhere. Don't drop it.
 
 ### Why not `EnterWorktree({name})` + the WorktreeCreate hook
 


### PR DESCRIPTION
The `wt-switch-create` skill (`/wt-switch-create`) had two gaps in how it describes re-rooting a session into a new worktree, plus a missing rationale — all surfaced by a background-job session whose cwd kept drifting back to its launch worktree.

**Rejection cause was incomplete.** Step 3's "Rejected" branch equated an `EnterWorktree({path})` rejection with "the worktree is in another repo." But the gate is session-state dependent (`rationale.md` M2): a plain session accepts any worktree registered to the repo, while a session already rooted in a worktree — or a pinned agent — is limited to `.claude/worktrees/` and rejects even a same-repo `wt` sibling. That second case is exactly what a background-job session hits, where the old text would misinform it. The branch now names both causes; both reduce to the same `cd`-reachability test, so the recovery steps are unchanged.

**`cd` fallback durability.** When `EnterWorktree` is rejected and the skill falls back to `cd`, that's a bare shell cwd, not a tracked re-root, so it can revert across turn boundaries. The reachable sub-bullet now says to pin commands with `git -C` / `wt -C` rather than trust the `cd` to persist.

**Why `--no-cd`.** The rationale explained every part of the design except the flag this skill leans on. Added a subsection: the Claude Code Bash tool replays the user's shell startup, so an installed `wt` wrapper runs with shell integration active, and a plain `wt switch` would re-root the session shell via a cd directive — a second, untracked re-root competing with `EnterWorktree`. `--no-cd` keeps `EnterWorktree` the single re-root. Verified live, and it corrects the rationale's implicit assumption that the harness runs no wrapper.

Doc-only; `skills/wt-switch-create/` is hand-authored and has no sync test.

> _This was written by Claude Code on behalf of max_
