### PR TITLE
feat(logging): list each -vv log path on its own gutter line

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -30,7 +30,7 @@ use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::util::SubscriberInitExt;
 use worktrunk::shell_exec::SUBPROCESS_FULL_TARGET;
-use worktrunk::styling::{eprintln, info_message};
+use worktrunk::styling::{eprintln, format_with_gutter, info_message};
 use worktrunk::trace::WT_TRACE_TARGET;
 use worktrunk::utils::escape_controls;
 
@@ -500,10 +500,12 @@ where
     Some(layer)
 }
 
-/// Print a one-line stderr pointer at `-vv` so users know where the noisy
-/// log pipeline output went. Silent if `trace.log` couldn't be opened
-/// (outside a git repo, permission error) — there's nothing meaningful to
-/// point at.
+/// Print a stderr pointer at `-vv` so users know where the noisy log
+/// pipeline output went — an info header over a gutter that lists each
+/// file's full path on its own line, so any one can be copied without
+/// joining a shared root to a filename. Silent if `trace.log` couldn't be
+/// opened (outside a git repo, permission error) — there's nothing
+/// meaningful to point at.
 fn announce_trace_destination() {
     // TRACE and SUBPROCESS open independently — `LogSink::init` succeeds per
     // file. The (Some, None) case (trace.log open, subprocess.log failed) is
@@ -518,16 +520,28 @@ fn announce_trace_destination() {
     // trace.log is always at `<git>/wt/logs/trace.log` (see `log_files::try_create`),
     // so the parent is structurally guaranteed.
     let dir = trace_path.parent().expect("trace.log path has a parent");
-    let dir_display = worktrunk::path::format_path_for_display(dir);
-    let msg = match log_files::SUBPROCESS.path() {
-        Some(_) => cformat!(
-            "Writing to <underline>{dir_display}/</> — trace.log, subprocess.log, diagnostic.md"
-        ),
-        None => cformat!(
-            "Writing to <underline>{dir_display}/</> — trace.log, diagnostic.md (subprocess.log unavailable)"
-        ),
+
+    // subprocess.log opening or not decides two things at once: whether it
+    // joins the gutter list, and whether the header flags it as unavailable.
+    // Keeping the "unavailable" note in the header leaves the gutter a clean
+    // list of live, copy-pasteable paths.
+    let mut paths = vec![dir.join("trace.log")];
+    let header = match log_files::SUBPROCESS.path() {
+        Some(_) => {
+            paths.push(dir.join("subprocess.log"));
+            "Writing to:"
+        }
+        None => "Writing to (subprocess.log unavailable):",
     };
-    eprintln!("{}", info_message(msg));
+    paths.push(dir.join("diagnostic.md"));
+
+    let gutter = paths
+        .iter()
+        .map(|p| worktrunk::path::format_path_for_display(p))
+        .collect::<Vec<_>>()
+        .join("\n");
+    eprintln!("{}", info_message(header));
+    eprintln!("{}", format_with_gutter(&gutter, None));
 }
 
 #[cfg(test)]

--- a/tests/integration_tests/diagnostic.rs
+++ b/tests/integration_tests/diagnostic.rs
@@ -400,7 +400,7 @@ fn test_vv_escapes_control_bytes_in_trace_not_subprocess(repo: TestRepo) {
 /// At `-vv`, Debug-level records (the noisy ones) stay out of stderr —
 /// the bounded subprocess preview lands in `trace.log` (not stderr), and
 /// `subprocess.log` still holds the unbounded body. Info-level routing
-/// from `-v` still applies at `-vv` (it's a superset), so the "Tracing
+/// from `-v` still applies at `-vv` (it's a superset), so the "Writing
 /// to ..." pointer and similar status lines DO appear on stderr; they're
 /// asserted at the end of this test. Guards against a regression that
 /// re-routes the debug stream to stderr and floods the terminal.
@@ -482,12 +482,20 @@ fn test_vv_debug_pipeline_silent_on_stderr(repo: TestRepo) {
         "trace.log should contain [wt-trace] records at -vv"
     );
 
-    // Stderr at -vv should contain the new pointer line (and the existing
-    // diagnostic line), so the user knows where the trace went.
+    // Stderr at -vv should announce each file's full path on its own line, so
+    // any one is copy-pasteable without joining a shared root to a filename.
+    // The `wt/logs/<file>` tails only appear contiguously when the full path
+    // is listed (the old root-plus-filenames form split them apart).
     assert!(
-        stderr.contains("Writing to") && stderr.contains("trace.log"),
-        "stderr should announce the trace destination at -vv: {stderr}"
+        stderr.contains("Writing to"),
+        "missing pointer header: {stderr}"
     );
+    for file in ["trace.log", "subprocess.log", "diagnostic.md"] {
+        assert!(
+            stderr.contains(&format!("wt/logs/{file}")),
+            "stderr should list the full path to {file}: {stderr}"
+        );
+    }
 }
 
 /// `RUST_LOG` is honored at every verbosity level — including `-v` — and
@@ -665,12 +673,18 @@ fn test_vv_pointer_handles_split_init(repo: TestRepo) {
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     assert!(
-        stderr.contains("Writing to") && stderr.contains("trace.log"),
-        "stderr should point at trace.log even when subprocess.log can't open: {stderr}"
+        stderr.contains("Writing to") && stderr.contains("wt/logs/trace.log"),
+        "stderr should list trace.log's full path even when subprocess.log can't open: {stderr}"
     );
     assert!(
         stderr.contains("subprocess.log unavailable"),
         "stderr should note subprocess.log is unavailable: {stderr}"
+    );
+    // subprocess.log didn't open, so it's named only in the unavailable note —
+    // never listed as a live path in the gutter.
+    assert!(
+        !stderr.contains("wt/logs/subprocess.log"),
+        "stderr should not list a path for the unavailable subprocess.log: {stderr}"
     );
     assert!(
         logs_dir.join("trace.log").exists(),


### PR DESCRIPTION
The `-vv` startup pointer that tells you where debug logs are written printed the log directory once (underlined) followed by the bare filenames, so copying any one file's full path meant joining the root to a filename by hand. This lists each full path on its own gutter line instead, so every path is independently copy-pasteable.

**Before:**

```
○ Writing to ~/repo/.git/wt/logs/ — trace.log, subprocess.log, diagnostic.md
```

**After:**

```
○ Writing to:
  ~/repo/.git/wt/logs/trace.log
  ~/repo/.git/wt/logs/subprocess.log
  ~/repo/.git/wt/logs/diagnostic.md
```

When `subprocess.log` can't be opened, the header becomes `Writing to (subprocess.log unavailable):` and it's omitted, so the gutter stays a clean list of live paths.

Tests: the two pointer assertions in `diagnostic.rs` were tightened to check the `wt/logs/<file>` path tail, which only appears contiguously when the full path is on one line (the old `contains("trace.log")` passed under both the old and new formats). The split-init test also asserts the negative — `subprocess.log` is not listed when it fails to open.

> _This was written by Claude Code on behalf of max_
