### PR TITLE
docs(skill): name the non-git-cwd rejection case in wt-switch-create

### DIFF
--- a/skills/wt-switch-create/SKILL.md
+++ b/skills/wt-switch-create/SKILL.md
@@ -63,13 +63,16 @@ design choices behind this — read it before re-adding guards or routes. -->
 
    - **Accepted** → the session is re-rooted in the worktree. Do the task (or,
      with no task text, confirm it's ready and wait).
-   - **Rejected** → graceful, and nothing is created. Two cases land here: the
-     worktree is in another repo (`EnterWorktree` re-roots only within the repo
-     your cwd is in), or this session is already rooted in a worktree (or is a
-     pinned agent), which limits entry to that repo's `.claude/worktrees/` and
-     refuses even a same-repo `wt` sibling. Both reduce to the same test:
-     whether you can `cd` into the worktree, which works when it's inside an
-     allowed directory (a `permissions.additionalDirectories` entry such as
+   - **Rejected** → graceful, and nothing is created. `EnterWorktree` re-roots
+     only to a worktree of the repo your cwd resolves to, so it refuses a fresh
+     `wt` sibling whenever that resolution can't reach it: the worktree is in
+     another repo; your cwd is outside any git repo (a non-git parent such as
+     `~/workspace` that only holds repos, as in a background job), which fails
+     with `the current directory is not in a git repository`; or the session is
+     already rooted in a worktree (or is a pinned agent), which narrows entry to
+     that repo's `.claude/worktrees/`. All reduce to the same test: whether you
+     can `cd` into the worktree, which works when it's inside an allowed
+     directory (a `permissions.additionalDirectories` entry such as
      `~/workspace`). So `cd <path>` and read the result:
      - no `Shell cwd was reset` notice → it stuck; the worktree is reachable.
        Work there, but a bare `cd` is not a tracked re-root, so the cwd can

--- a/skills/wt-switch-create/SKILL.md
+++ b/skills/wt-switch-create/SKILL.md
@@ -63,16 +63,19 @@ design choices behind this — read it before re-adding guards or routes. -->
 
    - **Accepted** → the session is re-rooted in the worktree. Do the task (or,
      with no task text, confirm it's ready and wait).
-   - **Rejected** → graceful, and nothing is created. `EnterWorktree` re-roots
-     only to a worktree of the repo your cwd resolves to, so it refuses a fresh
-     `wt` sibling whenever that resolution can't reach it: the worktree is in
-     another repo; your cwd is outside any git repo (a non-git parent such as
-     `~/workspace` that only holds repos, as in a background job), which fails
-     with `the current directory is not in a git repository`; or the session is
-     already rooted in a worktree (or is a pinned agent), which narrows entry to
-     that repo's `.claude/worktrees/`. All reduce to the same test: whether you
-     can `cd` into the worktree, which works when it's inside an allowed
-     directory (a `permissions.additionalDirectories` entry such as
+   - **Rejected** → graceful, and nothing is created. `EnterWorktree`
+     re-roots only into a worktree the session is permitted to enter, and that
+     permitted set is fixed by two factors: the repo your cwd resolves to, and
+     the session's state. Each rejection is just that set coming up empty or
+     without the target: no repo resolves (cwd is outside any git repo, e.g. a
+     non-git parent such as `~/workspace` that only holds repos, as in a
+     background job), which fails with `the current directory is not in a git
+     repository`; the target belongs to a different repo than the one resolved;
+     or the session is already rooted in a worktree (or is a pinned agent), a
+     state that narrows the set to the resolved repo's `.claude/worktrees/` and
+     so excludes even a same-repo `wt` sibling. All reduce to the same recovery
+     test: whether you can `cd` into the worktree, which works when it's inside
+     an allowed directory (a `permissions.additionalDirectories` entry such as
      `~/workspace`). So `cd <path>` and read the result:
      - no `Shell cwd was reset` notice → it stuck; the worktree is reachable.
        Work there, but a bare `cd` is not a tracked re-root, so the cwd can


### PR DESCRIPTION
SKILL.md's step-3 "Rejected" branch named two of the three rejection causes `rationale.md` already documents. It omitted the case where the session's cwd is outside any git repo. That's what a background-job session hits: its root is a non-git parent (e.g. `~/workspace`) that only contains repos, so `EnterWorktree({path})` for a `wt` sibling fails with `the current directory is not in a git repository`, distinct from the in-another-repo path.

This brings the operational procedure in line with `rationale.md`, whose Gate section and compose-table already list all three cases. The "Rejected" bullet is reframed around the gate's unifying principle: `EnterWorktree` re-roots only into a worktree the session is permitted to enter, and that permitted set is fixed by two factors (the repo the cwd resolves to, and the session's state). The three triggers then fall out as that set coming up empty or without the target, and the same `cd`-reachability recovery still follows. SKILL.md only; `rationale.md` already covered it.

Primary evidence: a background-job session launched at `~/workspace` (not a git repo) created a `wt` worktree in the `worktrunk` sub-repo via `wt -C`, and `EnterWorktree({path})` was rejected twice with that exact error; the `cd` fallback worked and the cwd reset across a resume, matching the existing caution.

Follow-up to #3162.

> _This was written by Claude Code on behalf of max_
