### PR TITLE
test: isolate bash PTY tests from the host ~/.bashrc

### DIFF
--- a/tests/integration_tests/shell_wrapper.rs
+++ b/tests/integration_tests/shell_wrapper.rs
@@ -445,6 +445,12 @@ fn exec_in_pty_shell(
             cmd.arg(script);
         }
         "bash" => {
+            // Isolate from user rc/profile files, mirroring the zsh arm and
+            // `exec_bash_truly_interactive`. A no-op for non-interactive
+            // `bash -c`, but it keeps interactive (`-i`) startup from sourcing
+            // the host's ~/.bashrc and leaking host-specific output.
+            cmd.arg("--norc");
+            cmd.arg("--noprofile");
             if interactive {
                 cmd.arg("-i");
             }


### PR DESCRIPTION
## Problem

The bash arm of `exec_in_pty_shell` (`tests/integration_tests/shell_wrapper.rs`) was the only shell arm without rc-file isolation. zsh sets `ZDOTDIR=/dev/null` + `--no-rcs`, nu sets `--no-config-file`, and the sibling `exec_bash_truly_interactive` already passes `--norc --noprofile` — but the bash arm did not. Because the PTY harness sets `HOME` to the real home, interactive `bash -i` sourced the host's `~/.bashrc`, leaking host-specific startup output into the captured PTY snapshots.

## Fix

Add `--norc --noprofile` to the bash arm, mirroring the zsh/nu arms and `exec_bash_truly_interactive`. It's orthogonal to job control (that's driven by `-i`), so the job-control leak-detection tests (`test_*_no_job_control*`) still exercise the interactive path; it's a no-op for the non-interactive `bash -c` path used by `test_source_flag_forwards_errors`.

Follow-up to #3161 / #3165, which fixed the macOS PTY-test hang and isolated several other tests but left this arm untouched.

## Tests

All 88 `shell_wrapper` tests pass, plus the full pre-merge gate (4102 tests, all lints and doctests).

> _This was written by Claude Code on behalf of max_
