### PR TITLE
feat(picker): sanitize untrusted terminal control sequences in TUI output

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -59,9 +59,10 @@ repos:
         types: ["rust"]
         entry: '\\x1b\['
         # format.rs strips ANSI codes injected by wrap_ansi crate
+        # sanitize.rs parses & strips ANSI from untrusted text (must name the codes)
         # picker tests verify ANSI dimming behavior
         # src/testing: validate_ansi_codes tests raw escape sequences
-        exclude: '^(tests/|.*_test\.rs$|src/styling/(mod|format)\.rs$|src/commands/picker/|src/testing/|vendor/)'
+        exclude: '^(tests/|.*_test\.rs$|src/styling/(mod|format|sanitize)\.rs$|src/commands/picker/|src/testing/|vendor/)'
       - id: no-std-canonicalize-in-tests
         name: no-std-canonicalize-in-tests
         description: Use dunce::canonicalize in tests to avoid Windows \\?\ prefix issues

--- a/src/commands/list/ci_status/mod.rs
+++ b/src/commands/list/ci_status/mod.rs
@@ -462,10 +462,17 @@ impl PrStatus {
     fn styled(&self, text: &str, include_link: bool) -> String {
         if let (true, Some(url)) = (include_link, &self.url) {
             let style = self.style().underline();
+            // The URL comes from forge JSON (untrusted). It is interpolated into
+            // an OSC-8 escape (`\x1b]8;;<url>\x07`), so an embedded BEL or ST
+            // would close the sequence early and let trailing bytes run as live
+            // terminal control on the `wt list` / statusline line — outside the
+            // picker's preview boundary. Strip control sequences from the link
+            // target here, at the sink, before it becomes an escape.
+            let url = worktrunk::styling::sanitize_untrusted_text(url);
             format!(
                 "{}{}{}{}{}",
                 style,
-                osc8::Hyperlink::new(url),
+                osc8::Hyperlink::new(url.as_ref()),
                 text,
                 osc8::Hyperlink::END,
                 style.render_reset()

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -1483,7 +1483,12 @@ pub fn collect(
         }
         item.commit = Some(CommitDetails {
             timestamp: *timestamp,
-            commit_message: commit_message.clone(),
+            // A commit message from a branch fetched off a malicious remote is
+            // untrusted free text shown in the `wt list` Message column and the
+            // picker rows. Strip terminal control sequences at this ingestion
+            // edge so a crafted subject can't clear the screen or move the cursor.
+            commit_message: worktrunk::styling::sanitize_untrusted_text(commit_message)
+                .into_owned(),
         });
     }
 
@@ -2004,7 +2009,11 @@ pub fn populate_item(
         if !is_prunable {
             item.commit = Some(CommitDetails {
                 timestamp: *timestamp,
-                commit_message: commit_message.clone(),
+                // Sanitize at this ingestion edge too, matching `collect()` — so
+                // both paths that build `item.commit` yield plain text and can't
+                // drift (this single-item path feeds `wt statusline`).
+                commit_message: worktrunk::styling::sanitize_untrusted_text(commit_message)
+                    .into_owned(),
             });
         }
     }

--- a/src/commands/picker/items.rs
+++ b/src/commands/picker/items.rs
@@ -194,6 +194,24 @@ pub(super) struct WorktreeSkimItem {
     pub pr_status: PrStatusSlot,
 }
 
+/// The single boundary where picker preview content reaches skim.
+///
+/// Preview panes interleave worktrunk's own styling and `git --color` output
+/// (both legitimate SGR) with untrusted free text — forge PR/MR titles and
+/// descriptions, LLM summaries, and commit messages / `git log` graphs from a
+/// branch that may have been fetched from a malicious remote. A crafted body
+/// could otherwise smuggle a `\x1b[2J` screen-clear, an alt-screen switch, a
+/// cursor move, an OSC-8 hyperlink, or a BEL straight to the terminal.
+///
+/// [`sanitize_styled_output`](worktrunk::styling::sanitize_styled_output) strips
+/// every terminal control sequence except SGR color/style, so colored diffs and
+/// styled markdown still render while the dangerous sequences are removed. Every
+/// `SkimItem::preview` impl must return through here rather than constructing
+/// `ItemPreview::AnsiText` directly (see [`PrSkimItem`](super::prs)).
+pub(super) fn sanitized_preview(result: String) -> ItemPreview {
+    ItemPreview::AnsiText(worktrunk::styling::sanitize_styled_output(&result).into_owned())
+}
+
 impl SkimItem for WorktreeSkimItem {
     fn text(&self) -> Cow<'_, str> {
         Cow::Borrowed(&self.search_text)
@@ -237,7 +255,7 @@ impl SkimItem for WorktreeSkimItem {
             _ => self.preview_for_mode(mode, context.width, context.height),
         });
 
-        ItemPreview::AnsiText(result)
+        sanitized_preview(result)
     }
 }
 

--- a/src/commands/picker/prs.rs
+++ b/src/commands/picker/prs.rs
@@ -311,6 +311,18 @@ fn fetch_github(repo_root: &Path) -> anyhow::Result<Vec<PrEntry>> {
     parse_github_prs(&output.stdout)
 }
 
+/// Strip terminal control sequences from a forge-supplied string at its
+/// ingestion edge. PR/MR titles, descriptions, author names, and URLs are
+/// attacker-influenceable free text; this makes the picker's data model plain
+/// text so the value is clean everywhere it is later used (the preview pane, the
+/// fuzzy-match `search_text`, and — for callers that persist it — any cache).
+/// The picker preview pane is independently sanitized at the skim boundary (see
+/// [`super::items::sanitized_preview`]); cleaning here additionally removes raw
+/// SGR recoloring that the display boundary must keep for `git --color` output.
+fn clean(s: String) -> String {
+    worktrunk::styling::sanitize_untrusted_text(&s).into_owned()
+}
+
 /// Map `gh pr list --json …` output to picker entries.
 fn parse_github_prs(stdout: &[u8]) -> anyhow::Result<Vec<PrEntry>> {
     let prs: Vec<GhPr> =
@@ -320,13 +332,13 @@ fn parse_github_prs(stdout: &[u8]) -> anyhow::Result<Vec<PrEntry>> {
         .into_iter()
         .map(|pr| PrEntry {
             number: pr.info.number.unwrap_or(0) as u32,
-            title: pr.title,
-            head_branch: pr.head_ref_name,
-            author: pr.author.login,
+            title: clean(pr.title),
+            head_branch: clean(pr.head_ref_name),
+            author: clean(pr.author.login),
             is_draft: pr.info.is_draft == Some(true),
-            url: pr.info.url.clone(),
+            url: pr.info.url.clone().map(clean),
             kind: RefKind::Pr,
-            body: pr.body,
+            body: clean(pr.body),
             status: Some(pr.info.open_pr_status()),
         })
         .collect())
@@ -401,13 +413,13 @@ fn parse_gitlab_mrs(stdout: &[u8]) -> anyhow::Result<Vec<PrEntry>> {
             );
             PrEntry {
                 number: mr.iid,
-                title: mr.title,
-                head_branch: mr.source_branch,
-                author: mr.author.username,
+                title: clean(mr.title),
+                head_branch: clean(mr.source_branch),
+                author: clean(mr.author.username),
                 is_draft: mr.draft,
-                url: mr.web_url,
+                url: mr.web_url.map(clean),
                 kind: RefKind::Mr,
-                body: mr.description,
+                body: clean(mr.description),
                 status: Some(status),
             }
         })
@@ -689,7 +701,7 @@ impl SkimItem for PrSkimItem {
         } else {
             result.push_str(&pr_row_empty_placeholder());
         }
-        ItemPreview::AnsiText(result)
+        super::items::sanitized_preview(result)
     }
 }
 
@@ -1245,6 +1257,80 @@ mod tests {
             !plain_pr.pr_pane.contains("\x1b[107m"),
             "no gutter when empty"
         );
+    }
+
+    /// A crafted body's terminal control sequences reach the rendered pane
+    /// verbatim (the markdown renderer is the trusted `--help` path and does not
+    /// sanitize), but the skim preview boundary strips them — while keeping the
+    /// gutter's color and all visible text. This pins the boundary established by
+    /// [`super::items::sanitized_preview`].
+    #[test]
+    fn pr_pane_control_sequences_stripped_at_preview_boundary() {
+        let mut e = entry(RefKind::Pr, 9, "title");
+        e.body = "alt\x1b[?1049h cur\x1b[5A clr\x1b[2J bell\x07 \
+                  \x1b]8;;https://evil.example\x07link\x1b]8;;\x07 and \x1b[31mred\x1b[0m"
+            .to_string();
+        let item = PrSkimItem::new(e, 120, Some(&grid()));
+
+        // Precondition: the renderer passed the raw escapes straight through.
+        assert!(
+            item.pr_pane.contains("\x1b[2J") && item.pr_pane.contains("\x1b]8;"),
+            "expected raw escapes in the rendered pane: {:?}",
+            item.pr_pane
+        );
+
+        let ItemPreview::AnsiText(out) =
+            super::super::items::sanitized_preview(item.pr_pane.clone())
+        else {
+            panic!("expected AnsiText preview");
+        };
+        for danger in [
+            "\x1b[?1049h",
+            "\x1b[5A",
+            "\x1b[2J",
+            "\x07",
+            "\x1b]8;",
+            "\x1b]",
+        ] {
+            assert!(
+                !out.contains(danger),
+                "dangerous sequence {danger:?} survived: {out:?}"
+            );
+        }
+        // Visible text survives, including the OSC-8 link's display text.
+        for visible in ["alt", "cur", "clr", "bell", "link", "red"] {
+            assert!(
+                out.contains(visible),
+                "lost visible text {visible:?}: {out:?}"
+            );
+        }
+        // Legitimate SGR (the gutter bar, the body's own color) is preserved.
+        assert!(out.contains("\x1b[107m"), "gutter color dropped: {out:?}");
+        assert!(out.contains("\x1b[31m"), "body SGR dropped: {out:?}");
+    }
+
+    /// Forge fields are sanitized at the ingestion edge, so the picker's data
+    /// model is plain text (covers the fuzzy-match `search_text` and any caller
+    /// that persists the value, on top of the preview boundary above).
+    #[test]
+    fn parse_github_prs_strips_control_sequences_from_fields() {
+        // serde_json encodes the real control chars to JSON `\uXXXX` (as gh
+        // does), and decoding on parse hands `clean` the raw bytes to strip.
+        let json = serde_json::json!([{
+            "number": 1,
+            "title": "Fix \u{1b}[2Jthing",
+            "headRefName": "feature",
+            "author": { "login": "al\u{1b}[31mice" },
+            "body": "Body \u{1b}[?1049h\u{7}text",
+            "url": "https://x/\u{1b}]8;;evil\u{7}",
+        }])
+        .to_string();
+        let entries = parse_github_prs(json.as_bytes()).unwrap();
+        let e = &entries[0];
+        assert_eq!(e.title, "Fix thing");
+        assert_eq!(e.author, "alice");
+        assert_eq!(e.body, "Body text");
+        assert_eq!(e.url.as_deref(), Some("https://x/"));
     }
 
     #[test]

--- a/src/commands/picker/summary.rs
+++ b/src/commands/picker/summary.rs
@@ -559,6 +559,22 @@ mod tests {
     }
 
     #[test]
+    fn test_generate_summary_strips_control_sequences_from_llm_output() {
+        let (t, repo, head) = temp_repo_with_feature();
+
+        // A model that emits a screen-clear and a BEL in its output. The ESC/BEL
+        // bytes are real here (single-quoted in the shell, printed verbatim).
+        let summary = crate::summary::generate_summary(
+            "feature",
+            &head,
+            Some(t.path()),
+            "cat >/dev/null && printf '%s' 'Add \x1b[2Jnew\x07 file'",
+            &repo,
+        );
+        assert_eq!(summary, "Add new file");
+    }
+
+    #[test]
     fn test_generate_summary_caches_result() {
         let (t, repo, head) = temp_repo_with_feature();
 

--- a/src/styling/mod.rs
+++ b/src/styling/mod.rs
@@ -18,6 +18,7 @@ mod format;
 mod highlighting;
 mod hyperlink;
 mod line;
+mod sanitize;
 mod suggest;
 
 use ansi_str::AnsiStr;
@@ -38,6 +39,7 @@ pub use format::{
 pub use highlighting::format_toml;
 pub use hyperlink::{Stream, hyperlink_stdout, strip_osc8_hyperlinks, supports_hyperlinks};
 pub use line::{StyledLine, StyledString, truncate_visible};
+pub use sanitize::{sanitize_styled_output, sanitize_untrusted_text};
 pub use suggest::{suggest_command, suggest_command_in_dir};
 
 // ============================================================================

--- a/src/styling/sanitize.rs
+++ b/src/styling/sanitize.rs
@@ -1,0 +1,366 @@
+//! Neutralizing terminal control sequences in untrusted free text.
+//!
+//! # Threat model
+//!
+//! The interactive picker (`wt switch`) renders text whose content is controlled
+//! by something other than worktrunk's maintainers or the user's own keystrokes:
+//!
+//! - **Forge free text** — PR/MR titles, descriptions, author names, and URLs
+//!   from `gh` / `glab` (and the other forges), shown in the picker's `pr`
+//!   preview tab.
+//! - **LLM output** — `[commit.generation]` model stdout, shown as branch
+//!   summaries in the picker and the `wt list` Summary column.
+//! - **Git object content** — commit messages and `git log --color` graphs from
+//!   a branch that may have been fetched from a malicious remote, shown in the
+//!   picker's log/diff preview tabs.
+//!
+//! A crafted string carrying raw terminal escapes (a `\x1b[2J` screen-clear, an
+//! `\x1b[?1049h` alt-screen switch, cursor moves, an `\x1b]52` clipboard write,
+//! an OSC-8 hyperlink the user never wrote, or a `\x07` BEL) flows verbatim to
+//! the terminal unless something strips it. The impact is bounded to display
+//! corruption — garble the pane, recolor, ring the bell, scramble skim's layout,
+//! all recoverable on redraw — but it is the first surface that renders directly
+//! attacker-influenced free text into the TUI, so it gets a deliberate boundary.
+//!
+//! # Why not sanitize inside the markdown renderer
+//!
+//! `md_help::render_markdown_in_help_with_width` is the shared markdown
+//! renderer, and it would be the obvious chokepoint — but it is also fed
+//! *trusted* ANSI: `wt --help` hands it clap's already-styled output, complete
+//! with SGR colors and clap-generated OSC-8 hyperlinks to the docs. The renderer
+//! cannot tell a trusted clap hyperlink from an attacker's body hyperlink by
+//! type alone, and stripping all escapes there would strip clap's styling too.
+//! So sanitization happens at the *trust boundary* instead: where untrusted text
+//! enters worktrunk (ingestion) and where the picker hands a preview to skim.
+//!
+//! # The two policies
+//!
+//! - [`sanitize_untrusted_text`] strips **every** control/escape sequence. Use
+//!   it at ingestion, on raw external strings (forge fields, LLM stdout) that are
+//!   plain text and should carry no terminal styling of their own.
+//! - [`sanitize_styled_output`] strips every sequence **except** the two
+//!   line-bounded CSI forms our own rendering relies on: SGR color/style
+//!   (`\x1b[…m`) and erase-in-line (`\x1b[…K`, emitted by pager front-ends like
+//!   delta and bat to fill a line's background). Use it on already-styled output
+//!   — the picker preview pane mixes worktrunk's own renderer styling, `git
+//!   --color` output, and paged diffs with whatever untrusted text was rendered
+//!   into it; those must survive so colored diffs and styled markdown still
+//!   render, while every cursor move, screen clear, alt-screen switch, OSC, and
+//!   stray control byte is removed.
+//!
+//! Both preserve `\n` (the line structure downstream wrapping relies on) and
+//! `\t`; everything else in the C0/C1 control ranges, plus DEL, is dropped.
+//!
+//! # Bounded by design
+//!
+//! The kept sequences are all confined to the line they appear on, matching the
+//! bounded display-corruption threat model: an attacker-supplied SGR can recolor
+//! or conceal (`8m`) a span and an erase-in-line can blank one line, but neither
+//! can move the cursor off the line, clear the screen, or persist past skim's
+//! next redraw. Tightening this to an SGR allowlist (dropping conceal/blink) is
+//! possible but risks dropping a legitimate `git --color` attribute, so the
+//! full SGR set is permitted. Unicode spoofing (bidi overrides, zero-width
+//! characters — "Trojan Source") is a separate, non-escape concern and is
+//! deliberately out of scope here.
+
+use std::borrow::Cow;
+
+/// Strip every terminal control/escape sequence from untrusted plain text.
+///
+/// For raw external strings at their ingestion edge — forge PR/MR titles,
+/// descriptions, author names, and LLM output — which are plain text and should
+/// carry no terminal styling. `\n` and `\t` are preserved; all other C0/C1
+/// controls, DEL, and every escape sequence (CSI, OSC, SGR, …) are removed.
+pub fn sanitize_untrusted_text(s: &str) -> Cow<'_, str> {
+    strip_sequences(s, false)
+}
+
+/// Strip every terminal control/escape sequence except SGR color/style.
+///
+/// For already-styled output handed to the terminal — the picker preview pane,
+/// which interleaves worktrunk's renderer styling and `git --color` output (both
+/// legitimate SGR) with untrusted text. SGR (`\x1b[…m`) survives so colors and
+/// styles still render; cursor moves, screen/line erases, alt-screen switches,
+/// scroll regions, OSC (titles, clipboard, hyperlinks), and stray control bytes
+/// are removed.
+pub fn sanitize_styled_output(s: &str) -> Cow<'_, str> {
+    strip_sequences(s, true)
+}
+
+/// True for the only characters an untrusted string may contain untouched in the
+/// fast path: anything that is not a control character, plus `\n` and `\t`.
+fn is_plain(c: char) -> bool {
+    !c.is_control() || c == '\n' || c == '\t'
+}
+
+type Scan<'a> = std::iter::Peekable<std::str::Chars<'a>>;
+
+/// Whether a CSI body (parameters + final byte, e.g. `31m`, `0K`, `?25h`) is one
+/// of the few sequences [`sanitize_styled_output`] keeps:
+///
+/// - **SGR** (`…m`) — color and style, emitted by our renderer and `git --color`.
+/// - **Erase-in-line** (`…K`) — emitted by pager front-ends (delta, bat) to fill
+///   a line's background to the pane edge.
+///
+/// Both are bounded to the current line: they cannot move the cursor off the
+/// line, erase the display, or switch screen buffers, so they fall inside the
+/// bounded display-corruption threat model. Every other final (cursor motion,
+/// erase-in-display `J`, mode set/reset `h`/`l`, scroll regions, …) is dropped.
+/// DEC-private forms (`?…`, `>…`) carry a non-numeric parameter byte, so they are
+/// never kept.
+fn is_kept_csi(body: &str) -> bool {
+    let Some(final_byte) = body.chars().last() else {
+        return false;
+    };
+    if !matches!(final_byte, 'm' | 'K') {
+        return false;
+    }
+    let params = &body[..body.len() - final_byte.len_utf8()];
+    params
+        .chars()
+        .all(|c| c.is_ascii_digit() || c == ';' || c == ':')
+}
+
+/// Consume a CSI body after the introducer (7-bit `ESC [` or 8-bit `\u{9b}`):
+/// parameter bytes (`0x30-0x3F`), intermediate bytes (`0x20-0x2F`), then one
+/// final byte (`0x40-0x7E`). Returns the consumed body for SGR classification.
+fn consume_csi_body(chars: &mut Scan<'_>) -> String {
+    let mut body = String::new();
+    while let Some(&p) = chars.peek() {
+        if ('\u{20}'..='\u{3f}').contains(&p) {
+            body.push(p);
+            chars.next();
+        } else {
+            break;
+        }
+    }
+    if let Some(&f) = chars.peek()
+        && ('\u{40}'..='\u{7e}').contains(&f)
+    {
+        body.push(f);
+        chars.next();
+    }
+    body
+}
+
+fn strip_sequences(s: &str, keep_sgr: bool) -> Cow<'_, str> {
+    // Fast path: no control characters at all (escape sequences start with ESC
+    // or an 8-bit C1 byte, all of which are control chars), so nothing to strip.
+    if s.chars().all(is_plain) {
+        return Cow::Borrowed(s);
+    }
+
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        match c {
+            // 7-bit escapes — ESC introduces; the next char selects the kind.
+            '\x1b' => match chars.peek().copied() {
+                Some('[') => {
+                    chars.next();
+                    let body = consume_csi_body(&mut chars);
+                    // Keep only the line-bounded 7-bit CSI our own renderer,
+                    // `git --color`, and pagers emit (SGR color/style and
+                    // erase-in-line); drop every other CSI.
+                    if keep_sgr && is_kept_csi(&body) {
+                        out.push('\x1b');
+                        out.push('[');
+                        out.push_str(&body);
+                    }
+                }
+                // OSC / DCS / SOS / PM / APC: string sequences (BEL- or
+                // ST-terminated). Always dropped — the preview has no legitimate
+                // OSC, and a body-supplied OSC-8 hyperlink or OSC-52 clipboard
+                // write is exactly the threat.
+                Some(']' | 'P' | 'X' | '^' | '_') => {
+                    chars.next();
+                    consume_string_terminator(&mut chars);
+                }
+                // Charset designators (`ESC ( B`), RIS (`ESC c`), keypad modes
+                // (`ESC =`), etc.: intermediates then one final byte. Dropped.
+                Some(_) => {
+                    while let Some(&p) = chars.peek() {
+                        if ('\u{20}'..='\u{2f}').contains(&p) {
+                            chars.next();
+                        } else {
+                            break;
+                        }
+                    }
+                    chars.next();
+                }
+                None => {} // lone trailing ESC
+            },
+            // 8-bit C1 introducers (the UTF-8-decoded single-char forms a
+            // terminal in 8-bit mode honors). We never emit 8-bit SGR ourselves,
+            // so even a C1 CSI is dropped wholesale rather than kept.
+            '\u{9b}' => {
+                let _ = consume_csi_body(&mut chars); // CSI
+            }
+            '\u{90}' | '\u{98}' | '\u{9d}' | '\u{9e}' | '\u{9f}' => {
+                consume_string_terminator(&mut chars); // DCS / SOS / OSC / PM / APC
+            }
+            // Keep the line structure and tabs; drop every other control
+            // character (the rest of C0, DEL, and the remaining C1 range).
+            '\n' | '\t' => out.push(c),
+            _ if c.is_control() => {}
+            _ => out.push(c),
+        }
+    }
+
+    Cow::Owned(out)
+}
+
+/// Consume a string-sequence body up to and including its terminator, or to end
+/// of input. Terminators: BEL, 7-bit ST (`ESC \`), or 8-bit ST (`\u{9c}`). The
+/// leading introducer (`]`, `P`, the C1 byte, …) has already been consumed.
+fn consume_string_terminator(chars: &mut Scan<'_>) {
+    while let Some(c) = chars.next() {
+        match c {
+            '\x07' | '\u{9c}' => break,
+            '\x1b' => {
+                if chars.peek() == Some(&'\\') {
+                    chars.next();
+                }
+                break;
+            }
+            _ => {}
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn plain_text_is_borrowed_unchanged() {
+        // No control chars — returned as-is without allocating.
+        let s = "Fix the **flaky** `retry` logic (see #123)";
+        assert!(matches!(sanitize_untrusted_text(s), Cow::Borrowed(_)));
+        assert_eq!(sanitize_untrusted_text(s), s);
+        assert!(matches!(sanitize_styled_output(s), Cow::Borrowed(_)));
+        assert_eq!(sanitize_styled_output(s), s);
+    }
+
+    #[test]
+    fn newlines_and_tabs_survive() {
+        let s = "line one\nline\ttwo\nline three";
+        assert_eq!(sanitize_untrusted_text(s), s);
+        assert_eq!(sanitize_styled_output(s), s);
+    }
+
+    #[test]
+    fn strips_csi_screen_and_cursor_sequences() {
+        // Screen clear, alt-screen, cursor move, scroll region — all dropped,
+        // leaving only the surrounding text.
+        let s = "a\x1b[2Jb\x1b[?1049hc\x1b[5Ad\x1b[1;40re";
+        assert_eq!(sanitize_untrusted_text(s), "abcde");
+        assert_eq!(sanitize_styled_output(s), "abcde");
+    }
+
+    #[test]
+    fn strips_c0_controls_and_del_and_c1() {
+        // BEL, backspace, vertical tab, form feed, CR, DEL, and a non-introducer
+        // C1 byte (U+0080). (C1 sequence introducers like U+009B are covered in
+        // strips_8bit_c1_introducers_and_their_bodies.)
+        let s = "a\x07b\x08c\x0bd\x0ce\rf\x7fg\u{80}h";
+        assert_eq!(sanitize_untrusted_text(s), "abcdefgh");
+        assert_eq!(sanitize_styled_output(s), "abcdefgh");
+    }
+
+    #[test]
+    fn strips_osc_including_hyperlinks_and_clipboard() {
+        // OSC-8 hyperlink (BEL-terminated), OSC-0 window title (ST-terminated),
+        // OSC-52 clipboard write — every OSC is dropped under both policies.
+        let link = "\x1b]8;;https://evil.example\x07click\x1b]8;;\x07";
+        assert_eq!(sanitize_untrusted_text(link), "click");
+        assert_eq!(sanitize_styled_output(link), "click");
+
+        let title = "before\x1b]0;pwned\x1b\\after";
+        assert_eq!(sanitize_untrusted_text(title), "beforeafter");
+        assert_eq!(sanitize_styled_output(title), "beforeafter");
+
+        let clip = "x\x1b]52;c;cGF3bz==\x07y";
+        assert_eq!(sanitize_styled_output(clip), "xy");
+    }
+
+    #[test]
+    fn untrusted_policy_strips_sgr_too() {
+        // Raw external text should carry no styling of its own.
+        let s = "\x1b[31mred\x1b[0m and \x1b[1mbold\x1b[0m";
+        assert_eq!(sanitize_untrusted_text(s), "red and bold");
+    }
+
+    #[test]
+    fn styled_policy_keeps_sgr() {
+        // Already-styled output keeps its colors so diffs and markdown render.
+        let s = "\x1b[31mred\x1b[0m and \x1b[1mbold\x1b[0m";
+        assert_eq!(sanitize_styled_output(s), s);
+        // Multi-parameter SGR (truecolor) is preserved.
+        let tc = "\x1b[38;2;255;0;0mhi\x1b[0m";
+        assert_eq!(sanitize_styled_output(tc), tc);
+        // An empty-parameter SGR (`\x1b[m`, reset) is valid and kept.
+        assert_eq!(sanitize_styled_output("\x1b[mx"), "\x1b[mx");
+    }
+
+    #[test]
+    fn styled_policy_drops_dangerous_csi_but_keeps_adjacent_sgr() {
+        // A DEC-private show-cursor (`\x1b[?25h`), a screen clear (`\x1b[2J`), and
+        // a cursor move (`\x1b[5A`) are dropped, even though they share the CSI
+        // shape with colors; the adjacent SGR survives.
+        let s = "\x1b[32mgreen\x1b[0m\x1b[?25h\x1b[2J\x1b[5Ax";
+        assert_eq!(sanitize_styled_output(s), "\x1b[32mgreen\x1b[0mx");
+        // A `>`-prefixed parameter is not a color SGR even with an `m` final.
+        assert_eq!(sanitize_styled_output("\x1b[>1mx"), "x");
+    }
+
+    #[test]
+    fn styled_policy_keeps_erase_in_line() {
+        // Pager front-ends (delta, bat) emit erase-in-line (`\x1b[0K`/`\x1b[K`)
+        // to fill a diff line's background to the pane edge. It is line-bounded,
+        // so it is kept — stripping it gave configured-pager diffs a ragged edge.
+        for el in ["\x1b[K", "\x1b[0K", "\x1b[2K"] {
+            let s = format!("\x1b[41mline{el}");
+            assert_eq!(sanitize_styled_output(&s), s, "EL {el:?} should survive");
+        }
+        // Erase-in-display (`\x1b[2J`) is NOT line-bounded and is still dropped.
+        assert_eq!(sanitize_styled_output("a\x1b[2Jb"), "ab");
+        // The strict (ingestion) policy drops erase-in-line too.
+        assert_eq!(sanitize_untrusted_text("a\x1b[Kb"), "ab");
+    }
+
+    #[test]
+    fn handles_truncated_sequences_at_end_of_input() {
+        // Malformed/truncated escapes at the end are consumed, not echoed.
+        assert_eq!(sanitize_untrusted_text("text\x1b"), "text");
+        assert_eq!(sanitize_untrusted_text("text\x1b["), "text");
+        assert_eq!(sanitize_untrusted_text("text\x1b[31"), "text");
+        assert_eq!(sanitize_untrusted_text("text\x1b]8;;url"), "text");
+    }
+
+    #[test]
+    fn strips_8bit_c1_introducers_and_their_bodies() {
+        // A terminal in 8-bit mode honors C1 controls: U+009B is CSI, U+009D is
+        // OSC, U+0090 is DCS. The whole sequence (introducer + body) is removed,
+        // not just the introducer byte — so no inert `2J`/`8;;url` litter remains.
+        let csi = "a\u{9b}2Jb\u{9b}?1049hc";
+        assert_eq!(sanitize_untrusted_text(csi), "abc");
+        assert_eq!(sanitize_styled_output(csi), "abc");
+
+        // 8-bit OSC terminated by 8-bit ST (U+009C).
+        let osc = "x\u{9d}8;;https://evil\u{9c}y";
+        assert_eq!(sanitize_styled_output(osc), "xy");
+
+        // An 8-bit SGR-shaped CSI is still dropped — we only keep the 7-bit form.
+        let c1_sgr = "\u{9b}31mred";
+        assert_eq!(sanitize_styled_output(c1_sgr), "red");
+    }
+
+    #[test]
+    fn strips_charset_designators_and_ris() {
+        // ESC ( B (select ASCII charset), ESC c (full reset) — dropped.
+        assert_eq!(sanitize_untrusted_text("a\x1b(Bb\x1bcc"), "abc");
+        assert_eq!(sanitize_styled_output("a\x1b(Bb\x1bcc"), "abc");
+    }
+}

--- a/src/summary.rs
+++ b/src/summary.rs
@@ -316,7 +316,14 @@ pub(crate) fn generate_summary_core(
     // clean `main` branch sits behind up to 8 slow summary calls and misses
     // the picker's collect deadline, surfacing as a `·` in the Summary column.
     let _permit = LLM_SEMAPHORE.acquire();
-    let summary = execute_llm_command(llm_command, &prompt)?;
+    // Sanitize the model's stdout at this ingestion edge: it is untrusted free
+    // text rendered into the picker preview and the `wt list` Summary column, and
+    // it is persisted to the on-disk summary cache below — so a control sequence
+    // here would otherwise survive across sessions. Stripping it now keeps every
+    // downstream consumer (and the cache) plain text.
+    let summary =
+        worktrunk::styling::sanitize_untrusted_text(&execute_llm_command(llm_command, &prompt)?)
+            .into_owned();
 
     let cached = CachedSummary {
         summary: summary.clone(),


### PR DESCRIPTION
## Problem

`wt`'s interactive picker (`wt switch`) and `wt list` render **untrusted / externally-controlled free text** into the terminal:

- **Forge free text** — PR/MR titles, descriptions, author names, and URLs from `gh` / `glab`, shown in the picker's `pr` preview tab (and, on the in-flight `pr-preview-worktree-body` branch, the worktree-row PR pane and the on-disk CI cache).
- **LLM output** — `[commit.generation]` model stdout, shown as branch summaries in the picker and the `wt list` Summary column.
- **Git object content** — commit messages and `git log --color` graphs / diffs from a branch that may have been fetched from a malicious remote, shown in the picker's log/diff preview tabs and the `wt list` Message column.

None of these stripped terminal control sequences. A crafted PR/MR body, commit subject, or forge URL carrying raw escapes — a `\x1b[2J` screen-clear, an `\x1b[?1049h` alt-screen switch, cursor moves, an OSC-8 hyperlink the user never wrote, an OSC-52 clipboard write, or a `\x07` BEL — flowed verbatim to the terminal.

Impact is **bounded to display corruption** (garble the pane, recolor, ring the bell, inject a clickable link, scramble skim's layout — all recoverable on redraw); it is **not** RCE and not data loss. But it is the first surface that renders directly attacker-influenced free text into the TUI, so it gets a deliberate boundary rather than a point-patch.

## Why not the shared markdown renderer

The obvious chokepoint would be `md_help::render_markdown_in_help_with_width` (the renderer the PR body and LLM summary both pass through). But it is **also fed trusted ANSI**: `wt --help` hands it clap's already-styled output, complete with SGR colors and clap-generated OSC-8 doc links. The renderer can't tell a trusted clap hyperlink from an attacker's body hyperlink by type alone, and blanket-stripping there would strip clap's styling. So the renderer is left as the trusted-help path, and sanitization happens at the **trust boundaries** instead.

## The boundary

One primitive — `src/styling/sanitize.rs` — applied at two kinds of edge:

- **`sanitize_untrusted_text`** strips **every** control/escape sequence (incl. SGR). Used at *ingestion*, on raw external strings that are plain text and should carry no styling of their own.
- **`sanitize_styled_output`** strips every sequence **except** the line-bounded CSI forms our rendering relies on — SGR color/style (`…m`) and erase-in-line (`…K`, which `delta`/`bat` emit). Used on *already-styled output* (the preview pane mixes our renderer styling, `git --color`, and paged diffs with untrusted text), so colored diffs and styled markdown still render while every cursor move, screen clear, alt-screen switch, OSC, and stray control byte is removed.

Both preserve `\n` and `\t`; both handle 7-bit (`ESC …`) and 8-bit (C1, e.g. `\u{9b}` CSI / `\u{9d}` OSC) introducers; everything else in the C0/C1 ranges plus DEL is dropped.

Applied at:

| Edge | Where | Policy |
|------|-------|--------|
| skim preview chokepoint (all tabs, both row types) | `picker::items::sanitized_preview`, called by both `SkimItem::preview` impls | keep SGR + EL |
| forge fields (title/body/author/url) | `picker::prs` `clean()` at JSON ingestion | strip all |
| LLM summary | `summary::generate_summary_core` (also cleans the on-disk cache) | strip all |
| commit messages | `list::collect` (both `collect()` and the statusline `populate_item()`) | strip all |
| forge CI URL → OSC-8 hyperlink (`wt list` TTY + statusline) | `ci_status::PrStatus::styled` | strip all |

The skim-preview chokepoint is the load-bearing, future-proof boundary: every preview tab and any future one flows through it, so the in-flight `pr_pane.rs` body render is covered automatically when it lands. The ingestion edges additionally make the data model plain text (covering the fuzzy-match `search_text`, the persisted caches, and the non-preview `wt list`/statusline sinks) and remove the bounded SGR-recolor that the display boundary must keep for `git --color`.

## What is stripped vs preserved

- **Stripped everywhere:** screen clear (`\x1b[2J`), alt-screen (`\x1b[?1049h`), cursor moves, scroll regions, mode set/reset, all OSC (titles, OSC-52 clipboard, OSC-8 hyperlinks), DCS/PM/APC, BEL and other C0, C1, DEL, charset designators, and the 8-bit C1 equivalents of all of these.
- **Preserved in styled output (preview / `git --color` / pagers):** SGR color/style and erase-in-line — both line-bounded, within the bounded display-corruption model.
- **Untouched:** `wt --help` (trusted clap markdown, keeps its SGR + OSC-8 doc links).

Two design points kept deliberately within the bounded model and documented in the module: SGR conceal (`8m`) is permitted (narrowing to an allowlist risks dropping a legitimate `git --color` attribute), and Unicode bidi / zero-width "Trojan Source" spoofing is out of scope (a non-escape concern).

## Review

An adversarial review (bypass / regression / coverage lenses) drove three additions beyond the initial preview-chokepoint fix: sanitizing the **forge CI URL** before it becomes an OSC-8 hyperlink in `wt list`/statusline (a sink outside the picker), preserving **erase-in-line** so `delta`/`bat` diffs don't get a ragged edge, and handling **8-bit C1 introducers**.

## Tests

Unit tests pin the sanitizer (CSI/OSC/C0/C1/DEL/charset, SGR + EL kept, conceal/truncation/8-bit edge cases) and the boundaries: the preview chokepoint strips a crafted body's escapes while keeping the gutter color and visible text; `parse_github_prs` strips control sequences from forge fields; an LLM that emits escapes yields a plain summary.

> _This was written by Claude Code on behalf of max_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
