### PR TITLE
feat(commit): surface a "still waiting" spinner for slow message generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 - **Faster file copies on macOS**: After a reflink (`clonefile` on APFS, which already preserves mode bits), worktrunk now skips the redundant follow-up `chmod` on macOS, saving one syscall per file in `wt step copy-ignored` and every other copy path. Linux (btrfs/XFS) still sets permissions, since `FICLONE` clones data extents only and drops the execute bit. ([#3149](https://github.com/max-sixty/worktrunk/pull/3149))
 
+- **"Still waiting" status for slow commit-message generation**: A configured `commit.generation` command captures stdout, so a slow or hung LLM previously showed nothing while `wt step commit`/`squash` waited. After a 2s delay worktrunk now shows a dim, in-place `○ Waiting for the commit message (Ns)` status, escalating at 10s to reveal the exact shell-escaped invocation in a gutter beneath it; the block clears on completion, mirroring `wt list`'s stall footer. ([#3178](https://github.com/max-sixty/worktrunk/pull/3178))
+
 ### Internal
 
 - **Picker migrated to skim 4.8 (ratatui/crossterm)**: The `wt switch` picker moved off skim 0.20.5 (tuikit) to skim 4.8.0, dropping the vendored `vendor/skim-tuikit/` patch tree (both patches it carried are now native or upstream). Two cosmetic picker changes come with it: the match counter no longer overlaps the preview-tab header, and the HEAD column shows the full short-SHA. ([#3137](https://github.com/max-sixty/worktrunk/pull/3137))

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -647,6 +647,14 @@ pub(crate) fn generate_commit_message(
     // Check if commit generation is configured (non-empty command)
     if commit_generation_config.is_configured() {
         let command = commit_generation_config.command.as_ref().unwrap();
+        // The shell-out captures stdout, so a slow or hung LLM is otherwise
+        // silent — show a dim "still waiting" status, escalating to reveal the
+        // exact invocation in a gutter after a longer delay. Held until the
+        // function returns, then dropped (clearing the block) before the caller
+        // prints the generated message.
+        let invocation = render_llm_invocation(command).ok();
+        let _watchdog =
+            worktrunk::progress::Watchdog::start("the commit message", invocation.as_deref());
         // Commit generation is explicitly configured - fail if it doesn't work
         return try_generate_commit_message(
             command,
@@ -818,6 +826,13 @@ pub(crate) fn generate_squash_message(
             project_append,
         )?;
 
+        // See `generate_commit_message` — surface a "still waiting" status so a
+        // slow squash-message generation isn't silent.
+        let invocation = render_llm_invocation(command).ok();
+        let _watchdog = worktrunk::progress::Watchdog::start(
+            "the squash commit message",
+            invocation.as_deref(),
+        );
         return execute_llm_command(command, &prompt).map_err(|e| {
             worktrunk::git::GitError::LlmCommandFailed {
                 command: command.clone(),

--- a/src/progress.rs
+++ b/src/progress.rs
@@ -1,4 +1,12 @@
-//! TTY spinner and file/byte counters for long-running file-walk operations.
+//! TTY spinners for long-running work.
+//!
+//! Two spinner types share one set of render primitives (spinner frames, cursor
+//! control, TTY gating, clear-on-drop): [`Progress`] shows file/byte counters
+//! for file-walk operations; [`Watchdog`] shows an elapsed-time "still waiting"
+//! line for a slow blocking subprocess (e.g. the `commit.generation` LLM) so a
+//! long or hung command isn't silent.
+//!
+//! ## `Progress`
 //!
 //! Shows a single-line stderr spinner (`⠋ Copying 1,234 files · 312 MiB`,
 //! `⠋ Removing 7,272 files · 64.5 MiB`) that updates in place while the work
@@ -28,6 +36,7 @@
 use color_print::cformat;
 
 pub use imp::Progress;
+pub use imp::Watchdog;
 
 #[cfg(feature = "cli")]
 mod imp {
@@ -40,7 +49,7 @@ mod imp {
     use color_print::cformat;
     use crossterm::{
         QueueableCommand,
-        cursor::MoveToColumn,
+        cursor::{MoveToColumn, MoveUp},
         terminal::{Clear, ClearType},
     };
 
@@ -50,6 +59,15 @@ mod imp {
     const TICK_INTERVAL: Duration = Duration::from_millis(100);
     /// Delay before the first frame renders, so sub-second operations stay silent.
     const STARTUP_DELAY: Duration = Duration::from_millis(300);
+    /// `Watchdog` waits longer before nagging — a configured LLM routinely takes
+    /// a couple of seconds, and the caller has already printed a "Generating…"
+    /// line, so the watchdog only surfaces once a command is genuinely slow.
+    const WATCHDOG_STARTUP_DELAY: Duration = Duration::from_secs(2);
+    /// Second tier: once a command has run this long, the bare status line
+    /// isn't enough to debug it, so the exact invocation is revealed in a gutter
+    /// beneath the status — cleared with the rest of the block when the command
+    /// finishes.
+    const WATCHDOG_ESCALATE_DELAY: Duration = Duration::from_secs(10);
 
     struct Shared {
         files: AtomicUsize,
@@ -171,7 +189,7 @@ mod imp {
             if shared.done.load(Ordering::Relaxed) {
                 return;
             }
-            thread::park_timeout(STARTUP_DELAY - start.elapsed());
+            thread::park_timeout(STARTUP_DELAY.saturating_sub(start.elapsed()));
         }
         while !shared.done.load(Ordering::Relaxed) {
             let frame_idx = (start.elapsed().as_millis() / TICK_INTERVAL.as_millis()) as usize
@@ -208,6 +226,257 @@ mod imp {
     fn clear_line<W: Write>(w: &mut W) -> std::io::Result<()> {
         w.queue(MoveToColumn(0))?;
         w.queue(Clear(ClearType::CurrentLine))?;
+        w.flush()
+    }
+
+    /// Shared state between the watchdog and its ticker thread. `rendered_rows`
+    /// is the terminal-row count of the block currently on screen — 0 means
+    /// nothing was drawn (a fast command that finished inside
+    /// [`WATCHDOG_STARTUP_DELAY`], the common case), so `Drop` leaves the
+    /// terminal untouched; >0 tells `Drop` how many rows to clear. `escalated`
+    /// records whether the command gutter has been revealed, for tests.
+    struct WatchdogShared {
+        done: AtomicBool,
+        rendered_rows: AtomicUsize,
+        escalated: AtomicBool,
+    }
+
+    impl WatchdogShared {
+        fn new() -> Self {
+            Self {
+                done: AtomicBool::new(false),
+                rendered_rows: AtomicUsize::new(0),
+                escalated: AtomicBool::new(false),
+            }
+        }
+    }
+
+    /// Live "still waiting" status for a single slow blocking subprocess.
+    ///
+    /// Unlike [`Progress`] (which counts work units), `Watchdog` just tracks
+    /// elapsed time. After a startup delay it renders a dim one-line status —
+    /// `○ Waiting for the commit message (4s)` — redrawn in place each second;
+    /// the ticking counter is the "still alive" signal. After a longer delay it
+    /// escalates, revealing the exact command in a gutter beneath the status:
+    ///
+    /// ```text
+    /// ○ Waiting for the commit message (12s)
+    ///    sh -c 'claude -p --model=haiku'
+    /// ```
+    ///
+    /// The whole block is cleared on drop — nothing persists — so the caller can
+    /// print its result immediately afterward. The dim, in-place look mirrors
+    /// `wt list`'s stall footer.
+    ///
+    /// It only reads a clock and writes to stderr; it never touches the child's
+    /// stdin/stdout or its `wait`, so it's safe to wrap a capture-mode
+    /// [`Cmd::run`](crate::shell_exec::Cmd) whose output is captured rather than
+    /// streamed (e.g. the LLM commit command). Don't pair it with a streaming
+    /// command — the child's own output would interleave with the status block.
+    pub struct Watchdog {
+        shared: Arc<WatchdogShared>,
+        /// Render thread; present only when enabled (stderr TTY, non-verbose).
+        ticker: Option<JoinHandle<()>>,
+    }
+
+    impl Watchdog {
+        /// Start a watchdog for a slow subprocess.
+        ///
+        /// `waiting_for` names what is being awaited (e.g. `"the commit
+        /// message"`). `command`, if given, is the exact invocation — revealed
+        /// in a gutter beneath the status line once the command runs past the
+        /// escalation delay, so a slow or stuck command is debuggable.
+        ///
+        /// Enabled only when stderr is a TTY and verbosity is 0 — under
+        /// `-v`/`-vv` the structured diagnostics take over, and a non-TTY (piped)
+        /// context renders nothing.
+        pub fn start(waiting_for: &str, command: Option<&str>) -> Self {
+            let enabled = std::io::stderr().is_terminal() && crate::styling::verbosity() == 0;
+            Self::start_with(waiting_for, command, enabled)
+        }
+
+        /// Dispatch helper picking enabled/disabled from an explicit flag, so
+        /// tests exercise both branches without depending on the ambient stderr
+        /// fd (see [`Progress::start_with`] for why).
+        fn start_with(waiting_for: &str, command: Option<&str>, enabled: bool) -> Self {
+            if enabled {
+                Self::enabled(waiting_for, command)
+            } else {
+                Self::disabled()
+            }
+        }
+
+        fn disabled() -> Self {
+            Self {
+                shared: Arc::new(WatchdogShared::new()),
+                ticker: None,
+            }
+        }
+
+        fn enabled(waiting_for: &str, command: Option<&str>) -> Self {
+            Self::enabled_with_delays(
+                waiting_for,
+                command,
+                WATCHDOG_STARTUP_DELAY,
+                WATCHDOG_ESCALATE_DELAY,
+            )
+        }
+
+        /// Spawn the ticker with explicit delays. The public path passes the
+        /// module constants; tests pass millisecond delays so the escalation
+        /// tier is exercisable without a 10-second wait.
+        fn enabled_with_delays(
+            waiting_for: &str,
+            command: Option<&str>,
+            startup_delay: Duration,
+            escalate_delay: Duration,
+        ) -> Self {
+            let shared = Arc::new(WatchdogShared::new());
+            let ticker = {
+                let shared = Arc::clone(&shared);
+                let waiting_for = waiting_for.to_owned();
+                let command = command.map(str::to_owned);
+                thread::spawn(move || {
+                    watchdog_loop(
+                        &shared,
+                        &waiting_for,
+                        command.as_deref(),
+                        startup_delay,
+                        escalate_delay,
+                    )
+                })
+            };
+            Self {
+                shared,
+                ticker: Some(ticker),
+            }
+        }
+
+        /// Stop the watchdog and clear its block. Equivalent to dropping.
+        pub fn finish(self) {
+            drop(self);
+        }
+    }
+
+    impl Drop for Watchdog {
+        fn drop(&mut self) {
+            if let Some(ticker) = self.ticker.take() {
+                self.shared.done.store(true, Ordering::Relaxed);
+                ticker.thread().unpark();
+                let _ = ticker.join();
+                // Clear the block the ticker left on screen. 0 rows means nothing
+                // was drawn (a fast command that never tripped the startup delay),
+                // so the terminal is left untouched.
+                let rows = self.shared.rendered_rows.load(Ordering::Relaxed);
+                if rows > 0 {
+                    let _ = clear_block(&mut std::io::stderr().lock(), rows);
+                }
+            }
+        }
+    }
+
+    fn watchdog_loop(
+        shared: &WatchdogShared,
+        waiting_for: &str,
+        command: Option<&str>,
+        startup_delay: Duration,
+        escalate_delay: Duration,
+    ) {
+        let start = Instant::now();
+        // park_timeout returns immediately on `unpark` from drop, so a command
+        // that finishes before the delay neither renders nor blocks shutdown.
+        while start.elapsed() < startup_delay {
+            if shared.done.load(Ordering::Relaxed) {
+                return;
+            }
+            thread::park_timeout(startup_delay.saturating_sub(start.elapsed()));
+        }
+        let mut prev_rows = 0usize;
+        let mut last_block: Vec<String> = Vec::new();
+        while !shared.done.load(Ordering::Relaxed) {
+            let elapsed = start.elapsed();
+            // Second tier: once the command has run long enough, reveal it in a
+            // gutter beneath the status line.
+            let escalated = command.is_some() && elapsed >= escalate_delay;
+            if escalated {
+                shared.escalated.store(true, Ordering::Relaxed);
+            }
+            let block = watchdog_block(
+                waiting_for,
+                elapsed.as_secs(),
+                if escalated { command } else { None },
+                crate::styling::terminal_width(),
+            );
+            // Redraw only when the content changes — the status counter ticks
+            // once a second, the gutter appears once — so the block doesn't
+            // flicker between the (sub-second) wake-ups.
+            if block != last_block {
+                let mut err = std::io::stderr().lock();
+                prev_rows = render_block(&mut err, &block, prev_rows);
+                shared.rendered_rows.store(prev_rows, Ordering::Relaxed);
+                last_block = block;
+            }
+            thread::park_timeout(TICK_INTERVAL);
+        }
+    }
+
+    /// Build the watchdog block: a dim status line, plus — once `command` is
+    /// given (escalated) — that command in a bash-highlighted gutter beneath it
+    /// (matching how worktrunk shows commands elsewhere, e.g. the LLM-failure
+    /// error).
+    ///
+    /// Every returned string must occupy exactly one terminal row, or the
+    /// in-place cursor math in [`render_block`]/[`clear_block`] desyncs from what
+    /// the terminal actually wrapped and corrupts the lines above. So both lines
+    /// are width-bounded rather than left to soft-wrap: the status is
+    /// ANSI-aware-truncated to `width`, and the command gutter is *chopped* (not
+    /// wrapped) so an over-wide invocation stays one row. `width` is the terminal
+    /// width (`None` → unknown, leave the status unbounded); the loop passes the
+    /// live width each tick so a resize is picked up.
+    fn watchdog_block(
+        waiting_for: &str,
+        secs: u64,
+        command: Option<&str>,
+        width: Option<usize>,
+    ) -> Vec<String> {
+        let status = cformat!("<dim>○ Waiting for {waiting_for} ({secs}s)</>");
+        let status = match width {
+            Some(w) => crate::styling::truncate_visible(&status, w),
+            None => status,
+        };
+        let mut lines = vec![status];
+        if let Some(cmd) = command {
+            lines.extend(
+                crate::styling::format_bash_with_gutter_chopped(cmd)
+                    .lines()
+                    .map(str::to_owned),
+            );
+        }
+        lines
+    }
+
+    /// Redraw the in-place block: clear the previous `prev_rows` rows, then write
+    /// the new lines (joined, no trailing newline). Returns the new row count.
+    /// Relies on each line being ≤ terminal width (one row), so `prev_rows`
+    /// equals the visual rows occupied.
+    fn render_block<W: Write>(w: &mut W, lines: &[String], prev_rows: usize) -> usize {
+        let _ = w.queue(MoveToColumn(0));
+        if prev_rows > 1 {
+            let _ = w.queue(MoveUp(prev_rows as u16 - 1));
+        }
+        let _ = w.queue(Clear(ClearType::FromCursorDown));
+        let _ = write!(w, "{}", lines.join("\n"));
+        let _ = w.flush();
+        lines.len()
+    }
+
+    /// Clear a `rows`-row block: move to its first row and clear downward.
+    fn clear_block<W: Write>(w: &mut W, rows: usize) -> std::io::Result<()> {
+        w.queue(MoveToColumn(0))?;
+        if rows > 1 {
+            w.queue(MoveUp(rows as u16 - 1))?;
+        }
+        w.queue(Clear(ClearType::FromCursorDown))?;
         w.flush()
     }
 
@@ -282,6 +551,122 @@ mod imp {
             std::thread::sleep(STARTUP_DELAY + TICK_INTERVAL + Duration::from_millis(50));
             p.finish();
         }
+
+        #[test]
+        fn test_watchdog_block_status_only() {
+            // Before escalation (no command) the block is a single dim status
+            // row. A wide width leaves the status untruncated.
+            let block = watchdog_block("the commit message", 4, None, Some(200));
+            assert_eq!(block.len(), 1);
+            assert!(block[0].contains("Waiting for the commit message"));
+            assert!(block[0].contains("(4s)"));
+            assert!(block[0].contains('○'));
+            assert!(!block[0].contains('…'));
+        }
+
+        #[test]
+        fn test_watchdog_block_escalated_adds_command_gutter() {
+            // Escalated, the command is revealed in a gutter row beneath the
+            // status. Assert on a bare word ("claude") rather than the whole
+            // command, since bash highlighting interleaves ANSI codes between
+            // tokens (a word itself is never split mid-token).
+            let block = watchdog_block(
+                "the commit message",
+                12,
+                Some("claude --model=haiku"),
+                Some(200),
+            );
+            assert!(block.len() >= 2);
+            assert!(block[0].contains("Waiting for the commit message"));
+            assert!(block.join("\n").contains("claude"));
+        }
+
+        #[test]
+        fn test_watchdog_block_status_truncated_to_width() {
+            // A width narrower than the status text truncates it to one row
+            // (visible width within budget, ellipsis appended) — without this the
+            // soft-wrapped second row desyncs the in-place cursor math.
+            use ansi_str::AnsiStr;
+            use unicode_width::UnicodeWidthStr;
+            let block = watchdog_block("the squash commit message", 1234, None, Some(20));
+            assert_eq!(block.len(), 1);
+            let visible = block[0].ansi_strip();
+            assert!(UnicodeWidthStr::width(visible.as_ref()) <= 20);
+            assert!(block[0].contains('…'));
+        }
+
+        #[test]
+        fn test_watchdog_start_with_non_tty_is_disabled() {
+            assert!(
+                Watchdog::start_with("the commit message", None, false)
+                    .ticker
+                    .is_none()
+            );
+        }
+
+        #[test]
+        fn test_watchdog_start_with_tty_is_enabled() {
+            let w = Watchdog::start_with("the commit message", None, true);
+            assert!(w.ticker.is_some());
+            w.finish();
+        }
+
+        #[test]
+        fn test_watchdog_renders_after_startup_delay() {
+            // Tiny startup delay, escalation far off: the status renders but the
+            // command gutter never appears.
+            let w = Watchdog::enabled_with_delays(
+                "the commit message",
+                Some("sh -c 'claude -p'"),
+                Duration::from_millis(10),
+                Duration::from_secs(3600),
+            );
+            std::thread::sleep(Duration::from_millis(120));
+            assert!(w.shared.rendered_rows.load(Ordering::Relaxed) > 0);
+            assert!(!w.shared.escalated.load(Ordering::Relaxed));
+            w.finish();
+        }
+
+        #[test]
+        fn test_watchdog_fast_command_leaves_no_trace() {
+            // A command that finishes before the startup delay must never draw a
+            // block — so Drop has nothing to clear and leaves no escape in output.
+            let w = Watchdog::enabled("the commit message", None);
+            assert_eq!(w.shared.rendered_rows.load(Ordering::Relaxed), 0);
+            w.finish();
+        }
+
+        #[test]
+        fn test_watchdog_escalates_and_grows_the_block() {
+            // Short startup + escalation delays so the second tier fires fast; the
+            // revealed gutter makes the block more than one row.
+            let w = Watchdog::enabled_with_delays(
+                "the commit message",
+                Some("sh -c 'claude -p'"),
+                Duration::from_millis(10),
+                Duration::from_millis(30),
+            );
+            std::thread::sleep(Duration::from_millis(150));
+            assert!(w.shared.escalated.load(Ordering::Relaxed));
+            assert!(w.shared.rendered_rows.load(Ordering::Relaxed) >= 2);
+            w.finish();
+        }
+
+        #[test]
+        fn test_watchdog_no_escalation_without_command() {
+            // No command → the gutter never appears, however long it runs, so the
+            // block stays a single status row.
+            let w = Watchdog::enabled_with_delays(
+                "the commit message",
+                None,
+                Duration::from_millis(10),
+                Duration::from_millis(30),
+            );
+            std::thread::sleep(Duration::from_millis(150));
+            assert_eq!(w.shared.rendered_rows.load(Ordering::Relaxed), 1);
+            assert!(!w.shared.escalated.load(Ordering::Relaxed));
+            w.finish();
+        }
     }
 }
 
@@ -321,6 +706,18 @@ mod imp {
                 self.files.load(Ordering::Relaxed),
                 self.bytes.load(Ordering::Relaxed),
             )
+        }
+
+        pub fn finish(self) {}
+    }
+
+    /// Spinner-less stub when the `cli` feature is off — mirrors [`Progress`]'s
+    /// stub. The watchdog has no counters to keep, so it carries no state.
+    pub struct Watchdog;
+
+    impl Watchdog {
+        pub fn start(_waiting_for: &str, _command: Option<&str>) -> Self {
+            Self
         }
 
         pub fn finish(self) {}


### PR DESCRIPTION
A configured `commit.generation` command shells out and **captures** stdout, so until it returns the terminal shows nothing — a slow or hung LLM looks like a freeze. This adds a "still waiting" notification, modeled on `wt list`'s dim stall footer.

`progress::Watchdog` is a TTY-gated, dim, in-place status line — `○ Waiting for the commit message (Ns)` — that appears after a 2s startup delay (so the common fast case stays silent) and escalates at 10s to reveal the exact shell-escaped invocation in a bash-highlighted gutter beneath it, so a stuck command is debuggable. The whole block is cleared on completion, so nothing persists. It's wired into both `generate_commit_message` and `generate_squash_message`; the concurrent summary path and the `wt config` self-test are deliberately left uncovered.

### Notes for review

- `Watchdog` shares `Progress`'s render primitives (TTY/verbosity gating, ticker thread, clear-on-drop). It only reads a clock and writes to stderr — never touches the child's stdin/stdout/`wait` — so it's safe to wrap a capture-mode command.
- The in-place multi-row redraw relies on each rendered line occupying exactly one terminal row. That invariant is now enforced rather than assumed: the status line is ANSI-aware-truncated and the command gutter is *chopped* (not wrapped), so a narrow terminal or an over-wide invocation can't desync the cursor math.
- Also aligns the sibling `Progress::ticker_loop` to `saturating_sub` for its startup-delay park, removing a latent panic under scheduler preemption.

Tested by the `progress` unit tests (status-only vs escalated block, width truncation, fast-command-leaves-no-trace, escalation timing) plus the full pre-merge suite. The rendering itself was verified live via `tmux capture-pane`.

> _This was written by Claude Code on behalf of max_
