### PR TITLE
test(progress): poll for watchdog ticker work instead of fixed sleeps

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -614,14 +614,25 @@ mod imp {
         #[test]
         fn test_watchdog_renders_after_startup_delay() {
             // Tiny startup delay, escalation far off: the status renders but the
-            // command gutter never appears.
+            // command gutter never appears. The first render happens on the
+            // background ticker thread, so poll for it rather than sleeping a
+            // fixed window the thread could be starved past under load. The
+            // far-off escalation delay keeps the gutter absent for the whole
+            // poll, so the `!escalated` assertion holds regardless of timing.
             let w = Watchdog::enabled_with_delays(
                 "the commit message",
                 Some("sh -c 'claude -p'"),
                 Duration::from_millis(10),
                 Duration::from_secs(3600),
             );
-            std::thread::sleep(Duration::from_millis(120));
+            let timeout = Duration::from_secs(5);
+            let start = Instant::now();
+            while start.elapsed() < timeout {
+                if w.shared.rendered_rows.load(Ordering::Relaxed) > 0 {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
             assert!(w.shared.rendered_rows.load(Ordering::Relaxed) > 0);
             assert!(!w.shared.escalated.load(Ordering::Relaxed));
             w.finish();
@@ -639,14 +650,28 @@ mod imp {
         #[test]
         fn test_watchdog_escalates_and_grows_the_block() {
             // Short startup + escalation delays so the second tier fires fast; the
-            // revealed gutter makes the block more than one row.
+            // revealed gutter makes the block more than one row. The escalation
+            // and render both happen on the background ticker thread, so poll for
+            // its work rather than sleeping a fixed window: a loaded runner can
+            // starve the ticker past any fixed deadline, but the condition itself
+            // is what we're verifying. Generous timeout, fast poll — fast when
+            // healthy, reliable under load.
             let w = Watchdog::enabled_with_delays(
                 "the commit message",
                 Some("sh -c 'claude -p'"),
                 Duration::from_millis(10),
                 Duration::from_millis(30),
             );
-            std::thread::sleep(Duration::from_millis(150));
+            let timeout = Duration::from_secs(5);
+            let start = Instant::now();
+            while start.elapsed() < timeout {
+                if w.shared.escalated.load(Ordering::Relaxed)
+                    && w.shared.rendered_rows.load(Ordering::Relaxed) >= 2
+                {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
             assert!(w.shared.escalated.load(Ordering::Relaxed));
             assert!(w.shared.rendered_rows.load(Ordering::Relaxed) >= 2);
             w.finish();


### PR DESCRIPTION
## What

De-flake two timing-dependent watchdog tests in `src/progress.rs` by replacing fixed wall-clock sleeps with condition polling.

## Why

`test_watchdog_escalates_and_grows_the_block` failed on a loaded macOS CI runner (an advisory/non-required check, so it didn't block, but it's a real flake):

```
thread '...' panicked at src/progress.rs:650:13:
assertion failed: w.shared.escalated.load(Ordering::Relaxed)
```

The watchdog spawns a background ticker thread (`watchdog_loop`) that, after its escalation delay, stores `escalated = true` and renders the command gutter (growing the block to ≥ 2 rows). The test set short delays (startup 10ms, escalate 30ms), then did a fixed `sleep(150ms)` and asserted the thread had by then done its work. On a loaded runner the ticker can be starved past the 150ms window, so the atomic is still `false` when the assertion runs — the test races the scheduler instead of waiting for the actual condition. This is precisely the "❌ BAD: Fixed sleep" anti-pattern in `tests/CLAUDE.md` → "Timing Tests: Long Timeouts with Fast Polling".

## Fix

Both positive-assertion tests now poll the condition with a generous 5s timeout and a 10ms poll interval, breaking as soon as it's satisfied, then assert — fast on a healthy machine, reliable under load:

- `test_watchdog_escalates_and_grows_the_block` — polls until `escalated` is set **and** `rendered_rows >= 2`.
- `test_watchdog_renders_after_startup_delay` — same fixed-sleep-then-assert-positive shape (`rendered_rows > 0`), so it carried the same latent flake; converted to poll for the first render. Its far-off escalation delay (3600s) keeps the gutter absent for the whole poll, so the `!escalated` assertion holds regardless of timing.

The two **absence-testing** watchdog tests are deliberately left as fixed sleeps — `test_watchdog_no_escalation_without_command` and `test_watchdog_fast_command_leaves_no_trace` verify that something did *not* happen, which polling can't prove (the `tests/CLAUDE.md` "testing absence" exception).

The assertions are kept as two separate `assert!`s rather than folded into the poll condition, so a genuine timeout still pinpoints which sub-condition failed.

## Verification

- `cargo test --features cli --lib progress::imp::tests::test_watchdog` — all 9 pass in ~0.15s.
- Stress: ran all 9 watchdog tests 25× while saturating all 18 cores with busy-loops (simulating a starved runner) — **25/25 passed**. The old fixed-sleep shape is exactly what fails under that pressure.
- Full `cargo run -- hook pre-merge --yes` gate green: 4126 tests passed (1 skipped), all clippy/lints clean.

> _This was written by Claude Code on behalf of max_
