### PR TITLE
feat: extend the "still waiting" watchdog to more slow foreground commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 - **"Still waiting" status for slow commit-message generation**: A configured `commit.generation` command captures stdout, so a slow or hung LLM previously showed nothing while `wt step commit`/`squash` waited. After a 2s delay worktrunk now shows a dim, in-place `○ Waiting for the commit message (Ns)` status, escalating at 10s to reveal the exact shell-escaped invocation in a gutter beneath it; the block clears on completion, mirroring `wt list`'s stall footer. ([#3178](https://github.com/max-sixty/worktrunk/pull/3178))
 
+- **"Still waiting" status extended to more slow commands**: The same waiting status now covers three more foreground commands that were silent while a captured subprocess ran — the `wt config show --full` commit-generation self-test, the `wt switch pr:`/`mr:` host lookup, and the `wt config show --full` version check. The version check no longer caps its fetch at an aggressive 5s, instead showing the status while a slow-but-working request completes (with a generous ceiling so a non-interactive run can't hang). ([#3183](https://github.com/max-sixty/worktrunk/pull/3183))
+
 ### Internal
 
 - **Picker migrated to skim 4.8 (ratatui/crossterm)**: The `wt switch` picker moved off skim 0.20.5 (tuikit) to skim 4.8.0, dropping the vendored `vendor/skim-tuikit/` patch tree (both patches it carried are now native or upstream). Two cosmetic picker changes come with it: the match counter no longer overlaps the preview-tab header, and the HEAD column shows the full short-SHA. ([#3137](https://github.com/max-sixty/worktrunk/pull/3137))

--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -1444,17 +1444,28 @@ fn fetch_latest_version() -> anyhow::Result<String> {
         "worktrunk/{} (https://worktrunk.dev)",
         env!("CARGO_PKG_VERSION")
     );
-    let output = Cmd::new("curl")
-        .args([
-            "--silent",
-            "--fail",
-            "--max-time",
-            "5",
-            "--header",
-            &format!("User-Agent: {user_agent}"),
-            "https://api.github.com/repos/max-sixty/worktrunk/releases/latest",
-        ])
-        .run()?;
+    // The watchdog (below) supplies "still waiting" feedback, so the fetch needn't
+    // be cut off at an aggressive 5s. But the watchdog is TTY-gated — a
+    // non-interactive run (CI, scripts, redirected stderr) gets no feedback — so a
+    // hard ceiling still has to exist or such a run could hang silently:
+    // --connect-timeout fails fast when offline, and a generous --max-time bounds a
+    // connected-but-stalled host without cutting off a slow-but-progressing fetch.
+    let output = {
+        let _watchdog = worktrunk::progress::Watchdog::start("the latest version", None);
+        Cmd::new("curl")
+            .args([
+                "--silent",
+                "--fail",
+                "--connect-timeout",
+                "10",
+                "--max-time",
+                "60",
+                "--header",
+                &format!("User-Agent: {user_agent}"),
+                "https://api.github.com/repos/max-sixty/worktrunk/releases/latest",
+            ])
+            .run()?
+    };
 
     if !output.status.success() {
         anyhow::bail!("GitHub API request failed");

--- a/src/commands/worktree/switch.rs
+++ b/src/commands/worktree/switch.rs
@@ -197,6 +197,25 @@ fn resolve_pr_base(
     }
 }
 
+/// Fetch PR/MR info while showing a "still waiting" status.
+///
+/// The host lookup (`gh`/`glab` API) captures its output and can stall on a slow
+/// network, so without feedback the command looks frozen. The watchdog clears
+/// before the caller prints the resolved ref context. No command gutter — the
+/// host CLI invocation isn't readily available here, and the status line alone
+/// is the signal.
+fn fetch_ref_info(
+    provider: &dyn RemoteRefProvider,
+    number: u32,
+    repo: &Repository,
+) -> anyhow::Result<RemoteRefInfo> {
+    let _watchdog = worktrunk::progress::Watchdog::start(
+        &format!("the {} info", provider.ref_type().name()),
+        None,
+    );
+    provider.fetch_info(number, repo)
+}
+
 /// Resolve a remote ref (PR or MR) using the unified provider interface.
 fn resolve_remote_ref(
     repo: &Repository,
@@ -219,7 +238,7 @@ fn resolve_remote_ref(
         progress_message(cformat!("Fetching {} {symbol}{number}...", ref_type.name()))
     );
 
-    let info = provider.fetch_info(number, repo)?;
+    let info = fetch_ref_info(provider, number, repo)?;
 
     // Display context with URL (as gutter under fetch progress)
     eprintln!("{}", format_with_gutter(&format_ref_context(&info), None));
@@ -513,7 +532,7 @@ fn resolve_remote_ref_as_base(
         ))
     );
 
-    let info = provider.fetch_info(number, repo)?;
+    let info = fetch_ref_info(provider, number, repo)?;
     eprintln!("{}", format_with_gutter(&format_ref_context(&info), None));
 
     if !info.is_cross_repo {

--- a/src/llm.rs
+++ b/src/llm.rs
@@ -88,6 +88,23 @@ pub(crate) fn render_llm_invocation(command: &str) -> anyhow::Result<String> {
     Ok(rendered)
 }
 
+/// Start a "still waiting" watchdog for a *foreground* LLM shell-out.
+///
+/// [`execute_llm_command`] captures stdout, so a slow or hung command is
+/// otherwise silent. The watchdog shows a dim status line that escalates to
+/// reveal the exact invocation (via [`render_llm_invocation`]) in a gutter. The
+/// caller holds the returned guard until the command returns; on drop it clears
+/// the status before the result is printed.
+///
+/// Only for single, foreground calls — never the concurrent summary path
+/// ([`generate_summary_core`](crate::summary::generate_summary_core), up to 8
+/// under a semaphore), where
+/// per-call spinners would interleave.
+fn watch_llm_command(command: &str, waiting_for: &str) -> worktrunk::progress::Watchdog {
+    let invocation = render_llm_invocation(command).ok();
+    worktrunk::progress::Watchdog::start(waiting_for, invocation.as_deref())
+}
+
 /// Format a reproduction command, only wrapping with `sh -c` if needed.
 ///
 /// Simple commands like `llm -m haiku` are shown as-is.
@@ -647,14 +664,10 @@ pub(crate) fn generate_commit_message(
     // Check if commit generation is configured (non-empty command)
     if commit_generation_config.is_configured() {
         let command = commit_generation_config.command.as_ref().unwrap();
-        // The shell-out captures stdout, so a slow or hung LLM is otherwise
-        // silent — show a dim "still waiting" status, escalating to reveal the
-        // exact invocation in a gutter after a longer delay. Held until the
-        // function returns, then dropped (clearing the block) before the caller
-        // prints the generated message.
-        let invocation = render_llm_invocation(command).ok();
-        let _watchdog =
-            worktrunk::progress::Watchdog::start("the commit message", invocation.as_deref());
+        // A slow or hung command is otherwise silent (stdout is captured); the
+        // watchdog surfaces a "still waiting" status. Held until this function
+        // returns, clearing the block before the caller prints the message.
+        let _watchdog = watch_llm_command(command, "the commit message");
         // Commit generation is explicitly configured - fail if it doesn't work
         return try_generate_commit_message(
             command,
@@ -826,13 +839,9 @@ pub(crate) fn generate_squash_message(
             project_append,
         )?;
 
-        // See `generate_commit_message` — surface a "still waiting" status so a
-        // slow squash-message generation isn't silent.
-        let invocation = render_llm_invocation(command).ok();
-        let _watchdog = worktrunk::progress::Watchdog::start(
-            "the squash commit message",
-            invocation.as_deref(),
-        );
+        // See `generate_commit_message` — keep a slow squash-message generation
+        // from being silent.
+        let _watchdog = watch_llm_command(command, "the squash commit message");
         return execute_llm_command(command, &prompt).map_err(|e| {
             worktrunk::git::GitError::LlmCommandFailed {
                 command: command.clone(),
@@ -956,6 +965,9 @@ pub(crate) fn test_commit_generation(
     };
     let prompt = build_prompt(commit_generation_config, TemplateType::Commit, &context)?;
 
+    // The connectivity test shells out the same way real generation does, so a
+    // slow command would be just as silent — surface the same waiting status.
+    let _watchdog = watch_llm_command(command, "the test commit message");
     execute_llm_command(command, &prompt).map_err(|e| {
         worktrunk::git::GitError::LlmCommandFailed {
             command: command.clone(),


### PR DESCRIPTION
Follow-up to #3178, which added the "still waiting" watchdog for slow `commit.generation` shell-outs. This extends it to three more foreground commands that were silent while a captured subprocess ran.

- **`wt config` LLM self-test** — the commit/squash watchdog wiring is now a shared `watch_llm_command(command, waiting_for)` helper, and `test_commit_generation` uses it too, so the self-test escalates to the command gutter just like real generation.
- **`wt switch pr:/mr:`** — a new `fetch_ref_info` helper wraps the gh/glab host lookup at both resolution sites. Status-only (no gutter) since the host CLI invocation isn't readily available there.
- **`wt config show --full` version check** — wrapped with the watchdog, and curl's aggressive `--max-time 5` total cap relaxed so a slow-but-working fetch finishes with feedback instead of being cut off.

### Note on the version-check timeout

An adversarial review flagged that simply dropping `--max-time` would let `wt config show --full` hang on a *connected-but-stalled* host — and since the watchdog is TTY-gated, a non-interactive run (CI, scripts, redirected stderr) would hang **silently and unbounded**, worse than today's graceful 5s failure. So the fetch keeps a hard ceiling: `--connect-timeout 10` (fails fast offline) plus a generous `--max-time 60` (bounds a stalled host without cutting off a realistic fetch). The watchdog supplies the interactive "still waiting" feedback during the wait.

The watchdog is deliberately **not** wired into the concurrent summary path (`generate_summary_core`, up to 8 under a semaphore), where per-call spinners would interleave.

Verified: full pre-merge suite (4122 tests) green; the self-test watchdog confirmed live via tmux; the version-check happy path confirmed end-to-end.

> _This was written by Claude Code on behalf of max_
