### PR TITLE
Polish profile summary line and surface profiler in bug-report docs

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -157,6 +157,14 @@ the issue gives us most of what we'd otherwise ask for piecemeal, so lead
 with this for unexplained failures rather than chaining version/config/repro
 questions across multiple round-trips.
 
+When the report is about a slow `wt` command, read its **Performance profile**
+section first. It renders the same breakdown as `wt config state logs profile`
+(subprocess time by command type, slowest calls, repeated `(command, context)`
+pairs) directly from the bundled `trace.log`, so you can spot redundant git
+calls and slow commands without parsing the raw trace by hand. The deeper
+per-render cache analysis is a separate tool — see **Weekly Maintenance:
+Statusline Cache-Check**.
+
 Reach for narrower asks only when the diagnostic is overkill:
 
 - `wt --version` — when the only question is whether a fix has landed.

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -1086,7 +1086,7 @@ All `post-*` hooks (post-start, post-switch, post-commit, post-merge) run in the
 | `subprocess.log` | Running with `-vv` |
 | `diagnostic.md` | Running with `-vv` |
 
-`trace.log` captures debug-level records at `-vv` — commands, `[wt-trace]` records, bounded subprocess previews. `wt config state logs profile` summarizes one into a performance report (where time went, parallelism, redundant commands). `subprocess.log` holds the raw uncapped subprocess stdout/stderr bodies. `diagnostic.md` is a markdown bug-report bundle that inlines `trace.log`; `wt` prints a `gh gist create` command pointing at it. All three are overwritten on each `-vv` run.
+`trace.log` captures debug-level records at `-vv` — commands, `[wt-trace]` records, bounded subprocess previews. `wt config state logs profile` summarizes one into a performance report (where time went, parallelism, redundant commands). `subprocess.log` holds the raw uncapped subprocess stdout/stderr bodies. `diagnostic.md` is a markdown bug-report bundle that inlines `trace.log` and a rendered performance profile; `wt` prints a `gh gist create` command pointing at it. All three are overwritten on each `-vv` run.
 
 ### Location
 

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -103,11 +103,11 @@ The three `-vv` files have distinct audiences:
 
 - **`trace.log`** — bounded preview (~1K lines), `[wt-trace]` records, gistable.
 - **`subprocess.log`** — raw uncapped stdout/stderr of every subprocess `wt` spawns (multi-MB possible, e.g. full `git log -p` output). The deep-dive escape hatch.
-- **`diagnostic.md`** — markdown bug-report bundle that inlines `trace.log`. `wt` prints a `gh gist create` command pointing at it.
+- **`diagnostic.md`** — markdown bug-report bundle that inlines `trace.log` and a rendered performance profile (subprocess time by command type, slowest calls, repeated calls). `wt` prints a `gh gist create` command pointing at it.
 
 `RUST_LOG` overrides the flag baseline when set (`RUST_LOG=debug wt -v` lifts `-v` to debug-on-stderr).
 
-The flags only reach a command you type; shell completion runs as its own process with nowhere to pass one. Set `WORKTRUNK_VERBOSE=0|1|2` to apply the level to *every* invocation, completion included — it's the env-var equivalent of `-v`/`-vv`, so level 2 writes the same `trace.log`/`subprocess.log`/`diagnostic.md` files. An explicit `-v`/`-vv` on a command raises the level further but never lowers this baseline. To profile a slow tab-completion, run it the way your shell does — e.g. `WORKTRUNK_VERBOSE=2 COMPLETE=fish wt -- wt switch ''` — then read `trace.log`.
+The flags only reach a command you type; shell completion runs as its own process with nowhere to pass one. Set `WORKTRUNK_VERBOSE=0|1|2` to apply the level to *every* invocation, completion included — it's the env-var equivalent of `-v`/`-vv`, so level 2 writes the same `trace.log`/`subprocess.log`/`diagnostic.md` files. An explicit `-v`/`-vv` on a command raises the level further but never lowers this baseline. To profile a slow tab-completion, run it the way your shell does — e.g. `WORKTRUNK_VERBOSE=2 COMPLETE=fish wt -- wt switch ''` — then render the result with `wt config state logs profile`.
 
 ## What files does Worktrunk create?
 

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -1121,7 +1121,7 @@ All `post-*` hooks (post-start, post-switch, post-commit, post-merge) run in the
 | `subprocess.log` | Running with `-vv` |
 | `diagnostic.md` | Running with `-vv` |
 
-`trace.log` captures debug-level records at `-vv` — commands, `[wt-trace]` records, bounded subprocess previews. `wt config state logs profile` summarizes one into a performance report (where time went, parallelism, redundant commands). `subprocess.log` holds the raw uncapped subprocess stdout/stderr bodies. `diagnostic.md` is a markdown bug-report bundle that inlines `trace.log`; `wt` prints a `gh gist create` command pointing at it. All three are overwritten on each `-vv` run.
+`trace.log` captures debug-level records at `-vv` — commands, `[wt-trace]` records, bounded subprocess previews. `wt config state logs profile` summarizes one into a performance report (where time went, parallelism, redundant commands). `subprocess.log` holds the raw uncapped subprocess stdout/stderr bodies. `diagnostic.md` is a markdown bug-report bundle that inlines `trace.log` and a rendered performance profile; `wt` prints a `gh gist create` command pointing at it. All three are overwritten on each `-vv` run.
 
 ### Location
 

--- a/skills/worktrunk/reference/faq.md
+++ b/skills/worktrunk/reference/faq.md
@@ -96,11 +96,11 @@ The three `-vv` files have distinct audiences:
 
 - **`trace.log`** — bounded preview (~1K lines), `[wt-trace]` records, gistable.
 - **`subprocess.log`** — raw uncapped stdout/stderr of every subprocess `wt` spawns (multi-MB possible, e.g. full `git log -p` output). The deep-dive escape hatch.
-- **`diagnostic.md`** — markdown bug-report bundle that inlines `trace.log`. `wt` prints a `gh gist create` command pointing at it.
+- **`diagnostic.md`** — markdown bug-report bundle that inlines `trace.log` and a rendered performance profile (subprocess time by command type, slowest calls, repeated calls). `wt` prints a `gh gist create` command pointing at it.
 
 `RUST_LOG` overrides the flag baseline when set (`RUST_LOG=debug wt -v` lifts `-v` to debug-on-stderr).
 
-The flags only reach a command you type; shell completion runs as its own process with nowhere to pass one. Set `WORKTRUNK_VERBOSE=0|1|2` to apply the level to *every* invocation, completion included — it's the env-var equivalent of `-v`/`-vv`, so level 2 writes the same `trace.log`/`subprocess.log`/`diagnostic.md` files. An explicit `-v`/`-vv` on a command raises the level further but never lowers this baseline. To profile a slow tab-completion, run it the way your shell does — e.g. `WORKTRUNK_VERBOSE=2 COMPLETE=fish wt -- wt switch ''` — then read `trace.log`.
+The flags only reach a command you type; shell completion runs as its own process with nowhere to pass one. Set `WORKTRUNK_VERBOSE=0|1|2` to apply the level to *every* invocation, completion included — it's the env-var equivalent of `-v`/`-vv`, so level 2 writes the same `trace.log`/`subprocess.log`/`diagnostic.md` files. An explicit `-v`/`-vv` on a command raises the level further but never lowers this baseline. To profile a slow tab-completion, run it the way your shell does — e.g. `WORKTRUNK_VERBOSE=2 COMPLETE=fish wt -- wt switch ''` — then render the result with `wt config state logs profile`.
 
 ## What files does Worktrunk create?
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -857,7 +857,7 @@ All `post-*` hooks (post-start, post-switch, post-commit, post-merge) run in the
 | `subprocess.log` | Running with `-vv` |
 | `diagnostic.md` | Running with `-vv` |
 
-`trace.log` captures debug-level records at `-vv` — commands, `[wt-trace]` records, bounded subprocess previews. `wt config state logs profile` summarizes one into a performance report (where time went, parallelism, redundant commands). `subprocess.log` holds the raw uncapped subprocess stdout/stderr bodies. `diagnostic.md` is a markdown bug-report bundle that inlines `trace.log`; `wt` prints a `gh gist create` command pointing at it. All three are overwritten on each `-vv` run.
+`trace.log` captures debug-level records at `-vv` — commands, `[wt-trace]` records, bounded subprocess previews. `wt config state logs profile` summarizes one into a performance report (where time went, parallelism, redundant commands). `subprocess.log` holds the raw uncapped subprocess stdout/stderr bodies. `diagnostic.md` is a markdown bug-report bundle that inlines `trace.log` and a rendered performance profile; `wt` prints a `gh gist create` command pointing at it. All three are overwritten on each `-vv` run.
 
 ## Location
 

--- a/src/trace/profile.rs
+++ b/src/trace/profile.rs
@@ -448,7 +448,10 @@ impl Profile {
         };
         // Build the summary from segments so the timestamp-derived fields
         // (thread count, traced wall span) drop out for a log without `ts`/`tid`
-        // rather than rendering a confusing `0 threads · traced 0.00ms`.
+        // rather than rendering a confusing `0 threads · 0.00ms traced`.
+        // Every magnitude leads with its value (`32.00ms subprocess time`,
+        // `5 subprocesses`); the derived metrics (`parallelism`, `peak`) lead
+        // with their label since they aren't measured quantities.
         let mut segments = vec![
             format!(
                 "{} subprocess{}",
@@ -467,7 +470,7 @@ impl Profile {
             ));
         }
         if !self.traced.is_zero() {
-            segments.push(format!("traced {}", fmt_dur(self.traced)));
+            segments.push(format!("{} traced", fmt_dur(self.traced)));
         }
         if !self.span_total.is_zero() {
             segments.push(format!("{} in-process", fmt_dur(self.span_total)));

--- a/src/trace/snapshots/worktrunk__trace__profile__tests__renders_collect_run_without_skeleton.snap
+++ b/src/trace/snapshots/worktrunk__trace__profile__tests__renders_collect_run_without_skeleton.snap
@@ -3,7 +3,7 @@ source: src/trace/profile.rs
 expression: "plain(profile.render_text(\"trace.log\"))"
 ---
 PERFORMANCE PROFILE @ trace.log
-  0 subprocesses · 0.00ms subprocess time · parallelism n/a · peak n/a · traced 8.00ms
+  0 subprocesses · 0.00ms subprocess time · parallelism n/a · peak n/a · 8.00ms traced
 
 CACHE
   no commands re-run with the same context

--- a/src/trace/snapshots/worktrunk__trace__profile__tests__renders_full_report.snap
+++ b/src/trace/snapshots/worktrunk__trace__profile__tests__renders_full_report.snap
@@ -3,7 +3,7 @@ source: src/trace/profile.rs
 expression: "plain(profile.render_text(\"trace.log\"))"
 ---
 PERFORMANCE PROFILE @ trace.log
-  5 subprocesses · 32.00ms subprocess time · parallelism 1.9× · peak 3 · 2 threads · traced 18.00ms · 2.00ms in-process
+  5 subprocesses · 32.00ms subprocess time · parallelism 1.9× · peak 3 · 2 threads · 18.00ms traced · 2.00ms in-process
 
 BY COMMAND TYPE
   command     count    total      max      avg

--- a/tests/snapshots/integration__integration_tests__config_state__logs_profile_from_stdin.snap
+++ b/tests/snapshots/integration__integration_tests__config_state__logs_profile_from_stdin.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/config_state.rs
 expression: "String::from_utf8_lossy(&output.stdout)"
 ---
 [36mPERFORMANCE PROFILE[39m @ stdin
-  5 subprocesses · 32.00ms subprocess time · parallelism 1.9× · peak 3 · 2 threads · traced 17.50ms · 2.00ms in-process
+  5 subprocesses · 32.00ms subprocess time · parallelism 1.9× · peak 3 · 2 threads · 17.50ms traced · 2.00ms in-process
 
 [36mBY COMMAND TYPE[39m
   command     count    total      max      avg

--- a/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_state_logs.snap
@@ -107,7 +107,7 @@ All [2mpost-*[0m hooks (post-start, post-switch, post-commit, post-merge) run 
  [2msubprocess.log[0m Running with [2m-vv[0m 
  [2mdiagnostic.md[0m  Running with [2m-vv[0m 
 
-[2mtrace.log[0m captures debug-level records at [2m-vv[0m — commands, [2m[wt-trace][0m records, bounded subprocess previews. [2mwt config state logs profile[0m summarizes one into a performance report (where time went, parallelism, redundant commands). [2msubprocess.log[0m holds the raw uncapped subprocess stdout/stderr bodies. [2mdiagnostic.md[0m is a markdown bug-report bundle that inlines [2mtrace.log[0m; [2mwt[0m prints a [2mgh gist create[0m command pointing at it. All three are overwritten on each [2m-vv[0m run.
+[2mtrace.log[0m captures debug-level records at [2m-vv[0m — commands, [2m[wt-trace][0m records, bounded subprocess previews. [2mwt config state logs profile[0m summarizes one into a performance report (where time went, parallelism, redundant commands). [2msubprocess.log[0m holds the raw uncapped subprocess stdout/stderr bodies. [2mdiagnostic.md[0m is a markdown bug-report bundle that inlines [2mtrace.log[0m and a rendered performance profile; [2mwt[0m prints a [2mgh gist create[0m command pointing at it. All three are overwritten on each [2m-vv[0m run.
 
 [1m[32mLocation[0m
 


### PR DESCRIPTION
Small follow-ups to the `wt config state logs profile` profiler (landed in #3184), polishing its output and making it discoverable when triaging perf reports.

**Summary line consistency.** The profile summary mixed duration shapes — `32.00ms subprocess time` led with the value, but `traced 18.00ms` led with the label. `traced` was the only outlier, so this flips it to `18.00ms traced`. Now every measured magnitude (counts and durations) leads with its value; the derived metrics (`parallelism`, `peak`) keep their label since they aren't quantities with units.

**Profiler in the bug-report path.** Every `-vv` run already writes `diagnostic.md`, and it now embeds a rendered performance profile — but nothing pointed reporters or triage at it. So: the FAQ's `diagnostic.md` entry now mentions the profile, the "profile a slow tab-completion" tip points at `wt config state logs profile` instead of "read `trace.log`", and the `running-tend` skill tells triage to read the Performance profile section first on slow-command reports.

Snapshot diffs are exactly the `traced` reorder. `fmt`/`clippy`/lib tests/docs-sync all green locally.

> _This was written by Claude Code on behalf of max_
