### PR TITLE
test(progress): drop fixed-sleep races from the watchdog absence tests

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -714,8 +714,16 @@ mod imp {
         #[test]
         fn test_watchdog_fast_command_leaves_no_trace() {
             // A command that finishes before the startup delay must never draw a
-            // block — so Drop has nothing to clear and leaves no escape in output.
-            let w = Watchdog::enabled("the commit message", None);
+            // block — so Drop has nothing to clear and leaves no escape in
+            // output. The startup delay sits far in the future so the assertion
+            // can't race the ticker into rendering under load; finish() wakes the
+            // parked thread immediately regardless.
+            let w = Watchdog::enabled_with_delays(
+                "the commit message",
+                None,
+                Duration::from_secs(3600),
+                WATCHDOG_ESCALATE_DELAY,
+            );
             assert_eq!(w.shared.rendered_rows.load(Ordering::Relaxed), 0);
             w.finish();
         }
@@ -753,14 +761,24 @@ mod imp {
         #[test]
         fn test_watchdog_no_escalation_without_command() {
             // No command → the gutter never appears, however long it runs, so the
-            // block stays a single status row.
+            // block stays a single status row. Poll for that first render rather
+            // than sleeping a fixed window the ticker could be starved past under
+            // load; escalation is gated on `command.is_some()`, so `!escalated`
+            // holds at any instant no matter how long the loop runs.
             let w = Watchdog::enabled_with_delays(
                 "the commit message",
                 None,
                 Duration::from_millis(10),
                 Duration::from_millis(30),
             );
-            std::thread::sleep(Duration::from_millis(150));
+            let timeout = Duration::from_secs(5);
+            let start = Instant::now();
+            while start.elapsed() < timeout {
+                if w.shared.rendered_rows.load(Ordering::Relaxed) >= 1 {
+                    break;
+                }
+                std::thread::sleep(Duration::from_millis(10));
+            }
             assert_eq!(w.shared.rendered_rows.load(Ordering::Relaxed), 1);
             assert!(!w.shared.escalated.load(Ordering::Relaxed));
             w.finish();


### PR DESCRIPTION
Two watchdog tests in `src/progress.rs` still leaned on fixed sleeps, the same anti-pattern the earlier de-flaking PRs removed from their siblings. This finishes the set.

`test_watchdog_fast_command_leaves_no_trace` started the watchdog with the real 2s `WATCHDOG_STARTUP_DELAY` and asserted `rendered_rows == 0` immediately — a theoretical race if the runner paused the main thread past 2s before the assert. It now uses a far-future startup delay via `enabled_with_delays`, mirroring its `Progress` sibling `test_fast_progress_leaves_no_trace`: the ticker provably can't render before the assert, and `finish()` unparks the thread immediately so the test stays fast.

`test_watchdog_no_escalation_without_command` slept a fixed 150ms, then asserted `rendered_rows == 1`. That positive assertion is the real flake risk — a loaded runner can starve the ticker past any fixed deadline (the same failure the original `test_watchdog_escalates_and_grows_the_block` flake had), and 150ms is below the `tests/CLAUDE.md` 500ms absence-window floor anyway. Reading the escalation predicate (`escalated = command.is_some() && elapsed >= escalate_delay`) shows escalation is structurally impossible without a command, so `!escalated` needs no timed window at all. The test now polls for the first render (5s timeout, 10ms interval) and relies on the structural guarantee for the absence — reshaping it rather than just widening the sleep.

Verified: the 20 `progress::imp::tests` pass 20/20 under 18-core saturation; `cargo fmt --check` and `cargo clippy --features cli --lib` clean; full `pre-merge` gate green (4152 passed).

> _This was written by Claude Code on behalf of max_
