### PR TITLE
refactor(switch): drop dead title/body clones from the --prs GitHub status

### DIFF
--- a/src/commands/list/ci_status/github.rs
+++ b/src/commands/list/ci_status/github.rs
@@ -317,13 +317,10 @@ impl GitHubPrInfo {
             url: self.url.clone(),
             number: self.number.map(PrRef::pr),
             review_state: self.review_state(),
-            // TODO(prs-status-title-body): the `--prs` pane reads title/body from
-            // the `PrEntry`, not from this status (which feeds only the CI column),
-            // so these clones are dead data here. GitLab's `gitlab_mr_status` sets
-            // both `None` for this reason — unify the two `--prs` status builders
-            // (drop them here to match, or have both read from the status).
-            title: self.title.clone(),
-            body: self.body.clone(),
+            // The `--prs` pane reads title/body from the `PrEntry`, not this status
+            // (which feeds only the CI column), so they stay absent here.
+            title: None,
+            body: None,
         }
     }
 }


### PR DESCRIPTION
Resolves the `TODO(prs-status-title-body)` in GitHub's `open_pr_status()`.

`open_pr_status()` builds the `PrStatus` for a `wt switch --prs` row. On that path the `pr` preview pane reads title/body straight off the `PrEntry` (`PrSkimItem::new` in `picker/prs.rs`), and the status feeds only the CI column (`render_grid_row` → `status.format_cell`). The status's `title`/`body` are never read there, so cloning them in was dead data. GitLab's `gitlab_mr_status` already set both `None` for this reason, so the two `--prs` builders had diverged; they now agree.

The change is the minimal of the two resolutions the TODO offered — drop the clones rather than rewire both panes to read from the status — because `PrEntry` is already the single source the `--prs` pane reads from.

The worktree-row `pr` pane (a non-`--prs` `wt switch`) still sources title/body from `PrStatus`, populated by `detect_github`/`detect_gitea`; that path is untouched, so there's no behavior change to either pane.

> _This was written by Claude Code on behalf of max_
