### PR TITLE
feat(step): add require-include option + CLI flags to copy-ignored

### DIFF
--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -393,6 +393,14 @@ After `.worktreeinclude` selects entries, you can add more gitignore-style exclu
 exclude = [".cache/", ".turbo/"]
 ```
 
+To copy nothing unless `.worktreeinclude` exists — matching Claude Code desktop, where the file is required — pass `--require-include`:
+
+```bash
+wt step copy-ignored --require-include
+```
+
+Without `.worktreeinclude`, the command is a no-op (it reports that nothing was copied and why). With the file present, only matching files copy as above. To apply this across every repository, put the flag in a user-config hook: `post-start = "wt step copy-ignored --require-include"`.
+
 ### Common patterns
 
 | Type | Patterns |
@@ -452,7 +460,7 @@ Virtual environments contain absolute paths and can't be copied. Use `uv sync` i
 
 The `.worktreeinclude` pattern is shared with [Claude Code on desktop](https://code.claude.com/docs/en/desktop), which copies matching files when creating worktrees. Differences:
 
-- worktrunk copies all gitignored files by default; Claude Code requires `.worktreeinclude`
+- worktrunk copies all gitignored files by default; Claude Code requires `.worktreeinclude`. Pass `--require-include` to match Claude Code (copy nothing without `.worktreeinclude`)
 - worktrunk uses copy-on-write for large directories like `target/` — potentially 30x faster on macOS, 6x on Linux
 - worktrunk runs as a configurable hook in the worktree lifecycle
 
@@ -481,6 +489,9 @@ Usage: <b><span class=c>wt step copy-ignored</span></b> <span class=c>[OPTIONS]<
 
       <b><span class=c>--force</span></b>
           Overwrite existing files in destination
+
+      <b><span class=c>--require-include</span></b>
+          Require .worktreeinclude to copy anything
 
   <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
           Print help (see a summary with &#39;-h&#39;)

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -404,6 +404,14 @@ After `.worktreeinclude` selects entries, you can add more gitignore-style exclu
 exclude = [".cache/", ".turbo/"]
 ```
 
+To copy nothing unless `.worktreeinclude` exists — matching Claude Code desktop, where the file is required — pass `--require-include`:
+
+```bash
+wt step copy-ignored --require-include
+```
+
+Without `.worktreeinclude`, the command is a no-op (it reports that nothing was copied and why). With the file present, only matching files copy as above. To apply this across every repository, put the flag in a user-config hook: `post-start = "wt step copy-ignored --require-include"`.
+
 ### Common patterns
 
 | Type | Patterns |
@@ -463,7 +471,7 @@ Virtual environments contain absolute paths and can't be copied. Use `uv sync` i
 
 The `.worktreeinclude` pattern is shared with [Claude Code on desktop](https://code.claude.com/docs/en/desktop), which copies matching files when creating worktrees. Differences:
 
-- worktrunk copies all gitignored files by default; Claude Code requires `.worktreeinclude`
+- worktrunk copies all gitignored files by default; Claude Code requires `.worktreeinclude`. Pass `--require-include` to match Claude Code (copy nothing without `.worktreeinclude`)
 - worktrunk uses copy-on-write for large directories like `target/` — potentially 30x faster on macOS, 6x on Linux
 - worktrunk runs as a configurable hook in the worktree lifecycle
 
@@ -492,6 +500,9 @@ Options:
 
       --force
           Overwrite existing files in destination
+
+      --require-include
+          Require .worktreeinclude to copy anything
 
   -h, --help
           Print help (see a summary with '-h')

--- a/src/cli/step.rs
+++ b/src/cli/step.rs
@@ -305,6 +305,14 @@ After `.worktreeinclude` selects entries, you can add more gitignore-style exclu
 exclude = [".cache/", ".turbo/"]
 ```
 
+To copy nothing unless `.worktreeinclude` exists — matching Claude Code desktop, where the file is required — pass `--require-include`:
+
+```console
+wt step copy-ignored --require-include
+```
+
+Without `.worktreeinclude`, the command is a no-op (it reports that nothing was copied and why). With the file present, only matching files copy as above. To apply this across every repository, put the flag in a user-config hook: `post-start = "wt step copy-ignored --require-include"`.
+
 ## Common patterns
 
 | Type | Patterns |
@@ -364,7 +372,7 @@ Virtual environments contain absolute paths and can't be copied. Use `uv sync` i
 
 The `.worktreeinclude` pattern is shared with [Claude Code on desktop](https://code.claude.com/docs/en/desktop), which copies matching files when creating worktrees. Differences:
 
-- worktrunk copies all gitignored files by default; Claude Code requires `.worktreeinclude`
+- worktrunk copies all gitignored files by default; Claude Code requires `.worktreeinclude`. Pass `--require-include` to match Claude Code (copy nothing without `.worktreeinclude`)
 - worktrunk uses copy-on-write for large directories like `target/` — potentially 30x faster on macOS, 6x on Linux
 - worktrunk runs as a configurable hook in the worktree lifecycle
 "#)]
@@ -388,6 +396,10 @@ The `.worktreeinclude` pattern is shared with [Claude Code on desktop](https://c
         /// Overwrite existing files in destination
         #[arg(long)]
         force: bool,
+
+        /// Require .worktreeinclude to copy anything
+        #[arg(long)]
+        require_include: bool,
 
         /// Output format
         ///

--- a/src/commands/step/copy_ignored.rs
+++ b/src/commands/step/copy_ignored.rs
@@ -4,12 +4,13 @@ use std::fs;
 use std::path::PathBuf;
 
 use anyhow::Context;
+use color_print::cformat;
 use worktrunk::copy::{copy_dir_recursive, copy_leaf};
 use worktrunk::git::Repository;
 use worktrunk::path::format_path_for_display;
 use worktrunk::progress::{Progress, format_bytes};
 use worktrunk::styling::{
-    eprintln, format_with_gutter, info_message, println, success_message, verbosity,
+    eprintln, format_with_gutter, hint_message, info_message, println, success_message, verbosity,
 };
 
 use super::shared::{list_and_filter_ignored_entries, resolve_copy_ignored_config};
@@ -26,6 +27,7 @@ pub fn step_copy_ignored(
     to: Option<&str>,
     dry_run: bool,
     force: bool,
+    require_include: bool,
     format: crate::cli::SwitchFormat,
 ) -> anyhow::Result<()> {
     // Self-lower only when we're running inside a background hook pipeline
@@ -100,6 +102,41 @@ pub fn step_copy_ignored(
         .iter()
         .map(|wt| wt.path.clone())
         .collect();
+
+    // `--require-include` gate: when passed, copy nothing unless a
+    // `.worktreeinclude` file exists in the source worktree. Checked before
+    // discovery so the `git ls-files --ignored` traversal is skipped entirely
+    // when nothing copies.
+    if require_include && !source_path.join(".worktreeinclude").exists() {
+        if json_mode {
+            let payload = serde_json::json!({
+                "outcome": if dry_run { "planned" } else { "copied" },
+                "dry_run": dry_run,
+                "from": source_path,
+                "to": dest_path,
+                "reason": "require-include-no-worktreeinclude",
+                "entries": Vec::<serde_json::Value>::new(),
+                "files": 0,
+                "bytes": 0,
+            });
+            println!("{}", serde_json::to_string_pretty(&payload)?);
+        } else {
+            eprintln!(
+                "{}",
+                info_message(cformat!(
+                    "Nothing copied — <bold>--require-include</> was passed but no <bold>.worktreeinclude</> exists"
+                ))
+            );
+            eprintln!(
+                "{}",
+                hint_message(cformat!(
+                    "Add a <underline>.worktreeinclude</> to select files, or drop <underline>--require-include</> to copy everything"
+                ))
+            );
+        }
+        return Ok(());
+    }
+
     let entries_to_copy = list_and_filter_ignored_entries(
         &source_path,
         &source_context,

--- a/src/main.rs
+++ b/src/main.rs
@@ -361,8 +361,16 @@ fn handle_step_command(action: StepCommand, yes: bool) -> anyhow::Result<()> {
             to,
             dry_run,
             force,
+            require_include,
             format,
-        } => step_copy_ignored(from.as_deref(), to.as_deref(), dry_run, force, format),
+        } => step_copy_ignored(
+            from.as_deref(),
+            to.as_deref(),
+            dry_run,
+            force,
+            require_include,
+            format,
+        ),
         StepCommand::Eval { template, format } => step_eval(&template, format),
         StepCommand::ForEach { format, args } => step_for_each(args, format),
         StepCommand::Promote { branch } => {

--- a/tests/integration_tests/help.rs
+++ b/tests/integration_tests/help.rs
@@ -73,6 +73,7 @@ fn snapshot_help(test_name: &str, args: &[&str]) {
 #[case("help_step_short", "step -h")]
 #[case("help_step_long", "step --help")]
 #[case("help_step_promote", "step promote --help")]
+#[case("help_step_copy_ignored", "step copy-ignored --help")]
 // Config subcommands (long help only - these are less frequently accessed)
 #[case("help_config_shell", "config shell --help")]
 #[case("help_config_create", "config create --help")]

--- a/tests/integration_tests/step_copy_ignored.rs
+++ b/tests/integration_tests/step_copy_ignored.rs
@@ -1744,3 +1744,125 @@ fn test_copy_ignored_no_matches_json(mut repo: TestRepo) {
         0
     );
 }
+
+// ============================================================================
+// --require-include flag
+// ============================================================================
+
+/// `--require-include` with no `.worktreeinclude` copies nothing and explains
+/// why (text mode). The recovery hint names the flag to drop, not a config key.
+#[rstest]
+fn test_copy_ignored_require_include_gates_and_hint(mut repo: TestRepo) {
+    let feature_path = repo.add_worktree("feature");
+    fs::write(repo.root_path().join(".env"), "SECRET=value").unwrap();
+    fs::write(repo.root_path().join(".gitignore"), ".env\n").unwrap();
+
+    let output = repo
+        .wt_command()
+        .args(["step", "copy-ignored", "--require-include"])
+        .current_dir(&feature_path)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "copy-ignored should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("--require-include"),
+        "stderr should explain the --require-include gate: {stderr}"
+    );
+    assert!(
+        !feature_path.join(".env").exists(),
+        "--require-include with no .worktreeinclude copies nothing"
+    );
+}
+
+/// The `--require-include` gate surfaces a machine-readable `reason` in JSON mode.
+#[rstest]
+fn test_copy_ignored_require_include_json_reason(mut repo: TestRepo) {
+    let feature_path = repo.add_worktree("feature");
+    fs::write(repo.root_path().join(".env"), "SECRET=value").unwrap();
+    fs::write(repo.root_path().join(".gitignore"), ".env\n").unwrap();
+
+    let output = repo
+        .wt_command()
+        .args(["step", "copy-ignored", "--require-include", "--format=json"])
+        .current_dir(&feature_path)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    let parsed: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).expect("valid JSON");
+    assert_eq!(parsed["reason"], "require-include-no-worktreeinclude");
+    assert_eq!(parsed["files"], 0);
+    assert!(!feature_path.join(".env").exists());
+}
+
+/// With `.worktreeinclude` present, `--require-include` does not gate — matching
+/// files copy as usual (the flag doesn't bypass the include filter).
+#[rstest]
+fn test_copy_ignored_require_include_with_worktreeinclude(mut repo: TestRepo) {
+    let feature_path = repo.add_worktree("feature");
+    fs::write(repo.root_path().join(".env"), "SECRET=value").unwrap();
+    fs::write(repo.root_path().join(".gitignore"), ".env\n").unwrap();
+    fs::write(repo.root_path().join(".worktreeinclude"), ".env\n").unwrap();
+
+    let output = repo
+        .wt_command()
+        .args(["step", "copy-ignored", "--require-include"])
+        .current_dir(&feature_path)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(
+        feature_path.join(".env").exists(),
+        ".env should copy when --require-include is set and .worktreeinclude matches it"
+    );
+}
+
+/// The gate checks the SOURCE worktree for `.worktreeinclude`, not the
+/// destination. Here only the destination has the file.
+#[rstest]
+fn test_copy_ignored_require_include_checks_source(mut repo: TestRepo) {
+    let feature_path = repo.add_worktree("feature");
+    fs::write(repo.root_path().join(".env"), "SECRET=value").unwrap();
+    fs::write(repo.root_path().join(".gitignore"), ".env\n").unwrap();
+    // `.worktreeinclude` in the DESTINATION only — source (main) lacks it.
+    fs::write(feature_path.join(".worktreeinclude"), ".env\n").unwrap();
+
+    let output = repo
+        .wt_command()
+        .args(["step", "copy-ignored", "--require-include"])
+        .current_dir(&feature_path)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(
+        !feature_path.join(".env").exists(),
+        "source has no .worktreeinclude — gate fires regardless of destination"
+    );
+}
+
+/// An empty `.worktreeinclude` is present (gate passes) but matches nothing,
+/// so nothing copies — distinct from the missing-file gate case.
+#[rstest]
+fn test_copy_ignored_require_include_empty_worktreeinclude(mut repo: TestRepo) {
+    let feature_path = repo.add_worktree("feature");
+    fs::write(repo.root_path().join(".env"), "SECRET=value").unwrap();
+    fs::write(repo.root_path().join(".gitignore"), ".env\n").unwrap();
+    fs::write(repo.root_path().join(".worktreeinclude"), "").unwrap();
+
+    let output = repo
+        .wt_command()
+        .args(["step", "copy-ignored", "--require-include"])
+        .current_dir(&feature_path)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    assert!(
+        !feature_path.join(".env").exists(),
+        "empty .worktreeinclude matches nothing — nothing copied"
+    );
+}

--- a/tests/integration_tests/step_promote.rs
+++ b/tests/integration_tests/step_promote.rs
@@ -477,6 +477,54 @@ fn test_promote_swap_only_main_has_ignored(mut repo: TestRepo) {
     );
 }
 
+/// `require-include` must not affect `wt step promote` — promote swaps all
+/// gitignored artifacts between worktrees by design and ignores copy-ignored
+/// config. Regression guard for the require-include feature.
+#[rstest]
+fn test_promote_swap_ignores_require_include(mut repo: TestRepo) {
+    let feature_path = repo.add_worktree("feature");
+
+    let gitignore = "build/\n*.log\n";
+    commit_gitignore(&repo, repo.root_path(), gitignore);
+    commit_gitignore(&repo, &feature_path, gitignore);
+
+    // require-include is set via CLI override, but promote must still swap
+    // ignored files — it never reads copy-ignored config. Using --config-set
+    // avoids leaving an untracked .config/ that would itself block promote.
+    fs::create_dir_all(repo.root_path().join("build")).unwrap();
+    fs::write(repo.root_path().join("build/artifact"), "main artifact").unwrap();
+    fs::write(repo.root_path().join("app.log"), "main log").unwrap();
+
+    let output = repo
+        .wt_command()
+        .args([
+            "--config-set",
+            "step.copy-ignored.require-include=true",
+            "step",
+            "promote",
+            "feature",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    // Ignored files still swapped to feature despite require-include.
+    assert!(!repo.root_path().join("build").exists());
+    assert!(!repo.root_path().join("app.log").exists());
+    assert_eq!(
+        fs::read_to_string(feature_path.join("build/artifact")).unwrap(),
+        "main artifact"
+    );
+    assert_eq!(
+        fs::read_to_string(feature_path.join("app.log")).unwrap(),
+        "main log"
+    );
+}
+
 /// Only feature worktree has gitignored files — they should move to the main worktree
 #[rstest]
 fn test_promote_swap_only_feature_has_ignored(mut repo: TestRepo) {

--- a/tests/snapshots/integration__integration_tests__help__help_step_copy_ignored.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_step_copy_ignored.snap
@@ -1,0 +1,181 @@
+---
+source: tests/integration_tests/help.rs
+info:
+  program: wt
+  args:
+    - step
+    - copy-ignored
+    - "--help"
+  env:
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    TERM: alacritty
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+---
+success: true
+exit_code: 0
+----- stdout -----
+wt step copy-ignored - Copy gitignored files to another worktree[0m
+
+Eliminates cold starts by copying build caches and dependencies.[0m
+
+Usage: [1m[36mwt step copy-ignored[0m [36m[OPTIONS][0m
+
+[1m[32mOptions:[0m
+      [1m[36m--from[0m[36m [0m[36m<FROM>[0m
+          Source worktree branch[0m
+          
+          Defaults to main worktree.[0m
+
+      [1m[36m--to[0m[36m [0m[36m<TO>[0m
+          Destination worktree branch[0m
+          
+          Defaults to current worktree.[0m
+
+      [1m[36m--dry-run[0m
+          Show what would be copied
+
+      [1m[36m--force[0m
+          Overwrite existing files in destination
+
+      [1m[36m--require-include[0m
+          Require .worktreeinclude to copy anything
+
+  [1m[36m-h[0m, [1m[36m--help[0m
+          Print help (see a summary with '-h')
+
+[1m[32mAutomation:[0m
+      [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m
+          Output format[0m
+          
+          JSON prints structured result to stdout after the copy completes.[0m
+          
+          [default: text]
+          [possible values: text, json]
+
+[1m[32mGlobal Options:[0m
+  [1m[36m-C[0m[36m [0m[36m<path>[0m
+          Working directory for this command
+
+      [1m[36m--config[0m[36m [0m[36m<path>[0m
+          User config file path
+
+      [1m[36m--config-set[0m[36m [0m[36m<toml>[0m
+          Override config with inline TOML, e.g. --config-set list.full=true (repeatable)
+
+  [1m[36m-v[0m, [1m[36m--verbose[0m[36m...[0m
+          Verbose output (-v: info logs + hook/alias template variables on stderr; -vv: also debug logs and raw subprocess output written to .git/wt/logs/). Set WORKTRUNK_VERBOSE=0|1|2 to apply the same level everywhere — including shell completion, which no flag can reach
+
+  [1m[36m-y[0m, [1m[36m--yes[0m
+          Skip approval prompts
+
+[1m[32mSetup[0m
+
+Add to the project config:
+
+[107m [0m [2m# .config/wt.toml[0m
+[107m [0m [2m[36m[post-start][0m
+[107m [0m [2mcopy = [0m[2m[32m"wt step copy-ignored"[0m
+
+[1m[32mWhat gets copied[0m
+
+All gitignored files are copied by default, except for built-in excluded directories: VCS metadata ([2m.bzr/[0m, [2m.hg/[0m, [2m.jj/[0m, [2m.pijul/[0m, [2m.sl/[0m, [2m.svn/[0m) and tool-state ([2m.conductor/[0m, [2m.entire/[0m, [2m.worktrees/[0m). Tracked files are never touched.
+
+To limit what gets copied further, create [2m.worktreeinclude[0m with gitignore-style patterns. Files must be [1mboth[0m gitignored [1mand[0m in [2m.worktreeinclude[0m:
+
+[107m [0m [2m# .worktreeinclude[0m
+[107m [0m [2m.env[0m
+[107m [0m [2mnode_modules/[0m
+[107m [0m [2mtarget/[0m
+
+After [2m.worktreeinclude[0m selects entries, you can add more gitignore-style excludes in user config, per-project user overrides, or project config:
+
+[107m [0m [2m[36m[step.copy-ignored][0m
+[107m [0m [2mexclude = [[0m[2m[32m".cache/"[0m[2m, [0m[2m[32m".turbo/"[0m[2m][0m
+
+To copy nothing unless [2m.worktreeinclude[0m exists — matching Claude Code desktop, where the file is required — pass [2m--require-include[0m:
+
+[107m [0m [2m[0m[2m[34mwt[0m[2m step copy-ignored [0m[2m[36m--require-include[0m
+
+Without [2m.worktreeinclude[0m, the command is a no-op (it reports that nothing was copied and why). With the file present, only matching files copy as above. To apply this across every repository, put the flag in a user-config hook: [2mpost-start = "wt step copy-ignored --require-include"[0m.
+
+[1m[32mCommon patterns[0m
+
+       Type                           Patterns                    
+ ───────────────── ────────────────────────────────────────────── 
+ Dependencies      [2mnode_modules/[0m, [2m.venv/[0m, [2mtarget/[0m, [2mvendor/[0m, [2mPods/[0m 
+ Build caches      [2m.cache/[0m, [2m.next/[0m, [2m.parcel-cache/[0m, [2m.turbo/[0m       
+ Generated assets  Images, ML models, binaries too large for git  
+ Environment files [2m.env[0m (if not generated per-worktree)           
+
+[1m[32mFeatures[0m
+
+- Uses copy-on-write (reflink) when available for space-efficient copies
+- Handles nested [2m.gitignore[0m files, global excludes, and [2m.git/info/exclude[0m
+- Skips existing files by default (safe to re-run)
+- [2m--force[0m overwrites existing files in the destination
+- Always skips built-in excluded directories — VCS metadata ([2m.bzr/[0m, [2m.hg/[0m, [2m.jj/[0m, [2m.pijul/[0m, [2m.sl/[0m, [2m.svn/[0m) and tool-state ([2m.conductor/[0m, [2m.entire/[0m, [2m.worktrees/[0m) — and nested worktrees
+
+[1m[32mPerformance[0m
+
+Reflink copies share disk blocks until modified — no data is actually copied. For a 14GB [2mtarget/[0m directory:
+
+            Command            Time 
+ ───────────────────────────── ──── 
+ [2mcp -R[0m (full copy)             2m   
+ [2mcp -Rc[0m / [2mwt step copy-ignored[0m 20s  
+
+Uses per-file reflink (like [2mcp -Rc[0m) — copy time scales with file count.
+
+Use the [2mpost-start[0m hook so the copy runs in the background. Use [2mpre-start[0m instead if subsequent hooks or [2m--execute[0m command need the copied files immediately.
+
+[1m[32mBackground-hook priority (experimental)[0m
+
+When invoked from a background hook pipeline ([2mpost-*[0m hooks), [2mwt step copy-ignored[0m self-lowers its CPU and I/O priority — [2mtaskpolicy -b[0m on macOS, [2mnice -n 19[0m plus [2mionice -c 3[0m on Linux — so it yields to interactive work. Foreground callers ([2mpre-*[0m hooks, direct interactive use) run at normal priority so the user isn't waiting on a throttled copy.
+
+wt signals background-hook context by exporting [2mWORKTRUNK_FOREGROUND=-1[0m into every detached hook pipeline; [2mcopy-ignored[0m inspects that variable on entry. The variable name is experimental and may change.
+
+[1m[32mLanguage-specific notes[0m
+
+[32mRust[0m
+
+The [2mtarget/[0m directory is huge (often 1-10GB). Copying with reflink cuts first build from ~68s to ~3s by reusing compiled dependencies.
+
+[32mNode.js[0m
+
+[2mnode_modules/[0m is large but mostly static. If the project has no native dependencies, symlinks are even faster:
+
+[107m [0m [2m[36m[pre-start][0m
+[107m [0m [2mdeps = [0m[2m[32m"ln -sf {{ primary_worktree_path }}/node_modules ."[0m
+
+[32mPython[0m
+
+Virtual environments contain absolute paths and can't be copied. Use [2muv sync[0m instead — it's fast enough that copying isn't worth it.
+
+[1m[32mBehavior vs Claude Code on desktop[0m
+
+The [2m.worktreeinclude[0m pattern is shared with Claude Code on desktop, which copies matching files when creating worktrees. Differences:
+
+- worktrunk copies all gitignored files by default; Claude Code requires [2m.worktreeinclude[0m. Pass [2m--require-include[0m to match Claude Code (copy nothing without [2m.worktreeinclude[0m)
+- worktrunk uses copy-on-write for large directories like [2mtarget/[0m — potentially 30x faster on macOS, 6x on Linux
+- worktrunk runs as a configurable hook in the worktree lifecycle
+
+----- stderr -----


### PR DESCRIPTION
`wt step copy-ignored` copies all gitignored files by default. Add a `require-include` setting that gates the copy on a `.worktreeinclude` file existing in the source worktree — matching Claude Code desktop, where the file is required. Without `.worktreeinclude`, the command is a no-op that reports why (text hint + JSON `reason`); with it, only matching files copy.

Config (additive, defaults off; `Option<bool>` merged via `.or()` so an explicit value overrides lower-priority config in either direction):

```toml
[step.copy-ignored]
require-include = true
```

CLI flags override config per run (precedence `CLI > --config-set > project > user > default`, mirroring `wt merge` / `wt remove`:

```
--require-include      copy nothing unless .worktreeinclude exists
--no-require-include   copy all gitignored files this run
```

The gate short-circuits before `git ls-files` discovery. The recovery hint names `--no-require-include` (correct whether the flag or config triggered it, since the flag overrides both). `wt step promote` is unaffected — it exchanges all gitignored artifacts by design.