### PR TITLE
feat(switch): show PR/MR comment count in the worktree pr preview pane

### DIFF
--- a/src/commands/list/ci_status/azure.rs
+++ b/src/commands/list/ci_status/azure.rs
@@ -140,6 +140,9 @@ pub(super) fn detect_azure_pr(
         review_state: None,
         title: pr.title.clone(),
         body: pr.description.clone(),
+        // `az repos pr list` carries no comment/thread count; surfacing one
+        // would need a separate per-PR threads call, which this fetch avoids.
+        comment_count: None,
     })
 }
 
@@ -223,6 +226,7 @@ pub(super) fn detect_azure_pipeline(
         review_state: None,
         title: None,
         body: None,
+        comment_count: None,
     })
 }
 

--- a/src/commands/list/ci_status/gitea.rs
+++ b/src/commands/list/ci_status/gitea.rs
@@ -124,6 +124,7 @@ pub(super) fn detect_gitea_pr(
         review_state: None,
         title: pr.title.clone(),
         body: pr.body.clone(),
+        comment_count: pr.comment_count(),
     })
 }
 
@@ -148,6 +149,7 @@ pub(super) fn detect_gitea_commit_status(
         review_state: None,
         title: None,
         body: None,
+        comment_count: None,
     })
 }
 
@@ -191,6 +193,18 @@ struct GiteaPr {
     /// PR description; rendered as markdown in the `pr` preview pane.
     #[serde(default)]
     body: Option<String>,
+    /// Comment count. Gitea's PR object carries it directly, so the `comments`
+    /// line in the `pr` pane rides this call with no extra round-trip.
+    #[serde(default)]
+    comments: Option<u32>,
+}
+
+impl GiteaPr {
+    /// Comment count for [`PrStatus::comment_count`], zero flattened to `None`
+    /// so a PR with no comments shows nothing in the `pr` pane.
+    fn comment_count(&self) -> Option<u32> {
+        self.comments.filter(|&n| n > 0)
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -217,6 +231,28 @@ struct GiteaOwner {
 mod tests {
     use super::*;
     use worktrunk::testing::TestRepo;
+
+    #[test]
+    fn test_gitea_pr_comment_count() {
+        let pr = |comments: Option<u32>| GiteaPr {
+            number: Some(1),
+            mergeable: None,
+            html_url: String::new(),
+            head: GiteaPrBranch {
+                ref_name: String::new(),
+                sha: None,
+                repo: None,
+            },
+            title: None,
+            body: None,
+            comments,
+        };
+
+        // Zero (or a missing count) flattens to None; a positive count carries through.
+        assert_eq!(pr(Some(0)).comment_count(), None);
+        assert_eq!(pr(None).comment_count(), None);
+        assert_eq!(pr(Some(2)).comment_count(), Some(2));
+    }
 
     #[test]
     fn test_parse_gitea_status_state() {

--- a/src/commands/list/ci_status/github.rs
+++ b/src/commands/list/ci_status/github.rs
@@ -68,9 +68,11 @@ pub(super) fn detect_github(
             "--limit",
             &MAX_PRS_TO_FETCH.to_string(),
             "--json",
-            // title,body ride this existing call so the picker's `pr` preview
-            // pane can show them — no extra round-trip.
-            "number,title,body,headRefOid,mergeStateStatus,statusCheckRollup,url,headRepositoryOwner,reviewDecision,isDraft",
+            // title,body and the comments array ride this existing call so the
+            // picker's `pr` preview pane can show them — no extra round-trip.
+            // `gh pr list` has no comment-count field, so we request the array and
+            // count it; for a `--head <branch>` call that's typically one PR.
+            "number,title,body,comments,headRefOid,mergeStateStatus,statusCheckRollup,url,headRepositoryOwner,reviewDecision,isDraft",
         ])
         .current_dir(&repo_root)
         .run()
@@ -135,6 +137,7 @@ pub(super) fn detect_github(
         review_state: pr_info.review_state(),
         title: pr_info.title.clone(),
         body: pr_info.body.clone(),
+        comment_count: pr_info.comment_count(),
     })
 }
 
@@ -205,6 +208,7 @@ pub(super) fn detect_github_commit_checks(
         review_state: None,
         title: None,
         body: None,
+        comment_count: None,
     })
 }
 
@@ -221,6 +225,13 @@ pub(crate) struct GitHubPrInfo {
     pub title: Option<String>,
     /// PR description; shown in the `pr` preview pane. Rides this call.
     pub body: Option<String>,
+    /// Conversation comments on the PR. Requested only on the worktree-row
+    /// [`detect_github`] call to count them for the `pr` pane; the `--prs` call
+    /// omits `comments` to keep its 50-PR payload light, so this stays empty
+    /// there (`#[serde(default)]`). Only the count is needed, so each element
+    /// deserializes as [`serde::de::IgnoredAny`] rather than a comment struct.
+    #[serde(default)]
+    pub comments: Vec<serde::de::IgnoredAny>,
     #[serde(rename = "headRefOid")]
     pub head_ref_oid: Option<String>,
     #[serde(rename = "mergeStateStatus")]
@@ -296,6 +307,13 @@ impl GitHubPrInfo {
         }
     }
 
+    /// The conversation-comment count for [`PrStatus::comment_count`], or `None`
+    /// when there are none — zero is flattened so a PR with no comments shows
+    /// nothing. The `--prs` call omits `comments`, so this is `None` there.
+    pub fn comment_count(&self) -> Option<u32> {
+        u32::try_from(self.comments.len()).ok().filter(|&n| n > 0)
+    }
+
     /// Build a [`PrStatus`] from this open-PR entry, for callers that already
     /// hold the open-PR list (the `--prs` picker) and want the same CI-column
     /// treatment [`detect_github`] produces per branch. PR rows have no local
@@ -324,6 +342,9 @@ impl GitHubPrInfo {
             // (drop them here to match, or have both read from the status).
             title: self.title.clone(),
             body: self.body.clone(),
+            // The `--prs` call omits `comments`, and the `--prs` rows have their
+            // own background-fetched comments tab, so this is always `None` here.
+            comment_count: self.comment_count(),
         }
     }
 }
@@ -407,6 +428,7 @@ mod tests {
             head_repository_owner: None,
             title: None,
             body: None,
+            comments: Vec::new(),
             review_decision: None,
             is_draft: None,
         };
@@ -425,6 +447,7 @@ mod tests {
             head_repository_owner: None,
             title: None,
             body: None,
+            comments: Vec::new(),
             review_decision: None,
             is_draft: None,
         };
@@ -440,6 +463,7 @@ mod tests {
             head_repository_owner: None,
             title: None,
             body: None,
+            comments: Vec::new(),
             review_decision: None,
             is_draft: None,
         };
@@ -460,6 +484,7 @@ mod tests {
                 head_repository_owner: None,
                 title: None,
                 body: None,
+                comments: Vec::new(),
                 review_decision: None,
                 is_draft: None,
             };
@@ -480,6 +505,7 @@ mod tests {
             head_repository_owner: None,
             title: None,
             body: None,
+            comments: Vec::new(),
             review_decision: None,
             is_draft: None,
         };
@@ -500,6 +526,7 @@ mod tests {
                 head_repository_owner: None,
                 title: None,
                 body: None,
+                comments: Vec::new(),
                 review_decision: None,
                 is_draft: None,
             };
@@ -521,6 +548,7 @@ mod tests {
                 head_repository_owner: None,
                 title: None,
                 body: None,
+                comments: Vec::new(),
                 review_decision: None,
                 is_draft: None,
             };
@@ -541,6 +569,7 @@ mod tests {
             head_repository_owner: None,
             title: None,
             body: None,
+            comments: Vec::new(),
             review_decision: None,
             is_draft: None,
         };
@@ -558,6 +587,7 @@ mod tests {
             head_repository_owner: None,
             title: None,
             body: None,
+            comments: Vec::new(),
             review_decision: review_decision.map(Into::into),
             is_draft,
         };
@@ -582,6 +612,31 @@ mod tests {
             pr(Some("APPROVED"), Some(true)).review_state(),
             Some(ReviewState::Draft)
         );
+    }
+
+    #[test]
+    fn test_github_pr_info_comment_count() {
+        // The count comes from the length of the requested `comments` array.
+        let with = |n: usize| GitHubPrInfo {
+            number: None,
+            head_ref_oid: None,
+            merge_state_status: None,
+            status_check_rollup: None,
+            url: None,
+            head_repository_owner: None,
+            title: None,
+            body: None,
+            comments: std::iter::repeat_with(|| serde::de::IgnoredAny)
+                .take(n)
+                .collect(),
+            review_decision: None,
+            is_draft: None,
+        };
+
+        // Zero comments flatten to None so a PR with no comments shows nothing.
+        assert_eq!(with(0).comment_count(), None);
+        assert_eq!(with(1).comment_count(), Some(1));
+        assert_eq!(with(4).comment_count(), Some(4));
     }
 
     #[test]

--- a/src/commands/list/ci_status/gitlab.rs
+++ b/src/commands/list/ci_status/gitlab.rs
@@ -189,6 +189,7 @@ pub(super) fn detect_gitlab(
             review_state: mr_entry.review_state(),
             title: mr_entry.title.clone(),
             body: mr_entry.description.clone(),
+            comment_count: mr_entry.comment_count(),
         });
     };
 
@@ -204,6 +205,7 @@ pub(super) fn detect_gitlab(
         review_state: mr_entry.review_state(),
         title: mr_entry.title.clone(),
         body: mr_entry.description.clone(),
+        comment_count: mr_entry.comment_count(),
     })
 }
 
@@ -275,6 +277,7 @@ pub(super) fn detect_gitlab_pipeline(
         review_state: None,
         title: None,
         body: None,
+        comment_count: None,
     })
 }
 
@@ -304,6 +307,11 @@ struct GitLabMrListEntry {
     /// MR description; rendered as markdown in the `pr` preview pane.
     #[serde(default)]
     pub description: Option<String>,
+    /// Count of user (non-system) notes on the MR. GitLab's MR-list response
+    /// carries this directly, so the `comments` line in the `pr` pane rides the
+    /// same call with no extra round-trip.
+    #[serde(default)]
+    pub user_notes_count: Option<u32>,
 }
 
 impl GitLabMrListEntry {
@@ -321,6 +329,12 @@ impl GitLabMrListEntry {
             return Some(ReviewState::Pending);
         }
         None
+    }
+
+    /// Comment count for [`PrStatus::comment_count`], zero flattened to `None`
+    /// so an MR with no notes shows nothing in the `pr` pane.
+    fn comment_count(&self) -> Option<u32> {
+        self.user_notes_count.filter(|&n| n > 0)
     }
 }
 
@@ -416,6 +430,7 @@ mod tests {
             draft,
             title: None,
             description: None,
+            user_notes_count: None,
         };
 
         // Draft wins over the approval gap
@@ -430,6 +445,28 @@ mod tests {
         // Other merge statuses carry no review signal
         assert_eq!(entry(Some(false), Some("mergeable")).review_state(), None);
         assert_eq!(entry(None, None).review_state(), None);
+    }
+
+    #[test]
+    fn test_mr_list_entry_comment_count() {
+        let entry = |count: Option<u32>| GitLabMrListEntry {
+            iid: 1,
+            sha: "abc".into(),
+            has_conflicts: false,
+            detailed_merge_status: None,
+            source_project_id: None,
+            web_url: None,
+            draft: None,
+            title: None,
+            description: None,
+            user_notes_count: count,
+        };
+
+        // Zero (or a missing count) flattens to None so an MR with no notes
+        // shows nothing in the `pr` pane; a positive count carries through.
+        assert_eq!(entry(Some(0)).comment_count(), None);
+        assert_eq!(entry(None).comment_count(), None);
+        assert_eq!(entry(Some(3)).comment_count(), Some(3));
     }
 
     #[test]

--- a/src/commands/list/ci_status/mod.rs
+++ b/src/commands/list/ci_status/mod.rs
@@ -398,6 +398,15 @@ pub struct PrStatus {
     /// rendered as markdown in the `pr` preview pane. Absent as for `title`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub body: Option<String>,
+    /// Number of conversation comments on the PR/MR — GitHub issue comments,
+    /// GitLab user notes, Gitea PR comments — shown as a `comments` line in the
+    /// picker's `pr` preview pane. Rides the same forge list call as
+    /// `title`/`body`. Zero is flattened to `None` at the mapping boundary so a
+    /// PR with no comments shows nothing; also `None` for branch workflows (no
+    /// PR), for Azure DevOps (its PR-list call carries no comment count), and
+    /// for cache entries written before this field existed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub comment_count: Option<u32>,
 }
 
 impl CiStatus {
@@ -519,6 +528,7 @@ impl PrStatus {
             review_state: None,
             title: None,
             body: None,
+            comment_count: None,
         }
     }
 
@@ -727,6 +737,7 @@ mod tests {
             review_state: None,
             title: None,
             body: None,
+            comment_count: None,
         };
         assert_eq!(pr_passed.indicator(), "#");
 
@@ -740,6 +751,7 @@ mod tests {
             review_state: None,
             title: None,
             body: None,
+            comment_count: None,
         };
         assert_eq!(branch_running.indicator(), "#");
 
@@ -753,6 +765,7 @@ mod tests {
             review_state: None,
             title: None,
             body: None,
+            comment_count: None,
         };
         assert_eq!(error_status.indicator(), "⚠");
     }
@@ -771,6 +784,7 @@ mod tests {
             review_state: None,
             title: None,
             body: None,
+            comment_count: None,
         };
 
         // Number fits → PR reference, hyperlinked when supported
@@ -866,6 +880,7 @@ mod tests {
             review_state: None,
             title: None,
             body: None,
+            comment_count: None,
         };
         let green = "\u{1b}[32m";
         let dim = "\u{1b}[2m";
@@ -906,6 +921,7 @@ mod tests {
             review_state,
             title: None,
             body: None,
+            comment_count: None,
         };
 
         // Changes-requested outranks running and passed — waiting can't clear it
@@ -1019,6 +1035,7 @@ mod tests {
             review_state: None,
             title: None,
             body: None,
+            comment_count: None,
         }
     }
 

--- a/src/commands/list/json_output.rs
+++ b/src/commands/list/json_output.rs
@@ -501,11 +501,11 @@ impl JsonCi {
             url: pr.url.clone(),
             review_state: pr.review_state,
             // TODO(json-pr-title-body): `PrStatus` now carries `title`/`body`
-            // (for the picker's `pr` preview pane), but they're deliberately not
-            // surfaced here — `wt list --json` stays scoped to CI/review status.
-            // Add them (with `skip_serializing_if = "Option::is_none"` plus a row
-            // in the docs/content/list.md ci-object table) if a JSON consumer
-            // needs them.
+            // and `comment_count` (for the picker's `pr` preview pane), but
+            // they're deliberately not surfaced here — `wt list --json` stays
+            // scoped to CI/review status. Add them (with
+            // `skip_serializing_if = "Option::is_none"` plus a row in the
+            // docs/content/list.md ci-object table) if a JSON consumer needs them.
         }
     }
 }
@@ -645,6 +645,7 @@ mod tests {
                 review_state: None,
                 title: None,
                 body: None,
+                comment_count: None,
             },
             None,
         );
@@ -685,6 +686,7 @@ mod tests {
                 review_state: None,
                 title: None,
                 body: None,
+                comment_count: None,
             },
             None,
         );
@@ -715,6 +717,7 @@ mod tests {
                     review_state: None,
                     title: None,
                     body: None,
+                    comment_count: None,
                 },
                 None,
             );
@@ -737,6 +740,7 @@ mod tests {
             review_state: None,
             title: None,
             body: None,
+            comment_count: None,
         };
 
         let without = JsonCi::from_pr_status(&pr, None);

--- a/src/commands/picker/items.rs
+++ b/src/commands/picker/items.rs
@@ -475,9 +475,9 @@ fn render_tab_row_compact(tabs: &[Tab], reset: Reset) -> String {
 /// missing lines.
 ///
 /// The `comments` line shows only the count — the full thread is a `--prs`-only
-/// fetch (see [`Self::comments_unavailable_pane`]). A PR with no comments
-/// carries `None` (zero is flattened at the mapping boundary), so the line is
-/// skipped.
+/// fetch (see [`WorktreeSkimItem::comments_unavailable_pane`]). A PR with no
+/// comments carries `None` (zero is flattened at the mapping boundary), so the
+/// line is skipped.
 ///
 /// `width` is the live preview-pane width, used to wrap the markdown body.
 fn render_worktree_pr(branch: &str, pr_ref: PrRef, status: &PrStatus, width: usize) -> String {

--- a/src/commands/picker/items.rs
+++ b/src/commands/picker/items.rs
@@ -468,10 +468,16 @@ fn render_tab_row_compact(tabs: &[Tab], reset: Reset) -> String {
 /// The `pr` pane for a worktree row whose branch has a PR/MR. Renders the same
 /// shape as the `--prs` rows' pane (`PrSkimItem::pr_pane`) — reference + title
 /// header, dim-labeled metadata, and the description as markdown — via the
-/// shared [`pr_pane`] helpers, so the two read alike. The title and body ride
-/// the same CI fetch the column already makes (see [`PrStatus`]); a status
-/// without them (an older cache entry, a forge that doesn't expose them) falls
-/// back to a reference-only header and skips the description.
+/// shared [`pr_pane`] helpers, so the two read alike. The title, body, and
+/// comment count ride the same CI fetch the column already makes (see
+/// [`PrStatus`]); a status without them (an older cache entry, a forge that
+/// doesn't expose them) falls back to a reference-only header and skips the
+/// missing lines.
+///
+/// The `comments` line shows only the count — the full thread is a `--prs`-only
+/// fetch (see [`Self::comments_unavailable_pane`]). A PR with no comments
+/// carries `None` (zero is flattened at the mapping boundary), so the line is
+/// skipped.
 ///
 /// `width` is the live preview-pane width, used to wrap the markdown body.
 fn render_worktree_pr(branch: &str, pr_ref: PrRef, status: &PrStatus, width: usize) -> String {
@@ -480,6 +486,9 @@ fn render_worktree_pr(branch: &str, pr_ref: PrRef, status: &PrStatus, width: usi
     out.push_str(&pr_pane::metadata_line("branch", branch));
     if let Some(url) = &status.url {
         out.push_str(&pr_pane::metadata_line("url", url));
+    }
+    if let Some(count) = status.comment_count {
+        out.push_str(&pr_pane::metadata_line("comments", &count.to_string()));
     }
     if let Some(body) = status.body.as_deref() {
         out.push_str(&pr_pane::description(body, width));
@@ -1305,6 +1314,7 @@ mod tests {
             review_state: Some(ReviewState::Approved),
             title: title.map(String::from),
             body: body.map(String::from),
+            comment_count: None,
         };
         // Build a row whose live `pr_status` slot carries a given state — what
         // the picker primes from the cache and then overwrites as the fetch lands.
@@ -1382,6 +1392,44 @@ mod tests {
     }
 
     #[test]
+    fn worktree_pr_pane_shows_comment_count() {
+        use crate::commands::list::ci_status::{CiSource, CiStatus, PrRef};
+
+        let status = |comment_count: Option<u32>| PrStatus {
+            ci_status: CiStatus::Passed,
+            source: CiSource::PullRequest,
+            is_stale: false,
+            is_priming: false,
+            url: Some("https://github.com/o/r/pull/7".into()),
+            number: Some(PrRef::pr(7)),
+            review_state: None,
+            title: Some("Fix the flaky retry".into()),
+            body: None,
+            comment_count,
+        };
+
+        // A PR with comments adds a `comments` metadata line carrying the count.
+        let with = render_worktree_pr("feature", PrRef::pr(7), &status(Some(3)), 80)
+            .ansi_strip()
+            .to_string();
+        assert!(
+            with.lines()
+                .any(|l| l.contains("comments") && l.contains('3')),
+            "comments line with count: {with:?}"
+        );
+
+        // No comments (zero is flattened to `None` at the mapping boundary, and an
+        // older cache entry carries `None` too) → the line is skipped entirely.
+        let without = render_worktree_pr("feature", PrRef::pr(7), &status(None), 80)
+            .ansi_strip()
+            .to_string();
+        assert!(
+            !without.contains("comments"),
+            "no comments line when absent: {without:?}"
+        );
+    }
+
+    #[test]
     fn preview_assembles_tab_bar_and_pr_pane() {
         use crate::commands::list::ci_status::{CiSource, CiStatus, PrRef, ReviewState};
 
@@ -1405,6 +1453,7 @@ mod tests {
                 review_state: Some(ReviewState::Approved),
                 title: Some("Fix the flaky retry".into()),
                 body: Some("Adds a **bounded** retry.".into()),
+                comment_count: None,
             })))),
         };
 
@@ -1465,6 +1514,7 @@ mod tests {
                 review_state: Some(ReviewState::Approved),
                 title: Some(title.into()),
                 body: Some("body".into()),
+                comment_count: None,
             }))
         };
         // Share the cache and slot Arcs so the test can mutate the slot and

--- a/src/commands/picker/prs.rs
+++ b/src/commands/picker/prs.rs
@@ -551,6 +551,7 @@ fn gitlab_mr_status(
         // (which feeds only the CI column), so they stay absent here.
         title: None,
         body: None,
+        comment_count: None,
     }
 }
 
@@ -1166,6 +1167,7 @@ mod tests {
                 review_state: None,
                 title: None,
                 body: None,
+                comment_count: None,
             }),
         }
     }


### PR DESCRIPTION
## What

The `pr` preview tab for a worktree row in the `wt switch` picker shows the
PR/MR reference, title, branch, URL, and description. It now also shows a
`comments` line with the conversation-comment count, for a PR/MR that has any.

## How

The count rides the CI fetch the picker already makes, so there's no new
network call — the same shape as the just-merged title/description change
(#3167):

- A `comment_count: Option<u32>` field was added to `PrStatus` (serde default +
  skip-if-none, so old CI-cache entries stay readable and a no-comment PR
  serializes nothing). The picker's prime-from-cache first frame can show it
  before the live fetch lands.
- Each forge maps the count from its existing list call:
  - **GitHub** — `gh pr list --json` is widened with `comments`. `gh` has no
    count-only field, so the array is requested and counted; for a
    `--head <branch>` call that's typically one PR.
  - **GitLab** — `user_notes_count` from `glab mr list`.
  - **Gitea** — `comments` (int) from the `tea api …/pulls` object.
  - **Azure DevOps** — left unset. `az repos pr list` carries no comment/thread
    count, and a per-PR threads call is exactly the extra round-trip this avoids.
- Zero is flattened to `None` at each mapping boundary (a `comment_count()`
  method on each forge's list struct — GitHub/GitLab/Gitea share the shape), so
  a PR with no comments shows nothing new; the render layer shows the line only
  when the count is `Some`.
- It renders as a `comments` metadata line in the shared `pr_pane`, on the
  worktree-row pane.

## Count, not comment text

A count — not the comment bodies — because:

- `PrStatus` is disk-cached (the CI cache); storing threads would bloat it.
- A count is the one comment datum every forge exposes cheaply on its existing
  list call, so it rides that call with no extra round-trip, consistent with the
  title/body precedent.
- The full thread already has a home: the `--prs` rows' `comments` tab fetches
  and renders it per-row in the background. Worktree rows still point there
  (their `comments` tab is unchanged).

`wt list --json` is deliberately unchanged — `comment_count`, like title/body,
stays out of the CI/review-scoped JSON.

## Testing

- The `comment_count()` zero-flatten (`Some(0)` → `None`) is pinned per forge:
  GitHub (array length), GitLab (`user_notes_count`), Gitea (`comments`). The
  `pr`-pane render is covered present + absent in `items.rs`.
- The four backends' new lines ride the mocked-CLI `ci_status` integration
  tests; `wt list --full` output is unchanged (CI column only), so there's no
  snapshot drift.
- Field names were confirmed against the live GitHub, GitLab, and Gitea APIs.
  `glab`/`tea`/`az` versions that omit the field degrade gracefully (serde
  default → no line), as with the title/body fields.

> _This was written by Claude Code on behalf of max_
