### PR TITLE
feat(switch): show a scrollbar on the interactive picker list

### DIFF
--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -665,6 +665,14 @@ pub fn handle_picker(
         // shows just the `>` pointer (the row's own `display()` ANSI spans carry
         // no background). skim 0.20's tuikit backend highlighted the row for free.
         .highlight_line(true)
+        // Draw a scrollbar thumb on the item list when it overflows the view.
+        // skim's `▐` default is the clap `default_value`, gated on skim's `cli`
+        // feature; with `default-features = false` the library `Default` for
+        // this `String` field is empty, which skim reads as "no scrollbar".
+        // Setting it explicitly restores the thumb — without it a long worktree
+        // (or `--prs`) list scrolls with no position cue, made worse by
+        // `no_info(true)` below hiding the matched/total counter.
+        .scrollbar("▐".to_string())
         .header_lines(1usize) // Make first line (header) non-selectable
         .multi(false)
         .no_info(true) // Hide info line (matched/total counter)

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -609,6 +609,48 @@ fn test_switch_picker_with_branches(mut repo: TestRepo) {
     });
 }
 
+/// A list taller than the viewport renders skim's scrollbar thumb (`▐`) down
+/// the right edge of the item pane. The thumb only appears because the picker
+/// sets `.scrollbar("▐")` explicitly: skim's `▐` default lives in its clap
+/// `default_value`, gated on the `cli` feature we disable, so the library
+/// `Default` for the field is the empty string ("no scrollbar"). Without the
+/// explicit setting a long worktree/`--prs` list scrolls with no position cue.
+/// `--branches` overflows the 30-row test terminal cheaply (one `git branch`
+/// per row, no `git worktree add`).
+#[rstest]
+fn test_switch_picker_scrollbar_on_overflow(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["remote", "remove", "origin"]);
+
+    // Far more branches than the ~24 item rows the 30-row terminal can show, so
+    // the list is guaranteed to overflow and skim paints the scrollbar.
+    for i in 0..50 {
+        let name = format!("scroll-{i:02}");
+        repo.run_git(&["branch", name.as_str()]);
+    }
+
+    let env_vars = repo.test_env_vars();
+    let result = exec_in_pty_capture_before_abort(
+        wt_bin().to_str().unwrap(),
+        &["switch", "--branches"],
+        repo.root_path(),
+        &env_vars,
+        // `@ main` is the current worktree, always the top row of the list:
+        // gating on it confirms the item rows rendered before capture, and a
+        // regression fails fast with the list shown rather than via a 30s
+        // stabilize timeout (the role `orphan-branch` plays above).
+        &[("", Some("@ main"))],
+    );
+
+    assert_valid_abort_exit_code(result.exit_code);
+
+    let (list, _preview) = result.panels();
+    assert!(
+        list.contains('▐'),
+        "scrollbar thumb (▐) should render when the list overflows the viewport:\n{list}"
+    );
+}
+
 /// Typing a gutter glyph filters the picker by row kind. `+` is the linked-
 /// worktree glyph, so it narrows to linked worktrees — excluding the current
 /// worktree (`@`) and branch rows (`/`). This is the end-to-end answer to "why


### PR DESCRIPTION
`wt switch`'s picker rendered no scrollbar. Scrolling a long worktree list (or a long `wt switch --prs` list) gave no sense of position, and since the builder already sets `no_info(true)` to hide skim's matched/total counter, there was no positional feedback at all.

## Why it was silently absent

skim's `scrollbar` option documents a `▐` default, but that default is a clap `default_value` on the field, gated on skim's `cli` feature:

```rust
// skim-4.8.0/src/options.rs
#[cfg_attr(feature = "cli", arg(long, default_value = "▐", ...))]
pub scrollbar: String,
```

The picker depends on skim with `default-features = false` — it drives the library directly and doesn't want skim's own clap CLI compiled in. With `cli` off, the `default_value` never applies, so the library `Default` for `scrollbar` is `String::default()`: the empty string. skim draws the thumb only when the indicator is non-empty and the list overflows (`!scrollbar_thumb.is_empty() && items.len() > available_rows`), so an empty indicator means no scrollbar, ever. The picker had been getting skim's *library* default, not its *CLI* default.

## The fix

Set the indicator explicitly on the builder, next to the other display options:

```rust
.scrollbar("▐".to_string())
```

skim draws it as a thumb-only widget (no track, no arrows) at the rightmost column of the list. It appears only when the list overflows the visible height, so short lists are unchanged and the existing picker snapshots are unaffected.

## Known limitation: the thumb inherits the row's color

skim styles the scrollbar thumb with no color of its own, so the `▐` takes on the color of whatever row sits beneath it — most visibly the current-line highlight as the cursor scrolls past the thumb's track. The fix lives upstream in [skim-rs/skim#1097](https://github.com/skim-rs/skim/pull/1097), which styles the thumb with the theme's `border` color so it stays uniform. Once that lands and the `skim` dependency is bumped, the picker's thumb picks up the `border` color (dark256's `59`) with no further change here.

Shipping ahead of that fix: the position cue is the point, and the color bleed is cosmetic.

## Verification

Driven interactively against a 48-row `--branches` list in a 30-row terminal, the thumb renders down the right edge of the item pane (column 59, just left of the `│` preview separator), at the top of its track since the cursor starts on `@ main`:

```
> @ main                ^                                 ▐│
  + feature-wt-1      ? ↑                ↑15              ▐│○ main has no uncommitted changes
  + feature-wt-2      ? ↑                ↑15              ▐│
  + feature-wt-3      ? ·                ↑15              ▐│
  + feature-wt-4      ? ↑                ↑15              ▐│
  / demo-scroll-01     /_                                 ▐│
  / demo-scroll-02     /_                                 ▐│
  / demo-scroll-03     /_                                 ▐│
  / demo-scroll-04     /_                                  │
  ...
```

`test_switch_picker_scrollbar_on_overflow` (a PTY test) creates enough branches to overflow the test terminal and asserts the thumb renders.

> _This was written by Claude Code on behalf of max_
