### PR TITLE
fix(switch): match encoded Azure project paths

### DIFF
--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -81,6 +81,7 @@ pub use repository::{
 };
 pub use url::parse_owner_repo;
 pub use url::{GitRemoteUrl, GitRepoInfo, GitRepoProvider};
+pub(crate) use url::{canonical_url_path_segment, url_path_segments_eq};
 /// Why branch content is considered integrated into the target branch.
 ///
 /// Used by both `wt list` (for status symbols) and `wt remove` (for messages).

--- a/src/git/remote_ref/azure.rs
+++ b/src/git/remote_ref/azure.rs
@@ -7,6 +7,7 @@ use anyhow::{Context, bail};
 use serde::Deserialize;
 
 use super::{CliApiRequest, PlatformData, RemoteRefInfo, RemoteRefProvider, cli_api_error};
+use crate::git::canonical_url_path_segment;
 use crate::git::url::GitRemoteUrl;
 use crate::git::{RefType, Repository};
 
@@ -40,6 +41,9 @@ impl RemoteRefProvider for AzureDevOpsProvider {
 /// public keys, so HTTPS — which works with both PAT and Azure CLI auth — is
 /// the safe default.
 pub fn fork_remote_url(host: &str, organization: &str, project: &str, repo: &str) -> String {
+    let organization = canonical_url_path_segment(organization);
+    let project = canonical_url_path_segment(project);
+    let repo = canonical_url_path_segment(repo);
     if host.to_ascii_lowercase().ends_with(".visualstudio.com") {
         format!("https://{}/{}/_git/{}", host, project, repo)
     } else {
@@ -52,6 +56,9 @@ pub fn fork_remote_url(host: &str, organization: &str, project: &str, repo: &str
 
 /// Construct the PR web URL for the user's actual host (handles `*.visualstudio.com`).
 pub fn pr_web_url(host: &str, organization: &str, project: &str, repo: &str, pr: u32) -> String {
+    let organization = canonical_url_path_segment(organization);
+    let project = canonical_url_path_segment(project);
+    let repo = canonical_url_path_segment(repo);
     if host.to_ascii_lowercase().ends_with(".visualstudio.com") {
         format!(
             "https://{}/{}/_git/{}/pullrequest/{}",
@@ -67,6 +74,8 @@ pub fn pr_web_url(host: &str, organization: &str, project: &str, repo: &str, pr:
 
 /// Construct the build-results web URL for the user's actual host.
 pub fn build_web_url(host: &str, organization: &str, project: &str, build_id: u32) -> String {
+    let organization = canonical_url_path_segment(organization);
+    let project = canonical_url_path_segment(project);
     if host.to_ascii_lowercase().ends_with(".visualstudio.com") {
         format!(
             "https://{}/{}/_build/results?buildId={}",

--- a/src/git/repository/remotes.rs
+++ b/src/git/repository/remotes.rs
@@ -93,6 +93,7 @@ use anyhow::Context;
 
 use super::{GitRemoteUrl, GitRepoInfo, Repository};
 use crate::git::error::RefType;
+use crate::git::url_path_segments_eq;
 
 impl Repository {
     /// Get the primary remote name for this repository.
@@ -234,8 +235,8 @@ impl Repository {
                 .is_some_and(|o| o.eq_ignore_ascii_case(organization))
                 && parsed
                     .azure_project()
-                    .is_some_and(|p| p.eq_ignore_ascii_case(project))
-                && parsed.repo().eq_ignore_ascii_case(repo_name)
+                    .is_some_and(|p| url_path_segments_eq(p, project))
+                && url_path_segments_eq(parsed.repo(), repo_name)
         })
     }
 

--- a/src/git/url.rs
+++ b/src/git/url.rs
@@ -146,6 +146,15 @@ fn split_namespace_repo(path: &str) -> Option<(String, String)> {
     Some((namespace, repo.to_string()))
 }
 
+pub(crate) fn canonical_url_path_segment(segment: &str) -> String {
+    let decoded = urlencoding::decode(segment).unwrap_or(std::borrow::Cow::Borrowed(segment));
+    urlencoding::encode(decoded.as_ref()).into_owned()
+}
+
+pub(crate) fn url_path_segments_eq(left: &str, right: &str) -> bool {
+    canonical_url_path_segment(left).eq_ignore_ascii_case(&canonical_url_path_segment(right))
+}
+
 impl GitRemoteUrl {
     /// Parse a git remote URL into structured components.
     ///

--- a/tests/integration_tests/switch.rs
+++ b/tests/integration_tests/switch.rs
@@ -5481,6 +5481,40 @@ fn test_switch_pr_azure_same_repo(#[from(repo_with_remote)] mut repo: TestRepo) 
     });
 }
 
+#[rstest]
+fn test_switch_pr_azure_project_name_with_spaces(#[from(repo_with_remote)] mut repo: TestRepo) {
+    repo.add_worktree("feature-auth");
+    repo.run_git(&["push", "origin", "feature-auth"]);
+
+    set_azure_remote_url(
+        &repo,
+        "https://dev.azure.com/myorg/project%20with%20spaces/_git/test-repo",
+    );
+
+    let az_response = r#"{
+        "title": "Fix authentication bug in login flow",
+        "createdBy": {"uniqueName": "alice@example.com"},
+        "status": "active",
+        "isDraft": false,
+        "sourceRefName": "refs/heads/feature-auth",
+        "repository": {
+            "name": "test-repo",
+            "project": {"name": "project with spaces"},
+            "webUrl": "https://dev.azure.com/myorg/project%20with%20spaces/_git/test-repo"
+        },
+        "forkSource": null
+    }"#;
+
+    let mock_bin = setup_mock_az(&repo, Some(az_response));
+
+    let settings = setup_snapshot_settings(&repo);
+    settings.bind(|| {
+        let mut cmd = make_snapshot_cmd(&repo, "switch", &["pr:101"], None);
+        configure_mock_cli_env(&mut cmd, &mock_bin);
+        assert_cmd_snapshot!("switch_pr_azure_project_name_with_spaces", cmd);
+    });
+}
+
 /// A full Azure DevOps PR web URL passed to `wt switch` resolves the same as the
 /// `pr:N` shortcut: the URL normalises to `pr:101` (shape-based `parse_ref_url`),
 /// dispatch selects `AzureDevOpsProvider`, and the worktree is created. The

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_azure_project_name_with_spaces.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_azure_project_name_with_spaces.snap
@@ -1,0 +1,55 @@
+---
+source: tests/integration_tests/switch.rs
+assertion_line: 5514
+info:
+  program: wt
+  args:
+    - switch
+    - "pr:101"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+
+----- stderr -----
+[36m◎[39m [36mFetching PR #101...[39m
+[107m [0m [1mFix authentication bug in login flow[22m (#101)
+[107m [0m by @alice@example.com · active · feature-auth · [90mhttps://dev.azure.com/myorg/project%20with%20spaces/_git/test-repo/pullrequest/101[39m
+[36m◎[39m [36mFetching [1mfeature-auth[22m from origin...[39m
+[33m▲[39m [33mWorktree for [1mfeature-auth[22m @ [1m_REPO_.feature-auth[22m, but cannot change directory — shell integration not installed[39m
+[2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m


### PR DESCRIPTION
Fixes #3203.

Azure DevOps returns decoded project names from `az repos pr show`, while Git remotes store project path segments URL-encoded. Canonicalize Azure path segments before comparing remotes and constructing Azure URLs, so `wt switch pr:N` works for projects like `project with spaces`.

Added an integration regression covering an encoded Azure project path with a decoded Azure API project name.