### PR TITLE
feat(switch): scale picker list height to the terminal

### DIFF
--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -26,8 +26,8 @@
 //!    `git diff HEAD` for the current worktree on `COLLECT_POOL`.
 //!    That bg work overlaps with everything below.
 //! 4. Computes `num_items_estimate` — `list_worktrees` plus (conditionally)
-//!    `local_branches` / `remote_branches`, capped at
-//!    `MAX_VISIBLE_ITEMS`. Only used to size skim's `preview_window`.
+//!    `local_branches` / `remote_branches`, capped at the Down layout's
+//!    `max_visible_items(available)`. Only used to size skim's `preview_window`.
 //! 5. Builds `SkimOptions` (immutable after this — which is why steps 1-4 have
 //!    to run first).
 //! 6. Spawns the `picker-collect` bg thread, which calls `collect::collect`.
@@ -583,11 +583,17 @@ pub fn handle_picker(
     .saturating_sub(2);
 
     // Estimate item count for the preview window spec (only the Down
-    // layout depends on it). Every row over MAX_VISIBLE_ITEMS is a no-op
-    // for the height computation, so we short-circuit once we know the
-    // list already fills the cap.
+    // layout depends on it). The Down layout caps visible rows at
+    // `max_visible_items(available)`; every row past that cap is a no-op
+    // for the height computation, so we short-circuit once the estimate
+    // reaches it.
     let num_items_estimate = {
-        let cap = preview::MAX_VISIBLE_ITEMS;
+        let cap = {
+            let term_height = terminal_size::terminal_size()
+                .map(|(_, terminal_size::Height(h))| h as usize)
+                .unwrap_or(24);
+            preview::max_visible_items(preview::available_height(term_height))
+        };
         let mut estimate = repo.list_worktrees().map(|w| w.len()).unwrap_or(cap);
         if estimate < cap && show_branches {
             // Local branches are a superset of worktree branches (each
@@ -650,9 +656,9 @@ pub fn handle_picker(
     let state_path_display = state.path.display().to_string();
     let state_path_str = shell_escape::unix::escape(state_path_display.into()).into_owned();
 
-    // Calculate half-page scroll: skim uses 90% of terminal height, half of that = 45%
+    // Half-page preview scroll: half of skim's usable height.
     let half_page = terminal_size::terminal_size()
-        .map(|(_, terminal_size::Height(h))| (h as usize * 45 / 100).max(5))
+        .map(|(_, terminal_size::Height(h))| (preview::available_height(h as usize) / 2).max(5))
         .unwrap_or(10);
 
     // Configure skim options with Rust-based preview and mode switching keybindings

--- a/src/commands/picker/preview.rs
+++ b/src/commands/picker/preview.rs
@@ -64,14 +64,14 @@ const CHAR_ASPECT_RATIO: f64 = 0.5;
 /// Skim uses this percentage of terminal height.
 pub(super) const SKIM_HEIGHT_PERCENT: usize = 90;
 
-/// Maximum number of list items visible in down layout before scrolling.
-pub(super) const MAX_VISIBLE_ITEMS: usize = 12;
-
 /// Lines reserved for skim chrome (header + prompt/margins).
 pub(super) const LIST_CHROME_LINES: usize = 4;
 
 /// Minimum preview lines to keep usable even with many items.
 pub(super) const MIN_PREVIEW_LINES: usize = 5;
+
+/// Minimum list rows to keep selectable even on a short terminal.
+pub(super) const MIN_VISIBLE_ITEMS: usize = 3;
 
 /// Preview width as percentage of terminal width (for Right layout).
 const PREVIEW_WIDTH_PERCENT: usize = 50;
@@ -81,6 +81,33 @@ const PREVIEW_WIDTH_PERCENT: usize = 50;
 /// Below this width, the list panel in Right layout is too narrow
 /// for branch names to be readable. Fall back to Down layout instead.
 const MIN_COLS_FOR_RIGHT_LAYOUT: f64 = 80.0;
+
+/// Skim's usable height: the share of the terminal it actually paints
+/// (`SkimOptions::height("90%")`).
+///
+/// The single home for the `SKIM_HEIGHT_PERCENT` conversion. Every site that
+/// needs the available row budget — both layout arms in `dimensions_for`, the
+/// picker's `num_items_estimate` cap, and the preview half-page scroll — derives
+/// it here, so the definition can't drift between them.
+pub(super) fn available_height(term_height: usize) -> usize {
+    term_height * SKIM_HEIGHT_PERCENT / 100
+}
+
+/// Maximum list rows the Down layout shows before scrolling.
+///
+/// The list may claim up to half of skim's area (`available / 2`); the preview
+/// keeps the other half, so visible rows scale with terminal height instead of a
+/// fixed ceiling. Integer division truncates the list's half toward the preview —
+/// a deliberate preview-favoring tie-break. Floored at `MIN_VISIBLE_ITEMS` so the
+/// cap stays usable on a short terminal; on a terminal too short to fit both this
+/// floor and `MIN_PREVIEW_LINES`, `dimensions_for` lets the preview floor win and
+/// skim clamps the remainder. The single source of truth for the cap: both
+/// `dimensions_for` and the picker's `num_items_estimate` short-circuit gate on it,
+/// applying one formula at both sites.
+pub(super) fn max_visible_items(available: usize) -> usize {
+    let rows = (available / 2).saturating_sub(LIST_CHROME_LINES);
+    rows.max(MIN_VISIBLE_ITEMS)
+}
 
 /// Preview layout orientation for the interactive selector
 ///
@@ -146,22 +173,39 @@ impl PreviewLayout {
 
     /// Calculate preview dimensions (width, height) in characters.
     /// Single source of truth for preview sizing — used by both skim config
-    /// and background pre-computation.
+    /// and background pre-computation. Reads the live terminal size, then
+    /// delegates the pure layout math to `dimensions_for`.
     pub(super) fn preview_dimensions(self, num_items: usize) -> (usize, usize) {
         let (term_width, term_height) = terminal_size::terminal_size()
             .map(|(terminal_size::Width(w), terminal_size::Height(h))| (w as usize, h as usize))
             .unwrap_or((80, 24));
 
+        self.dimensions_for(term_width, term_height, num_items)
+    }
+
+    /// Pure layout math behind `preview_dimensions`, with the terminal size
+    /// passed in so the split is testable without a live TTY.
+    ///
+    /// Right keeps a fixed 50%/90% split independent of `num_items`. Down lets
+    /// the list grow to `max_visible_items(available)` rows (half of skim's
+    /// area) and hands the rest to the preview, floored at `MIN_PREVIEW_LINES`
+    /// and clamped to never exceed `available`.
+    fn dimensions_for(
+        self,
+        term_width: usize,
+        term_height: usize,
+        num_items: usize,
+    ) -> (usize, usize) {
         match self {
             Self::Right => {
                 let width = term_width * PREVIEW_WIDTH_PERCENT / 100;
-                let height = term_height * SKIM_HEIGHT_PERCENT / 100;
+                let height = available_height(term_height);
                 (width, height)
             }
             Self::Down => {
                 let width = term_width;
-                let available = term_height * SKIM_HEIGHT_PERCENT / 100;
-                let list_lines = LIST_CHROME_LINES + num_items.min(MAX_VISIBLE_ITEMS);
+                let available = available_height(term_height);
+                let list_lines = LIST_CHROME_LINES + num_items.min(max_visible_items(available));
                 let remaining = available.saturating_sub(list_lines);
                 let height = remaining.max(MIN_PREVIEW_LINES).min(available);
                 (width, height)
@@ -255,6 +299,142 @@ mod tests {
         // Down calculates based on item count
         let spec = PreviewLayout::Down.to_preview_window_spec(5);
         assert!(spec.starts_with("down:"));
+    }
+
+    #[test]
+    fn test_available_height_is_skim_height_percent() {
+        // The single home for skim's 90%-of-terminal conversion.
+        assert_eq!(available_height(0), 0);
+        assert_eq!(available_height(24), 21); // 24 * 90 / 100
+        assert_eq!(available_height(50), 45);
+        assert_eq!(available_height(100), 90);
+    }
+
+    #[test]
+    fn test_max_visible_items_scales_with_height() {
+        // available -> cap. The list claims half of skim's area minus chrome,
+        // floored at MIN_VISIBLE_ITEMS(3). The floor binds until available/2
+        // exceeds chrome by 3 (available >= 14); above that the cap grows
+        // linearly with the terminal instead of the former fixed 12.
+        let cases = [
+            (0, 3),
+            (8, 3),    // 4 - 4 = 0 -> floor
+            (12, 3),   // 6 - 4 = 2 -> floor
+            (14, 3),   // 7 - 4 = 3 -> floor boundary
+            (16, 4),   // 8 - 4 = 4 -> floor releases
+            (24, 8),   // 12 - 4
+            (28, 10),  // 14 - 4
+            (36, 14),  // 18 - 4
+            (72, 32),  // 36 - 4
+            (100, 46), // 50 - 4
+            (216, 104),
+        ];
+        for (available, expected) in cases {
+            assert_eq!(
+                max_visible_items(available),
+                expected,
+                "max_visible_items({available})"
+            );
+        }
+    }
+
+    #[test]
+    fn test_down_preview_dimensions_scenarios() {
+        // (term_height, num_items) -> preview lines, for the balanced 50/50
+        // split. Width is irrelevant to the Down height, so pass a fixed 80.
+        // Mirrors the design's scenario grid: visible rows scale with height
+        // (h=80/n=30 -> 30 rows, h=120/n=100 -> 50 rows) while the preview
+        // keeps ~half and never collapses to its floor on a roomy terminal.
+        let cases = [
+            (20, 3, 11),
+            (20, 12, 9),
+            (20, 30, 9),
+            (20, 100, 9),
+            (24, 3, 14),
+            (24, 12, 11),
+            (24, 30, 11),
+            (24, 100, 11),
+            (40, 3, 29),
+            (40, 12, 20),
+            (40, 30, 18),
+            (40, 100, 18),
+            (50, 3, 38),
+            (50, 12, 29),
+            (50, 30, 23),
+            (50, 100, 23),
+            (80, 3, 65),
+            (80, 12, 56),
+            (80, 30, 38),
+            (80, 100, 36),
+            (120, 3, 101),
+            (120, 12, 92),
+            (120, 30, 74),
+            (120, 100, 54),
+        ];
+        for (term_height, num_items, expected_preview) in cases {
+            let (width, preview) = PreviewLayout::Down.dimensions_for(80, term_height, num_items);
+            assert_eq!(width, 80, "Down width is the full terminal width");
+            assert_eq!(
+                preview, expected_preview,
+                "Down preview height for {term_height}h x {num_items} items"
+            );
+            // The list region is whatever skim has left after the preview.
+            // It must hold the chrome plus exactly the visible rows we sized
+            // for, never more than there are items, and never overflow skim.
+            let available = term_height * SKIM_HEIGHT_PERCENT / 100;
+            assert!(preview <= available, "preview must fit skim's area");
+            let list_region = available - preview;
+            let visible = list_region.saturating_sub(LIST_CHROME_LINES);
+            assert!(visible <= num_items, "never show more rows than items");
+        }
+    }
+
+    #[test]
+    fn test_down_preview_no_phantom_rows_when_empty() {
+        // With no worktrees yet, the list reserves only its chrome — the
+        // MIN_VISIBLE_ITEMS floor must not invent rows that don't exist.
+        let term_height = 50;
+        let available = term_height * SKIM_HEIGHT_PERCENT / 100;
+        let (_, preview) = PreviewLayout::Down.dimensions_for(80, term_height, 0);
+        assert_eq!(available - preview, LIST_CHROME_LINES);
+    }
+
+    #[test]
+    fn test_down_preview_dimensions_never_panic_on_tiny_terminals() {
+        // Saturating math must hold for degenerate terminals and absurd item
+        // counts: the preview band always fits within skim's area.
+        for term_height in [0, 1, 2, 3, 8, 10, 12, 14] {
+            for num_items in [0, 1, 1000] {
+                let available = term_height * SKIM_HEIGHT_PERCENT / 100;
+                let (_, preview) = PreviewLayout::Down.dimensions_for(80, term_height, num_items);
+                assert!(
+                    preview <= available,
+                    "preview {preview} exceeds available {available} at {term_height}h"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_down_preview_saturates_at_cap() {
+        // The picker's num_items_estimate short-circuit stops counting at
+        // max_visible_items(available). This is sound only if any item count
+        // at or above the cap yields the same preview spec as the cap itself.
+        for term_height in [24, 40, 80, 120] {
+            let available = term_height * SKIM_HEIGHT_PERCENT / 100;
+            let cap = max_visible_items(available);
+            let at_cap = PreviewLayout::Down.dimensions_for(80, term_height, cap);
+            assert_eq!(
+                at_cap,
+                PreviewLayout::Down.dimensions_for(80, term_height, cap + 1),
+                "cap+1 must match cap at {term_height}h"
+            );
+            assert_eq!(
+                at_cap,
+                PreviewLayout::Down.dimensions_for(80, term_height, 100_000),
+                "a huge count must match cap at {term_height}h"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
The interactive picker's Down layout (preview below the list) capped the worktree list at a fixed 12 rows. On a tall terminal with many worktrees that meant seeing only 12 — with all the surplus height going to a near-empty preview pane — and the list never adapted to the space available.

This replaces the `MAX_VISIBLE_ITEMS = 12` constant with `max_visible_items(available)`, a balanced 50/50 split: the list may claim up to half of skim's area (`available / 2`) and the preview keeps the other half, so visible rows scale with terminal height. Integer division truncates the list's half toward the preview — a deliberate preview-favoring tie-break — and a `MIN_VISIBLE_ITEMS = 3` floor keeps the list usable on a short terminal.

The tradeoff is at the common 80×24: it now shows ~6 rows / 11 preview lines instead of the old 12 rows / 5-line (floor-crushed) preview — a more balanced split. On a 50-row terminal it shows up to 18 rows; on a 120-row terminal up to 50.

### Navigating the diff

- `src/commands/picker/preview.rs` — the policy. `available_height()` is the single home for skim's 90%-of-terminal conversion (both layout arms, the estimate cap, and the half-page scroll all derive from it, retiring a duplicated magic `45`). `max_visible_items()` is the cap; `dimensions_for()` is a pure seam extracted from `preview_dimensions()` so the split is unit-testable without a TTY.
- `src/commands/picker/mod.rs` — the `num_items_estimate` perf short-circuit now gates on the same height-derived cap, and `half_page` routes through `available_height()`.
- Right layout is untouched — it already used the full height and ignores the item count.

### Testing

Six unit tests in `preview.rs` pin the full scenario grid (6 terminal heights × 4 item counts), the cap table, the no-phantom-rows-when-empty case, no-panic on degenerate terminals, and the saturation invariant that keeps the estimate short-circuit sound.

> _This was written by Claude Code on behalf of max_
