### PR TITLE
fix(step): apply -C to the tethered command; tether the docs server

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -2,7 +2,11 @@
 # Copy target/ from main worktree using CoW (~3s vs ~68s full rebuild)
 deps = "wt step copy-ignored"
 assets = "task fetch-assets"
-docs = "cd docs && zola serve -p {{ branch | hash_port }}"
+# `zola serve` runs forever; tether kills its whole process tree when the
+# worktree is removed (any path — `wt remove`, `git worktree remove`, `rm -rf`),
+# so no `pre-remove`/`post-remove` cleanup is needed. `-C docs` runs zola in the
+# docs subdir; the worktree root is still what teardown watches.
+docs = "wt step tether -C docs -- zola serve -p {{ branch | hash_port }}"
 
 [post-merge]
 clippy = "pre-commit run clippy --all-files || true"
@@ -24,6 +28,3 @@ doc = "RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps --document-private-items"
 
 [list]
 url = "http://127.0.0.1:{{ branch | hash_port }}"
-
-[post-remove]
-docs = "lsof -ti :{{ branch | hash_port }} -sTCP:LISTEN | xargs kill 2>/dev/null || true"

--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -980,6 +980,12 @@ For pipes, redirects, variables, or globs, wrap in `sh -c`:
 
 {{ terminal(cmd="wt step tether -- sh -c 'PORT=$P npm run dev | tee dev.log'") }}
 
+To run the command from a subdirectory, pass the global `-C` flag (teardown
+still watches the worktree root, so a server launched with a relative `-C` is
+torn down with the worktree):
+
+{{ terminal(cmd="wt step tether -C frontend -- npm run dev") }}
+
 ### Examples
 
 Run a dev server, torn down automatically when the worktree goes away:

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -1029,6 +1029,14 @@ For pipes, redirects, variables, or globs, wrap in `sh -c`:
 $ wt step tether -- sh -c 'PORT=$P npm run dev | tee dev.log'
 ```
 
+To run the command from a subdirectory, pass the global `-C` flag (teardown
+still watches the worktree root, so a server launched with a relative `-C` is
+torn down with the worktree):
+
+```bash
+$ wt step tether -C frontend -- npm run dev
+```
+
 ### Examples
 
 Run a dev server, torn down automatically when the worktree goes away:

--- a/src/cli/step.rs
+++ b/src/cli/step.rs
@@ -734,6 +734,14 @@ For pipes, redirects, variables, or globs, wrap in `sh -c`:
 $ wt step tether -- sh -c 'PORT=$P npm run dev | tee dev.log'
 ```
 
+To run the command from a subdirectory, pass the global `-C` flag (teardown
+still watches the worktree root, so a server launched with a relative `-C` is
+torn down with the worktree):
+
+```console
+$ wt step tether -C frontend -- npm run dev
+```
+
 ## Examples
 
 Run a dev server, torn down automatically when the worktree goes away:

--- a/src/commands/step/tether.rs
+++ b/src/commands/step/tether.rs
@@ -39,15 +39,27 @@ const POLL_INTERVAL: Duration = Duration::from_millis(250);
 
 /// Run `command` supervised; tear its whole process tree down when the command
 /// exits or its worktree is removed.
-pub(crate) fn step_tether(command: &[String]) -> Result<()> {
+///
+/// `working_dir` is the global `-C <path>` flag — applied as the child's
+/// current directory so the tethered command can run from a subdirectory (a
+/// dev server in `frontend/`, zola in `docs/`), the same way `-C` works for
+/// custom subcommands. The reaper still watches the captured cwd (the worktree
+/// root), not `working_dir`, so a relative `-C docs` server is still torn down
+/// when the worktree is removed.
+pub(crate) fn step_tether(command: &[String], working_dir: Option<&Path>) -> Result<()> {
     // post-start hooks run with cwd at the worktree root; capture it now so
     // the reaper can notice the worktree being removed. `None` (cwd
     // unavailable) degrades to "tear down only on the command's own exit",
-    // never a false teardown.
+    // never a false teardown. Captured before applying `-C` to the child so
+    // the reaper watches the worktree root even when the command runs in a
+    // subdirectory.
     let worktree = std::env::current_dir().ok();
 
     let mut cmd = std::process::Command::new(&command[0]);
     cmd.args(&command[1..]);
+    if let Some(dir) = working_dir {
+        cmd.current_dir(dir);
+    }
     // Direct exec, no implicit shell, same as `wt step for-each`; scrub the
     // directive env vars so a long-lived child can't write to the parent
     // shell's cd/exec directive files.
@@ -157,7 +169,7 @@ mod tests {
         // started — exercising the `trace.fail` arm. (The success path, where
         // the child runs and is reaped, is covered by the `step_tether`
         // integration tests.)
-        let err = step_tether(&["worktrunk-nonexistent-binary-7f3a9b2c".to_string()])
+        let err = step_tether(&["worktrunk-nonexistent-binary-7f3a9b2c".to_string()], None)
             .expect_err("spawning a missing binary should fail");
         assert!(
             err.to_string().contains("spawn tethered command"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -183,7 +183,11 @@ fn handle_hook_command(action: HookCommand, yes: bool) -> anyhow::Result<()> {
     }
 }
 
-fn handle_step_command(action: StepCommand, yes: bool) -> anyhow::Result<()> {
+fn handle_step_command(
+    action: StepCommand,
+    working_dir: Option<std::path::PathBuf>,
+    yes: bool,
+) -> anyhow::Result<()> {
     match action {
         StepCommand::Commit(args) => {
             let verify = args.hooks.resolve();
@@ -391,7 +395,7 @@ fn handle_step_command(action: StepCommand, yes: bool) -> anyhow::Result<()> {
             clobber,
             format,
         } => step_relocate(branches, dry_run, commit, clobber, format),
-        StepCommand::Tether { command } => step_tether(&command),
+        StepCommand::Tether { command } => step_tether(&command, working_dir.as_deref()),
         StepCommand::External(args) => commands::step_alias(args, yes),
     }
 }
@@ -867,7 +871,7 @@ fn dispatch_command(
 ) -> anyhow::Result<()> {
     match command {
         Commands::Config { action } => handle_config_command(action, yes),
-        Commands::Step { action } => handle_step_command(action, yes),
+        Commands::Step { action } => handle_step_command(action, working_dir, yes),
         Commands::Hook { action } => handle_hook_command(action, yes),
         Commands::Select { branches, remotes } => handle_select_command(branches, remotes),
         Commands::List(args) => handle_list_command(args),

--- a/tests/integration_tests/step_tether.rs
+++ b/tests/integration_tests/step_tether.rs
@@ -132,3 +132,47 @@ fn test_tether_kills_process_group_when_command_exits(repo: TestRepo) {
         "the tether supervisor must exit after the command exits"
     );
 }
+
+/// The global `-C <dir>` flag runs the tethered command in that directory —
+/// the canonical way to start a server from a subdirectory (zola in `docs/`,
+/// a dev server in `frontend/`) given the command runs directly with no shell
+/// to `cd`. The reaper still watches the launch cwd, not `-C`.
+#[rstest]
+fn test_tether_runs_command_in_working_dir(repo: TestRepo) {
+    let subdir = repo.path().join("subdir");
+    std::fs::create_dir(&subdir).unwrap();
+    let cwdfile = repo.home_path().join("tether-cwd.txt");
+
+    // The command writes its cwd and exits; the supervisor then sweeps the
+    // group and returns, so `status()` completes with nothing left running.
+    let status = repo
+        .wt_command()
+        .args([
+            "-C",
+            subdir.to_str().unwrap(),
+            "step",
+            "tether",
+            "--",
+            "sh",
+            "-c",
+            &format!("pwd -P > \"{}\"", cwdfile.display()),
+        ])
+        .current_dir(repo.path())
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("run wt step tether -C");
+    assert!(
+        status.success(),
+        "tether should exit 0 on command self-exit"
+    );
+
+    let recorded =
+        std::fs::read_to_string(&cwdfile).expect("tethered command should record its cwd");
+    assert_eq!(
+        std::fs::canonicalize(recorded.trim()).unwrap(),
+        std::fs::canonicalize(&subdir).unwrap(),
+        "the tethered command must run in the -C directory"
+    );
+}


### PR DESCRIPTION
## What

Tether this repo's docs preview server (`zola serve`) to the worktree lifecycle via `wt step tether`, replacing a bare backgrounded `zola serve` plus a best-effort `[post-remove]` port-kill hook.

```toml
# before
[post-start]
docs = "cd docs && zola serve -p {{ branch | hash_port }}"
[post-remove]
docs = "lsof -ti :{{ branch | hash_port }} -sTCP:LISTEN | xargs kill 2>/dev/null || true"

# after
[post-start]
docs = "wt step tether -C docs -- zola serve -p {{ branch | hash_port }}"
# (no [post-remove])
```

## The leak this fixes

`zola serve` runs forever, so the detached `wt hook run-pipeline` supervisor parked in an unbounded `child.wait()` and the server lived until something killed it. The only teardown was the `[post-remove]` port-kill, which is fragile and best-effort: it fires only on an explicit `wt remove` (so abandoned or out-of-band-removed worktrees — `git worktree remove`, `rm -rf`, a crashed hook — leak); it targets only the port via `branch | hash_port` (a hash collision across many branches can kill the wrong server or none); and it kills only the listener, not the supervisor.

On my machine this had left ~83 `zola serve` processes across ~49 worktrees, including 2 whose worktrees had already been removed (still running, rooted in `.git/wt/trash/`).

`wt step tether` exists for exactly this: it runs a command in its own process group and tears the whole tree down (`SIGTERM` → `SIGKILL`) when the worktree disappears, by **any** path — it polls for the worktree directory rather than relying on a removal hook, so `wt remove`, `git worktree remove`, `rm -rf`, and crashed hooks are all covered. No `pre-remove`/`post-remove` cleanup is needed, so the port-kill workaround is gone.

## Why a code change came along

`wt step tether -- <cmd>` runs the command directly with no shell, so `cd docs && …` can't work. The natural fix is the global `-C` flag — and tether's own `--help` already advertises `-C` as "Working directory for this command". But `-C` was a **silent no-op** for `step tether`: it only set the internal `BASE_PATH` used for repo discovery, and `step_tether` spawned the child without ever calling `.current_dir()`. So `wt step tether -C docs -- zola serve` would have run zola in the worktree root and failed to find `docs/config.toml`.

The sibling spawn site for custom subcommands (`run_custom` in `src/commands/custom.rs`) already applies `-C` as the spawned child's working directory. This change makes `step tether` do the same: thread `working_dir` from `dispatch_command` → `handle_step_command` → `step_tether`, applied via `cmd.current_dir(dir)`. The reaper still captures `std::env::current_dir()` (the worktree root) **before** `-C` is applied, so a server launched with a relative `-C docs` is still torn down when the worktree is removed — teardown watches the worktree root, not the subdir.

## Caveat: `wt step tether` is experimental

`wt step tether` is marked `[experimental]` and may change. I verified the behavior end-to-end against this repo's docs site: `wt step tether -C docs -- zola serve -p <port>` starts zola serving from `docs/` (HTTP 200), and removing the directory the reaper watches kills both the zola process and the supervisor within ~0.75s, leaving nothing behind. Both `wt remove` (rename-into-trash) and outright deletion are covered by the existing `test_tether_kills_process_group_when_worktree_removed` integration test.

## Changes

- `.config/wt.toml` — `docs` post-start hook now runs under `wt step tether -C docs`; `[post-remove]` section removed.
- `src/commands/step/tether.rs`, `src/main.rs` — `step_tether` honors the global `-C` as the tethered command's working directory (consistent with `run_custom`).
- `src/cli/step.rs` — documents `-C` for tether (subdirectory servers); regenerated `docs/content/step.md` and `skills/worktrunk/reference/step.md`.
- `tests/integration_tests/step_tether.rs` — new `test_tether_runs_command_in_working_dir`.

`cargo run -- hook pre-merge --yes` passes (fmt, clippy, 4180 tests, doctest, doc).

> _This was written by Claude Code on behalf of max_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
