### PR TITLE
feat(switch): rank picker matches by the distinct worktree path

### DIFF
--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -678,6 +678,14 @@ pub fn handle_picker(
         // criterion, so setting the knobs directly is the same effect without the
         // artifact. (Default tiebreak is `[Score, Begin, End]`.) Paired with the
         // distinct-path `search_text` built in `progressive_handler::on_skeleton`.
+        //
+        // `PathName` reads the whole `search_text`, including the trailing gutter
+        // glyph. Local-branch rows fold in `/` as that glyph (the gutter sigil),
+        // which `PathName` then reads as a path separator, so on a *score tie* a
+        // local-branch row sorts just under a worktree/remote row whose glyph
+        // (`+`/`@`/`^`/`|`) isn't a separator. The effect is confined to exact
+        // ties (`PathName` is the 2nd criterion) and only reorders rows, so it
+        // rides along rather than warranting a change to the gutter sigils.
         .last_match(true)
         .tiebreak(vec![
             RankCriteria::Score,

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -665,6 +665,26 @@ pub fn handle_picker(
     let options = SkimOptionsBuilder::default()
         .height("90%".to_string())
         .reverse(true)
+        // Rank matches by a row's *distinguishing* tail, not the shared
+        // `~/workspace/` prefix every worktree path carries. `last_match` makes
+        // the matcher prefer the query's rightmost occurrence, and front-loading
+        // `PathName` in the tiebreak ranks leaf-segment matches (at/after the
+        // last `/`) above parent-directory ones — so `feature/auth` ranks on
+        // `auth`, and the worktree folder name ranks on its tail. This is skim's
+        // `Path` scheme spelled out as its two underlying knobs: a
+        // `.scheme(MatchScheme::Path)` call would also expand here (the builder's
+        // `build()` runs `SkimOptions::build`, which expands the scheme — unlike
+        // the clap-only `scrollbar` default), but it injects a duplicate `Score`
+        // criterion, so setting the knobs directly is the same effect without the
+        // artifact. (Default tiebreak is `[Score, Begin, End]`.) Paired with the
+        // distinct-path `search_text` built in `progressive_handler::on_skeleton`.
+        .last_match(true)
+        .tiebreak(vec![
+            RankCriteria::Score,
+            RankCriteria::PathName,
+            RankCriteria::Begin,
+            RankCriteria::End,
+        ])
         // Fill the whole selected row with the `current` background (set via
         // `current_bg` in `.color(...)` below). skim 4.x applies the current-row
         // style at the line level only when this is on; without it the selection

--- a/src/commands/picker/progressive_handler.rs
+++ b/src/commands/picker/progressive_handler.rs
@@ -33,6 +33,7 @@
 //!   workers' local deques during drain.
 
 use std::collections::HashSet;
+use std::path::Path;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex, OnceLock};
 use std::time::{Duration, Instant};
@@ -164,6 +165,22 @@ impl PickerProgressHandler for PickerHandler {
             .unwrap_or_default();
         let summaries_enabled = self.llm_command.is_some();
 
+        // Parent of the primary worktree — stripped from each row's matcher path
+        // (below) so the fuzzy matcher indexes only the distinguishing tail
+        // (`worktrunk.skim-features`), not the `~/workspace/` prefix every sibling
+        // worktree shares. Worktrunk's convention is flat siblings under one
+        // parent, so this is that parent. Computed once; a worktree living outside
+        // it keeps its full path via the `strip_prefix` fallback. Cheap and
+        // network-free here — `primary_worktree()` reads the already-warmed
+        // `repo_path()` / worktree-list caches.
+        let path_base = self
+            .orchestrator
+            .repo()
+            .primary_worktree()
+            .ok()
+            .flatten()
+            .and_then(|p| p.parent().map(Path::to_path_buf));
+
         // Header row — non-selectable via `header_lines(1)` on the options.
         // In `--prs` mode it shows a dim "loading open PRs…" line (in place of
         // the column labels) until the forge call's rows land — wording mirrors
@@ -184,9 +201,21 @@ impl PickerProgressHandler for PickerHandler {
         for (item, rendered_line) in items.into_iter().zip(rendered) {
             let branch_name = item.branch_name().to_string();
             let has_upstream = upstream_branches.contains(&branch_name);
+            // The *distinct* path (leaf relative to the shared worktree parent),
+            // not the absolute path — see `path_base`. This feeds only the
+            // matcher's `search_text`; the rendered Path column is a separate
+            // field and is untouched.
             let path_str = item
                 .worktree_path()
-                .map(|p| p.to_string_lossy().into_owned())
+                .map(|p| {
+                    let p = p.as_path();
+                    path_base
+                        .as_deref()
+                        .and_then(|base| p.strip_prefix(base).ok())
+                        .unwrap_or(p)
+                        .to_string_lossy()
+                        .into_owned()
+                })
                 .unwrap_or_default();
             // `search_text` is what the matcher sees — fuzzy ranks stay
             // stable across progressive updates because this field only
@@ -473,6 +502,58 @@ mod tests {
         // Branch name stays searchable alongside the folded-in glyph.
         assert!(text(1).contains("localbr"));
         assert!(text(2).contains("origin/remotebr"));
+    }
+
+    /// `on_skeleton` strips the shared primary-worktree parent from each row's
+    /// matcher `search_text`, so the fuzzy matcher indexes the distinguishing
+    /// leaf (`repo.feat`) rather than the absolute prefix every sibling worktree
+    /// carries. Uses a real `git worktree add` path so the strip runs against the
+    /// same canonicalization production sees (`primary_worktree()` vs the
+    /// list-worktrees path); a divergence would surface here as a retained
+    /// absolute path. A worktree outside the shared parent keeps its full path
+    /// via the `strip_prefix` fallback.
+    #[test]
+    fn search_text_strips_shared_worktree_parent() {
+        use crate::commands::list::model::{ItemKind, WorktreeData};
+
+        let (handler, mut test, rx) = make_handler();
+        // A genuine sibling worktree at `{temp}/repo.feat`; its leaf is `repo.feat`.
+        let inside_path = test.add_worktree("feat");
+        let outside_path = std::path::PathBuf::from("/nonexistent-root/external-wt");
+
+        let worktree_item = |branch: &str, path: &Path| {
+            let mut item = ListItem::new_branch("abc".into(), branch.into());
+            item.kind = ItemKind::Worktree(Box::new(WorktreeData {
+                path: path.to_path_buf(),
+                ..Default::default()
+            }));
+            item
+        };
+
+        handler.on_skeleton(
+            vec![
+                worktree_item("inside", &inside_path),
+                worktree_item("outside", &outside_path),
+            ],
+            vec!["skel-inside".into(), "skel-outside".into()],
+            header("hdr"),
+            grid(),
+        );
+
+        let received = rx.recv().expect("skeleton batch");
+        let text = |i: usize| received[i].text().into_owned();
+
+        // Inside the shared parent: only the leaf is indexed (gutter `+` for a
+        // non-current linked worktree). The absolute prefix is gone.
+        assert_eq!(text(1), "inside repo.feat +", "leaf only: {:?}", text(1));
+
+        // Outside the shared parent: the full path is retained (fallback).
+        assert_eq!(
+            text(2),
+            "outside /nonexistent-root/external-wt +",
+            "out-of-tree path kept whole: {:?}",
+            text(2)
+        );
     }
 
     /// Locks the gutter-sigil filtering contract against skim's default engine —

--- a/src/commands/picker/progressive_handler.rs
+++ b/src/commands/picker/progressive_handler.rs
@@ -165,21 +165,24 @@ impl PickerProgressHandler for PickerHandler {
             .unwrap_or_default();
         let summaries_enabled = self.llm_command.is_some();
 
-        // Parent of the primary worktree — stripped from each row's matcher path
+        // Parent of the main worktree — stripped from each row's matcher path
         // (below) so the fuzzy matcher indexes only the distinguishing tail
         // (`worktrunk.skim-features`), not the `~/workspace/` prefix every sibling
-        // worktree shares. Worktrunk's convention is flat siblings under one
-        // parent, so this is that parent. Computed once; a worktree living outside
-        // it keeps its full path via the `strip_prefix` fallback. Cheap and
-        // network-free here — `primary_worktree()` reads the already-warmed
-        // `repo_path()` / worktree-list caches.
+        // worktree shares. The base comes from `list_worktrees()` — the same
+        // source the row paths come from — so it shares their exact
+        // canonicalization (the strip can't miss on a `/private/var`-vs-`/var`
+        // mismatch) and adds no network or uncached work (the skeleton was just
+        // built from this list). `[0]` is the main worktree for normal repos and
+        // the first linked worktree for bare ones; either way its parent is the
+        // shared sibling parent. Computed once; a worktree outside that parent
+        // keeps its full path via the `strip_prefix` fallback.
         let path_base = self
             .orchestrator
             .repo()
-            .primary_worktree()
+            .list_worktrees()
             .ok()
-            .flatten()
-            .and_then(|p| p.parent().map(Path::to_path_buf));
+            .and_then(|worktrees| worktrees.first())
+            .and_then(|wt| wt.path.parent().map(Path::to_path_buf));
 
         // Header row — non-selectable via `header_lines(1)` on the options.
         // In `--prs` mode it shows a dim "loading open PRs…" line (in place of
@@ -504,21 +507,28 @@ mod tests {
         assert!(text(2).contains("origin/remotebr"));
     }
 
-    /// `on_skeleton` strips the shared primary-worktree parent from each row's
+    /// `on_skeleton` strips the shared main-worktree parent from each row's
     /// matcher `search_text`, so the fuzzy matcher indexes the distinguishing
     /// leaf (`repo.feat`) rather than the absolute prefix every sibling worktree
-    /// carries. Uses a real `git worktree add` path so the strip runs against the
-    /// same canonicalization production sees (`primary_worktree()` vs the
-    /// list-worktrees path); a divergence would surface here as a retained
-    /// absolute path. A worktree outside the shared parent keeps its full path
-    /// via the `strip_prefix` fallback.
+    /// carries. The inside row's path is read back from `worktree_for_branch`, so
+    /// the strip runs against the real `list_worktrees()` path the rows carry, not
+    /// `add_worktree`'s separately canonicalized return. A worktree outside the
+    /// shared parent keeps its full path via the `strip_prefix` fallback.
     #[test]
     fn search_text_strips_shared_worktree_parent() {
         use crate::commands::list::model::{ItemKind, WorktreeData};
 
         let (handler, mut test, rx) = make_handler();
-        // A genuine sibling worktree at `{temp}/repo.feat`; its leaf is `repo.feat`.
-        let inside_path = test.add_worktree("feat");
+        // A genuine sibling worktree at `{temp}/repo.feat`; read its path back from
+        // the worktree list (the production path source — both the row path and
+        // the stripped base come from `list_worktrees()`, so they share one
+        // canonicalization).
+        test.add_worktree("feat");
+        let inside_path = test
+            .repo
+            .worktree_for_branch("feat")
+            .unwrap()
+            .expect("feat worktree is registered");
         let outside_path = std::path::PathBuf::from("/nonexistent-root/external-wt");
 
         let worktree_item = |branch: &str, path: &Path| {

--- a/src/commands/picker/progressive_handler.rs
+++ b/src/commands/picker/progressive_handler.rs
@@ -552,17 +552,16 @@ mod tests {
 
         let received = rx.recv().expect("skeleton batch");
         let text = |i: usize| received[i].text().into_owned();
+        let (inside, outside) = (text(1), text(2));
 
         // Inside the shared parent: only the leaf is indexed (gutter `+` for a
         // non-current linked worktree). The absolute prefix is gone.
-        assert_eq!(text(1), "inside repo.feat +", "leaf only: {:?}", text(1));
+        assert_eq!(inside, "inside repo.feat +", "leaf only: {inside:?}");
 
         // Outside the shared parent: the full path is retained (fallback).
         assert_eq!(
-            text(2),
-            "outside /nonexistent-root/external-wt +",
-            "out-of-tree path kept whole: {:?}",
-            text(2)
+            outside, "outside /nonexistent-root/external-wt +",
+            "out-of-tree path kept whole: {outside:?}"
         );
     }
 


### PR DESCRIPTION
The interactive `wt switch` picker built the string skim's matcher sees (`search_text`) from each row's absolute worktree path. Every row therefore shared the same `~/workspace/` prefix, and skim's default `[Score, Begin, End]` tiebreak (on a score tie it prefers the earliest match position) biased matches toward that shared noise. Two coupled changes make the matcher rank on the part of a row that actually distinguishes it.

## Part A: path-scheme tiebreak

skim's `Path` scheme sets `last_match = true` (prefer the query's rightmost occurrence) and front-loads the `PathName` tiebreak criterion (rank matches in the leaf segment, at or after the last `/`, above matches in a parent directory). Set directly on the builder:

```rust
.last_match(true)
.tiebreak(vec![
    RankCriteria::Score,
    RankCriteria::PathName,
    RankCriteria::Begin,
    RankCriteria::End,
])
```

These are set as the two underlying knobs rather than `.scheme(MatchScheme::Path)`. The brief flagged `.scheme()` as a silent no-op through the library builder, but that is not the case for skim 4.8.0: `SkimOptionsBuilder::build()` is a manual wrapper that calls `SkimOptions::build()` (`self.final_build().map(SkimOptions::build)`), and `SkimOptions::build()` is exactly where the scheme expands. Verified empirically: `.scheme(MatchScheme::Path)` yields `last_match=true` and tiebreak `[Score, PathName, Score, Begin, End]`. So `.scheme()` would work; the reason to set the knobs directly is that the scheme inserts a duplicate `Score` criterion (harmless, since the first wins, but an artifact), whereas the direct form gives the clean `[Score, PathName, Begin, End]`.

The scrollbar gap that motivated the original concern is a different mechanism: `scrollbar`'s default comes from a clap `default_value` attribute that the derive-builder path doesn't apply (so it falls back to `String::default()`), not from `SkimOptions::build()` going uncalled.

### Known interaction

`PathName` reads the whole `search_text`, including the trailing gutter glyph each row folds in for sigil-filtering. Local-branch rows use `/` as that glyph, which `PathName` reads as a path separator, so on a score tie a local-branch row sorts just under a worktree/remote row whose glyph (`+`/`@`/`^`/`|`) is not a separator. The effect is confined to exact ties (`PathName` is the second criterion) and only reorders rows; the alternative (changing the gutter sigils or dropping the path scheme) costs more than the tie-order quirk, so it rides along, documented in the code.

## Part B: distinct path

`search_text` now strips the shared worktree parent from each worktree path, so the matcher indexes only the distinguishing tail (`worktrunk.skim-features`, not the full absolute path). The base is `list_worktrees()[0].path.parent()`, computed once before the per-row loop; a worktree outside that parent keeps its full path via the `strip_prefix` fallback.

I first used `primary_worktree()` for the base, but review surfaced three problems with it, all of which dissolve by sourcing the base from `list_worktrees()` instead:

- `primary_worktree()` is not network-free for bare repos: it routes through `default_branch()`, which can `git ls-remote` on the first call per repo.
- `primary_worktree()` resolves to `repo_path()`, which is `dunce::canonicalize`d. The row paths come from `list_worktrees()` (raw `git worktree list --porcelain`). Those are two different derivations, so they could in principle diverge (e.g. `/private/var` vs `/var`) and silently defeat the strip. Sourcing the base from `list_worktrees()` too means base and rows share one canonicalization, so the strip can't miss.
- `primary_worktree()` returns `None` for a bare repo whose default branch has no worktree; `list_worktrees()[0]` yields a base whenever any worktree exists.

`list_worktrees()[0]` is the main worktree for normal repos and the first linked worktree for bare ones; either way its parent is the shared sibling parent. It is already cached by the time the skeleton renders (the rows were just built from it), so this adds no network or extra git work.

Only `search_text` changes; the rendered Path column is a separate field and is untouched. `--prs` rows build their own `search_text` with no worktree path, so they are unaffected.

## Verification

- New unit test `search_text_strips_shared_worktree_parent` pins the exact stripped format and the out-of-tree fallback, reading the inside row's path back via `worktree_for_branch` so it strips a real `list_worktrees()` path.
- Drove the picker interactively against a repo with namespaced worktrees (`api/users`, `users/api`, `db/users`, `feature/payment`, `payment/refund`). Querying `users` matched only the three `*users*` rows, not all six. Querying `claude`, a fragment that lives only in the now-stripped shared parent (`~/.claude/jobs/...`), matched zero rows, where before it would have fuzzy-matched `.claude` on every row.
- Multi-angle review (8 finder angles + adversarial verify) drove the move to `list_worktrees()` and the documented tiebreak interaction above.
- `cargo run -- hook pre-merge --yes` passes (4180 tests, lints).

> _This was written by Claude Code on behalf of max_
