### PR TITLE
fix(switch): keep the picker gutter sigil when filtering

### DIFF
--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -819,6 +819,22 @@ pub fn handle_picker(
         // shows just the `>` pointer (the row's own `display()` ANSI spans carry
         // no background). skim 0.20's tuikit backend highlighted the row for free.
         .highlight_line(true)
+        // Each row's `display()` owns its layout: a leading gutter sigil
+        // (`+`/`@`/`^`/`/`/`|`), then columns, right-truncated to the list width
+        // with a trailing `…`. skim's horizontal scroll is a second, conflicting
+        // layout authority over the same row — on a query match it scrolls the row
+        // left to bring the matched char into view, deriving the offset from that
+        // char's *position* in the match text (`search_text` = branch + full path +
+        // glyph), which is far longer than the visible row, while clamping against
+        // the rendered line's own width. Any row whose rendered width exceeds skim's
+        // container (e.g. a long branch name, or a width-count disagreement on wide
+        // glyphs) then gets shifted left far enough to clip its leading gutter sigil
+        // — typing a few chars made the sigil vanish from every overflowing row.
+        // Disabling hscroll leaves worktrunk as the sole row-layout
+        // authority: overflow truncates on the right (gutter kept) instead of
+        // scrolling left. The picker doesn't reveal matches by scrolling anyway —
+        // `display()` ignores the match context and renders its own ANSI.
+        .no_hscroll(true)
         // First line (header) non-selectable. `PICKER_HEADER_ROWS` mirrors this
         // count so the alt-r cursor-reposition math stays in sync — keep them one.
         .header_lines(PICKER_HEADER_ROWS)


### PR DESCRIPTION
The `wt switch` picker dropped each row's leading gutter sigil (`+`/`@`/`^`/`/`/`|`) when you typed filter characters — in the reported case, every row but the top one lost its sigil after typing a couple of letters.

The cause is that skim's horizontal scroll is a second layout authority over a row that worktrunk already lays out. On a query match, skim scrolls the matched row left to bring the matched character into view, deriving the scroll offset from that character's *position* in the match text (`search_text` = branch + full path + glyph — far longer than the visible row) while clamping against the rendered line's own width. Any row whose rendered width exceeds skim's `container_width` — a long branch name, or a width-count disagreement on wide glyphs (worktrunk measures with `unicode-width`, skim with `unicode-display-width`) — then shifts left far enough that its leading gutter sigil falls off the left edge. The top row survives because its best-ranked match sits near char 0, so its shift is 0.

The fix sets `no_hscroll(true)` on the picker's skim options. worktrunk already owns row layout and right-truncates each row to the list width, so skim's match-driven hscroll is a redundant, conflicting mechanism — and it never served its purpose here anyway, since the picker's `display()` ignores skim's match context and renders its own ANSI. With hscroll off, an overflowing row truncates on the right (gutter kept) instead of scrolling left; non-overflowing rows are unchanged.

Verified by reproducing with a long branch name (before: `>  zzz-very-long-…` with the sigil gone; after: `> / zzz-very-long-…` with the `/` restored). The picker's skim options are config wiring built inline in `handle_picker` with no existing unit coverage, so this carries no new test — the rationale lives in a comment so it survives future skim upgrades.

> _This was written by Claude Code on behalf of max_
