### PR TITLE
test: poll PTY output instead of blind sleeps in bash job-control test

### DIFF
--- a/tests/integration_tests/shell_wrapper.rs
+++ b/tests/integration_tests/shell_wrapper.rs
@@ -523,17 +523,22 @@ fn exec_in_pty_shell(
 ///
 /// The setup_script is written to a temp file and sourced. Then final_cmd is run
 /// directly at the prompt (where job notifications appear).
+///
+/// `success_marker` is a substring the command is expected to print; the helper
+/// polls for it to know the command finished, instead of sleeping a fixed guess.
 #[cfg(all(test, unix))]
 fn exec_bash_truly_interactive(
     setup_script: &str,
     final_cmd: &str,
+    success_marker: &str,
     working_dir: &std::path::Path,
     env_vars: &[(&str, &str)],
 ) -> (String, i32) {
     use portable_pty::CommandBuilder;
     use std::io::{Read, Write};
+    use std::sync::mpsc;
     use std::thread;
-    use std::time::Duration;
+    use std::time::{Duration, Instant};
 
     // Write setup script to a temp file
     let tmp_dir = tempfile::tempdir().unwrap();
@@ -580,47 +585,89 @@ fn exec_bash_truly_interactive(
     let mut child = pair.slave.spawn_command(cmd).unwrap();
     drop(pair.slave); // Close slave in parent
 
-    // Get both reader and writer
     let reader = pair.master.try_clone_reader().unwrap();
     let mut writer = pair.master.take_writer().unwrap();
 
-    // Give bash time to start up. Unlike async operations, bash startup is deterministic
-    // and fast (<50ms typical), so a fixed sleep is acceptable here. We use 200ms for CI margin.
-    thread::sleep(Duration::from_millis(200));
+    // Stream PTY output over a channel so the main thread can poll for prompts and
+    // command output as they arrive, rather than reading only after `exit`. This is
+    // what lets the blind startup/command sleeps become waits on real output.
+    let (tx, rx) = mpsc::channel::<Vec<u8>>();
+    let reader_thread = thread::spawn(move || {
+        let mut reader = reader;
+        let mut buf = [0u8; 4096];
+        loop {
+            match reader.read(&mut buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    if tx.send(buf[..n].to_vec()).is_err() {
+                        break;
+                    }
+                }
+                Err(_) => break,
+            }
+        }
+    });
 
-    // Write setup and command (but not exit yet)
+    let mut accumulated: Vec<u8> = Vec::new();
+    let poll = Duration::from_millis(10);
+
+    // Drain pending chunks, then poll until `needle` appears or the timeout elapses.
+    // This is the presence half: wait on the output that the command must produce.
+    let mut wait_for = |needle: &[u8], timeout: Duration, what: &str| {
+        let start = Instant::now();
+        loop {
+            while let Ok(chunk) = rx.try_recv() {
+                accumulated.extend_from_slice(&chunk);
+            }
+            if accumulated.windows(needle.len()).any(|w| w == needle) {
+                return;
+            }
+            if start.elapsed() > timeout {
+                panic!(
+                    "Timed out waiting for {} ({:?}). Output so far:\n{}",
+                    what,
+                    String::from_utf8_lossy(needle),
+                    String::from_utf8_lossy(&accumulated)
+                );
+            }
+            thread::sleep(poll);
+        }
+    };
+
+    // Wait for bash's first prompt instead of guessing a startup delay.
+    wait_for(b"$ ", Duration::from_secs(10), "bash startup prompt");
+
+    // Write setup and command (but not exit yet).
     let commands = format!("source '{}'\n{}\n", script_path.display(), final_cmd);
     writer.write_all(commands.as_bytes()).unwrap();
     writer.flush().unwrap();
 
-    // Wait for the command to complete and bash to show job notifications.
-    // The `[1]+ Done` message appears when bash prepares to show the next prompt.
-    // Without this delay, bash might receive `exit` before it reports job completion.
-    thread::sleep(Duration::from_millis(500));
+    // Wait for the command's success output, confirming it ran to completion.
+    wait_for(
+        success_marker.as_bytes(),
+        Duration::from_secs(30),
+        "command output",
+    );
 
-    // Now send exit
+    // Absence window: a leaked `[1]+ Done` surfaces at prompt-time after the
+    // backgrounded post-start hook finishes. Hold a fixed window so a leak has time
+    // to appear. The assertion is that it does not, so there is no event to poll for.
+    thread::sleep(crate::common::SLEEP_FOR_ABSENCE_CHECK);
+
+    // Now send exit.
     writer.write_all(b"exit\n").unwrap();
     writer.flush().unwrap();
-    drop(writer); // Close writer after sending all commands
+    drop(writer);
 
-    // Read output in a thread. This is necessary because bash outputs the `[1]+ Done`
-    // notification between command completion and the next prompt, and we need to
-    // capture that output while waiting for the child to exit.
-    let reader_thread = thread::spawn(move || {
-        let mut reader = reader;
-        let mut buf = String::new();
-        reader.read_to_string(&mut buf).unwrap();
-        buf
-    });
-
-    // Wait for bash to exit
+    // Drain the remaining output once bash has exited.
     let status = child.wait().unwrap();
+    reader_thread.join().unwrap();
+    while let Ok(chunk) = rx.try_recv() {
+        accumulated.extend_from_slice(&chunk);
+    }
 
-    // Get the captured output
-    let buf = reader_thread.join().unwrap();
-
-    // Normalize CRLF to LF (same as exec_in_pty_interactive)
-    let normalized = buf.replace("\r\n", "\n");
+    // Normalize CRLF to LF (same as exec_in_pty_interactive).
+    let normalized = String::from_utf8_lossy(&accumulated).replace("\r\n", "\n");
 
     (normalized, status.exit_code() as i32)
 }
@@ -1798,6 +1845,7 @@ approved-commands = ["echo 'bash background'"]
         let (output, exit_code) = exec_bash_truly_interactive(
             &setup_script,
             "wt switch --create bash-job-test",
+            "and worktree",
             repo.root_path(),
             &env_vars,
         );


### PR DESCRIPTION
`exec_bash_truly_interactive` (used only by `test_bash_job_control_suppression`) gated bash startup and command completion on fixed `thread::sleep` calls, then read the PTY only after sending `exit`. This streams the PTY over a channel and polls for the startup prompt and the command's success output, so the presence half of the test waits on real output instead of a timing guess.

The test's core assertion is that suppressed job-control notifications (`[1]+ Done`) do not leak: an absence check with no event to poll for. That keeps a fixed window, but now the shared `SLEEP_FOR_ABSENCE_CHECK` marker, and the window starts after the command's output appears rather than before it runs, so a leak has the full window to surface even on slow CI.

The expected success substring is now a parameter so the generically-named helper doesn't silently depend on one caller's output.

Follow-up to #3206, which consolidated absence-window sleeps behind `SLEEP_FOR_ABSENCE_CHECK`; this sleep was missed there because it read as PTY output sequencing.

> _This was written by Claude Code on behalf of max_
