### PR TITLE
docs(list): note --full requirement on the JSON ci object

### DIFF
--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -237,7 +237,7 @@ Query structured data with `--format=json`:
 | `is_main` | boolean | Is the main worktree |
 | `is_current` | boolean | Is the current worktree |
 | `is_previous` | boolean | Previous worktree from wt switch |
-| `ci` | object | CI status (see below); absent when no CI |
+| `ci` | object | CI status (see below); `--full` only, then absent when no PR/MR or branch workflow |
 | `repo_url` | string | Repository web URL derived from the primary remote; absent when the remote URL cannot be parsed |
 | `repo` | object | Structured repository metadata (see below); includes `remote` |
 | `url` | string | Dev server URL from project config; absent when not configured |

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -246,7 +246,7 @@ $ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 | `is_main` | boolean | Is the main worktree |
 | `is_current` | boolean | Is the current worktree |
 | `is_previous` | boolean | Previous worktree from wt switch |
-| `ci` | object | CI status (see below); absent when no CI |
+| `ci` | object | CI status (see below); `--full` only, then absent when no PR/MR or branch workflow |
 | `repo_url` | string | Repository web URL derived from the primary remote; absent when the remote URL cannot be parsed |
 | `repo` | object | Structured repository metadata (see below); includes `remote` |
 | `url` | string | Dev server URL from project config; absent when not configured |

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -984,7 +984,7 @@ $ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 | `is_main` | boolean | Is the main worktree |
 | `is_current` | boolean | Is the current worktree |
 | `is_previous` | boolean | Previous worktree from wt switch |
-| `ci` | object | CI status (see below); absent when no CI |
+| `ci` | object | CI status (see below); `--full` only, then absent when no PR/MR or branch workflow |
 | `repo_url` | string | Repository web URL derived from the primary remote; absent when the remote URL cannot be parsed |
 | `repo` | object | Structured repository metadata (see below); includes `remote` |
 | `url` | string | Dev server URL from project config; absent when not configured |

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -313,7 +313,7 @@ Query structured data with [2m--format=json[0m:
  [2mis_main[0m            boolean     Is the main worktree                                                                             
  [2mis_current[0m         boolean     Is the current worktree                                                                          
  [2mis_previous[0m        boolean     Previous worktree from wt switch                                                                 
- [2mci[0m                 object      CI status (see below); absent when no CI                                                         
+ [2mci[0m                 object      CI status (see below); [2m--full[0m only, then absent when no PR/MR or branch workflow                 
  [2mrepo_url[0m           string      Repository web URL derived from the primary remote; absent when the remote URL cannot be parsed  
  [2mrepo[0m               object      Structured repository metadata (see below); includes [2mremote[0m                                      
  [2murl[0m                string      Dev server URL from project config; absent when not configured                                   

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -359,46 +359,46 @@ Query structured data with [2m--format=json[0m:
 
 [1mFields:[0m
 
-       Field          Type                       Description                    
- ───────────────── ─────────── ──────────────────────────────────────────────── 
- [2mbranch[0m            string/null Branch name (null for detached HEAD)             
- [2mpath[0m              string      Worktree path (absent for branches without       
-                               worktrees)                                       
- [2mkind[0m              string      [2m"worktree"[0m or [2m"branch"[0m                           
- [2mcommit[0m            object      Commit info (see below)                          
- [2mworking_tree[0m      object      Working tree state (see below)                   
- [2mmain_state[0m        string      Relation to the default branch (see below)       
- [2mintegration_reaso[0m string      Why branch is integrated (see below)             
- [2mn[0m                                                                              
- [2moperation_state[0m   string      [2m"conflicts"[0m, [2m"rebase"[0m, or [2m"merge"[0m (see           
-                               Worktree); absent when clean                     
- [2mmain[0m              object      Relationship to the default branch (see below);  
-                               absent when is_main                              
- [2mremote[0m            object      Tracking branch info (see below); absent when no 
-                               tracking                                         
- [2mworktree[0m          object      Worktree metadata (see below)                    
- [2mis_main[0m           boolean     Is the main worktree                             
- [2mis_current[0m        boolean     Is the current worktree                          
- [2mis_previous[0m       boolean     Previous worktree from wt switch                 
- [2mci[0m                object      CI status (see below); absent when no CI         
- [2mrepo_url[0m          string      Repository web URL derived from the primary      
-                               remote; absent when the remote URL cannot be     
-                               parsed                                           
- [2mrepo[0m              object      Structured repository metadata (see below);      
-                               includes [2mremote[0m                                  
- [2murl[0m               string      Dev server URL from project config; absent when  
-                               not configured                                   
- [2murl_active[0m        boolean     Whether the URL's port is listening; absent when 
-                               not configured                                   
- [2msummary[0m           string      LLM-generated branch summary; absent when not    
-                               configured or no summary                         
- [2mstatusline[0m        string      Pre-formatted status with ANSI colors            
- [2msymbols[0m           string      Raw status symbols without colors (e.g., [2m"!?↓"[0m)  
- [2mvars[0m              object      Per-branch variables from [2mwt config state vars[0m   
-                               (absent when empty)                              
- [2mcolumns[0m           object      Rendered custom column values keyed by header;   
-                               empty cells omitted (absent when none            
-                               configured)                                      
+      Field          Type                        Description                    
+ ──────────────── ─────────── ───────────────────────────────────────────────── 
+ [2mbranch[0m           string/null Branch name (null for detached HEAD)              
+ [2mpath[0m             string      Worktree path (absent for branches without        
+                              worktrees)                                        
+ [2mkind[0m             string      [2m"worktree"[0m or [2m"branch"[0m                            
+ [2mcommit[0m           object      Commit info (see below)                           
+ [2mworking_tree[0m     object      Working tree state (see below)                    
+ [2mmain_state[0m       string      Relation to the default branch (see below)        
+ [2mintegration_reas[0m string      Why branch is integrated (see below)              
+ [2mon[0m                                                                             
+ [2moperation_state[0m  string      [2m"conflicts"[0m, [2m"rebase"[0m, or [2m"merge"[0m (see Worktree); 
+                              absent when clean                                 
+ [2mmain[0m             object      Relationship to the default branch (see below);   
+                              absent when is_main                               
+ [2mremote[0m           object      Tracking branch info (see below); absent when no  
+                              tracking                                          
+ [2mworktree[0m         object      Worktree metadata (see below)                     
+ [2mis_main[0m          boolean     Is the main worktree                              
+ [2mis_current[0m       boolean     Is the current worktree                           
+ [2mis_previous[0m      boolean     Previous worktree from wt switch                  
+ [2mci[0m               object      CI status (see below); [2m--full[0m only, then absent   
+                              when no PR/MR or branch workflow                  
+ [2mrepo_url[0m         string      Repository web URL derived from the primary       
+                              remote; absent when the remote URL cannot be      
+                              parsed                                            
+ [2mrepo[0m             object      Structured repository metadata (see below);       
+                              includes [2mremote[0m                                   
+ [2murl[0m              string      Dev server URL from project config; absent when   
+                              not configured                                    
+ [2murl_active[0m       boolean     Whether the URL's port is listening; absent when  
+                              not configured                                    
+ [2msummary[0m          string      LLM-generated branch summary; absent when not     
+                              configured or no summary                          
+ [2mstatusline[0m       string      Pre-formatted status with ANSI colors             
+ [2msymbols[0m          string      Raw status symbols without colors (e.g., [2m"!?↓"[0m)   
+ [2mvars[0m             object      Per-branch variables from [2mwt config state vars[0m    
+                              (absent when empty)                               
+ [2mcolumns[0m          object      Rendered custom column values keyed by header;    
+                              empty cells omitted (absent when none configured) 
 
 [32mCommit object[0m
 


### PR DESCRIPTION
The `wt list --json` Fields table described the `ci` object as "absent when no CI", which omits the actual gate: `ci` is only populated under `--full` (or `[list] full`, or the statusline JSON path) — the same `--full` requirement the Columns table and the `[list] columns` note already document. A consumer scripting plain `wt list --json` sees `ci` always absent and reasonably misreads it as "no CI configured" rather than "needs `--full`".

This states the requirement on the field row: `--full` only, then absent when no PR/MR or branch workflow. Source edit is in `src/cli/mod.rs` (the `after_long_help` primary source); the `docs/content/list.md` and skill-reference mirrors plus the two `--help` snapshots are regenerated.

> _This was written by Claude Code on behalf of max_
