### PR TITLE
test(switch): run the interactive picker tests on Windows

### DIFF
--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -105,8 +105,6 @@ On narrow previews the tab bar compacts to digits — only the active tab keeps 
 pager = "delta --paging=never --width=$COLUMNS"
 ```
 
-Available on Unix only (macOS, Linux). On Windows, use `wt list` or `wt switch <branch>` directly.
-
 ## Pull requests and merge requests
 
 The `pr:<number>` / `mr:<number>` shortcut and the PR/MR's web URL both resolve to its branch. For same-repo PRs/MRs, worktrunk switches to the branch directly. For fork PRs/MRs, it fetches the ref (`refs/pull/N/head` or `refs/merge-requests/N/head`) and configures `pushRemote` to the fork URL.

--- a/skills/worktrunk/reference/switch.md
+++ b/skills/worktrunk/reference/switch.md
@@ -101,8 +101,6 @@ On narrow previews the tab bar compacts to digits — only the active tab keeps 
 pager = "delta --paging=never --width=$COLUMNS"
 ```
 
-Available on Unix only (macOS, Linux). On Windows, use `wt list` or `wt switch <branch>` directly.
-
 ## Pull requests and merge requests
 
 The `pr:<number>` / `mr:<number>` shortcut and the PR/MR's web URL both resolve to its branch. For same-repo PRs/MRs, worktrunk switches to the branch directly. For fork PRs/MRs, it fetches the ref (`refs/pull/N/head` or `refs/merge-requests/N/head`) and configures `pushRemote` to the fork URL.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -695,8 +695,6 @@ On narrow previews the tab bar compacts to digits — only the active tab keeps 
 pager = "delta --paging=never --width=$COLUMNS"
 ```
 
-Available on Unix only (macOS, Linux). On Windows, use `wt list` or `wt switch <branch>` directly.
-
 ## Pull requests and merge requests
 
 The `pr:<number>` / `mr:<number>` shortcut and the PR/MR's web URL both resolve to its branch. For same-repo PRs/MRs, worktrunk switches to the branch directly. For fork PRs/MRs, it fetches the ref (`refs/pull/N/head` or `refs/merge-requests/N/head`) and configures `pushRemote` to the fork URL.

--- a/tests/integration_tests/switch.rs
+++ b/tests/integration_tests/switch.rs
@@ -1813,7 +1813,6 @@ fn test_switch_ping_pong_realistic(repo: TestRepo) {
     );
 }
 
-#[cfg(unix)] // Interactive picker only available on Unix
 #[rstest]
 fn test_switch_no_args_requires_tty(repo: TestRepo) {
     // Run switch with no arguments in non-TTY - should fail with TTY requirement
@@ -1821,7 +1820,6 @@ fn test_switch_no_args_requires_tty(repo: TestRepo) {
     snapshot_switch("switch_missing_argument_hints", &repo, &[]);
 }
 
-#[cfg(unix)] // `wt select` is a deprecated alias for the Unix-only picker
 #[rstest]
 fn test_select_deprecated_alias_requires_tty(repo: TestRepo) {
     // `wt select` warns that it is deprecated, then delegates to the same
@@ -2318,7 +2316,6 @@ fn set_github_remote_url(repo: &TestRepo) {
 
 /// Install a mock forge CLI (`gh`/`glab`) answering the `--prs` list call
 /// (`pr list` / `mr list`) from a canned JSON file. Returns the mock bin dir.
-#[cfg(unix)]
 fn setup_mock_forge_list(
     repo: &TestRepo,
     cli: &str,
@@ -2343,7 +2340,6 @@ fn setup_mock_forge_list(
 /// captured. (The interactive picker exits via skim's abort, which never
 /// flushes a profile, so its `--prs` code is otherwise unmeasurable.) The mock
 /// `gh pr list` keeps it off the network.
-#[cfg(unix)]
 #[rstest]
 fn test_switch_prs_dry_run_github(repo: TestRepo) {
     // Pin the forge explicitly so detection needs no remote/network.
@@ -2362,11 +2358,17 @@ fn test_switch_prs_dry_run_github(repo: TestRepo) {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
-    // The forge call ran (no "could not determine the forge" warning).
+    // The fetch + parse + row-render actually ran (not a fail-soft no-op): a PR
+    // row was created with the token `pr:42`, which seeds its preview cache. The
+    // fetch path swallows every error into a stashed warning and still exits 0,
+    // so asserting on the dump — not just the exit code — is what makes this
+    // meaningful on a platform where the mock `gh` might fail to resolve.
+    let stdout = String::from_utf8(output.stdout).expect("stdout is utf-8");
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("stdout is valid JSON");
+    let entries = parsed["entries"].as_array().expect("entries array");
     assert!(
-        !String::from_utf8_lossy(&output.stderr).contains("could not determine the forge"),
-        "forge not detected:\n{}",
-        String::from_utf8_lossy(&output.stderr),
+        entries.iter().any(|e| e["branch"] == "pr:42"),
+        "expected a pr:42 cache entry proving the PR row rendered, got:\n{stdout}"
     );
 }
 
@@ -2381,7 +2383,6 @@ fn test_switch_prs_dry_run_github(repo: TestRepo) {
 /// `compute_pr_log`'s local-`git log` fast path misses and falls back to the
 /// forge API — exercising that branch (the present-head fast path has its own
 /// test, `test_switch_prs_dry_run_github_log_tab_local`).
-#[cfg(unix)]
 #[rstest]
 fn test_switch_prs_dry_run_github_log_tab(repo: TestRepo) {
     repo.write_project_config("[forge]\nplatform = \"github\"\n");
@@ -2440,7 +2441,6 @@ fn test_switch_prs_dry_run_github_log_tab(repo: TestRepo) {
 /// empty — so the present Log entry (local fast path) and the present, non-empty
 /// Comments entry (failure pane) both prove the row streamed and resolved. The
 /// tab shows a clear failure for the session, never a perpetual loading spinner.
-#[cfg(unix)]
 #[rstest]
 fn test_switch_prs_dry_run_github_log_tab_local(repo: TestRepo) {
     repo.write_project_config("[forge]\nplatform = \"github\"\n");
@@ -2509,7 +2509,6 @@ fn test_switch_prs_dry_run_github_log_tab_local(repo: TestRepo) {
 /// local fast path and must hit the forge API, and `gh pr view` is rigged to
 /// exit 1 — so both the `log` (mode 2) and `comments` (mode 7) cache entries are
 /// present and non-empty, each the couldn't-load pane.
-#[cfg(unix)]
 #[rstest]
 fn test_switch_prs_dry_run_github_deferred_fetch_failure(repo: TestRepo) {
     repo.write_project_config("[forge]\nplatform = \"github\"\n");
@@ -2565,7 +2564,6 @@ fn test_switch_prs_dry_run_github_deferred_fetch_failure(repo: TestRepo) {
 /// commits` and `--json comments` both match the mock's `pr view` key, so the
 /// canned response carries both arrays; serde ignores the one each renderer
 /// doesn't read.)
-#[cfg(unix)]
 #[rstest]
 fn test_switch_prs_dry_run_github_comments_tab(repo: TestRepo) {
     repo.write_project_config("[forge]\nplatform = \"github\"\n");
@@ -2612,7 +2610,6 @@ fn test_switch_prs_dry_run_github_comments_tab(repo: TestRepo) {
 /// GitLab counterpart of [`test_switch_prs_dry_run_github`], covering the
 /// `fetch_gitlab` / `parse_gitlab_mrs` / `gitlab_mr_status` path via a mocked
 /// `glab mr list`.
-#[cfg(unix)]
 #[rstest]
 fn test_switch_prs_dry_run_gitlab(repo: TestRepo) {
     repo.write_project_config("[forge]\nplatform = \"gitlab\"\n");
@@ -2630,6 +2627,16 @@ fn test_switch_prs_dry_run_gitlab(repo: TestRepo) {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr),
     );
+    // Prove the fetch + parse + row-render ran (the fetch path is fail-soft and
+    // still exits 0): an MR row was created with the token `mr:7`, seeding its
+    // preview cache. See `test_switch_prs_dry_run_github` for the rationale.
+    let stdout = String::from_utf8(output.stdout).expect("stdout is utf-8");
+    let parsed: serde_json::Value = serde_json::from_str(&stdout).expect("stdout is valid JSON");
+    let entries = parsed["entries"].as_array().expect("entries array");
+    assert!(
+        entries.iter().any(|e| e["branch"] == "mr:7"),
+        "expected an mr:7 cache entry proving the MR row rendered, got:\n{stdout}"
+    );
 }
 
 /// GitLab counterpart of the GitHub `_log_tab` / `_comments_tab` dry-run tests:
@@ -2645,7 +2652,6 @@ fn test_switch_prs_dry_run_gitlab(repo: TestRepo) {
 /// compound key, so one canned response carries all fields each renderer reads
 /// (`short_id`/`title` for commits; `body`/`author`/`created_at`/`system` for
 /// notes) — serde ignores the rest.
-#[cfg(unix)]
 #[rstest]
 fn test_switch_prs_dry_run_gitlab_deferred_tabs(repo: TestRepo) {
     repo.write_project_config("[forge]\nplatform = \"gitlab\"\n");
@@ -2693,7 +2699,6 @@ fn test_switch_prs_dry_run_gitlab_deferred_tabs(repo: TestRepo) {
 
 /// An empty forge list still runs `stream_open_prs` to completion, exercising
 /// the empty-list branch and `forge_noun` (`_ => "PRs"` on GitHub).
-#[cfg(unix)]
 #[rstest]
 fn test_switch_prs_dry_run_empty(repo: TestRepo) {
     repo.write_project_config("[forge]\nplatform = \"github\"\n");
@@ -2709,10 +2714,17 @@ fn test_switch_prs_dry_run_empty(repo: TestRepo) {
         "dry-run --prs (empty) failed:\nstderr: {}",
         String::from_utf8_lossy(&output.stderr),
     );
+    // Only the genuine empty-list branch stashes this exact warning (forge_noun
+    // = "PRs"). A missing/failed mock would stash a *different* error and still
+    // exit 0, so asserting the warning pins the empty path — not just exit 0.
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("No open PRs found"),
+        "expected the empty-list warning on stderr, got:\n{}",
+        String::from_utf8_lossy(&output.stderr),
+    );
 }
 
 /// GitLab empty list — exercises `forge_noun`'s `GitLab => "MRs"` arm.
-#[cfg(unix)]
 #[rstest]
 fn test_switch_prs_dry_run_empty_gitlab(repo: TestRepo) {
     repo.write_project_config("[forge]\nplatform = \"gitlab\"\n");
@@ -2726,6 +2738,13 @@ fn test_switch_prs_dry_run_empty_gitlab(repo: TestRepo) {
     assert!(
         output.status.success(),
         "dry-run --prs (empty gitlab) failed:\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr),
+    );
+    // Only the genuine empty-list branch stashes this exact warning (forge_noun
+    // = "MRs"); see `test_switch_prs_dry_run_empty` for the rationale.
+    assert!(
+        String::from_utf8_lossy(&output.stderr).contains("No open MRs found"),
+        "expected the empty-list warning on stderr, got:\n{}",
         String::from_utf8_lossy(&output.stderr),
     );
 }

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -1,9 +1,11 @@
-#![cfg(all(unix, feature = "shell-integration-tests"))]
+#![cfg(feature = "shell-integration-tests")]
 //! TUI snapshot tests for `wt switch` interactive picker
 //!
 //! These tests use PTY execution combined with vt100 terminal emulation to capture
 //! what the user actually sees on screen, enabling meaningful snapshot testing of
-//! the skim-based TUI interface.
+//! the skim-based TUI interface. They run on every platform — `portable_pty` uses a
+//! ConPTY on Windows (see `tests/common/pty.rs`), and capturing the vt100-emulated
+//! grid (not raw escape sequences) keeps the snapshots backend-agnostic.
 //!
 //! ## Capture-Before-Abort Pattern
 //!

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -1007,11 +1007,15 @@ fn mock_forge_env(
         "MOCK_CONFIG_DIR".to_string(),
         mock_bin.display().to_string(),
     ));
-    let base_path = std::env::var("PATH").unwrap_or_default();
-    env_vars.push((
-        "PATH".to_string(),
-        format!("{}:{base_path}", mock_bin.display()),
-    ));
+    // Prepend mock-bin to PATH using the OS separator (`;` on Windows, `:` on
+    // Unix) — a hardcoded `:` corrupts the PATH on Windows, so the mock
+    // `gh.exe`/`glab.exe` is never found and the `--prs` fetch silently no-ops.
+    // `configure_pty_command` sets `PATH` (uppercase), which this entry overrides.
+    let base_path = std::env::var_os("PATH").unwrap_or_default();
+    let mut paths = vec![mock_bin.clone()];
+    paths.extend(std::env::split_paths(&base_path));
+    let joined = std::env::join_paths(paths).expect("mock-bin joins into PATH");
+    env_vars.push(("PATH".to_string(), joined.to_string_lossy().into_owned()));
     env_vars
 }
 
@@ -1667,6 +1671,13 @@ fn test_switch_picker_no_cd_switches_without_cd_directive(mut repo: TestRepo) {
 /// without a prompt — inconsistent with every other hook the picker gates, and
 /// a hole in "Project Commands Run Only After Approval". Here the hook is
 /// declined at the prompt; it must not run, and the switch must still succeed.
+// TODO(windows-picker): on Windows this exits 1 instead of 0. Declining the
+// hook returns Ok on both platforms, so the failure is in the interactive
+// approval prompt's stdin handoff after skim releases the ConPTY — not yet
+// reproduced or fixed (needs a Windows box). The other accept-path picker
+// tests, which switch without an approval prompt, pass on Windows. Ignored on
+// Windows so it still compiles there; runs everywhere else.
+#[cfg_attr(windows, ignore = "pre-switch hook decline exits 1 on Windows; needs investigation")]
 #[rstest]
 fn test_switch_picker_pre_switch_hook_requires_approval(mut repo: TestRepo) {
     repo.remove_fixture_worktrees();

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -1677,7 +1677,10 @@ fn test_switch_picker_no_cd_switches_without_cd_directive(mut repo: TestRepo) {
 // reproduced or fixed (needs a Windows box). The other accept-path picker
 // tests, which switch without an approval prompt, pass on Windows. Ignored on
 // Windows so it still compiles there; runs everywhere else.
-#[cfg_attr(windows, ignore = "pre-switch hook decline exits 1 on Windows; needs investigation")]
+#[cfg_attr(
+    windows,
+    ignore = "pre-switch hook decline exits 1 on Windows; needs investigation"
+)]
 #[rstest]
 fn test_switch_picker_pre_switch_hook_requires_approval(mut repo: TestRepo) {
     repo.remove_fixture_worktrees();

--- a/tests/integration_tests/switch_picker_dry_run.rs
+++ b/tests/integration_tests/switch_picker_dry_run.rs
@@ -6,11 +6,8 @@
 //! preview-cache inventory as JSON, and exits. This exercises the non-TUI
 //! wiring inside `handle_picker` without needing a PTY.
 //!
-//! Unix-only: `wt switch` rejects the interactive picker on Windows
-//! ("Interactive picker is not available on Windows") before the dry-run
-//! bypass is consulted.
-
-#![cfg(unix)]
+//! Runs on every platform: the dry-run bypass is consulted before the
+//! interactive TTY path, so these exercise the picker pipeline on Windows too.
 
 use crate::common::{TEST_EPOCH, TestRepo, repo};
 use rstest::rstest;
@@ -164,8 +161,10 @@ fn test_picker_dry_run_drains_stashed_warnings(mut repo: TestRepo) {
 
 /// Same as above but with `list.summary=true` and a fake LLM command
 /// configured, to exercise the `spawn_summary` branch in `handle_picker`.
-/// Uses `/bin/cat` as the LLM: it reads stdin and writes it back, so the
-/// summary pipeline runs end-to-end without a real model.
+/// Uses `cat` as the LLM: it reads stdin and writes it back, so the
+/// summary pipeline runs end-to-end without a real model. The command runs
+/// via the platform shell (`sh` on Unix, Git Bash on Windows), so the bare
+/// name resolves on PATH on both.
 #[rstest]
 fn test_picker_dry_run_with_summary(mut repo: TestRepo) {
     repo.add_worktree("feature-a");
@@ -175,7 +174,7 @@ fn test_picker_dry_run_with_summary(mut repo: TestRepo) {
         .args(["switch"])
         .env("WORKTRUNK_PICKER_DRY_RUN", "1")
         .env("WORKTRUNK_LIST__SUMMARY", "true")
-        .env("WORKTRUNK_COMMIT__GENERATION__COMMAND", "/bin/cat")
+        .env("WORKTRUNK_COMMIT__GENERATION__COMMAND", "cat")
         .output()
         .unwrap();
 

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -211,8 +211,6 @@ On narrow previews the tab bar compacts to digits — only the active tab keeps 
 [107m [0m [2m[36m[switch.picker][0m
 [107m [0m [2mpager = [0m[2m[32m"delta --paging=never --width=$COLUMNS"[0m
 
-Available on Unix only (macOS, Linux). On Windows, use [2mwt list[0m or [2mwt switch <branch>[0m directly.
-
 [1m[32mPull requests and merge requests[0m
 
 The [2mpr:<number>[0m / [2mmr:<number>[0m shortcut and the PR/MR's web URL both resolve to its branch. For same-repo PRs/MRs, worktrunk switches to the branch directly. For fork PRs/MRs, it fetches the ref ([2mrefs/pull/N/head[0m or [2mrefs/merge-requests/N/head[0m) and configures [2mpushRemote[0m to the fork URL.


### PR DESCRIPTION
PR #3217 made `wt switch`'s interactive picker run on Windows, but its tests stayed `#[cfg(unix)]` — so the Windows CI leg proved the picker *compiled* without ever exercising its runtime. This ungates them so Windows CI drives the real thing.

**What's ungated** (the test infra — `mock_commands`, the ConPTY handling in `tests/common/pty.rs` — was already cross-platform, so this is largely a gate flip):

- `switch_picker_dry_run.rs` — the headless dry-run pipeline (collect → render → preview cache → summary spawn → warning drain).
- The `--prs` dry-run tests in `switch.rs` — forge fetch + row render via the cross-platform mock `gh`/`glab`.
- The two requires-tty snapshots — the no-TTY bail is uniform across platforms.
- `switch_picker.rs` — the PTY/vt100 TUI snapshot tests.

**Test-quality fix folded in:** the four `--prs` dry-run tests asserted only `output.status.success()`, but the fetch path is fail-soft (any error → stashed warning → exit 0). On a platform where the mock didn't resolve they would pass vacuously. They now assert the fetched row actually rendered (a `pr:42`/`mr:7` preview-cache entry, or the empty-list warning).

**Also:** `/bin/cat` → `cat` in the summary test (resolves via the platform shell on Unix and Git Bash alike); removed the stale "picker is Unix-only" line that #3217 left in the `wt switch` docs (and regenerated the help snapshot).

**Windows results (first full run):** of the ~50 ungated tests, 46 passed on Windows on the first run — including every PTY/vt100 snapshot test (skim renders byte-identically under ConPTY), the accept-path drain tests, and the `cat`-via-Git-Bash summary test. Two issues surfaced and are handled here:

- The three interactive `--prs` picker tests failed because the test helper `mock_forge_env` joined mock-bin onto `PATH` with a hardcoded `:` separator — malformed on Windows (`;`), so the mock `gh.exe`/`glab.exe` was never found. Fixed to use `std::env::join_paths` (OS-aware), matching the dry-run path's helper.
- `test_switch_picker_pre_switch_hook_requires_approval` exits 1 instead of 0 on Windows: declining the hook returns `Ok` on both platforms, so the failure is in the interactive approval prompt's stdin handoff after skim releases the ConPTY. Not reproducible locally — `#[cfg_attr(windows, ignore)]` with a TODO until a Windows box can debug it (still compiles on Windows, runs on Unix). This is a genuine picker-on-Windows gap surfaced by this work, tracked for follow-up.

> _This was written by Claude Code on behalf of max_
