### PR TITLE
docs(list): note --full requirement on summary and main.diff JSON fields

### DIFF
--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -242,7 +242,7 @@ Query structured data with `--format=json`:
 | `repo` | object | Structured repository metadata (see below); includes `remote` |
 | `url` | string | Dev server URL from project config; absent when not configured |
 | `url_active` | boolean | Whether the URL's port is listening; absent when not configured |
-| `summary` | string | LLM-generated branch summary; absent when not configured or no summary |
+| `summary` | string | LLM-generated branch summary; `--full` only, then absent when not configured or no summary |
 | `statusline` | string | Pre-formatted status with ANSI colors |
 | `symbols` | string | Raw status symbols without colors (e.g., `"!?↓"`) |
 | `vars` | object | Per-branch variables from [`wt config state vars`](@/config.md#wt-config-state-vars) (absent when empty) |
@@ -276,7 +276,7 @@ The five change flags map to the [Working tree](#working-tree) symbols (`renamed
 |-------|------|-------------|
 | `ahead` | number | Commits ahead of the default branch |
 | `behind` | number | Commits behind the default branch |
-| `diff` | object | Lines changed vs the default branch: `{added, deleted}` |
+| `diff` | object | Lines changed vs the default branch: `{added, deleted}`; `--full` only |
 
 ### remote object
 

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -251,7 +251,7 @@ $ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 | `repo` | object | Structured repository metadata (see below); includes `remote` |
 | `url` | string | Dev server URL from project config; absent when not configured |
 | `url_active` | boolean | Whether the URL's port is listening; absent when not configured |
-| `summary` | string | LLM-generated branch summary; absent when not configured or no summary |
+| `summary` | string | LLM-generated branch summary; `--full` only, then absent when not configured or no summary |
 | `statusline` | string | Pre-formatted status with ANSI colors |
 | `symbols` | string | Raw status symbols without colors (e.g., `"!?↓"`) |
 | `vars` | object | Per-branch variables from [`wt config state vars`](https://worktrunk.dev/config/#wt-config-state-vars) (absent when empty) |
@@ -285,7 +285,7 @@ The five change flags map to the [Working tree](#working-tree) symbols (`renamed
 |-------|------|-------------|
 | `ahead` | number | Commits ahead of the default branch |
 | `behind` | number | Commits behind the default branch |
-| `diff` | object | Lines changed vs the default branch: `{added, deleted}` |
+| `diff` | object | Lines changed vs the default branch: `{added, deleted}`; `--full` only |
 
 ### remote object
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -989,7 +989,7 @@ $ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 | `repo` | object | Structured repository metadata (see below); includes `remote` |
 | `url` | string | Dev server URL from project config; absent when not configured |
 | `url_active` | boolean | Whether the URL's port is listening; absent when not configured |
-| `summary` | string | LLM-generated branch summary; absent when not configured or no summary |
+| `summary` | string | LLM-generated branch summary; `--full` only, then absent when not configured or no summary |
 | `statusline` | string | Pre-formatted status with ANSI colors |
 | `symbols` | string | Raw status symbols without colors (e.g., `"!?↓"`) |
 | `vars` | object | Per-branch variables from [`wt config state vars`](@/config.md#wt-config-state-vars) (absent when empty) |
@@ -1023,7 +1023,7 @@ The five change flags map to the [Working tree](#working-tree) symbols (`renamed
 |-------|------|-------------|
 | `ahead` | number | Commits ahead of the default branch |
 | `behind` | number | Commits behind the default branch |
-| `diff` | object | Lines changed vs the default branch: `{added, deleted}` |
+| `diff` | object | Lines changed vs the default branch: `{added, deleted}`; `--full` only |
 
 ### remote object
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -318,7 +318,7 @@ Query structured data with [2m--format=json[0m:
  [2mrepo[0m               object      Structured repository metadata (see below); includes [2mremote[0m                                      
  [2murl[0m                string      Dev server URL from project config; absent when not configured                                   
  [2murl_active[0m         boolean     Whether the URL's port is listening; absent when not configured                                  
- [2msummary[0m            string      LLM-generated branch summary; absent when not configured or no summary                           
+ [2msummary[0m            string      LLM-generated branch summary; [2m--full[0m only, then absent when not configured or no summary         
  [2mstatusline[0m         string      Pre-formatted status with ANSI colors                                                            
  [2msymbols[0m            string      Raw status symbols without colors (e.g., [2m"!?↓"[0m)                                                  
  [2mvars[0m               object      Per-branch variables from [2mwt config state vars[0m (absent when empty)                               
@@ -348,11 +348,11 @@ The five change flags map to the Working tree symbols ([2mrenamed[0m and [2md
 
 [32mmain object[0m
 
- Field   Type                       Description                      
- ────── ────── ───────────────────────────────────────────────────── 
- [2mahead[0m  number Commits ahead of the default branch                   
- [2mbehind[0m number Commits behind the default branch                     
- [2mdiff[0m   object Lines changed vs the default branch: [2m{added, deleted}[0m 
+ Field   Type                             Description                             
+ ────── ────── ────────────────────────────────────────────────────────────────── 
+ [2mahead[0m  number Commits ahead of the default branch                                
+ [2mbehind[0m number Commits behind the default branch                                  
+ [2mdiff[0m   object Lines changed vs the default branch: [2m{added, deleted}[0m; [2m--full[0m only 
 
 [32mremote object[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -359,46 +359,46 @@ Query structured data with [2m--format=json[0m:
 
 [1mFields:[0m
 
-      Field          Type                        Description                    
- ──────────────── ─────────── ───────────────────────────────────────────────── 
- [2mbranch[0m           string/null Branch name (null for detached HEAD)              
- [2mpath[0m             string      Worktree path (absent for branches without        
-                              worktrees)                                        
- [2mkind[0m             string      [2m"worktree"[0m or [2m"branch"[0m                            
- [2mcommit[0m           object      Commit info (see below)                           
- [2mworking_tree[0m     object      Working tree state (see below)                    
- [2mmain_state[0m       string      Relation to the default branch (see below)        
- [2mintegration_reas[0m string      Why branch is integrated (see below)              
- [2mon[0m                                                                             
- [2moperation_state[0m  string      [2m"conflicts"[0m, [2m"rebase"[0m, or [2m"merge"[0m (see Worktree); 
-                              absent when clean                                 
- [2mmain[0m             object      Relationship to the default branch (see below);   
-                              absent when is_main                               
- [2mremote[0m           object      Tracking branch info (see below); absent when no  
-                              tracking                                          
- [2mworktree[0m         object      Worktree metadata (see below)                     
- [2mis_main[0m          boolean     Is the main worktree                              
- [2mis_current[0m       boolean     Is the current worktree                           
- [2mis_previous[0m      boolean     Previous worktree from wt switch                  
- [2mci[0m               object      CI status (see below); [2m--full[0m only, then absent   
-                              when no PR/MR or branch workflow                  
- [2mrepo_url[0m         string      Repository web URL derived from the primary       
-                              remote; absent when the remote URL cannot be      
-                              parsed                                            
- [2mrepo[0m             object      Structured repository metadata (see below);       
-                              includes [2mremote[0m                                   
- [2murl[0m              string      Dev server URL from project config; absent when   
-                              not configured                                    
- [2murl_active[0m       boolean     Whether the URL's port is listening; absent when  
-                              not configured                                    
- [2msummary[0m          string      LLM-generated branch summary; absent when not     
-                              configured or no summary                          
- [2mstatusline[0m       string      Pre-formatted status with ANSI colors             
- [2msymbols[0m          string      Raw status symbols without colors (e.g., [2m"!?↓"[0m)   
- [2mvars[0m             object      Per-branch variables from [2mwt config state vars[0m    
-                              (absent when empty)                               
- [2mcolumns[0m          object      Rendered custom column values keyed by header;    
-                              empty cells omitted (absent when none configured) 
+      Field         Type                        Description                     
+ ─────────────── ─────────── ────────────────────────────────────────────────── 
+ [2mbranch[0m          string/null Branch name (null for detached HEAD)               
+ [2mpath[0m            string      Worktree path (absent for branches without         
+                             worktrees)                                         
+ [2mkind[0m            string      [2m"worktree"[0m or [2m"branch"[0m                             
+ [2mcommit[0m          object      Commit info (see below)                            
+ [2mworking_tree[0m    object      Working tree state (see below)                     
+ [2mmain_state[0m      string      Relation to the default branch (see below)         
+ [2mintegration_rea[0m string      Why branch is integrated (see below)               
+ [2mson[0m                                                                            
+ [2moperation_state[0m string      [2m"conflicts"[0m, [2m"rebase"[0m, or [2m"merge"[0m (see Worktree);  
+                             absent when clean                                  
+ [2mmain[0m            object      Relationship to the default branch (see below);    
+                             absent when is_main                                
+ [2mremote[0m          object      Tracking branch info (see below); absent when no   
+                             tracking                                           
+ [2mworktree[0m        object      Worktree metadata (see below)                      
+ [2mis_main[0m         boolean     Is the main worktree                               
+ [2mis_current[0m      boolean     Is the current worktree                            
+ [2mis_previous[0m     boolean     Previous worktree from wt switch                   
+ [2mci[0m              object      CI status (see below); [2m--full[0m only, then absent    
+                             when no PR/MR or branch workflow                   
+ [2mrepo_url[0m        string      Repository web URL derived from the primary        
+                             remote; absent when the remote URL cannot be       
+                             parsed                                             
+ [2mrepo[0m            object      Structured repository metadata (see below);        
+                             includes [2mremote[0m                                    
+ [2murl[0m             string      Dev server URL from project config; absent when    
+                             not configured                                     
+ [2murl_active[0m      boolean     Whether the URL's port is listening; absent when   
+                             not configured                                     
+ [2msummary[0m         string      LLM-generated branch summary; [2m--full[0m only, then    
+                             absent when not configured or no summary           
+ [2mstatusline[0m      string      Pre-formatted status with ANSI colors              
+ [2msymbols[0m         string      Raw status symbols without colors (e.g., [2m"!?↓"[0m)    
+ [2mvars[0m            object      Per-branch variables from [2mwt config state vars[0m     
+                             (absent when empty)                                
+ [2mcolumns[0m         object      Rendered custom column values keyed by header;     
+                             empty cells omitted (absent when none configured)  
 
 [32mCommit object[0m
 
@@ -426,11 +426,12 @@ none of their own):
 
 [32mmain object[0m
 
- Field   Type                       Description                      
- ────── ────── ───────────────────────────────────────────────────── 
- [2mahead[0m  number Commits ahead of the default branch                   
- [2mbehind[0m number Commits behind the default branch                     
- [2mdiff[0m   object Lines changed vs the default branch: [2m{added, deleted}[0m 
+ Field   Type                            Description                            
+ ────── ────── ──────────────────────────────────────────────────────────────── 
+ [2mahead[0m  number Commits ahead of the default branch                              
+ [2mbehind[0m number Commits behind the default branch                                
+ [2mdiff[0m   object Lines changed vs the default branch: [2m{added, deleted}[0m; [2m--full[0m    
+               only                                                             
 
 [32mremote object[0m
 


### PR DESCRIPTION
Follow-up to #3220. That PR added the `--full` qualifier to the JSON `ci` field row; the `summary` field and the `main` object's `diff` sub-field have the identical omission. Both are gated by `--full` in the same `skip_tasks` block (`SummaryGenerate` and `BranchDiff` are dropped when not `--full`), and both Columns-table rows already say "`--full` only" while their JSON field rows didn't — so a consumer scripting plain `wt list --json` would see `summary`/`main.diff` always absent and misread the cause.

This states the requirement on both rows, so all three `--full`-gated JSON surfaces (`ci`, `summary`, `main.diff`) read consistently. Edited in `src/cli/mod.rs` (the `after_long_help` primary source); the `docs/content/list.md` and skill-reference mirrors plus the two `--help` snapshots are regenerated.

> _This was written by Claude Code on behalf of max_
