### PR TITLE
fix(switch): suppress skim's alt-l/alt-h horizontal scroll in the picker

### DIFF
--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -1194,6 +1194,16 @@ pub fn handle_picker(
             // Preview toggle (alt-p shows/hides preview)
             // Note: skim doesn't support change-preview-window like fzf, only toggle
             "alt-p:toggle-preview".to_string(),
+            // Suppress skim's default manual horizontal scroll (alt-h / alt-l map to
+            // ScrollLeft / ScrollRight in its built-in keymap). `no_hscroll(true)`
+            // above only zeros the *automatic* match-following shift; it doesn't gate
+            // the manual `manual_hscroll` offset these keys push, so they still slide
+            // each row's `display()` left under the fixed gutter — clipping the leading
+            // worktree-status sigil (`+`/`@`/`^`/`/`/`|`) and the branch name with no
+            // ellipsis. The row table is laid out to fit the pane, so there is nothing
+            // to scroll to; ignore both.
+            "alt-h:ignore".to_string(),
+            "alt-l:ignore".to_string(),
             // Preview scrolling (half-page based on terminal height)
             format!("ctrl-u:preview-up({half_page})"),
             format!("ctrl-d:preview-down({half_page})"),

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -573,6 +573,44 @@ fn test_switch_picker_with_multiple_worktrees(mut repo: TestRepo) {
     });
 }
 
+/// Alt-l / alt-h are skim's built-in horizontal-scroll keys (ScrollRight /
+/// ScrollLeft). The picker binds both to `ignore` because each row's `display()`
+/// owns its layout with a leading worktree-status sigil; an unbound alt-l slides
+/// every row left, clipping that sigil gutter (`no_hscroll(true)` only gates the
+/// automatic match-following shift, not the manual offset these keys push).
+/// Pressing alt-l here must leave the list byte-for-byte unscrolled — the same
+/// frame `test_switch_picker_with_multiple_worktrees` snapshots.
+#[rstest]
+fn test_switch_picker_alt_l_does_not_hscroll(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    // Remove origin so snapshots don't show origin/main
+    repo.run_git(&["remote", "remove", "origin"]);
+    repo.add_worktree("feature-one");
+    repo.add_worktree("feature-two");
+
+    let env_vars = repo.test_env_vars();
+    let result = exec_in_pty_capture_before_abort(
+        wt_bin().to_str().unwrap(),
+        &["switch"],
+        repo.root_path(),
+        &env_vars,
+        &[
+            ("", Some("feature-two")), // wait for items to render
+            ("\x1bl", None),           // Alt-l: ignored, must not scroll
+            ("\x1bl", None),           // a second press, still ignored
+            ("\x1bh", None),           // Alt-h: ignored too
+        ],
+    );
+
+    assert_valid_abort_exit_code(result.exit_code);
+
+    let (list, _preview) = result.panels();
+    let settings = switch_picker_settings(&repo);
+    settings.bind(|| {
+        assert_snapshot!("switch_picker_alt_l_ignored_list", list);
+    });
+}
+
 #[rstest]
 fn test_switch_picker_with_branches(mut repo: TestRepo) {
     repo.remove_fixture_worktrees();

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_alt_l_ignored_list.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_alt_l_ignored_list.snap
@@ -1,0 +1,9 @@
+---
+source: tests/integration_tests/switch_picker.rs
+expression: list
+---
+>
+    Branch       Status        HEAD±    main↕  CI     Age
+> @ main             ^                                [TIME]
+  + feature-one      _                                [TIME]
+  + feature-two      _                                [TIME]


### PR DESCRIPTION
## What

`alt-l` (and its mirror `alt-h`) horizontally scrolled the `wt switch` picker's list, sliding each row left under the fixed cursor gutter and clipping the leading worktree-status sigil (`@`/`^`/`+`/`⊂`) and the branch name — with no ellipsis to mark the cut. This binds both keys to skim's `ignore` no-op so the carefully laid-out table stops sliding.

## Why it happened

The picker never bound `alt-l`/`alt-h`, so they fell through to skim 4.8's default keymap, where they map to `ScrollRight(1)` / `ScrollLeft(1)`. Those actions mutate skim's `manual_hscroll` offset. `no_hscroll(true)` (added in #3213 specifically to keep the sigil gutter stable) only zeros the *automatic*, match-following shift — `calc_hscroll_for_width` still adds `manual_hscroll` on top, so the manual-scroll keys escaped the guard entirely.

Two visible symptoms, both reproduced live in a real picker:

- One `alt-l` press shifts every row's content left by a column; the leading sigil scrolls off and one extra char appears on the right. Repeated presses chew further into the branch name (`picker-alt-l-gutter` → `er-alt-l-gutter`). The skim `>` cursor lives in a separate prefix gutter that is *not* scrolled, so it visibly detaches from the content it normally sits beside.
- `manual_hscroll` is an `i32` clamped to `>= 0` only at render time (`.max(0)`), not at the state level, so `alt-h` drives it negative. After scrolling back you must "pay off" that negative backlog with `alt-l` before scrolling resumes — the keys feel unresponsive.

## Fix

```rust
"alt-h:ignore".to_string(),
"alt-l:ignore".to_string(),
```

`alt-h`/`alt-l` are the *only* default keys that produce `ScrollLeft`/`ScrollRight`, and skim's query word-navigation uses `alt-b`/`alt-f`/`alt-d` instead — so suppressing these two fully closes the manual-hscroll path with no collateral to query editing. The preview-tab keys (`alt-1`…`alt-7`, `Tab`) are unaffected (verified live).

This is the manual-scroll counterpart to #3213's `no_hscroll(true)`; that PR closed the automatic path, this one closes the manual path the same guard left open.

## Testing

Adds `test_switch_picker_alt_l_does_not_hscroll`, a PTY test that drives `alt-l`/`alt-l`/`alt-h` and snapshots the list with its gutter sigils intact. Verified the test **fails** when the fix is removed (the `@`/`+` sigils clip: `> @ main` → `>  main`) and passes with it. Full `pre-merge` gate green (4199 tests, all lints, `--features shell-integration-tests`).

> _This was written by Claude Code on behalf of max_
