### PR TITLE
test(switch): regen alt-l picker snapshot for the new Remote⇅ column

### DIFF
--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_alt_l_ignored_list.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_alt_l_ignored_list.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: list
 ---
 >
-    Branch       Status        HEAD±    main↕  CI     Age
-> @ main             ^                                [TIME]
-  + feature-one      _                                [TIME]
-  + feature-two      _                                [TIME]
+    Branch       Status        HEAD±    main↕  Remote⇅  CI
+> @ main             ^
+  + feature-one      _
+  + feature-two      _


### PR DESCRIPTION
Follow-up to #3226. The picker list gained a `Remote⇅` column and dropped `Age` (from concurrent picker work) in the window between when `test_switch_picker_alt_l_does_not_hscroll`'s snapshot was generated and when #3226 merged. Both PRs were green independently, but main ended up with the new columns plus the old-column snapshot, so the test fails on main.

This regenerates the snapshot for the current layout. The assertion is unchanged in spirit — the worktree-status gutter sigils (`@`/`+`) stay intact after `alt-l`/`alt-h`, proving the keys still don't horizontally scroll the list; only the surrounding column header/data moved.

> _This was written by Claude Code on behalf of max_
