### PR TITLE
refactor(switch): pin the picker alt-r keep path to BranchOnly

### DIFF
--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -832,13 +832,12 @@ impl CommandCollector for PickerCollector {
                                 result,
                             );
                         } else if let RemoveResult::BranchOnly { branch_name, .. } = &result {
+                            // The only non-removing outcome: `removal_will_remove_target`
+                            // returns false solely for an unmerged `BranchOnly` row (a
+                            // `RemovedWorktree` always removes, so it never reaches here).
+                            // `keep_unremovable_row` taking the branch name — not the whole
+                            // result — keeps that narrowing at the type level.
                             self.keep_unremovable_row(&selected_output, branch_name);
-                        } else {
-                            // Unreachable: `removal_will_remove_target` returns false
-                            // only for an unmerged `BranchOnly` row — a
-                            // `RemovedWorktree` always removes. Pin the invariant
-                            // (fail tests) rather than silently leave the row.
-                            debug_assert!(false, "keep path reached for a RemovedWorktree result");
                         }
                     }
                     Err(e) => {

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -490,12 +490,15 @@ impl PickerCollector {
     /// and drained to stderr when the picker exits. (This is a by-design retain,
     /// not a failure — distinct from [`restore_failed_removal`]'s `kept … could
     /// not remove it` warning.)
-    fn keep_unremovable_row(&self, selected_output: &str, result: &RemoveResult) {
-        if let RemoveResult::BranchOnly { branch_name, .. } = result {
-            // The canonical "retained; unmerged" info + hint `wt remove` prints,
-            // shared so the picker copy can't drift (see
-            // `retained_unmerged_branch_messages`).
-            let (info, hint) = crate::output::retained_unmerged_branch_messages(branch_name);
+    fn keep_unremovable_row(&self, selected_output: &str, branch_name: &str) {
+        // The canonical "retained; unmerged" info + hint `wt remove` prints,
+        // shared so the picker copy can't drift (see
+        // `retained_unmerged_branch_messages`). Taking the branch name (not the
+        // whole `RemoveResult`) makes it unrepresentable for this keep path to be
+        // handed a `RemovedWorktree`, which always removes — see the dispatch in
+        // `invoke` and [`removal_will_remove_target`].
+        let (info, hint) = crate::output::retained_unmerged_branch_messages(branch_name);
+        {
             let mut stashed = self.stashed_warnings.lock().unwrap();
             // Dedup on repeated alt-r of the same kept row.
             if !stashed.contains(&info) {
@@ -654,6 +657,14 @@ fn reposition_cursor_action(
 /// (back onto the re-inserted row). A no-op before `render_tx` is set or once the
 /// receiver is gone (teardown); the queued action is dropped if the channel is
 /// full.
+///
+/// Rapid alt-r (or a background restore overtaking the optimistic drop) can leave
+/// more than one chain in flight. Each carries its own counters and self-terminates
+/// once the rows land, so the last to run wins — under a burst the cursor may
+/// briefly sit on a superseded (but valid) row's slot, corrected on the next
+/// render. Bounding this to only the newest reposition would take a generation
+/// token threaded through every chain (and every `PickerCollector` construction
+/// site); the self-correcting transient isn't worth that cross-chain state.
 fn send_reposition(render_tx: &OnceLock<tokio::sync::mpsc::Sender<Event>>, target: usize) {
     if let Some(event_tx) = render_tx.get() {
         let _ = event_tx.try_send(Event::Action(reposition_cursor_action(
@@ -820,8 +831,14 @@ impl CommandCollector for PickerCollector {
                                 planning_repo,
                                 result,
                             );
+                        } else if let RemoveResult::BranchOnly { branch_name, .. } = &result {
+                            self.keep_unremovable_row(&selected_output, branch_name);
                         } else {
-                            self.keep_unremovable_row(&selected_output, &result);
+                            // Unreachable: `removal_will_remove_target` returns false
+                            // only for an unmerged `BranchOnly` row — a
+                            // `RemovedWorktree` always removes. Pin the invariant
+                            // (fail tests) rather than silently leave the row.
+                            debug_assert!(false, "keep path reached for a RemovedWorktree result");
                         }
                     }
                     Err(e) => {


### PR DESCRIPTION
Two review follow-ups from #3211 (the picker's up-front alt-r removability prediction), no behavior change.

`keep_unremovable_row` took the whole `RemoveResult` and re-matched for `BranchOnly`, silently no-oping the impossible `RemovedWorktree` arm. It now takes `branch_name: &str`, so the keep path is unrepresentable for a worktree result, and `invoke` destructures the branch in the keep arm. The invariant that only a `BranchOnly` row reaches that arm is already pinned by `removal_will_remove_target`'s tested truth table — every `RemovedWorktree` returns `true`, so the non-removing branch can only be `BranchOnly`. The impossible case therefore needs no runtime guard: an `else { debug_assert!(false) }` would duplicate that guarantee (belt-and-suspenders) and add a permanently-uncovered line, so it's left out.

The second change is doc-only: it records the overlapping reposition-chains tradeoff in `send_reposition`. Rapid alt-r leaves several self-terminating chains in flight; the last to run wins, and the cursor self-corrects on the next render. Pinning this to only the newest reposition would mean threading a generation token through every chain and every `PickerCollector` construction site — not worth it for a self-correcting cosmetic transient.

> _This was written by Claude Code on behalf of max_
