### PR TITLE
test(switch): decline the picker approval with CR for Windows

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ Load relevant skills before starting; reload when scope changes mid-session. Pro
 
 ## Documentation
 
-Behavior changes require doc updates. `src/cli/mod.rs` (`after_long_help` plus clap attributes) is the PRIMARY SOURCE for command pages; never hand-edit the generated mirrors under `docs/content/` or `skills/worktrunk/reference/`. Ask: "does `--help` still describe what the code does?" After any doc change run `cargo test --test integration test_docs_are_in_sync`. Sync taxonomy, help-text authoring (three render contexts, link text, config-TOML blocks): `docs/CLAUDE.md`.
+Behavior changes require doc updates. `src/cli/mod.rs` (`after_long_help` plus clap attributes) is the PRIMARY SOURCE for command pages; never hand-edit the generated mirrors under `docs/content/` or `skills/worktrunk/reference/`. Ask: "does `--help` still describe what the code does?" After any doc change run `cargo test --test integration test_docs_are_in_sync`; editing help text (`after_long_help`, `about`, arg docs) also changes the rendered `--help` snapshots, which that test leaves untouched — regenerate them with `cargo insta test --accept -- --test integration "test_help"` (the pre-merge hook runs both). Sync taxonomy, help-text authoring (three render contexts, link text, config-TOML blocks): `docs/CLAUDE.md`.
 
 ## Plugin Layout
 

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -82,7 +82,7 @@ wt --source -C /path/to/repo switch
 1. Add the subcommand to the `Cli` enum in `src/cli/mod.rs`.
 2. Implement it in `src/commands/` (e.g. `src/commands/mycommand.rs`).
 3. Add an `after_long_help` attribute — it is the source of truth for `docs/content/{command}.md`.
-4. Run `cargo test --test integration test_docs_are_in_sync`.
+4. Run `cargo test --test integration test_docs_are_in_sync`. Editing help text also changes the rendered `--help` snapshots, which that test leaves untouched — regenerate them with `cargo insta test --accept -- --test integration "test_help"` (or run the pre-merge hook, which does both).
 
 ## Branch Argument Conventions
 

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -1759,16 +1759,6 @@ fn test_switch_picker_no_cd_switches_without_cd_directive(mut repo: TestRepo) {
 /// without a prompt — inconsistent with every other hook the picker gates, and
 /// a hole in "Project Commands Run Only After Approval". Here the hook is
 /// declined at the prompt; it must not run, and the switch must still succeed.
-// TODO(windows-picker): on Windows this exits 1 instead of 0. Declining the
-// hook returns Ok on both platforms, so the failure is in the interactive
-// approval prompt's stdin handoff after skim releases the ConPTY — not yet
-// reproduced or fixed (needs a Windows box). The other accept-path picker
-// tests, which switch without an approval prompt, pass on Windows. Ignored on
-// Windows so it still compiles there; runs everywhere else.
-#[cfg_attr(
-    windows,
-    ignore = "pre-switch hook decline exits 1 on Windows; needs investigation"
-)]
 #[rstest]
 fn test_switch_picker_pre_switch_hook_requires_approval(mut repo: TestRepo) {
     repo.remove_fixture_worktrees();
@@ -1795,7 +1785,14 @@ fn test_switch_picker_pre_switch_hook_requires_approval(mut repo: TestRepo) {
             // Preview-pane gate: see test_switch_picker_emits_cd_directive_by_default.
             ("target", Some("target-branch has no uncommitted changes")),
             ("\r", Some("needs approval")), // Enter; wait for the approval prompt
-            ("n\n", None),                  // decline
+            // Decline. The line terminator is CR, not LF: once skim releases the
+            // terminal, the approval prompt's `read_line` runs in the OS line
+            // discipline (cooked mode). Windows' console terminates a line on CR
+            // (the Enter key) and never on a bare LF, so "n\n" would leave the
+            // read blocked until the harness kills the hung process (exit 1). CR
+            // terminates on both platforms — Windows reads it as Enter, and on
+            // Unix the PTY's ICRNL maps it to LF.
+            ("n\r", None), // decline
         ],
     );
 


### PR DESCRIPTION
Two follow-ups from #3221 (running the interactive picker tests on Windows).

## `test_switch_picker_pre_switch_hook_requires_approval` on Windows

#3221 landed this test `#[cfg_attr(windows, ignore)]` with a TODO that suspected the picker's approval prompt couldn't read stdin after skim released the ConPTY. The actual cause, from the failing run's screen (prompt shown, `n` echoed, yet exit 1) and its timing (`FAIL [ 7.963s]` — the harness's 5s kill window plus setup): a **hang**, not an error.

Once skim releases the terminal, the approval prompt's `read_line` runs in the OS line discipline (cooked mode). Windows' console line-input terminates a line on **CR** (the Enter key) and never on a bare **LF** — so the test's `"n\n"` left `read_line` blocked until the harness killed the hung process. Every other `[y/N]` `read_line` PTY test (`approval_pty.rs`, `config_show`'s `plugin_prompt_pty`) is `#[cfg(unix)]`-gated, so this picker test was the first to drive one on Windows.

This was a test input-convention bug, not a product gap — a real Windows user presses Enter (CR) and is unaffected. The fix sends `"n\r"`: Windows reads it as Enter, and Unix's ICRNL maps it to LF. Verified on macOS (passes in ~3.5s, no hang); the Windows leg is confirmed by this PR's CI.

## Doc: `--help` snapshot regen

Editing help text changes two generated artifacts — the doc mirrors (regenerated by `test_docs_are_in_sync`) and the rendered `--help` snapshots (`test_help`). Only `docs/CLAUDE.md` documented the second, so an agent following root `CLAUDE.md` or `src/commands/CLAUDE.md` would leave the help snapshots stale and fail required CI. Added the regen step to both.

> _This was written by Claude Code on behalf of max_
