### PR TITLE
feat(switch): bold the branch, underline the url in the pr preview pane

### DIFF
--- a/src/commands/picker/items.rs
+++ b/src/commands/picker/items.rs
@@ -467,8 +467,9 @@ fn render_tab_row_compact(tabs: &[Tab], reset: Reset) -> String {
 
 /// The `pr` pane for a worktree row whose branch has a PR/MR. Renders the same
 /// shape as the `--prs` rows' pane (`PrSkimItem::pr_pane`) — reference + title
-/// header, dim-labeled metadata, and the description as markdown — via the
-/// shared [`pr_pane`] helpers, so the two read alike. The title, body, and
+/// header, cyan all-caps labeled metadata (the branch bold, the url underlined),
+/// and the description as markdown — via the shared [`pr_pane`] helpers, so the
+/// two read alike. The title, body, and
 /// comment count ride the same CI fetch the column already makes (see
 /// [`PrStatus`]); a status without them (an older cache entry, a forge that
 /// doesn't expose them) falls back to a reference-only header and skips the
@@ -483,9 +484,9 @@ fn render_tab_row_compact(tabs: &[Tab], reset: Reset) -> String {
 fn render_worktree_pr(branch: &str, pr_ref: PrRef, status: &PrStatus, width: usize) -> String {
     let title = status.title.as_deref().filter(|t| !t.is_empty());
     let mut out = pr_pane::header(pr_ref, title);
-    out.push_str(&pr_pane::metadata_line("branch", branch));
+    out.push_str(&pr_pane::branch_line(branch));
     if let Some(url) = &status.url {
-        out.push_str(&pr_pane::metadata_line("url", url));
+        out.push_str(&pr_pane::url_line(url));
     }
     if let Some(count) = status.comment_count {
         out.push_str(&pr_pane::metadata_line("comments", &count.to_string()));

--- a/src/commands/picker/pr_pane.rs
+++ b/src/commands/picker/pr_pane.rs
@@ -10,6 +10,9 @@
 //! Every label (`BRANCH`, `URL`, `DESCRIPTION`, …) goes through [`field_label`],
 //! which renders the app's cyan all-caps title style, so they all match the
 //! headings elsewhere in the CLI (`wt config show`, `wt step`, …).
+//! The values carry the app's own conventions in turn: the branch name bold and
+//! the url underlined (via [`branch_line`]/[`url_line`]), the same way branches
+//! and links render across the rest of the CLI.
 
 use anstyle::Reset;
 use color_print::cformat;
@@ -53,6 +56,27 @@ fn field_label(text: &str) -> String {
 pub(super) fn metadata_line(label: &str, value: &str) -> String {
     let pad = " ".repeat(VALUE_COLUMN.saturating_sub(label.len()));
     format!("{}{pad}{value}\n", field_label(label))
+}
+
+/// The `BRANCH` metadata line, with the branch name bold — the app convention
+/// for branch identifiers (git and error messages throughout the CLI, the
+/// branch summary in `src/summary.rs`). Both panes build
+/// the line through here so the styling can't drift between them. The trailing
+/// full `{reset}` closes the bold span: skim's ANSI parser drops the SGR 22 that
+/// color_print's `</>` emits, exactly as the `DESCRIPTION` label and the `draft`
+/// state value handle their own closers.
+pub(super) fn branch_line(branch: &str) -> String {
+    let reset = Reset;
+    metadata_line("branch", &cformat!("<bold>{branch}</>{reset}"))
+}
+
+/// The `URL` metadata line, with the url underlined — the app convention for
+/// inline links and references (hints, the fork-push notice). Both panes build
+/// the line through here so the styling can't drift. The trailing full `{reset}`
+/// closes the underline span (skim drops the SGR 24 that `</>` emits).
+pub(super) fn url_line(url: &str) -> String {
+    let reset = Reset;
+    metadata_line("url", &cformat!("<underline>{url}</>{reset}"))
 }
 
 /// The description block: a cyan all-caps `DESCRIPTION` label (via
@@ -143,6 +167,43 @@ mod tests {
             branch.find("feature"),
             Some(VALUE_COLUMN),
             "branch value at the shared column: {branch:?}"
+        );
+    }
+
+    #[test]
+    fn branch_line_bolds_the_value() {
+        use ansi_str::AnsiStr;
+        let out = branch_line("feature/auth");
+        // Bold (SGR 1) wraps the value — the app convention for branch
+        // identifiers — closed by a full reset so it doesn't bleed past the
+        // value (skim drops color_print's `</>`).
+        assert!(out.contains("\x1b[1m"), "bold value: {out:?}");
+        assert!(
+            out.contains("\x1b[0m"),
+            "full reset closes the span: {out:?}"
+        );
+        // The value still lands at the shared column behind the cyan label.
+        let stripped = out.ansi_strip();
+        assert_eq!(
+            stripped.find("feature"),
+            Some(VALUE_COLUMN),
+            "value aligned behind the label: {stripped:?}"
+        );
+    }
+
+    #[test]
+    fn url_line_underlines_the_value() {
+        let out = url_line("https://github.com/o/r/pull/7");
+        // Underline (SGR 4) wraps the value — the app convention for inline
+        // links — closed by a full reset.
+        assert!(out.contains("\x1b[4m"), "underline value: {out:?}");
+        assert!(
+            out.contains("\x1b[0m"),
+            "full reset closes the span: {out:?}"
+        );
+        assert!(
+            out.contains("https://github.com/o/r/pull/7"),
+            "url preserved intact: {out:?}"
         );
     }
 

--- a/src/commands/picker/prs.rs
+++ b/src/commands/picker/prs.rs
@@ -618,10 +618,10 @@ impl PrSkimItem {
         // shape as the worktree-row pane (see `items::render_worktree_pr`), so
         // the two read alike. They close each styled span with a full `{reset}`
         // (\x1b[0m) because skim's ANSI parser drops color_print's `</>` (SGR
-        // 22/39); the `draft` value below does the same.
+        // 22/24/39 — bold/underline/color); the `draft` value below does the same.
         let reset = Reset;
         let mut pr_pane = pr_pane::header(pr_ref, Some(&title));
-        pr_pane.push_str(&pr_pane::metadata_line("branch", &head_branch));
+        pr_pane.push_str(&pr_pane::branch_line(&head_branch));
         pr_pane.push_str(&pr_pane::metadata_line("author", &format!("@{author}")));
         if is_draft {
             pr_pane.push_str(&pr_pane::metadata_line(
@@ -630,7 +630,7 @@ impl PrSkimItem {
             ));
         }
         if let Some(url) = url {
-            pr_pane.push_str(&pr_pane::metadata_line("url", &url));
+            pr_pane.push_str(&pr_pane::url_line(&url));
         }
         pr_pane.push_str(&pr_pane::description(&body, list_width));
 


### PR DESCRIPTION
Follow-up to #3195. The `pr` preview pane's metadata values rendered plain after their cyan labels; this gives the two most identifier-like values the app's own conventions.

- **Branch name → bold** — the convention for branch identifiers across the CLI (`git`/error messages, the branch summary in `src/summary.rs`).
- **URL → underlined** — the inline-link convention used by hints and the fork-push notice.

Both panes — the worktree row (`render_worktree_pr`) and the `--prs` row (`PrSkimItem`) — now route branch/url through shared `pr_pane::branch_line` / `url_line` helpers, so the styling can't drift between them. The author handle and comment count stay plain, the draft state stays yellow, and the header reference stays bold.

Each styled value closes with a full `\x1b[0m` because skim's ANSI parser drops the SGR 22/24/39 that color_print's `</>` emits — the same pattern the existing `draft` value and `field_label` already use. Verified live in the picker that skim renders both the bold branch and the underlined URL on the real pane.

Also fixes two stale docstrings: a "dim-labeled" reference left from the cyan-label change in #3195, and a `branch_line` doc that cited a non-existent `wt summary` command.

> _This was written by Claude Code on behalf of max_
