### PR TITLE
feat(switch): picker shortcuts — copy branch, open PR, refresh, remap remove to alt-x

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -197,6 +197,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 
 [[package]]
+name = "arboard"
+version = "3.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0348a1c054491f4bfe6ab86a7b6ab1e44e45d899005de92f58b3df180b36ddaf"
+dependencies = [
+ "clipboard-win",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+ "parking_lot",
+ "percent-encoding",
+ "windows-sys 0.60.2",
+ "wl-clipboard-rs",
+ "x11rb",
+]
+
+[[package]]
 name = "arg_enum_proc_macro"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -680,6 +698,15 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+
+[[package]]
+name = "clipboard-win"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde03770d3df201d4fb868f2c9c59e66a3e4e2bd06692a0fe701e7103c7e84d4"
+dependencies = [
+ "error-code",
+]
 
 [[package]]
 name = "color-eyre"
@@ -1206,6 +1233,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+]
+
+[[package]]
 name = "doctest-file"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1291,6 +1328,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "error-code"
+version = "3.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea2df4cf52843e0452895c455a1a2cfbb842a1e7329671acf418fdc53ed4c59"
 
 [[package]]
 name = "etcetera"
@@ -1403,6 +1446,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
+name = "fixedbitset"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1466,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -1555,6 +1610,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "gethostname"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
+dependencies = [
+ "rustix 1.1.4",
+ "windows-link",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1642,13 +1707,22 @@ checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 
 [[package]]
 name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1659,7 +1733,7 @@ checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -1892,6 +1966,25 @@ dependencies = [
  "tokio",
  "widestring",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
 ]
 
 [[package]]
@@ -2412,6 +2505,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-app-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d49e936b501e5c5bf01fda3a9452ff86dc3ea98ad5f283e1455153142d97518c"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-graphics",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.0",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-graphics"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
+dependencies = [
+ "bitflags 2.13.0",
+ "dispatch2",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-io-surface",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-io-surface"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
+dependencies = [
+ "bitflags 2.13.0",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2439,6 +2605,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "open"
+version = "5.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+dependencies = [
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2460,6 +2637,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2612,6 +2799,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "petgraph"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
+dependencies = [
+ "fixedbitset 0.5.7",
+ "hashbrown 0.15.5",
+ "indexmap",
+]
+
+[[package]]
 name = "petname"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2689,6 +2887,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plotters"
@@ -2871,6 +3075,15 @@ name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
+name = "quick-xml"
+version = "0.39.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "quote"
@@ -3979,7 +4192,7 @@ dependencies = [
  "fancy-regex",
  "filedescriptor",
  "finl_unicode",
- "fixedbitset",
+ "fixedbitset 0.4.2",
  "hex",
  "lazy_static",
  "libc",
@@ -4356,6 +4569,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ae62f7eae5eb549c71b76658648b72cc6111f2d87d24a1e31fa907f4943e3ce"
 
 [[package]]
+name = "tree_magic_mini"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8765b90061cba6c22b5831f675da109ae5561588290f9fa2317adab2714d5a6"
+dependencies = [
+ "memchr",
+ "nom 8.0.0",
+ "petgraph",
+]
+
+[[package]]
 name = "tui-term"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4657,6 +4881,76 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wayland-backend"
+version = "0.3.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2857dd20b54e916ec7253b3d6b4d5c4d7d4ca2c33c2e11c6c76a99bd8744755d"
+dependencies = [
+ "cc",
+ "downcast-rs",
+ "rustix 1.1.4",
+ "smallvec",
+ "wayland-sys",
+]
+
+[[package]]
+name = "wayland-client"
+version = "0.31.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "645c7c96bb74690c3189b5c9cb4ca1627062bb23693a4fad9d8c3de958260144"
+dependencies = [
+ "bitflags 2.13.0",
+ "rustix 1.1.4",
+ "wayland-backend",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols"
+version = "0.32.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23d0c813de3daa2ed6520af85a3bd49b0e722a3078506899aa9686fea58dc4b6"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-protocols-wlr"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb04e52f7836d7c7976c78ca0250d61e33873c34156a2a1fc9474828ec268234"
+dependencies = [
+ "bitflags 2.13.0",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-scanner",
+]
+
+[[package]]
+name = "wayland-scanner"
+version = "0.31.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c324a910fd86ebdc364a3e61ec1f11737d3b1d6c273c0239ee8ff4bc0d24b4a"
+dependencies = [
+ "proc-macro2",
+ "quick-xml",
+ "quote",
+]
+
+[[package]]
+name = "wayland-sys"
+version = "0.31.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8eab23fefc9e41f8e841df4a9c707e8a8c4ed26e944ef69297184de2785e3be"
+dependencies = [
+ "pkg-config",
 ]
 
 [[package]]
@@ -5167,6 +5461,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 
 [[package]]
+name = "wl-clipboard-rs"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9651471a32e87d96ef3a127715382b2d11cc7c8bb9822ded8a7cc94072eb0a3"
+dependencies = [
+ "libc",
+ "log",
+ "os_pipe",
+ "rustix 1.1.4",
+ "thiserror 2.0.18",
+ "tree_magic_mini",
+ "wayland-backend",
+ "wayland-client",
+ "wayland-protocols",
+ "wayland-protocols-wlr",
+]
+
+[[package]]
 name = "worktrunk"
 version = "0.61.0"
 dependencies = [
@@ -5176,6 +5488,7 @@ dependencies = [
  "anstream",
  "anstyle",
  "anyhow",
+ "arboard",
  "askama",
  "chrono",
  "clap",
@@ -5200,6 +5513,7 @@ dependencies = [
  "nix 0.31.3",
  "normalize-path",
  "once_cell",
+ "open",
  "osc8",
  "path-slash",
  "pathdiff",
@@ -5280,6 +5594,23 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "x11rb"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9993aa5be5a26815fe2c3eacfc1fde061fc1a1f094bf1ad2a18bf9c495dd7414"
+dependencies = [
+ "gethostname",
+ "rustix 1.1.4",
+ "x11rb-protocol",
+]
+
+[[package]]
+name = "x11rb-protocol"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
 
 [[package]]
 name = "y4m"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,6 +86,8 @@ cli = [
     "dep:ratatui",
     "dep:ansi-to-tui",
     "dep:tokio",
+    "dep:arboard",
+    "dep:open",
     "dep:termimad",
     "dep:tracing-log",
     "dep:tracing-subscriber",
@@ -267,6 +269,14 @@ ansi-to-tui = { version = "8.0.1", optional = true }
 # collect mutates rows in place — skim 4.x renders on demand, not on a heartbeat.
 # `Runtime::new()` needs `rt-multi-thread`; `event_sender()` is a `sync::mpsc`.
 tokio = { version = "1.52.3", optional = true, default-features = false, features = ["rt-multi-thread", "sync"] }
+# Picker row shortcuts: `alt-y` copies the selected branch to the system
+# clipboard, `alt-o` opens its PR/MR URL in the browser. Both are cross-platform
+# (so they sit in the main table alongside the picker stack, not under
+# `[target.'cfg(unix)']`). `arboard` drops `default-features` to skip the `image`
+# crate — the picker only copies text — while keeping `wayland-data-control` so
+# Linux Wayland clipboards work alongside X11 and macOS.
+arboard = { version = "3.4", optional = true, default-features = false, features = ["wayland-data-control"] }
+open = { version = "5.3", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 # Unix-only syscall crates: `nix` (process/signal) backs the fsmonitor reap and

--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -75,12 +75,17 @@ The CI column shows each row's PR/MR CI and review status, the same as [`wt list
 | (type) | Filter worktrees |
 | `Enter` | Switch to selected worktree |
 | `Alt-c` | Create new worktree named as entered text |
+| `Alt-x` | Remove selected worktree/branch |
+| `Alt-y` | Copy selected branch name to the clipboard |
+| `Alt-o` | Open the selected row's PR/MR URL in the browser |
+| `Alt-r` | Refresh the list (pick up worktrees created elsewhere) |
 | `Esc` | Cancel |
 | `Alt-1`–`Alt-7` | Jump to a preview tab |
 | `Tab`/`Shift-Tab` | Cycle preview tabs forward/backward |
 | `Alt-p` | Toggle preview panel |
 | `Ctrl-u`/`Ctrl-d` | Scroll preview up/down |
-<!-- Alt-r (remove worktree) works but is omitted: cursor resets after skim reload (#1695). Add once fixed. See #1881. -->
+
+Discrete actions live on `Alt`. `Alt-y` and `Alt-o` run in the background — the picker stays open — and `Alt-o` is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
 
 Plain digits go to the filter, so a branch name containing a number can be typed directly; the preview tabs move to `Alt`.
 

--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -85,7 +85,7 @@ The CI column shows each row's PR/MR CI and review status, the same as [`wt list
 | `Alt-p` | Toggle preview panel |
 | `Ctrl-u`/`Ctrl-d` | Scroll preview up/down |
 
-Discrete actions live on `Alt`. `Alt-y` and `Alt-o` run in the background — the picker stays open — and `Alt-o` is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
+`Alt-o` is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
 
 Plain digits go to the filter, so a branch name containing a number can be typed directly; the preview tabs move to `Alt`.
 

--- a/skills/worktrunk/reference/switch.md
+++ b/skills/worktrunk/reference/switch.md
@@ -81,7 +81,7 @@ The CI column shows each row's PR/MR CI and review status, the same as [`wt list
 | `Alt-p` | Toggle preview panel |
 | `Ctrl-u`/`Ctrl-d` | Scroll preview up/down |
 
-Discrete actions live on `Alt`. `Alt-y` and `Alt-o` run in the background — the picker stays open — and `Alt-o` is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
+`Alt-o` is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
 
 Plain digits go to the filter, so a branch name containing a number can be typed directly; the preview tabs move to `Alt`.
 

--- a/skills/worktrunk/reference/switch.md
+++ b/skills/worktrunk/reference/switch.md
@@ -71,12 +71,17 @@ The CI column shows each row's PR/MR CI and review status, the same as [`wt list
 | (type) | Filter worktrees |
 | `Enter` | Switch to selected worktree |
 | `Alt-c` | Create new worktree named as entered text |
+| `Alt-x` | Remove selected worktree/branch |
+| `Alt-y` | Copy selected branch name to the clipboard |
+| `Alt-o` | Open the selected row's PR/MR URL in the browser |
+| `Alt-r` | Refresh the list (pick up worktrees created elsewhere) |
 | `Esc` | Cancel |
 | `Alt-1`–`Alt-7` | Jump to a preview tab |
 | `Tab`/`Shift-Tab` | Cycle preview tabs forward/backward |
 | `Alt-p` | Toggle preview panel |
 | `Ctrl-u`/`Ctrl-d` | Scroll preview up/down |
-<!-- Alt-r (remove worktree) works but is omitted: cursor resets after skim reload (#1695). Add once fixed. See #1881. -->
+
+Discrete actions live on `Alt`. `Alt-y` and `Alt-o` run in the background — the picker stays open — and `Alt-o` is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
 
 Plain digits go to the filter, so a branch name containing a number can be typed directly; the preview tabs move to `Alt`.
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -675,7 +675,7 @@ The CI column shows each row's PR/MR CI and review status, the same as [`wt list
 | `Alt-p` | Toggle preview panel |
 | `Ctrl-u`/`Ctrl-d` | Scroll preview up/down |
 
-Discrete actions live on `Alt`. `Alt-y` and `Alt-o` run in the background — the picker stays open — and `Alt-o` is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
+`Alt-o` is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
 
 Plain digits go to the filter, so a branch name containing a number can be typed directly; the preview tabs move to `Alt`.
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -665,12 +665,17 @@ The CI column shows each row's PR/MR CI and review status, the same as [`wt list
 | (type) | Filter worktrees |
 | `Enter` | Switch to selected worktree |
 | `Alt-c` | Create new worktree named as entered text |
+| `Alt-x` | Remove selected worktree/branch |
+| `Alt-y` | Copy selected branch name to the clipboard |
+| `Alt-o` | Open the selected row's PR/MR URL in the browser |
+| `Alt-r` | Refresh the list (pick up worktrees created elsewhere) |
 | `Esc` | Cancel |
 | `Alt-1`–`Alt-7` | Jump to a preview tab |
 | `Tab`/`Shift-Tab` | Cycle preview tabs forward/backward |
 | `Alt-p` | Toggle preview panel |
 | `Ctrl-u`/`Ctrl-d` | Scroll preview up/down |
-<!-- Alt-r (remove worktree) works but is omitted: cursor resets after skim reload (#1695). Add once fixed. See #1881. -->
+
+Discrete actions live on `Alt`. `Alt-y` and `Alt-o` run in the background — the picker stays open — and `Alt-o` is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
 
 Plain digits go to the filter, so a branch name containing a number can be typed directly; the preview tabs move to `Alt`.
 

--- a/src/commands/picker/items.rs
+++ b/src/commands/picker/items.rs
@@ -72,6 +72,66 @@ pub(super) type PrStatusSlot = Arc<Mutex<Option<Option<PrStatus>>>>;
 /// worktree path (which is unique) behind this prefix instead.
 pub(super) const WORKTREE_OUTPUT_PREFIX: &str = "worktree-path:";
 
+/// Per-row data the picker's `alt-y` (copy branch) and `alt-o` (open PR/MR URL)
+/// shortcuts need at key-press time, looked up by the row's `output()` token.
+///
+/// The shortcut callbacks read the *selected* `Arc<dyn SkimItem>` straight off
+/// skim's `App`, but skim's cross-thread `downcast_ref` is unreliable (see
+/// `picker_item_identifier`), so the row's typed fields aren't reachable that
+/// way. This table carries them instead, keyed by the same `output()` token
+/// both sides already share. It's filled where the rows are built —
+/// `progressive_handler::on_skeleton` for worktree/branch rows,
+/// `prs::stream_open_prs` for `--prs` rows — and read by the keybinding
+/// callbacks in `picker::install_shortcut_keybindings`.
+pub(super) struct RowShortcutData {
+    /// The row's branch name — what `alt-y` copies. For a `--prs` row this is
+    /// the PR/MR's head branch.
+    pub branch: String,
+    /// Where `alt-o` finds the row's PR/MR URL.
+    pub url: RowUrl,
+}
+
+/// Source of a row's PR/MR URL for the `alt-o` shortcut.
+pub(super) enum RowUrl {
+    /// Worktree/branch row: the URL (if any) lives in the live `pr_status`
+    /// slot, populated only once the CI fetch reports — so `alt-o` is a no-op
+    /// until the row's PR resolves.
+    Live(PrStatusSlot),
+    /// `--prs` row: the URL is known when the row is built.
+    Static(Option<String>),
+}
+
+impl RowUrl {
+    /// The row's URL, if one is known right now.
+    pub(super) fn resolve(&self) -> Option<String> {
+        match self {
+            RowUrl::Live(slot) => match &*slot.lock().unwrap() {
+                Some(Some(status)) => status.url.clone(),
+                _ => None,
+            },
+            RowUrl::Static(url) => url.clone(),
+        }
+    }
+}
+
+/// The `alt-y` / `alt-o` lookup table, keyed by `output()` token. Shared between
+/// the collect handler and `--prs` thread (which fill it) and the keybinding
+/// callbacks (which read it). Rebuilt on every skeleton, so a refresh re-collect
+/// repopulates it.
+pub(super) type ShortcutTable = Arc<Mutex<std::collections::HashMap<String, RowShortcutData>>>;
+
+/// The `output()` token for a worktree/branch row: the unique worktree path
+/// (behind [`WORKTREE_OUTPUT_PREFIX`]) for any worktree-backed row, else the
+/// bare branch name. Shared by [`WorktreeSkimItem::output`] and the shortcut
+/// table fill in `progressive_handler::on_skeleton`, so the selection token and
+/// the lookup key can't drift.
+pub(super) fn worktree_output_token(item: &ListItem, branch_name: &str) -> String {
+    match item.worktree_path() {
+        Some(path) => format!("{WORKTREE_OUTPUT_PREFIX}{}", path.to_string_lossy()),
+        None => branch_name.to_string(),
+    }
+}
+
 /// A `--prs` picker's header shows a dim "loading…" line while the forge call
 /// is still in flight, since its rows arrive (~1s) after the local rows. The
 /// `--prs` thread clears `pending` and repaints once the fetch resolves (rows
@@ -208,13 +268,7 @@ impl SkimItem for WorktreeSkimItem {
     }
 
     fn output(&self) -> Cow<'_, str> {
-        match self.item.worktree_path() {
-            Some(path) => Cow::Owned(format!(
-                "{WORKTREE_OUTPUT_PREFIX}{}",
-                path.to_string_lossy()
-            )),
-            None => Cow::Borrowed(&self.branch_name),
-        }
+        Cow::Owned(worktree_output_token(&self.item, &self.branch_name))
     }
 
     fn preview(&self, context: PreviewContext<'_>) -> ItemPreview {
@@ -403,9 +457,10 @@ pub(super) fn render_preview_tabs(
     // The controls line is intentionally NOT width-managed: skim clips it on the
     // right on a narrow pane, but it's only a reminder — the accelerators it
     // names live in the tab bar above, which IS width-managed, so nothing
-    // navigable is lost when the tail clips.
+    // navigable is lost when the tail clips. Row actions lead so they survive a
+    // narrow-pane clip; the preview controls and Esc trail.
     let controls = cformat!(
-        "<dim,yellow>Enter: switch | Tab/alt-1…7: preview | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle</>"
+        "<dim,yellow>Enter: switch | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Tab/alt-1…7: preview | ctrl-u/d: scroll | Esc: cancel</>"
     );
 
     // Each tab/segment already ends with a full reset (so styling never bleeds
@@ -1294,6 +1349,46 @@ mod tests {
         assert_snapshot!(
             "cache_miss",
             cache_miss.preview_for_mode(PreviewMode::Summary, 80, 40)
+        );
+    }
+
+    #[test]
+    fn row_url_resolve() {
+        use crate::commands::list::ci_status::{CiSource, CiStatus, PrRef, ReviewState};
+
+        // Static URL (a `--prs` row): resolves directly.
+        assert_eq!(
+            RowUrl::Static(Some("https://x/pull/1".into()))
+                .resolve()
+                .as_deref(),
+            Some("https://x/pull/1")
+        );
+        assert_eq!(RowUrl::Static(None).resolve(), None);
+
+        // Live slot (a worktree row): `None` (still fetching) and `Some(None)`
+        // (no PR) both resolve to no URL — alt-o is a no-op until a PR lands.
+        let loading: PrStatusSlot = Arc::new(Mutex::new(None));
+        assert_eq!(RowUrl::Live(loading).resolve(), None);
+        let no_pr: PrStatusSlot = Arc::new(Mutex::new(Some(None)));
+        assert_eq!(RowUrl::Live(no_pr).resolve(), None);
+
+        // A live status carrying a URL resolves to it.
+        let status = PrStatus {
+            ci_status: CiStatus::Passed,
+            source: CiSource::PullRequest,
+            is_stale: false,
+            is_priming: false,
+            url: Some("https://x/pull/2".into()),
+            number: Some(PrRef::pr(2)),
+            review_state: Some(ReviewState::Approved),
+            title: None,
+            body: None,
+            comment_count: None,
+        };
+        let with_url: PrStatusSlot = Arc::new(Mutex::new(Some(Some(status))));
+        assert_eq!(
+            RowUrl::Live(with_url).resolve().as_deref(),
+            Some("https://x/pull/2")
         );
     }
 

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -1658,6 +1658,31 @@ fn install_preview_tab_keybindings(keymap: &mut skim::binds::KeyMap) {
     }
 }
 
+/// The branch name `alt-y` copies for the row whose `output()` token is `token`:
+/// its `RowShortcutData.branch`. `None` when the token isn't in the table or the
+/// row has no branch (a detached worktree), so `alt-y` no-ops. Pulled out of the
+/// keybinding closure so the lookup — the part that doesn't need a live skim
+/// `App` — is unit-testable.
+fn resolve_shortcut_branch(table: &ShortcutTable, token: &str) -> Option<String> {
+    table
+        .lock()
+        .unwrap()
+        .get(token)
+        .and_then(|d| d.branch.clone())
+}
+
+/// The PR/MR URL `alt-o` opens for the row whose `output()` token is `token`.
+/// `None` when the token isn't in the table or the row has no URL (a worktree
+/// whose PR hasn't resolved, or has none), so `alt-o` no-ops. The counterpart to
+/// [`resolve_shortcut_branch`].
+fn resolve_shortcut_url(table: &ShortcutTable, token: &str) -> Option<String> {
+    table
+        .lock()
+        .unwrap()
+        .get(token)
+        .and_then(|d| d.url.resolve())
+}
+
 /// Install the `alt-y` (copy branch) and `alt-o` (open PR/MR URL) row shortcuts
 /// as native callbacks, alongside the preview-tab keys.
 ///
@@ -1678,13 +1703,10 @@ fn install_shortcut_keybindings(keymap: &mut skim::binds::KeyMap, shortcut_table
         keymap.insert(
             key,
             vec![Action::Custom(ActionCallback::new_sync(move |app| {
-                let branch = app.item_list.selected().and_then(|m| {
-                    table
-                        .lock()
-                        .unwrap()
-                        .get(m.item.output().as_ref())
-                        .and_then(|d| d.branch.clone())
-                });
+                let branch = app
+                    .item_list
+                    .selected()
+                    .and_then(|m| resolve_shortcut_branch(&table, m.item.output().as_ref()));
                 if let Some(branch) = branch {
                     spawn_shortcut("picker-copy", move || os::copy_to_clipboard(&branch));
                 }
@@ -1699,13 +1721,10 @@ fn install_shortcut_keybindings(keymap: &mut skim::binds::KeyMap, shortcut_table
         keymap.insert(
             key,
             vec![Action::Custom(ActionCallback::new_sync(move |app| {
-                let url = app.item_list.selected().and_then(|m| {
-                    table
-                        .lock()
-                        .unwrap()
-                        .get(m.item.output().as_ref())
-                        .and_then(|d| d.url.resolve())
-                });
+                let url = app
+                    .item_list
+                    .selected()
+                    .and_then(|m| resolve_shortcut_url(&table, m.item.output().as_ref()));
                 if let Some(url) = url {
                     spawn_shortcut("picker-open", move || os::open_url(&url));
                 }
@@ -1817,7 +1836,7 @@ pub mod tests {
     use super::{
         PickerAction, PickerCollector, PickerRemovalTarget, drain_stashed_warnings,
         install_preview_tab_keybindings, install_shortcut_keybindings, parse_reload_remove_token,
-        picker_item_identifier, resolve_identifier,
+        picker_item_identifier, resolve_identifier, resolve_shortcut_branch, resolve_shortcut_url,
     };
     use crate::commands::list::model::{ItemKind, ListItem, WorktreeData};
     use crate::commands::worktree::RemoveResult;
@@ -1906,6 +1925,47 @@ pub mod tests {
                 chain[0]
             );
         }
+    }
+
+    /// The lookup the `alt-y` / `alt-o` closures delegate to — pure table logic,
+    /// no live skim `App`. Covers a row with a branch + URL, a detached row (no
+    /// branch, no URL — both shortcuts no-op), and a token absent from the table.
+    #[test]
+    fn resolve_shortcut_branch_and_url() {
+        use super::items::{RowShortcutData, RowUrl, ShortcutTable};
+
+        let table: ShortcutTable = Arc::new(Mutex::new(std::collections::HashMap::new()));
+        {
+            let mut t = table.lock().unwrap();
+            t.insert(
+                "feat".into(),
+                RowShortcutData {
+                    branch: Some("feat".into()),
+                    url: RowUrl::Static(Some("https://example.test/pr/1".into())),
+                },
+            );
+            t.insert(
+                "wt".into(),
+                RowShortcutData {
+                    branch: None,
+                    url: RowUrl::Static(None),
+                },
+            );
+        }
+
+        assert_eq!(
+            resolve_shortcut_branch(&table, "feat").as_deref(),
+            Some("feat")
+        );
+        assert_eq!(resolve_shortcut_branch(&table, "wt"), None); // detached: no branch
+        assert_eq!(resolve_shortcut_branch(&table, "missing"), None);
+
+        assert_eq!(
+            resolve_shortcut_url(&table, "feat").as_deref(),
+            Some("https://example.test/pr/1")
+        );
+        assert_eq!(resolve_shortcut_url(&table, "wt"), None); // no URL
+        assert_eq!(resolve_shortcut_url(&table, "missing"), None);
     }
 
     #[test]

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -92,6 +92,7 @@
 
 mod items;
 mod log_formatter;
+mod os;
 mod pager;
 mod pr_pane;
 mod preview;
@@ -130,7 +131,7 @@ use crate::cli::SwitchFormat;
 use crate::output::{BackgroundFallbackMode, handle_remove_output};
 use worktrunk::git::{BranchDeletionMode, delete_branch_if_safe};
 
-use items::{PreviewCache, WORKTREE_OUTPUT_PREFIX};
+use items::{PreviewCache, ShortcutTable, WORKTREE_OUTPUT_PREFIX};
 use preview::{PreviewLayout, PreviewMode, PreviewState, PreviewStateData};
 use preview_orchestrator::PreviewOrchestrator;
 
@@ -235,6 +236,11 @@ struct PickerCollector {
     /// cursor after the reload. `None` until the TUI is up — but a reload can
     /// only fire after skim is showing rows, so it's always set by then.
     render_tx: Arc<OnceLock<tokio::sync::mpsc::Sender<Event>>>,
+    /// Re-runs the collect pipeline for the `alt-r` refresh: `reload(refresh)`
+    /// routes here, and [`PipelineFactory::spawn`] streams a fresh item list
+    /// back. Shared (`Rc`) with `handle_picker`, which used it for the initial
+    /// spawn.
+    factory: Rc<PipelineFactory>,
 }
 
 impl PickerCollector {
@@ -471,6 +477,23 @@ impl CommandCollector for PickerCollector {
         cmd: &str,
         components_to_stop: Arc<AtomicUsize>,
     ) -> (SkimItemReceiver, Sender<i32>) {
+        let _ = components_to_stop;
+
+        // alt-r refresh: `reload(refresh)` re-runs collect and streams a fresh
+        // list. The new pipeline's threads feed `rx`; on completion their senders
+        // drop and skim's reload sees EOF. The returned handler and join handles
+        // are kept alive by those threads, so let them drop here. On a spawn
+        // failure we fall through and re-stream the current items unchanged.
+        if cmd.trim() == "refresh" {
+            match self.factory.spawn() {
+                Ok(SpawnedPipeline { rx, .. }) => {
+                    let (tx_interrupt, _rx_interrupt) = bounded(1);
+                    return (rx, tx_interrupt);
+                }
+                Err(e) => log::warn!("picker: refresh failed: {e:#}"),
+            }
+        }
+
         // skim's `reload(remove {})` expands `{}` to the selected row's
         // shell-quoted output() token; pull it back out (see
         // `parse_reload_remove_token`). No signal file — that raced the reader.
@@ -569,9 +592,8 @@ impl CommandCollector for PickerCollector {
         drop(tx);
 
         // Dummy interrupt channel — no subprocess to kill.
-        // The reader's collect_item thread handles its own components_to_stop accounting;
-        // we just need a valid Sender to satisfy the trait signature.
-        let _ = components_to_stop;
+        // The reader's collect_item thread handles its own components_to_stop
+        // accounting; we just need a valid Sender to satisfy the trait signature.
         let (tx_interrupt, _rx_interrupt) = bounded(1);
         (rx, tx_interrupt)
     }
@@ -607,6 +629,164 @@ fn approved_removal_plan(
     builder.add(worktree_path, &[HookType::PreRemove, HookType::PostRemove]);
     builder.add(main_path, &[HookType::PostSwitch]);
     Ok(builder.finish().approve_readonly(approvals, pid))
+}
+
+/// Everything needed to (re)spawn the picker's collect pipeline. Used once at
+/// startup and again on every `alt-r` refresh — which re-runs `collect` so
+/// worktrees and branches created outside the session (a teammate's push, a
+/// parallel agent) appear without reopening the picker.
+///
+/// Each [`spawn`](Self::spawn) builds a *fresh* progressive handler (its
+/// `OnceLock` slots can't be reset) and item channel, but shares the
+/// session-long state — the orchestrator / preview cache (so previews stay
+/// warm), `shared_items` and `shortcut_table` (which `on_skeleton` overwrites),
+/// and skim's `render_tx`. Held by [`PickerCollector`] so a refresh can
+/// re-enter the pipeline.
+struct PipelineFactory {
+    repo: Repository,
+    render_tx: Arc<OnceLock<tokio::sync::mpsc::Sender<Event>>>,
+    shared_items: Arc<Mutex<Vec<Arc<dyn SkimItem>>>>,
+    shortcut_table: ShortcutTable,
+    preview_cache: PreviewCache,
+    orchestrator: Arc<PreviewOrchestrator>,
+    stashed_warnings: Arc<Mutex<Vec<String>>>,
+    grid_slot: Arc<prs::GridSlot>,
+    preview_dims: (usize, usize),
+    skim_list_width: usize,
+    command_timeout: Option<std::time::Duration>,
+    skip_tasks: std::collections::HashSet<collect::TaskKind>,
+    llm_command: Option<String>,
+    summary_hint: Option<String>,
+    show_branches: bool,
+    show_remotes: bool,
+    show_prs: bool,
+    is_preview_bench: bool,
+}
+
+/// The product of one [`PipelineFactory::spawn`]: skim's item receiver plus the
+/// handler and thread handles the caller manages (joined in the dry-run path,
+/// dropped — detaching the threads — in the interactive and refresh paths).
+struct SpawnedPipeline {
+    rx: SkimItemReceiver,
+    handler: Arc<progressive_handler::PickerHandler>,
+    collect_handle: std::thread::JoinHandle<()>,
+    prs_handle: Option<std::thread::JoinHandle<()>>,
+}
+
+impl PipelineFactory {
+    /// Build a fresh handler + item channel, start the `picker-collect` thread
+    /// (and the `picker-prs` thread when `--prs` is active), and hand back the
+    /// receiver skim reads. The handler holds the only non-thread `tx` clone, so
+    /// once the spawned threads finish the channel closes and skim's reader sees
+    /// EOF — the "background work done → picker idle" contract, which a refresh
+    /// relies on to end its `reload`.
+    fn spawn(&self) -> anyhow::Result<SpawnedPipeline> {
+        let (tx, rx): (SkimItemSender, SkimItemReceiver) = unbounded();
+
+        // Fresh per spawn: the header shows a "loading…" marker keyed to this
+        // flag while the forge call is in flight.
+        let prs_loading: Option<Arc<AtomicBool>> =
+            (self.show_prs && !self.is_preview_bench).then(|| Arc::new(AtomicBool::new(true)));
+
+        let handler: Arc<progressive_handler::PickerHandler> =
+            Arc::new(progressive_handler::PickerHandler {
+                tx: tx.clone(),
+                render_tx: Arc::clone(&self.render_tx),
+                last_render_poke: Mutex::new(Instant::now()),
+                shared_items: Arc::clone(&self.shared_items),
+                shortcut_table: Arc::clone(&self.shortcut_table),
+                rendered_slots: OnceLock::new(),
+                pr_status_slots: OnceLock::new(),
+                preview_cache: Arc::clone(&self.preview_cache),
+                orchestrator: Arc::clone(&self.orchestrator),
+                preview_dims: self.preview_dims,
+                llm_command: self.llm_command.clone(),
+                summary_hint: self.summary_hint.clone(),
+                stashed_warnings: Arc::clone(&self.stashed_warnings),
+                deferred_items: OnceLock::new(),
+                grid_slot: Arc::clone(&self.grid_slot),
+                prs_loading: prs_loading.clone(),
+            });
+
+        let bg_handler: Arc<dyn collect::PickerProgressHandler> = handler.clone();
+        let bg_repo = self.repo.clone();
+        let bg_skip_tasks = self.skip_tasks.clone();
+        let show_branches = self.show_branches;
+        let show_remotes = self.show_remotes;
+        let command_timeout = self.command_timeout;
+        let skim_list_width = self.skim_list_width;
+        let collect_handle = std::thread::Builder::new()
+            .name("picker-collect".into())
+            .spawn(move || {
+                let _ = collect::collect(
+                    &bg_repo,
+                    collect::ShowConfig::Resolved {
+                        show_branches,
+                        show_remotes,
+                        skip_tasks: bg_skip_tasks,
+                        command_timeout,
+                        collect_deadline: None,
+                        list_width: Some(skim_list_width),
+                        progressive_handler: Some(bg_handler),
+                    },
+                    // Picker renders its own UI through `progressive_handler`;
+                    // collect must not write to stdout.
+                    RenderTarget::Json,
+                );
+            })
+            .context("Failed to spawn picker-collect thread")?;
+
+        // PR/MR streaming (`--prs`). One forge call on its own thread holding
+        // another `tx` clone, so the frame paints from local data immediately and
+        // PR rows stream in (~1s) when the call returns.
+        let prs_handle = if let Some(prs_loading) = prs_loading {
+            let prs_tx = tx.clone();
+            let prs_repo = self.repo.clone();
+            let prs_warnings = Arc::clone(&self.stashed_warnings);
+            let prs_orchestrator = Arc::clone(&self.orchestrator);
+            let prs_render_tx = Arc::clone(&self.render_tx);
+            let prs_shared = prs::PrsShared {
+                grid_slot: Arc::clone(&self.grid_slot),
+                shortcut_table: Arc::clone(&self.shortcut_table),
+            };
+            let prs_layout = prs::PrsLayout {
+                list_width: self.skim_list_width,
+                preview_dims: self.preview_dims,
+            };
+            Some(
+                std::thread::Builder::new()
+                    .name("picker-prs".into())
+                    .spawn(move || {
+                        prs::stream_open_prs(
+                            &prs_repo,
+                            &prs_layout,
+                            &prs_tx,
+                            &prs_warnings,
+                            &prs_orchestrator,
+                            &prs_shared,
+                            &prs::PrsStreamSignal {
+                                pending: &prs_loading,
+                                render_tx: &prs_render_tx,
+                            },
+                        );
+                    })
+                    .context("Failed to spawn picker-prs thread")?,
+            )
+        } else {
+            None
+        };
+
+        // Drop the local `tx` so the handler's clone (and the threads' clones)
+        // are the only senders left — their drop is what signals EOF to skim.
+        drop(tx);
+
+        Ok(SpawnedPipeline {
+            rx,
+            handler,
+            collect_handle,
+            prs_handle,
+        })
+    }
 }
 
 pub fn handle_picker(
@@ -796,6 +976,11 @@ pub fn handle_picker(
     // the handler has already published them.
     let shared_items: Arc<Mutex<Vec<Arc<dyn SkimItem>>>> = Arc::new(Mutex::new(Vec::new()));
 
+    // `alt-y` / `alt-o` lookup table (token → branch + URL). The collect handler
+    // fills it with worktree/branch rows and the `--prs` thread extends it; the
+    // shortcut keybinding callbacks read it. See `ShortcutTable`.
+    let shortcut_table: ShortcutTable = Arc::new(Mutex::new(std::collections::HashMap::new()));
+
     // Approvals snapshot for the session: alt-r removals consult it read-only
     // to filter the hook plan; see `approved_removal_plan`.
     let approvals = Arc::new(Approvals::load().context("Failed to load approvals")?);
@@ -808,11 +993,41 @@ pub fn handle_picker(
     // module docstring.
     let render_tx: Arc<OnceLock<tokio::sync::mpsc::Sender<Event>>> = Arc::new(OnceLock::new());
 
+    // Shared between the bg-thread handler (which pushes warnings while skim owns
+    // the terminal) and the main thread (which drains them after skim returns).
+    let stashed_warnings: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+
+    // The collect pipeline, captured so the initial spawn below and every alt-r
+    // refresh build it the same way. See `PipelineFactory`.
+    let factory = Rc::new(PipelineFactory {
+        repo: repo.clone(),
+        render_tx: Arc::clone(&render_tx),
+        shared_items: Arc::clone(&shared_items),
+        shortcut_table: Arc::clone(&shortcut_table),
+        preview_cache: Arc::clone(&preview_cache),
+        orchestrator: Arc::clone(&orchestrator),
+        stashed_warnings: Arc::clone(&stashed_warnings),
+        // Column-geometry handoff: the collect thread fills it at skeleton time,
+        // the `--prs` thread reads it to align PR rows with the worktree rows.
+        grid_slot: Arc::new(prs::GridSlot::new()),
+        preview_dims,
+        skim_list_width,
+        command_timeout,
+        skip_tasks,
+        llm_command,
+        summary_hint,
+        show_branches,
+        show_remotes,
+        show_prs,
+        is_preview_bench,
+    });
+
     let collector = PickerCollector {
         items: Arc::clone(&shared_items),
         repo: repo.clone(),
         approvals,
         render_tx: Arc::clone(&render_tx),
+        factory: Rc::clone(&factory),
     };
 
     // Half-page preview scroll: half of skim's usable height.
@@ -919,7 +1134,15 @@ pub fn handle_picker(
             // which raced the reader and removed nothing. The collector also
             // re-positions the cursor onto the removed row's slot afterward —
             // reload otherwise snaps it back to the top (see PickerCollector).
-            "alt-r:reload(remove {})".to_string(),
+            // alt-x for "remove" — alt-r is the refresh key (below), and putting
+            // the destructive action on a less-reflexive key guards against a
+            // mis-hit, the safe direction being a stray refresh.
+            "alt-x:reload(remove {})".to_string(),
+            // Refresh the list (alt-r for "refresh"): `reload(refresh)` re-runs
+            // collect through PickerCollector, picking up worktrees/branches
+            // created outside the session (a teammate's push, a parallel agent)
+            // without reopening the picker.
+            "alt-r:reload(refresh)".to_string(),
             // Preview toggle (alt-p shows/hides preview)
             // Note: skim doesn't support change-preview-window like fzf, only toggle
             "alt-p:toggle-preview".to_string(),
@@ -934,122 +1157,26 @@ pub fn handle_picker(
     // preview-tab switches on top as native `Action::Custom` callbacks (skim's
     // string bind API can't express a custom action).
     install_preview_tab_keybindings(&mut options.keymap);
+    // Row shortcuts (alt-y copy branch, alt-o open PR/MR URL) — native callbacks
+    // that read the selected row off skim's `App` and run the OS action on a
+    // background thread. Like the preview-tab keys, they can't be string binds.
+    install_shortcut_keybindings(&mut options.keymap, Arc::clone(&shortcut_table));
     worktrunk::trace::instant("Picker skim options built");
 
-    let (tx, rx): (SkimItemSender, SkimItemReceiver) = unbounded();
-
-    // Shared between the bg-thread handler (which pushes warnings while
-    // skim owns the terminal) and the main thread (which drains them after
-    // `Skim::run_with` returns and stderr is safe again).
-    let stashed_warnings: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-
-    // Column-geometry handoff: the collect thread fills it at skeleton time,
-    // the `--prs` thread reads it to align PR rows with the worktree rows.
-    let grid_slot = Arc::new(prs::GridSlot::new());
-
-    // `--prs` loading flag, shared between the header (shows a "loading…"
-    // marker while true) and the `--prs` thread (clears it when the forge call
-    // resolves). `Some` exactly when that thread spawns below, so the marker
-    // tracks its lifetime.
-    let prs_loading: Option<Arc<AtomicBool>> =
-        (show_prs && !is_preview_bench).then(|| Arc::new(AtomicBool::new(true)));
-
-    // Concrete type so the dry-run dump can read the handler's rendered rows.
-    let handler: Arc<progressive_handler::PickerHandler> =
-        Arc::new(progressive_handler::PickerHandler {
-            tx: tx.clone(),
-            render_tx: Arc::clone(&render_tx),
-            last_render_poke: Mutex::new(Instant::now()),
-            shared_items: Arc::clone(&shared_items),
-            rendered_slots: std::sync::OnceLock::new(),
-            pr_status_slots: std::sync::OnceLock::new(),
-            preview_cache: Arc::clone(&preview_cache),
-            orchestrator: Arc::clone(&orchestrator),
-            preview_dims,
-            llm_command,
-            summary_hint,
-            stashed_warnings: Arc::clone(&stashed_warnings),
-            deferred_items: std::sync::OnceLock::new(),
-            grid_slot: Arc::clone(&grid_slot),
-            prs_loading: prs_loading.clone(),
-        });
-
-    // Spawn collect on a background thread. The handler holds the only
-    // remaining `tx` clone; when the bg thread exits, `tx` drops, skim's reader
-    // sees EOF, and the picker goes idle. Contract: background work done →
-    // picker idle.
-    let bg_handler: Arc<dyn collect::PickerProgressHandler> = handler.clone();
-    let bg_repo = repo.clone();
-    let bg_skip_tasks = skip_tasks.clone();
-    let bg_handle = std::thread::Builder::new()
-        .name("picker-collect".into())
-        .spawn(move || {
-            let _ = collect::collect(
-                &bg_repo,
-                collect::ShowConfig::Resolved {
-                    show_branches,
-                    show_remotes,
-                    skip_tasks: bg_skip_tasks,
-                    command_timeout,
-                    collect_deadline: None,
-                    list_width: Some(skim_list_width),
-                    progressive_handler: Some(bg_handler),
-                },
-                // Picker renders its own UI through `progressive_handler`;
-                // collect must not write to stdout.
-                RenderTarget::Json,
-            );
-        })
-        .context("Failed to spawn picker-collect thread")?;
+    // Spawn the collect pipeline (and the `--prs` thread when active). The
+    // handler holds the only non-thread `tx` clone; when the bg threads exit,
+    // `tx` drops, skim's reader sees EOF, and the picker goes idle. Every alt-r
+    // refresh re-runs this same `factory.spawn()` — see `PipelineFactory`.
+    let SpawnedPipeline {
+        rx,
+        handler,
+        collect_handle,
+        prs_handle,
+    } = factory.spawn()?;
     worktrunk::trace::instant("Picker collect spawned");
 
-    // PR/MR streaming (`--prs`). One forge call on its own thread that holds
-    // another `tx` clone, so the picker frame paints from local worktree data
-    // immediately and PR rows stream in (~1s) when the call returns. The
-    // clone defers EOF: skim's reader sees end-of-stream only once both this
-    // thread and the collect thread drop their senders. The dry-run runs it
-    // (joined below) so the fetch/render path is exercised headlessly — the only
-    // way it gets coverage, since the interactive picker's skim-abort exit never
-    // flushes a profile. Only the preview-bench skips it: that path measures the
-    // preview workload and must not reach the network.
-    let prs_handle = if let Some(prs_loading) = prs_loading.clone() {
-        let prs_tx = tx.clone();
-        let prs_repo = repo.clone();
-        let prs_warnings = Arc::clone(&stashed_warnings);
-        let prs_grid = Arc::clone(&grid_slot);
-        let prs_orchestrator = Arc::clone(&orchestrator);
-        let prs_render_tx = Arc::clone(&render_tx);
-        Some(
-            std::thread::Builder::new()
-                .name("picker-prs".into())
-                .spawn(move || {
-                    prs::stream_open_prs(
-                        &prs_repo,
-                        &prs::PrsLayout {
-                            list_width: skim_list_width,
-                            preview_dims,
-                        },
-                        &prs_tx,
-                        &prs_warnings,
-                        &prs_grid,
-                        &prs_orchestrator,
-                        &prs::PrsStreamSignal {
-                            pending: &prs_loading,
-                            render_tx: &prs_render_tx,
-                        },
-                    );
-                })
-                .context("Failed to spawn picker-prs thread")?,
-        )
-    } else {
-        None
-    };
-
-    // Drop main-thread copies so the bg threads' `tx` clones are the last
-    // senders (their drop is what signals EOF to skim's reader). The dry run
-    // keeps the handler: skim never runs there, so the EOF contract doesn't
-    // apply, and the dump below reads its rendered rows.
-    drop(tx);
+    // The dry run keeps the handler: skim never runs there, so the EOF contract
+    // doesn't apply, and the dump below reads its rendered rows.
     let dry_run_handler = is_dry_run.then_some(handler);
 
     // Dry-run / preview-bench: skim is bypassed. Wait for collect (which
@@ -1061,7 +1188,7 @@ pub fn handle_picker(
     // the hot path.
     if skip_tui {
         drop(rx);
-        let _ = bg_handle.join();
+        let _ = collect_handle.join();
         // Join the `--prs` thread (present only for the dry-run, not the bench)
         // so its forge fetch and row render run to completion before we dump
         // and exit — this normal-exit path is what gives the streaming code its
@@ -1099,13 +1226,13 @@ pub fn handle_picker(
     // handler pushes repaints through `render_tx` (filled inside `run_skim`)
     // as it mutates rows in place.
     //
-    // Don't join `bg_handle` after skim exits: drain may still be running
+    // Don't join `collect_handle` after skim exits: drain may still be running
     // network tasks, and joining would block exit for up to DRAIN_TIMEOUT
     // (120s). Process exit terminates the bg thread; its git subprocesses
     // are read-only.
     let output = run_skim(options, rx, &render_tx);
-    drop(bg_handle);
-    // Same rationale as `bg_handle`: don't join — the forge call may still be
+    drop(collect_handle);
+    // Same rationale as `collect_handle`: don't join — the forge call may still be
     // in flight, and process exit terminates the thread (its `gh`/`glab`
     // subprocess is read-only).
     drop(prs_handle);
@@ -1229,6 +1356,77 @@ fn install_preview_tab_keybindings(keymap: &mut skim::binds::KeyMap) {
     }
 }
 
+/// Install the `alt-y` (copy branch) and `alt-o` (open PR/MR URL) row shortcuts
+/// as native callbacks, alongside the preview-tab keys.
+///
+/// Both read the selected row off skim's `App` — its `output()` token, looked up
+/// in `shortcut_table` for the branch / URL — and run the OS action (clipboard,
+/// browser) on a background thread, so skim's event loop never blocks and a slow
+/// clipboard or opener can't freeze the frame. Neither touches the list, so
+/// there's no reload and the cursor stays put. A row with no URL (a worktree
+/// whose PR hasn't resolved, or has none) makes `alt-o` a no-op. Failures are
+/// logged, not surfaced — skim owns the terminal.
+fn install_shortcut_keybindings(keymap: &mut skim::binds::KeyMap, shortcut_table: ShortcutTable) {
+    use skim::binds::parse_key;
+
+    // alt-y: copy the selected row's branch name to the system clipboard.
+    if let Ok(key) = parse_key("alt-y") {
+        let table = Arc::clone(&shortcut_table);
+        keymap.insert(
+            key,
+            vec![Action::Custom(ActionCallback::new_sync(move |app| {
+                let branch = app.item_list.selected().and_then(|m| {
+                    table
+                        .lock()
+                        .unwrap()
+                        .get(m.item.output().as_ref())
+                        .map(|d| d.branch.clone())
+                });
+                if let Some(branch) = branch {
+                    spawn_shortcut("picker-copy", move || os::copy_to_clipboard(&branch));
+                }
+                Ok(Vec::new())
+            }))],
+        );
+    }
+
+    // alt-o: open the selected row's PR/MR URL in the browser.
+    if let Ok(key) = parse_key("alt-o") {
+        let table = Arc::clone(&shortcut_table);
+        keymap.insert(
+            key,
+            vec![Action::Custom(ActionCallback::new_sync(move |app| {
+                let url = app.item_list.selected().and_then(|m| {
+                    table
+                        .lock()
+                        .unwrap()
+                        .get(m.item.output().as_ref())
+                        .and_then(|d| d.url.resolve())
+                });
+                if let Some(url) = url {
+                    spawn_shortcut("picker-open", move || os::open_url(&url));
+                }
+                Ok(Vec::new())
+            }))],
+        );
+    }
+}
+
+/// Run a row shortcut's OS action on a named background thread, logging any
+/// failure — the picker owns the terminal, so an error can't be shown inline.
+fn spawn_shortcut<F>(name: &str, action: F)
+where
+    F: FnOnce() -> anyhow::Result<()> + Send + 'static,
+{
+    let _ = std::thread::Builder::new()
+        .name(name.to_string())
+        .spawn(move || {
+            if let Err(e) = action() {
+                log::warn!("picker: {e:#}");
+            }
+        });
+}
+
 /// Run skim to completion, exposing its event sender for progressive repaints.
 ///
 /// This inlines what `Skim::run_with` does, plus one addition: after the TUI is
@@ -1315,8 +1513,8 @@ pub mod tests {
     use super::items::WorktreeSkimItem;
     use super::{
         PickerAction, PickerCollector, PickerRemovalTarget, drain_stashed_warnings,
-        install_preview_tab_keybindings, parse_reload_remove_token, picker_item_identifier,
-        resolve_identifier,
+        install_preview_tab_keybindings, install_shortcut_keybindings, parse_reload_remove_token,
+        picker_item_identifier, resolve_identifier,
     };
     use crate::commands::list::model::{ItemKind, ListItem, WorktreeData};
     use crate::commands::worktree::RemoveResult;
@@ -1367,6 +1565,34 @@ pub mod tests {
         specs.extend(["tab", "btab", "shift-btab", "shift-tab"].map(String::from));
         for spec in specs {
             let key = parse_key(&spec).expect("known key spec parses");
+            let chain = keymap
+                .get(&key)
+                .unwrap_or_else(|| panic!("{spec} not bound"));
+            assert_eq!(chain.len(), 1, "{spec} should bind a single action");
+            assert!(
+                matches!(chain[0], Action::Custom(_)),
+                "{spec} should bind a native custom action, got {:?}",
+                chain[0]
+            );
+        }
+    }
+
+    #[test]
+    fn test_install_shortcut_keybindings() {
+        use skim::binds::{KeyMap, parse_key};
+        use skim::prelude::Action;
+
+        // alt-y (copy branch) and alt-o (open URL) bind native custom actions
+        // that read the selected row off skim's `App` and look it up in the
+        // shortcut table — no shell binds, so they work cross-platform. The
+        // callback behavior (clipboard / browser) is driven by the `switch_picker`
+        // PTY tests; here we just assert the wiring, mirroring the tab test above.
+        let mut keymap = KeyMap::default();
+        let table = Arc::new(Mutex::new(std::collections::HashMap::new()));
+        install_shortcut_keybindings(&mut keymap, table);
+
+        for spec in ["alt-y", "alt-o"] {
+            let key = parse_key(spec).expect("known key spec parses");
             let chain = keymap
                 .get(&key)
                 .unwrap_or_else(|| panic!("{spec} not bound"));
@@ -1630,12 +1856,7 @@ pub mod tests {
         repo.run_command(&["branch", "branch-only-feature"])
             .unwrap();
 
-        let collector = PickerCollector {
-            items: Arc::new(Mutex::new(Vec::new())),
-            repo,
-            approvals: Arc::new(Approvals::default()),
-            render_tx: Arc::new(OnceLock::new()),
-        };
+        let collector = test_collector(Arc::new(Mutex::new(Vec::new())), repo);
 
         let target = PickerRemovalTarget::from_signal("branch-only-feature").unwrap();
         let (_planning_repo, result) = collector.prepare_removal(&target).unwrap();
@@ -1653,12 +1874,7 @@ pub mod tests {
         let test = worktrunk::testing::TestRepo::with_initial_commit();
         let repo = worktrunk::git::Repository::at(test.path()).unwrap();
 
-        let collector = PickerCollector {
-            items: Arc::new(Mutex::new(Vec::new())),
-            repo,
-            approvals: Arc::new(Approvals::default()),
-            render_tx: Arc::new(OnceLock::new()),
-        };
+        let collector = test_collector(Arc::new(Mutex::new(Vec::new())), repo);
 
         // `RemoveResult` isn't `Debug`; drop the Ok payload so `unwrap_err`
         // (which needs `T: Debug`) can report a failure cleanly.
@@ -1768,6 +1984,48 @@ pub mod tests {
         )
     }
 
+    /// A [`PickerCollector`] for the removal / `invoke` tests, wrapping the given
+    /// `items` and `repo`. The `factory` is a real [`PipelineFactory`] (empty
+    /// config) — its `spawn()` is only reached by the refresh verb, which these
+    /// tests don't exercise, so the minimal field set is enough to satisfy the
+    /// type without standing up a full picker.
+    fn test_collector(
+        items: Arc<Mutex<Vec<Arc<dyn SkimItem>>>>,
+        repo: worktrunk::git::Repository,
+    ) -> PickerCollector {
+        let orchestrator = Arc::new(super::preview_orchestrator::PreviewOrchestrator::new(
+            repo.clone(),
+        ));
+        let preview_cache = Arc::clone(&orchestrator.cache);
+        let factory = std::rc::Rc::new(super::PipelineFactory {
+            repo: repo.clone(),
+            render_tx: Arc::new(OnceLock::new()),
+            shared_items: Arc::new(Mutex::new(Vec::new())),
+            shortcut_table: Arc::new(Mutex::new(std::collections::HashMap::new())),
+            preview_cache,
+            orchestrator,
+            stashed_warnings: Arc::new(Mutex::new(Vec::new())),
+            grid_slot: Arc::new(super::prs::GridSlot::new()),
+            preview_dims: (80, 24),
+            skim_list_width: 80,
+            command_timeout: None,
+            skip_tasks: std::collections::HashSet::new(),
+            llm_command: None,
+            summary_hint: None,
+            show_branches: false,
+            show_remotes: false,
+            show_prs: false,
+            is_preview_bench: false,
+        });
+        PickerCollector {
+            items,
+            repo,
+            approvals: Arc::new(Approvals::default()),
+            render_tx: Arc::new(OnceLock::new()),
+            factory,
+        }
+    }
+
     /// Two detached worktrees both render the branch label `(detached)`, but
     /// each row's `output()` token carries its unique path. alt-r on the
     /// second row must remove exactly that worktree — not the first detached
@@ -1823,12 +2081,7 @@ pub mod tests {
             Arc::clone(&first_item),
             Arc::clone(&second_item),
         ]));
-        let mut collector = PickerCollector {
-            items: Arc::clone(&items),
-            repo: repo.clone(),
-            approvals: Arc::new(Approvals::default()),
-            render_tx: Arc::new(OnceLock::new()),
-        };
+        let mut collector = test_collector(Arc::clone(&items), repo.clone());
 
         // skim's `reload(remove {})` hands invoke `remove <single-quoted token>`.
         let cmd = format!("remove '{second_output}'");
@@ -1861,12 +2114,7 @@ pub mod tests {
         let repo = worktrunk::git::Repository::at(test.path()).unwrap();
         let item = branch_only_picker_item("some-branch");
         let items = Arc::new(Mutex::new(vec![Arc::clone(&item)]));
-        let mut collector = PickerCollector {
-            items: Arc::clone(&items),
-            repo,
-            approvals: Arc::new(Approvals::default()),
-            render_tx: Arc::new(OnceLock::new()),
-        };
+        let mut collector = test_collector(Arc::clone(&items), repo);
         let (_rx, _interrupt) = collector.invoke("remove ''", Arc::new(AtomicUsize::new(0)));
         assert_eq!(
             items.lock().unwrap().len(),

--- a/src/commands/picker/os.rs
+++ b/src/commands/picker/os.rs
@@ -1,0 +1,30 @@
+//! OS integration for the picker's row shortcuts: copy a branch name to the
+//! system clipboard (`alt-y`) and open a row's PR/MR URL in the browser
+//! (`alt-o`).
+//!
+//! Both run on a background thread off skim's event loop, and neither can write
+//! to the picker frame (skim owns the terminal), so the caller logs a failure
+//! rather than surfacing it — see `PickerCollector`'s copy/open verbs.
+
+use anyhow::Context;
+
+/// Copy `text` to the system clipboard.
+///
+/// macOS, Windows, and Wayland persist the copy after `wt` exits. On Linux/X11
+/// the selection is served by `arboard` only while this process holds it, so a
+/// copy survives past exit only if a clipboard manager captured it — the same
+/// caveat as `xclip`/`xsel` without `-loops`. The picker is short-lived, so the
+/// copy is meant to be pasted promptly regardless.
+pub(super) fn copy_to_clipboard(text: &str) -> anyhow::Result<()> {
+    let mut clipboard = arboard::Clipboard::new().context("Failed to open the system clipboard")?;
+    clipboard
+        .set_text(text.to_owned())
+        .context("Failed to copy to the system clipboard")
+}
+
+/// Open `url` in the user's default browser via the OS opener (`open` on macOS,
+/// `xdg-open` on Linux). Fire-and-forget: the opener detaches, so this returns
+/// as soon as it's launched.
+pub(super) fn open_url(url: &str) -> anyhow::Result<()> {
+    open::that(url).with_context(|| format!("Failed to open {url}"))
+}

--- a/src/commands/picker/progressive_handler.rs
+++ b/src/commands/picker/progressive_handler.rs
@@ -32,7 +32,7 @@
 //!   that pool's injector while row tasks are still landing on
 //!   workers' local deques during drain.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Mutex, OnceLock};
@@ -48,7 +48,10 @@ use worktrunk::styling::{StyledLine, strip_osc8_hyperlinks};
 /// `Event::Render` bypasses skim's own frame-rate cap, so we cap it here.
 const RENDER_THROTTLE: Duration = Duration::from_millis(16);
 
-use super::items::{HeaderLoading, HeaderSkimItem, PrStatusSlot, PreviewCache, WorktreeSkimItem};
+use super::items::{
+    HeaderLoading, HeaderSkimItem, PrStatusSlot, PreviewCache, RowShortcutData, RowUrl,
+    ShortcutTable, WorktreeSkimItem, worktree_output_token,
+};
 use super::preview::PreviewMode;
 use super::preview_orchestrator::PreviewOrchestrator;
 use crate::commands::list::collect::PickerProgressHandler;
@@ -75,6 +78,10 @@ pub(super) struct PickerHandler {
     /// Mirror of the skim item vec visible to `PickerCollector`. Populated
     /// atomically in `on_skeleton`.
     pub(super) shared_items: Arc<Mutex<Vec<Arc<dyn SkimItem>>>>,
+    /// The `alt-y` / `alt-o` lookup table (token → branch + URL). Replaced
+    /// atomically in `on_skeleton` with this skeleton's worktree/branch rows;
+    /// the `--prs` thread extends it with PR/MR rows. See [`ShortcutTable`].
+    pub(super) shortcut_table: ShortcutTable,
     /// One `Arc<Mutex<String>>` per data row — same Arcs `WorktreeSkimItem`
     /// holds. Set once in `on_skeleton`, read lock-free thereafter.
     pub(super) rendered_slots: OnceLock<Box<[Arc<Mutex<String>>]>>,
@@ -145,6 +152,11 @@ impl PickerProgressHandler for PickerHandler {
         let mut pr_slots: Vec<PrStatusSlot> = Vec::with_capacity(items.len());
         let mut skim_items: Vec<Arc<dyn SkimItem>> = Vec::with_capacity(items.len() + 1);
         let mut list_items: Vec<Arc<ListItem>> = Vec::with_capacity(items.len());
+        // `alt-y` / `alt-o` lookup entries for this skeleton's rows, keyed by the
+        // same `output()` token the rows carry. Replaces the table wholesale below
+        // (a refresh re-collect rebuilds it); the `--prs` thread extends it later.
+        let mut shortcut_map: HashMap<String, RowShortcutData> =
+            HashMap::with_capacity(items.len());
 
         // Synchronous skeleton-time tab-availability facts (see `TabAvailability`).
         // Branches with an upstream tracking ref drive the tab-4 (remote⇅) empty
@@ -248,6 +260,16 @@ impl PickerProgressHandler for PickerHandler {
             let pr_status_arc: PrStatusSlot = Arc::new(Mutex::new(item_arc.pr_status.clone()));
             pr_slots.push(Arc::clone(&pr_status_arc));
 
+            // Shortcut lookup for this row: `alt-y` copies `branch`, `alt-o`
+            // opens the URL once the live `pr_status` slot reports one.
+            shortcut_map.insert(
+                worktree_output_token(&item_arc, &branch_name),
+                RowShortcutData {
+                    branch: branch_name.clone(),
+                    url: RowUrl::Live(Arc::clone(&pr_status_arc)),
+                },
+            );
+
             skim_items.push(Arc::new(WorktreeSkimItem {
                 search_text,
                 rendered: rendered_arc,
@@ -266,6 +288,7 @@ impl PickerProgressHandler for PickerHandler {
         let _ = self.rendered_slots.set(slots.into_boxed_slice());
         let _ = self.pr_status_slots.set(pr_slots.into_boxed_slice());
         *self.shared_items.lock().unwrap() = skim_items.clone();
+        *self.shortcut_table.lock().unwrap() = shortcut_map;
 
         // skim 4.x's item channel carries Vec batches; the skeleton is a single
         // batch. This append wakes skim's reader (`items_available`) and drives
@@ -369,6 +392,7 @@ mod tests {
             render_tx: Arc::new(OnceLock::new()),
             last_render_poke: Mutex::new(Instant::now()),
             shared_items,
+            shortcut_table: Arc::new(Mutex::new(std::collections::HashMap::new())),
             rendered_slots: OnceLock::new(),
             pr_status_slots: OnceLock::new(),
             preview_cache,
@@ -477,6 +501,19 @@ mod tests {
         assert_eq!(shared.len(), 3);
         assert_eq!(shared[1].output().as_ref(), "feat-a");
         assert_eq!(shared[2].output().as_ref(), "feat-b");
+
+        // The shortcut table is keyed by each row's `output()` token (the branch
+        // name for these branch-only rows) and carries the branch for `alt-y`.
+        let table = handler.shortcut_table.lock().unwrap();
+        assert_eq!(table.len(), 2);
+        assert_eq!(
+            table.get("feat-a").map(|d| d.branch.as_str()),
+            Some("feat-a")
+        );
+        assert_eq!(
+            table.get("feat-b").map(|d| d.branch.as_str()),
+            Some("feat-b")
+        );
     }
 
     /// `on_skeleton` folds each row's gutter glyph onto the end of the

--- a/src/commands/picker/prs.rs
+++ b/src/commands/picker/prs.rs
@@ -58,7 +58,8 @@ use super::super::list::ci_status::{
 use super::super::list::columns::ColumnKind;
 use super::super::list::layout::ColumnGrid;
 use super::items::{
-    PreviewCache, TabAvailability, WorktreeSkimItem, ansi_to_line, render_preview_tabs,
+    PreviewCache, RowShortcutData, RowUrl, ShortcutTable, TabAvailability, WorktreeSkimItem,
+    ansi_to_line, render_preview_tabs,
 };
 use super::pr_pane;
 use super::preview::{PreviewMode, PreviewStateData};
@@ -195,6 +196,15 @@ pub(super) struct PrsLayout {
     pub preview_dims: (usize, usize),
 }
 
+/// The structures the `--prs` thread coordinates with the collect side: the
+/// column-geometry handoff that aligns PR rows with the worktree grid, and the
+/// `alt-y` / `alt-o` shortcut table it extends with PR/MR rows. Bundled so the
+/// streaming entry points stay within the argument budget.
+pub(super) struct PrsShared {
+    pub grid_slot: Arc<GridSlot>,
+    pub shortcut_table: ShortcutTable,
+}
+
 /// Stream the open PRs/MRs into the picker, then clear the header's "loading…"
 /// marker — whatever the outcome.
 ///
@@ -208,11 +218,11 @@ pub(super) fn stream_open_prs(
     layout: &PrsLayout,
     tx: &SkimItemSender,
     stashed_warnings: &Mutex<Vec<String>>,
-    grid_slot: &GridSlot,
     orchestrator: &PreviewOrchestrator,
+    shared: &PrsShared,
     signal: &PrsStreamSignal,
 ) {
-    fetch_and_stream(repo, layout, tx, stashed_warnings, grid_slot, orchestrator);
+    fetch_and_stream(repo, layout, tx, stashed_warnings, orchestrator, shared);
 
     signal.pending.store(false, Ordering::Relaxed);
     if let Some(tx) = signal.render_tx.get() {
@@ -230,8 +240,8 @@ fn fetch_and_stream(
     layout: &PrsLayout,
     tx: &SkimItemSender,
     stashed_warnings: &Mutex<Vec<String>>,
-    grid_slot: &GridSlot,
     orchestrator: &PreviewOrchestrator,
+    shared: &PrsShared,
 ) {
     let entries = match fetch_open_prs(repo) {
         Ok(entries) => entries,
@@ -256,7 +266,7 @@ fn fetch_and_stream(
     // The forge call above (~1s) almost always outlasts the skeleton
     // (~50ms), so this returns immediately; the wait covers a mocked forge
     // CLI winning the race.
-    let grid = grid_slot.wait(Duration::from_secs(5));
+    let grid = shared.grid_slot.wait(Duration::from_secs(5));
 
     // skim 4.x takes a batch per send; the forge call already returned every
     // row, so stream them in one shot. As each row is built, kick off its
@@ -267,6 +277,15 @@ fn fetch_and_stream(
         .into_iter()
         .map(|entry| {
             spawn_pr_previews(orchestrator, &entry, layout.preview_dims);
+            // Shortcut lookup for this row: `alt-y` copies the PR/MR head
+            // branch, `alt-o` opens its already-known web URL.
+            shared.shortcut_table.lock().unwrap().insert(
+                entry.output_token(),
+                RowShortcutData {
+                    branch: entry.head_branch.clone(),
+                    url: RowUrl::Static(entry.url.clone()),
+                },
+            );
             Arc::new(PrSkimItem::new(
                 entry,
                 layout.list_width,
@@ -1600,9 +1619,12 @@ mod tests {
         let test = worktrunk::testing::TestRepo::with_initial_commit();
         let (tx, _rx): (SkimItemSender, SkimItemReceiver) = unbounded();
         let warnings = Mutex::new(Vec::new());
-        let grid = GridSlot::new();
         let orchestrator = PreviewOrchestrator::new(test.repo.clone());
         let loading = AtomicBool::new(true);
+        let shared = PrsShared {
+            grid_slot: Arc::new(GridSlot::new()),
+            shortcut_table: Arc::new(Mutex::new(std::collections::HashMap::new())),
+        };
         let (rtx, mut rrx) = tokio::sync::mpsc::channel(8);
         let render_tx = OnceLock::new();
         render_tx.set(rtx).unwrap();
@@ -1615,8 +1637,8 @@ mod tests {
             },
             &tx,
             &warnings,
-            &grid,
             &orchestrator,
+            &shared,
             &PrsStreamSignal {
                 pending: &loading,
                 render_tx: &render_tx,

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__branch_diff.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__branch_diff.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "render_preview_tabs(mode, wt, WIDE)"
 ---
 1: [2mHEAD±[22m[0m | 2: [2mlog[22m[0m | 3: [1mmain…±[22m[0m | 4: [2mremote⇅[22m[0m | 5: [2msummary[22m[0m | [2m6:[22m [2mpr[22m[0m | [2m7:[22m [2mcomments[22m[0m
-[33m[2mEnter: switch | Tab/alt-1…7: preview | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m
+[33m[2mEnter: switch | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Tab/alt-1…7: preview | ctrl-u/d: scroll | Esc: cancel[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__empty_upstream_and_summary.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__empty_upstream_and_summary.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "render_preview_tabs(PreviewMode::WorkingTree,\nTabAvailability::worktree(false, false, false), WIDE,)"
 ---
 1: [1mHEAD±[22m[0m | 2: [2mlog[22m[0m | 3: [2mmain…±[22m[0m | [2m4:[22m [2mremote⇅[22m[0m | [2m5:[22m [2msummary[22m[0m | [2m6:[22m [2mpr[22m[0m | [2m7:[22m [2mcomments[22m[0m
-[33m[2mEnter: switch | Tab/alt-1…7: preview | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m
+[33m[2mEnter: switch | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Tab/alt-1…7: preview | ctrl-u/d: scroll | Esc: cancel[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__log.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__log.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "render_preview_tabs(mode, wt, WIDE)"
 ---
 1: [2mHEAD±[22m[0m | 2: [1mlog[22m[0m | 3: [2mmain…±[22m[0m | 4: [2mremote⇅[22m[0m | 5: [2msummary[22m[0m | [2m6:[22m [2mpr[22m[0m | [2m7:[22m [2mcomments[22m[0m
-[33m[2mEnter: switch | Tab/alt-1…7: preview | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m
+[33m[2mEnter: switch | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Tab/alt-1…7: preview | ctrl-u/d: scroll | Esc: cancel[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__pr.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__pr.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "render_preview_tabs(mode, wt, WIDE)"
 ---
 1: [2mHEAD±[22m[0m | 2: [2mlog[22m[0m | 3: [2mmain…±[22m[0m | 4: [2mremote⇅[22m[0m | 5: [2msummary[22m[0m | [2m6:[22m [1mpr[22m[0m | [2m7:[22m [2mcomments[22m[0m
-[33m[2mEnter: switch | Tab/alt-1…7: preview | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m
+[33m[2mEnter: switch | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Tab/alt-1…7: preview | ctrl-u/d: scroll | Esc: cancel[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__pr_row.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__pr_row.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "render_preview_tabs(PreviewMode::Pr, TabAvailability::pull_request(), WIDE)"
 ---
 [2m1:[22m [2mHEAD±[22m[0m | 2: [2mlog[22m[0m | [2m3:[22m [2mmain…±[22m[0m | [2m4:[22m [2mremote⇅[22m[0m | [2m5:[22m [2msummary[22m[0m | 6: [1mpr[22m[0m | 7: [2mcomments[22m[0m
-[33m[2mEnter: switch | Tab/alt-1…7: preview | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m
+[33m[2mEnter: switch | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Tab/alt-1…7: preview | ctrl-u/d: scroll | Esc: cancel[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__summary.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__summary.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "render_preview_tabs(mode, wt, WIDE)"
 ---
 1: [2mHEAD±[22m[0m | 2: [2mlog[22m[0m | 3: [2mmain…±[22m[0m | 4: [2mremote⇅[22m[0m | 5: [1msummary[22m[0m | [2m6:[22m [2mpr[22m[0m | [2m7:[22m [2mcomments[22m[0m
-[33m[2mEnter: switch | Tab/alt-1…7: preview | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m
+[33m[2mEnter: switch | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Tab/alt-1…7: preview | ctrl-u/d: scroll | Esc: cancel[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__upstream_diff.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__upstream_diff.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "render_preview_tabs(mode, wt, WIDE)"
 ---
 1: [2mHEAD±[22m[0m | 2: [2mlog[22m[0m | 3: [2mmain…±[22m[0m | 4: [1mremote⇅[22m[0m | 5: [2msummary[22m[0m | [2m6:[22m [2mpr[22m[0m | [2m7:[22m [2mcomments[22m[0m
-[33m[2mEnter: switch | Tab/alt-1…7: preview | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m
+[33m[2mEnter: switch | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Tab/alt-1…7: preview | ctrl-u/d: scroll | Esc: cancel[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__working_tree.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__working_tree.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "render_preview_tabs(mode, wt, WIDE)"
 ---
 1: [1mHEAD±[22m[0m | 2: [2mlog[22m[0m | 3: [2mmain…±[22m[0m | 4: [2mremote⇅[22m[0m | 5: [2msummary[22m[0m | [2m6:[22m [2mpr[22m[0m | [2m7:[22m [2mcomments[22m[0m
-[33m[2mEnter: switch | Tab/alt-1…7: preview | alt-c: create | Esc: cancel | ctrl-u/d: scroll | alt-p: toggle[39m[22m[0m
+[33m[2mEnter: switch | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Tab/alt-1…7: preview | ctrl-u/d: scroll | Esc: cancel[39m[22m[0m

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -1707,12 +1707,12 @@ fn test_switch_picker_pre_switch_hook_requires_approval(mut repo: TestRepo) {
     assert!(!marker.exists(), "a declined pre-switch hook must not run");
 }
 
-/// Drive the picker to remove the first non-current worktree with alt-r, then
+/// Drive the picker to remove the first non-current worktree with alt-x, then
 /// switch — capturing the screen between steps so the assertion doesn't depend on
 /// the picker's commit-recency row order. Returns `(landing_branch, final_screen,
 /// exit_code)`, where `landing_branch` is the worktree that slid into the removed
 /// row's slot (the row the sticky cursor must land on).
-fn drive_alt_r_then_switch(
+fn drive_alt_x_then_switch(
     args: &[&str],
     working_dir: &Path,
     env_vars: &[(String, String)],
@@ -1767,7 +1767,7 @@ fn drive_alt_r_then_switch(
     wait_for_stable_with_content(&rx, &mut parser, Some(candidates[0]));
 
     // Learn the row order: the candidate on the earlier list line is row 1 — the
-    // one Down lands on and alt-r removes; the other is the sticky landing row.
+    // one Down lands on and alt-x removes; the other is the sticky landing row.
     let (row1, row2) = {
         let screen = parser.screen();
         let list = screen
@@ -1794,10 +1794,10 @@ fn drive_alt_r_then_switch(
         Some(&format!("{row1} has no uncommitted changes")),
     );
 
-    // alt-r removes row 1; the cursor must stick to its slot — now holding row 2.
+    // alt-x removes row 1; the cursor must stick to its slot — now holding row 2.
     // Gating on row 2's preview *is* the sticky assertion: a cursor reset to the
     // top would show the current worktree's preview and time this out.
-    send(&writer, b"\x1br");
+    send(&writer, b"\x1bx");
     wait_for_stable_with_content(
         &rx,
         &mut parser,
@@ -1822,19 +1822,19 @@ fn drive_alt_r_then_switch(
     (row2.to_string(), parser.screen().contents(), exit_code)
 }
 
-/// alt-r keeps the cursor on the removed row's slot. After removing the first
+/// alt-x keeps the cursor on the removed row's slot. After removing the first
 /// non-current worktree, the cursor stays on the row that slides up (the next
 /// worktree), so Enter switches there — not back to the current worktree at the
 /// top, which is where skim's reload would otherwise reset the cursor.
 #[rstest]
-fn test_switch_picker_alt_r_keeps_cursor_sticky(mut repo: TestRepo) {
+fn test_switch_picker_alt_x_keeps_cursor_sticky(mut repo: TestRepo) {
     repo.remove_fixture_worktrees();
     repo.run_git(&["remote", "remove", "origin"]);
     repo.add_worktree("wt-keep");
     repo.add_worktree("wt-drop");
 
     let env_vars = repo.test_env_vars();
-    let (landing, screen, exit_code) = drive_alt_r_then_switch(
+    let (landing, screen, exit_code) = drive_alt_x_then_switch(
         &["switch", "--no-cd", "--format=json"],
         repo.root_path(),
         &env_vars,
@@ -1843,7 +1843,7 @@ fn test_switch_picker_alt_r_keeps_cursor_sticky(mut repo: TestRepo) {
 
     assert_eq!(
         exit_code, 0,
-        "switch after alt-r should exit 0.\nScreen:\n{screen}"
+        "switch after alt-x should exit 0.\nScreen:\n{screen}"
     );
     // The structured result reaches stdout only after the switch pipeline ran;
     // it targets the sticky row, not the current worktree.
@@ -1862,7 +1862,7 @@ fn test_switch_picker_alt_r_keeps_cursor_sticky(mut repo: TestRepo) {
 /// spinning the event loop. The picker stays responsive — its screen stabilizes,
 /// then aborts cleanly.
 #[rstest]
-fn test_switch_picker_alt_r_no_match_stays_responsive(mut repo: TestRepo) {
+fn test_switch_picker_alt_x_no_match_stays_responsive(mut repo: TestRepo) {
     repo.remove_fixture_worktrees();
     repo.run_git(&["remote", "remove", "origin"]);
     repo.add_worktree("solo-wt");
@@ -1875,7 +1875,7 @@ fn test_switch_picker_alt_r_no_match_stays_responsive(mut repo: TestRepo) {
         &env_vars,
         &[
             ("solo-wt", Some("solo-wt")), // filter to the sole matching worktree
-            ("\x1br", None),              // alt-r removes it; query now matches nothing
+            ("\x1bx", None),              // alt-x removes it; query now matches nothing
         ],
     );
 

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -178,17 +178,23 @@ The CI column shows each row's PR/MR CI and review status, the same as [2mwt li
 
 [1mKeybindings:[0m
 
-      Key                       Action                   
- ───────────── ───────────────────────────────────────── 
- [2m↑[0m/[2m↓[0m           Navigate worktree list                    
- (type)        Filter worktrees                          
- [2mEnter[0m         Switch to selected worktree               
- [2mAlt-c[0m         Create new worktree named as entered text 
- [2mEsc[0m           Cancel                                    
- [2mAlt-1[0m–[2mAlt-7[0m   Jump to a preview tab                     
- [2mTab[0m/[2mShift-Tab[0m Cycle preview tabs forward/backward       
- [2mAlt-p[0m         Toggle preview panel                      
- [2mCtrl-u[0m/[2mCtrl-d[0m Scroll preview up/down                    
+      Key                              Action                         
+ ───────────── ────────────────────────────────────────────────────── 
+ [2m↑[0m/[2m↓[0m           Navigate worktree list                                 
+ (type)        Filter worktrees                                       
+ [2mEnter[0m         Switch to selected worktree                            
+ [2mAlt-c[0m         Create new worktree named as entered text              
+ [2mAlt-x[0m         Remove selected worktree/branch                        
+ [2mAlt-y[0m         Copy selected branch name to the clipboard             
+ [2mAlt-o[0m         Open the selected row's PR/MR URL in the browser       
+ [2mAlt-r[0m         Refresh the list (pick up worktrees created elsewhere) 
+ [2mEsc[0m           Cancel                                                 
+ [2mAlt-1[0m–[2mAlt-7[0m   Jump to a preview tab                                  
+ [2mTab[0m/[2mShift-Tab[0m Cycle preview tabs forward/backward                    
+ [2mAlt-p[0m         Toggle preview panel                                   
+ [2mCtrl-u[0m/[2mCtrl-d[0m Scroll preview up/down                                 
+
+Discrete actions live on [2mAlt[0m. [2mAlt-y[0m and [2mAlt-o[0m run in the background — the picker stays open — and [2mAlt-o[0m is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
 
 Plain digits go to the filter, so a branch name containing a number can be typed directly; the preview tabs move to [2mAlt[0m.
 

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -194,7 +194,7 @@ The CI column shows each row's PR/MR CI and review status, the same as [2mwt li
  [2mAlt-p[0m         Toggle preview panel                                   
  [2mCtrl-u[0m/[2mCtrl-d[0m Scroll preview up/down                                 
 
-Discrete actions live on [2mAlt[0m. [2mAlt-y[0m and [2mAlt-o[0m run in the background — the picker stays open — and [2mAlt-o[0m is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
+[2mAlt-o[0m is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
 
 Plain digits go to the filter, so a branch name containing a number can be typed directly; the preview tabs move to [2mAlt[0m.
 

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_abort_escape_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_abort_escape_preview.snap
@@ -3,6 +3,6 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± 2 3 4 5 6 7
-Enter: switch | Tab/alt-1…7: preview | alt-c: create | Esc:
+Enter: switch | alt-c: create | alt-x: remove | alt-y: copy
 
 ○ main has no uncommitted changes

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_multiple_worktrees_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_multiple_worktrees_preview.snap
@@ -3,6 +3,6 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± 2 3 4 5 6 7
-Enter: switch | Tab/alt-1…7: preview | alt-c: create | Esc:
+Enter: switch | alt-c: create | alt-x: remove | alt-y: copy
 
 ○ main has no uncommitted changes

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_log_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_log_preview.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1 2: log 3 4 5 6 7
-Enter: switch | Tab/alt-1…7: preview | alt-c: create | Esc:
+Enter: switch | alt-c: create | alt-x: remove | alt-y: copy
 
 * [HASH]   +1        [TIME] (feature) Add file 5 with content
 * [HASH]   +1        [TIME] Add file 4 with content

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_main_diff_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_main_diff_preview.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1 2 3: main…± 4 5 6 7
-Enter: switch | Tab/alt-1…7: preview | alt-c: create | Esc:
+Enter: switch | alt-c: create | alt-x: remove | alt-y: copy
 
  feature_code.rs | 6 ++++++
  tests.rs        | 4 ++++

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_summary_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_summary_preview.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1 2 3 4 5: summary 6 7
-Enter: switch | Tab/alt-1…7: preview | alt-c: create | Esc:
+Enter: switch | alt-c: create | alt-x: remove | alt-y: copy
 
 Configure [commit.generation] command to enable LLM summari
 

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_uncommitted_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_uncommitted_preview.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± 2 3 4 5 6 7
-Enter: switch | Tab/alt-1…7: preview | alt-c: create | Esc:
+Enter: switch | alt-c: create | alt-x: remove | alt-y: copy
 
  tracked.txt | 4 +++-
  1 file changed, 3 insertions(+), 1 deletion(-)

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_with_branches_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_with_branches_preview.snap
@@ -3,6 +3,6 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± 2 3 4 5 6 7
-Enter: switch | Tab/alt-1…7: preview | alt-c: create | Esc:
+Enter: switch | alt-c: create | alt-x: remove | alt-y: copy
 
 ○ main has no uncommitted changes


### PR DESCRIPTION
Adds four keyboard shortcuts to the interactive `wt switch` picker:

- `alt-y` — copy the selected branch name to the system clipboard
- `alt-o` — open the selected row's PR/MR in the browser
- `alt-r` — refresh the worktree list (pick up worktrees created elsewhere)
- `alt-x` — remove the selected worktree/branch (remapped from `alt-r`)

## Approach

`alt-y` and `alt-o` are native skim `Action::Custom` callbacks that read the selected row off `App.item_list` and run the OS action on a background thread — no `reload`, so the cursor doesn't reset and `--prs` rows aren't dropped. A side table keyed by each row's `output()` token maps to the row's branch and URL, which avoids skim's unreliable cross-thread downcasting.

`alt-r` refresh re-enters the collect pipeline via a new `PipelineFactory`, extracted so startup and refresh build the pipeline identically; worktrees and branches created outside the session then appear without reopening the picker.

The one breaking change is the `alt-r` → `alt-x` remap for remove. It fails safe — an old-habit `alt-r` now refreshes rather than removes.

## Key files

- `src/commands/picker/mod.rs` — `PipelineFactory`, `install_shortcut_keybindings`, the refresh branch in `invoke`, and the bind block
- `src/commands/picker/os.rs` (new) — `copy_to_clipboard` / `open_url` via `arboard` + `open`
- `src/commands/picker/items.rs` — the row-shortcut side table and the controls line
- `src/cli/mod.rs` — the keybindings table and help text

New cross-platform dependencies: `arboard` (clipboard, with its `image` feature dropped) and `open` (browser launch), both gated behind the `cli` feature.

## Testing

Unit tests cover the keybinding wiring, the row → branch/URL resolution, and the refresh/remove dispatch; PTY tests cover the alt-x sticky-cursor reposition and the unmerged-branch-keep path. The OS side effects themselves — the clipboard write and the browser launch — are not asserted (both are headless-hostile in CI), so they want a manual check on a desktop; they work on macOS, with the one documented limitation being X11 without a clipboard manager.

> _This was written by Claude Code on behalf of max_
