### PR TITLE
feat(list): show the main…± column by default; --full gates only off-machine columns

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,6 +1,15 @@
 [files]
 extend-exclude = ["docs/demos/vhs-keystrokes/", "*.snap", "vendor/", "*.log"]
 
+[default]
+# Generated `wt list` doc embeds (README, docs/content, skills mirrors) truncate
+# long commit messages with a trailing … . The cut leaves a word fragment glued
+# to the ellipsis (e.g. "authenticat…"), which typos would "correct" to the full
+# word — re-breaking the doc-sync test on every run. A token immediately followed
+# by … is a truncation, not a typo; *.snap is already excluded, this covers the
+# rendered mirrors that embed the same output.
+extend-ignore-re = ['\w+…']
+
 [default.extend-identifiers]
 # "PNGs" is correct (Portable Network Graphics plural). The plural form
 # tokenizes to the word "PN", which typos would otherwise correct to "ON";

--- a/README.md
+++ b/README.md
@@ -163,9 +163,9 @@ This creates a new branch and worktree, then switches to it. Do your work, then 
 
 ```console
 $ wt list
-  Branch        Status        HEAD±    main↕  Remote⇅  Commit    Age   Message
-@ feature-auth  +   ↑      +27   -8   ↑1               4bc72dc9  2h    Add authentication module
-^ main              ^⇡                         ⇡1      0e631add  1d    Initial commit
+  Branch        Status        HEAD±    main↕     main…±  Remote⇅  Commit    Age   Message
+@ feature-auth  +   ↑      +27   -8   ↑1       +31                4bc72dc9  2h    Add authenticat…
+^ main              ^⇡                                    ⇡1      0e631add  1d    Initial commit
 
 ○ Showing 2 worktrees, 1 with changes, 1 ahead, 1 column hidden
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ This creates a new branch and worktree, then switches to it. Do your work, then 
 ```console
 $ wt list
   Branch        Status        HEAD±    main↕     main…±  Remote⇅  Commit    Age   Message
-@ feature-auth  +   ↑      +27   -8   ↑1       +31                4bc72dc9  2h    Add authenticat…
+@ feature-auth  +   ↑      +27   -8   ↑1       +31                4bc72dc9  2h    Add authenticate…
 ^ main              ^⇡                                    ⇡1      0e631add  1d    Initial commit
 
 ○ Showing 2 worktrees, 1 with changes, 1 ahead, 1 column hidden

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ This creates a new branch and worktree, then switches to it. Do your work, then 
 ```console
 $ wt list
   Branch        Status        HEAD±    main↕     main…±  Remote⇅  Commit    Age   Message
-@ feature-auth  +   ↑      +27   -8   ↑1       +31                4bc72dc9  2h    Add authenticate…
+@ feature-auth  +   ↑      +27   -8   ↑1       +31                4bc72dc9  2h    Add authenticat…
 ^ main              ^⇡                                    ⇡1      0e631add  1d    Initial commit
 
 ○ Showing 2 worktrees, 1 with changes, 1 ahead, 1 column hidden

--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -95,7 +95,7 @@
 # [list]
 # summary = false    # Enable LLM branch summaries (requires [commit.generation])
 #
-# full = false       # Show CI, main…± diffstat, and LLM summaries (--full)
+# full = false       # Show CI status and LLM summaries (--full)
 # branches = false   # Include branches without worktrees (--branches)
 # remotes = false    # Include remote-only branches (--remotes)
 #

--- a/docs/content/claude-code.md
+++ b/docs/content/claude-code.md
@@ -69,11 +69,11 @@ The Claude Code, OpenCode, and Gemini plugins track agent sessions with status m
 
 {% terminal(cmd="wt list") %}
 <span class="cmd">wt list</span>
-  <b>Branch</b>       <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>  <b>Remote⇅</b>  <b>Path</b>                 <b>Commit</b>    <b>Age</b>   <b>Message</b>
-@ main             <span class=d>^</span><span class=d>⇡</span>                         <span class=g>⇡1</span>      .                    <span class=d>33323bc1</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
-+ feature-api      <span class=d>↑</span> 🤖              <span class=g>↑1</span>               ../repo.feature-api  <span class=d>70343f03</span>  <span class=d>1d</span>    <span class=d>Add REST API endpoints</span>
-+ review-ui      <span class=c>?</span> <span class=d>↑</span> 💬              <span class=g>↑1</span>               ../repo.review-ui    <span class=d>a585d6ed</span>  <span class=d>1d</span>    <span class=d>Add dashboard component</span>
-+ wip-docs       <span class=c>?</span> <span class=d>–</span>                                  ../repo.wip-docs     <span class=d>33323bc1</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
+  <b>Branch</b>       <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>     <b>main…±</b>  <b>Remote⇅</b>  <b>Path</b>                 <b>Commit</b>    <b>Age</b>   <b>Message</b>
+@ main             <span class=d>^</span><span class=d>⇡</span>                                    <span class=g>⇡1</span>      .                    <span class=d>33323bc1</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
++ feature-api      <span class=d>↑</span> 🤖              <span class=g>↑1</span>        <span class=g>+1</span>                ../repo.feature-api  <span class=d>70343f03</span>  <span class=d>1d</span>    <span class=d>Add REST API endpoints</span>
++ review-ui      <span class=c>?</span> <span class=d>↑</span> 💬              <span class=g>↑1</span>        <span class=g>+1</span>                ../repo.review-ui    <span class=d>a585d6ed</span>  <span class=d>1d</span>    <span class=d>Add dashboard component</span>
++ wip-docs       <span class=c>?</span> <span class=d>–</span>                                             ../repo.wip-docs     <span class=d>33323bc1</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
 
 <span class=d>○</span> <span class=d>Showing 4 worktrees, 2 with changes, 2 ahead</span>
 {% end %}

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -182,7 +182,7 @@ Persistent flag values for `wt list`. Override on command line as needed.
 [list]
 summary = false    # Enable LLM branch summaries (requires [commit.generation])
 
-full = false       # Show CI, main…± diffstat, and LLM summaries (--full)
+full = false       # Show CI status and LLM summaries (--full)
 branches = false   # Include branches without worktrees (--branches)
 remotes = false    # Include remote-only branches (--remotes)
 
@@ -1230,11 +1230,11 @@ Custom status text or emoji shown in the `wt list` Status column.
 Markers appear at the end of the Status column, after git symbols:
 
 {% terminal(cmd="wt list") %}
-&#32;&#32;<b>Branch</b>       <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>  <b>Remote⇅</b>  <b>Commit</b>    <b>Age</b>   <b>Message</b>
-@ main             <span class=d>^</span><span class=d>⇡</span>                         <span class=g>⇡1</span>      <span class=d>33323bc1</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
-+ feature-api      <span class=d>↑</span> 🤖              <span class=g>↑1</span>               <span class=d>70343f03</span>  <span class=d>1d</span>    <span class=d>Add REST API endpoints</span>
-+ review-ui      <span class=c>?</span> <span class=d>↑</span> 💬              <span class=g>↑1</span>               <span class=d>a585d6ed</span>  <span class=d>1d</span>    <span class=d>Add dashboard component</span>
-+ wip-docs       <span class=c>?</span> <span class=d>–</span>                                  <span class=d>33323bc1</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
+&#32;&#32;<b>Branch</b>       <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>     <b>main…±</b>  <b>Remote⇅</b>  <b>Commit</b>    <b>Age</b>   <b>Message</b>
+@ main             <span class=d>^</span><span class=d>⇡</span>                                    <span class=g>⇡1</span>      <span class=d>33323bc1</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
++ feature-api      <span class=d>↑</span> 🤖              <span class=g>↑1</span>        <span class=g>+1</span>                <span class=d>70343f03</span>  <span class=d>1d</span>    <span class=d>Add REST API end…</span>
++ review-ui      <span class=c>?</span> <span class=d>↑</span> 💬              <span class=g>↑1</span>        <span class=g>+1</span>                <span class=d>a585d6ed</span>  <span class=d>1d</span>    <span class=d>Add dashboard co…</span>
++ wip-docs       <span class=c>?</span> <span class=d>–</span>                                             <span class=d>33323bc1</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
 
 <span class=d>○</span> <span class=d>Showing 4 worktrees, 2 with changes, 2 ahead, 1 column hidden</span>
 {% end %}

--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -24,23 +24,23 @@ The table renders progressively: branch names, paths, and commit hashes appear i
 
 ## Full mode
 
-`--full` adds columns that require network access or LLM calls: [CI status](#ci-status) (GitHub/GitLab pipeline pass/fail), line diffs since the merge-base, and [LLM-generated summaries](#llm-summaries) of each branch's changes.
+`--full` adds the two columns that reach off-machine: [CI status](#ci-status) (GitHub/GitLab pipeline pass/fail, over the network) and [LLM-generated summaries](#llm-summaries) of each branch's changes. The `main…±` line diffs are local git, so they show by default.
 
 ## Examples
 
 List all worktrees:
 
 {% terminal(cmd="wt list") %}
-&#32;&#32;<b>Branch</b>       <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>  <b>Remote⇅</b>  <b>Commit</b>    <b>Age</b>   <b>Message</b>
-@ feature-api  <span class=c>+</span>   <span class=d>↕</span><span class=d>⇡</span>     <span class=g>+54</span>   <span class=r>-5</span>   <span class=g>↑4</span>  <span class=d><span class=r>↓1</span></span>   <span class=g>⇡3</span>      <span class=d>6814f02a</span>  <span class=d>30m</span>   <span class=d>Add API tests</span>
-^ main             <span class=d>^</span><span class=d>⇅</span>                         <span class=g>⇡1</span>  <span class=d><span class=r>⇣1</span></span>  <span class=d>41ee0834</span>  <span class=d>4d</span>    <span class=d>Merge fix-auth: hardened to…</span>
-+ fix-auth         <span class=d>↕</span><span class=d>|</span>                <span class=g>↑2</span>  <span class=d><span class=r>↓1</span></span>     <span class=d>|</span>     <span class=d>b772e68b</span>  <span class=d>5h</span>    <span class=d>Add secure token storage</span>
-+ <span class=d>fix-typos</span>        <span class=d>_</span><span class=d>|</span>                           <span class=d>|</span>     <span class=d>41ee0834</span>  <span class=d>4d</span>    <span class=d>Merge fix-auth: hardened to…</span>
+&#32;&#32;<b>Branch</b>       <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>     <b>main…±</b>  <b>Remote⇅</b>  <b>Commit</b>    <b>Age</b>   <b>Message</b>
+@ feature-api  <span class=c>+</span>   <span class=d>↕</span><span class=d>⇡</span>     <span class=g>+54</span>   <span class=r>-5</span>   <span class=g>↑4</span>  <span class=d><span class=r>↓1</span></span>  <span class=g>+234</span>  <span class=r>-24</span>   <span class=g>⇡3</span>      <span class=d>6814f02a</span>  <span class=d>30m</span>   <span class=d>Add API tests</span>
+^ main             <span class=d>^</span><span class=d>⇅</span>                                    <span class=g>⇡1</span>  <span class=d><span class=r>⇣1</span></span>  <span class=d>41ee0834</span>  <span class=d>4d</span>    <span class=d>Merge fix-auth:…</span>
++ fix-auth         <span class=d>↕</span><span class=d>|</span>                <span class=g>↑2</span>  <span class=d><span class=r>↓1</span></span>   <span class=g>+25</span>  <span class=r>-11</span>     <span class=d>|</span>     <span class=d>b772e68b</span>  <span class=d>5h</span>    <span class=d>Add secure token…</span>
++ <span class=d>fix-typos</span>        <span class=d>_</span><span class=d>|</span>                                      <span class=d>|</span>     <span class=d>41ee0834</span>  <span class=d>4d</span>    <span class=d>Merge fix-auth:…</span>
 
 <span class=d>○</span> <span class=d>Showing 4 worktrees, 1 with changes, 2 ahead, 1 column hidden</span>
 {% end %}
 
-Include CI status, line diffs, and LLM summaries:
+Include CI status and LLM summaries:
 
 {% terminal(cmd="wt list --full") %}
 &#32;&#32;<b>Branch</b>       <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>     <b>main…±</b>  <b>Summary</b>                                                <b>Remote⇅</b>  <b>CI</b>    <b>Commit</b>
@@ -78,7 +78,7 @@ Output as JSON for scripting:
 | Status | Compact symbols (see below) |
 | HEAD± | Uncommitted changes: +added -deleted lines |
 | main↕ | Commits ahead/behind default branch |
-| main…± | Line diffs since the merge-base (three-dot) with the default branch; `--full` only |
+| main…± | Line diffs since the merge-base (three-dot) with the default branch |
 | Summary | LLM-generated branch summary; requires `--full`, `summary = true`, and [`commit.generation`](@/config.md#commit) <span class="badge-experimental"></span> |
 | Remote⇅ | Commits ahead/behind tracking branch |
 | CI | PR/MR number colored by pipeline status; `--full` only |
@@ -276,7 +276,7 @@ The five change flags map to the [Working tree](#working-tree) symbols (`renamed
 |-------|------|-------------|
 | `ahead` | number | Commits ahead of the default branch |
 | `behind` | number | Commits behind the default branch |
-| `diff` | object | Lines changed vs the default branch: `{added, deleted}`; `--full` only |
+| `diff` | object | Lines changed vs the default branch: `{added, deleted}` |
 
 ### remote object
 
@@ -377,7 +377,7 @@ Usage: <b><span class=c>wt list</span></b> <span class=c>[OPTIONS]</span>
           Include remote branches
 
       <b><span class=c>--full</span></b>
-          Show CI, diff analysis, and LLM summaries
+          Show CI status and LLM summaries
 
       <b><span class=c>--progressive</span></b>
           Show fast info immediately, update with slow info

--- a/docs/content/tips-patterns.md
+++ b/docs/content/tips-patterns.md
@@ -65,13 +65,13 @@ The URL column in `wt list` shows each worktree's dev server:
 
 {% terminal(cmd="wt list") %}
 <span class="cmd">wt list</span>
-  <b>Branch</b>       <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>  <b>Remote⇅</b>  <b>URL</b>                     <b>Commit</b>    <b>Age</b>
-@ main           <span class=c>?</span> <span class=d>^</span><span class=d>⇅</span>                         <span class=g>⇡1</span>  <span class=d><span class=r>⇣1</span></span>  <span class=d>http://localhost:12107</span>  <span class=d>41ee0834</span>  <span class=d>4d</span>
-+ feature-api  <span class=c>+</span>   <span class=d>↕</span><span class=d>⇡</span>     <span class=g>+54</span>   <span class=r>-5</span>   <span class=g>↑4</span>  <span class=d><span class=r>↓1</span></span>   <span class=g>⇡3</span>      <span class=d>http://localhost:10703</span>  <span class=d>6814f02a</span>  <span class=d>30m</span>
-+ fix-auth         <span class=d>↕</span><span class=d>|</span>                <span class=g>↑2</span>  <span class=d><span class=r>↓1</span></span>     <span class=d>|</span>     <span class=d>http://localhost:16460</span>  <span class=d>b772e68b</span>  <span class=d>5h</span>
-+ <span class=d>fix-typos</span>        <span class=d>_</span><span class=d>|</span>                           <span class=d>|</span>     <span class=d>http://localhost:14301</span>  <span class=d>41ee0834</span>  <span class=d>4d</span>
+  <b>Branch</b>       <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>     <b>main…±</b>  <b>Remote⇅</b>  <b>URL</b>                     <b>Commit</b>
+@ main           <span class=c>?</span> <span class=d>^</span><span class=d>⇅</span>                                    <span class=g>⇡1</span>  <span class=d><span class=r>⇣1</span></span>  <span class=d>http://localhost:12107</span>  <span class=d>41ee0834</span>
++ feature-api  <span class=c>+</span>   <span class=d>↕</span><span class=d>⇡</span>     <span class=g>+54</span>   <span class=r>-5</span>   <span class=g>↑4</span>  <span class=d><span class=r>↓1</span></span>  <span class=g>+234</span>  <span class=r>-24</span>   <span class=g>⇡3</span>      <span class=d>http://localhost:10703</span>  <span class=d>6814f02a</span>
++ fix-auth         <span class=d>↕</span><span class=d>|</span>                <span class=g>↑2</span>  <span class=d><span class=r>↓1</span></span>   <span class=g>+25</span>  <span class=r>-11</span>     <span class=d>|</span>     <span class=d>http://localhost:16460</span>  <span class=d>b772e68b</span>
++ <span class=d>fix-typos</span>        <span class=d>_</span><span class=d>|</span>                                      <span class=d>|</span>     <span class=d>http://localhost:14301</span>  <span class=d>41ee0834</span>
 
-<span class=d>○</span> <span class=d>Showing 4 worktrees, 2 with changes, 2 ahead, 2 columns hidden</span>
+<span class=d>○</span> <span class=d>Showing 4 worktrees, 2 with changes, 2 ahead, 3 columns hidden</span>
 {% end %}
 
 <!-- END AUTO-GENERATED -->

--- a/docs/content/worktrunk.md
+++ b/docs/content/worktrunk.md
@@ -157,7 +157,7 @@ This creates a new branch and worktree, then switches to it. Do your work, then 
 {% terminal(cmd="wt list") %}
 <span class="cmd">wt list</span>
   <b>Branch</b>        <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>     <b>main…±</b>  <b>Remote⇅</b>  <b>Commit</b>    <b>Age</b>   <b>Message</b>
-@ feature-auth  <span class=c>+</span>   <span class=d>↑</span>      <span class=g>+27</span>   <span class=r>-8</span>   <span class=g>↑1</span>       <span class=g>+31</span>                <span class=d>4bc72dc9</span>  <span class=d>2h</span>    <span class=d>Add authenticate…</span>
+@ feature-auth  <span class=c>+</span>   <span class=d>↑</span>      <span class=g>+27</span>   <span class=r>-8</span>   <span class=g>↑1</span>       <span class=g>+31</span>                <span class=d>4bc72dc9</span>  <span class=d>2h</span>    <span class=d>Add authenticat…</span>
 ^ main              <span class=d>^</span><span class=d>⇡</span>                                    <span class=g>⇡1</span>      <span class=d>0e631add</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
 
 <span class=d>○</span> <span class=d>Showing 2 worktrees, 1 with changes, 1 ahead, 1 column hidden</span>

--- a/docs/content/worktrunk.md
+++ b/docs/content/worktrunk.md
@@ -156,9 +156,9 @@ This creates a new branch and worktree, then switches to it. Do your work, then 
 
 {% terminal(cmd="wt list") %}
 <span class="cmd">wt list</span>
-  <b>Branch</b>        <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>  <b>Remote⇅</b>  <b>Commit</b>    <b>Age</b>   <b>Message</b>
-@ feature-auth  <span class=c>+</span>   <span class=d>↑</span>      <span class=g>+27</span>   <span class=r>-8</span>   <span class=g>↑1</span>               <span class=d>4bc72dc9</span>  <span class=d>2h</span>    <span class=d>Add authentication module</span>
-^ main              <span class=d>^</span><span class=d>⇡</span>                         <span class=g>⇡1</span>      <span class=d>0e631add</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
+  <b>Branch</b>        <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>     <b>main…±</b>  <b>Remote⇅</b>  <b>Commit</b>    <b>Age</b>   <b>Message</b>
+@ feature-auth  <span class=c>+</span>   <span class=d>↑</span>      <span class=g>+27</span>   <span class=r>-8</span>   <span class=g>↑1</span>       <span class=g>+31</span>                <span class=d>4bc72dc9</span>  <span class=d>2h</span>    <span class=d>Add authenticat…</span>
+^ main              <span class=d>^</span><span class=d>⇡</span>                                    <span class=g>⇡1</span>      <span class=d>0e631add</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
 
 <span class=d>○</span> <span class=d>Showing 2 worktrees, 1 with changes, 1 ahead, 1 column hidden</span>
 {% end %}

--- a/docs/content/worktrunk.md
+++ b/docs/content/worktrunk.md
@@ -157,7 +157,7 @@ This creates a new branch and worktree, then switches to it. Do your work, then 
 {% terminal(cmd="wt list") %}
 <span class="cmd">wt list</span>
   <b>Branch</b>        <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>     <b>main…±</b>  <b>Remote⇅</b>  <b>Commit</b>    <b>Age</b>   <b>Message</b>
-@ feature-auth  <span class=c>+</span>   <span class=d>↑</span>      <span class=g>+27</span>   <span class=r>-8</span>   <span class=g>↑1</span>       <span class=g>+31</span>                <span class=d>4bc72dc9</span>  <span class=d>2h</span>    <span class=d>Add authenticat…</span>
+@ feature-auth  <span class=c>+</span>   <span class=d>↑</span>      <span class=g>+27</span>   <span class=r>-8</span>   <span class=g>↑1</span>       <span class=g>+31</span>                <span class=d>4bc72dc9</span>  <span class=d>2h</span>    <span class=d>Add authenticate…</span>
 ^ main              <span class=d>^</span><span class=d>⇡</span>                                    <span class=g>⇡1</span>      <span class=d>0e631add</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
 
 <span class=d>○</span> <span class=d>Showing 2 worktrees, 1 with changes, 1 ahead, 1 column hidden</span>

--- a/skills/worktrunk/reference/claude-code.md
+++ b/skills/worktrunk/reference/claude-code.md
@@ -73,11 +73,11 @@ The Claude Code, OpenCode, and Gemini plugins track agent sessions with status m
 
 ```bash
 $ wt list
-  <b>Branch</b>       <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>  <b>Remote⇅</b>  <b>Path</b>                 <b>Commit</b>    <b>Age</b>   <b>Message</b>
-@ main             <span class=d>^</span><span class=d>⇡</span>                         <span class=g>⇡1</span>      .                    <span class=d>33323bc1</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
-+ feature-api      <span class=d>↑</span> 🤖              <span class=g>↑1</span>               ../repo.feature-api  <span class=d>70343f03</span>  <span class=d>1d</span>    <span class=d>Add REST API endpoints</span>
-+ review-ui      <span class=c>?</span> <span class=d>↑</span> 💬              <span class=g>↑1</span>               ../repo.review-ui    <span class=d>a585d6ed</span>  <span class=d>1d</span>    <span class=d>Add dashboard component</span>
-+ wip-docs       <span class=c>?</span> <span class=d>–</span>                                  ../repo.wip-docs     <span class=d>33323bc1</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
+  <b>Branch</b>       <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>     <b>main…±</b>  <b>Remote⇅</b>  <b>Path</b>                 <b>Commit</b>    <b>Age</b>   <b>Message</b>
+@ main             <span class=d>^</span><span class=d>⇡</span>                                    <span class=g>⇡1</span>      .                    <span class=d>33323bc1</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
++ feature-api      <span class=d>↑</span> 🤖              <span class=g>↑1</span>        <span class=g>+1</span>                ../repo.feature-api  <span class=d>70343f03</span>  <span class=d>1d</span>    <span class=d>Add REST API endpoints</span>
++ review-ui      <span class=c>?</span> <span class=d>↑</span> 💬              <span class=g>↑1</span>        <span class=g>+1</span>                ../repo.review-ui    <span class=d>a585d6ed</span>  <span class=d>1d</span>    <span class=d>Add dashboard component</span>
++ wip-docs       <span class=c>?</span> <span class=d>–</span>                                             ../repo.wip-docs     <span class=d>33323bc1</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
 
 <span class=d>○</span> <span class=d>Showing 4 worktrees, 2 with changes, 2 ahead</span>
 ```

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -181,7 +181,7 @@ Persistent flag values for `wt list`. Override on command line as needed.
 [list]
 summary = false    # Enable LLM branch summaries (requires [commit.generation])
 
-full = false       # Show CI, main…± diffstat, and LLM summaries (--full)
+full = false       # Show CI status and LLM summaries (--full)
 branches = false   # Include branches without worktrees (--branches)
 remotes = false    # Include remote-only branches (--remotes)
 
@@ -1276,11 +1276,11 @@ Markers appear at the end of the Status column, after git symbols:
 
 ```
 $ wt list
-  Branch       Status        HEAD±    main↕  Remote⇅  Commit    Age   Message
-@ main             ^⇡                         ⇡1      33323bc1  1d    Initial commit
-+ feature-api      ↑ 🤖              ↑1               70343f03  1d    Add REST API endpoints
-+ review-ui      ? ↑ 💬              ↑1               a585d6ed  1d    Add dashboard component
-+ wip-docs       ? –                                  33323bc1  1d    Initial commit
+  Branch       Status        HEAD±    main↕     main…±  Remote⇅  Commit    Age   Message
+@ main             ^⇡                                    ⇡1      33323bc1  1d    Initial commit
++ feature-api      ↑ 🤖              ↑1        +1                70343f03  1d    Add REST API end…
++ review-ui      ? ↑ 💬              ↑1        +1                a585d6ed  1d    Add dashboard co…
++ wip-docs       ? –                                             33323bc1  1d    Initial commit
 
 ○ Showing 4 worktrees, 2 with changes, 2 ahead, 1 column hidden
 ```

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -8,7 +8,7 @@ The table renders progressively: branch names, paths, and commit hashes appear i
 
 ## Full mode
 
-`--full` adds columns that require network access or LLM calls: [CI status](#ci-status) (GitHub/GitLab pipeline pass/fail), line diffs since the merge-base, and [LLM-generated summaries](#llm-summaries) of each branch's changes.
+`--full` adds the two columns that reach off-machine: [CI status](#ci-status) (GitHub/GitLab pipeline pass/fail, over the network) and [LLM-generated summaries](#llm-summaries) of each branch's changes. The `main…±` line diffs are local git, so they show by default.
 
 ## Examples
 
@@ -16,16 +16,16 @@ List all worktrees:
 
 ```
 $ wt list
-  Branch       Status        HEAD±    main↕  Remote⇅  Commit    Age   Message
-@ feature-api  +   ↕⇡     +54   -5   ↑4  ↓1   ⇡3      6814f02a  30m   Add API tests
-^ main             ^⇅                         ⇡1  ⇣1  41ee0834  4d    Merge fix-auth: hardened to…
-+ fix-auth         ↕|                ↑2  ↓1     |     b772e68b  5h    Add secure token storage
-+ fix-typos        _|                           |     41ee0834  4d    Merge fix-auth: hardened to…
+  Branch       Status        HEAD±    main↕     main…±  Remote⇅  Commit    Age   Message
+@ feature-api  +   ↕⇡     +54   -5   ↑4  ↓1  +234  -24   ⇡3      6814f02a  30m   Add API tests
+^ main             ^⇅                                    ⇡1  ⇣1  41ee0834  4d    Merge fix-auth:…
++ fix-auth         ↕|                ↑2  ↓1   +25  -11     |     b772e68b  5h    Add secure token…
++ fix-typos        _|                                      |     41ee0834  4d    Merge fix-auth:…
 
 ○ Showing 4 worktrees, 1 with changes, 2 ahead, 1 column hidden
 ```
 
-Include CI status, line diffs, and LLM summaries:
+Include CI status and LLM summaries:
 
 ```
 $ wt list --full
@@ -67,7 +67,7 @@ $ wt list --format=json
 | Status | Compact symbols (see below) |
 | HEAD± | Uncommitted changes: +added -deleted lines |
 | main↕ | Commits ahead/behind default branch |
-| main…± | Line diffs since the merge-base (three-dot) with the default branch; `--full` only |
+| main…± | Line diffs since the merge-base (three-dot) with the default branch |
 | Summary | LLM-generated branch summary; requires `--full`, `summary = true`, and [`commit.generation`](https://worktrunk.dev/config/#commit) [experimental] |
 | Remote⇅ | Commits ahead/behind tracking branch |
 | CI | PR/MR number colored by pipeline status; `--full` only |
@@ -285,7 +285,7 @@ The five change flags map to the [Working tree](#working-tree) symbols (`renamed
 |-------|------|-------------|
 | `ahead` | number | Commits ahead of the default branch |
 | `behind` | number | Commits behind the default branch |
-| `diff` | object | Lines changed vs the default branch: `{added, deleted}`; `--full` only |
+| `diff` | object | Lines changed vs the default branch: `{added, deleted}` |
 
 ### remote object
 
@@ -382,7 +382,7 @@ Options:
           Include remote branches
 
       --full
-          Show CI, diff analysis, and LLM summaries
+          Show CI status and LLM summaries
 
       --progressive
           Show fast info immediately, update with slow info

--- a/skills/worktrunk/reference/tips-patterns.md
+++ b/skills/worktrunk/reference/tips-patterns.md
@@ -60,13 +60,13 @@ The URL column in `wt list` shows each worktree's dev server:
 
 ```bash
 $ wt list
-  <b>Branch</b>       <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>  <b>Remote⇅</b>  <b>URL</b>                     <b>Commit</b>    <b>Age</b>
-@ main           <span class=c>?</span> <span class=d>^</span><span class=d>⇅</span>                         <span class=g>⇡1</span>  <span class=d><span class=r>⇣1</span></span>  <span class=d>http://localhost:12107</span>  <span class=d>41ee0834</span>  <span class=d>4d</span>
-+ feature-api  <span class=c>+</span>   <span class=d>↕</span><span class=d>⇡</span>     <span class=g>+54</span>   <span class=r>-5</span>   <span class=g>↑4</span>  <span class=d><span class=r>↓1</span></span>   <span class=g>⇡3</span>      <span class=d>http://localhost:10703</span>  <span class=d>6814f02a</span>  <span class=d>30m</span>
-+ fix-auth         <span class=d>↕</span><span class=d>|</span>                <span class=g>↑2</span>  <span class=d><span class=r>↓1</span></span>     <span class=d>|</span>     <span class=d>http://localhost:16460</span>  <span class=d>b772e68b</span>  <span class=d>5h</span>
-+ <span class=d>fix-typos</span>        <span class=d>_</span><span class=d>|</span>                           <span class=d>|</span>     <span class=d>http://localhost:14301</span>  <span class=d>41ee0834</span>  <span class=d>4d</span>
+  <b>Branch</b>       <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>     <b>main…±</b>  <b>Remote⇅</b>  <b>URL</b>                     <b>Commit</b>
+@ main           <span class=c>?</span> <span class=d>^</span><span class=d>⇅</span>                                    <span class=g>⇡1</span>  <span class=d><span class=r>⇣1</span></span>  <span class=d>http://localhost:12107</span>  <span class=d>41ee0834</span>
++ feature-api  <span class=c>+</span>   <span class=d>↕</span><span class=d>⇡</span>     <span class=g>+54</span>   <span class=r>-5</span>   <span class=g>↑4</span>  <span class=d><span class=r>↓1</span></span>  <span class=g>+234</span>  <span class=r>-24</span>   <span class=g>⇡3</span>      <span class=d>http://localhost:10703</span>  <span class=d>6814f02a</span>
++ fix-auth         <span class=d>↕</span><span class=d>|</span>                <span class=g>↑2</span>  <span class=d><span class=r>↓1</span></span>   <span class=g>+25</span>  <span class=r>-11</span>     <span class=d>|</span>     <span class=d>http://localhost:16460</span>  <span class=d>b772e68b</span>
++ <span class=d>fix-typos</span>        <span class=d>_</span><span class=d>|</span>                                      <span class=d>|</span>     <span class=d>http://localhost:14301</span>  <span class=d>41ee0834</span>
 
-<span class=d>○</span> <span class=d>Showing 4 worktrees, 2 with changes, 2 ahead, 2 columns hidden</span>
+<span class=d>○</span> <span class=d>Showing 4 worktrees, 2 with changes, 2 ahead, 3 columns hidden</span>
 ```
 
 `fix-auth` always gets port 16460, on any machine. The URL dims if the server isn't running.

--- a/skills/worktrunk/reference/worktrunk.md
+++ b/skills/worktrunk/reference/worktrunk.md
@@ -139,7 +139,7 @@ This creates a new branch and worktree, then switches to it. Do your work, then 
 ```bash
 $ wt list
   <b>Branch</b>        <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>     <b>main…±</b>  <b>Remote⇅</b>  <b>Commit</b>    <b>Age</b>   <b>Message</b>
-@ feature-auth  <span class=c>+</span>   <span class=d>↑</span>      <span class=g>+27</span>   <span class=r>-8</span>   <span class=g>↑1</span>       <span class=g>+31</span>                <span class=d>4bc72dc9</span>  <span class=d>2h</span>    <span class=d>Add authenticate…</span>
+@ feature-auth  <span class=c>+</span>   <span class=d>↑</span>      <span class=g>+27</span>   <span class=r>-8</span>   <span class=g>↑1</span>       <span class=g>+31</span>                <span class=d>4bc72dc9</span>  <span class=d>2h</span>    <span class=d>Add authenticat…</span>
 ^ main              <span class=d>^</span><span class=d>⇡</span>                                    <span class=g>⇡1</span>      <span class=d>0e631add</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
 
 <span class=d>○</span> <span class=d>Showing 2 worktrees, 1 with changes, 1 ahead, 1 column hidden</span>

--- a/skills/worktrunk/reference/worktrunk.md
+++ b/skills/worktrunk/reference/worktrunk.md
@@ -138,9 +138,9 @@ This creates a new branch and worktree, then switches to it. Do your work, then 
 
 ```bash
 $ wt list
-  <b>Branch</b>        <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>  <b>Remote⇅</b>  <b>Commit</b>    <b>Age</b>   <b>Message</b>
-@ feature-auth  <span class=c>+</span>   <span class=d>↑</span>      <span class=g>+27</span>   <span class=r>-8</span>   <span class=g>↑1</span>               <span class=d>4bc72dc9</span>  <span class=d>2h</span>    <span class=d>Add authentication module</span>
-^ main              <span class=d>^</span><span class=d>⇡</span>                         <span class=g>⇡1</span>      <span class=d>0e631add</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
+  <b>Branch</b>        <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>     <b>main…±</b>  <b>Remote⇅</b>  <b>Commit</b>    <b>Age</b>   <b>Message</b>
+@ feature-auth  <span class=c>+</span>   <span class=d>↑</span>      <span class=g>+27</span>   <span class=r>-8</span>   <span class=g>↑1</span>       <span class=g>+31</span>                <span class=d>4bc72dc9</span>  <span class=d>2h</span>    <span class=d>Add authenticat…</span>
+^ main              <span class=d>^</span><span class=d>⇡</span>                                    <span class=g>⇡1</span>      <span class=d>0e631add</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
 
 <span class=d>○</span> <span class=d>Showing 2 worktrees, 1 with changes, 1 ahead, 1 column hidden</span>
 ```

--- a/skills/worktrunk/reference/worktrunk.md
+++ b/skills/worktrunk/reference/worktrunk.md
@@ -139,7 +139,7 @@ This creates a new branch and worktree, then switches to it. Do your work, then 
 ```bash
 $ wt list
   <b>Branch</b>        <b>Status</b>        <b>HEAD±</b>    <b>main↕</b>     <b>main…±</b>  <b>Remote⇅</b>  <b>Commit</b>    <b>Age</b>   <b>Message</b>
-@ feature-auth  <span class=c>+</span>   <span class=d>↑</span>      <span class=g>+27</span>   <span class=r>-8</span>   <span class=g>↑1</span>       <span class=g>+31</span>                <span class=d>4bc72dc9</span>  <span class=d>2h</span>    <span class=d>Add authenticat…</span>
+@ feature-auth  <span class=c>+</span>   <span class=d>↑</span>      <span class=g>+27</span>   <span class=r>-8</span>   <span class=g>↑1</span>       <span class=g>+31</span>                <span class=d>4bc72dc9</span>  <span class=d>2h</span>    <span class=d>Add authenticate…</span>
 ^ main              <span class=d>^</span><span class=d>⇡</span>                                    <span class=g>⇡1</span>      <span class=d>0e631add</span>  <span class=d>1d</span>    <span class=d>Initial commit</span>
 
 <span class=d>○</span> <span class=d>Showing 2 worktrees, 1 with changes, 1 ahead, 1 column hidden</span>

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -450,7 +450,7 @@ pub(crate) struct ListArgs {
     #[arg(long)]
     pub(crate) remotes: bool,
 
-    /// Show CI, diff analysis, and LLM summaries
+    /// Show CI status and LLM summaries
     #[arg(long)]
     pub(crate) full: bool,
 
@@ -743,7 +743,7 @@ The table renders progressively: branch names, paths, and commit hashes appear i
 
 ## Full mode
 
-`--full` adds columns that require network access or LLM calls: [CI status](#ci-status) (GitHub/GitLab pipeline pass/fail), line diffs since the merge-base, and [LLM-generated summaries](#llm-summaries) of each branch's changes.
+`--full` adds the two columns that reach off-machine: [CI status](#ci-status) (GitHub/GitLab pipeline pass/fail, over the network) and [LLM-generated summaries](#llm-summaries) of each branch's changes. The `main…±` line diffs are local git, so they show by default.
 
 ## Examples
 
@@ -752,16 +752,16 @@ List all worktrees:
 <!-- wt list -->
 ```console
 $ wt list
-  Branch       Status        HEAD±    main↕  Remote⇅  Commit    Age   Message
-@ feature-api  +   ↕⇡     +54   -5   ↑4  ↓1   ⇡3      6814f02a  30m   Add API tests
-^ main             ^⇅                         ⇡1  ⇣1  41ee0834  4d    Merge fix-auth: hardened to…
-+ fix-auth         ↕|                ↑2  ↓1     |     b772e68b  5h    Add secure token storage
-+ fix-typos        _|                           |     41ee0834  4d    Merge fix-auth: hardened to…
+  Branch       Status        HEAD±    main↕     main…±  Remote⇅  Commit    Age   Message
+@ feature-api  +   ↕⇡     +54   -5   ↑4  ↓1  +234  -24   ⇡3      6814f02a  30m   Add API tests
+^ main             ^⇅                                    ⇡1  ⇣1  41ee0834  4d    Merge fix-auth:…
++ fix-auth         ↕|                ↑2  ↓1   +25  -11     |     b772e68b  5h    Add secure token…
++ fix-typos        _|                                      |     41ee0834  4d    Merge fix-auth:…
 
 ○ Showing 4 worktrees, 1 with changes, 2 ahead, 1 column hidden
 ```
 
-Include CI status, line diffs, and LLM summaries:
+Include CI status and LLM summaries:
 
 <!-- wt list --full -->
 ```console
@@ -805,7 +805,7 @@ $ wt list --format=json
 | Status | Compact symbols (see below) |
 | HEAD± | Uncommitted changes: +added -deleted lines |
 | main↕ | Commits ahead/behind default branch |
-| main…± | Line diffs since the merge-base (three-dot) with the default branch; `--full` only |
+| main…± | Line diffs since the merge-base (three-dot) with the default branch |
 | Summary | LLM-generated branch summary; requires `--full`, `summary = true`, and [`commit.generation`](@/config.md#commit) [experimental] |
 | Remote⇅ | Commits ahead/behind tracking branch |
 | CI | PR/MR number colored by pipeline status; `--full` only |
@@ -1023,7 +1023,7 @@ The five change flags map to the [Working tree](#working-tree) symbols (`renamed
 |-------|------|-------------|
 | `ahead` | number | Commits ahead of the default branch |
 | `behind` | number | Commits behind the default branch |
-| `diff` | object | Lines changed vs the default branch: `{added, deleted}`; `--full` only |
+| `diff` | object | Lines changed vs the default branch: `{added, deleted}` |
 
 ### remote object
 
@@ -1901,7 +1901,7 @@ Persistent flag values for `wt list`. Override on command line as needed.
 [list]
 summary = false    # Enable LLM branch summaries (requires [commit.generation])
 
-full = false       # Show CI, main…± diffstat, and LLM summaries (--full)
+full = false       # Show CI status and LLM summaries (--full)
 branches = false   # Include branches without worktrees (--branches)
 remotes = false    # Include remote-only branches (--remotes)
 

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -111,7 +111,7 @@ Keep the first line of flag and argument descriptions brief—aim for 3-6 words.
 
 **Good examples:**
 - `/// Skip approval prompts`
-- `/// Show CI and \`main\` diffstat`
+- `/// Show CI status and LLM summaries`
 - `/// Target branch (defaults to default branch)`
 
 **Bad examples (too verbose):**

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -816,13 +816,14 @@ pub fn collect(
             let skip_tasks: HashSet<TaskKind> = if show_full {
                 HashSet::new()
             } else {
-                [
-                    TaskKind::BranchDiff,
-                    TaskKind::CiStatus,
-                    TaskKind::SummaryGenerate,
-                ]
-                .into_iter()
-                .collect()
+                // BranchDiff (the `main…±` column) is pure local git — a cached
+                // `git diff --shortstat` against the merge-base — so it always
+                // runs, under the non-`--full` timeout below as a backstop.
+                // `--full` gates only the off-machine columns: CI status
+                // (network) and LLM branch summaries.
+                [TaskKind::CiStatus, TaskKind::SummaryGenerate]
+                    .into_iter()
+                    .collect()
             };
             // Resolve timeouts from merged config (--full disables both)
             let (command_timeout, collect_deadline) = if show_full {

--- a/src/commands/list/layout.rs
+++ b/src/commands/list/layout.rs
@@ -105,12 +105,15 @@
 //!
 //! Some columns have non-standard behavior that extends beyond the basic two-tier model:
 //!
-//! 1. **BranchDiff** and **CiStatus** - Visibility gate (`show_full` flag)
-//!    - Both require `show_full=true` (hidden by default as too noisy for typical usage)
-//!    - Gated via `skip_tasks`: when `show_full=false`, their `TaskKind` is in `skip_tasks`
-//!      and the column is filtered out entirely (bypasses the tier system)
-//!    - Within the visibility gate, follows normal two-tier priority
-//!      (BranchDiff: 6/16, CiStatus: 5/15)
+//! 1. **CiStatus** and **Summary** - Visibility gate (`show_full` flag)
+//!    - Both require `show_full=true` — they reach off-machine (CI status over
+//!      the network, branch summaries via the LLM), so they're hidden by default
+//!    - Gated via `skip_tasks`: when `show_full=false`, their `TaskKind` is in
+//!      `skip_tasks` and the column is filtered out entirely (bypasses the tier
+//!      system)
+//!    - **BranchDiff** (`main…±`) is pure local git, so it is *not* gated — it
+//!      shows by default and follows the normal two-tier priority (6/16);
+//!      CiStatus is 5/15
 //!
 //! 2. **Low-priority columns** yield to Summary
 //!    - Columns with effective priority > Summary's (10) are dropped to reclaim
@@ -1787,15 +1790,12 @@ mod tests {
         )
     }
 
-    /// Default skip_tasks for non-full mode (Summary, BranchDiff, CI skipped).
+    /// Default skip_tasks for non-full mode (CI and Summary skipped; BranchDiff
+    /// runs and the `main…±` column shows by default).
     fn non_full_skip_tasks() -> HashSet<TaskKind> {
-        [
-            TaskKind::BranchDiff,
-            TaskKind::CiStatus,
-            TaskKind::SummaryGenerate,
-        ]
-        .into_iter()
-        .collect()
+        [TaskKind::CiStatus, TaskKind::SummaryGenerate]
+            .into_iter()
+            .collect()
     }
 
     /// Full mode skip_tasks (nothing skipped).

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -967,17 +967,19 @@ pub fn handle_picker(
         orchestrator.spawn_preview(Arc::new(item), PreviewMode::WorkingTree, dims);
     }
 
-    // Skip BranchDiff — it walks history per item for a column the picker
-    // doesn't surface. Keep the CiStatus task: the picker primes its CI cells
-    // from the local cache so the first frame shows cached status (see
-    // `populate_from_cache`), then this task fetches live and streams each row's
-    // status in behind the frame — the same 30–60s-TTL cache plus live fetch as
-    // `wt list --full`. The picker's lifetime is bounded by the user, so a slow forge call
-    // never blocks anything (see the "Network Access" notes in CLAUDE.md). The
-    // `pr` preview tab reads the same live status. `--prs` rows carry their own
-    // number from the explicit `--prs` forge call.
-    let skip_tasks: std::collections::HashSet<collect::TaskKind> =
-        [collect::TaskKind::BranchDiff].into_iter().collect();
+    // Run every task — the picker is `wt list --full`. `main…±` (BranchDiff) is
+    // now a default `wt list` column, so the picker surfaces it too; it's local
+    // git keyed by a persistent content-addressed cache, so warm rows are instant
+    // and a cold row computes once in the background (its merge-base walk streams
+    // in behind the frame, never blocking the picker). CiStatus is primed from
+    // the local cache so the first frame shows cached status (see
+    // `populate_from_cache`), then fetched live and streamed in — the same
+    // 30–60s-TTL cache plus live fetch as `wt list --full`. The picker's lifetime
+    // is bounded by the user, so a slow forge call never blocks anything (see the
+    // "Network Access" notes in CLAUDE.md). The `pr` preview tab reads the same
+    // live status. `--prs` rows carry their own number from the explicit `--prs`
+    // forge call.
+    let skip_tasks: std::collections::HashSet<collect::TaskKind> = std::collections::HashSet::new();
 
     // Per-task command timeout (bounds any single git invocation) from
     // shared `[list]` config. Still applies in progressive mode.

--- a/src/commands/picker/preview.rs
+++ b/src/commands/picker/preview.rs
@@ -27,7 +27,7 @@ use std::sync::atomic::{AtomicU8, Ordering};
 /// Loosely aligned with `wt list` columns, though not a perfect match:
 /// - Tab 1 corresponds to "HEAD±" column
 /// - Tab 2 shows commits (related to "main↕" counts)
-/// - Tab 3 corresponds to "main…± (--full)" column
+/// - Tab 3 corresponds to "main…±" column
 /// - Tab 4 corresponds to "Remote⇅" column
 /// - Tab 6 corresponds to the "CI" column's PR/MR
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -590,6 +590,11 @@ pub fn add_standard_env_redactions(settings: &mut insta::Settings) {
     );
     // OpenCode config directory (platform-independent override for tests)
     settings.add_redaction(".env.OPENCODE_CONFIG_DIR", "[TEST_OPENCODE_CONFIG]");
+    // Claude Code config directory: `set_temp_home_env` pins it to the temp
+    // home's `.claude` for hermeticity, so the value is a per-run temp path that
+    // would leak (and fail the host-path guard) when regenerated under an
+    // ambient CLAUDE_CONFIG_DIR. Redact it like its OpenCode sibling above.
+    settings.add_redaction(".env.CLAUDE_CONFIG_DIR", "[TEST_CLAUDE_CONFIG]");
     // `wt config show --full` tests inject WORKTRUNK_TEST_LATEST_VERSION = the
     // current crate version (so the version-check line reads "Up to date"), which
     // would otherwise churn this `info` block on every release bump. Redact any

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -1077,25 +1077,27 @@ fn test_switch_picker_prs_github_list(mut repo: TestRepo) {
         &["switch", "--prs"],
         repo.root_path(),
         &env_vars,
-        // Wait for the PR row to stream into the list (the `#42` content gate),
-        // then assert on the row itself — deterministic, with no dependency on
-        // selecting an async-arrived row.
-        &[("", Some("#42"))],
+        // `main…±` now occupies the preview-shown list pane, clipping the CI
+        // column (`#42`) past skim's split. Toggle the preview off (alt-p) so
+        // the list spans full width and renders the number, then gate on it —
+        // deterministic, no dependency on selecting an async-arrived row.
+        &[("\x1bp", Some("#42"))],
     );
 
     assert_valid_abort_exit_code(result.exit_code);
-    let (list, _preview) = result.panels();
-    // `#42` in the CI column; the head branch is truncated in the narrow list.
-    assert!(list.contains("#42"), "PR number in list:\n{list}");
-    // The title is NOT on the row — it lives in the preview so columns align.
+    // Preview off → full-width list renders the CI column; assert on the whole
+    // screen since `#42` sits past the panel split column.
+    let screen = result.screen();
+    assert!(screen.contains("#42"), "PR number on screen:\n{screen}");
+    // The title lives in the preview (now hidden), never on the row itself.
     assert!(
-        !list.contains("Retry the flaky network test"),
-        "PR title should stay off the row:\n{list}"
+        !screen.contains("Retry the flaky network test"),
+        "PR title should stay off the row:\n{screen}"
     );
     // The header's loading marker is gone once the rows have streamed in.
     assert!(
-        !list.contains("loading open PRs"),
-        "loading marker cleared once rows arrived:\n{list}"
+        !screen.contains("loading open PRs"),
+        "loading marker cleared once rows arrived:\n{screen}"
     );
 }
 
@@ -1119,18 +1121,20 @@ fn test_switch_picker_prs_gitlab_list(mut repo: TestRepo) {
         &["switch", "--prs"],
         repo.root_path(),
         &env_vars,
-        // `!7` (GitLab MR ref) is the row's stable substring; the title lives in
-        // the preview, not the row.
-        &[("", Some("!7"))],
+        // `main…±` clips the CI column (`!7`) past skim's split in the
+        // preview-shown pane. Toggle the preview off (alt-p) so the full-width
+        // list renders the ref, then gate on it.
+        &[("\x1bp", Some("!7"))],
     );
 
     assert_valid_abort_exit_code(result.exit_code);
-    let (list, _preview) = result.panels();
-    // `!7` (GitLab MR ref) in the CI column; source branch truncates.
-    assert!(list.contains("!7"), "MR number in list:\n{list}");
+    // Preview off → full-width list renders the CI column; assert on the whole
+    // screen since `!7` sits past the panel split column.
+    let screen = result.screen();
+    assert!(screen.contains("!7"), "MR number on screen:\n{screen}");
     assert!(
-        !list.contains("Cache the dependency graph"),
-        "MR title should stay off the row:\n{list}"
+        !screen.contains("Cache the dependency graph"),
+        "MR title should stay off the row:\n{screen}"
     );
 }
 

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_commands_from_bare_directory.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_commands_from_bare_directory.snap
@@ -35,8 +35,8 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-^ main        [2m^[22m                                  .     [2mb834638e[0m  [2m1d[0m    [2mInitial commit[0m
+  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+^ main        [2m^[22m                                             .     [2mb834638e[0m  [2m1d[0m    [2mInitial commit[0m
 
 [2m○[22m [2mShowing 1 worktree[0m
 

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_identifies_primary_correctly.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_identifies_primary_correctly.snap
@@ -35,10 +35,10 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m    [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m         [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main          [2m^[22m                                  .            [2mb37a293c[0m  [2m1d[0m    [2mMain commit[0m
-+ [2mfeature1[0m      [2m_[22m                                  [2m../feature1[0m  [2mb37a293c[0m  [2m1d[0m    [2mMain commit[0m
-+ [2mfeature2[0m      [2m_[22m                                  [2m../feature2[0m  [2mb37a293c[0m  [2m1d[0m    [2mMain commit[0m
+  [1mBranch[0m    [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m         [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main          [2m^[22m                                             .            [2mb37a293c[0m  [2m1d[0m    [2mMain commit[0m
++ [2mfeature1[0m      [2m_[22m                                             [2m../feature1[0m  [2mb37a293c[0m  [2m1d[0m    [2mMain commit[0m
++ [2mfeature2[0m      [2m_[22m                                             [2m../feature2[0m  [2mb37a293c[0m  [2m1d[0m    [2mMain commit[0m
 
 [2m○[22m [2mShowing 3 worktrees[0m
 

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_list_shows_no_bare_entry.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_list_shows_no_bare_entry.snap
@@ -35,8 +35,8 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main        [2m^[22m                                  .     [2mb834638e[0m  [2m1d[0m    [2mInitial commit[0m
+  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main        [2m^[22m                                             .     [2mb834638e[0m  [2m1d[0m    [2mInitial commit[0m
 
 [2m○[22m [2mShowing 1 worktree[0m
 

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_list_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_list_worktrees.snap
@@ -35,9 +35,9 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m        [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main         [2m^[22m                                  .           [2m6c3da842[0m  [2m1d[0m    [2mInitial commit on main[0m
-+ feature      [2m↑[22m                 [32m↑1[0m               ../feature  [2m72413a3b[0m  [2m1d[0m    [2mWork on feature[0m
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m        [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main         [2m^[22m                                             .           [2m6c3da842[0m  [2m1d[0m    [2mInitial commit on main[0m
++ feature      [2m↑[22m                 [32m↑1[0m        [32m+1[0m   [31m-1[0m           ../feature  [2m72413a3b[0m  [2m1d[0m    [2mWork on feature[0m
 
 [2m○[22m [2mShowing 2 worktrees, 1 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__bare_repository__nested_bare_repo_list_snapshot.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__nested_bare_repo_list_snapshot.snap
@@ -35,9 +35,9 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m        [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main         [2m^[22m                                  .           [2ma6c13b13[0m  [2m1d[0m    [2mInitial[0m
-+ [2mfeature[0m      [2m_[22m                                  [2m../feature[0m  [2ma6c13b13[0m  [2m1d[0m    [2mInitial[0m
+  [1mBranch[0m   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m        [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main         [2m^[22m                                             .           [2ma6c13b13[0m  [2m1d[0m    [2mInitial[0m
++ [2mfeature[0m      [2m_[22m                                             [2m../feature[0m  [2ma6c13b13[0m  [2m1d[0m    [2mInitial[0m
 
 [2m○[22m [2mShowing 2 worktrees[0m
 

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_project_level_shows_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_project_level_shows_warning.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_section_shows_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_section_shows_warning.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_show_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_show_warning.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_verbose_shows_content.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_verbose_shows_content.snap
@@ -7,6 +7,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,11 +45,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__config_show__explicit_config_path_not_found_shows_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__explicit_config_path_not_found_shows_warning.snap
@@ -8,6 +8,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -45,11 +46,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -161,7 +161,7 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# [list][0m
 [107m [0m [2m# summary = false    # Enable LLM branch summaries (requires [commit.generation])[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# full = false       # Show CI, main…± diffstat, and LLM summaries (--full)[0m
+[107m [0m [2m# full = false       # Show CI status and LLM summaries (--full)[0m
 [107m [0m [2m# branches = false   # Include branches without worktrees (--branches)[0m
 [107m [0m [2m# remotes = false    # Include remote-only branches (--remotes)[0m
 [107m [0m [2m#[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -209,7 +209,7 @@ Persistent flag values for [2mwt list[0m. Override on command line as needed.
 [107m [0m [2m[36m[list][0m
 [107m [0m [2msummary = [0m[2m[33mfalse[0m[2m    [0m[2m# Enable LLM branch summaries (requires [commit.generation])[0m
 [107m [0m 
-[107m [0m [2mfull = [0m[2m[33mfalse[0m[2m       [0m[2m# Show CI, main…± diffstat, and LLM summaries (--full)[0m
+[107m [0m [2mfull = [0m[2m[33mfalse[0m[2m       [0m[2m# Show CI status and LLM summaries (--full)[0m
 [107m [0m [2mbranches = [0m[2m[33mfalse[0m[2m   [0m[2m# Include branches without worktrees (--branches)[0m
 [107m [0m [2mremotes = [0m[2m[33mfalse[0m[2m    [0m[2m# Include remote-only branches (--remotes)[0m
 [107m [0m 

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -54,7 +54,7 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
           Include remote branches
 
       [1m[36m--full[0m
-          Show CI, diff analysis, and LLM summaries
+          Show CI status and LLM summaries
 
       [1m[36m--progressive[0m
           Show fast info immediately, update with slow info[0m
@@ -86,22 +86,22 @@ The table renders progressively: branch names, paths, and commit hashes appear i
 
 [1m[32mFull mode[0m
 
-[2m--full[0m adds columns that require network access or LLM calls: CI status (GitHub/GitLab pipeline pass/fail), line diffs since the merge-base, and LLM-generated summaries of each branch's changes.
+[2m--full[0m adds the two columns that reach off-machine: CI status (GitHub/GitLab pipeline pass/fail, over the network) and LLM-generated summaries of each branch's changes. The [2mmain…±[0m line diffs are local git, so they show by default.
 
 [1m[32mExamples[0m
 
 List all worktrees:
 
 [107m [0m [2m[0m[2m[34mwt[0m[2m list[0m
-[107m [0m [2m  [0m[2m[34mBranch[0m[2m       Status        HEAD±    main↕  Remote⇅  Commit    Age   Message[0m
-[107m [0m [2m[0m[2m[34m@[0m[2m feature-api  +   ↕⇡     +54   [0m[2m[36m-5[0m[2m   ↑4  ↓1   ⇡3      6814f02a  30m   Add API tests[0m
-[107m [0m [2m[0m[2m[34m^[0m[2m main             ^⇅                         ⇡1  ⇣1  41ee0834  4d    Merge fix-auth: hardened to…[0m
-[107m [0m [2m[0m[2m[34m+[0m[2m fix-auth         ↕[0m[2m[36m|[0m[2m                [0m[2m[34m↑2[0m[2m  ↓1     [0m[2m[36m|[0m[2m     [0m[2m[34mb772e68b[0m[2m  5h    Add secure token storage[0m
-[107m [0m [2m+ fix-typos        _[0m[2m[36m|[0m[2m                           [0m[2m[36m|[0m[2m     [0m[2m[34m41ee0834[0m[2m  4d    Merge fix-auth: hardened to…[0m
+[107m [0m [2m  [0m[2m[34mBranch[0m[2m       Status        HEAD±    main↕     main…±  Remote⇅  Commit    Age   Message[0m
+[107m [0m [2m[0m[2m[34m@[0m[2m feature-api  +   ↕⇡     +54   [0m[2m[36m-5[0m[2m   ↑4  ↓1  +234  [0m[2m[36m-24[0m[2m   ⇡3      6814f02a  30m   Add API tests[0m
+[107m [0m [2m[0m[2m[34m^[0m[2m main             ^⇅                                    ⇡1  ⇣1  41ee0834  4d    Merge fix-auth:…[0m
+[107m [0m [2m[0m[2m[34m+[0m[2m fix-auth         ↕[0m[2m[36m|[0m[2m                [0m[2m[34m↑2[0m[2m  ↓1   +25  [0m[2m[36m-11[0m[2m     [0m[2m[36m|[0m[2m     [0m[2m[34mb772e68b[0m[2m  5h    Add secure token…[0m
+[107m [0m [2m+ fix-typos        _[0m[2m[36m|[0m[2m                                      [0m[2m[36m|[0m[2m     [0m[2m[34m41ee0834[0m[2m  4d    Merge fix-auth:…[0m
 [107m [0m [0m
 [107m [0m [2m○ Showing 4 worktrees, 1 with changes, 2 ahead, 1 column hidden[0m
 
-Include CI status, line diffs, and LLM summaries:
+Include CI status and LLM summaries:
 
 [107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--full[0m
 [107m [0m [2m  [0m[2m[34mBranch[0m[2m       Status        HEAD±    main↕     main…±  Summary                                                Remote⇅  CI    Commit[0m
@@ -137,7 +137,7 @@ Output as JSON for scripting:
  Status   Compact symbols (see below)                                                                         
  HEAD±    Uncommitted changes: +added -deleted lines                                                          
  main↕    Commits ahead/behind default branch                                                                 
- main…±   Line diffs since the merge-base (three-dot) with the default branch; [2m--full[0m only                    
+ main…±   Line diffs since the merge-base (three-dot) with the default branch                                 
  Summary  LLM-generated branch summary; requires [2m--full[0m, [2msummary = true[0m, and [2mcommit.generation[0m [experimental] 
  Remote⇅  Commits ahead/behind tracking branch                                                                
  CI       PR/MR number colored by pipeline status; [2m--full[0m only                                                
@@ -348,11 +348,11 @@ The five change flags map to the Working tree symbols ([2mrenamed[0m and [2md
 
 [32mmain object[0m
 
- Field   Type                             Description                             
- ────── ────── ────────────────────────────────────────────────────────────────── 
- [2mahead[0m  number Commits ahead of the default branch                                
- [2mbehind[0m number Commits behind the default branch                                  
- [2mdiff[0m   object Lines changed vs the default branch: [2m{added, deleted}[0m; [2m--full[0m only 
+ Field   Type                       Description                      
+ ────── ────── ───────────────────────────────────────────────────── 
+ [2mahead[0m  number Commits ahead of the default branch                   
+ [2mbehind[0m number Commits behind the default branch                     
+ [2mdiff[0m   object Lines changed vs the default branch: [2m{added, deleted}[0m 
 
 [32mremote object[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -54,7 +54,7 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
           Include remote branches
 
       [1m[36m--full[0m
-          Show CI, diff analysis, and LLM summaries
+          Show CI status and LLM summaries
 
       [1m[36m--progressive[0m
           Show fast info immediately, update with slow info[0m
@@ -95,24 +95,24 @@ git operations complete.
 
 [1m[32mFull mode[0m
 
-[2m--full[0m adds columns that require network access or LLM calls: CI status 
-(GitHub/GitLab pipeline pass/fail), line diffs since the merge-base, and 
-LLM-generated summaries of each branch's changes.
+[2m--full[0m adds the two columns that reach off-machine: CI status (GitHub/GitLab 
+pipeline pass/fail, over the network) and LLM-generated summaries of each 
+branch's changes. The [2mmain…±[0m line diffs are local git, so they show by default.
 
 [1m[32mExamples[0m
 
 List all worktrees:
 
 [107m [0m [2m[0m[2m[34mwt[0m[2m list[0m
-[107m [0m [2m  [0m[2m[34mBranch[0m[2m       Status        HEAD±    main↕  Remote⇅  Commit    Age   Message[0m
-[107m [0m [2m[0m[2m[34m@[0m[2m feature-api  +   ↕⇡     +54   [0m[2m[36m-5[0m[2m   ↑4  ↓1   ⇡3      6814f02a  30m   Add API[22m[2m…[0m
-[107m [0m [2m[0m[2m[34m^[0m[2m main             ^⇅                         ⇡1  ⇣1  41ee0834  4d    Merge f[22m[2m…[0m
-[107m [0m [2m[0m[2m[34m+[0m[2m fix-auth         ↕[0m[2m[36m|[0m[2m                [0m[2m[34m↑2[0m[2m  ↓1     [0m[2m[36m|[0m[2m     [0m[2m[34mb772e68b[0m[2m  5h    Add sec[22m[2m…[0m
-[107m [0m [2m+ fix-typos        _[0m[2m[36m|[0m[2m                           [0m[2m[36m|[0m[2m     [0m[2m[34m41ee0834[0m[2m  4d    Merge f[22m[2m…[0m
+[107m [0m [2m  [0m[2m[34mBranch[0m[2m       Status        HEAD±    main↕     main…±  Remote⇅  Commit    Ag[22m[2m…[0m
+[107m [0m [2m[0m[2m[34m@[0m[2m feature-api  +   ↕⇡     +54   [0m[2m[36m-5[0m[2m   ↑4  ↓1  +234  [0m[2m[36m-24[0m[2m   ⇡3      6814f02a  30[22m[2m…[0m
+[107m [0m [2m[0m[2m[34m^[0m[2m main             ^⇅                                    ⇡1  ⇣1  41ee0834  4d[22m[2m…[0m
+[107m [0m [2m[0m[2m[34m+[0m[2m fix-auth         ↕[0m[2m[36m|[0m[2m                [0m[2m[34m↑2[0m[2m  ↓1   +25  [0m[2m[36m-11[0m[2m     [0m[2m[36m|[0m[2m     [0m[2m[34mb772e68b[0m[2m  5h[22m[2m…[0m
+[107m [0m [2m+ fix-typos        _[0m[2m[36m|[0m[2m                                      [0m[2m[36m|[0m[2m     [0m[2m[34m41ee0834[0m[2m  4d[22m[2m…[0m
 [107m [0m [0m
 [107m [0m [2m○ Showing 4 worktrees, 1 with changes, 2 ahead, 1 column hidden[0m
 
-Include CI status, line diffs, and LLM summaries:
+Include CI status and LLM summaries:
 
 [107m [0m [2m[0m[2m[34mwt[0m[2m list [0m[2m[36m--full[0m
 [107m [0m [2m  [0m[2m[34mBranch[0m[2m       Status        HEAD±    main↕     main…±  Summary              [22m[2m…[0m
@@ -148,8 +148,7 @@ Output as JSON for scripting:
  Status   Compact symbols (see below)                                           
  HEAD±    Uncommitted changes: +added -deleted lines                            
  main↕    Commits ahead/behind default branch                                   
- main…±   Line diffs since the merge-base (three-dot) with the default branch;  
-          [2m--full[0m only                                                           
+ main…±   Line diffs since the merge-base (three-dot) with the default branch   
  Summary  LLM-generated branch summary; requires [2m--full[0m, [2msummary = true[0m, and    
           [2mcommit.generation[0m [experimental]                                      
  Remote⇅  Commits ahead/behind tracking branch                                  
@@ -426,12 +425,11 @@ none of their own):
 
 [32mmain object[0m
 
- Field   Type                            Description                            
- ────── ────── ──────────────────────────────────────────────────────────────── 
- [2mahead[0m  number Commits ahead of the default branch                              
- [2mbehind[0m number Commits behind the default branch                                
- [2mdiff[0m   object Lines changed vs the default branch: [2m{added, deleted}[0m; [2m--full[0m    
-               only                                                             
+ Field   Type                       Description                      
+ ────── ────── ───────────────────────────────────────────────────── 
+ [2mahead[0m  number Commits ahead of the default branch                   
+ [2mbehind[0m number Commits behind the default branch                     
+ [2mdiff[0m   object Lines changed vs the default branch: [2m{added, deleted}[0m 
 
 [32mremote object[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_short.snap
@@ -44,7 +44,7 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
       [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m  Output format [default: table] [possible values: table, json]
       [1m[36m--branches[0m         Include branches without worktrees
       [1m[36m--remotes[0m          Include remote branches
-      [1m[36m--full[0m             Show CI, diff analysis, and LLM summaries
+      [1m[36m--full[0m             Show CI status and LLM summaries
       [1m[36m--progressive[0m      Show fast info immediately, update with slow info
   [1m[36m-h[0m, [1m[36m--help[0m             Print help (see more with '--help')
 

--- a/tests/snapshots/integration__integration_tests__list__commit_conflicts_without_full.snap
+++ b/tests/snapshots/integration__integration_tests__list__commit_conflicts_without_full.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,12 +44,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m⇡[22m                         [32m⇡2[0m      .                  [2m1edd043e[0m  [2m1d[0m    [2mMain changes shared.txt[0m
-+ feature-a      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m           ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m           ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m           ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ feature        [33m✗[39m                 [32m↑1[0m  [2m[31m↓1[0m           ../repo.feature    [2mdee7183a[0m  [2m1d[0m    [2mFeature changes shared.txt[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m⇡[22m                                    [32m⇡2[0m      .                  [2m1edd043e[0m  [2m1d[0m    [2mMain changes shared.txt[0m
++ feature-a      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ feature        [33m✗[39m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m   [31m-1[0m           ../repo.feature    [2mdee7183a[0m  [2m1d[0m    [2mFeature changes shared.txt[0m
 
 [2m○[22m [2mShowing 5 worktrees, 4 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_branch_only_with_status.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_branch_only_with_status.snap
@@ -7,6 +7,7 @@ info:
     - "--branches"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,12 +45,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m       [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main             [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a        [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b        [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c        [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-[2m/ [0m[2mbranch-only[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m       [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main             [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a        [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b        [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c        [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+[2m/ [0m[2mbranch-only[0m     [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_branches_with_nonexistent_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_branches_with_nonexistent_default_branch.snap
@@ -7,6 +7,7 @@ info:
     - "--branches"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,11 +45,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main          [31m⚑[39m[2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a                                         ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b                                         ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c                                         ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main          [31m⚑[39m[2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a                                                    ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b                                                    ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c                                                    ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_detached_head.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_detached_head.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ -             [31m⚑[39m[2m^[22m                                  .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ -             [31m⚑[39m[2m^[22m                                             .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_detached_head_in_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_detached_head_in_worktree.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,12 +44,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2m-[0m             [31m⚑[39m[2m_[22m                                  [2m../repo.feature[0m    [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2m-[0m             [31m⚑[39m[2m_[22m                                             [2m../repo.feature[0m    [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_empty_repo.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_empty_repo.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -41,8 +42,8 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main    [2m·[0m  [2m·[0m[2m^[22m             [2m·[0m                    .               [2m·[0m     [2m·[0m
+  [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main    [2m·[0m  [2m·[0m[2m^[22m             [2m·[0m                               .               [2m·[0m     [2m·[0m
 
 [2m○[22m [2mShowing 1 worktree[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_handles_orphan_branch.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_handles_orphan_branch.snap
@@ -7,6 +7,7 @@ info:
     - "--branches"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,12 +45,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-[2m/ [0massets        [2m/[22m[2m∅[22m                                                     [2m50209039[0m  [2m1d[0m    [2mAdd asset[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+[2m/ [0massets        [2m/[22m[2m∅[22m                                                                [2m50209039[0m  [2m1d[0m    [2mAdd asset[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_json_tree_matches_main_after_merge.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_json_tree_matches_main_after_merge.snap
@@ -7,6 +7,7 @@ info:
     - "--format=json"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -106,7 +107,11 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 1
+      "behind": 1,
+      "diff": {
+        "added": 1,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false
@@ -114,7 +119,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-a  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m",
+    "statusline": "feature-a  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m  ^\u001b[32m+1\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -141,7 +146,11 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 1
+      "behind": 1,
+      "diff": {
+        "added": 1,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false
@@ -149,7 +158,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-b  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m",
+    "statusline": "feature-b  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m  ^\u001b[32m+1\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -176,7 +185,11 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 1
+      "behind": 1,
+      "diff": {
+        "added": 1,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false
@@ -184,7 +197,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-c  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m",
+    "statusline": "feature-c  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m  ^\u001b[32m+1\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -212,7 +225,11 @@ exit_code: 0
     "integration_reason": "no-added-changes",
     "main": {
       "ahead": 2,
-      "behind": 0
+      "behind": 0,
+      "diff": {
+        "added": 0,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false

--- a/tests/snapshots/integration__integration_tests__list__list_json_with_display_fields.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_json_with_display_fields.snap
@@ -7,6 +7,7 @@ info:
     - "--format=json"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -106,7 +107,11 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 3
+      "behind": 3,
+      "diff": {
+        "added": 1,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false
@@ -114,7 +119,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-a  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓3\u001b[0m",
+    "statusline": "feature-a  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓3\u001b[0m  ^\u001b[32m+1\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -141,7 +146,11 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 3
+      "behind": 3,
+      "diff": {
+        "added": 1,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false
@@ -149,7 +158,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-b  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓3\u001b[0m",
+    "statusline": "feature-b  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓3\u001b[0m  ^\u001b[32m+1\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -176,7 +185,11 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 3
+      "behind": 3,
+      "diff": {
+        "added": 1,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false
@@ -184,7 +197,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-c  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓3\u001b[0m",
+    "statusline": "feature-c  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓3\u001b[0m  ^\u001b[32m+1\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -211,7 +224,11 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 2,
-      "behind": 2
+      "behind": 2,
+      "diff": {
+        "added": 1,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false
@@ -219,7 +236,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-ahead  \u001b[36m!\u001b[39m\u001b[36m?\u001b[39m\u001b[2m↕\u001b[22m  @\u001b[32m+1\u001b[0m \u001b[31m-1\u001b[0m  \u001b[32m↑2\u001b[0m \u001b[2m\u001b[31m↓2\u001b[0m",
+    "statusline": "feature-ahead  \u001b[36m!\u001b[39m\u001b[36m?\u001b[39m\u001b[2m↕\u001b[22m  @\u001b[32m+1\u001b[0m \u001b[31m-1\u001b[0m  \u001b[32m↑2\u001b[0m \u001b[2m\u001b[31m↓2\u001b[0m  ^\u001b[32m+1\u001b[0m",
     "symbols": "!?↕"
   },
   {
@@ -247,7 +264,11 @@ exit_code: 0
     "integration_reason": "ancestor",
     "main": {
       "ahead": 0,
-      "behind": 2
+      "behind": 2,
+      "diff": {
+        "added": 0,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false

--- a/tests/snapshots/integration__integration_tests__list__list_json_with_git_operation.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_json_with_git_operation.snap
@@ -7,6 +7,7 @@ info:
     - "--format=json"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -106,7 +107,11 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 2
+      "behind": 2,
+      "diff": {
+        "added": 1,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false
@@ -114,7 +119,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-a  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓2\u001b[0m",
+    "statusline": "feature-a  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓2\u001b[0m  ^\u001b[32m+1\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -141,7 +146,11 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 2
+      "behind": 2,
+      "diff": {
+        "added": 1,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false
@@ -149,7 +158,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-b  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓2\u001b[0m",
+    "statusline": "feature-b  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓2\u001b[0m  ^\u001b[32m+1\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -176,7 +185,11 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 2
+      "behind": 2,
+      "diff": {
+        "added": 1,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false
@@ -184,7 +197,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-c  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓2\u001b[0m",
+    "statusline": "feature-c  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓2\u001b[0m  ^\u001b[32m+1\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -212,7 +225,11 @@ exit_code: 0
     "operation_state": "conflicts",
     "main": {
       "ahead": 1,
-      "behind": 1
+      "behind": 1,
+      "diff": {
+        "added": 2,
+        "deleted": 2
+      }
     },
     "worktree": {
       "detached": true
@@ -220,7 +237,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature  \u001b[31m✘\u001b[39m\u001b[33m✗\u001b[39m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m",
+    "statusline": "feature  \u001b[31m✘\u001b[39m\u001b[33m✗\u001b[39m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m  ^\u001b[32m+2\u001b[0m \u001b[31m-2\u001b[0m",
     "symbols": "✗✘"
   }
 ]

--- a/tests/snapshots/integration__integration_tests__list__list_json_with_metadata.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_json_with_metadata.snap
@@ -7,6 +7,7 @@ info:
     - "--format=json"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -106,7 +107,11 @@ exit_code: 0
     "main_state": "ahead",
     "main": {
       "ahead": 1,
-      "behind": 0
+      "behind": 0,
+      "diff": {
+        "added": 1,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false
@@ -114,7 +119,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-a  \u001b[2m↑\u001b[22m  \u001b[32m↑1\u001b[0m",
+    "statusline": "feature-a  \u001b[2m↑\u001b[22m  \u001b[32m↑1\u001b[0m  ^\u001b[32m+1\u001b[0m",
     "symbols": "↑"
   },
   {
@@ -141,7 +146,11 @@ exit_code: 0
     "main_state": "ahead",
     "main": {
       "ahead": 1,
-      "behind": 0
+      "behind": 0,
+      "diff": {
+        "added": 1,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false
@@ -149,7 +158,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-b  \u001b[2m↑\u001b[22m  \u001b[32m↑1\u001b[0m",
+    "statusline": "feature-b  \u001b[2m↑\u001b[22m  \u001b[32m↑1\u001b[0m  ^\u001b[32m+1\u001b[0m",
     "symbols": "↑"
   },
   {
@@ -176,7 +185,11 @@ exit_code: 0
     "main_state": "ahead",
     "main": {
       "ahead": 1,
-      "behind": 0
+      "behind": 0,
+      "diff": {
+        "added": 1,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false
@@ -184,7 +197,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-c  \u001b[2m↑\u001b[22m  \u001b[32m↑1\u001b[0m",
+    "statusline": "feature-c  \u001b[2m↑\u001b[22m  \u001b[32m↑1\u001b[0m  ^\u001b[32m+1\u001b[0m",
     "symbols": "↑"
   },
   {
@@ -211,7 +224,11 @@ exit_code: 0
     "main_state": "empty",
     "main": {
       "ahead": 0,
-      "behind": 0
+      "behind": 0,
+      "diff": {
+        "added": 0,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false
@@ -246,7 +263,11 @@ exit_code: 0
     "main_state": "empty",
     "main": {
       "ahead": 0,
-      "behind": 0
+      "behind": 0,
+      "diff": {
+        "added": 0,
+        "deleted": 0
+      }
     },
     "worktree": {
       "state": "locked",

--- a/tests/snapshots/integration__integration_tests__list__list_json_with_user_marker.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_json_with_user_marker.snap
@@ -7,6 +7,7 @@ info:
     - "--format=json"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -106,7 +107,11 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 1
+      "behind": 1,
+      "diff": {
+        "added": 1,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false
@@ -114,7 +119,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-a  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m",
+    "statusline": "feature-a  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m  ^\u001b[32m+1\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -141,7 +146,11 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 1
+      "behind": 1,
+      "diff": {
+        "added": 1,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false
@@ -149,7 +158,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-b  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m",
+    "statusline": "feature-b  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m  ^\u001b[32m+1\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -176,7 +185,11 @@ exit_code: 0
     "main_state": "diverged",
     "main": {
       "ahead": 1,
-      "behind": 1
+      "behind": 1,
+      "diff": {
+        "added": 1,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false
@@ -184,7 +197,7 @@ exit_code: 0
     "is_main": false,
     "is_current": false,
     "is_previous": false,
-    "statusline": "feature-c  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m",
+    "statusline": "feature-c  \u001b[2m↕\u001b[22m  \u001b[32m↑1\u001b[0m \u001b[2m\u001b[31m↓1\u001b[0m  ^\u001b[32m+1\u001b[0m",
     "symbols": "↕"
   },
   {
@@ -211,7 +224,11 @@ exit_code: 0
     "main_state": "empty",
     "main": {
       "ahead": 0,
-      "behind": 0
+      "behind": 0,
+      "diff": {
+        "added": 0,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false
@@ -246,7 +263,11 @@ exit_code: 0
     "main_state": "empty",
     "main": {
       "ahead": 0,
-      "behind": 0
+      "behind": 0,
+      "diff": {
+        "added": 0,
+        "deleted": 0
+      }
     },
     "worktree": {
       "detached": false

--- a/tests/snapshots/integration__integration_tests__list__list_large_diffs_alignment.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_large_diffs_alignment.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,14 +44,14 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m           [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m                     [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main                 [2m^[22m[2m|[22m                           [2m|[0m     .                        [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a            [2m↑[22m                 [32m↑1[0m               ../repo.feature-a        [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b            [2m↑[22m                 [32m↑1[0m               ../repo.feature-b        [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c            [2m↑[22m                 [32m↑1[0m               ../repo.feature-c        [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ fix                [36m?[39m [2m–[22m 💬                               ../repo.fix              [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ diverged          [36m![39m  [2m↑[22m 💬   [32m+40[0m  [31m-60[0m   [32m↑1[0m               ../repo.diverged         [2m96d1fd92[0m  [2m1d[0m    [2mDiverged commit[0m
-+ feature-changes   [36m![39m[36m?[39m [2m↑[22m 🤖   [32m+50[0m [31m-100[0m   [32m↑1[0m               ../repo.feature-changes  [2mf5306ded[0m  [2m1d[0m    [2mAdd 100 lines[0m
+  [1mBranch[0m           [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m                     [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main                 [2m^[22m[2m|[22m                                      [2m|[0m     .                        [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a            [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a        [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b            [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b        [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c            [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c        [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ fix                [36m?[39m [2m–[22m 💬                                          ../repo.fix              [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ diverged          [36m![39m  [2m↑[22m 💬   [32m+40[0m  [31m-60[0m   [32m↑1[0m       [32m+60[0m                ../repo.diverged         [2m96d1fd92[0m  [2m1d[0m    [2mDiverged commit[0m
++ feature-changes   [36m![39m[36m?[39m [2m↑[22m 🤖   [32m+50[0m [31m-100[0m   [32m↑1[0m      [32m+100[0m                ../repo.feature-changes  [2mf5306ded[0m  [2m1d[0m    [2mAdd 100 lines[0m
 
 [2m○[22m [2mShowing 7 worktrees, 3 with changes, 5 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_locked_no_reason.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_locked_no_reason.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,12 +44,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m            [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m                      [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main                  [2m^[22m[2m|[22m                           [2m|[0m     .                         [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a             [2m↑[22m                 [32m↑1[0m               ../repo.feature-a         [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b             [2m↑[22m                 [32m↑1[0m               ../repo.feature-b         [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c             [2m↑[22m                 [32m↑1[0m               ../repo.feature-c         [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ [2mlocked-no-reason[0m     [33m⊞[39m[2m_[22m                                  [2m../repo.locked-no-reason[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m            [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m                      [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main                  [2m^[22m[2m|[22m                                      [2m|[0m     .                         [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a             [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a         [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b             [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b         [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c             [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c         [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ [2mlocked-no-reason[0m     [33m⊞[39m[2m_[22m                                             [2m../repo.locked-no-reason[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_locked_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_locked_worktree.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,12 +44,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m          [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m                    [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main                [2m^[22m[2m|[22m                           [2m|[0m     .                       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a           [2m↑[22m                 [32m↑1[0m               ../repo.feature-a       [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b           [2m↑[22m                 [32m↑1[0m               ../repo.feature-b       [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c           [2m↑[22m                 [32m↑1[0m               ../repo.feature-c       [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ [2mlocked-feature[0m     [33m⊞[39m[2m_[22m                                  [2m../repo.locked-feature[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m          [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m                    [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main                [2m^[22m[2m|[22m                                      [2m|[0m     .                       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a           [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a       [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b           [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b       [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c           [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c       [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ [2mlocked-feature[0m     [33m⊞[39m[2m_[22m                                             [2m../repo.locked-feature[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_long_commit_message.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_long_commit_message.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m⇡[22m                         [32m⇡2[0m      .                  [2m8cf0f3d3[0m  [2m1d[0m    [2mShort message[0m
-+ feature-a      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m           ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m           ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m           ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m⇡[22m                                    [32m⇡2[0m      .                  [2m8cf0f3d3[0m  [2m1d[0m    [2mShort message[0m
++ feature-a      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_many_worktrees_with_varied_stats.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_many_worktrees_with_varied_stats.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,15 +44,15 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m                      [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m                                [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main                            [2m^[22m[2m|[22m                           [2m|[0m     .                                   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a                       [2m↑[22m                 [32m↑1[0m               ../repo.feature-a                   [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b                       [2m↑[22m                 [32m↑1[0m               ../repo.feature-b                   [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c                       [2m↑[22m                 [32m↑1[0m               ../repo.feature-c                   [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ [2mmedium-name[0m                     [2m_[22m                                  [2m../repo.medium-name[0m                 [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mshort[0m                           [2m_[22m                                  [2m../repo.short[0m                       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mvery-long-branch-name-here[0m      [2m_[22m                                  [2m../repo.very-long-branch-name-here[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mwith-changes[0m                    [2m_[22m                                  [2m../repo.with-changes[0m                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m                      [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m                                [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main                            [2m^[22m[2m|[22m                                      [2m|[0m     .                                   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a                       [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a                   [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b                       [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b                   [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c                       [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c                   [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ [2mmedium-name[0m                     [2m_[22m                                             [2m../repo.medium-name[0m                 [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mshort[0m                           [2m_[22m                                             [2m../repo.short[0m                       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mvery-long-branch-name-here[0m      [2m_[22m                                             [2m../repo.very-long-branch-name-here[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mwith-changes[0m                    [2m_[22m                                             [2m../repo.with-changes[0m                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 8 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_maximum_working_tree_symbols.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_maximum_working_tree_symbols.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,12 +44,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ feature    [36m+[39m[36m![39m[36m?[39m [2m↑[22m       [32m+2[0m   [31m-3[0m   [32m↑1[0m               ../repo.feature    [2mda422a12[0m  [2m1d[0m    [2mAdd files[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ feature    [36m+[39m[36m![39m[36m?[39m [2m↑[22m       [32m+2[0m   [31m-3[0m   [32m↑1[0m        [32m+4[0m                ../repo.feature    [2mda422a12[0m  [2m1d[0m    [2mAdd files[0m
 
 [2m○[22m [2mShowing 5 worktrees, 1 with changes, 4 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_multiple_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_multiple_worktrees.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_nested_worktree_current_indicator.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_nested_worktree_current_indicator.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,12 +44,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m                  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ [2mfeature[0m       [31m⚑[39m[2m_[22m                                  [2m./.worktrees/feature[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-^ main         [36m?[39m [2m^[22m[2m|[22m                           [2m|[0m     .                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a     [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b     [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c     [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m                  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ [2mfeature[0m       [31m⚑[39m[2m_[22m                                             [2m./.worktrees/feature[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+^ main         [36m?[39m [2m^[22m[2m|[22m                                      [2m|[0m     .                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a     [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b     [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c     [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 5 worktrees, 1 with changes, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_no_progressive_flag.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_no_progressive_flag.snap
@@ -7,6 +7,7 @@ info:
     - "--no-progressive"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,12 +45,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mfeature[0m        [2m_[22m                                  [2m../repo.feature[0m    [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mfeature[0m        [2m_[22m                                             [2m../repo.feature[0m    [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_ordering_rules.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_ordering_rules.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,15 +44,15 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m           [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m                     [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ feature-current      [2m↑[22m                 [32m↑1[0m               ../repo.feature-current  [2mf8d9dc91[0m  [2m23h[0m   [2mCommit at 01:00[0m
-^ main                 [2m^[22m[2m⇡[22m                         [32m⇡1[0m      .                        [2m01cab36c[0m  [2m1d[0m    [2mInitial commit on main[0m
-+ feature-a            [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m           ../repo.feature-a        [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b            [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m           ../repo.feature-b        [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c            [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m           ../repo.feature-c        [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ feature-newest       [2m↑[22m                 [32m↑1[0m               ../repo.feature-newest   [2m57c29ea7[0m  [2m21h[0m   [2mCommit at 03:00[0m
-+ feature-middle       [2m↑[22m                 [32m↑1[0m               ../repo.feature-middle   [2ma63f3739[0m  [2m22h[0m   [2mCommit at 02:00[0m
-+ feature-oldest       [2m↑[22m                 [32m↑1[0m               ../repo.feature-oldest   [2ma9b3e5b7[0m  [2m23h[0m   [2mCommit at 00:30[0m
+  [1mBranch[0m           [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m                     [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ feature-current      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-current  [2mf8d9dc91[0m  [2m23h[0m   [2mCommit at 01:00[0m
+^ main                 [2m^[22m[2m⇡[22m                                    [32m⇡1[0m      .                        [2m01cab36c[0m  [2m1d[0m    [2mInitial commit on main[0m
++ feature-a            [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m                ../repo.feature-a        [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b            [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m                ../repo.feature-b        [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c            [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m                ../repo.feature-c        [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ feature-newest       [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-newest   [2m57c29ea7[0m  [2m21h[0m   [2mCommit at 03:00[0m
++ feature-middle       [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-middle   [2ma63f3739[0m  [2m22h[0m   [2mCommit at 02:00[0m
++ feature-oldest       [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-oldest   [2ma9b3e5b7[0m  [2m23h[0m   [2mCommit at 00:30[0m
 
 [2m○[22m [2mShowing 8 worktrees, 7 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_previous_worktree_gutter.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_previous_worktree_gutter.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,12 +44,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mfeature[0m        [2m_[22m                                  [2m../repo.feature[0m    [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mfeature[0m        [2m_[22m                                             [2m../repo.feature[0m    [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_primary_on_different_branch.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_primary_on_different_branch.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ develop       [31m⚑[39m[2m^[22m                                  .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ develop       [31m⚑[39m[2m^[22m                                             .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_progressive_flag.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_progressive_flag.snap
@@ -7,6 +7,7 @@ info:
     - "--progressive"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,11 +45,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_progressive_with_branches.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_progressive_with_branches.snap
@@ -8,6 +8,7 @@ info:
     - "--branches"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -45,13 +46,13 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-[2m/ [0m[2morphan-1[0m      [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-[2m/ [0m[2morphan-2[0m      [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+[2m/ [0m[2morphan-1[0m      [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2morphan-2[0m      [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 2 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_shows_warning_on_git_error.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_shows_warning_on_git_error.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,20 +44,21 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m·[0m                              [2m·[0m  .                  [2m05a4a45d[0m  [2m·[0m     [2m·[0m
-+ feature    [2m·[0m  [2m·[0m[2m·[0m[2m·[0m            [2m·[0m        [2m·[0m        [2m·[0m  ../repo.feature    [2m00000000[0m  [2m·[0m     [2m·[0m
-+ feature-a      [2m↑[22m[2m·[0m                [32m↑1[0m            [2m·[0m  ../repo.feature-a  [2m1b87d473[0m  [2m·[0m     [2m·[0m
-+ feature-b      [2m↑[22m[2m·[0m                [32m↑1[0m            [2m·[0m  ../repo.feature-b  [2mf62940fc[0m  [2m·[0m     [2m·[0m
-+ feature-c      [2m↑[22m[2m·[0m                [32m↑1[0m            [2m·[0m  ../repo.feature-c  [2m345c7c93[0m  [2m·[0m     [2m·[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m·[0m                                         [2m·[0m  .                  [2m05a4a45d[0m  [2m·[0m     [2m·[0m
++ feature    [2m·[0m  [2m·[0m[2m·[0m[2m·[0m            [2m·[0m        [2m·[0m          [2m·[0m        [2m·[0m  ../repo.feature    [2m00000000[0m  [2m·[0m     [2m·[0m
++ feature-a      [2m↑[22m[2m·[0m                [32m↑1[0m        [32m+1[0m             [2m·[0m  ../repo.feature-a  [2m1b87d473[0m  [2m·[0m     [2m·[0m
++ feature-b      [2m↑[22m[2m·[0m                [32m↑1[0m        [32m+1[0m             [2m·[0m  ../repo.feature-b  [2mf62940fc[0m  [2m·[0m     [2m·[0m
++ feature-c      [2m↑[22m[2m·[0m                [32m↑1[0m        [32m+1[0m             [2m·[0m  ../repo.feature-c  [2m345c7c93[0m  [2m·[0m     [2m·[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead. 9 tasks failed[0m
+[2m○[22m [2mShowing 5 worktrees, 3 ahead. 10 tasks failed[0m
 
 ----- stderr -----
 [33m▲[39m [33mFailed to batch-fetch commit details: fatal: bad object 0000000000000000000000000000000000000001[39m
 [33m▲[39m [33mSome git operations failed:
 [107m [0m [1mmain[22m: upstream (fatal: missing object 0000000000000000000000000000000000000001 for refs/heads/feature)
 [107m [0m [1mfeature[22m: ahead-behind (git merge-base failed for 05a4a45d0b981dad5c27db59dca482836d59f89e 0000000000000000000000000000000000000001: fatal: Not a valid commit name 0000000000000000000000000000000000000001)
+[107m [0m [1mfeature[22m: branch-diff (git merge-base failed for 05a4a45d0b981dad5c27db59dca482836d59f89e 0000000000000000000000000000000000000001: fatal: Not a valid commit name 0000000000000000000000000000000000000001)
 [107m [0m [1mfeature[22m: working-tree-diff (fatal: bad object HEAD)
 [107m [0m [1mfeature[22m: merge-tree-conflicts (fatal: bad object HEAD)
 [107m [0m [1mfeature[22m: working-tree-conflicts (fatal: bad object HEAD)

--- a/tests/snapshots/integration__integration_tests__list__list_single_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_single_worktree.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_skips_operations_for_prunable_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_skips_operations_for_prunable_worktrees.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,12 +44,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature       [33m⊟[39m              [2m·[0m        [2m·[0m        [2m·[0m  ../repo.feature    [2m05a4a45d[0m  [2m·[0m     [2m·[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature       [33m⊟[39m              [2m·[0m        [2m·[0m          [2m·[0m        [2m·[0m  ../repo.feature    [2m05a4a45d[0m  [2m·[0m     [2m·[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_status_column_padding_with_emoji.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_status_column_padding_with_emoji.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,14 +44,14 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m        [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m                  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main              [2m^[22m[2m|[22m                           [2m|[0m     .                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a         [2m↑[22m                 [32m↑1[0m               ../repo.feature-a     [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b         [2m↑[22m                 [32m↑1[0m               ../repo.feature-b     [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c         [2m↑[22m                 [32m↑1[0m               ../repo.feature-c     [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ main-symbol       [2m↑[22m 💬              [32m↑1[0m               ../repo.main-symbol   [2m113f1df5[0m  [2m1d[0m    [2mSymbol commit[0m
-+ pr-link           [2m↑[22m 🤖              [32m↑1[0m               ../repo.pr-link       [2m152b5dea[0m  [2m1d[0m    [2mPR commit[0m
-+ wli-sequence   [36m![39m[36m?[39m [2m↑[22m 🤖    [32m+1[0m [31m-112[0m   [32m↑1[0m               ../repo.wli-sequence  [2m4353e28e[0m  [2m1d[0m    [2mInitial content[0m
+  [1mBranch[0m        [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m                  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main              [2m^[22m[2m|[22m                                      [2m|[0m     .                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a         [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a     [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b         [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b     [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c         [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c     [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ main-symbol       [2m↑[22m 💬              [32m↑1[0m        [32m+1[0m                ../repo.main-symbol   [2m113f1df5[0m  [2m1d[0m    [2mSymbol commit[0m
++ pr-link           [2m↑[22m 🤖              [32m↑1[0m        [32m+1[0m                ../repo.pr-link       [2m152b5dea[0m  [2m1d[0m    [2mPR commit[0m
++ wli-sequence   [36m![39m[36m?[39m [2m↑[22m 🤖    [32m+1[0m [31m-112[0m   [32m↑1[0m      [32m+200[0m                ../repo.wli-sequence  [2m4353e28e[0m  [2m1d[0m    [2mInitial content[0m
 
 [2m○[22m [2mShowing 7 worktrees, 1 with changes, 6 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_task_dag_detached_head.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_task_dag_detached_head.snap
@@ -7,6 +7,7 @@ info:
     - "--progressive"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,11 +45,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ -             [31m⚑[39m[2m^[22m                                  .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ -             [31m⚑[39m[2m^[22m                                             .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_task_dag_many_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_task_dag_many_worktrees.snap
@@ -7,6 +7,7 @@ info:
     - "--progressive"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,21 +45,21 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m      [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m                [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main            [2m^[22m[2m|[22m                           [2m|[0m     .                   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mfeature-1[0m       [2m_[22m                                  [2m../repo.feature-1[0m   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mfeature-10[0m      [2m_[22m                                  [2m../repo.feature-10[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mfeature-2[0m       [2m_[22m                                  [2m../repo.feature-2[0m   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mfeature-3[0m       [2m_[22m                                  [2m../repo.feature-3[0m   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mfeature-4[0m       [2m_[22m                                  [2m../repo.feature-4[0m   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mfeature-5[0m       [2m_[22m                                  [2m../repo.feature-5[0m   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mfeature-6[0m       [2m_[22m                                  [2m../repo.feature-6[0m   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mfeature-7[0m       [2m_[22m                                  [2m../repo.feature-7[0m   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mfeature-8[0m       [2m_[22m                                  [2m../repo.feature-8[0m   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mfeature-9[0m       [2m_[22m                                  [2m../repo.feature-9[0m   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a       [2m↑[22m                 [32m↑1[0m               ../repo.feature-a   [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b       [2m↑[22m                 [32m↑1[0m               ../repo.feature-b   [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c       [2m↑[22m                 [32m↑1[0m               ../repo.feature-c   [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m      [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m                [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main            [2m^[22m[2m|[22m                                      [2m|[0m     .                   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mfeature-1[0m       [2m_[22m                                             [2m../repo.feature-1[0m   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mfeature-10[0m      [2m_[22m                                             [2m../repo.feature-10[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mfeature-2[0m       [2m_[22m                                             [2m../repo.feature-2[0m   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mfeature-3[0m       [2m_[22m                                             [2m../repo.feature-3[0m   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mfeature-4[0m       [2m_[22m                                             [2m../repo.feature-4[0m   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mfeature-5[0m       [2m_[22m                                             [2m../repo.feature-5[0m   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mfeature-6[0m       [2m_[22m                                             [2m../repo.feature-6[0m   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mfeature-7[0m       [2m_[22m                                             [2m../repo.feature-7[0m   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mfeature-8[0m       [2m_[22m                                             [2m../repo.feature-8[0m   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mfeature-9[0m       [2m_[22m                                             [2m../repo.feature-9[0m   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a       [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a   [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b       [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b   [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c       [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c   [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 14 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_task_dag_multiple_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_task_dag_multiple_worktrees.snap
@@ -7,6 +7,7 @@ info:
     - "--progressive"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,11 +45,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_task_dag_single_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_task_dag_single_worktree.snap
@@ -7,6 +7,7 @@ info:
     - "--progressive"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,11 +45,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_task_dag_with_locked_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_task_dag_with_locked_worktree.snap
@@ -7,6 +7,7 @@ info:
     - "--progressive"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,13 +45,13 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ [2mlocked[0m        [33m⊞[39m[2m_[22m                                  [2m../repo.locked[0m     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mnormal[0m         [2m_[22m                                  [2m../repo.normal[0m     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ [2mlocked[0m        [33m⊞[39m[2m_[22m                                             [2m../repo.locked[0m     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mnormal[0m         [2m_[22m                                             [2m../repo.normal[0m     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 6 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_unicode_commit_message.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_unicode_commit_message.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,12 +44,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m        [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m                  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main              [2m^[22m[2m⇡[22m                         [32m⇡2[0m      .                     [2mba0edbd5[0m  [2m1d[0m    [2mFix bug with café ☕ handling[0m
-+ feature-a         [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m           ../repo.feature-a     [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b         [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m           ../repo.feature-b     [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c         [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m           ../repo.feature-c     [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ [2mfeature-test[0m      [2m⊂[22m                     [2m[31m↓1[0m           [2m../repo.feature-test[0m  [2m4b80044d[0m  [2m1d[0m    [2mAdd support for 日本語 and émoji 🎉[0m
+  [1mBranch[0m        [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m                  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main              [2m^[22m[2m⇡[22m                                    [32m⇡2[0m      .                     [2mba0edbd5[0m  [2m1d[0m    [2mFix bug with café ☕ handling[0m
++ feature-a         [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                ../repo.feature-a     [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b         [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                ../repo.feature-b     [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c         [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                ../repo.feature-c     [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ [2mfeature-test[0m      [2m⊂[22m                     [2m[31m↓1[0m                      [2m../repo.feature-test[0m  [2m4b80044d[0m  [2m1d[0m    [2mAdd support for 日本語 and émoji 🎉[0m
 
 [2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_user_marker_with_special_characters.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_user_marker_with_special_characters.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,13 +44,13 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2memoji[0m          [2m_[22m 🔄                               [2m../repo.emoji[0m      [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ [2mmulti[0m          [2m_[22m 👨‍💻                               [2m../repo.multi[0m      [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2memoji[0m          [2m_[22m 🔄                                          [2m../repo.emoji[0m      [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ [2mmulti[0m          [2m_[22m 👨‍💻                                          [2m../repo.multi[0m      [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 6 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_warns_when_commit_details_batch_fails.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_warns_when_commit_details_batch_fails.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,20 +44,21 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m·[0m     [2m·[0m
-+ -          [2m·[0m  [2m·[0m[2m·[0m             [2m·[0m        [2m·[0m           ../repo.feature    [2m00000000[0m  [2m·[0m     [2m·[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m·[0m     [2m·[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m·[0m     [2m·[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m·[0m     [2m·[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m·[0m     [2m·[0m
++ -          [2m·[0m  [2m·[0m[2m·[0m             [2m·[0m        [2m·[0m          [2m·[0m           ../repo.feature    [2m00000000[0m  [2m·[0m     [2m·[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m·[0m     [2m·[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m·[0m     [2m·[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m·[0m     [2m·[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead. 5 tasks failed[0m
+[2m○[22m [2mShowing 5 worktrees, 3 ahead. 6 tasks failed[0m
 
 ----- stderr -----
 [33m▲[39m [33mFailed to batch-fetch commit details: fatal: bad object 0000000000000000000000000000000000000001[39m
 [33m▲[39m [33mSome git operations failed:
 [107m [0m [1m(detached)[22m: ahead-behind (git merge-base failed for 05a4a45d0b981dad5c27db59dca482836d59f89e 0000000000000000000000000000000000000001: fatal: Not a valid commit name 0000000000000000000000000000000000000001)
 [107m [0m [1m(detached)[22m: committed-trees-match (fatal: ambiguous argument '0000000000000000000000000000000000000001^{tree}': unknown revision or path not in the working tree.)
+[107m [0m [1m(detached)[22m: branch-diff (git merge-base failed for 05a4a45d0b981dad5c27db59dca482836d59f89e 0000000000000000000000000000000000000001: fatal: Not a valid commit name 0000000000000000000000000000000000000001)
 [107m [0m [1m(detached)[22m: working-tree-diff (fatal: bad object HEAD)
 [107m [0m [1m(detached)[22m: merge-tree-conflicts (fatal: bad object HEAD)
 [107m [0m [1m(detached)[22m: working-tree-conflicts (fatal: bad object HEAD)[39m

--- a/tests/snapshots/integration__integration_tests__list__list_warns_when_default_branch_missing_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_warns_when_default_branch_missing_worktree.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ develop       [31m⚑[39m[2m^[22m                                  .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ develop       [31m⚑[39m[2m^[22m                                             .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_with_branches_flag.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_branches_flag.snap
@@ -7,6 +7,7 @@ info:
     - "--branches"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,15 +45,15 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m                    [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m                           [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main                          [2m^[22m[2m|[22m                           [2m|[0m     .                              [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a                     [2m↑[22m                 [32m↑1[0m               ../repo.feature-a              [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b                     [2m↑[22m                 [32m↑1[0m               ../repo.feature-b              [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c                     [2m↑[22m                 [32m↑1[0m               ../repo.feature-c              [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ [2mfeature-with-worktree[0m         [2m_[22m                                  [2m../repo.feature-with-worktree[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-[2m/ [0m[2manother-branch[0m               [2m/[22m[2m_[22m                                                                 [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-[2m/ [0m[2mfeature-without-worktree[0m     [2m/[22m[2m_[22m                                                                 [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-[2m/ [0m[2mfix-bug[0m                      [2m/[22m[2m_[22m                                                                 [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m                    [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m                           [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main                          [2m^[22m[2m|[22m                                      [2m|[0m     .                              [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a                     [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a              [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b                     [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b              [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c                     [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c              [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ [2mfeature-with-worktree[0m         [2m_[22m                                             [2m../repo.feature-with-worktree[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2manother-branch[0m               [2m/[22m[2m_[22m                                                                            [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2mfeature-without-worktree[0m     [2m/[22m[2m_[22m                                                                            [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2mfix-bug[0m                      [2m/[22m[2m_[22m                                                                            [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 5 worktrees, 3 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_with_branches_flag_no_available.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_branches_flag_no_available.snap
@@ -7,6 +7,7 @@ info:
     - "--branches"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,11 +45,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_with_branches_flag_only_branches.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_branches_flag_only_branches.snap
@@ -7,6 +7,7 @@ info:
     - "--branches"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,14 +45,14 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m        [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main              [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a         [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b         [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c         [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-[2m/ [0m[2mbranch-alpha[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-[2m/ [0m[2mbranch-beta[0m      [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-[2m/ [0m[2mbranch-gamma[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m        [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main              [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a         [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b         [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c         [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+[2m/ [0m[2mbranch-alpha[0m     [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2mbranch-beta[0m      [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2mbranch-gamma[0m     [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_with_c_flag.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_c_flag.snap
@@ -33,11 +33,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_with_nonexistent_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_nonexistent_default_branch.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main          [31m⚑[39m[2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a                                         ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b                                         ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c                                         ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main          [31m⚑[39m[2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a                                                    ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b                                                    ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c                                                    ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_with_remotes_and_branches.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_remotes_and_branches.snap
@@ -8,6 +8,7 @@ info:
     - "--remotes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -45,15 +46,15 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m                [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main                      [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a                 [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b                 [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c                 [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-[2m/ [0m[2mlocal-only-1[0m             [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-[2m/ [0m[2mlocal-only-2[0m             [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-[2m| [0m[2morigin/remote-only-1[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-[2m| [0m[2morigin/remote-only-2[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m                [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main                      [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a                 [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b                 [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c                 [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+[2m/ [0m[2mlocal-only-1[0m             [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m/ [0m[2mlocal-only-2[0m             [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m| [0m[2morigin/remote-only-1[0m     [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m| [0m[2morigin/remote-only-2[0m     [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 2 branches, 2 remote branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_with_remotes_filters_tracked_branches.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_remotes_filters_tracked_branches.snap
@@ -7,6 +7,7 @@ info:
     - "--remotes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,12 +45,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m              [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main                    [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a               [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b               [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c               [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-[2m| [0m[2morigin/remote-only[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m              [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main                    [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a               [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b               [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c               [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+[2m| [0m[2morigin/remote-only[0m     [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 remote branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_with_remotes_filters_tracked_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_remotes_filters_tracked_worktrees.snap
@@ -7,6 +7,7 @@ info:
     - "--remotes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,13 +45,13 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m                 [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m                           [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main                       [2m^[22m[2m|[22m                           [2m|[0m     .                              [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a                  [2m↑[22m                 [32m↑1[0m               ../repo.feature-a              [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b                  [2m↑[22m                 [32m↑1[0m               ../repo.feature-b              [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c                  [2m↑[22m                 [32m↑1[0m               ../repo.feature-c              [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ [2mfeature-with-worktree[0m      [2m_[22m[2m|[22m                           [2m|[0m     [2m../repo.feature-with-worktree[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-[2m| [0m[2morigin/remote-only[0m        [2m/[22m[2m_[22m                                                                 [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m                 [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m                           [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main                       [2m^[22m[2m|[22m                                      [2m|[0m     .                              [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a              [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b              [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c              [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ [2mfeature-with-worktree[0m      [2m_[22m[2m|[22m                                      [2m|[0m     [2m../repo.feature-with-worktree[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m| [0m[2morigin/remote-only[0m        [2m/[22m[2m_[22m                                                                            [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 5 worktrees, 1 remote branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_with_remotes_flag.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_remotes_flag.snap
@@ -7,6 +7,7 @@ info:
     - "--remotes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,13 +45,13 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m                   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main                         [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a                    [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b                    [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c                    [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-[2m| [0m[2morigin/remote-feature-1[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-[2m| [0m[2morigin/remote-feature-2[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m                   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main                         [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a                    [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b                    [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c                    [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+[2m| [0m[2morigin/remote-feature-1[0m     [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+[2m| [0m[2morigin/remote-feature-2[0m     [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 2 remote branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__list_with_user_marker.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_user_marker.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m       [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m                 [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main             [2m^[22m[2m⇡[22m                         [32m⇡1[0m      .                    [2m33323bc1[0m  [2m1d[0m    [2mInitial commit[0m
-+ feature-api      [2m↑[22m 🤖              [32m↑1[0m               ../repo.feature-api  [2m70343f03[0m  [2m1d[0m    [2mAdd REST API endpoints[0m
-+ review-ui      [36m?[39m [2m↑[22m 💬              [32m↑1[0m               ../repo.review-ui    [2ma585d6ed[0m  [2m1d[0m    [2mAdd dashboard component[0m
-+ wip-docs       [36m?[39m [2m–[22m                                  ../repo.wip-docs     [2m33323bc1[0m  [2m1d[0m    [2mInitial commit[0m
+  [1mBranch[0m       [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m                 [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main             [2m^[22m[2m⇡[22m                                    [32m⇡1[0m      .                    [2m33323bc1[0m  [2m1d[0m    [2mInitial commit[0m
++ feature-api      [2m↑[22m 🤖              [32m↑1[0m        [32m+1[0m                ../repo.feature-api  [2m70343f03[0m  [2m1d[0m    [2mAdd REST API endpoints[0m
++ review-ui      [36m?[39m [2m↑[22m 💬              [32m↑1[0m        [32m+1[0m                ../repo.review-ui    [2ma585d6ed[0m  [2m1d[0m    [2mAdd dashboard component[0m
++ wip-docs       [36m?[39m [2m–[22m                                             ../repo.wip-docs     [2m33323bc1[0m  [2m1d[0m    [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 2 with changes, 2 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__quickstart_list.snap
+++ b/tests/snapshots/integration__integration_tests__list__quickstart_list.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "98"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,9 +44,9 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m        [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ feature-auth  [36m+[39m   [2m↑[22m      [32m+27[0m   [31m-8[0m   [32m↑1[0m               [2m4bc72dc9[0m  [2m2h[0m    [2mAdd authentication module[0m
-^ main              [2m^[22m[2m⇡[22m                         [32m⇡1[0m      [2m0e631add[0m  [2m1d[0m    [2mInitial commit[0m
+  [1mBranch[0m        [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ feature-auth  [36m+[39m   [2m↑[22m      [32m+27[0m   [31m-8[0m   [32m↑1[0m       [32m+31[0m                [2m4bc72dc9[0m  [2m2h[0m    [2mAdd authenticat…[0m
+^ main              [2m^[22m[2m⇡[22m                                    [32m⇡1[0m      [2m0e631add[0m  [2m1d[0m    [2mInitial commit[0m
 
 [2m○[22m [2mShowing 2 worktrees, 1 with changes, 1 ahead, 1 column hidden[0m
 

--- a/tests/snapshots/integration__integration_tests__list__readme_example_list.snap
+++ b/tests/snapshots/integration__integration_tests__list__readme_example_list.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "98"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m       [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ feature-api  [36m+[39m   [2m↕[22m[2m⇡[22m     [32m+54[0m   [31m-5[0m   [32m↑4[0m  [2m[31m↓1[0m   [32m⇡3[0m      [2m6814f02a[0m  [2m30m[0m   [2mAdd API tests[0m
-^ main             [2m^[22m[2m⇅[22m                         [32m⇡1[0m  [2m[31m⇣1[0m  [2m41ee0834[0m  [2m4d[0m    [2mMerge fix-auth: hardened to…[0m
-+ fix-auth         [2m↕[22m[2m|[22m                [32m↑2[0m  [2m[31m↓1[0m     [2m|[0m     [2mb772e68b[0m  [2m5h[0m    [2mAdd secure token storage[0m
-+ [2mfix-typos[0m        [2m_[22m[2m|[22m                           [2m|[0m     [2m41ee0834[0m  [2m4d[0m    [2mMerge fix-auth: hardened to…[0m
+  [1mBranch[0m       [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ feature-api  [36m+[39m   [2m↕[22m[2m⇡[22m     [32m+54[0m   [31m-5[0m   [32m↑4[0m  [2m[31m↓1[0m  [32m+234[0m  [31m-24[0m   [32m⇡3[0m      [2m6814f02a[0m  [2m30m[0m   [2mAdd API tests[0m
+^ main             [2m^[22m[2m⇅[22m                                    [32m⇡1[0m  [2m[31m⇣1[0m  [2m41ee0834[0m  [2m4d[0m    [2mMerge fix-auth:…[0m
++ fix-auth         [2m↕[22m[2m|[22m                [32m↑2[0m  [2m[31m↓1[0m   [32m+25[0m  [31m-11[0m     [2m|[0m     [2mb772e68b[0m  [2m5h[0m    [2mAdd secure token…[0m
++ [2mfix-typos[0m        [2m_[22m[2m|[22m                                      [2m|[0m     [2m41ee0834[0m  [2m4d[0m    [2mMerge fix-auth:…[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 with changes, 2 ahead, 1 column hidden[0m
 

--- a/tests/snapshots/integration__integration_tests__list__readme_example_list_marker.snap
+++ b/tests/snapshots/integration__integration_tests__list__readme_example_list_marker.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "98"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m       [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main             [2m^[22m[2m⇡[22m                         [32m⇡1[0m      [2m33323bc1[0m  [2m1d[0m    [2mInitial commit[0m
-+ feature-api      [2m↑[22m 🤖              [32m↑1[0m               [2m70343f03[0m  [2m1d[0m    [2mAdd REST API endpoints[0m
-+ review-ui      [36m?[39m [2m↑[22m 💬              [32m↑1[0m               [2ma585d6ed[0m  [2m1d[0m    [2mAdd dashboard component[0m
-+ wip-docs       [36m?[39m [2m–[22m                                  [2m33323bc1[0m  [2m1d[0m    [2mInitial commit[0m
+  [1mBranch[0m       [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main             [2m^[22m[2m⇡[22m                                    [32m⇡1[0m      [2m33323bc1[0m  [2m1d[0m    [2mInitial commit[0m
++ feature-api      [2m↑[22m 🤖              [32m↑1[0m        [32m+1[0m                [2m70343f03[0m  [2m1d[0m    [2mAdd REST API end…[0m
++ review-ui      [36m?[39m [2m↑[22m 💬              [32m↑1[0m        [32m+1[0m                [2ma585d6ed[0m  [2m1d[0m    [2mAdd dashboard co…[0m
++ wip-docs       [36m?[39m [2m–[22m                                             [2m33323bc1[0m  [2m1d[0m    [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 2 with changes, 2 ahead, 1 column hidden[0m
 

--- a/tests/snapshots/integration__integration_tests__list__task_dag_ordering_stability.snap
+++ b/tests/snapshots/integration__integration_tests__list__task_dag_ordering_stability.snap
@@ -7,6 +7,7 @@ info:
     - "--progressive"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,15 +45,15 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m           [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m                     [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ feature-current      [2m↑[22m                 [32m↑1[0m               ../repo.feature-current  [2mf8d9dc91[0m  [2m23h[0m   [2mCommit at 01:00[0m
-^ main                 [2m^[22m[2m⇡[22m                         [32m⇡1[0m      .                        [2m01cab36c[0m  [2m1d[0m    [2mInitial commit on main[0m
-+ feature-a            [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m           ../repo.feature-a        [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b            [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m           ../repo.feature-b        [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c            [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m           ../repo.feature-c        [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ feature-newest       [2m↑[22m                 [32m↑1[0m               ../repo.feature-newest   [2m57c29ea7[0m  [2m21h[0m   [2mCommit at 03:00[0m
-+ feature-middle       [2m↑[22m                 [32m↑1[0m               ../repo.feature-middle   [2ma63f3739[0m  [2m22h[0m   [2mCommit at 02:00[0m
-+ feature-oldest       [2m↑[22m                 [32m↑1[0m               ../repo.feature-oldest   [2ma9b3e5b7[0m  [2m23h[0m   [2mCommit at 00:30[0m
+  [1mBranch[0m           [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m                     [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ feature-current      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-current  [2mf8d9dc91[0m  [2m23h[0m   [2mCommit at 01:00[0m
+^ main                 [2m^[22m[2m⇡[22m                                    [32m⇡1[0m      .                        [2m01cab36c[0m  [2m1d[0m    [2mInitial commit on main[0m
++ feature-a            [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m                ../repo.feature-a        [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b            [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m                ../repo.feature-b        [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c            [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m                ../repo.feature-c        [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ feature-newest       [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-newest   [2m57c29ea7[0m  [2m21h[0m   [2mCommit at 03:00[0m
++ feature-middle       [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-middle   [2ma63f3739[0m  [2m22h[0m   [2mCommit at 02:00[0m
++ feature-oldest       [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-oldest   [2ma9b3e5b7[0m  [2m23h[0m   [2mCommit at 00:30[0m
 
 [2m○[22m [2mShowing 8 worktrees, 7 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list__tips_dev_server_workflow.snap
+++ b/tests/snapshots/integration__integration_tests__list__tips_dev_server_workflow.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "98"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,12 +44,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m       [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mURL[0m                     [1mCommit[0m    [1mAge[0m
-@ main           [36m?[39m [2m^[22m[2m⇅[22m                         [32m⇡1[0m  [2m[31m⇣1[0m  [2mhttp://localhost:12107[0m  [2m41ee0834[0m  [2m4d[0m
-+ feature-api  [36m+[39m   [2m↕[22m[2m⇡[22m     [32m+54[0m   [31m-5[0m   [32m↑4[0m  [2m[31m↓1[0m   [32m⇡3[0m      [2mhttp://localhost:10703[0m  [2m6814f02a[0m  [2m30m[0m
-+ fix-auth         [2m↕[22m[2m|[22m                [32m↑2[0m  [2m[31m↓1[0m     [2m|[0m     [2mhttp://localhost:16460[0m  [2mb772e68b[0m  [2m5h[0m
-+ [2mfix-typos[0m        [2m_[22m[2m|[22m                           [2m|[0m     [2mhttp://localhost:14301[0m  [2m41ee0834[0m  [2m4d[0m
+  [1mBranch[0m       [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mURL[0m                     [1mCommit[0m
+@ main           [36m?[39m [2m^[22m[2m⇅[22m                                    [32m⇡1[0m  [2m[31m⇣1[0m  [2mhttp://localhost:12107[0m  [2m41ee0834[0m
++ feature-api  [36m+[39m   [2m↕[22m[2m⇡[22m     [32m+54[0m   [31m-5[0m   [32m↑4[0m  [2m[31m↓1[0m  [32m+234[0m  [31m-24[0m   [32m⇡3[0m      [2mhttp://localhost:10703[0m  [2m6814f02a[0m
++ fix-auth         [2m↕[22m[2m|[22m                [32m↑2[0m  [2m[31m↓1[0m   [32m+25[0m  [31m-11[0m     [2m|[0m     [2mhttp://localhost:16460[0m  [2mb772e68b[0m
++ [2mfix-typos[0m        [2m_[22m[2m|[22m                                      [2m|[0m     [2mhttp://localhost:14301[0m  [2m41ee0834[0m
 
-[2m○[22m [2mShowing 4 worktrees, 2 with changes, 2 ahead, 2 columns hidden[0m
+[2m○[22m [2mShowing 4 worktrees, 2 with changes, 2 ahead, 3 columns hidden[0m
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__list__working_tree_conflicts_without_full.snap
+++ b/tests/snapshots/integration__integration_tests__list__working_tree_conflicts_without_full.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,12 +44,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m⇡[22m                         [32m⇡2[0m      .                  [2m1edd043e[0m  [2m1d[0m    [2mMain changes shared.txt[0m
-+ feature-a      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m           ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m           ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m           ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ feature     [36m![39m  [33m✗[39m       [32m+1[0m   [31m-1[0m       [2m[31m↓1[0m           ../repo.feature    [2ma756a743[0m  [2m1d[0m    [2mInitial commit[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m⇡[22m                                    [32m⇡2[0m      .                  [2m1edd043e[0m  [2m1d[0m    [2mMain changes shared.txt[0m
++ feature-a      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ feature     [36m![39m  [33m✗[39m       [32m+1[0m   [31m-1[0m       [2m[31m↓1[0m                      ../repo.feature    [2ma756a743[0m  [2m1d[0m    [2mInitial commit[0m
 
 [2m○[22m [2mShowing 5 worktrees, 1 with changes, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_column_alignment__status_column_alignment_with_header.snap
+++ b/tests/snapshots/integration__integration_tests__list_column_alignment__status_column_alignment_with_header.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,12 +44,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ test        [36m![39m[36m?[39m [2m↑[22m       [32m+1[0m   [31m-1[0m   [32m↑1[0m               ../repo.test       [2m572ec619[0m  [2m1d[0m    [2mTest[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ test        [36m![39m[36m?[39m [2m↑[22m       [32m+1[0m   [31m-1[0m   [32m↑1[0m        [32m+1[0m   [31m-1[0m           ../repo.test       [2m572ec619[0m  [2m1d[0m    [2mTest[0m
 
 [2m○[22m [2mShowing 5 worktrees, 1 with changes, 4 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_column_alignment__status_column_width_consistency.snap
+++ b/tests/snapshots/integration__integration_tests__list_column_alignment__status_column_width_consistency.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,13 +44,13 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ complex    [36m+[39m [36m?[39m [2m↑[22m       [32m+1[0m   [31m-1[0m   [32m↑1[0m               ../repo.complex    [2m0fdc439a[0m  [2m1d[0m    [2mComplex[0m
-+ simple       [36m?[39m [2m↑[22m                 [32m↑1[0m               ../repo.simple     [2m42a9d012[0m  [2m1d[0m    [2mSimple[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ complex    [36m+[39m [36m?[39m [2m↑[22m       [32m+1[0m   [31m-1[0m   [32m↑1[0m        [32m+1[0m   [31m-1[0m           ../repo.complex    [2m0fdc439a[0m  [2m1d[0m    [2mComplex[0m
++ simple       [36m?[39m [2m↑[22m                 [32m↑1[0m        [32m+1[0m   [31m-1[0m           ../repo.simple     [2m42a9d012[0m  [2m1d[0m    [2mSimple[0m
 
 [2m○[22m [2mShowing 6 worktrees, 2 with changes, 5 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_branches_enabled.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_branches_enabled.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,12 +44,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_branches_flag_overrides_file.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_branches_flag_overrides_file.snap
@@ -7,6 +7,7 @@ info:
     - "--branches"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,12 +45,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_cli_override_after_subcommand.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_cli_override_after_subcommand.snap
@@ -8,6 +8,7 @@ info:
     - list.branches = true
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -45,12 +46,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_cli_override_beats_file.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_cli_override_beats_file.snap
@@ -3,11 +3,12 @@ source: tests/integration_tests/list_config.rs
 info:
   program: wt
   args:
-    - "-c"
+    - "--config-set"
     - list.branches = true
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -45,12 +46,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_cli_override_deprecated_key_silently_migrated.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_cli_override_deprecated_key_silently_migrated.snap
@@ -8,6 +8,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -45,12 +46,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_cli_override_malformed_warns_on_stderr.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_cli_override_malformed_warns_on_stderr.snap
@@ -8,6 +8,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -45,12 +46,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_columns_env_override_not_yet_supported.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_columns_env_override_not_yet_supported.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "200"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,11 +45,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_env_deprecated_type_mismatch_drops_layer.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_env_deprecated_type_mismatch_drops_layer.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,11 +45,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_bad_value_preserves_file_config.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_bad_value_preserves_file_config.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,12 +45,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_bad_value_warns_on_stderr.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_bad_value_warns_on_stderr.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,11 +45,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_preserves_file_fields.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_preserves_file_fields.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,12 +45,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+[2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_validation_failure.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_validation_failure.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,11 +45,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_config_warns_on_stderr.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_config_warns_on_stderr.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_non_section_field_warns_on_stderr.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_non_section_field_warns_on_stderr.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_system_config_non_section_field.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_system_config_non_section_field.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main         [36m?[39m [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main         [36m?[39m [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 with changes, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_system_config_warns_on_stderr.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_system_config_warns_on_stderr.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main         [36m?[39m [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main         [36m?[39m [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 with changes, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_validation_error_warns_on_stderr.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_validation_error_warns_on_stderr.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_custom_column_empty_everywhere_dropped.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_custom_column_empty_everywhere_dropped.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_custom_columns.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_custom_columns.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mTicket[0m     [1mCodename[0m            [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                             mellow-kite         [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  JIRA-1234  fearless-iguanodon  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b             spirited-mink       [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c             secure-sicklebill   [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mTicket[0m     [1mCodename[0m            [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                             mellow-kite         [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  JIRA-1234  fearless-iguanodon  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b             spirited-mink       [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c             secure-sicklebill   [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_no_config.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_no_config.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__list_config__list_project_url_column.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_project_url_column.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mURL[0m                     [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main         [36m?[39m [2m^[22m[2m|[22m                           [2m|[0m     .                  [2mhttp://localhost:12107[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2mhttp://localhost:11521[0m  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mhttp://localhost:14072[0m  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2mhttp://localhost:14303[0m  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mURL[0m                     [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main         [36m?[39m [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2mhttp://localhost:12107[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2mhttp://localhost:11521[0m  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mhttp://localhost:14072[0m  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2mhttp://localhost:14303[0m  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 with changes, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__security__commit_message_with_directive_not_executed.snap
+++ b/tests/snapshots/integration__integration_tests__security__commit_message_with_directive_not_executed.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,12 +44,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m⇡[22m                         [32m⇡1[0m      .                  [2m252b848b[0m  [2m1d[0m    [2mFix bug __WORKTRUNK_EXEC__echo PWNED > /tmp/hacked4[0m
-+ feature-a      [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m           ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m           ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m           ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ [2mfeature[0m        [2m_[22m                                  [2m../repo.feature[0m    [2m252b848b[0m  [2m1d[0m    [2mFix bug __WORKTRUNK_EXEC__echo PWNED > /tmp/hacked4[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m⇡[22m                                    [32m⇡1[0m      .                  [2m252b848b[0m  [2m1d[0m    [2mFix bug __WORKTRUNK_EXEC__echo PWNED > /tmp/hacked4[0m
++ feature-a      [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ [2mfeature[0m        [2m_[22m                                             [2m../repo.feature[0m    [2m252b848b[0m  [2m1d[0m    [2mFix bug __WORKTRUNK_EXEC__echo PWNED > /tmp/hacked4[0m
 
 [2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__security__git_ignores_malformed_refs_with_ansi.snap
+++ b/tests/snapshots/integration__integration_tests__security__git_ignores_malformed_refs_with_ansi.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__security__literal_escape_like_branch_names_displayed_safely.snap
+++ b/tests/snapshots/integration__integration_tests__security__literal_escape_like_branch_names_displayed_safely.snap
@@ -7,6 +7,7 @@ info:
     - "--branches"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -44,12 +45,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m                  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main                        [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a                   [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b                   [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c                   [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-[2m/ [0m[2mfix-backslash-x1b-test[0m     [2m/[22m[2m_[22m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m                  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main                        [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a                   [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b                   [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c                   [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+[2m/ [0m[2mfix-backslash-x1b-test[0m     [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__security__path_with_directive_not_executed.snap
+++ b/tests/snapshots/integration__integration_tests__security__path_with_directive_not_executed.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,11 +44,11 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_empty_diffs.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_empty_diffs.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "180"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,14 +44,14 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m           [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m                     [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main                 [2m^[22m[2m|[22m                           [2m|[0m     .                        [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2malso-no-changes[0m      [2m_[22m                                  [2m../repo.also-no-changes[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a            [2m↑[22m                 [32m↑1[0m               ../repo.feature-a        [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b            [2m↑[22m                 [32m↑1[0m               ../repo.feature-b        [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c            [2m↑[22m                 [32m↑1[0m               ../repo.feature-c        [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ [2mno-changes[0m           [2m_[22m                                  [2m../repo.no-changes[0m       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ with-changes      [36m![39m  [2m–[22m       [32m+1[0m   [31m-1[0m                    ../repo.with-changes     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m           [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m                     [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main                 [2m^[22m[2m|[22m                                      [2m|[0m     .                        [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2malso-no-changes[0m      [2m_[22m                                             [2m../repo.also-no-changes[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a            [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a        [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b            [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b        [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c            [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c        [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ [2mno-changes[0m           [2m_[22m                                             [2m../repo.no-changes[0m       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ with-changes      [36m![39m  [2m–[22m       [32m+1[0m   [31m-1[0m                               ../repo.with-changes     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_extreme_diffs.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_extreme_diffs.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "180"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,13 +44,13 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ huge         [36m?[39m [2m–[22m                                  ../repo.huge       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ tiny        [36m![39m  [2m–[22m       [32m+1[0m   [31m-1[0m                    ../repo.tiny       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ huge         [36m?[39m [2m–[22m                                             ../repo.huge       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ tiny        [36m![39m  [2m–[22m       [32m+1[0m   [31m-1[0m                               ../repo.tiny       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 6 worktrees, 2 with changes, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_varying_diffs.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_varying_diffs.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "180"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,14 +44,14 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m          [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m                    [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main                [2m^[22m[2m|[22m                           [2m|[0m     .                       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a           [2m↑[22m                 [32m↑1[0m               ../repo.feature-a       [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b           [2m↑[22m                 [32m↑1[0m               ../repo.feature-b       [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c           [2m↑[22m                 [32m↑1[0m               ../repo.feature-c       [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ feature-large     [36m?[39m [2m–[22m                                  ../repo.feature-large   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-medium    [36m?[39m [2m–[22m                                  ../repo.feature-medium  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-small     [36m?[39m [2m–[22m                                  ../repo.feature-small   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m          [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m                    [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main                [2m^[22m[2m|[22m                                      [2m|[0m     .                       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a           [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a       [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b           [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b       [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c           [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c       [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ feature-large     [36m?[39m [2m–[22m                                             ../repo.feature-large   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-medium    [36m?[39m [2m–[22m                                             ../repo.feature-medium  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-small     [36m?[39m [2m–[22m                                             ../repo.feature-small   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 7 worktrees, 3 with changes, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__long_branch_names.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__long_branch_names.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,14 +44,14 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m                            [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m                                      [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main                                  [2m^[22m[2m|[22m                           [2m|[0m     .                                         [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2manother-extremely-long-name-here[0m      [2m_[22m                                  [2m../repo.another-extremely-long-name-here[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a                             [2m↑[22m                 [32m↑1[0m               ../repo.feature-a                         [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b                             [2m↑[22m                 [32m↑1[0m               ../repo.feature-b                         [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c                             [2m↑[22m                 [32m↑1[0m               ../repo.feature-c                         [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ [2mshort[0m                                 [2m_[22m                                  [2m../repo.short[0m                             [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mvery-long-feature-branch-name[0m         [2m_[22m                                  [2m../repo.very-long-feature-branch-name[0m     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m                            [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m                                      [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main                                  [2m^[22m[2m|[22m                                      [2m|[0m     .                                         [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2manother-extremely-long-name-here[0m      [2m_[22m                                             [2m../repo.another-extremely-long-name-here[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a                             [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a                         [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b                             [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b                         [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c                             [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c                         [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ [2mshort[0m                                 [2m_[22m                                             [2m../repo.short[0m                             [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mvery-long-feature-branch-name[0m         [2m_[22m                                             [2m../repo.very-long-feature-branch-name[0m     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 7 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__mixed_length_branch_names.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__mixed_length_branch_names.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,14 +44,14 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m                                                     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m                                                               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main                                                           [2m^[22m[2m|[22m                           [2m|[0m     .                                                                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mextremely-long-branch-name-that-might-cause-layout-issues[0m      [2m_[22m                                  [2m../repo.extremely-long-branch-name-that-might-cause-layout-issues[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a                                                      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a                                                  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b                                                      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b                                                  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c                                                      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c                                                  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ [2mmedium[0m                                                         [2m_[22m                                  [2m../repo.medium[0m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mx[0m                                                              [2m_[22m                                  [2m../repo.x[0m                                                          [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m                                                     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m                                                               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main                                                           [2m^[22m[2m|[22m                                      [2m|[0m     .                                                                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mextremely-long-branch-name-that-might-cause-layout-issues[0m      [2m_[22m                                             [2m../repo.extremely-long-branch-name-that-might-cause-layout-issues[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a                                                      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a                                                  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b                                                      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b                                                  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c                                                      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c                                                  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ [2mmedium[0m                                                         [2m_[22m                                             [2m../repo.medium[0m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mx[0m                                                              [2m_[22m                                             [2m../repo.x[0m                                                          [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 7 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__short_branch_names.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__short_branch_names.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,14 +44,14 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2ma[0m              [2m_[22m                                  [2m../repo.a[0m          [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mbb[0m             [2m_[22m                                  [2m../repo.bb[0m         [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mccc[0m            [2m_[22m                                  [2m../repo.ccc[0m        [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2ma[0m              [2m_[22m                                             [2m../repo.a[0m          [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mbb[0m             [2m_[22m                                             [2m../repo.bb[0m         [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mccc[0m            [2m_[22m                                             [2m../repo.ccc[0m        [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 7 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__unicode_branch_names.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__unicode_branch_names.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,14 +44,14 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main           [2m^[22m[2m|[22m                           [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mcafe[0m           [2m_[22m                                  [2m../repo.cafe[0m       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ [2mnaive[0m          [2m_[22m                                  [2m../repo.naive[0m      [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mresume[0m         [2m_[22m                                  [2m../repo.resume[0m     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mcafe[0m           [2m_[22m                                             [2m../repo.cafe[0m       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ [2mnaive[0m          [2m_[22m                                             [2m../repo.naive[0m      [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mresume[0m         [2m_[22m                                             [2m../repo.resume[0m     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 7 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_100.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_100.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "100"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,15 +44,15 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m                                   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m
-@ main                                         [2m^[22m[2m|[22m                           [2m|[0m     [2m05a4a45d[0m  [2m16h[0m
-+ feature-a                                    [2m↑[22m                 [32m↑1[0m               [2m1b87d473[0m  [2m16h[0m
-+ feature-b                                    [2m↑[22m                 [32m↑1[0m               [2mf62940fc[0m  [2m16h[0m
-+ feature-c                                    [2m↑[22m                 [32m↑1[0m               [2m345c7c93[0m  [2m16h[0m
-+ feature/implement-oauth2-social-login      [36m?[39m [2m–[22m                                  [2m05a4a45d[0m  [2m16h[0m
-+ [2mfix/database-connection-pool-exhaustion[0m      [2m_[22m                                  [2m05a4a45d[0m  [2m16h[0m
-+ [2mshort[0m                                        [2m_[22m                                  [2m05a4a45d[0m  [2m16h[0m
+  [1mBranch[0m                                   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mAge[0m
+@ main                                         [2m^[22m[2m|[22m                                      [2m|[0m     [2m16h[0m
++ feature-a                                    [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2m16h[0m
++ feature-b                                    [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2m16h[0m
++ feature-c                                    [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2m16h[0m
++ feature/implement-oauth2-social-login      [36m?[39m [2m–[22m                                             [2m16h[0m
++ [2mfix/database-connection-pool-exhaustion[0m      [2m_[22m                                             [2m16h[0m
++ [2mshort[0m                                        [2m_[22m                                             [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 2 columns hidden[0m
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 3 columns hidden[0m
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_120.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_120.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "120"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,14 +44,14 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m                                   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main                                         [2m^[22m[2m|[22m                           [2m|[0m     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a                                    [2m↑[22m                 [32m↑1[0m               [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b                                    [2m↑[22m                 [32m↑1[0m               [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c                                    [2m↑[22m                 [32m↑1[0m               [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ feature/implement-oauth2-social-login      [36m?[39m [2m–[22m                                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mfix/database-connection-pool-exhaustion[0m      [2m_[22m                                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mshort[0m                                        [2m_[22m                                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m                                   [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main                                         [2m^[22m[2m|[22m                                      [2m|[0m     [2m05a4a45d[0m  [2m16h[0m   [2mInitial co…[0m
++ feature-a                                    [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2m1b87d473[0m  [2m16h[0m   [2mAdd featur…[0m
++ feature-b                                    [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2mf62940fc[0m  [2m16h[0m   [2mAdd featur…[0m
++ feature-c                                    [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2m345c7c93[0m  [2m16h[0m   [2mAdd featur…[0m
++ feature/implement-oauth2-social-login      [36m?[39m [2m–[22m                                             [2m05a4a45d[0m  [2m16h[0m   [2mInitial co…[0m
++ [2mfix/database-connection-pool-exhaustion[0m      [2m_[22m                                             [2m05a4a45d[0m  [2m16h[0m   [2mInitial co…[0m
++ [2mshort[0m                                        [2m_[22m                                             [2m05a4a45d[0m  [2m16h[0m   [2mInitial co…[0m
 
 [2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 1 column hidden[0m
 

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_30.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_30.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "30"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -52,6 +53,6 @@ exit_code: 0
 + [2mfix/database-connection-poo[22m…[0m
 + [2mshort[0m
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 8 columns hidden[0m
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 9 columns hidden[0m
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_40.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_40.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "40"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -52,6 +53,6 @@ exit_code: 0
 + [2mfix/database-connection-pool-exhausti[22m…[0m
 + [2mshort[0m
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 8 columns hidden[0m
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 9 columns hidden[0m
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_50.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_50.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "50"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -52,6 +53,6 @@ exit_code: 0
 + [2mfix/database-connection-pool-exhaustion[0m  
 + [2mshort[0m                                    
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 7 columns hidden[0m
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 8 columns hidden[0m
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_60.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_60.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "60"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -52,6 +53,6 @@ exit_code: 0
 + [2mfix/database-connection-pool-exhaustion[0m      [2m_[22m     
 + [2mshort[0m                                        [2m_[22m     
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 6 columns hidden[0m
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 7 columns hidden[0m
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_80.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_80.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "80"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -52,6 +53,6 @@ exit_code: 0
 + [2mfix/database-connection-pool-exhaustion[0m      [2m_[22m                         
 + [2mshort[0m                                        [2m_[22m                         
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 4 columns hidden[0m
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 5 columns hidden[0m
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_100.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_100.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "50"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -52,6 +53,6 @@ exit_code: 0
 + feature-c                  [2m↑[22m                [2m16h[0m
 + [2mfix/login-timeout[0m          [2m_[22m                [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 5 columns hidden[0m
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 6 columns hidden[0m
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_120.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_120.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "60"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -52,6 +53,6 @@ exit_code: 0
 + feature-c                  [2m↑[22m                 [32m↑1[0m      [2m16h[0m
 + [2mfix/login-timeout[0m          [2m_[22m                         [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 4 columns hidden[0m
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 5 columns hidden[0m
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_160.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_160.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "80"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,15 +44,15 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m                 [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m
-@ main                       [2m^[22m[2m|[22m                           [2m|[0m     [2m05a4a45d[0m  [2m16h[0m
-+ [2mchore/update-deps[0m          [2m_[22m                                  [2m05a4a45d[0m  [2m16h[0m
-+ feature-a                  [2m↑[22m                 [32m↑1[0m               [2m1b87d473[0m  [2m16h[0m
-+ feature/auth-redesign    [36m?[39m [2m–[22m                                  [2m05a4a45d[0m  [2m16h[0m
-+ feature-b                  [2m↑[22m                 [32m↑1[0m               [2mf62940fc[0m  [2m16h[0m
-+ feature-c                  [2m↑[22m                 [32m↑1[0m               [2m345c7c93[0m  [2m16h[0m
-+ [2mfix/login-timeout[0m          [2m_[22m                                  [2m05a4a45d[0m  [2m16h[0m
+  [1mBranch[0m                 [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mAge[0m
+@ main                       [2m^[22m[2m|[22m                                      [2m|[0m     [2m16h[0m
++ [2mchore/update-deps[0m          [2m_[22m                                             [2m16h[0m
++ feature-a                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2m16h[0m
++ feature/auth-redesign    [36m?[39m [2m–[22m                                             [2m16h[0m
++ feature-b                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2m16h[0m
++ feature-c                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2m16h[0m
++ [2mfix/login-timeout[0m          [2m_[22m                                             [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 2 columns hidden[0m
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 3 columns hidden[0m
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_60.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_60.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "30"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -52,6 +53,6 @@ exit_code: 0
 + feature-c              [2m16h[0m
 + [2mfix/login-timeout[0m      [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 7 columns hidden[0m
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 8 columns hidden[0m
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_80.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_80.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "40"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -52,6 +53,6 @@ exit_code: 0
 + feature-c                  [2m↑[22m     [2m16h[0m
 + [2mfix/login-timeout[0m          [2m_[22m     [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 6 columns hidden[0m
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 7 columns hidden[0m
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_100.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_100.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "100"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,15 +44,15 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m                 [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main                       [2m^[22m[2m|[22m                           [2m|[0m     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mchore/update-deps[0m          [2m_[22m                                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a                  [2m↑[22m                 [32m↑1[0m               [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature/auth-redesign    [36m?[39m [2m–[22m                                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-b                  [2m↑[22m                 [32m↑1[0m               [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c                  [2m↑[22m                 [32m↑1[0m               [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ fix/login-timeout        [36m?[39m [2m–[22m                                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m                 [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m
+@ main                       [2m^[22m[2m|[22m                                      [2m|[0m     [2m05a4a45d[0m  [2m16h[0m
++ [2mchore/update-deps[0m          [2m_[22m                                             [2m05a4a45d[0m  [2m16h[0m
++ feature-a                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2m1b87d473[0m  [2m16h[0m
++ feature/auth-redesign    [36m?[39m [2m–[22m                                             [2m05a4a45d[0m  [2m16h[0m
++ feature-b                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2mf62940fc[0m  [2m16h[0m
++ feature-c                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2m345c7c93[0m  [2m16h[0m
++ fix/login-timeout        [36m?[39m [2m–[22m                                             [2m05a4a45d[0m  [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 1 column hidden[0m
+[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 2 columns hidden[0m
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_120.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_120.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "120"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,14 +44,14 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m                 [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main                       [2m^[22m[2m|[22m                           [2m|[0m     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mchore/update-deps[0m          [2m_[22m                                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a                  [2m↑[22m                 [32m↑1[0m               [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature/auth-redesign    [36m?[39m [2m–[22m                                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-b                  [2m↑[22m                 [32m↑1[0m               [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c                  [2m↑[22m                 [32m↑1[0m               [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ fix/login-timeout        [36m?[39m [2m–[22m                                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m                 [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main                       [2m^[22m[2m|[22m                                      [2m|[0m     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mchore/update-deps[0m          [2m_[22m                                             [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature/auth-redesign    [36m?[39m [2m–[22m                                             [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-b                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ fix/login-timeout        [36m?[39m [2m–[22m                                             [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 1 column hidden[0m
 

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_30.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_30.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "30"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -52,6 +53,6 @@ exit_code: 0
 + feature-c              [2m16h[0m
 + fix/login-timeout      [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 7 columns hidden[0m
+[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 8 columns hidden[0m
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_40.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_40.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "40"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -52,6 +53,6 @@ exit_code: 0
 + feature-c                  [2m↑[22m     [2m16h[0m
 + fix/login-timeout        [36m?[39m [2m–[22m     [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 6 columns hidden[0m
+[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 7 columns hidden[0m
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_50.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_50.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "50"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -52,6 +53,6 @@ exit_code: 0
 + feature-c                  [2m↑[22m                [2m16h[0m
 + fix/login-timeout        [36m?[39m [2m–[22m                [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 5 columns hidden[0m
+[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 6 columns hidden[0m
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_60.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_60.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "60"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -52,6 +53,6 @@ exit_code: 0
 + feature-c                  [2m↑[22m                 [32m↑1[0m      [2m16h[0m
 + fix/login-timeout        [36m?[39m [2m–[22m                         [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 4 columns hidden[0m
+[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 5 columns hidden[0m
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_80.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_80.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "80"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,15 +44,15 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m                 [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mCommit[0m    [1mAge[0m
-@ main                       [2m^[22m[2m|[22m                           [2m|[0m     [2m05a4a45d[0m  [2m16h[0m
-+ [2mchore/update-deps[0m          [2m_[22m                                  [2m05a4a45d[0m  [2m16h[0m
-+ feature-a                  [2m↑[22m                 [32m↑1[0m               [2m1b87d473[0m  [2m16h[0m
-+ feature/auth-redesign    [36m?[39m [2m–[22m                                  [2m05a4a45d[0m  [2m16h[0m
-+ feature-b                  [2m↑[22m                 [32m↑1[0m               [2mf62940fc[0m  [2m16h[0m
-+ feature-c                  [2m↑[22m                 [32m↑1[0m               [2m345c7c93[0m  [2m16h[0m
-+ fix/login-timeout        [36m?[39m [2m–[22m                                  [2m05a4a45d[0m  [2m16h[0m
+  [1mBranch[0m                 [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mAge[0m
+@ main                       [2m^[22m[2m|[22m                                      [2m|[0m     [2m16h[0m
++ [2mchore/update-deps[0m          [2m_[22m                                             [2m16h[0m
++ feature-a                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2m16h[0m
++ feature/auth-redesign    [36m?[39m [2m–[22m                                             [2m16h[0m
++ feature-b                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2m16h[0m
++ feature-c                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2m16h[0m
++ fix/login-timeout        [36m?[39m [2m–[22m                                             [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 2 columns hidden[0m
+[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 3 columns hidden[0m
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__step_promote__promote_shows_mismatch_in_list.snap
+++ b/tests/snapshots/integration__integration_tests__step_promote__promote_shows_mismatch_in_list.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,12 +44,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ feature       [31m⚑[39m[2m^[22m                                  .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2mmain[0m          [31m⚑[39m[2m_[22m[2m|[22m                           [2m|[0m     [2m../repo.feature[0m    [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a      [2m↑[22m                 [32m↑1[0m               ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b      [2m↑[22m                 [32m↑1[0m               ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c      [2m↑[22m                 [32m↑1[0m               ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ feature       [31m⚑[39m[2m^[22m                                             .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2mmain[0m          [31m⚑[39m[2m_[22m[2m|[22m                                      [2m|[0m     [2m../repo.feature[0m    [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
 [2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__switch__list_with_relative_paths.snap
+++ b/tests/snapshots/integration__integration_tests__switch__list_with_relative_paths.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -43,12 +44,12 @@ info:
 success: true
 exit_code: 0
 ----- stdout -----
-  [1mBranch[0m         [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m  [1mRemote⇅[0m  [1mPath[0m                   [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ main               [2m^[22m[2m|[22m                           [2m|[0m     .                      [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ feature-a          [2m↑[22m                 [32m↑1[0m               ../repo.feature-a      [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
-+ feature-b          [2m↑[22m                 [32m↑1[0m               ../repo.feature-b      [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
-+ feature-c          [2m↑[22m                 [32m↑1[0m               ../repo.feature-c      [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
-+ [2mrelative-test[0m      [2m_[22m                                  [2m../repo.relative-test[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+  [1mBranch[0m         [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m                   [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main               [2m^[22m[2m|[22m                                      [2m|[0m     .                      [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a          [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a      [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b          [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b      [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c          [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c      [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ [2mrelative-test[0m      [2m_[22m                                             [2m../repo.relative-test[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
 [2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
 

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_abort_escape_list.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_abort_escape_list.snap
@@ -3,5 +3,5 @@ source: tests/integration_tests/switch_picker.rs
 expression: list
 ---
 >
-    Branch  Status        HEAD±    main↕  Remote⇅  CI     P
-> @ main        ^                                         .
+    Branch  Status        HEAD±    main↕     main…±  Remote
+> @ main        ^

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_alt_l_ignored_list.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_alt_l_ignored_list.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: list
 ---
 >
-    Branch       Status        HEAD±    main↕  CI     Age
-> @ main             ^                                [TIME]
-  + feature-one      _                                [TIME]
-  + feature-two      _                                [TIME]
+    Branch       Status        HEAD±    main↕     main…±  R
+> @ main             ^
+  + feature-one      _
+  + feature-two      _

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_multiple_worktrees_list.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_multiple_worktrees_list.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: list
 ---
 >
-    Branch       Status        HEAD±    main↕  Remote⇅  CI
+    Branch       Status        HEAD±    main↕     main…±  R
 > @ main             ^
   + feature-one      _
   + feature-two      _

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_log_list.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_log_list.snap
@@ -3,6 +3,6 @@ source: tests/integration_tests/switch_picker.rs
 expression: list
 ---
 >
-    Branch   Status        HEAD±    main↕  Remote⇅  CI
+    Branch   Status        HEAD±    main↕     main…±  Remot
   @ main         ^
-> + feature      ↑                 ↑5
+> + feature      ↑                 ↑5        +5

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_main_diff_list.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_main_diff_list.snap
@@ -3,6 +3,6 @@ source: tests/integration_tests/switch_picker.rs
 expression: list
 ---
 >
-    Branch   Status        HEAD±    main↕  Remote⇅  CI
+    Branch   Status        HEAD±    main↕     main…±  Remot
   @ main         ^
-> + feature      ↑                 ↑2
+> + feature      ↑                 ↑2       +10

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_summary_list.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_summary_list.snap
@@ -3,6 +3,6 @@ source: tests/integration_tests/switch_picker.rs
 expression: list
 ---
 >
-    Branch   Status        HEAD±    main↕  Remote⇅  CI
+    Branch   Status        HEAD±    main↕     main…±  Remot
   @ main         ^
-> + feature      ↑                 ↑1
+> + feature      ↑                 ↑1        +1

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_uncommitted_list.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_uncommitted_list.snap
@@ -3,6 +3,6 @@ source: tests/integration_tests/switch_picker.rs
 expression: list
 ---
 >
-    Branch   Status        HEAD±    main↕  Remote⇅  CI
+    Branch   Status        HEAD±    main↕     main…±  Remot
   @ main         ^
-> + feature   !  ↑       +3   -1   ↑1
+> + feature   !  ↑       +3   -1   ↑1        +1

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_with_branches_list.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_with_branches_list.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: list
 ---
 >
-    Branch           Status        HEAD±    main↕  Remote⇅
+    Branch           Status        HEAD±    main↕     main…
 > @ main                 ^
   + active-worktree      _
   / orphan-branch       /_


### PR DESCRIPTION
The `main…±` column (line diffs since the merge-base with the default branch) was hidden unless `--full` was passed, grouped with CI status and LLM summaries. But it is pure local git — a `git diff --shortstat` against the merge-base, now backed by a persistent content-addressed cache (#2098) — so the original reason for gating it (a one-time, blocking merge-base walk over deeply-diverged history, the ~15s freeze behind #461/#505) no longer holds. Warm rows are instant and a cold row computes once in the background under progressive rendering.

So `main…±` moves into the default `wt list` view, and `--full` now gates only the two columns that reach off-machine: CI status (network) and LLM-generated branch summaries.

## Navigating the diff

- `src/commands/list/collect/mod.rs` — `BranchDiff` drops out of the non-`--full` skip set; only `CiStatus` and `SummaryGenerate` remain gated.
- `src/commands/picker/mod.rs` — the picker's skip set is now empty, so `wt switch` is effectively `wt list --full` and surfaces `main…±` too. It's local git keyed by the same cache, so cold rows stream in behind the frame and never block the picker.
- `src/commands/list/layout.rs` — module docs updated: `BranchDiff` is no longer behind the `show_full` gate; the test helper's non-full skip set follows.
- `src/cli/mod.rs` + doc mirrors — `--full` help text, the Columns table, and JSON-field notes reframed; the `wt list` example now shows `main…±` by default.

## Trade-off: picker CI clipping

The picker lays the table out at full terminal width and clips at the preview boundary. With the preview shown on a narrow terminal, the new `main…±` column pushes CI past the split and clips it; `alt-p` toggles the preview off to reveal the full-width row (no reload, no column moves). On wide terminals both fit. The two `--prs` tests now assert through that `alt-p` toggle.

## Testing

Well covered: the existing `wt list` and picker snapshot suites exercise the new default column across widths, configs, and the picker's narrow/wide panes; `test_docs_are_in_sync` keeps the doc mirrors honest. The merge from `main` (12 commits, several touching the picker) re-ran clean against the merged binary — 2055 integration tests, 0 pending snapshots.

> _This was written by Claude Code on behalf of max_
