### PR TITLE
Recolor picker legend dim-cyan and reorder controls

### DIFF
--- a/src/commands/picker/items.rs
+++ b/src/commands/picker/items.rs
@@ -584,22 +584,26 @@ pub(super) fn render_preview_tabs(
         render_tab_row_compact(&tabs, reset)
     };
 
-    // Controls use dim yellow to distinguish from dimmed (white) tabs.
+    // Controls use dim cyan to distinguish from the dimmed (white) tabs above.
     // The tab numbers above are the alt-N accelerators (bare digits type
     // into the query); Tab/shift-tab cycle the same tabs.
     //
+    // Order: primary action (Enter), preview navigation (ctrl-u/d scroll, then
+    // the Tab/alt-1…7 accelerators), then row actions, with Esc last.
+    //
     // The controls line is intentionally NOT width-managed: skim clips it on the
-    // right on a narrow pane, but it's only a reminder — the accelerators it
-    // names live in the tab bar above, which IS width-managed, so nothing
-    // navigable is lost when the tail clips. Row actions lead so they survive a
-    // narrow-pane clip; the preview controls and Esc trail.
+    // right on a narrow pane, but it's only a reminder. Note the trade-off of
+    // this order: the row actions (alt-c/x/y/o/r/p) now trail and clip first, and
+    // unlike the preview accelerators they are not duplicated in the (width-
+    // managed) tab bar above — so on a narrow pane the only on-screen reminder of
+    // them can clip away.
     let controls = cformat!(
-        "<dim,yellow>Enter: switch | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Tab/alt-1…7: preview | ctrl-u/d: scroll | Esc: cancel</>"
+        "<dim,cyan>Enter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Esc: cancel</>"
     );
 
     // Each tab/segment already ends with a full reset (so styling never bleeds
     // into the dividers or preview content); `{reset}` here only closes the
-    // controls line's dim-yellow span.
+    // controls line's dim-cyan span.
     format!("{bar}\n{controls}{reset}\n\n")
 }
 

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__branch_diff.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__branch_diff.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "render_preview_tabs(mode, wt, WIDE)"
 ---
 1: [2mHEAD±[22m[0m | 2: [2mlog[22m[0m | 3: [1mmain…±[22m[0m | 4: [2mremote⇅[22m[0m | 5: [2msummary[22m[0m | [2m6:[22m [2mpr[22m[0m | [2m7:[22m [2mcomments[22m[0m
-[33m[2mEnter: switch | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Tab/alt-1…7: preview | ctrl-u/d: scroll | Esc: cancel[39m[22m[0m
+[36m[2mEnter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Esc: cancel[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__empty_all_local_diffs.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__empty_all_local_diffs.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "render_preview_tabs(PreviewMode::WorkingTree,\nTabAvailability::worktree(CONTENT_EMPTY, true, false, false), WIDE,)"
 ---
 [2m1:[22m [1mHEAD±[22m[0m | 2: [2mlog[22m[0m | [2m3:[22m [2mmain…±[22m[0m | [2m4:[22m [2mremote⇅[22m[0m | [2m5:[22m [2msummary[22m[0m | [2m6:[22m [2mpr[22m[0m | [2m7:[22m [2mcomments[22m[0m
-[33m[2mEnter: switch | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Tab/alt-1…7: preview | ctrl-u/d: scroll | Esc: cancel[39m[22m[0m
+[36m[2mEnter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Esc: cancel[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__empty_upstream_and_summary.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__empty_upstream_and_summary.snap
@@ -1,6 +1,6 @@
 ---
 source: src/commands/picker/items.rs
-expression: "render_preview_tabs(PreviewMode::WorkingTree,\nTabAvailability::worktree(false, false, false), WIDE,)"
+expression: "render_preview_tabs(PreviewMode::WorkingTree,\nTabAvailability::worktree(LocalContent::default(), false, false, false),\nWIDE,)"
 ---
 1: [1mHEAD±[22m[0m | 2: [2mlog[22m[0m | 3: [2mmain…±[22m[0m | [2m4:[22m [2mremote⇅[22m[0m | [2m5:[22m [2msummary[22m[0m | [2m6:[22m [2mpr[22m[0m | [2m7:[22m [2mcomments[22m[0m
-[33m[2mEnter: switch | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Tab/alt-1…7: preview | ctrl-u/d: scroll | Esc: cancel[39m[22m[0m
+[36m[2mEnter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Esc: cancel[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__log.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__log.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "render_preview_tabs(mode, wt, WIDE)"
 ---
 1: [2mHEAD±[22m[0m | 2: [1mlog[22m[0m | 3: [2mmain…±[22m[0m | 4: [2mremote⇅[22m[0m | 5: [2msummary[22m[0m | [2m6:[22m [2mpr[22m[0m | [2m7:[22m [2mcomments[22m[0m
-[33m[2mEnter: switch | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Tab/alt-1…7: preview | ctrl-u/d: scroll | Esc: cancel[39m[22m[0m
+[36m[2mEnter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Esc: cancel[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__pr.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__pr.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "render_preview_tabs(mode, wt, WIDE)"
 ---
 1: [2mHEAD±[22m[0m | 2: [2mlog[22m[0m | 3: [2mmain…±[22m[0m | 4: [2mremote⇅[22m[0m | 5: [2msummary[22m[0m | [2m6:[22m [1mpr[22m[0m | [2m7:[22m [2mcomments[22m[0m
-[33m[2mEnter: switch | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Tab/alt-1…7: preview | ctrl-u/d: scroll | Esc: cancel[39m[22m[0m
+[36m[2mEnter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Esc: cancel[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__pr_row.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__pr_row.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "render_preview_tabs(PreviewMode::Pr, TabAvailability::listed_pr(), WIDE)"
 ---
 [2m1:[22m [2mHEAD±[22m[0m | 2: [2mlog[22m[0m | [2m3:[22m [2mmain…±[22m[0m | [2m4:[22m [2mremote⇅[22m[0m | [2m5:[22m [2msummary[22m[0m | 6: [1mpr[22m[0m | 7: [2mcomments[22m[0m
-[33m[2mEnter: switch | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Tab/alt-1…7: preview | ctrl-u/d: scroll | Esc: cancel[39m[22m[0m
+[36m[2mEnter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Esc: cancel[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__summary.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__summary.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "render_preview_tabs(mode, wt, WIDE)"
 ---
 1: [2mHEAD±[22m[0m | 2: [2mlog[22m[0m | 3: [2mmain…±[22m[0m | 4: [2mremote⇅[22m[0m | 5: [1msummary[22m[0m | [2m6:[22m [2mpr[22m[0m | [2m7:[22m [2mcomments[22m[0m
-[33m[2mEnter: switch | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Tab/alt-1…7: preview | ctrl-u/d: scroll | Esc: cancel[39m[22m[0m
+[36m[2mEnter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Esc: cancel[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__upstream_diff.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__upstream_diff.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "render_preview_tabs(mode, wt, WIDE)"
 ---
 1: [2mHEAD±[22m[0m | 2: [2mlog[22m[0m | 3: [2mmain…±[22m[0m | 4: [1mremote⇅[22m[0m | 5: [2msummary[22m[0m | [2m6:[22m [2mpr[22m[0m | [2m7:[22m [2mcomments[22m[0m
-[33m[2mEnter: switch | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Tab/alt-1…7: preview | ctrl-u/d: scroll | Esc: cancel[39m[22m[0m
+[36m[2mEnter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Esc: cancel[39m[22m[0m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__working_tree.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__working_tree.snap
@@ -3,4 +3,4 @@ source: src/commands/picker/items.rs
 expression: "render_preview_tabs(mode, wt, WIDE)"
 ---
 1: [1mHEAD±[22m[0m | 2: [2mlog[22m[0m | 3: [2mmain…±[22m[0m | 4: [2mremote⇅[22m[0m | 5: [2msummary[22m[0m | [2m6:[22m [2mpr[22m[0m | [2m7:[22m [2mcomments[22m[0m
-[33m[2mEnter: switch | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Tab/alt-1…7: preview | ctrl-u/d: scroll | Esc: cancel[39m[22m[0m
+[36m[2mEnter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | alt-c: create | alt-x: remove | alt-y: copy | alt-o: open | alt-r: refresh | alt-p: toggle | Esc: cancel[39m[22m[0m

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_abort_escape_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_abort_escape_preview.snap
@@ -3,6 +3,6 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± 2 3 4 5 6 7
-Enter: switch | alt-c: create | alt-x: remove | alt-y: copy
+Enter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | a
 
 ○ main has no uncommitted changes

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_multiple_worktrees_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_multiple_worktrees_preview.snap
@@ -3,6 +3,6 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± 2 3 4 5 6 7
-Enter: switch | alt-c: create | alt-x: remove | alt-y: copy
+Enter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | a
 
 ○ main has no uncommitted changes

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_log_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_log_preview.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1 2: log 3 4 5 6 7
-Enter: switch | alt-c: create | alt-x: remove | alt-y: copy
+Enter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | a
 
 * [HASH]   +1        [TIME] (feature) Add file 5 with content
 * [HASH]   +1        [TIME] Add file 4 with content

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_main_diff_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_main_diff_preview.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1 2 3: main…± 4 5 6 7
-Enter: switch | alt-c: create | alt-x: remove | alt-y: copy
+Enter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | a
 
  feature_code.rs | 6 ++++++
  tests.rs        | 4 ++++

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_summary_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_summary_preview.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1 2 3 4 5: summary 6 7
-Enter: switch | alt-c: create | alt-x: remove | alt-y: copy
+Enter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | a
 
 Configure [commit.generation] command to enable LLM summari
 

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_uncommitted_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_uncommitted_preview.snap
@@ -3,7 +3,7 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± 2 3 4 5 6 7
-Enter: switch | alt-c: create | alt-x: remove | alt-y: copy
+Enter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | a
 
  tracked.txt | 4 +++-
  1 file changed, 3 insertions(+), 1 deletion(-)

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_with_branches_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_with_branches_preview.snap
@@ -3,6 +3,6 @@ source: tests/integration_tests/switch_picker.rs
 expression: preview
 ---
 1: HEAD± 2 3 4 5 6 7
-Enter: switch | alt-c: create | alt-x: remove | alt-y: copy
+Enter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | a
 
 ○ main has no uncommitted changes


### PR DESCRIPTION
Recolors the picker's legend (the controls line under the preview tab bar) from dim yellow to dim cyan, and reorders it so navigation leads — `Enter`, then preview scroll (`ctrl-u/d`) and tab nav (`Tab/alt-1…7`), then the alt-letter row actions, with `Esc` last.

Note one trade-off this ordering makes: the controls line isn't width-managed, so skim clips its right tail on a narrow preview pane. The old order led with the row actions (`alt-c/x/y/o/r/p`) precisely because those accelerators appear *only* on this line — the preview accelerators are echoed in the width-managed tab bar above. The new order leads with the preview controls, so on a narrow pane the row-action reminders clip first. The comment above the string documents this.

The legend lives in one place (`render_preview_tabs` in `src/commands/picker/items.rs`) and is snapshot-tested in two suites; both are regenerated to match — the 9 unit snapshots under `src/commands/picker/snapshots/` and the 7 `switch_picker` preview snapshots under `tests/snapshots/`.

> _This was written by Claude Code on behalf of max_
