### PR TITLE
test(switch): deflake comments-tab preview wait by re-issuing the tab key

### DIFF
--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -62,6 +62,12 @@ const STABLE_DURATION: Duration = Duration::from_millis(500);
 /// Fast polling ensures tests complete quickly when ready.
 const POLL_INTERVAL: Duration = Duration::from_millis(10);
 
+/// How often [`send_input_awaiting_content`] re-issues a preview-tab keystroke
+/// while its expected content is still absent. Long enough to clear skim's 50ms
+/// preview debounce and give a background preview compute time to land in the
+/// cache; short enough to retry many times within [`STABILIZE_TIMEOUT`].
+const PREVIEW_REISSUE_INTERVAL: Duration = Duration::from_secs(1);
+
 /// Columns that split the list and preview panels in the 120-col test terminal.
 /// skim 4.x draws the │ separator at col 59, with the list to its left (cols
 /// 0..59) and the preview interior to its right (cols 60..120). Slicing around
@@ -228,14 +234,7 @@ fn exec_in_pty_with_input_expectations(
 
     // Send each input and wait for screen to stabilize after each
     for (input, expected_content) in inputs {
-        {
-            let mut w = writer.lock().unwrap();
-            w.write_all(input.as_bytes()).unwrap();
-            w.flush().unwrap();
-        }
-
-        // Wait for screen to stabilize after this input, optionally requiring specific content
-        wait_for_stable_with_content(&rx, &mut parser, *expected_content);
+        send_input_awaiting_content(&writer, &rx, &mut parser, input, *expected_content);
     }
 
     // Release the main thread's writer handle. The reader thread holds the
@@ -340,12 +339,7 @@ fn exec_in_pty_capture_before_abort(
 
     // Send pre-abort inputs (filter text, panel switches, etc.)
     for (input, expected_content) in pre_abort_inputs {
-        {
-            let mut w = writer.lock().unwrap();
-            w.write_all(input.as_bytes()).unwrap();
-            w.flush().unwrap();
-        }
-        wait_for_stable_with_content(&rx, &mut parser, *expected_content);
+        send_input_awaiting_content(&writer, &rx, &mut parser, input, *expected_content);
     }
 
     // === CAPTURE: screen state is now stable — snapshot BEFORE aborting ===
@@ -404,6 +398,7 @@ fn wait_for_stable_with_content(
         parser,
         |screen| expected_content.is_none_or(|c| screen.contains(c)),
         describe.as_deref(),
+        None,
     );
 }
 
@@ -433,6 +428,7 @@ fn wait_for_cursor_on_row(rx: &mpsc::Receiver<Vec<u8>>, parser: &mut vt100::Pars
                 .any(|line| line.starts_with('>') && line.contains(name))
         },
         Some(&describe),
+        None,
     );
 }
 
@@ -451,11 +447,17 @@ fn wait_for_cursor_on_row(rx: &mpsc::Receiver<Vec<u8>>, parser: &mut vt100::Pars
 /// stability after STABLE_DURATION even if the screen keeps churning. With no
 /// readiness condition there is nothing to find, so the screen must settle the
 /// hard way (the cosmetic-redraw fallback never engages).
+///
+/// `nudge`, when `Some`, is invoked every [`PREVIEW_REISSUE_INTERVAL`] while
+/// `ready` is unmet — used to re-issue a `RunPreview` trigger so a preview that
+/// finished computing after the initial keystroke gets surfaced (see
+/// [`send_input_awaiting_content`]).
 fn wait_for_stable_until(
     rx: &mpsc::Receiver<Vec<u8>>,
     parser: &mut vt100::Parser,
     ready: impl Fn(&str) -> bool,
     describe: Option<&str>,
+    nudge: Option<&dyn Fn()>,
 ) {
     let start = Instant::now();
     let mut last_change = Instant::now();
@@ -463,6 +465,7 @@ fn wait_for_stable_until(
     // Tracks when `ready` first held continuously on screen. Used as a fallback
     // stability signal when skim keeps redrawing cosmetically.
     let mut ready_since: Option<Instant> = None;
+    let mut last_nudge = Instant::now();
     let has_condition = describe.is_some();
 
     while start.elapsed() < STABILIZE_TIMEOUT {
@@ -504,6 +507,19 @@ fn wait_for_stable_until(
             return;
         }
 
+        // While the readiness condition is still unmet, periodically re-issue the
+        // RunPreview trigger. skim reads the preview cache only when it runs a
+        // preview, so a diff that finished computing after the initial keystroke
+        // would otherwise stay stranded behind a "Loading…" placeholder with no
+        // event to surface it.
+        if !content_ready
+            && let Some(nudge) = nudge
+            && last_nudge.elapsed() >= PREVIEW_REISSUE_INTERVAL
+        {
+            nudge();
+            last_nudge = Instant::now();
+        }
+
         std::thread::sleep(POLL_INTERVAL);
     }
 
@@ -525,6 +541,64 @@ fn wait_for_stable_until(
         "Warning: Screen did not fully stabilize within {:?}",
         STABILIZE_TIMEOUT
     );
+}
+
+/// True for an Alt-<digit> preview-tab switch (`ESC` + one ASCII digit) — the
+/// only inputs safe to re-issue while waiting for preview content. Switching to
+/// the tab you're already on is idempotent, whereas Tab / Shift-Tab cycle and
+/// typed filter text accumulates, so neither may be repeated.
+fn is_alt_digit_tab(input: &str) -> bool {
+    let b = input.as_bytes();
+    b.len() == 2 && b[0] == 0x1b && b[1].is_ascii_digit()
+}
+
+/// Send `input`, then wait for the screen to satisfy the per-input expectation
+/// and settle.
+///
+/// For an Alt-<digit> preview-tab switch carrying `expected_content`, the wait
+/// re-issues the keystroke every [`PREVIEW_REISSUE_INTERVAL`] until the content
+/// appears. The picker's preview pane is served from a cache populated by
+/// background workers and is re-read only when skim runs a preview, which a
+/// keystroke triggers exactly once (`Event::RunPreview`). If the row's preview
+/// hasn't finished computing, skim paints a "Loading…" placeholder and never
+/// re-queries — the finished preview lands in the cache with no event to surface
+/// it, stranding the placeholder. That is a Windows-CI flake under load, where
+/// the `git diff` / forge compute loses the race against the keystroke (the
+/// surrounding background subprocesses make it worse). Re-issuing the idempotent
+/// tab keystroke forces a fresh `RunPreview` against the now-warm cache,
+/// mirroring the placeholder's own "Press alt-N again to refresh" instruction.
+///
+/// Inputs without an Alt-<digit> shape fall back to a plain
+/// [`wait_for_stable_with_content`]: list content (rows streaming in, filter
+/// matches) repaints on every `Event::Render` and never strands, and the
+/// non-idempotent inputs (Tab, filter text, Enter) must not be repeated.
+fn send_input_awaiting_content(
+    writer: &crate::common::pty::SharedPtyWriter,
+    rx: &mpsc::Receiver<Vec<u8>>,
+    parser: &mut vt100::Parser,
+    input: &str,
+    expected_content: Option<&str>,
+) {
+    let send = || {
+        let mut w = writer.lock().unwrap();
+        w.write_all(input.as_bytes()).unwrap();
+        w.flush().unwrap();
+    };
+    send();
+
+    match expected_content {
+        Some(content) if is_alt_digit_tab(input) => {
+            let describe = format!("expected content {content:?}");
+            wait_for_stable_until(
+                rx,
+                parser,
+                |screen| screen.contains(content),
+                Some(&describe),
+                Some(&send),
+            );
+        }
+        _ => wait_for_stable_with_content(rx, parser, expected_content),
+    }
 }
 
 /// Create insta settings with filters for switch picker snapshot stability.


### PR DESCRIPTION
## Deflake `test_switch_picker_worktree_row_comments_tab_shows_thread`

This PTY/TUI test intermittently failed on `test (windows)` with `Timed out after 30s waiting for expected content "diff --git"`, while Linux and macOS stayed green and a plain re-run passed. It presented as a slow-runner timing flake, but the timeout is structural — bumping it would never help.

### Root cause

The picker's preview pane is served from a `DashMap` cache populated by background `COLLECT_POOL` workers (`preview_orchestrator.rs` just does `cache.insert(...)`, with no poke back to skim). skim 4.8 re-reads that cache only inside `run_preview`, which fires only on `Event::RunPreview` — a cursor move or a tab switch. On a cache miss it synchronously paints a "Loading working-tree diff. Press alt-1 again to refresh." placeholder. The other events don't help: `Event::Render` (sent by every background `on_update` — CI status, row pipeline, the comments fetch) only redraws the current state, and the heartbeat re-runs the preview only inside skim's 50ms debounce window, which two keystrokes 500ms apart never hit.

So a single Alt-1 keystroke produces a single `RunPreview` that reads the cache once. If `feature`'s `WorkingTree` precompute (a real `git diff HEAD`) hasn't landed by that instant, the placeholder is painted and **never refreshed** — the finished diff lands in the cache with no event to surface it. That race is what loses on a contended Windows runner: this test seeds an open PR and mocks `gh pr view`, so the `WorkingTree` precompute competes with an extra `gh` subprocess (plus 16-way CI parallelism). A re-run shifts the timing and the precompute wins.

### Fix

Re-issue the (idempotent) Alt-`<digit>` tab keystroke every second while the expected preview content is still absent — exactly what the placeholder's own "Press alt-N again to refresh" instruction tells a user to do. Each re-issue forces a fresh `RunPreview` against the now-warm cache, so the diff surfaces as soon as the precompute lands. The change lives entirely in the shared PTY drivers (`tests/integration_tests/switch_picker.rs`); the wait keeps its existing 30s ceiling and its loud panic diagnostics.

Only Alt-`<digit>` tab switches are re-issued. They jump to a fixed tab, so repeating one is a no-op. Tab / Shift-Tab cycle, typed filter text accumulates, and Enter commits — none may be repeated — and list-content waits (rows streaming in, filter matches) repaint on every `Event::Render` and never strand, so all of those keep the plain wait.

### Verification

With a temporary env-gated 3s delay injected into the `WorkingTree` precompute (forcing the cold cache deterministically):

- reverting the re-issue reproduces the exact `Timed out after 30s waiting for expected content "diff --git"` panic;
- with the re-issue active the test passes in ~5.7s, once the delayed precompute lands.

All temporary instrumentation was removed. The full `switch_picker` suite (34 tests, incl. the Alt-digit, Tab/Shift-Tab cycle, and snapshot-asserting siblings) passes; the snapshot tests are unaffected because re-issue stops the instant content appears, so the captured screen is identical. `cargo fmt --check` and `cargo clippy --tests --features shell-integration-tests` are clean.

> _This was written by Claude Code on behalf of max_
