### PR TITLE
Unify wt switch and --prs: differ only by the extra PR rows

### DIFF
--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -87,7 +87,7 @@ The CI column shows each row's PR/MR CI and review status, the same as [`wt list
 
 `Alt-o` is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
 
-Plain digits go to the filter, so a branch name containing a number can be typed directly; the preview tabs move to `Alt`.
+Each row filters by its branch, path, and — when it has a PR/MR — the PR/MR's number, title, and author, the same fields whether the PR is checked out (a worktree row) or listed via `--prs`. Plain digits go to the filter, so a number can be typed directly and the preview tabs move to `Alt`.
 
 Typing a gutter sigil filters by row kind: `+` narrows to linked worktrees and `@` to the current worktree. The other sigils don't filter cleanly — `^` and `|` are skim's prefix-anchor and OR query operators (so `^` matches every row and `|` none), and `/` matches most rows because every worktree path contains it.
 
@@ -120,7 +120,7 @@ Both work anywhere a branch is accepted, including `--base`. The `--create` flag
 
 If the PR or MR is on a fork, the local branch uses its branch name directly, so `git push` works normally. A pre-existing local branch with that name tracking something else requires renaming first.
 
-The `--prs` flag adds the repository's open PRs (GitHub) or MRs (GitLab) to the interactive picker. Each row resolves to the same `pr:`/`mr:` shortcut, so selecting one fetches the ref and switches to its branch. A `--prs` row has no local worktree, so its `pr` and `comments` preview tabs load the PR/MR's metadata and comments from the forge in the background. The `log` tab uses a local `git log` — graph and merge-base dimming included — whenever the head commit is already in the object store (a same-repo PR off a fetched remote), falling back to a flat forge-fetched commit list otherwise.
+The `--prs` flag adds the repository's open PRs (GitHub) or MRs (GitLab) to the interactive picker — only the ones not already there: a PR whose branch is already shown (as a worktree, or a local or remote branch) isn't listed twice, so `--prs` only adds the rest and the two pickers differ solely by those extra rows. Each added row resolves to the same `pr:`/`mr:` shortcut, so selecting one fetches the ref and switches to its branch. A `--prs` row has no local worktree, so its `pr` and `comments` preview tabs load the PR/MR's metadata and comments from the forge in the background. The `log` tab uses a local `git log` — graph and merge-base dimming included — whenever the head commit is already in the object store (a same-repo PR off a fetched remote), falling back to a flat forge-fetched commit list otherwise.
 
 Requires `gh` (GitHub), `glab` (GitLab), or an equivalent CLI installed and authenticated; see [forge platform](@/config.md#forge-platform) for Gitea, Azure DevOps, and other supported platforms.
 

--- a/skills/worktrunk/reference/switch.md
+++ b/skills/worktrunk/reference/switch.md
@@ -83,7 +83,7 @@ The CI column shows each row's PR/MR CI and review status, the same as [`wt list
 
 `Alt-o` is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
 
-Plain digits go to the filter, so a branch name containing a number can be typed directly; the preview tabs move to `Alt`.
+Each row filters by its branch, path, and — when it has a PR/MR — the PR/MR's number, title, and author, the same fields whether the PR is checked out (a worktree row) or listed via `--prs`. Plain digits go to the filter, so a number can be typed directly and the preview tabs move to `Alt`.
 
 Typing a gutter sigil filters by row kind: `+` narrows to linked worktrees and `@` to the current worktree. The other sigils don't filter cleanly — `^` and `|` are skim's prefix-anchor and OR query operators (so `^` matches every row and `|` none), and `/` matches most rows because every worktree path contains it.
 
@@ -122,7 +122,7 @@ Both work anywhere a branch is accepted, including `--base`. The `--create` flag
 
 If the PR or MR is on a fork, the local branch uses its branch name directly, so `git push` works normally. A pre-existing local branch with that name tracking something else requires renaming first.
 
-The `--prs` flag adds the repository's open PRs (GitHub) or MRs (GitLab) to the interactive picker. Each row resolves to the same `pr:`/`mr:` shortcut, so selecting one fetches the ref and switches to its branch. A `--prs` row has no local worktree, so its `pr` and `comments` preview tabs load the PR/MR's metadata and comments from the forge in the background. The `log` tab uses a local `git log` — graph and merge-base dimming included — whenever the head commit is already in the object store (a same-repo PR off a fetched remote), falling back to a flat forge-fetched commit list otherwise.
+The `--prs` flag adds the repository's open PRs (GitHub) or MRs (GitLab) to the interactive picker — only the ones not already there: a PR whose branch is already shown (as a worktree, or a local or remote branch) isn't listed twice, so `--prs` only adds the rest and the two pickers differ solely by those extra rows. Each added row resolves to the same `pr:`/`mr:` shortcut, so selecting one fetches the ref and switches to its branch. A `--prs` row has no local worktree, so its `pr` and `comments` preview tabs load the PR/MR's metadata and comments from the forge in the background. The `log` tab uses a local `git log` — graph and merge-base dimming included — whenever the head commit is already in the object store (a same-repo PR off a fetched remote), falling back to a flat forge-fetched commit list otherwise.
 
 Requires `gh` (GitHub), `glab` (GitLab), or an equivalent CLI installed and authenticated; see [forge platform](https://worktrunk.dev/config/#forge-platform) for Gitea, Azure DevOps, and other supported platforms.
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -677,7 +677,7 @@ The CI column shows each row's PR/MR CI and review status, the same as [`wt list
 
 `Alt-o` is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
 
-Plain digits go to the filter, so a branch name containing a number can be typed directly; the preview tabs move to `Alt`.
+Each row filters by its branch, path, and — when it has a PR/MR — the PR/MR's number, title, and author, the same fields whether the PR is checked out (a worktree row) or listed via `--prs`. Plain digits go to the filter, so a number can be typed directly and the preview tabs move to `Alt`.
 
 Typing a gutter sigil filters by row kind: `+` narrows to linked worktrees and `@` to the current worktree. The other sigils don't filter cleanly — `^` and `|` are skim's prefix-anchor and OR query operators (so `^` matches every row and `|` none), and `/` matches most rows because every worktree path contains it.
 
@@ -716,7 +716,7 @@ Both work anywhere a branch is accepted, including `--base`. The `--create` flag
 
 If the PR or MR is on a fork, the local branch uses its branch name directly, so `git push` works normally. A pre-existing local branch with that name tracking something else requires renaming first.
 
-The `--prs` flag adds the repository's open PRs (GitHub) or MRs (GitLab) to the interactive picker. Each row resolves to the same `pr:`/`mr:` shortcut, so selecting one fetches the ref and switches to its branch. A `--prs` row has no local worktree, so its `pr` and `comments` preview tabs load the PR/MR's metadata and comments from the forge in the background. The `log` tab uses a local `git log` — graph and merge-base dimming included — whenever the head commit is already in the object store (a same-repo PR off a fetched remote), falling back to a flat forge-fetched commit list otherwise.
+The `--prs` flag adds the repository's open PRs (GitHub) or MRs (GitLab) to the interactive picker — only the ones not already there: a PR whose branch is already shown (as a worktree, or a local or remote branch) isn't listed twice, so `--prs` only adds the rest and the two pickers differ solely by those extra rows. Each added row resolves to the same `pr:`/`mr:` shortcut, so selecting one fetches the ref and switches to its branch. A `--prs` row has no local worktree, so its `pr` and `comments` preview tabs load the PR/MR's metadata and comments from the forge in the background. The `log` tab uses a local `git log` — graph and merge-base dimming included — whenever the head commit is already in the object store (a same-repo PR off a fetched remote), falling back to a flat forge-fetched commit list otherwise.
 
 Requires `gh` (GitHub), `glab` (GitLab), or an equivalent CLI installed and authenticated; see [forge platform](@/config.md#forge-platform) for Gitea, Azure DevOps, and other supported platforms.
 

--- a/src/commands/list/ci_status/azure.rs
+++ b/src/commands/list/ci_status/azure.rs
@@ -144,6 +144,7 @@ pub(super) fn detect_azure_pr(
         body: pr.description.clone(),
         // `az repos pr list` carries no comment/thread count; surfacing one
         // would need a separate per-PR threads call, which this fetch avoids.
+        author: None,
         comment_count: None,
     })
 }
@@ -230,6 +231,7 @@ pub(super) fn detect_azure_pipeline(
         review_state: None,
         title: None,
         body: None,
+        author: None,
         comment_count: None,
     })
 }

--- a/src/commands/list/ci_status/gitea.rs
+++ b/src/commands/list/ci_status/gitea.rs
@@ -124,6 +124,7 @@ pub(super) fn detect_gitea_pr(
         review_state: None,
         title: pr.title.clone(),
         body: pr.body.clone(),
+        author: None,
         comment_count: pr.comment_count(),
     })
 }
@@ -149,6 +150,7 @@ pub(super) fn detect_gitea_commit_status(
         review_state: None,
         title: None,
         body: None,
+        author: None,
         comment_count: None,
     })
 }

--- a/src/commands/list/ci_status/github.rs
+++ b/src/commands/list/ci_status/github.rs
@@ -69,11 +69,12 @@ pub(super) fn detect_github(
             "--limit",
             &MAX_PRS_TO_FETCH.to_string(),
             "--json",
-            // title,body and the comments array ride this existing call so the
-            // picker's `pr` preview pane can show them — no extra round-trip.
-            // `gh pr list` has no comment-count field, so we request the array and
-            // count it; for a `--head <branch>` call that's typically one PR.
-            "number,title,body,comments,headRefOid,mergeStateStatus,statusCheckRollup,url,headRepositoryOwner,reviewDecision,isDraft",
+            // title,body,author and the comments array ride this existing call so
+            // the picker's `pr` preview pane and matcher text can use them — no
+            // extra round-trip. `gh pr list` has no comment-count field, so we
+            // request the array and count it; for a `--head <branch>` call that's
+            // typically one PR.
+            "number,title,body,author,comments,headRefOid,mergeStateStatus,statusCheckRollup,url,headRepositoryOwner,reviewDecision,isDraft",
         ])
         .current_dir(&repo_root)
         .run()
@@ -143,6 +144,7 @@ pub(super) fn detect_github(
         review_state: pr_info.review_state(),
         title: pr_info.title.clone(),
         body: pr_info.body.clone(),
+        author: pr_info.author.as_ref().map(|a| a.login.clone()),
         comment_count: pr_info.comment_count(),
     })
 }
@@ -216,6 +218,7 @@ pub(super) fn detect_github_commit_checks(
         review_state: None,
         title: None,
         body: None,
+        author: None,
         comment_count: None,
     })
 }
@@ -233,6 +236,10 @@ pub(crate) struct GitHubPrInfo {
     pub title: Option<String>,
     /// PR description; shown in the `pr` preview pane. Rides this call.
     pub body: Option<String>,
+    /// PR author; folded into the row's matcher text. Requested by both the
+    /// worktree-row [`detect_github`] call and the `--prs` list call.
+    #[serde(default)]
+    pub author: Option<GitHubAuthor>,
     /// Conversation comments on the PR. Requested only on the worktree-row
     /// [`detect_github`] call to count them for the `pr` pane; the `--prs` call
     /// omits `comments` to keep its 50-PR payload light, so this stays empty
@@ -263,6 +270,13 @@ pub(crate) struct GitHubPrInfo {
 #[derive(Debug, Deserialize)]
 pub(crate) struct HeadRepositoryOwner {
     /// The login (username/org name) of the repository owner.
+    pub login: String,
+}
+
+/// PR author from `gh pr list --json author` (`{"login": ...}`).
+#[derive(Debug, Default, Deserialize)]
+pub(crate) struct GitHubAuthor {
+    #[serde(default)]
     pub login: String,
 }
 
@@ -348,6 +362,7 @@ impl GitHubPrInfo {
             // background-fetched comments tab, and the list call omits `comments`.
             title: None,
             body: None,
+            author: None,
             comment_count: None,
         }
     }
@@ -434,6 +449,7 @@ mod tests {
             comments: Vec::new(),
             review_decision: None,
             is_draft: None,
+            author: None,
         };
         assert_eq!(pr.open_pr_status().ci_status, CiStatus::Conflicts);
     }
@@ -453,6 +469,7 @@ mod tests {
             comments: Vec::new(),
             review_decision: None,
             is_draft: None,
+            author: None,
         };
         assert_eq!(pr.ci_status(), CiStatus::NoCI);
 
@@ -469,6 +486,7 @@ mod tests {
             comments: Vec::new(),
             review_decision: None,
             is_draft: None,
+            author: None,
         };
         assert_eq!(pr.ci_status(), CiStatus::NoCI);
 
@@ -490,6 +508,7 @@ mod tests {
                 comments: Vec::new(),
                 review_decision: None,
                 is_draft: None,
+                author: None,
             };
             assert_eq!(pr.ci_status(), CiStatus::Running, "status={status}");
         }
@@ -511,6 +530,7 @@ mod tests {
             comments: Vec::new(),
             review_decision: None,
             is_draft: None,
+            author: None,
         };
         assert_eq!(pr.ci_status(), CiStatus::Running);
 
@@ -532,6 +552,7 @@ mod tests {
                 comments: Vec::new(),
                 review_decision: None,
                 is_draft: None,
+                author: None,
             };
             assert_eq!(pr.ci_status(), CiStatus::Failed, "conclusion={conclusion}");
         }
@@ -554,6 +575,7 @@ mod tests {
                 comments: Vec::new(),
                 review_decision: None,
                 is_draft: None,
+                author: None,
             };
             assert_eq!(pr.ci_status(), CiStatus::Failed, "state={state}");
         }
@@ -575,6 +597,7 @@ mod tests {
             comments: Vec::new(),
             review_decision: None,
             is_draft: None,
+            author: None,
         };
         assert_eq!(pr.ci_status(), CiStatus::Passed);
     }
@@ -593,6 +616,7 @@ mod tests {
             comments: Vec::new(),
             review_decision: review_decision.map(Into::into),
             is_draft,
+            author: None,
         };
 
         assert_eq!(
@@ -634,6 +658,7 @@ mod tests {
                 .collect(),
             review_decision: None,
             is_draft: None,
+            author: None,
         };
 
         // Zero comments flatten to None so a PR with no comments shows nothing.

--- a/src/commands/list/ci_status/gitlab.rs
+++ b/src/commands/list/ci_status/gitlab.rs
@@ -196,6 +196,7 @@ pub(super) fn detect_gitlab(
             review_state: mr_entry.review_state(),
             title: mr_entry.title.clone(),
             body: mr_entry.description.clone(),
+            author: mr_entry.author.as_ref().map(|a| a.username.clone()),
             comment_count: mr_entry.comment_count(),
         });
     };
@@ -212,6 +213,7 @@ pub(super) fn detect_gitlab(
         review_state: mr_entry.review_state(),
         title: mr_entry.title.clone(),
         body: mr_entry.description.clone(),
+        author: mr_entry.author.as_ref().map(|a| a.username.clone()),
         comment_count: mr_entry.comment_count(),
     })
 }
@@ -286,6 +288,7 @@ pub(super) fn detect_gitlab_pipeline(
         review_state: None,
         title: None,
         body: None,
+        author: None,
         comment_count: None,
     })
 }
@@ -297,6 +300,12 @@ pub(super) fn detect_gitlab_pipeline(
 ///
 /// We include `source_project_id` for client-side filtering by source project.
 /// See `parse_owner_repo()` for why we filter by source, not by author.
+#[derive(Debug, Default, Deserialize)]
+struct GitLabMrAuthor {
+    #[serde(default)]
+    username: String,
+}
+
 #[derive(Debug, Deserialize)]
 struct GitLabMrListEntry {
     /// The internal MR ID (used to fetch full details via `glab mr view <iid>`)
@@ -313,6 +322,9 @@ struct GitLabMrListEntry {
     /// MR title; shown in the picker's `pr` preview pane. Rides this call.
     #[serde(default)]
     pub title: Option<String>,
+    /// MR author; folded into the row's matcher text. Rides this call.
+    #[serde(default)]
+    pub author: Option<GitLabMrAuthor>,
     /// MR description; rendered as markdown in the `pr` preview pane.
     #[serde(default)]
     pub description: Option<String>,
@@ -433,6 +445,7 @@ mod tests {
             iid: 1,
             sha: "abc".into(),
             has_conflicts: false,
+            author: None,
             detailed_merge_status: status.map(Into::into),
             source_project_id: None,
             web_url: None,
@@ -462,6 +475,7 @@ mod tests {
             iid: 1,
             sha: "abc".into(),
             has_conflicts: false,
+            author: None,
             detailed_merge_status: None,
             source_project_id: None,
             web_url: None,

--- a/src/commands/list/ci_status/mod.rs
+++ b/src/commands/list/ci_status/mod.rs
@@ -393,6 +393,11 @@ pub struct PrStatus {
     /// `pr` preview pane, riding the same forge call the CI column already makes.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub title: Option<String>,
+    /// PR/MR author login (GitHub) / username (GitLab). Absent as for `title`.
+    /// Folded into a worktree row's matcher text so a PR filters by author the
+    /// same whether it's shown as a worktree row or a listed `--prs` row.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub author: Option<String>,
     /// PR/MR description (GitHub `body`, GitLab/Azure/Gitea `description`/`body`),
     /// rendered as markdown in the `pr` preview pane. Absent as for `title`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -527,6 +532,7 @@ impl PrStatus {
             review_state: None,
             title: None,
             body: None,
+            author: None,
             comment_count: None,
         }
     }
@@ -748,6 +754,7 @@ mod tests {
             review_state: None,
             title: None,
             body: None,
+            author: None,
             comment_count: None,
         };
         assert_eq!(pr_passed.indicator(), "#");
@@ -762,6 +769,7 @@ mod tests {
             review_state: None,
             title: None,
             body: None,
+            author: None,
             comment_count: None,
         };
         assert_eq!(branch_running.indicator(), "#");
@@ -776,6 +784,7 @@ mod tests {
             review_state: None,
             title: None,
             body: None,
+            author: None,
             comment_count: None,
         };
         assert_eq!(error_status.indicator(), "⚠");
@@ -795,6 +804,7 @@ mod tests {
             review_state: None,
             title: None,
             body: None,
+            author: None,
             comment_count: None,
         };
 
@@ -891,6 +901,7 @@ mod tests {
             review_state: None,
             title: None,
             body: None,
+            author: None,
             comment_count: None,
         };
         let green = "\u{1b}[32m";
@@ -932,6 +943,7 @@ mod tests {
             review_state,
             title: None,
             body: None,
+            author: None,
             comment_count: None,
         };
 
@@ -1046,6 +1058,7 @@ mod tests {
             review_state: None,
             title: None,
             body: None,
+            author: None,
             comment_count: None,
         }
     }

--- a/src/commands/list/json_output.rs
+++ b/src/commands/list/json_output.rs
@@ -645,6 +645,7 @@ mod tests {
                 review_state: None,
                 title: None,
                 body: None,
+                author: None,
                 comment_count: None,
             },
             None,
@@ -686,6 +687,7 @@ mod tests {
                 review_state: None,
                 title: None,
                 body: None,
+                author: None,
                 comment_count: None,
             },
             None,
@@ -717,6 +719,7 @@ mod tests {
                     review_state: None,
                     title: None,
                     body: None,
+                    author: None,
                     comment_count: None,
                 },
                 None,
@@ -740,6 +743,7 @@ mod tests {
             review_state: None,
             title: None,
             body: None,
+            author: None,
             comment_count: None,
         };
 

--- a/src/commands/picker/items.rs
+++ b/src/commands/picker/items.rs
@@ -227,13 +227,53 @@ fn compute_diff_preview(
 /// mutation (see `progressive_handler`); skim then re-reads `display()` and the
 /// new value surfaces — no re-send through the item channel.
 ///
-/// `search_text` (what the matcher sees) stays based on fast-only fields
-/// so cached ranks don't need to re-compute when a slow field lands.
+/// Append the PR/MR fields a row filters on — reference (`#123`/`!7`), title,
+/// author — to `text`, space-separated, in the order shared by worktree rows
+/// and listed `--prs` rows. A PR thus filters identically however it's shown,
+/// the rule the picker holds to. Empty title/author are skipped; the caller
+/// owns the trailing gutter glyph (which must stay last). `text` is assumed
+/// non-empty (it starts with the branch), so every token is space-prefixed.
+pub(super) fn push_pr_search_tokens(
+    text: &mut String,
+    reference: PrRef,
+    title: Option<&str>,
+    author: Option<&str>,
+) {
+    for token in [
+        Some(reference.to_string()),
+        title
+            .map(str::trim)
+            .filter(|t| !t.is_empty())
+            .map(str::to_owned),
+        author
+            .map(str::trim)
+            .filter(|a| !a.is_empty())
+            .map(str::to_owned),
+    ]
+    .into_iter()
+    .flatten()
+    {
+        text.push(' ');
+        text.push_str(&token);
+    }
+}
+
+/// The matcher text (`text()`) is assembled live from `search_base` + the
+/// `gutter` glyph + the current `pr_status` slot, so a PR's reference, title,
+/// and author become filterable the moment the CI fetch lands them — the same
+/// fields a listed `--prs` row filters on (see [`push_pr_search_tokens`]). skim
+/// re-reads `text()` on each query keystroke, so the live PR data folds in
+/// without a re-send; the row may re-rank as that data streams in during the
+/// first frame.
 pub(super) struct WorktreeSkimItem {
-    /// Stable text used for fuzzy matching — branch name + path. Keeping
-    /// this independent of the rendered display means skim's matcher
-    /// cache survives progressive updates.
-    pub search_text: String,
+    /// The stable, skeleton-time head of the matcher text: branch name + the
+    /// distinct worktree path. The PR tokens and trailing gutter glyph are
+    /// appended live in `text()`.
+    pub search_base: String,
+    /// Trailing gutter glyph (`@`/`^`/`+`/`/`/`|`), kept last in `text()` so a
+    /// typed sigil filters by row kind. A skeleton-time fact from
+    /// `ItemKind::gutter_glyph`.
+    pub gutter: char,
     /// Current ANSI-colored display line. Starts as the skeleton render;
     /// replaced in place as data arrives.
     pub rendered: Arc<Mutex<String>>,
@@ -274,7 +314,24 @@ pub(super) struct WorktreeSkimItem {
 
 impl SkimItem for WorktreeSkimItem {
     fn text(&self) -> Cow<'_, str> {
-        Cow::Borrowed(&self.search_text)
+        // branch + path (stable), then the live PR/MR tokens (reference, title,
+        // author) from the current `pr_status` slot, then the gutter glyph last.
+        // Read live so a PR filters by number/title/author as soon as the CI
+        // fetch lands them — the same fields a `--prs` row carries.
+        let mut text = self.search_base.clone();
+        if let Some(Some(status)) = &*self.pr_status.lock().unwrap()
+            && let Some(reference) = status.number
+        {
+            push_pr_search_tokens(
+                &mut text,
+                reference,
+                status.title.as_deref(),
+                status.author.as_deref(),
+            );
+        }
+        text.push(' ');
+        text.push(self.gutter);
+        Cow::Owned(text)
     }
 
     fn display(&self, _context: DisplayContext) -> Line<'_> {
@@ -660,13 +717,12 @@ fn render_tab_row_compact(tabs: &[Tab], reset: Reset) -> String {
 
 /// The `pr` pane for a worktree row whose branch has a PR/MR. Renders the same
 /// shape as the `--prs` rows' pane (`PrSkimItem::pr_pane`) — reference + title
-/// header, cyan all-caps labeled metadata (the branch bold, the url underlined),
-/// and the description as markdown — via the shared [`pr_pane`] helpers, so the
-/// two read alike. The title, body, and
-/// comment count ride the same CI fetch the column already makes (see
-/// [`PrStatus`]); a status without them (an older cache entry, a forge that
-/// doesn't expose them) falls back to a reference-only header and skips the
-/// missing lines.
+/// header, cyan all-caps labeled metadata (the branch bold, the author, the url
+/// underlined), and the description as markdown — via the shared [`pr_pane`]
+/// helpers, so the two read alike. The title, author, body, and comment count
+/// ride the same CI fetch the column already makes (see [`PrStatus`]); a status
+/// without them (an older cache entry, a forge that doesn't expose them) falls
+/// back to a reference-only header and skips the missing lines.
 ///
 /// The `comments` line shows only the count; the full thread is the `comments`
 /// tab's own background fetch (see [`WorktreeSkimItem::render_comments_pane`]).
@@ -678,6 +734,9 @@ fn render_worktree_pr(branch: &str, pr_ref: PrRef, status: &PrStatus, width: usi
     let title = status.title.as_deref().filter(|t| !t.is_empty());
     let mut out = pr_pane::header(pr_ref, title);
     out.push_str(&pr_pane::branch_line(branch));
+    if let Some(author) = status.author.as_deref().filter(|a| !a.is_empty()) {
+        out.push_str(&pr_pane::metadata_line("author", &format!("@{author}")));
+    }
     if let Some(url) = &status.url {
         out.push_str(&pr_pane::url_line(url));
     }
@@ -1663,7 +1722,8 @@ mod tests {
                 "Add auth module\n\nImplements JWT-based authentication.".to_string(),
             );
             WorktreeSkimItem {
-                search_text: String::new(),
+                search_base: String::new(),
+                gutter: '@',
                 rendered: Arc::new(Mutex::new(String::new())),
                 branch_name: "feature".to_string(),
                 item: Arc::clone(&item),
@@ -1678,7 +1738,8 @@ mod tests {
         let cache_miss = {
             let preview_cache: PreviewCache = Arc::new(DashMap::new());
             WorktreeSkimItem {
-                search_text: String::new(),
+                search_base: String::new(),
+                gutter: '@',
                 rendered: Arc::new(Mutex::new(String::new())),
                 branch_name: "feature".to_string(),
                 item: Arc::clone(&item),
@@ -1731,6 +1792,7 @@ mod tests {
             review_state: Some(ReviewState::Approved),
             title: None,
             body: None,
+            author: None,
             comment_count: None,
         };
         let with_url: PrStatusSlot = Arc::new(Mutex::new(Some(Some(status))));
@@ -1757,6 +1819,7 @@ mod tests {
             review_state: Some(ReviewState::Approved),
             title: title.map(String::from),
             body: body.map(String::from),
+            author: None,
             comment_count: None,
         };
         // Build a row whose live `pr_status` slot carries a given state — what
@@ -1764,7 +1827,8 @@ mod tests {
         let row = |pr_status: Option<Option<PrStatus>>| {
             let item = ListItem::new_branch("abc".into(), "feature".into());
             WorktreeSkimItem {
-                search_text: String::new(),
+                search_base: String::new(),
+                gutter: '@',
                 rendered: Arc::new(Mutex::new(String::new())),
                 branch_name: "feature".into(),
                 item: Arc::new(item),
@@ -1867,11 +1931,13 @@ mod tests {
                 review_state: None,
                 title: None,
                 body: None,
+                author: None,
                 comment_count: None,
             }))
         };
         let row = |slot: Option<Option<PrStatus>>, cache: PreviewCache| WorktreeSkimItem {
-            search_text: String::new(),
+            search_base: String::new(),
+            gutter: '@',
             rendered: Arc::new(Mutex::new(String::new())),
             branch_name: "feature".into(),
             item: Arc::new(ListItem::new_branch("abc".into(), "feature".into())),
@@ -1932,6 +1998,7 @@ mod tests {
             review_state: None,
             title: Some("Fix the flaky retry".into()),
             body: None,
+            author: None,
             comment_count,
         };
 
@@ -1957,6 +2024,45 @@ mod tests {
         );
     }
 
+    /// The worktree-row `pr` pane shows the PR author, the same as a `--prs`
+    /// row's pane — `PrStatus` now carries it from the CI fetch. Absent author
+    /// (older cache entry, forge without the field) skips the line.
+    #[test]
+    fn worktree_pr_pane_shows_author() {
+        use crate::commands::list::ci_status::{CiSource, CiStatus, PrRef};
+
+        let status = |author: Option<&str>| PrStatus {
+            ci_status: CiStatus::Passed,
+            source: CiSource::PullRequest,
+            is_stale: false,
+            is_priming: false,
+            url: None,
+            number: Some(PrRef::pr(7)),
+            review_state: None,
+            title: Some("Fix the flaky retry".into()),
+            body: None,
+            author: author.map(str::to_owned),
+            comment_count: None,
+        };
+
+        let with = render_worktree_pr("feature", PrRef::pr(7), &status(Some("bob")), 80)
+            .ansi_strip()
+            .to_string();
+        assert!(
+            with.lines()
+                .any(|l| l.contains("AUTHOR") && l.contains("@bob")),
+            "author line: {with:?}"
+        );
+
+        let without = render_worktree_pr("feature", PrRef::pr(7), &status(None), 80)
+            .ansi_strip()
+            .to_string();
+        assert!(
+            !without.contains("AUTHOR"),
+            "no author line when absent: {without:?}"
+        );
+    }
+
     #[test]
     fn preview_assembles_tab_bar_and_pr_pane() {
         use crate::commands::list::ci_status::{CiSource, CiStatus, PrRef, ReviewState};
@@ -1964,7 +2070,8 @@ mod tests {
         // A worktree row whose live status carries a PR with title + body.
         let item = ListItem::new_branch("abc".into(), "feature".into());
         let row = WorktreeSkimItem {
-            search_text: String::new(),
+            search_base: String::new(),
+            gutter: '@',
             rendered: Arc::new(Mutex::new(String::new())),
             branch_name: "feature".into(),
             item: Arc::new(item),
@@ -1981,6 +2088,7 @@ mod tests {
                 review_state: Some(ReviewState::Approved),
                 title: Some("Fix the flaky retry".into()),
                 body: Some("Adds a **bounded** retry.".into()),
+                author: None,
                 comment_count: None,
             })))),
             local_content: Arc::new(Mutex::new(LocalContent::default())),
@@ -2048,6 +2156,7 @@ mod tests {
                 review_state: Some(ReviewState::Approved),
                 title: Some(title.into()),
                 body: Some("body".into()),
+                author: None,
                 comment_count: None,
             }))
         };
@@ -2057,7 +2166,8 @@ mod tests {
         let slot: PrStatusSlot = Arc::new(Mutex::new(status("First title")));
         let key = ("feature".to_string(), PreviewMode::Pr);
         let row = WorktreeSkimItem {
-            search_text: String::new(),
+            search_base: String::new(),
+            gutter: '@',
             rendered: Arc::new(Mutex::new(String::new())),
             branch_name: "feature".into(),
             item: Arc::new(ListItem::new_branch("abc".into(), "feature".into())),

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -941,7 +941,6 @@ struct PipelineFactory {
     preview_cache: PreviewCache,
     orchestrator: Arc<PreviewOrchestrator>,
     stashed_warnings: Arc<Mutex<Vec<String>>>,
-    grid_slot: Arc<prs::GridSlot>,
     preview_dims: (usize, usize),
     skim_list_width: usize,
     command_timeout: Option<std::time::Duration>,
@@ -979,6 +978,15 @@ impl PipelineFactory {
         let prs_loading: Option<Arc<AtomicBool>> =
             (self.show_prs && !self.is_preview_bench).then(|| Arc::new(AtomicBool::new(true)));
 
+        // The skeleton→`--prs` handoff (column geometry + the branches already
+        // shown for dedup). Fresh per spawn so an alt-r reload's `--prs` thread
+        // reads *this* reload's branch set — a session-shared first-write-wins
+        // slot would feed it the original skeleton's stale set, double-listing or
+        // dropping a PR whose worktree was created/removed since (see
+        // `prs::Skeleton`). The grid is width-stable, so per-spawn grids are
+        // identical anyway.
+        let grid_slot = Arc::new(prs::GridSlot::new());
+
         let handler: Arc<progressive_handler::PickerHandler> =
             Arc::new(progressive_handler::PickerHandler {
                 tx: tx.clone(),
@@ -997,7 +1005,7 @@ impl PipelineFactory {
                 summary_hint: self.summary_hint.clone(),
                 stashed_warnings: Arc::clone(&self.stashed_warnings),
                 deferred_items: OnceLock::new(),
-                grid_slot: Arc::clone(&self.grid_slot),
+                grid_slot: Arc::clone(&grid_slot),
                 prs_loading: prs_loading.clone(),
             });
 
@@ -1039,7 +1047,7 @@ impl PipelineFactory {
             let prs_orchestrator = Arc::clone(&self.orchestrator);
             let prs_render_tx = Arc::clone(&self.render_tx);
             let prs_shared = prs::PrsShared {
-                grid_slot: Arc::clone(&self.grid_slot),
+                grid_slot: Arc::clone(&grid_slot),
                 shortcut_table: Arc::clone(&self.shortcut_table),
             };
             let prs_layout = prs::PrsLayout {
@@ -1317,9 +1325,6 @@ pub fn handle_picker(
         preview_cache: Arc::clone(&preview_cache),
         orchestrator: Arc::clone(&orchestrator),
         stashed_warnings: Arc::clone(&stashed_warnings),
-        // Column-geometry handoff: the collect thread fills it at skeleton time,
-        // the `--prs` thread reads it to align PR rows with the worktree rows.
-        grid_slot: Arc::new(prs::GridSlot::new()),
         preview_dims,
         skim_list_width,
         command_timeout,
@@ -2356,7 +2361,8 @@ pub mod tests {
     fn picker_item(branch_name: &str, item: ListItem) -> Arc<dyn SkimItem> {
         let pr_status = Arc::new(Mutex::new(item.pr_status.clone()));
         Arc::new(WorktreeSkimItem {
-            search_text: branch_name.to_string(),
+            search_base: branch_name.to_string(),
+            gutter: '@',
             rendered: Arc::new(Mutex::new(String::new())),
             branch_name: branch_name.to_string(),
             item: Arc::new(item),
@@ -2415,7 +2421,6 @@ pub mod tests {
             preview_cache,
             orchestrator,
             stashed_warnings: Arc::new(Mutex::new(Vec::new())),
-            grid_slot: Arc::new(super::prs::GridSlot::new()),
             preview_dims: (80, 24),
             skim_list_width: 80,
             command_timeout: None,

--- a/src/commands/picker/progressive_handler.rs
+++ b/src/commands/picker/progressive_handler.rs
@@ -57,7 +57,7 @@ use super::items::{
 use super::preview::PreviewMode;
 use super::preview_orchestrator::PreviewOrchestrator;
 use crate::commands::list::collect::PickerProgressHandler;
-use crate::commands::list::model::ListItem;
+use crate::commands::list::model::{BranchScope, ItemKind, ListItem};
 
 /// Handler owned by the background collect thread. Implements the
 /// `PickerProgressHandler` trait that `collect` drives.
@@ -123,8 +123,10 @@ pub(super) struct PickerHandler {
     /// to fan out the bulk preview pre-compute for items 1..N. Set once
     /// (`OnceLock`) because skeletons fire exactly once per collect.
     pub(super) deferred_items: OnceLock<Vec<Arc<ListItem>>>,
-    /// Handoff of the layout's column geometry to the `--prs` thread, which
-    /// renders PR rows on the same grid as the worktree rows.
+    /// Handoff to the `--prs` thread: the layout's column geometry (PR rows
+    /// align to the worktree grid) plus the branches already shown (so `--prs`
+    /// skips PRs already represented). Filled in `on_skeleton`. See
+    /// [`super::prs::Skeleton`].
     pub(super) grid_slot: Arc<super::prs::GridSlot>,
     /// Shared with the header: `Some(true)` while the `--prs` forge call is in
     /// flight, so the header shows a "loading…" marker. The `--prs` thread
@@ -200,6 +202,27 @@ impl PickerHandler {
     }
 }
 
+/// Branch names the skeleton shows, for the `--prs` thread's dedup: a PR whose
+/// head branch is in this set is already on screen, so its row is dropped. A
+/// remote row ("origin/foo") also contributes its bare "foo" — remote names
+/// carry no '/', so the first segment is the remote — so a PR for "foo" dedups
+/// against a shown "origin/foo". Detached rows (no branch) contribute nothing.
+fn collect_shown_branches(items: &[ListItem]) -> HashSet<String> {
+    let mut shown = HashSet::new();
+    for item in items {
+        let Some(name) = item.branch.as_deref() else {
+            continue;
+        };
+        shown.insert(name.to_string());
+        if matches!(item.kind, ItemKind::Branch(BranchScope::Remote))
+            && let Some((_, bare)) = name.split_once('/')
+        {
+            shown.insert(bare.to_string());
+        }
+    }
+    shown
+}
+
 impl PickerProgressHandler for PickerHandler {
     fn on_skeleton(
         &self,
@@ -209,7 +232,16 @@ impl PickerProgressHandler for PickerHandler {
         grid: crate::commands::list::layout::ColumnGrid,
     ) {
         debug_assert_eq!(items.len(), rendered.len());
-        self.grid_slot.set(grid);
+
+        // Hand the `--prs` thread the column geometry plus the branches already
+        // shown, so it aligns PR rows *and* skips PRs already represented by a
+        // worktree/branch row (see `prs::Skeleton`). Built before the row loop
+        // consumes `items`, and set before any other handoff so the `--prs`
+        // thread's wait sees both.
+        self.grid_slot.set(super::prs::Skeleton {
+            grid,
+            shown_branches: collect_shown_branches(&items),
+        });
 
         let mut slots: Vec<Arc<Mutex<String>>> = Vec::with_capacity(items.len());
         let mut pr_slots: Vec<PrStatusSlot> = Vec::with_capacity(items.len());
@@ -297,19 +329,26 @@ impl PickerProgressHandler for PickerHandler {
                         .into_owned()
                 })
                 .unwrap_or_default();
-            // `search_text` is what the matcher sees — fuzzy ranks stay
-            // stable across progressive updates because this field only
-            // depends on fast data (branch + path + gutter glyph). The
-            // trailing gutter glyph lets typing a sigil filter by row kind:
-            // `+` to linked worktrees, `@` to the current one, `/`/`|` to
+            // `search_base` is the stable head of the matcher text: branch +
+            // distinct path. The PR/MR tokens (reference, title, author) and the
+            // trailing gutter glyph are appended live in
+            // `WorktreeSkimItem::text()`, which reads the row's `pr_status` slot
+            // each time skim matches — so a PR filters by number/title/author as
+            // soon as the CI fetch lands them, the same fields a `--prs` row
+            // carries. The gutter glyph stays last so a typed sigil filters by
+            // row kind: `+` linked worktrees, `@` the current one, `/`/`|`
             // local/remote branches (`gutter_glyph` is the same skeleton-time
-            // fact the rendered Gutter column uses).
+            // fact the rendered Gutter column uses). The folded reference also
+            // lets `#` isolate PR-bearing rows (a plain fuzzy char); the GitLab
+            // `!` is skim's inverse-match operator, so only the bare number
+            // filters those (see
+            // `folded_pr_reference_filters_under_skims_default_engine`).
             let gutter = item.kind.gutter_glyph();
-            let search_text = if path_str.is_empty() {
-                format!("{branch_name} {gutter}")
-            } else {
-                format!("{branch_name} {path_str} {gutter}")
-            };
+            let mut search_base = branch_name.clone();
+            if !path_str.is_empty() {
+                search_base.push(' ');
+                search_base.push_str(&path_str);
+            }
 
             // Strip OSC 8 hyperlinks — skim's pipeline mangles them into
             // garbage like `^[8;;…`. Colors (SGR codes) are preserved.
@@ -348,7 +387,8 @@ impl PickerProgressHandler for PickerHandler {
             );
 
             skim_items.push(Arc::new(WorktreeSkimItem {
-                search_text,
+                search_base,
+                gutter,
                 rendered: rendered_arc,
                 branch_name,
                 item: item_arc,
@@ -628,6 +668,7 @@ mod tests {
                 review_state: None,
                 title: None,
                 body: None,
+                author: None,
                 comment_count: None,
             }));
             item
@@ -779,6 +820,114 @@ mod tests {
         assert!(text(2).contains("origin/remotebr"));
     }
 
+    /// A worktree row's matcher text folds in its PR's reference, title, and
+    /// author — the same fields a `--prs` row carries — so a PR filters
+    /// identically however it's shown. Here the PR is primed at skeleton (the
+    /// cache case); the gutter glyph stays trailing for sigil filtering.
+    #[test]
+    fn worktree_row_matcher_text_folds_in_pr_number_title_author() {
+        use crate::commands::list::ci_status::{CiSource, CiStatus, PrRef, PrStatus};
+
+        let (handler, _test, rx) = make_handler();
+        let mut item = ListItem::new_branch("abc".into(), "localbr".into());
+        item.pr_status = Some(Some(PrStatus {
+            ci_status: CiStatus::Passed,
+            source: CiSource::PullRequest,
+            is_stale: false,
+            is_priming: false,
+            url: None,
+            number: Some(PrRef::pr(123)),
+            review_state: None,
+            title: Some("Speed up startup".into()),
+            body: None,
+            author: Some("alice".into()),
+            comment_count: None,
+        }));
+        handler.on_skeleton(vec![item], vec!["skel".into()], header("hdr"), grid());
+
+        let received = rx.recv().expect("skeleton batch");
+        let text = received[1].text().into_owned();
+        // The CI column shows `#123`; typing the number (or title/author) filters.
+        assert!(text.contains("#123"), "PR reference folded in: {text:?}");
+        assert!(
+            text.contains("Speed up startup"),
+            "title folded in: {text:?}"
+        );
+        assert!(text.contains("alice"), "author folded in: {text:?}");
+        assert!(
+            text.contains("localbr"),
+            "branch still searchable: {text:?}"
+        );
+        assert!(text.ends_with('/'), "gutter glyph stays trailing: {text:?}");
+    }
+
+    /// The freeze is relaxed: a worktree row's matcher text is read live from its
+    /// `pr_status` slot, so a PR the live CI fetch discovers (cold cache, nothing
+    /// primed at skeleton) becomes filterable by number/title/author once
+    /// `on_update` lands it — not just on a later run.
+    #[test]
+    fn worktree_row_matcher_text_updates_when_live_fetch_lands_pr() {
+        use crate::commands::list::ci_status::{CiSource, CiStatus, PrRef, PrStatus};
+
+        let (handler, _test, rx) = make_handler();
+        // Skeleton with no PR (cold cache).
+        handler.on_skeleton(
+            vec![ListItem::new_branch("abc".into(), "localbr".into())],
+            vec!["skel".into()],
+            header("hdr"),
+            grid(),
+        );
+        let received = rx.recv().expect("skeleton batch");
+        let row = Arc::clone(&received[1]);
+        assert!(
+            !row.text().contains("#7"),
+            "no PR before the fetch: {:?}",
+            row.text()
+        );
+
+        // The live fetch reports a PR for the row.
+        let mut updated = ListItem::new_branch("abc".into(), "localbr".into());
+        updated.pr_status = Some(Some(PrStatus {
+            ci_status: CiStatus::Passed,
+            source: CiSource::PullRequest,
+            is_stale: false,
+            is_priming: false,
+            url: None,
+            number: Some(PrRef::pr(7)),
+            review_state: None,
+            title: Some("Add caching".into()),
+            body: None,
+            author: Some("bob".into()),
+            comment_count: None,
+        }));
+        handler.on_update(0, "rendered".into(), &updated);
+
+        // Same row item; its matcher text now reflects the landed PR.
+        let text = row.text().into_owned();
+        assert!(text.contains("#7"), "number now filters: {text:?}");
+        assert!(text.contains("Add caching"), "title now filters: {text:?}");
+        assert!(text.contains("bob"), "author now filters: {text:?}");
+        assert!(text.ends_with('/'), "gutter glyph stays trailing: {text:?}");
+    }
+
+    /// `collect_shown_branches` gathers branch names for the `--prs` dedup, and
+    /// adds a remote row's bare name so a PR for "foo" dedups against a shown
+    /// "origin/foo".
+    #[test]
+    fn collect_shown_branches_adds_remote_bare_names() {
+        let items = vec![
+            ListItem::new_branch("a".into(), "local-feat".into()),
+            ListItem::new_remote_branch("b".into(), "origin/remote-feat".into()),
+        ];
+        let shown = collect_shown_branches(&items);
+        assert!(shown.contains("local-feat"), "local branch name");
+        assert!(shown.contains("origin/remote-feat"), "full remote ref");
+        assert!(
+            shown.contains("remote-feat"),
+            "bare name so a PR head dedups against the remote row"
+        );
+    }
+
     /// `on_skeleton` strips the shared main-worktree parent from each row's
     /// matcher `search_text`, so the fuzzy matcher indexes the distinguishing
     /// leaf (`repo.feat`) rather than the absolute prefix every sibling worktree
@@ -894,6 +1043,51 @@ mod tests {
                 "| (OR operator) matches nothing — not a filter: {row:?}"
             );
         }
+    }
+
+    /// Locks the PR/MR filtering contract: a worktree row folds its PR's
+    /// reference, title, and author into the matcher text, so under skim's
+    /// default engine all three filter the row regardless of forge sigil. `#`
+    /// (GitHub/Gitea/Azure) is a plain fuzzy char that also isolates PR-bearing
+    /// rows, while the GitLab `!` is skim's inverse-match operator, so typing the
+    /// literal `!7` *excludes* its own MR row — only the number filters there.
+    /// Companion to `gutter_glyphs_filter_under_skims_default_engine`.
+    #[test]
+    fn folded_pr_reference_filters_under_skims_default_engine() {
+        struct TextItem(String);
+        impl SkimItem for TextItem {
+            fn text(&self) -> std::borrow::Cow<'_, str> {
+                std::borrow::Cow::Borrowed(&self.0)
+            }
+        }
+        let matches = |query: &str, haystack: &str| -> bool {
+            AndOrEngineFactory::new(ExactOrFuzzyEngineFactory::builder().build())
+                .create_engine(query)
+                .match_item(&TextItem(haystack.to_string()))
+                .is_some()
+        };
+
+        // Folded matcher text for a worktree row carrying a PR (`#123`) / MR
+        // (`!7`) — branch, path, reference, title, author, gutter — and one with
+        // no PR. The PR fields are exactly what a `--prs` row also folds in.
+        let github = "feature feature.wt #123 Add caching alice +";
+        let gitlab = "feature feature.wt !7 Speed up startup bob +";
+        let no_pr = "plain plain.wt +";
+
+        // The number, title, and author all filter — the same fields in both
+        // pickers, regardless of forge sigil.
+        assert!(matches("123", github), "PR number filters the GitHub row");
+        assert!(matches("7", gitlab), "MR number filters the GitLab row");
+        assert!(matches("caching", github), "title filters");
+        assert!(matches("alice", github), "author filters");
+        assert!(matches("bob", gitlab), "MR author filters");
+        // `#` is a plain fuzzy char: it isolates PR-bearing rows and skips
+        // PR-less ones (same as the `--prs` gutter sigil).
+        assert!(matches("#", github), "# selects a PR-bearing row");
+        assert!(!matches("#", no_pr), "# skips a PR-less row");
+        // `!7` is skim's inverse-match operator — it excludes rows containing
+        // `7`, hiding the very MR row it names. The bare number is reliable.
+        assert!(!matches("!7", gitlab), "!7 inverse-excludes its own MR row");
     }
 
     /// `stash_warning` accumulates lines in arrival order so the picker can

--- a/src/commands/picker/prs.rs
+++ b/src/commands/picker/prs.rs
@@ -36,6 +36,7 @@
 //! single known number but have no listing path here yet.
 
 use std::borrow::Cow;
+use std::collections::HashSet;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Condvar, Mutex, OnceLock};
@@ -59,45 +60,57 @@ use super::super::list::columns::ColumnKind;
 use super::super::list::layout::ColumnGrid;
 use super::items::{
     PreviewCache, RowShortcutData, RowUrl, ShortcutTable, TabAvailability, WorktreeSkimItem,
-    ansi_to_line, render_preview_tabs,
+    ansi_to_line, push_pr_search_tokens, render_preview_tabs,
 };
 use super::pr_pane;
 use super::preview::{PreviewMode, PreviewStateData};
 use super::preview_orchestrator::PreviewOrchestrator;
 
-/// One-shot handoff of the picker's column geometry from the collect thread
-/// (which computes the layout at skeleton time) to the `--prs` thread (which
-/// renders rows once the forge call returns). First write wins — an alt-r
-/// reload re-fires the skeleton at the same width, so later grids are
-/// identical.
+/// One-shot handoff from the collect thread (which builds the skeleton) to the
+/// `--prs` thread: the picker's column geometry, so PR rows align to the
+/// worktree grid, plus the branch names already shown, so `--prs` skips PRs
+/// already represented by a worktree/branch row — the rule that the two pickers
+/// differ only by the extra PR rows. Created fresh per `spawn()`, so an alt-r
+/// reload's `--prs` thread reads that reload's branch set (not a stale one); the
+/// skeleton fires once per spawn, so the first-write-wins guard is just defense.
 pub(super) struct GridSlot {
-    grid: Mutex<Option<ColumnGrid>>,
+    slot: Mutex<Option<Skeleton>>,
     ready: Condvar,
+}
+
+/// What the `--prs` thread takes from the skeleton (see [`GridSlot`]).
+#[derive(Clone)]
+pub(super) struct Skeleton {
+    pub grid: ColumnGrid,
+    /// Branch names of every worktree/branch row the skeleton showed. A PR whose
+    /// head branch is here is already on screen, so `--prs` drops its row.
+    pub shown_branches: HashSet<String>,
 }
 
 impl GridSlot {
     pub(super) fn new() -> Self {
         Self {
-            grid: Mutex::new(None),
+            slot: Mutex::new(None),
             ready: Condvar::new(),
         }
     }
 
-    pub(super) fn set(&self, grid: ColumnGrid) {
-        let mut slot = self.grid.lock().unwrap();
+    pub(super) fn set(&self, skeleton: Skeleton) {
+        let mut slot = self.slot.lock().unwrap();
         if slot.is_none() {
-            *slot = Some(grid);
+            *slot = Some(skeleton);
         }
         self.ready.notify_all();
     }
 
-    /// Block until the grid is set or `timeout` elapses. The timeout covers
-    /// collect exiting without a skeleton (zero items, error) — the rows
-    /// then render freeform rather than never.
-    fn wait(&self, timeout: Duration) -> Option<ColumnGrid> {
+    /// Block until the skeleton is set or `timeout` elapses. The timeout covers
+    /// collect exiting without a skeleton (zero items, error) — the rows then
+    /// render freeform rather than never, and with no shown-branch set every PR
+    /// lists (nothing to dedup against).
+    fn wait(&self, timeout: Duration) -> Option<Skeleton> {
         let (slot, _) = self
             .ready
-            .wait_timeout_while(self.grid.lock().unwrap(), timeout, |grid| grid.is_none())
+            .wait_timeout_while(self.slot.lock().unwrap(), timeout, |s| s.is_none())
             .unwrap();
         slot.clone()
     }
@@ -230,6 +243,27 @@ pub(super) fn stream_open_prs(
     }
 }
 
+/// Keep only PRs not already shown as a worktree/branch row. `shown_branches`
+/// is `None` when no skeleton arrived (collect errored / zero rows) — then every
+/// PR lists, there being nothing to dedup against.
+///
+/// Matching is by bare head-branch name, so a fork PR whose head name collides
+/// with a shown branch (e.g. a fork's `patch-1` while you have a local `patch-1`)
+/// is dropped even though the shown row's own CI fetch — filtered to the origin
+/// owner — won't surface that fork PR. Rare; the alternative (PR-identity-aware
+/// dedup) needs each shown row's PR number, which isn't known until its async CI
+/// fetch lands. Filtering by the bare name there too (`gh pr list --head`) is the
+/// same owner-scoped behavior, so this stays consistent rather than special-cased.
+fn additional_prs(entries: Vec<PrEntry>, shown_branches: Option<&HashSet<String>>) -> Vec<PrEntry> {
+    match shown_branches {
+        Some(shown) => entries
+            .into_iter()
+            .filter(|entry| !shown.contains(&entry.head_branch))
+            .collect(),
+        None => entries,
+    }
+}
+
 /// Fetch open PRs/MRs, build picker rows, and stream them into skim.
 ///
 /// On failure (forge unsupported, CLI missing/unauthenticated, network error)
@@ -265,8 +299,24 @@ fn fetch_and_stream(
 
     // The forge call above (~1s) almost always outlasts the skeleton
     // (~50ms), so this returns immediately; the wait covers a mocked forge
-    // CLI winning the race.
-    let grid = shared.grid_slot.wait(Duration::from_secs(5));
+    // CLI winning the race. A `None` (collect errored / zero rows) leaves both
+    // the grid and the dedup set empty: rows render freeform and every PR lists.
+    let (grid, shown_branches) = match shared.grid_slot.wait(Duration::from_secs(5)) {
+        Some(skeleton) => (Some(skeleton.grid), Some(skeleton.shown_branches)),
+        None => (None, None),
+    };
+
+    // Drop PRs already on screen as a worktree/branch row, so `--prs` only adds
+    // PRs not already represented — the two pickers differ solely by the extra
+    // rows. A worktree row folds the same number/title/author into its matcher
+    // text (see `WorktreeSkimItem::text`), so the dropped PR stays just as
+    // filterable under its worktree row.
+    let entries = additional_prs(entries, shown_branches.as_ref());
+    if entries.is_empty() {
+        // Every open PR already has a worktree/branch row — nothing to add. Not
+        // the "no open PRs" case, so no warning: the PRs are on screen already.
+        return;
+    }
 
     // skim 4.x takes a batch per send; the forge call already returned every
     // row, so stream them in one shot. As each row is built, kick off its
@@ -446,14 +496,13 @@ struct GhPr {
     /// Head commit SHA; lets the `log` tab use a local `git log` when present.
     #[serde(rename = "headRefOid", default)]
     head_ref_oid: String,
-    #[serde(default)]
-    author: GhAuthor,
     /// CI/review and display fields reused via the shared `gh pr list` mapping:
-    /// number, `title`, `body`, `isDraft`, `url`, `statusCheckRollup`,
+    /// number, `title`, `body`, `author`, `isDraft`, `url`, `statusCheckRollup`,
     /// `reviewDecision`, `mergeStateStatus`. Flattened so one parse feeds the
     /// row display, the `pr` preview pane, and the CI-column status. `title`/
-    /// `body` live on [`GitHubPrInfo`] (not here) so the worktree-row fetch,
-    /// which parses `GitHubPrInfo` directly, gets them from the same widened call.
+    /// `body`/`author` live on [`GitHubPrInfo`] (not here) so the worktree-row
+    /// fetch, which parses `GitHubPrInfo` directly, gets them from the same
+    /// widened call.
     #[serde(flatten)]
     info: GitHubPrInfo,
 }
@@ -505,7 +554,12 @@ fn parse_github_prs(stdout: &[u8]) -> anyhow::Result<Vec<PrEntry>> {
             title: pr.info.title.clone().unwrap_or_default(),
             head_branch: pr.head_ref_name,
             head_oid: Some(pr.head_ref_oid).filter(|s| !s.is_empty()),
-            author: pr.author.login,
+            author: pr
+                .info
+                .author
+                .as_ref()
+                .map(|a| a.login.clone())
+                .unwrap_or_default(),
             is_draft: pr.info.is_draft == Some(true),
             url: pr.info.url.clone(),
             kind: RefKind::Pr,
@@ -636,6 +690,7 @@ fn gitlab_mr_status(
         // (which feeds only the CI column), so they stay absent here.
         title: None,
         body: None,
+        author: None,
         comment_count: None,
     }
 }
@@ -644,7 +699,8 @@ fn gitlab_mr_status(
 /// carries no `ListItem` and resolves to a `pr:`/`mr:` shortcut rather than a
 /// branch or worktree path.
 pub(super) struct PrSkimItem {
-    /// What skim's fuzzy matcher sees: kind, number, title, branch, author.
+    /// What skim's fuzzy matcher sees: head branch, then the PR/MR reference,
+    /// title, and author — the same fields a worktree row folds in.
     search_text: String,
     /// ANSI-colored display line — cells on the worktree rows' column grid,
     /// or a freeform line when no grid is available.
@@ -672,17 +728,24 @@ impl PrSkimItem {
         grid: Option<&ColumnGrid>,
         preview_cache: &PreviewCache,
     ) -> Self {
-        let label = entry.kind.shortcut();
         let output_token = entry.output_token();
 
-        // Trailing gutter glyph (the `#` from `PR_GUTTER_SIGIL`, sans pad) so
-        // typing `#` filters to PR/MR rows, matching how the worktree/branch
-        // rows fold their sigil in (see `progressive_handler` `on_skeleton`).
+        // Same matcher text a worktree row builds (see `WorktreeSkimItem::text`
+        // and `push_pr_search_tokens`): head branch, then the PR/MR reference,
+        // title, and author, so a PR filters identically however it's shown.
+        // The trailing gutter glyph (`#` from `PR_GUTTER_SIGIL`, sans pad) stays
+        // last so typing `#` filters to PR/MR rows, matching the worktree/branch
+        // rows' folded sigils.
         let gutter = PR_GUTTER_SIGIL.trim_end();
-        let search_text = format!(
-            "{label} {} {} {} {} {gutter}",
-            entry.number, entry.title, entry.head_branch, entry.author
+        let mut search_text = entry.head_branch.clone();
+        push_pr_search_tokens(
+            &mut search_text,
+            entry.pr_ref(),
+            Some(&entry.title),
+            Some(&entry.author),
         );
+        search_text.push(' ');
+        search_text.push_str(gutter);
 
         let rendered = match grid {
             Some(grid) => render_grid_row(&entry, grid, list_width),
@@ -1254,9 +1317,30 @@ mod tests {
                 review_state: None,
                 title: None,
                 body: None,
+                author: None,
                 comment_count: None,
             }),
         }
+    }
+
+    /// `--prs` drops a PR already shown as a worktree/branch row (so the two
+    /// pickers differ only by the extra rows); with no skeleton every PR lists.
+    #[test]
+    fn additional_prs_drops_already_shown_branches() {
+        let pr = |number, head: &str| {
+            let mut e = entry(RefKind::Pr, number, "t");
+            e.head_branch = head.to_string();
+            e
+        };
+        let shown: HashSet<String> = ["checked-out".to_string()].into_iter().collect();
+
+        let kept = additional_prs(vec![pr(1, "checked-out"), pr(2, "not-local")], Some(&shown));
+        assert_eq!(kept.len(), 1, "the already-shown PR is dropped");
+        assert_eq!(kept[0].head_branch, "not-local");
+
+        // No skeleton (None) → nothing to dedup against, every PR lists.
+        let all = additional_prs(vec![pr(1, "checked-out"), pr(2, "x")], None);
+        assert_eq!(all.len(), 2);
     }
 
     /// Grid that includes a CI column (the picker's layout once CiStatus is no

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -196,7 +196,7 @@ The CI column shows each row's PR/MR CI and review status, the same as [2mwt li
 
 [2mAlt-o[0m is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
 
-Plain digits go to the filter, so a branch name containing a number can be typed directly; the preview tabs move to [2mAlt[0m.
+Each row filters by its branch, path, and — when it has a PR/MR — the PR/MR's number, title, and author, the same fields whether the PR is checked out (a worktree row) or listed via [2m--prs[0m. Plain digits go to the filter, so a number can be typed directly and the preview tabs move to [2mAlt[0m.
 
 Typing a gutter sigil filters by row kind: [36m+[0m narrows to linked worktrees and [2m@[0m to the current worktree. The other sigils don't filter cleanly — [2m^[0m and [2m|[0m are skim's prefix-anchor and OR query operators (so [2m^[0m matches every row and [2m|[0m none), and [2m/[0m matches most rows because every worktree path contains it.
 
@@ -231,8 +231,8 @@ Both work anywhere a branch is accepted, including [2m--base[0m. The [2m--cre
 
 If the PR or MR is on a fork, the local branch uses its branch name directly, so [2mgit push[0m works normally. A pre-existing local branch with that name tracking something else requires renaming first.
 
-The [2m--prs[0m flag adds the repository's open PRs (GitHub) or MRs (GitLab) to the interactive picker. Each row resolves to the same [2mpr:[0m/[2mmr:[0m shortcut, so selecting one fetches the ref and switches to its branch. A [2m--prs[0m row has no local worktree, so its [2mpr[0m and [2mcomments[0m preview tabs load the PR/MR's metadata and comments from the forge in the background. The [2mlog[0m tab uses a local [2mgit log[0m — graph and merge-base dimming included — whenever the head commit is already in the object store (a same-repo PR 
-off a fetched remote), falling back to a flat forge-fetched commit list otherwise.
+The [2m--prs[0m flag adds the repository's open PRs (GitHub) or MRs (GitLab) to the interactive picker — only the ones not already there: a PR whose branch is already shown (as a worktree, or a local or remote branch) isn't listed twice, so [2m--prs[0m only adds the rest and the two pickers differ solely by those extra rows. Each added row resolves to the same [2mpr:[0m/[2mmr:[0m shortcut, so selecting one fetches the ref and switches to its branch. A [2m--prs[0m row has no local worktree, so its [2mpr[0m and [2mcomments[0m preview tabs
+ load the PR/MR's metadata and comments from the forge in the background. The [2mlog[0m tab uses a local [2mgit log[0m — graph and merge-base dimming included — whenever the head commit is already in the object store (a same-repo PR off a fetched remote), falling back to a flat forge-fetched commit list otherwise.
 
 Requires [2mgh[0m (GitHub), [2mglab[0m (GitLab), or an equivalent CLI installed and authenticated; see forge platform for Gitea, Azure DevOps, and other supported platforms.
 


### PR DESCRIPTION
Previously `wt switch` and `wt switch --prs` diverged in more than just which rows they showed: filterability and match text differed between the two. This makes the only difference between them whether the extra (not-checked-out) PR rows are listed — everything else, including what you can filter by, is now identical.

## What changed

- **Full filter parity.** Every row filters by its branch, path, and — when it has a PR/MR — the PR/MR's number, title, and author. The same fields apply whether the PR is checked out (a worktree row) or listed via `--prs`. A shared `push_pr_search_tokens` helper builds the match text for both row types, so they can't drift apart again.
- **Dedup.** `--prs` now lists only the PRs that aren't already shown as worktree rows, instead of duplicating a branch you already have checked out.
- **Live match text.** A worktree row's match text folds in PR number/title/author as soon as the live forge fetch lands, rather than freezing at the cache snapshot taken when the picker opened.

Author data is plumbed through both forges (`github.rs`/`gitlab.rs` → `PrStatus.author`) to support author filtering and to show the author in the preview pane.

## Reviewer orientation

- `src/commands/picker/items.rs` — `push_pr_search_tokens` + the live `text()` on the worktree item.
- `src/commands/picker/progressive_handler.rs` — `collect_shown_branches`, the skeleton handoff, `search_base` construction.
- `src/commands/picker/prs.rs` — `additional_prs` dedup + the per-spawn `GridSlot`/`Skeleton` handoff (re-created inside `spawn()` so `alt-r` re-fetches don't read a stale snapshot).
- The rest is author plumbing through the ci_status forge modules + help/doc/snapshot regeneration.

Tested via the picker unit + integration suites (match-engine parity, dedup, live-update, author rendering).

> _This was written by Claude Code on behalf of max_
