### PR TITLE
feat(switch): show picker preview loading placeholders as dim hints

### DIFF
--- a/src/commands/picker/items.rs
+++ b/src/commands/picker/items.rs
@@ -14,7 +14,7 @@ use dashmap::DashMap;
 use ratatui::text::{Line, Span};
 use skim::prelude::*;
 use worktrunk::git::Repository;
-use worktrunk::styling::{INFO_SYMBOL, visual_width};
+use worktrunk::styling::{HINT_SYMBOL, INFO_SYMBOL, visual_width};
 
 use super::super::list::ci_status::{PrRef, PrStatus};
 use super::super::list::model::ListItem;
@@ -795,7 +795,7 @@ impl WorktreeSkimItem {
         let branch = self.item.branch_name();
         match pr {
             PrPreview::Loading => {
-                cformat!("○ Fetching PR status for <bold>{branch}</>{reset}…\n")
+                cformat!("{HINT_SYMBOL} <dim>Fetching PR status for {branch}…</>\n")
             }
             PrPreview::NoPr => {
                 cformat!("{INFO_SYMBOL}{reset} <bold>{branch}</>{reset} has no PR\n")
@@ -821,7 +821,7 @@ impl WorktreeSkimItem {
             // The CI fetch hasn't reported yet — we don't know whether there's a
             // PR to fetch comments for. Mirror the `pr` tab's loading state.
             PrPreview::Loading => {
-                cformat!("○ Fetching PR status for <bold>{branch}</>{reset}…\n")
+                cformat!("{HINT_SYMBOL} <dim>Fetching PR status for {branch}…</>\n")
             }
             PrPreview::NoPr => {
                 cformat!("{INFO_SYMBOL}{reset} <bold>{branch}</>{reset} has no PR\n")
@@ -879,7 +879,7 @@ impl WorktreeSkimItem {
                 unreachable!("comments tab renders via render_comments_pane")
             }
         };
-        format!("○ {verb} {label}…\n")
+        cformat!("{HINT_SYMBOL} <dim>{verb} {label}…</>\n")
     }
 
     /// Compute preview and apply pager for diff modes. Returns the

--- a/src/commands/picker/prs.rs
+++ b/src/commands/picker/prs.rs
@@ -49,7 +49,7 @@ use serde::Deserialize;
 use skim::prelude::*;
 use unicode_width::UnicodeWidthStr;
 use worktrunk::git::{CiPlatform, Repository};
-use worktrunk::styling::{INFO_SYMBOL, StyledLine, WARNING_SYMBOL, warning_message};
+use worktrunk::styling::{HINT_SYMBOL, INFO_SYMBOL, StyledLine, WARNING_SYMBOL, warning_message};
 
 use super::super::list::ci_status::{
     CiSource, CiStatus, GitHubPrInfo, PrRef, PrStatus, ReviewState, non_interactive_cmd,
@@ -770,20 +770,19 @@ fn pr_row_empty_placeholder() -> String {
 /// [`super::items::WorktreeSkimItem::render_comments_pane`]) so both row types
 /// show the identical in-flight pane.
 pub(super) fn pr_deferred_loading(mode: PreviewMode) -> String {
-    let reset = Reset;
     let label = match mode {
         PreviewMode::Log => "commit log",
         PreviewMode::Comments => "comments",
         // Only the deferred tabs reach here; other modes render synchronously.
         _ => "preview",
     };
-    cformat!("{INFO_SYMBOL}{reset} Loading {label}…\n")
+    cformat!("{HINT_SYMBOL} <dim>Loading {label}…</>\n")
 }
 
 /// Terminal pane for a `--prs` deferred tab whose background fetch failed (forge
 /// CLI missing/unauthenticated, network error, unparsable JSON). The deferred
 /// closures cache this in place of an empty slot, so the tab shows a clear
-/// "couldn't load" rather than [`pr_deferred_loading`]'s spinner forever: the
+/// "couldn't load" rather than [`pr_deferred_loading`]'s placeholder forever: the
 /// fetch is spawned once per row and never retried in-session (see
 /// [`spawn_pr_previews`]), so a `None` left uncached would strand the tab on
 /// "Loading…". The warning glyph distinguishes it from the benign info states

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__cache_miss.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__cache_miss.snap
@@ -2,4 +2,4 @@
 source: src/commands/picker/items.rs
 expression: "cache_miss.preview_for_mode(PreviewMode::Summary, 80, 40)"
 ---
-[1m○ Generating summary…[0m
+[2m↳[22m [2mGenerating summary…[22m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_branch_diff.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_branch_diff.snap
@@ -2,4 +2,4 @@
 source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::loading_placeholder(mode)"
 ---
-○ Loading branch diff…
+[2m↳[22m [2mLoading branch diff…[22m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_log.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_log.snap
@@ -2,4 +2,4 @@
 source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::loading_placeholder(mode)"
 ---
-○ Loading log…
+[2m↳[22m [2mLoading log…[22m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_summary.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_summary.snap
@@ -2,4 +2,4 @@
 source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::loading_placeholder(mode)"
 ---
-○ Generating summary…
+[2m↳[22m [2mGenerating summary…[22m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_upstream_diff.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_upstream_diff.snap
@@ -2,4 +2,4 @@
 source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::loading_placeholder(mode)"
 ---
-○ Loading upstream diff…
+[2m↳[22m [2mLoading upstream diff…[22m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_working_tree.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_working_tree.snap
@@ -2,4 +2,4 @@
 source: src/commands/picker/items.rs
 expression: "WorktreeSkimItem::loading_placeholder(mode)"
 ---
-○ Loading working-tree diff…
+[2m↳[22m [2mLoading working-tree diff…[22m


### PR DESCRIPTION
The preview pane's loading placeholders used the info bullet (`○`) — the same glyph the settled states beside them wear (`feature has no PR`, `… has no changes`), so "still loading" and "nothing here" looked identical. They also rendered at full brightness, unlike every other waiting state in the library.

Now that the preview auto-refreshes (#3247) these placeholders are transient: they resolve themselves with no keystroke. So they move to the hint style (`↳`, whole line dim), matching the dim waiting look that `wt list`'s stall footer and `wt step commit`'s watchdog already use.

The result is a clean three-way split in the pane:

- `↳` dim — transient, loading, resolves itself
- `○` dim — settled neutral (`has no PR`, `has no changes`)
- `▲` yellow — failed (`Couldn't load … — reopen to retry`)

The change is text-preserving — only the glyph and dimming move — so the shell-integration PTY tests (which match on text, not the glyph) are unaffected. The only snapshots that change are the picker's `loading_placeholder` set.

> _This was written by Claude Code on behalf of max_
