### PR TITLE
refactor(picker): unify worktree and PR rows into one PickerRow

### DIFF
--- a/src/commands/list/render.rs
+++ b/src/commands/list/render.rs
@@ -422,9 +422,9 @@ impl ColumnLayout {
                 //
                 // PR rows (open PRs with no local branch, `wt switch --prs`)
                 // also carry a gutter sigil — a dim `#` — but they're a picker
-                // source (`PrSkimItem`), not a `ListItem`, so they render their
-                // gutter in `commands::picker::prs` (`PR_GUTTER_SIGIL`) rather
-                // than through this `ItemKind` match.
+                // row built without a `ListItem`, so they render their gutter in
+                // `commands::picker::prs` (`PR_GUTTER_SIGIL`) rather than through
+                // this `ItemKind` match.
                 let mut cell = StyledLine::new();
                 // `glyph` + trailing space = the two-cell sigil; the bare glyph
                 // also feeds the picker's fuzzy-search text (`gutter_glyph`).

--- a/src/commands/picker/items.rs
+++ b/src/commands/picker/items.rs
@@ -1,6 +1,8 @@
 //! Skim item implementations.
 //!
-//! Wrappers for ListItem and header row that implement SkimItem for the interactive selector.
+//! The unified [`PickerRow`] (a branch/worktree row or a listed `--prs` row,
+//! distinguished by `local: Option<LocalCheckout>`) and the header row, both
+//! implementing `SkimItem` for the interactive selector.
 
 use std::borrow::Cow;
 use std::collections::HashSet;
@@ -16,7 +18,7 @@ use skim::prelude::*;
 use worktrunk::git::Repository;
 use worktrunk::styling::{HINT_SYMBOL, INFO_SYMBOL, visual_width};
 
-use super::super::list::ci_status::{PrRef, PrStatus};
+use super::super::list::ci_status::{PrRef, PrStatus, ReviewState};
 use super::super::list::model::ListItem;
 use super::log_formatter::{
     FIELD_DELIM, batch_fetch_stats, format_log_output, process_log_with_dimming, strip_hash_markers,
@@ -54,11 +56,13 @@ pub(super) fn ansi_to_line(s: &str) -> Line<'static> {
     }
 }
 
-/// Cache key for pre-computed previews: (branch_name, mode).
+/// Cache key for pre-computed previews: `(row-key, mode)`, where the row-key is
+/// the row's [`PickerRow::preview_key`] — a branch for a worktree row, the
+/// `pr:N` / `mr:N` token for a listed `--prs` row.
 pub(super) type PreviewCacheKey = (String, PreviewMode);
 
-/// Cache for pre-computed previews, keyed by (branch_name, mode).
-/// Shared across all WorktreeSkimItems for background pre-computation.
+/// Cache for pre-computed previews, keyed by [`PreviewCacheKey`].
+/// Shared across all PickerRows for background pre-computation.
 pub(super) type PreviewCache = Arc<DashMap<PreviewCacheKey, String>>;
 
 /// Per-row live `pr_status` for the `pr` tab, shared with the collect handler.
@@ -72,7 +76,7 @@ pub(super) type PrStatusSlot = Arc<Mutex<Option<Option<PrStatus>>>>;
 /// collect handler. Like [`PrStatusSlot`], the frozen `item` snapshot can't
 /// carry these (its `counts` / `upstream` / `working_tree_status` are `None` at
 /// skeleton and never update), so the handler mirrors them here as the list
-/// pipeline lands (`on_update`). Read live by [`WorktreeSkimItem::render_preview`]
+/// pipeline lands (`on_update`). Read live by [`PickerRow::render_preview`]
 /// to dim a tab once its diff is known empty.
 pub(super) type LocalContentSlot = Arc<Mutex<LocalContent>>;
 
@@ -133,7 +137,7 @@ pub(super) type ShortcutTable = Arc<Mutex<std::collections::HashMap<String, RowS
 
 /// The `output()` token for a worktree/branch row: the unique worktree path
 /// (behind [`WORKTREE_OUTPUT_PREFIX`]) for any worktree-backed row, else the
-/// bare branch name. Shared by [`WorktreeSkimItem::output`] and the shortcut
+/// bare branch name. Shared by [`PickerRow::output`] and the shortcut
 /// table fill in `progressive_handler::on_skeleton`, so the selection token and
 /// the lookup key can't drift.
 pub(super) fn worktree_output_token(item: &ListItem, branch_name: &str) -> String {
@@ -266,30 +270,55 @@ pub(super) fn push_pr_search_tokens(
 /// re-reads `text()` on each query keystroke, so the live PR data folds in
 /// without a re-send; the row may re-rank as that data streams in during the
 /// first frame.
-pub(super) struct WorktreeSkimItem {
-    /// The stable, skeleton-time head of the matcher text: branch name + the
-    /// distinct worktree path. The PR tokens and trailing gutter glyph are
-    /// appended live in `text()`.
+pub(super) struct PickerRow {
+    /// The stable, skeleton-time head of the matcher text: branch name plus —
+    /// for a worktree row — the distinct worktree path. The PR tokens and
+    /// trailing gutter glyph are appended live in `text()`.
     pub search_base: String,
-    /// Trailing gutter glyph (`@`/`^`/`+`/`/`/`|`), kept last in `text()` so a
-    /// typed sigil filters by row kind. A skeleton-time fact from
-    /// `ItemKind::gutter_glyph`.
+    /// Trailing gutter glyph (`@`/`^`/`+`/`/`/`|`, or `#` for a listed `--prs`
+    /// row), kept last in `text()` so a typed sigil filters by row kind. A
+    /// skeleton-time fact from `ItemKind::gutter_glyph`.
     pub gutter: char,
-    /// Current ANSI-colored display line. Starts as the skeleton render;
-    /// replaced in place as data arrives.
+    /// Current ANSI-colored display line. For a worktree row it starts as the
+    /// skeleton render and is replaced in place as data arrives; for a `--prs`
+    /// row it's built once and never mutated.
     pub rendered: Arc<Mutex<String>>,
-    /// Branch name used by switch selection and preview cache keys.
+    /// Branch name (the head branch for a `--prs` row). Used by switch
+    /// selection, the `pr` pane's branch line, and — for a worktree row — the
+    /// preview cache key (see [`Self::preview_key`]).
     pub branch_name: String,
-    /// Skeleton-snapshot of the underlying ListItem. Preview computation
-    /// reads only skeleton-time fields (`branch_name`, `head`,
-    /// `worktree_data`) and runs git directly for anything else — see
-    /// `compute_*_preview` in this file — so the snapshot staying frozen
-    /// while slow fields (`counts`, `upstream`) arrive via the list-row
-    /// task pipeline (see `commands::list::collect`) is intentional and
-    /// correct.
-    pub item: Arc<ListItem>,
+    /// Selection result returned by `output()`, and the `shortcut_table` key.
+    /// `worktree_output_token` (`worktree-path:<path>` or `<branch>`) for a
+    /// worktree row; `pr:N` / `mr:N` for a `--prs` row. Distinct from the
+    /// *preview* key (see [`Self::preview_key`]): for a worktree row the two
+    /// differ (path-token vs branch).
+    pub output_token: String,
     /// Shared cache for pre-computed previews (all modes)
     pub preview_cache: PreviewCache,
+    /// PR/MR status for the `pr`/`comments` tabs and the folded matcher tokens.
+    /// LIVE for a worktree row — primed from the CI cache and overwritten as the
+    /// `CiStatus` task streams in (so the `pr` tab reflects the live fetch);
+    /// PRE-FILLED and STATIC for a `--prs` row (from `PrEntry::display_status`,
+    /// never mutated within a row's life; a rebuild re-renders the `(pr:N, Pr)`
+    /// memo — see `prs::listed_pr_row`).
+    pub pr_status: PrStatusSlot,
+    /// Surfaces a background preview fill without a keystroke. `preview()`
+    /// records the row's awaited `(preview_key, mode)` here on every render; the
+    /// orchestrator pokes a repaint when that key's compute lands (see
+    /// [`PreviewNotifier`]).
+    pub notifier: Arc<PreviewNotifier>,
+    /// Local-checkout data — `Some` for a worktree row, `None` for a listed
+    /// `--prs` row (whose head branch isn't checked out, so it has no working
+    /// tree, diffs, or local `ListItem`). Its presence is the single axis the
+    /// preview/output paths branch on.
+    pub local: Option<LocalCheckout>,
+}
+
+/// The worktree-backed half of a [`PickerRow`]: present only when the row's
+/// branch is checked out locally. A listed `--prs` row carries `None` and
+/// renders its local-checkout tabs (working-tree, branch-diff, upstream,
+/// summary) as placeholders.
+pub(super) struct LocalCheckout {
     /// Whether this branch has an upstream tracking ref, for the tab-4
     /// (remote⇅) empty state. A SYNCHRONOUS skeleton-time fact read from
     /// `Repository::local_branches()` at construction — never from the async
@@ -299,11 +328,6 @@ pub(super) struct WorktreeSkimItem {
     /// Whether `[commit.generation]` summaries are configured, for the tab-5
     /// (summary) empty state. A process-wide static fact (`llm_command.is_some()`).
     pub summaries_enabled: bool,
-    /// Live CI status for the `pr` tab, shared with the collect handler. Unlike
-    /// the frozen `item` snapshot (whose `pr_status` never updates after
-    /// skeleton), this slot is primed from the cache and then overwritten as the
-    /// `CiStatus` task streams in — so the `pr` tab reflects the live fetch.
-    pub pr_status: PrStatusSlot,
     /// Live diff-content signals for the `working_tree` / `branch_diff` /
     /// `upstream` tabs, shared with the collect handler. The frozen `item`
     /// snapshot can't carry these (its `counts` / `upstream` /
@@ -311,14 +335,25 @@ pub(super) struct WorktreeSkimItem {
     /// handler mirrors them here as the pipeline lands — letting those tabs dim
     /// once their diff is known empty (see [`LocalContent`]).
     pub local_content: LocalContentSlot,
-    /// Surfaces a background preview fill without a keystroke. `preview()`
-    /// records the row's awaited `(branch, mode)` here on every render; the
-    /// orchestrator pokes a repaint when that key's compute lands (see
-    /// [`PreviewNotifier`]).
-    pub notifier: Arc<PreviewNotifier>,
 }
 
-impl SkimItem for WorktreeSkimItem {
+impl PickerRow {
+    /// Key for every preview-cache read, the `pr`-pane memo, and the
+    /// `PreviewNotifier` `awaiting` record: the branch name for a worktree row
+    /// (its local previews are computed and cached by branch), the `pr:N` /
+    /// `mr:N` token for a `--prs` row (its deferred `log`/`comments` fetches key
+    /// by that token — see the `prs` module). Git forbids `:` in branch names,
+    /// so the two keyspaces never collide.
+    fn preview_key(&self) -> &str {
+        if self.local.is_some() {
+            &self.branch_name
+        } else {
+            &self.output_token
+        }
+    }
+}
+
+impl SkimItem for PickerRow {
     fn text(&self) -> Cow<'_, str> {
         // branch + path (stable), then the live PR/MR tokens (reference, title,
         // author) from the current `pr_status` slot, then the gutter glyph last.
@@ -348,7 +383,9 @@ impl SkimItem for WorktreeSkimItem {
     }
 
     fn output(&self) -> Cow<'_, str> {
-        Cow::Owned(worktree_output_token(&self.item, &self.branch_name))
+        // Precomputed at construction (a worktree-path/branch token, or `pr:N`);
+        // see `output_token`. Distinct from `preview_key`.
+        Cow::Borrowed(&self.output_token)
     }
 
     fn preview(&self, context: PreviewContext<'_>) -> ItemPreview {
@@ -359,14 +396,16 @@ impl SkimItem for WorktreeSkimItem {
         let mode = PreviewStateData::read_mode();
         // Record what this (selected) row is showing *before* reading the cache,
         // so a background fill that lands right after a miss still finds the key
-        // set and pokes a repaint (see `PreviewNotifier`).
-        self.notifier.note_awaiting(&self.branch_name, mode);
+        // set and pokes a repaint (see `PreviewNotifier`). Keyed by `preview_key`
+        // (branch for a worktree row, `pr:N` for a `--prs` row) so the awaited
+        // key matches the one the background fill writes.
+        self.notifier.note_awaiting(self.preview_key(), mode);
         ItemPreview::AnsiText(self.render_preview(mode, context.width, context.height))
     }
 }
 
 /// The `pr` tab's state for a worktree row, derived from the row's live CI
-/// status slot ([`WorktreeSkimItem::pr_status`]).
+/// status slot ([`PickerRow::pr_status`]).
 enum PrPreview {
     /// The live CI fetch hasn't reported for this branch yet, and no cache
     /// primed it — the tab shows a "fetching" hint rather than claiming the
@@ -377,14 +416,14 @@ enum PrPreview {
     NoPr,
     /// The branch has a PR/MR. The `PrRef` rides alongside the status so the
     /// reference is structurally guaranteed (a status with no `number` is
-    /// `NoPr`, not `HasPr`) — `render_worktree_pr` needs no fallback.
+    /// `NoPr`, not `HasPr`) — `render_pr_pane_body` needs no fallback.
     HasPr(PrRef, PrStatus),
 }
 
 /// Live, content-aware availability for the local-checkout tabs whose pane is a
 /// diff — `working_tree`, `branch_diff`, and `upstream`. Each tab dims once its
 /// diff is *known* empty, the same way the `pr` tab dims once the fetch reports
-/// no PR (see [`WorktreeSkimItem::pr_tab_available`]).
+/// no PR (see [`PickerRow::pr_tab_available`]).
 ///
 /// The diff emptiness is async (the `counts` / `upstream` / `working_tree_status`
 /// fields are `None` at skeleton and land via the list pipeline), so each signal
@@ -494,7 +533,7 @@ impl LocalTabs {
 /// - The PR-backed tabs: `pr` and `comments` are available together, gated by
 ///   `has_pr`. On a worktree row that's the live status slot (primed from the CI
 ///   cache, then refreshed by the `CiStatus` task — see
-///   [`WorktreeSkimItem::pr_tab_available`]): it dims once the fetch reports no
+///   [`PickerRow::pr_tab_available`]): it dims once the fetch reports no
 ///   PR, and stays available while loading or with a PR. A `--prs` row always
 ///   has a PR, so both are available.
 ///
@@ -535,7 +574,7 @@ impl TabAvailability {
     /// A worktree-backed row: the local-checkout tabs follow [`LocalTabs`]
     /// (diff tabs gated by the live [`LocalContent`] + the `has_upstream` floor);
     /// the PR-backed tabs follow the live PR status (see
-    /// [`WorktreeSkimItem::pr_tab_available`]).
+    /// [`PickerRow::pr_tab_available`]).
     pub(super) fn worktree(
         content: LocalContent,
         has_upstream: bool,
@@ -725,27 +764,34 @@ fn render_tab_row_compact(tabs: &[Tab], reset: Reset) -> String {
         .join(" ")
 }
 
-/// The `pr` pane for a worktree row whose branch has a PR/MR. Renders the same
-/// shape as the `--prs` rows' pane (`PrSkimItem::pr_pane`) — reference + title
-/// header, cyan all-caps labeled metadata (the branch bold, the author, the url
-/// underlined), and the description as markdown — via the shared [`pr_pane`]
-/// helpers, so the two read alike. The title, author, body, and comment count
-/// ride the same CI fetch the column already makes (see [`PrStatus`]); a status
-/// without them (an older cache entry, a forge that doesn't expose them) falls
-/// back to a reference-only header and skips the missing lines.
+/// The sole `pr`-tab pane renderer, shared by worktree rows and listed `--prs`
+/// rows (both feed it a [`PrStatus`] — live from the CI fetch for a worktree
+/// row, pre-filled via `PrEntry::display_status` for a `--prs` row). Renders
+/// the reference + title header, cyan all-caps labeled metadata (the branch
+/// bold, the author, draft state, the url underlined), and the description as
+/// markdown via the shared [`pr_pane`] helpers. Any field a status doesn't
+/// carry (an older cache entry, a forge that doesn't expose it) is skipped, the
+/// header falling back to reference-only.
 ///
 /// The `comments` line shows only the count; the full thread is the `comments`
-/// tab's own background fetch (see [`WorktreeSkimItem::render_comments_pane`]).
+/// tab's own background fetch (see [`PickerRow::render_comments_pane`]).
 /// A PR with no comments carries `None` (zero is flattened at the mapping
 /// boundary), so the line is skipped.
 ///
 /// `width` is the live preview-pane width, used to wrap the markdown body.
-fn render_worktree_pr(branch: &str, pr_ref: PrRef, status: &PrStatus, width: usize) -> String {
+fn render_pr_pane_body(branch: &str, pr_ref: PrRef, status: &PrStatus, width: usize) -> String {
     let title = status.title.as_deref().filter(|t| !t.is_empty());
     let mut out = pr_pane::header(pr_ref, title);
     out.push_str(&pr_pane::branch_line(branch));
     if let Some(author) = status.author.as_deref().filter(|a| !a.is_empty()) {
         out.push_str(&pr_pane::metadata_line("author", &format!("@{author}")));
+    }
+    if status.review_state == Some(ReviewState::Draft) {
+        let reset = Reset;
+        out.push_str(&pr_pane::metadata_line(
+            "state",
+            &cformat!("<yellow>draft</>{reset}"),
+        ));
     }
     if let Some(url) = &status.url {
         out.push_str(&pr_pane::url_line(url));
@@ -759,7 +805,7 @@ fn render_worktree_pr(branch: &str, pr_ref: PrRef, status: &PrStatus, width: usi
     out
 }
 
-impl WorktreeSkimItem {
+impl PickerRow {
     /// Render the full preview pane (tab bar + mode content) for an explicit
     /// `mode`. Split out of [`SkimItem::preview`] so the dispatch — including
     /// the `pr` tab's `render_pr_pane` call — is testable with a given mode
@@ -773,20 +819,33 @@ impl WorktreeSkimItem {
         // selections — a tab dims once its diff (or PR) is known empty, and stays
         // available while still loading. Both reads are cheap (no body clone); the
         // panes themselves are rendered once and memoized.
-        let avail = TabAvailability::worktree(
-            self.local_content(),
-            self.has_upstream,
-            self.summaries_enabled,
-            self.pr_tab_available(),
-        );
+        let avail = match &self.local {
+            Some(local) => TabAvailability::worktree(
+                self.local_content(),
+                local.has_upstream,
+                local.summaries_enabled,
+                self.pr_tab_available(),
+            ),
+            // A listed `--prs` row: the local-checkout tabs are empty (no
+            // working tree to diff) and the `pr` tab always has content (the
+            // static slot carries a `number`), matching `pr_tab_available`.
+            None => TabAvailability::listed_pr(),
+        };
         let mut result = render_preview_tabs(mode, avail, width);
         result.push_str(&match mode {
+            // The PR-backed tabs read the same `pr_status` slot for both row
+            // kinds: `pr` renders from it, `comments` reads the background-fetched
+            // thread when the row has a PR (always, for a `--prs` row).
             PreviewMode::Pr => self.render_pr_pane_cached(width),
-            // The PR-backed tabs share one source: the live `pr_status` slot. The
-            // `comments` tab renders the same background-fetched thread a `--prs`
-            // row's does when the branch has a PR (see `render_comments_pane`).
             PreviewMode::Comments => self.render_comments_pane(),
-            _ => self.preview_for_mode(mode, width, height),
+            // The local-checkout tabs (working-tree/log/branch-diff/upstream/
+            // summary) compute locally for a worktree row; a `--prs` row has no
+            // checkout, so its `log` loads from the forge and the rest point at
+            // the `pr` tab (see `render_listed_pr_mode`).
+            _ => match &self.local {
+                Some(_) => self.preview_for_mode(mode, width, height),
+                None => self.render_listed_pr_mode(mode),
+            },
         });
         result
     }
@@ -824,9 +883,13 @@ impl WorktreeSkimItem {
     /// Snapshot the row's live diff-content signals for the `working_tree` /
     /// `branch_diff` / `upstream` tabs (see [`LocalContent`]). A cheap copy of
     /// three `Option<bool>`s; the collect handler overwrites the slot as the list
-    /// pipeline lands.
+    /// pipeline lands. A listed `--prs` row has no checkout, so it reports the
+    /// default (all-`None`) signals — its diff tabs render placeholders anyway.
     fn local_content(&self) -> LocalContent {
-        *self.local_content.lock().unwrap()
+        self.local
+            .as_ref()
+            .map(|l| *l.local_content.lock().unwrap())
+            .unwrap_or_default()
     }
 
     /// Render the `pr` pane, memoized in the shared `preview_cache` so repeated
@@ -834,11 +897,13 @@ impl WorktreeSkimItem {
     /// the markdown render of the body. The other modes are pre-computed into
     /// this same cache by the orchestrator; the `pr` pane is filled lazily here
     /// instead because its inputs aren't known at skeleton time — they stream in
-    /// on the `CiStatus` task. The collect handler's `on_update` removes this
-    /// entry whenever the live `pr_status` slot changes (fetch lands, manual
-    /// refresh), so a cache hit is always consistent with the current slot.
-    fn render_pr_pane_cached(&self, width: usize) -> String {
-        let key = (self.branch_name.clone(), PreviewMode::Pr);
+    /// on the `CiStatus` task. The entry is invalidated so a cache hit always
+    /// matches the current PR data: for a worktree row, `on_update` removes it
+    /// whenever the live `pr_status` slot changes (fetch lands, manual refresh);
+    /// for a `--prs` row, whose slot is static, `prs::listed_pr_row` removes it
+    /// when the row is (re)built on an `alt-r` reload.
+    pub(super) fn render_pr_pane_cached(&self, width: usize) -> String {
+        let key = (self.preview_key().to_string(), PreviewMode::Pr);
         if let Some(cached) = self.preview_cache.get(&key) {
             return cached.value().clone();
         }
@@ -851,7 +916,7 @@ impl WorktreeSkimItem {
     /// is the live preview-pane width, threaded to wrap the description markdown.
     fn render_pr_pane(&self, pr: PrPreview, width: usize) -> String {
         let reset = Reset;
-        let branch = self.item.branch_name();
+        let branch = self.branch_name.as_str();
         match pr {
             PrPreview::Loading => {
                 cformat!("{HINT_SYMBOL} <dim>Fetching PR status for {branch}…</>\n")
@@ -859,7 +924,7 @@ impl WorktreeSkimItem {
             PrPreview::NoPr => {
                 cformat!("{INFO_SYMBOL}{reset} <bold>{branch}</>{reset} has no PR\n")
             }
-            PrPreview::HasPr(pr_ref, status) => render_worktree_pr(branch, pr_ref, &status, width),
+            PrPreview::HasPr(pr_ref, status) => render_pr_pane_body(branch, pr_ref, &status, width),
         }
     }
 
@@ -872,24 +937,45 @@ impl WorktreeSkimItem {
     /// PR — or a CI fetch that hasn't resolved yet — mirrors the `pr` tab's
     /// empty/loading states, so the two PR-backed tabs stay consistent. The
     /// background fetch renders at the preview width, so this reads it back
-    /// without re-wrapping (matching `PrSkimItem::cached_pane`).
+    /// without re-wrapping (via `cached_or_loading`).
     fn render_comments_pane(&self) -> String {
         let reset = Reset;
-        let branch = self.item.branch_name();
+        let branch = self.branch_name.as_str();
         match self.pr_preview() {
             // The CI fetch hasn't reported yet — we don't know whether there's a
             // PR to fetch comments for. Mirror the `pr` tab's loading state.
+            // (A `--prs` row's static slot is always `HasPr`, so it never lands
+            // here.)
             PrPreview::Loading => {
                 cformat!("{HINT_SYMBOL} <dim>Fetching PR status for {branch}…</>\n")
             }
             PrPreview::NoPr => {
                 cformat!("{INFO_SYMBOL}{reset} <bold>{branch}</>{reset} has no PR\n")
             }
-            PrPreview::HasPr(..) => self
-                .preview_cache
-                .get(&(self.branch_name.clone(), PreviewMode::Comments))
-                .map(|v| v.value().clone())
-                .unwrap_or_else(|| super::prs::pr_deferred_loading(PreviewMode::Comments)),
+            PrPreview::HasPr(..) => self.cached_or_loading(PreviewMode::Comments),
+        }
+    }
+
+    /// Read a deferred forge-fetch tab's pane from the shared cache (keyed by
+    /// the row's [`Self::preview_key`]), or a loading placeholder on a miss. The
+    /// background fetch (worktree rows' `comments`, `--prs` rows' `log`/
+    /// `comments`) writes the same key, and the orchestrator pokes a repaint
+    /// once it lands.
+    pub(super) fn cached_or_loading(&self, mode: PreviewMode) -> String {
+        self.preview_cache
+            .get(&(self.preview_key().to_string(), mode))
+            .map(|v| v.value().clone())
+            .unwrap_or_else(|| super::prs::pr_deferred_loading(mode))
+    }
+
+    /// Non-PR-tab content for a listed `--prs` row (no local checkout): the
+    /// `log` tab loads commits in the background and reads from the cache; the
+    /// local-only tabs (working-tree, branch-diff, upstream, summary) have no
+    /// PR equivalent, so they point the user at the `pr` tab.
+    fn render_listed_pr_mode(&self, mode: PreviewMode) -> String {
+        match mode {
+            PreviewMode::Log => self.cached_or_loading(PreviewMode::Log),
+            _ => super::prs::pr_row_empty_placeholder(),
         }
     }
 
@@ -901,7 +987,10 @@ impl WorktreeSkimItem {
     /// the orchestrator pokes a repaint for the awaited key once the fill lands
     /// (see [`PreviewNotifier`]).
     fn preview_for_mode(&self, mode: PreviewMode, width: usize, _height: usize) -> String {
-        let cache_key = (self.branch_name.clone(), mode);
+        // Reached only for a worktree row (the `Some(_)` arm in `render_preview`),
+        // so `preview_key` is the branch — the key the orchestrator precomputes
+        // local previews under.
+        let cache_key = (self.preview_key().to_string(), mode);
         let content = self
             .preview_cache
             .get(&cache_key)
@@ -1392,6 +1481,31 @@ mod tests {
     use ansi_str::AnsiStr;
     use insta::assert_snapshot;
 
+    /// Build a worktree-backed [`PickerRow`] (`local: Some`) for tests, with the
+    /// given branch, preview cache, and live `pr_status` slot value; the local
+    /// signals default (no upstream, no summaries, unknown diff content).
+    fn worktree_test_row(
+        branch: &str,
+        preview_cache: PreviewCache,
+        pr_status: Option<Option<PrStatus>>,
+    ) -> PickerRow {
+        PickerRow {
+            search_base: String::new(),
+            gutter: '@',
+            rendered: Arc::new(Mutex::new(String::new())),
+            branch_name: branch.to_string(),
+            output_token: branch.to_string(),
+            preview_cache,
+            pr_status: Arc::new(Mutex::new(pr_status)),
+            notifier: PreviewNotifier::detached(),
+            local: Some(LocalCheckout {
+                has_upstream: false,
+                summaries_enabled: false,
+                local_content: Arc::new(Mutex::new(LocalContent::default())),
+            }),
+        }
+    }
+
     /// Width at which all seven full-form tabs fit, so the snapshots capture the
     /// full bar (the compact fallback has its own test).
     const WIDE: usize = 200;
@@ -1709,7 +1823,7 @@ mod tests {
         ] {
             assert_snapshot!(
                 format!("loading_placeholder_{name}"),
-                WorktreeSkimItem::loading_placeholder(mode)
+                PickerRow::loading_placeholder(mode)
             );
         }
     }
@@ -1717,48 +1831,16 @@ mod tests {
     #[test]
     fn test_preview_for_mode_summary_cache() {
         // Cache hit returns cached content; cache miss computes the placeholder
-        let item = Arc::new(ListItem::new_branch(
-            "abc123".to_string(),
-            "feature".to_string(),
-        ));
-
         let cache_hit = {
             let preview_cache: PreviewCache = Arc::new(DashMap::new());
             preview_cache.insert(
                 ("feature".to_string(), PreviewMode::Summary),
                 "Add auth module\n\nImplements JWT-based authentication.".to_string(),
             );
-            WorktreeSkimItem {
-                search_base: String::new(),
-                gutter: '@',
-                rendered: Arc::new(Mutex::new(String::new())),
-                branch_name: "feature".to_string(),
-                item: Arc::clone(&item),
-                preview_cache,
-                has_upstream: false,
-                summaries_enabled: false,
-                pr_status: Arc::new(Mutex::new(None)),
-                local_content: Arc::new(Mutex::new(LocalContent::default())),
-                notifier: PreviewNotifier::detached(),
-            }
+            worktree_test_row("feature", preview_cache, None)
         };
 
-        let cache_miss = {
-            let preview_cache: PreviewCache = Arc::new(DashMap::new());
-            WorktreeSkimItem {
-                search_base: String::new(),
-                gutter: '@',
-                rendered: Arc::new(Mutex::new(String::new())),
-                branch_name: "feature".to_string(),
-                item: Arc::clone(&item),
-                preview_cache,
-                has_upstream: false,
-                summaries_enabled: false,
-                pr_status: Arc::new(Mutex::new(None)),
-                local_content: Arc::new(Mutex::new(LocalContent::default())),
-                notifier: PreviewNotifier::detached(),
-            }
-        };
+        let cache_miss = worktree_test_row("feature", Arc::new(DashMap::new()), None);
 
         assert_snapshot!(
             "cache_hit",
@@ -1834,20 +1916,7 @@ mod tests {
         // Build a row whose live `pr_status` slot carries a given state — what
         // the picker primes from the cache and then overwrites as the fetch lands.
         let row = |pr_status: Option<Option<PrStatus>>| {
-            let item = ListItem::new_branch("abc".into(), "feature".into());
-            WorktreeSkimItem {
-                search_base: String::new(),
-                gutter: '@',
-                rendered: Arc::new(Mutex::new(String::new())),
-                branch_name: "feature".into(),
-                item: Arc::new(item),
-                preview_cache: Arc::new(DashMap::new()),
-                has_upstream: false,
-                summaries_enabled: false,
-                pr_status: Arc::new(Mutex::new(pr_status)),
-                local_content: Arc::new(Mutex::new(LocalContent::default())),
-                notifier: PreviewNotifier::detached(),
-            }
+            worktree_test_row("feature", Arc::new(DashMap::new()), pr_status)
         };
 
         // No result yet (outer `None`) → Loading; the pane shows a fetching hint.
@@ -1945,18 +2014,8 @@ mod tests {
                 comment_count: None,
             }))
         };
-        let row = |slot: Option<Option<PrStatus>>, cache: PreviewCache| WorktreeSkimItem {
-            search_base: String::new(),
-            gutter: '@',
-            rendered: Arc::new(Mutex::new(String::new())),
-            branch_name: "feature".into(),
-            item: Arc::new(ListItem::new_branch("abc".into(), "feature".into())),
-            preview_cache: cache,
-            has_upstream: false,
-            summaries_enabled: false,
-            pr_status: Arc::new(Mutex::new(slot)),
-            local_content: Arc::new(Mutex::new(LocalContent::default())),
-            notifier: PreviewNotifier::detached(),
+        let row = |slot: Option<Option<PrStatus>>, cache: PreviewCache| {
+            worktree_test_row("feature", cache, slot)
         };
 
         // CI hasn't reported (None) → the shared "Fetching PR status…" hint (it
@@ -2015,7 +2074,7 @@ mod tests {
 
         // A PR with comments adds a cyan all-caps `COMMENTS` metadata line
         // carrying the count (same `field_label` styling as BRANCH/URL).
-        let with = render_worktree_pr("feature", PrRef::pr(7), &status(Some(3)), 80)
+        let with = render_pr_pane_body("feature", PrRef::pr(7), &status(Some(3)), 80)
             .ansi_strip()
             .to_string();
         assert!(
@@ -2026,7 +2085,7 @@ mod tests {
 
         // No comments (zero is flattened to `None` at the mapping boundary, and an
         // older cache entry carries `None` too) → the line is skipped entirely.
-        let without = render_worktree_pr("feature", PrRef::pr(7), &status(None), 80)
+        let without = render_pr_pane_body("feature", PrRef::pr(7), &status(None), 80)
             .ansi_strip()
             .to_string();
         assert!(
@@ -2056,7 +2115,7 @@ mod tests {
             comment_count: None,
         };
 
-        let with = render_worktree_pr("feature", PrRef::pr(7), &status(Some("bob")), 80)
+        let with = render_pr_pane_body("feature", PrRef::pr(7), &status(Some("bob")), 80)
             .ansi_strip()
             .to_string();
         assert!(
@@ -2065,7 +2124,7 @@ mod tests {
             "author line: {with:?}"
         );
 
-        let without = render_worktree_pr("feature", PrRef::pr(7), &status(None), 80)
+        let without = render_pr_pane_body("feature", PrRef::pr(7), &status(None), 80)
             .ansi_strip()
             .to_string();
         assert!(
@@ -2079,17 +2138,10 @@ mod tests {
         use crate::commands::list::ci_status::{CiSource, CiStatus, PrRef, ReviewState};
 
         // A worktree row whose live status carries a PR with title + body.
-        let item = ListItem::new_branch("abc".into(), "feature".into());
-        let row = WorktreeSkimItem {
-            search_base: String::new(),
-            gutter: '@',
-            rendered: Arc::new(Mutex::new(String::new())),
-            branch_name: "feature".into(),
-            item: Arc::new(item),
-            preview_cache: Arc::new(DashMap::new()),
-            has_upstream: false,
-            summaries_enabled: false,
-            pr_status: Arc::new(Mutex::new(Some(Some(PrStatus {
+        let row = worktree_test_row(
+            "feature",
+            Arc::new(DashMap::new()),
+            Some(Some(PrStatus {
                 ci_status: CiStatus::Passed,
                 source: CiSource::PullRequest,
                 is_stale: false,
@@ -2101,10 +2153,8 @@ mod tests {
                 body: Some("Adds a **bounded** retry.".into()),
                 author: None,
                 comment_count: None,
-            })))),
-            local_content: Arc::new(Mutex::new(LocalContent::default())),
-            notifier: PreviewNotifier::detached(),
-        };
+            })),
+        );
 
         // In Pr mode, `render_preview` assembles the tab bar plus the worktree PR
         // pane — the dispatch arm `SkimItem::preview` reaches once the picker-state
@@ -2177,18 +2227,20 @@ mod tests {
         let cache: PreviewCache = Arc::new(DashMap::new());
         let slot: PrStatusSlot = Arc::new(Mutex::new(status("First title")));
         let key = ("feature".to_string(), PreviewMode::Pr);
-        let row = WorktreeSkimItem {
+        let row = PickerRow {
             search_base: String::new(),
             gutter: '@',
             rendered: Arc::new(Mutex::new(String::new())),
             branch_name: "feature".into(),
-            item: Arc::new(ListItem::new_branch("abc".into(), "feature".into())),
+            output_token: "feature".into(),
             preview_cache: Arc::clone(&cache),
-            has_upstream: false,
-            summaries_enabled: false,
             pr_status: Arc::clone(&slot),
-            local_content: Arc::new(Mutex::new(LocalContent::default())),
             notifier: PreviewNotifier::detached(),
+            local: Some(LocalCheckout {
+                has_upstream: false,
+                summaries_enabled: false,
+                local_content: Arc::new(Mutex::new(LocalContent::default())),
+            }),
         };
 
         // First render populates the shared cache.
@@ -2251,7 +2303,7 @@ mod tests {
         let (_t, repo) = repo_with_main();
         repo.run_command(&["branch", "parity"]).unwrap();
         let item = item_at(&repo, "parity");
-        let output = WorktreeSkimItem::compute_branch_diff_preview(&repo, &item, 80);
+        let output = PickerRow::compute_branch_diff_preview(&repo, &item, 80);
         assert!(
             output.contains("has no file changes vs"),
             "expected empty-diff fallback, got: {output:?}"
@@ -2267,7 +2319,7 @@ mod tests {
         repo.run_command(&["add", "feat.txt"]).unwrap();
         repo.run_command(&["commit", "-m", "feat"]).unwrap();
         let item = item_at(&repo, "feature");
-        let output = WorktreeSkimItem::compute_branch_diff_preview(&repo, &item, 80);
+        let output = PickerRow::compute_branch_diff_preview(&repo, &item, 80);
         assert!(
             output.contains("feat.txt"),
             "expected diff to mention feat.txt, got: {output:?}"
@@ -2291,7 +2343,7 @@ mod tests {
         let sentinel = "SENTINEL_FROM_CACHE";
         super::preview_cache::write_branch_diff(&repo, &base_sha, item.head(), 80, sentinel);
 
-        let output = WorktreeSkimItem::compute_branch_diff_preview(&repo, &item, 80);
+        let output = PickerRow::compute_branch_diff_preview(&repo, &item, 80);
         assert_eq!(output, sentinel, "cache hit must return cached value");
     }
 
@@ -2311,7 +2363,7 @@ mod tests {
         assert!(
             super::preview_cache::read_branch_diff(&repo, &base_sha, item.head(), 80).is_none()
         );
-        let _ = WorktreeSkimItem::compute_branch_diff_preview(&repo, &item, 80);
+        let _ = PickerRow::compute_branch_diff_preview(&repo, &item, 80);
         assert!(
             super::preview_cache::read_branch_diff(&repo, &base_sha, item.head(), 80).is_some()
         );
@@ -2333,7 +2385,7 @@ mod tests {
         let item = item_at(&repo, "feature");
 
         assert!(super::preview_cache::read_log(&repo, item.head(), 80, 24).is_none());
-        let _ = WorktreeSkimItem::compute_log_preview(&repo, &item, 80, 24).0;
+        let _ = PickerRow::compute_log_preview(&repo, &item, 80, 24).0;
         let entry = super::preview_cache::read_log(&repo, item.head(), 80, 24)
             .expect("cache populated after first compute");
         assert!(
@@ -2378,7 +2430,7 @@ mod tests {
         // which removes that escape. The dim SGR `\x1b[2m` is unsuitable
         // because `format_log_output` already wraps every relative-time
         // column in dim, so it appears even in bright lines.
-        let before = WorktreeSkimItem::compute_log_preview(&repo, &item, 80, 24).0;
+        let before = PickerRow::compute_log_preview(&repo, &item, 80, 24).0;
         let before_subject_line = before
             .lines()
             .find(|l| l.contains("feature commit"))
@@ -2396,7 +2448,7 @@ mod tests {
             .unwrap();
         repo.run_command(&["checkout", "feature"]).unwrap();
 
-        let after = WorktreeSkimItem::compute_log_preview(&repo, &item, 80, 24).0;
+        let after = PickerRow::compute_log_preview(&repo, &item, 80, 24).0;
         let after_subject_line = after
             .lines()
             .find(|l| l.contains("feature commit"))
@@ -2419,7 +2471,7 @@ mod tests {
         let sentinel = "SENTINEL_UPSTREAM_VALUE";
         super::preview_cache::write_upstream_diff(&repo, item.head(), &upstream_sha, 80, sentinel);
 
-        let output = WorktreeSkimItem::compute_upstream_diff_preview(&repo, &item, 80);
+        let output = PickerRow::compute_upstream_diff_preview(&repo, &item, 80);
         assert_eq!(output, sentinel);
     }
 
@@ -2430,7 +2482,7 @@ mod tests {
         let (_t, repo) = repo_with_main();
         repo.run_command(&["branch", "orphan"]).unwrap();
         let item = item_at(&repo, "orphan");
-        let output = WorktreeSkimItem::compute_upstream_diff_preview(&repo, &item, 80);
+        let output = PickerRow::compute_upstream_diff_preview(&repo, &item, 80);
         assert!(
             output.contains("has no upstream tracking branch"),
             "expected no-upstream message, got: {output:?}"
@@ -2452,7 +2504,7 @@ mod tests {
     fn upstream_diff_up_to_date() {
         let (_t, repo) = repo_with_tracked_pair();
         let item = item_at(&repo, "feature");
-        let output = WorktreeSkimItem::compute_upstream_diff_preview(&repo, &item, 80);
+        let output = PickerRow::compute_upstream_diff_preview(&repo, &item, 80);
         assert!(
             output.contains("is up to date with upstream"),
             "expected up-to-date message, got: {output:?}"
@@ -2466,7 +2518,7 @@ mod tests {
         repo.run_command(&["add", "ahead.txt"]).unwrap();
         repo.run_command(&["commit", "-m", "ahead"]).unwrap();
         let item = item_at(&repo, "feature");
-        let output = WorktreeSkimItem::compute_upstream_diff_preview(&repo, &item, 80);
+        let output = PickerRow::compute_upstream_diff_preview(&repo, &item, 80);
         assert!(
             output.contains("ahead.txt"),
             "expected diff to mention ahead.txt, got: {output:?}"
@@ -2483,7 +2535,7 @@ mod tests {
         repo.run_command(&["commit", "-m", "behind"]).unwrap();
         repo.run_command(&["checkout", "feature"]).unwrap();
         let item = item_at(&repo, "feature");
-        let output = WorktreeSkimItem::compute_upstream_diff_preview(&repo, &item, 80);
+        let output = PickerRow::compute_upstream_diff_preview(&repo, &item, 80);
         assert!(
             output.contains("behind.txt"),
             "expected diff to mention behind.txt, got: {output:?}"
@@ -2504,7 +2556,7 @@ mod tests {
         repo.run_command(&["commit", "-m", "upstream"]).unwrap();
         repo.run_command(&["checkout", "feature"]).unwrap();
         let item = item_at(&repo, "feature");
-        let output = WorktreeSkimItem::compute_upstream_diff_preview(&repo, &item, 80);
+        let output = PickerRow::compute_upstream_diff_preview(&repo, &item, 80);
         // Diverged path runs the diff; symmetric difference includes both files.
         assert!(
             output.contains("feat.txt") || output.contains("upstream.txt"),

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -191,7 +191,7 @@ impl PickerRemovalTarget {
 /// detached *and* branched alike. A branch-only row has no worktree, so its
 /// branch name is the only handle.
 ///
-/// Decoding `output()` rather than `downcast_ref::<WorktreeSkimItem>()` also
+/// Decoding `output()` rather than `downcast_ref::<PickerRow>()` also
 /// sidesteps skim's cross-thread `TypeId` mismatch, which can make the
 /// downcast fail when the item originates on the reader thread.
 fn picker_item_identifier(item: &dyn SkimItem) -> String {
@@ -1901,7 +1901,7 @@ fn resolve_identifier(
 
 #[cfg(test)]
 pub mod tests {
-    use super::items::{LocalContent, WorktreeSkimItem};
+    use super::items::{LocalCheckout, LocalContent, PickerRow, worktree_output_token};
     use super::{
         PickerAction, PickerCollector, PickerRemovalTarget, drain_stashed_warnings,
         install_preview_tab_keybindings, install_shortcut_keybindings, parse_reload_remove_token,
@@ -2391,25 +2391,28 @@ pub mod tests {
         assert!(!marker.exists(), "unapproved pre-remove hook must not run");
     }
 
-    /// Build a `WorktreeSkimItem` from a snapshot `ListItem`.
+    /// Build a `PickerRow` from a snapshot `ListItem`.
     fn picker_item(branch_name: &str, item: ListItem) -> Arc<dyn SkimItem> {
         let pr_status = Arc::new(Mutex::new(item.pr_status.clone()));
-        Arc::new(WorktreeSkimItem {
+        let output_token = worktree_output_token(&item, branch_name);
+        Arc::new(PickerRow {
             search_base: branch_name.to_string(),
             gutter: '@',
             rendered: Arc::new(Mutex::new(String::new())),
             branch_name: branch_name.to_string(),
-            item: Arc::new(item),
+            output_token,
             preview_cache: Arc::new(dashmap::DashMap::new()),
-            has_upstream: false,
-            summaries_enabled: false,
             pr_status,
-            local_content: Arc::new(Mutex::new(LocalContent::default())),
             notifier: super::preview_notify::PreviewNotifier::detached(),
+            local: Some(LocalCheckout {
+                has_upstream: false,
+                summaries_enabled: false,
+                local_content: Arc::new(Mutex::new(LocalContent::default())),
+            }),
         }) as Arc<dyn SkimItem>
     }
 
-    /// Build a `WorktreeSkimItem` standing in for a detached-worktree row.
+    /// Build a `PickerRow` standing in for a detached-worktree row.
     fn detached_picker_item(path: &Path) -> Arc<dyn SkimItem> {
         let mut item = ListItem::new_branch("abc123".to_string(), "(detached)".to_string());
         item.branch = None;
@@ -2421,7 +2424,7 @@ pub mod tests {
         picker_item("(detached)", item)
     }
 
-    /// Build a `WorktreeSkimItem` standing in for a branched-worktree row.
+    /// Build a `PickerRow` standing in for a branched-worktree row.
     fn branched_picker_item(branch: &str, path: &Path) -> Arc<dyn SkimItem> {
         let mut item = ListItem::new_branch("abc123".to_string(), branch.to_string());
         item.kind = ItemKind::Worktree(Box::new(WorktreeData {
@@ -2431,7 +2434,7 @@ pub mod tests {
         picker_item(branch, item)
     }
 
-    /// Build a `WorktreeSkimItem` standing in for a branch-only row (no worktree).
+    /// Build a `PickerRow` standing in for a branch-only row (no worktree).
     fn branch_only_picker_item(branch: &str) -> Arc<dyn SkimItem> {
         picker_item(
             branch,
@@ -3092,7 +3095,7 @@ pub mod tests {
         assert!(!branch_list.is_empty(), "the unmerged branch is preserved");
     }
 
-    // Note: skim's `as_any().downcast_ref::<WorktreeSkimItem>()` can fail at
+    // Note: skim's `as_any().downcast_ref::<PickerRow>()` can fail at
     // runtime due to a TypeId mismatch between skim's reader thread and the main
     // compilation unit. The invoke() code path uses output() matching instead.
     // Full TUI tests require interactive skim — verified via tmux-cli during

--- a/src/commands/picker/pr_pane.rs
+++ b/src/commands/picker/pr_pane.rs
@@ -1,11 +1,12 @@
 //! Shared rendering for the picker's `pr` preview pane.
 //!
-//! Two rows show a PR/MR: a worktree row whose branch has one
-//! (`render_worktree_pr` in [`super::items`]) and a `--prs` row
-//! ([`super::prs::PrSkimItem`]). Both render the same shape — a bold reference +
-//! title header, cyan all-caps labeled metadata lines whose values share one
-//! column, and a matching `DESCRIPTION` heading above the full body rendered
-//! flush as markdown — so they read alike.
+//! Both picker row kinds show a PR/MR through one renderer
+//! (`render_pr_pane_body` in [`super::items`]): a worktree row whose branch has
+//! one, and a listed `--prs` row (a `PickerRow` with no local checkout). They
+//! render the same shape — a bold reference + title header, cyan all-caps
+//! labeled metadata lines whose values share one column, and a matching
+//! `DESCRIPTION` heading above the full body rendered flush as markdown — so
+//! they read alike.
 //! They build from these shared pieces rather than each formatting their own.
 //! Every label (`BRANCH`, `URL`, `DESCRIPTION`, …) goes through [`field_label`],
 //! which renders the app's cyan all-caps title style, so they all match the

--- a/src/commands/picker/preview.rs
+++ b/src/commands/picker/preview.rs
@@ -213,7 +213,7 @@ impl PreviewLayout {
 /// The active preview tab, shared across the picker session.
 ///
 /// One picker runs per process, so a single process-wide value is the source of
-/// truth: `WorktreeSkimItem::preview` / `PrSkimItem::preview` read it to choose
+/// truth: `PickerRow::preview` reads it to choose
 /// what to render, and the keymap's `Action::Custom` callbacks (installed in
 /// `super::install_preview_tab_keybindings`) write it on alt-1…alt-7 / tab /
 /// shift-tab, then re-run the preview.

--- a/src/commands/picker/preview_orchestrator.rs
+++ b/src/commands/picker/preview_orchestrator.rs
@@ -25,7 +25,7 @@ use skim::prelude::Event;
 use tokio::sync::mpsc::Sender;
 use worktrunk::git::Repository;
 
-use super::items::{PreviewCache, PreviewCacheKey, WorktreeSkimItem};
+use super::items::{PickerRow, PreviewCache, PreviewCacheKey};
 use super::preview::PreviewMode;
 use super::preview_notify::PreviewNotifier;
 use super::summary;
@@ -148,7 +148,7 @@ impl PreviewOrchestrator {
                 return;
             }
             let (value, log_disk_hit) =
-                WorktreeSkimItem::compute_and_page_preview(&repo, &item, mode, w, h);
+                PickerRow::compute_and_page_preview(&repo, &item, mode, w, h);
             Self::fill(&cache, &notifier, cache_key, value);
             if log_disk_hit {
                 pending.fetch_add(1, Ordering::SeqCst);
@@ -159,7 +159,7 @@ impl PreviewOrchestrator {
                 let repo = repo.clone();
                 rayon::spawn_fifo(move || {
                     let _g = guard;
-                    let rendered = WorktreeSkimItem::refresh_log_preview(&repo, &item, w, h);
+                    let rendered = PickerRow::refresh_log_preview(&repo, &item, w, h);
                     // Skip empty results so a transient `git log` failure
                     // doesn't poison the in-memory cache with "" and wipe
                     // out the value the producer just inserted.
@@ -196,8 +196,8 @@ impl PreviewOrchestrator {
     ///
     /// The general-purpose companion to [`Self::spawn_preview`]: that method
     /// computes a worktree `ListItem`'s preview via the local-git
-    /// `compute_and_page_preview`, whereas `--prs` rows (`PrSkimItem`) have no
-    /// local worktree, so they fetch their `log` / `comments` panes through a
+    /// `compute_and_page_preview`, whereas `--prs` rows (no local checkout) have
+    /// no local worktree, so they fetch their `log` / `comments` panes through a
     /// forge CLI and pass that work in as `compute`. Both share the same
     /// [`PreviewCache`], the same `COLLECT_POOL` routing, and the same
     /// pending-counter accounting (so the dry-run path's `wait_for_idle` and

--- a/src/commands/picker/progressive_handler.rs
+++ b/src/commands/picker/progressive_handler.rs
@@ -52,8 +52,8 @@ use super::super::list::ci_status::PrStatus;
 const RENDER_THROTTLE: Duration = Duration::from_millis(16);
 
 use super::items::{
-    HeaderLoading, HeaderSkimItem, LocalContent, LocalContentSlot, PrStatusSlot, PreviewCache,
-    RowShortcutData, RowUrl, ShortcutTable, WorktreeSkimItem, worktree_output_token,
+    HeaderLoading, HeaderSkimItem, LocalCheckout, LocalContent, LocalContentSlot, PickerRow,
+    PrStatusSlot, PreviewCache, RowShortcutData, RowUrl, ShortcutTable, worktree_output_token,
 };
 use super::preview::PreviewMode;
 use super::preview_orchestrator::PreviewOrchestrator;
@@ -85,11 +85,11 @@ pub(super) struct PickerHandler {
     /// atomically in `on_skeleton` with this skeleton's worktree/branch rows;
     /// the `--prs` thread extends it with PR/MR rows. See [`ShortcutTable`].
     pub(super) shortcut_table: ShortcutTable,
-    /// One `Arc<Mutex<String>>` per data row — same Arcs `WorktreeSkimItem`
+    /// One `Arc<Mutex<String>>` per data row — same Arcs `PickerRow`
     /// holds. Set once in `on_skeleton`, read lock-free thereafter.
     pub(super) rendered_slots: OnceLock<Box<[Arc<Mutex<String>>]>>,
     /// One live `pr_status` slot per data row — same `PrStatusSlot` Arcs the
-    /// `WorktreeSkimItem`s hold. Set once in `on_skeleton` (primed from the
+    /// `PickerRow`s hold. Set once in `on_skeleton` (primed from the
     /// cache-filled snapshot), then written by `on_update` as the `CiStatus`
     /// task reports, so the `pr` tab reflects the live fetch.
     pub(super) pr_status_slots: OnceLock<Box<[PrStatusSlot]>>,
@@ -103,7 +103,7 @@ pub(super) struct PickerHandler {
     /// consistent with the `pr` tab. See [`Self::maybe_spawn_comments`].
     pub(super) comments_fetched: OnceLock<Box<[Arc<AtomicU64>]>>,
     /// One live `LocalContent` slot per data row — same Arcs the
-    /// `WorktreeSkimItem`s hold. Set once in `on_skeleton` (all-loading), then
+    /// `PickerRow`s hold. Set once in `on_skeleton` (all-loading), then
     /// overwritten by `on_update` from the row's `ListItem` as the list pipeline
     /// lands, so the `working_tree` / `branch_diff` / `upstream` tabs dim once
     /// their diff is known empty.
@@ -169,7 +169,7 @@ impl PickerHandler {
     /// Spawn row `idx`'s `comments` background fetch if its branch has an open
     /// PR and that PR's thread hasn't been fetched yet. The `comments` tab on a
     /// worktree row shows the same forge-fetched thread a `--prs` row's tab does
-    /// (see `items::WorktreeSkimItem::render_comments_pane`); the PR number comes
+    /// (see `items::PickerRow::render_comments_pane`); the PR number comes
     /// from the row's live status, which arrives asynchronously, so this fires
     /// from both the skeleton prime and `on_update`. The per-row
     /// [`Self::comments_fetched`] slot records which PR number was fetched, so
@@ -341,7 +341,7 @@ impl PickerProgressHandler for PickerHandler {
             // `search_base` is the stable head of the matcher text: branch +
             // distinct path. The PR/MR tokens (reference, title, author) and the
             // trailing gutter glyph are appended live in
-            // `WorktreeSkimItem::text()`, which reads the row's `pr_status` slot
+            // `PickerRow::text()`, which reads the row's `pr_status` slot
             // each time skim matches — so a PR filters by number/title/author as
             // soon as the CI fetch lands them, the same fields a `--prs` row
             // carries. The gutter glyph stays last so a typed sigil filters by
@@ -387,26 +387,29 @@ impl PickerProgressHandler for PickerHandler {
             // opens the URL once the live `pr_status` slot reports one. Carry the
             // raw `Option` (not `branch_name()`'s `"(detached)"` fallback) so
             // `alt-y` no-ops on a detached worktree instead of copying the label.
+            let output_token = worktree_output_token(&item_arc, &branch_name);
             shortcut_map.insert(
-                worktree_output_token(&item_arc, &branch_name),
+                output_token.clone(),
                 RowShortcutData {
                     branch: item_arc.branch.clone(),
                     url: RowUrl::Live(Arc::clone(&pr_status_arc)),
                 },
             );
 
-            skim_items.push(Arc::new(WorktreeSkimItem {
+            skim_items.push(Arc::new(PickerRow {
                 search_base,
                 gutter,
                 rendered: rendered_arc,
                 branch_name,
-                item: item_arc,
+                output_token,
                 preview_cache: Arc::clone(&self.preview_cache),
-                has_upstream,
-                summaries_enabled,
                 pr_status: pr_status_arc,
-                local_content: local_content_arc,
                 notifier: Arc::clone(self.orchestrator.notifier()),
+                local: Some(LocalCheckout {
+                    has_upstream,
+                    summaries_enabled,
+                    local_content: local_content_arc,
+                }),
             }) as Arc<dyn SkimItem>);
         }
 
@@ -473,7 +476,7 @@ impl PickerProgressHandler for PickerHandler {
             *slot.lock().unwrap() = item.pr_status.clone();
             // Drop the memoized `pr` pane for this row so the next `preview()`
             // re-renders from the status just mirrored — see
-            // `WorktreeSkimItem::render_pr_pane_cached`.
+            // `PickerRow::render_pr_pane_cached`.
             self.preview_cache
                 .remove(&(item.branch_name().to_string(), PreviewMode::Pr));
         }
@@ -662,7 +665,7 @@ mod tests {
     }
 
     /// Skeleton → update → reveal: verifies that each event writes through
-    /// to the shared `rendered` string the `WorktreeSkimItem` holds. Skim
+    /// to the shared `rendered` string the `PickerRow` holds. Skim
     /// reads these strings each time it repaints (which `request_render`
     /// triggers); the matcher-stable search text (branch + path) never changes.
     #[test]
@@ -889,7 +892,7 @@ mod tests {
     }
 
     /// Header + items get published in order. `output()` of the
-    /// WorktreeSkimItem is the branch name so skim returns the correct
+    /// PickerRow is the branch name so skim returns the correct
     /// identifier when the user hits Enter.
     #[test]
     fn skeleton_publishes_header_then_items() {

--- a/src/commands/picker/prs.rs
+++ b/src/commands/picker/prs.rs
@@ -35,7 +35,6 @@
 //! GitHub and GitLab only. Gitea and Azure DevOps support `pr:{N}` for a
 //! single known number but have no listing path here yet.
 
-use std::borrow::Cow;
 use std::collections::HashSet;
 use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -45,7 +44,6 @@ use std::time::Duration;
 use anstyle::{Reset, Style};
 use anyhow::Context;
 use color_print::cformat;
-use ratatui::text::Line;
 use serde::Deserialize;
 use skim::prelude::*;
 use unicode_width::UnicodeWidthStr;
@@ -58,12 +56,9 @@ use super::super::list::ci_status::{
 };
 use super::super::list::columns::ColumnKind;
 use super::super::list::layout::ColumnGrid;
-use super::items::{
-    PreviewCache, RowShortcutData, RowUrl, ShortcutTable, TabAvailability, WorktreeSkimItem,
-    ansi_to_line, push_pr_search_tokens, render_preview_tabs,
-};
+use super::items::{PickerRow, PreviewCache, RowShortcutData, RowUrl, ShortcutTable};
 use super::pr_pane;
-use super::preview::{PreviewMode, PreviewStateData};
+use super::preview::PreviewMode;
 use super::preview_notify::PreviewNotifier;
 use super::preview_orchestrator::PreviewOrchestrator;
 
@@ -188,6 +183,42 @@ impl PrEntry {
     fn output_token(&self) -> String {
         format!("{}:{}", self.kind.shortcut(), self.number)
     }
+
+    /// The `PrStatus` a listed `--prs` row feeds into the unified row's static
+    /// PR slot. Its CI status (or a no-CI base when the forge couldn't supply
+    /// one in the list call) is overlaid with the entry's display fields —
+    /// number, title, author, body, url, and draft state — so the unified
+    /// `text()` and `pr` pane read every field from the slot exactly as a
+    /// worktree row does. Unlike the worktree slot (which `on_update`
+    /// overwrites as the live CI fetch lands), this one is built once and never
+    /// mutated, so its `(pr:N, Pr)` preview memo stays valid for the row's life.
+    fn display_status(&self) -> PrStatus {
+        let mut status = self.status.clone().unwrap_or(PrStatus {
+            ci_status: CiStatus::NoCI,
+            source: CiSource::PullRequest,
+            is_stale: false,
+            is_priming: false,
+            url: None,
+            number: None,
+            review_state: None,
+            title: None,
+            body: None,
+            author: None,
+            comment_count: None,
+        });
+        status.number = status.number.or_else(|| Some(self.pr_ref()));
+        status.title = Some(self.title.clone()).filter(|t| !t.is_empty());
+        status.author = Some(self.author.clone()).filter(|a| !a.is_empty());
+        status.body = Some(self.body.clone()).filter(|b| !b.is_empty());
+        status.url = self.url.clone();
+        // The `--prs` pane's draft line keys off `is_draft` directly; mirror it
+        // onto the slot's `review_state` so the unified `render_pr_pane_body`
+        // renders the `state: draft` line for listed rows too.
+        if self.is_draft {
+            status.review_state = Some(ReviewState::Draft);
+        }
+        status
+    }
 }
 
 /// How the `--prs` thread reports that its forge call has resolved: drop the
@@ -310,7 +341,7 @@ fn fetch_and_stream(
     // Drop PRs already on screen as a worktree/branch row, so `--prs` only adds
     // PRs not already represented — the two pickers differ solely by the extra
     // rows. A worktree row folds the same number/title/author into its matcher
-    // text (see `WorktreeSkimItem::text`), so the dropped PR stays just as
+    // text (see `PickerRow::text`), so the dropped PR stays just as
     // filterable under its worktree row.
     let entries = additional_prs(entries, shown_branches.as_ref());
     if entries.is_empty() {
@@ -337,20 +368,64 @@ fn fetch_and_stream(
                     url: RowUrl::Static(entry.url.clone()),
                 },
             );
-            Arc::new(PrSkimItem::new(
-                entry,
-                layout.list_width,
+            Arc::new(listed_pr_row(
+                &entry,
                 grid.as_ref(),
-                &orchestrator.cache,
-                orchestrator.notifier(),
+                layout.list_width,
+                Arc::clone(&orchestrator.cache),
+                Arc::clone(orchestrator.notifier()),
             )) as Arc<dyn SkimItem>
         })
         .collect();
     let _ = tx.send(items);
 }
 
+/// Build a listed `--prs` row: a [`PickerRow`] with `local: None` and a static
+/// PR slot pre-filled from `entry` via [`PrEntry::display_status`], which
+/// overlays the entry's number/title/author/body/url/draft onto its CI status
+/// so `text()` folds the same tokens and `render_pr_pane_body` renders the same
+/// pane a worktree row's PR does. The gutter glyph is the trimmed
+/// `PR_GUTTER_SIGIL` (`#`), kept last in `text()` so typing `#` filters to
+/// PR/MR rows. Both the `--prs` fetch thread and the row tests build rows here,
+/// so the two constructions can't drift.
+///
+/// The `pr` pane renders lazily from that static metadata and is memoized in
+/// the shared `preview_cache` under `(pr:N, Pr)`. That cache outlives any one
+/// row, so a fresh build — an `alt-r` reload re-running `fetch_and_stream` —
+/// drops the prior entry for this `pr:N`; otherwise the rebuilt row would serve
+/// the pre-reload pane after the PR changed upstream. A worktree row gets the
+/// equivalent invalidation from `progressive_handler::on_update` when its live
+/// slot changes; a `--prs` row has no live slot, so construction is the analog.
+fn listed_pr_row(
+    entry: &PrEntry,
+    grid: Option<&ColumnGrid>,
+    list_width: usize,
+    preview_cache: PreviewCache,
+    notifier: Arc<PreviewNotifier>,
+) -> PickerRow {
+    let output_token = entry.output_token();
+    preview_cache.remove(&(output_token.clone(), PreviewMode::Pr));
+    // The display line is built once and never mutated (a `--prs` row has no
+    // live list pipeline behind it).
+    let rendered = match grid {
+        Some(grid) => render_grid_row(entry, grid, list_width),
+        None => render_freeform_row(entry, list_width),
+    };
+    PickerRow {
+        search_base: entry.head_branch.clone(),
+        gutter: '#',
+        rendered: Arc::new(Mutex::new(rendered)),
+        branch_name: entry.head_branch.clone(),
+        output_token,
+        preview_cache,
+        pr_status: Arc::new(Mutex::new(Some(Some(entry.display_status())))),
+        notifier,
+        local: None,
+    }
+}
+
 /// Spawn the deferred per-row preview fetches for one `--prs` row, keyed by the
-/// row's `pr:{N}` / `mr:{N}` token so [`PrSkimItem::preview`] reads them back.
+/// row's `pr:{N}` / `mr:{N}` token so the row's `preview()` reads them back.
 /// Each is fire-and-forget on `COLLECT_POOL`, spawned once per row. `preview()`
 /// only reads the cache, and the fetch runs once per row with no in-session
 /// retry, so each closure resolves to a terminal pane: the rendered content, or
@@ -361,7 +436,7 @@ fn fetch_and_stream(
 /// Both tabs are spawned eagerly, once per row, for all rows — so a `--prs` open
 /// queues up to `2 × MAX_PRS` (~100) per-PR forge calls. This is deliberate and
 /// mirrors how the picker already fetches per-row CI status: spawning once here
-/// (not from `preview()`) keeps [`PrSkimItem::preview`] a pure cache read with no
+/// (not from `preview()`) keeps the row's `preview()` a pure cache read with no
 /// in-flight bookkeeping, so skim's UI thread never blocks and a row can't spawn
 /// a duplicate fetch on every repaint. `COLLECT_POOL` bounds how many run at once,
 /// and the picker's lifetime is user-bounded, so a slow forge call never blocks
@@ -697,125 +772,12 @@ fn gitlab_mr_status(
     }
 }
 
-/// A picker row for one open PR/MR. Distinct from `WorktreeSkimItem`: it
-/// carries no `ListItem` and resolves to a `pr:`/`mr:` shortcut rather than a
-/// branch or worktree path.
-pub(super) struct PrSkimItem {
-    /// What skim's fuzzy matcher sees: head branch, then the PR/MR reference,
-    /// title, and author — the same fields a worktree row folds in.
-    search_text: String,
-    /// ANSI-colored display line — cells on the worktree rows' column grid,
-    /// or a freeform line when no grid is available.
-    rendered: String,
-    /// Selection result — the `pr:{N}` / `mr:{N}` shortcut. Routed verbatim
-    /// through `resolve_identifier` → `SwitchPipeline`.
-    output_token: String,
-    /// The tab-6 (`pr`) pane: PR/MR metadata and web URL, built once at
-    /// construction from already-fetched data. A `--prs` row has no local
-    /// worktree, so the working-tree/branch-diff/upstream tabs render an empty
-    /// placeholder instead.
-    pr_pane: String,
-    /// Shared preview cache (same map the worktree rows use), read by the
-    /// deferred `log` tab. Keyed by `(output_token, mode)`; the background
-    /// fetch spawned in [`spawn_pr_previews`] populates it off-thread, and a
-    /// miss falls back to a loading placeholder (auto-surfaced once the fetch
-    /// lands — see `notifier`).
-    preview_cache: PreviewCache,
-    /// Surfaces a deferred-tab fetch without a keystroke. `preview()` records
-    /// the row's awaited `(output_token, mode)` here; the orchestrator pokes a
-    /// repaint when that tab's background fetch lands (see [`PreviewNotifier`]).
-    notifier: Arc<PreviewNotifier>,
-}
-
-impl PrSkimItem {
-    fn new(
-        entry: PrEntry,
-        list_width: usize,
-        grid: Option<&ColumnGrid>,
-        preview_cache: &PreviewCache,
-        notifier: &Arc<PreviewNotifier>,
-    ) -> Self {
-        let output_token = entry.output_token();
-
-        // Same matcher text a worktree row builds (see `WorktreeSkimItem::text`
-        // and `push_pr_search_tokens`): head branch, then the PR/MR reference,
-        // title, and author, so a PR filters identically however it's shown.
-        // The trailing gutter glyph (`#` from `PR_GUTTER_SIGIL`, sans pad) stays
-        // last so typing `#` filters to PR/MR rows, matching the worktree/branch
-        // rows' folded sigils.
-        let gutter = PR_GUTTER_SIGIL.trim_end();
-        let mut search_text = entry.head_branch.clone();
-        push_pr_search_tokens(
-            &mut search_text,
-            entry.pr_ref(),
-            Some(&entry.title),
-            Some(&entry.author),
-        );
-        search_text.push(' ');
-        search_text.push_str(gutter);
-
-        let rendered = match grid {
-            Some(grid) => render_grid_row(&entry, grid, list_width),
-            None => render_freeform_row(&entry, list_width),
-        };
-
-        let pr_ref = entry.pr_ref();
-        let PrEntry {
-            title,
-            head_branch,
-            author,
-            is_draft,
-            url,
-            body,
-            ..
-        } = entry;
-        // The shared `pr_pane` helpers build the same header / metadata / body
-        // shape as the worktree-row pane (see `items::render_worktree_pr`), so
-        // the two read alike. They close each styled span with a full `{reset}`
-        // (\x1b[0m) because skim's ANSI parser drops color_print's `</>` (SGR
-        // 22/24/39 — bold/underline/color); the `draft` value below does the same.
-        let reset = Reset;
-        let mut pr_pane = pr_pane::header(pr_ref, Some(&title));
-        pr_pane.push_str(&pr_pane::branch_line(&head_branch));
-        pr_pane.push_str(&pr_pane::metadata_line("author", &format!("@{author}")));
-        if is_draft {
-            pr_pane.push_str(&pr_pane::metadata_line(
-                "state",
-                &cformat!("<yellow>draft</>{reset}"),
-            ));
-        }
-        if let Some(url) = url {
-            pr_pane.push_str(&pr_pane::url_line(&url));
-        }
-        pr_pane.push_str(&pr_pane::description(&body, list_width));
-
-        Self {
-            search_text,
-            rendered,
-            output_token,
-            pr_pane,
-            preview_cache: Arc::clone(preview_cache),
-            notifier: Arc::clone(notifier),
-        }
-    }
-
-    /// Read a deferred tab's pane from the shared cache, or a loading
-    /// placeholder on a miss. The background fetch (see [`spawn_pr_previews`])
-    /// keys by this row's `output_token`, the same as [`PrEntry::output_token`].
-    fn cached_pane(&self, mode: PreviewMode) -> String {
-        self.preview_cache
-            .get(&(self.output_token.clone(), mode))
-            .map(|v| v.value().clone())
-            .unwrap_or_else(|| pr_deferred_loading(mode))
-    }
-}
-
 /// The pane for the tabs a `--prs` row leaves empty — working-tree (1),
 /// branch-diff (3), upstream (4), summary (5). The head branch isn't checked
 /// out locally, so there's no working tree or diff to show; point the user at
 /// the `pr` tab, which holds the PR/MR metadata. The `log` tab (2) is *not*
 /// empty — it loads commits in the background (see [`compute_pr_log`]).
-fn pr_row_empty_placeholder() -> String {
+pub(super) fn pr_row_empty_placeholder() -> String {
     let reset = Reset;
     cformat!(
         "{INFO_SYMBOL}{reset} Not checked out locally — press <bold>alt-6</>{reset} for PR details, Enter to fetch & switch\n"
@@ -824,13 +786,13 @@ fn pr_row_empty_placeholder() -> String {
 
 /// Placeholder for a deferred forge-fetch tab while its background fetch is still
 /// in flight. The pane fills in on its own once the fetch lands — the orchestrator
-/// pokes a repaint for the awaited tab (see [`PreviewNotifier`]) — so the
+/// pokes a repaint for the awaited tab (see `PreviewNotifier`) — so the
 /// placeholder just states what's loading, the same contract as the worktree
 /// rows' `loading_placeholder`. Shown only during the in-flight window: once the
 /// fetch resolves, a terminal pane replaces it — the rendered content or
 /// [`pr_unavailable_pane`] on failure — so it never persists past the fetch.
 /// Shared with worktree rows' `comments` tab (see
-/// [`super::items::WorktreeSkimItem::render_comments_pane`]) so both row types
+/// [`super::items::PickerRow::render_comments_pane`]) so both row types
 /// show the identical in-flight pane.
 pub(super) fn pr_deferred_loading(mode: PreviewMode) -> String {
     let label = match mode {
@@ -951,7 +913,7 @@ fn local_log(
     {
         return None;
     }
-    let rendered = WorktreeSkimItem::compute_log_for_head(repo, oid, head_branch, width, height);
+    let rendered = PickerRow::compute_log_for_head(repo, oid, head_branch, width, height);
     (!rendered.is_empty()).then_some(rendered)
 }
 
@@ -1182,8 +1144,8 @@ fn relative_time(iso: &str) -> Option<String> {
 /// The PR title and author are NOT on the row — they have no worktree-column
 /// equivalent, so showing them would either misalign PR rows against worktree
 /// rows or overrun the status columns. They live in the `pr` preview tab
-/// instead (see `PrSkimItem::pr_pane`); the title still feeds `search_text`, so
-/// fuzzy matching on it works even though it isn't displayed. The other
+/// instead (see `render_pr_pane_body`); the title still feeds the row's matcher
+/// text, so fuzzy matching on it works even though it isn't displayed. The other
 /// worktree-data columns PR rows leave blank (status, diffs, URL, age) are a
 /// follow-up — see TODO(pr-row-columns).
 fn render_grid_row(entry: &PrEntry, grid: &ColumnGrid, list_width: usize) -> String {
@@ -1256,57 +1218,40 @@ fn render_freeform_row(entry: &PrEntry, list_width: usize) -> String {
 // summary would feed those commits (or the PR body) through the same
 // `[commit.generation]` LLM path the worktree `summary` tab uses, keyed and
 // cached the same way via `spawn_pr_previews`.
-impl SkimItem for PrSkimItem {
-    fn text(&self) -> Cow<'_, str> {
-        Cow::Borrowed(&self.search_text)
-    }
-
-    fn display(&self, _context: DisplayContext) -> Line<'_> {
-        ansi_to_line(&self.rendered)
-    }
-
-    fn output(&self) -> Cow<'_, str> {
-        Cow::Borrowed(&self.output_token)
-    }
-
-    fn preview(&self, context: PreviewContext<'_>) -> ItemPreview {
-        // Share the worktree rows' tab bar. A `--prs` row has content on the
-        // `pr` tab (built at construction) and the `log` / `comments` tabs
-        // (fetched in the background, read from the shared cache); the
-        // working-tree/branch-diff/upstream/summary tabs are de-emphasized and
-        // show a placeholder. The active tab is the same global digit, so an
-        // empty tab shows its placeholder until the user switches with alt-N / Tab.
-        let mode = PreviewStateData::read_mode();
-        // Record what this (selected) row is showing before reading the cache, so
-        // a deferred-tab fetch that lands after a miss pokes a repaint (see
-        // `PreviewNotifier`). Keyed by the row's `output_token`, matching the
-        // cache key the fetch fills.
-        self.notifier.note_awaiting(&self.output_token, mode);
-        let mut result = render_preview_tabs(mode, TabAvailability::listed_pr(), context.width);
-        match mode {
-            PreviewMode::Pr => result.push_str(&self.pr_pane),
-            PreviewMode::Log | PreviewMode::Comments => result.push_str(&self.cached_pane(mode)),
-            _ => result.push_str(&pr_row_empty_placeholder()),
-        }
-        ItemPreview::AnsiText(result)
-    }
-}
-
 #[cfg(test)]
 mod tests {
+    use super::super::items::PreviewCache;
+    use super::super::preview_notify::PreviewNotifier;
     use super::*;
     use dashmap::DashMap;
 
-    /// Build a `PrSkimItem` with a throwaway empty preview cache — the deferred
+    /// Build a listed-`--prs` `PickerRow` (`local: None`) with a throwaway empty
+    /// preview cache — the same shape `fetch_and_stream` builds. The deferred
     /// `log` tab is exercised separately (see `log_tab_reads_cache_then_placeholder`).
-    fn pr_item(entry: PrEntry, list_width: usize, grid: Option<&ColumnGrid>) -> PrSkimItem {
-        PrSkimItem::new(
-            entry,
-            list_width,
+    fn pr_item(entry: PrEntry, list_width: usize, grid: Option<&ColumnGrid>) -> PickerRow {
+        pr_item_with_cache(entry, list_width, grid, Arc::new(DashMap::new()))
+    }
+
+    /// As [`pr_item`], but sharing an explicit cache so a test can pre-seed a
+    /// deferred-tab pane and then read it back.
+    fn pr_item_with_cache(
+        entry: PrEntry,
+        list_width: usize,
+        grid: Option<&ColumnGrid>,
+        preview_cache: PreviewCache,
+    ) -> PickerRow {
+        listed_pr_row(
+            &entry,
             grid,
-            &Arc::new(DashMap::new()),
-            &PreviewNotifier::detached(),
+            list_width,
+            preview_cache,
+            PreviewNotifier::detached(),
         )
+    }
+
+    /// Read a row's current display line (the `rendered` slot).
+    fn rendered_of(row: &PickerRow) -> String {
+        row.rendered.lock().unwrap().clone()
     }
 
     fn entry(kind: RefKind, number: u32, title: &str) -> PrEntry {
@@ -1427,7 +1372,7 @@ mod tests {
         // and author have no column, so they stay off the row — but the title
         // still feeds `search_text`.
         let pr = pr_item(entry(RefKind::Pr, 1, "Retry the flaky test"), 80, None);
-        let row = plain(&pr.rendered);
+        let row = plain(&rendered_of(&pr));
         assert!(row.contains("feature/auth"), "branch on the row: {row:?}");
         assert!(row.contains("#1"), "reference on the row: {row:?}");
         assert!(
@@ -1448,7 +1393,7 @@ mod tests {
         let mut e = entry(RefKind::Pr, 1, "Title");
         e.head_branch = "a-very-long-branch-name-that-would-otherwise-overflow".to_string();
         let pr = pr_item(e, 40, None);
-        let row = plain(&pr.rendered);
+        let row = plain(&rendered_of(&pr));
         assert!(row.contains("#1"), "reference survives: {row:?}");
         assert!(row.contains('…'), "branch truncated: {row:?}");
         assert!(row.width() <= 40, "row within pane: {row:?}");
@@ -1462,7 +1407,35 @@ mod tests {
         let mut e = entry(RefKind::Pr, 9, "WIP refactor");
         e.is_draft = true;
         let pr = pr_item(e, 120, None);
-        assert!(pr.pr_pane.contains("draft"));
+        assert!(pr.render_pr_pane_cached(120).contains("draft"));
+    }
+
+    /// An `alt-r` reload rebuilds a `--prs` row for the same `pr:N` against the
+    /// session-long preview cache. The rebuilt row must render the freshly
+    /// fetched metadata, not the `pr` pane the previous build memoized: a
+    /// worktree row gets this invalidation from `on_update` when its live slot
+    /// changes, a `--prs` row from its construction in `listed_pr_row`.
+    #[test]
+    fn rebuilt_listed_pr_row_drops_the_stale_pr_pane() {
+        let cache: PreviewCache = Arc::new(DashMap::new());
+
+        // First build: PR #42 is a draft; rendering its `pr` tab memoizes the
+        // draft pane under (pr:42, Pr).
+        let mut draft = entry(RefKind::Pr, 42, "WIP refactor");
+        draft.is_draft = true;
+        let row = pr_item_with_cache(draft, 120, None, Arc::clone(&cache));
+        assert!(
+            row.render_pr_pane_cached(120).contains("draft"),
+            "first build caches the draft pane"
+        );
+
+        // Reload: #42 is now marked ready. The rebuilt row shares the cache.
+        let ready = entry(RefKind::Pr, 42, "WIP refactor");
+        let row = pr_item_with_cache(ready, 120, None, Arc::clone(&cache));
+        assert!(
+            !row.render_pr_pane_cached(120).contains("draft"),
+            "the rebuilt row must re-render, not serve the stale draft pane"
+        );
     }
 
     use super::super::super::list::layout::GridColumn;
@@ -1509,7 +1482,7 @@ mod tests {
             120,
             Some(&grid()),
         );
-        let text = plain(&pr.rendered);
+        let text = plain(&rendered_of(&pr));
         // The dim `#` gutter sigil sits at column 0; branch in the Branch column.
         assert!(text.starts_with("# feature/auth"));
         assert_eq!(display_col(&text, "feature/auth"), 2, "branch column");
@@ -1530,7 +1503,7 @@ mod tests {
         let mut e = entry(RefKind::Pr, 5, "Title");
         e.head_branch = "a-very-long-branch-name-overflowing".to_string();
         let pr = pr_item(e, 120, Some(&grid_with_ci()));
-        let text = plain(&pr.rendered);
+        let text = plain(&rendered_of(&pr));
         // The branch is shortened to its column; the number still lands in CI.
         assert!(text.contains('…'));
         assert_eq!(display_col(&text, "#5"), 34, "number in CI column");
@@ -1546,17 +1519,20 @@ mod tests {
             120,
             Some(&grid_with_ci()),
         );
-        let row = plain(&mr.rendered);
+        let row = plain(&rendered_of(&mr));
         assert!(row.contains("!42"), "grid row uses ! for MRs: {row:?}");
         assert!(
             !row.contains("#42"),
             "grid row must not use # for MRs: {row:?}"
         );
-        assert!(mr.pr_pane.contains("!42"), "preview uses ! for MRs");
+        assert!(
+            mr.render_pr_pane_cached(120).contains("!42"),
+            "preview uses ! for MRs"
+        );
 
         let mr_freeform = pr_item(entry(RefKind::Mr, 42, "Add caching"), 120, None);
         assert!(
-            plain(&mr_freeform.rendered).contains("!42"),
+            plain(&rendered_of(&mr_freeform)).contains("!42"),
             "freeform row uses !"
         );
 
@@ -1567,7 +1543,7 @@ mod tests {
             Some(&grid_with_ci()),
         );
         assert!(
-            plain(&pr.rendered).contains("#42"),
+            plain(&rendered_of(&pr)).contains("#42"),
             "grid row uses # for PRs"
         );
     }
@@ -1585,7 +1561,7 @@ mod tests {
         let mut e = entry(RefKind::Pr, 1, "Title");
         e.head_branch = "a-very-long-branch-name-that-runs-past-the-edge".to_string();
         let pr = pr_item(e, 60, Some(&no_flexible));
-        let text = plain(&pr.rendered);
+        let text = plain(&rendered_of(&pr));
         assert!(text.width() <= 60);
         // Skim's overflow check uses CJK widths, where the truncation `…`
         // counts as 2 — the row must pass it too or skim repaints the last
@@ -1600,7 +1576,7 @@ mod tests {
             120,
             Some(&grid_with_ci()),
         );
-        let text = plain(&pr.rendered);
+        let text = plain(&rendered_of(&pr));
         // The number sits in the CI column (start 34), aligned with worktree
         // rows; the title is not on the row at all.
         assert_eq!(display_col(&text, "#123"), 34, "number in CI column");
@@ -1625,7 +1601,7 @@ mod tests {
             120,
             Some(&grid),
         );
-        let text = plain(&pr.rendered);
+        let text = plain(&rendered_of(&pr));
         assert_eq!(display_col(&text, "feature/auth"), 2, "branch");
         assert_eq!(display_col(&text, "#42"), 24, "number in CI column");
         assert!(
@@ -1644,7 +1620,7 @@ mod tests {
             status.review_state = Some(ReviewState::Draft);
         }
         let pr = pr_item(e, 120, Some(&grid_with_ci()));
-        let text = plain(&pr.rendered);
+        let text = plain(&rendered_of(&pr));
         assert!(
             !text.contains("draft"),
             "no draft flag on the row: {text:?}"
@@ -1860,36 +1836,29 @@ mod tests {
         let mut with_body = entry(RefKind::Pr, 1, "t");
         with_body.body = "A short summary of the change.".to_string();
         let pr = pr_item(with_body, 120, Some(&grid()));
-        assert!(pr.pr_pane.contains("A short summary of the change."));
+        let pane = pr.render_pr_pane_cached(120);
+        assert!(pane.contains("A short summary of the change."));
         // The body renders flush, not quoted in a gutter bar; `description`
         // prefixes its block with a blank line + full reset.
-        assert!(
-            !pr.pr_pane.contains("\x1b[107m"),
-            "no gutter bar: {:?}",
-            pr.pr_pane
-        );
-        assert!(
-            pr.pr_pane.contains("\n\n\x1b[0m"),
-            "description block present"
-        );
+        assert!(!pane.contains("\x1b[107m"), "no gutter bar: {pane:?}");
+        assert!(pane.contains("\n\n\x1b[0m"), "description block present");
         // The block is headed by a cyan `DESCRIPTION` label, matching branch/url.
         assert!(
-            pr.pr_pane.contains("DESCRIPTION"),
-            "DESCRIPTION label present: {:?}",
-            pr.pr_pane
+            pane.contains("DESCRIPTION"),
+            "DESCRIPTION label present: {pane:?}"
         );
 
         // The base fixture has an empty body — the description block is skipped,
         // label and all.
         let plain_pr = pr_item(entry(RefKind::Pr, 2, "t"), 120, Some(&grid()));
+        let plain_pane = plain_pr.render_pr_pane_cached(120);
         assert!(
-            !plain_pr.pr_pane.contains("\n\n\x1b[0m"),
+            !plain_pane.contains("\n\n\x1b[0m"),
             "no description block when empty"
         );
         assert!(
-            !plain_pr.pr_pane.contains("DESCRIPTION"),
-            "no DESCRIPTION label when empty: {:?}",
-            plain_pr.pr_pane
+            !plain_pane.contains("DESCRIPTION"),
+            "no DESCRIPTION label when empty: {plain_pane:?}"
         );
     }
 
@@ -1933,22 +1902,16 @@ mod tests {
         // alt-2); once the background fetch lands a value under that key, the
         // pane shows it.
         let cache: PreviewCache = Arc::new(DashMap::new());
-        let pr = PrSkimItem::new(
-            entry(RefKind::Pr, 42, "t"),
-            120,
-            None,
-            &cache,
-            &PreviewNotifier::detached(),
-        );
+        let pr = pr_item_with_cache(entry(RefKind::Pr, 42, "t"), 120, None, Arc::clone(&cache));
 
-        let miss = pr.cached_pane(PreviewMode::Log);
+        let miss = pr.cached_or_loading(PreviewMode::Log);
         assert!(miss.contains("Loading commit log"), "miss: {miss:?}");
 
         cache.insert(
             ("pr:42".to_string(), PreviewMode::Log),
             "abc12345  Fix it\n".to_string(),
         );
-        assert_eq!(pr.cached_pane(PreviewMode::Log), "abc12345  Fix it\n");
+        assert_eq!(pr.cached_or_loading(PreviewMode::Log), "abc12345  Fix it\n");
     }
 
     #[test]
@@ -2060,22 +2023,19 @@ mod tests {
         // keyed by the row's output token, with a loading placeholder (pointing
         // at alt-7) on a miss.
         let cache: PreviewCache = Arc::new(DashMap::new());
-        let pr = PrSkimItem::new(
-            entry(RefKind::Mr, 7, "t"),
-            120,
-            None,
-            &cache,
-            &PreviewNotifier::detached(),
-        );
+        let pr = pr_item_with_cache(entry(RefKind::Mr, 7, "t"), 120, None, Arc::clone(&cache));
 
-        let miss = pr.cached_pane(PreviewMode::Comments);
+        let miss = pr.cached_or_loading(PreviewMode::Comments);
         assert!(miss.contains("Loading comments"), "miss: {miss:?}");
 
         cache.insert(
             ("mr:7".to_string(), PreviewMode::Comments),
             "rendered thread".to_string(),
         );
-        assert_eq!(pr.cached_pane(PreviewMode::Comments), "rendered thread");
+        assert_eq!(
+            pr.cached_or_loading(PreviewMode::Comments),
+            "rendered thread"
+        );
     }
 
     #[test]

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_branch_diff.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_branch_diff.snap
@@ -1,5 +1,5 @@
 ---
 source: src/commands/picker/items.rs
-expression: "WorktreeSkimItem::loading_placeholder(mode)"
+expression: "PickerRow::loading_placeholder(mode)"
 ---
 [2m↳[22m [2mLoading branch diff…[22m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_log.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_log.snap
@@ -1,5 +1,5 @@
 ---
 source: src/commands/picker/items.rs
-expression: "WorktreeSkimItem::loading_placeholder(mode)"
+expression: "PickerRow::loading_placeholder(mode)"
 ---
 [2m↳[22m [2mLoading log…[22m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_summary.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_summary.snap
@@ -1,5 +1,5 @@
 ---
 source: src/commands/picker/items.rs
-expression: "WorktreeSkimItem::loading_placeholder(mode)"
+expression: "PickerRow::loading_placeholder(mode)"
 ---
 [2m↳[22m [2mGenerating summary…[22m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_upstream_diff.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_upstream_diff.snap
@@ -1,5 +1,5 @@
 ---
 source: src/commands/picker/items.rs
-expression: "WorktreeSkimItem::loading_placeholder(mode)"
+expression: "PickerRow::loading_placeholder(mode)"
 ---
 [2m↳[22m [2mLoading upstream diff…[22m

--- a/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_working_tree.snap
+++ b/src/commands/picker/snapshots/wt__commands__picker__items__tests__loading_placeholder_working_tree.snap
@@ -1,5 +1,5 @@
 ---
 source: src/commands/picker/items.rs
-expression: "WorktreeSkimItem::loading_placeholder(mode)"
+expression: "PickerRow::loading_placeholder(mode)"
 ---
 [2m↳[22m [2mLoading working-tree diff…[22m

--- a/tests/integration_tests/switch.rs
+++ b/tests/integration_tests/switch.rs
@@ -2335,7 +2335,7 @@ fn setup_mock_forge_list(
 
 /// `wt switch --prs` in the headless dry-run (`WORKTRUNK_PICKER_DRY_RUN`)
 /// exercises the full forge fetch + row-render path — `stream_open_prs`,
-/// `fetch_github`, `parse_github_prs`, `PrSkimItem::new`, `render_grid_row`,
+/// `fetch_github`, `parse_github_prs`, `PrEntry::display_status`, `render_grid_row`,
 /// `render_pr_description` — as a normal-exit subprocess, so its coverage is
 /// captured. (The interactive picker exits via skim's abort, which never
 /// flushes a profile, so its `--prs` code is otherwise unmeasurable.) The mock

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -1367,7 +1367,7 @@ fn forge_mock_env_vars(repo: &TestRepo, mock_bin: &Path) -> Vec<(String, String)
 /// via a mocked `gh pr list`. Asserts the PR row reaches the list (the `#42`
 /// reference in the CI column), which deterministically exercises the whole
 /// fetch → stream → render path (`fetch_open_prs`, `fetch_github`,
-/// `parse_github_prs`, `stream_open_prs`, `PrSkimItem::new`, `render_grid_row`,
+/// `parse_github_prs`, `stream_open_prs`, `PrEntry::display_status`, `render_grid_row`,
 /// `render_pr_description`). The title isn't on the row — it lives in the `pr`
 /// preview tab so the columns align — so the row's stable substring is `#42`.
 /// The full list isn't snapshotted because the worktree rows' CI cells fill


### PR DESCRIPTION
Collapse the picker's two `SkimItem` types into one. `WorktreeSkimItem` (a checked-out worktree row) and `PrSkimItem` (a listed `--prs` row) become a single `PickerRow` whose only branching axis is `local: Option<LocalCheckout>` — `Some` for a worktree row, `None` for a listed PR. This is the type-level completion of #3252, which made the two row kinds behave identically; they now share one `text()`, `display()`, `output()`, `preview()`, and PR-pane renderer instead of two parallel implementations.

## What changed

- `PrSkimItem` and its standalone `impl SkimItem` are deleted. Listed `--prs` rows are built by `prs::listed_pr_row` (shared by `fetch_and_stream` and the row tests) as `PickerRow { local: None, … }` with a static `pr_status` slot pre-filled by the new `PrEntry::display_status()`.
- The worktree-only fields (`has_upstream`, `summaries_enabled`, `local_content`) move into a `LocalCheckout` sub-struct behind `local`. The frozen `Arc<ListItem>` handle is gone, replaced by a precomputed `output_token`.
- `pr_status` and the preview cache are shared by both row kinds, keyed by `PickerRow::preview_key()` — the branch for a worktree row, `pr:N`/`mr:N` for a listed PR. A `--prs` row's `pr` pane is memoized in that session-long cache, so `listed_pr_row` drops the prior `(pr:N, Pr)` entry on each build; an `alt-r` reload then re-renders the freshly fetched PR metadata instead of the pre-reload pane (the worktree-row analog of `on_update`'s invalidation).

## Behavior change

A worktree row tracking a draft PR now shows a `state: draft` line in its `pr` pane. Previously only `--prs` rows surfaced draft state. This falls out of both kinds sharing `render_pr_pane_body`.

## Reviewer orientation

- `src/commands/picker/items.rs` — the unified `PickerRow`/`LocalCheckout`, `preview_key()`, `render_pr_pane_body()`, `render_listed_pr_mode()`.
- `src/commands/picker/prs.rs` — `PrSkimItem` removed; `PrEntry::display_status()` and the `listed_pr_row` constructor (with its cache invalidation).
- `src/commands/picker/progressive_handler.rs` — worktree-row construction with `local: Some(LocalCheckout { … })`.
- The remaining files are call-site and doc renames.

Rendered output is unchanged — the integration snapshots still pass, and the `loading_placeholder` snapshots change only their `expression:` metadata line. Rebased on main's #3253 (the `↳` loading-placeholder glyph), which is preserved.

> _This was written by Claude Code on behalf of max_
