### PR TITLE
feat(switch): rework the alt-x picker removal — morph in place, decline current worktree, identity cursor

### DIFF
--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -87,6 +87,8 @@ The CI column shows each row's PR/MR CI and review status, the same as [`wt list
 
 `Alt-o` is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
 
+`Alt-x` is a no-op on the current worktree (the `@` row) — removing the worktree in use would have to switch elsewhere first, so switch away and remove it from there.
+
 Each row filters by its branch, path, and — when it has a PR/MR — the PR/MR's number, title, and author, the same fields whether the PR is checked out (a worktree row) or listed via `--prs`. Plain digits go to the filter, so a number can be typed directly and the preview tabs move to `Alt`.
 
 Typing a gutter sigil filters by row kind: `+` narrows to linked worktrees and `@` to the current worktree. The other sigils don't filter cleanly — `^` and `|` are skim's prefix-anchor and OR query operators (so `^` matches every row and `|` none), and `/` matches most rows because every worktree path contains it.

--- a/skills/worktrunk/reference/switch.md
+++ b/skills/worktrunk/reference/switch.md
@@ -83,6 +83,8 @@ The CI column shows each row's PR/MR CI and review status, the same as [`wt list
 
 `Alt-o` is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
 
+`Alt-x` is a no-op on the current worktree (the `@` row) — removing the worktree in use would have to switch elsewhere first, so switch away and remove it from there.
+
 Each row filters by its branch, path, and — when it has a PR/MR — the PR/MR's number, title, and author, the same fields whether the PR is checked out (a worktree row) or listed via `--prs`. Plain digits go to the filter, so a number can be typed directly and the preview tabs move to `Alt`.
 
 Typing a gutter sigil filters by row kind: `+` narrows to linked worktrees and `@` to the current worktree. The other sigils don't filter cleanly — `^` and `|` are skim's prefix-anchor and OR query operators (so `^` matches every row and `|` none), and `/` matches most rows because every worktree path contains it.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -677,6 +677,8 @@ The CI column shows each row's PR/MR CI and review status, the same as [`wt list
 
 `Alt-o` is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
 
+`Alt-x` is a no-op on the current worktree (the `@` row) — removing the worktree in use would have to switch elsewhere first, so switch away and remove it from there.
+
 Each row filters by its branch, path, and — when it has a PR/MR — the PR/MR's number, title, and author, the same fields whether the PR is checked out (a worktree row) or listed via `--prs`. Plain digits go to the filter, so a number can be typed directly and the preview tabs move to `Alt`.
 
 Typing a gutter sigil filters by row kind: `+` narrows to linked worktrees and `@` to the current worktree. The other sigils don't filter cleanly — `^` and `|` are skim's prefix-anchor and OR query operators (so `^` matches every row and `|` none), and `/` matches most rows because every worktree path contains it.

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -508,6 +508,14 @@ pub trait PickerProgressHandler: Send + Sync {
     /// benchmark early-exit, nor on the zero-worktree `Ok(None)` return
     /// (which exits before `on_skeleton`). Default: no-op.
     fn on_collect_complete(&self) {}
+
+    /// Hand the picker a clone of the collect layout, right after `on_skeleton`.
+    /// `LayoutConfig` is `!Sync`, so the handler stows it behind a lock for the
+    /// collector to read at `alt-x` time, where it renders a `/ branch` row on
+    /// the same grid as the worktree rows (the in-place morph). Default: no-op —
+    /// only the picker needs it. Column geometry is stable after skeleton (the
+    /// `--prs` rows already rely on that via `grid`), so one clone here suffices.
+    fn provide_layout(&self, _layout: &super::layout::LayoutConfig) {}
 }
 
 /// Controls how show flags (branches/remotes/full) are determined in [`collect`].
@@ -516,15 +524,6 @@ pub enum ShowConfig {
     Resolved {
         show_branches: bool,
         show_remotes: bool,
-        /// Branch-only rows to include even when `show_branches` is false. The
-        /// picker pins a branch here after `alt-x` removes its worktree but
-        /// keeps the (unmerged) branch, so the row returns as a `/ branch` row
-        /// on the next refresh instead of vanishing — the worktree is gone, the
-        /// branch remains. Filtered against the live branch inventory (a deleted
-        /// entry shows nothing) and against worktree branches (a re-attached one
-        /// renders as a worktree row, never duplicated), so a stale entry can't
-        /// produce a phantom row. Empty for `wt list`.
-        pinned_branches: HashSet<String>,
         skip_tasks: HashSet<TaskKind>,
         command_timeout: Option<std::time::Duration>,
         /// Wall-clock deadline for the collect phase. `None` uses the default
@@ -784,7 +783,6 @@ pub fn collect(
     let (
         show_branches,
         show_remotes,
-        pinned_branches,
         skip_tasks,
         command_timeout,
         collect_deadline,
@@ -795,7 +793,6 @@ pub fn collect(
         ShowConfig::Resolved {
             show_branches,
             show_remotes,
-            pinned_branches,
             skip_tasks,
             command_timeout,
             collect_deadline,
@@ -804,7 +801,6 @@ pub fn collect(
         } => (
             show_branches,
             show_remotes,
-            pinned_branches,
             skip_tasks,
             command_timeout,
             collect_deadline,
@@ -848,8 +844,6 @@ pub fn collect(
             (
                 show_branches,
                 show_remotes,
-                // `wt list` never pins branches; only the picker does.
-                HashSet::new(),
                 skip_tasks,
                 command_timeout,
                 collect_deadline,
@@ -886,12 +880,11 @@ pub fn collect(
     let needs_stale_check = default_branch
         .as_deref()
         .is_some_and(|b| !worktree_branches.contains(b));
-    let fetched_local: Option<&[LocalBranch]> =
-        if show_branches || needs_stale_check || !pinned_branches.is_empty() {
-            Some(repo.local_branches()?)
-        } else {
-            None
-        };
+    let fetched_local: Option<&[LocalBranch]> = if show_branches || needs_stale_check {
+        Some(repo.local_branches()?)
+    } else {
+        None
+    };
     let warn_stale_default = needs_stale_check
         && fetched_local.is_some_and(|all| {
             !all.iter()
@@ -899,14 +892,12 @@ pub fn collect(
         });
 
     // Filter local branches to those without worktrees (CPU-only, no git
-    // commands). With `show_branches` off, only branches the picker pinned
-    // (orphaned by an `alt-x` removal) survive — every other branch-only row
-    // stays hidden.
+    // commands). With `show_branches` off there are no branch-only rows.
     let branches_without_worktrees: Vec<(String, String)> = fetched_local
         .unwrap_or(&[])
         .iter()
+        .filter(|_| show_branches)
         .filter(|b| !worktree_branches.contains(b.name.as_str()))
-        .filter(|b| show_branches || pinned_branches.contains(&b.name))
         .map(|b| (b.name.clone(), b.commit_sha.clone()))
         .collect();
 
@@ -1291,6 +1282,9 @@ pub fn collect(
             layout.render_header_line(),
             layout.column_grid(),
         );
+        // Hand the picker the layout so `alt-x` can render a `/ branch` row on
+        // this same grid without re-collecting. No-op for non-picker handlers.
+        handler.provide_layout(&layout);
         // Mirror the `wt list` progressive-table marker so `wt-perf phases`
         // sees the same boundary across both commands.
         worktrunk::trace::instant("Skeleton rendered");
@@ -2173,60 +2167,6 @@ mod tests {
         assert_eq!(collect_pool_num_threads(true), 0);
         // Env var unset: explicit 2× CPU, since Rayon's own default is 1×.
         assert_eq!(collect_pool_num_threads(false), crate::rayon_thread_count());
-    }
-
-    /// `pinned_branches` surfaces a worktree-less branch as a `/ branch` row
-    /// even with `show_branches` off — the picker's `alt-x` row transform (a
-    /// removed worktree whose branch survives). Without pinning, the same branch
-    /// stays hidden, so the pin is what makes the row reappear.
-    #[test]
-    fn test_collect_pins_worktreeless_branch_without_show_branches() {
-        let test = worktrunk::testing::TestRepo::with_initial_commit();
-        let repo = worktrunk::git::Repository::at(test.path()).unwrap();
-        // A local branch with no worktree — the shape `alt-x` leaves behind.
-        repo.run_command(&["branch", "orphaned"]).unwrap();
-
-        let resolved = |pinned: HashSet<String>| ShowConfig::Resolved {
-            show_branches: false,
-            show_remotes: false,
-            pinned_branches: pinned,
-            skip_tasks: [
-                TaskKind::BranchDiff,
-                TaskKind::CiStatus,
-                TaskKind::SummaryGenerate,
-            ]
-            .into_iter()
-            .collect(),
-            command_timeout: None,
-            collect_deadline: None,
-            list_width: Some(80),
-            progressive_handler: None,
-        };
-
-        // Unpinned: `show_branches` off hides every branch-only row.
-        let data = collect(&repo, resolved(HashSet::new()), RenderTarget::Json)
-            .unwrap()
-            .expect("the main worktree makes the list non-empty");
-        assert!(
-            !data.items.iter().any(|i| i.branch_name() == "orphaned"),
-            "an unpinned worktree-less branch stays hidden with show_branches off"
-        );
-
-        // Pinned: the branch surfaces as a local `/` branch-only row.
-        let pinned = ["orphaned".to_string()].into_iter().collect();
-        let data = collect(&repo, resolved(pinned), RenderTarget::Json)
-            .unwrap()
-            .expect("the main worktree makes the list non-empty");
-        let row = data
-            .items
-            .iter()
-            .find(|i| i.branch_name() == "orphaned")
-            .expect("the pinned branch surfaces as a row");
-        assert_eq!(
-            row.kind.gutter_glyph(),
-            '/',
-            "a pinned worktree-less branch renders as a local branch-only `/` row"
-        );
     }
 
     #[test]

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -516,6 +516,15 @@ pub enum ShowConfig {
     Resolved {
         show_branches: bool,
         show_remotes: bool,
+        /// Branch-only rows to include even when `show_branches` is false. The
+        /// picker pins a branch here after `alt-x` removes its worktree but
+        /// keeps the (unmerged) branch, so the row returns as a `/ branch` row
+        /// on the next refresh instead of vanishing — the worktree is gone, the
+        /// branch remains. Filtered against the live branch inventory (a deleted
+        /// entry shows nothing) and against worktree branches (a re-attached one
+        /// renders as a worktree row, never duplicated), so a stale entry can't
+        /// produce a phantom row. Empty for `wt list`.
+        pinned_branches: HashSet<String>,
         skip_tasks: HashSet<TaskKind>,
         command_timeout: Option<std::time::Duration>,
         /// Wall-clock deadline for the collect phase. `None` uses the default
@@ -775,6 +784,7 @@ pub fn collect(
     let (
         show_branches,
         show_remotes,
+        pinned_branches,
         skip_tasks,
         command_timeout,
         collect_deadline,
@@ -785,6 +795,7 @@ pub fn collect(
         ShowConfig::Resolved {
             show_branches,
             show_remotes,
+            pinned_branches,
             skip_tasks,
             command_timeout,
             collect_deadline,
@@ -793,6 +804,7 @@ pub fn collect(
         } => (
             show_branches,
             show_remotes,
+            pinned_branches,
             skip_tasks,
             command_timeout,
             collect_deadline,
@@ -835,6 +847,8 @@ pub fn collect(
             (
                 show_branches,
                 show_remotes,
+                // `wt list` never pins branches; only the picker does.
+                HashSet::new(),
                 skip_tasks,
                 command_timeout,
                 collect_deadline,
@@ -871,28 +885,29 @@ pub fn collect(
     let needs_stale_check = default_branch
         .as_deref()
         .is_some_and(|b| !worktree_branches.contains(b));
-    let fetched_local: Option<&[LocalBranch]> = if show_branches || needs_stale_check {
-        Some(repo.local_branches()?)
-    } else {
-        None
-    };
+    let fetched_local: Option<&[LocalBranch]> =
+        if show_branches || needs_stale_check || !pinned_branches.is_empty() {
+            Some(repo.local_branches()?)
+        } else {
+            None
+        };
     let warn_stale_default = needs_stale_check
         && fetched_local.is_some_and(|all| {
             !all.iter()
                 .any(|b| Some(b.name.as_str()) == default_branch.as_deref())
         });
 
-    // Filter local branches to those without worktrees (CPU-only, no git commands)
-    let branches_without_worktrees: Vec<(String, String)> = if show_branches {
-        fetched_local
-            .unwrap_or(&[])
-            .iter()
-            .filter(|b| !worktree_branches.contains(b.name.as_str()))
-            .map(|b| (b.name.clone(), b.commit_sha.clone()))
-            .collect()
-    } else {
-        Vec::new()
-    };
+    // Filter local branches to those without worktrees (CPU-only, no git
+    // commands). With `show_branches` off, only branches the picker pinned
+    // (orphaned by an `alt-x` removal) survive — every other branch-only row
+    // stays hidden.
+    let branches_without_worktrees: Vec<(String, String)> = fetched_local
+        .unwrap_or(&[])
+        .iter()
+        .filter(|b| !worktree_branches.contains(b.name.as_str()))
+        .filter(|b| show_branches || pinned_branches.contains(&b.name))
+        .map(|b| (b.name.clone(), b.commit_sha.clone()))
+        .collect();
 
     if warn_stale_default && let Some(branch) = default_branch.as_deref() {
         emit_warning(
@@ -2157,6 +2172,60 @@ mod tests {
         assert_eq!(collect_pool_num_threads(true), 0);
         // Env var unset: explicit 2× CPU, since Rayon's own default is 1×.
         assert_eq!(collect_pool_num_threads(false), crate::rayon_thread_count());
+    }
+
+    /// `pinned_branches` surfaces a worktree-less branch as a `/ branch` row
+    /// even with `show_branches` off — the picker's `alt-x` row transform (a
+    /// removed worktree whose branch survives). Without pinning, the same branch
+    /// stays hidden, so the pin is what makes the row reappear.
+    #[test]
+    fn test_collect_pins_worktreeless_branch_without_show_branches() {
+        let test = worktrunk::testing::TestRepo::with_initial_commit();
+        let repo = worktrunk::git::Repository::at(test.path()).unwrap();
+        // A local branch with no worktree — the shape `alt-x` leaves behind.
+        repo.run_command(&["branch", "orphaned"]).unwrap();
+
+        let resolved = |pinned: HashSet<String>| ShowConfig::Resolved {
+            show_branches: false,
+            show_remotes: false,
+            pinned_branches: pinned,
+            skip_tasks: [
+                TaskKind::BranchDiff,
+                TaskKind::CiStatus,
+                TaskKind::SummaryGenerate,
+            ]
+            .into_iter()
+            .collect(),
+            command_timeout: None,
+            collect_deadline: None,
+            list_width: Some(80),
+            progressive_handler: None,
+        };
+
+        // Unpinned: `show_branches` off hides every branch-only row.
+        let data = collect(&repo, resolved(HashSet::new()), RenderTarget::Json)
+            .unwrap()
+            .expect("the main worktree makes the list non-empty");
+        assert!(
+            !data.items.iter().any(|i| i.branch_name() == "orphaned"),
+            "an unpinned worktree-less branch stays hidden with show_branches off"
+        );
+
+        // Pinned: the branch surfaces as a local `/` branch-only row.
+        let pinned = ["orphaned".to_string()].into_iter().collect();
+        let data = collect(&repo, resolved(pinned), RenderTarget::Json)
+            .unwrap()
+            .expect("the main worktree makes the list non-empty");
+        let row = data
+            .items
+            .iter()
+            .find(|i| i.branch_name() == "orphaned")
+            .expect("the pinned branch surfaces as a row");
+        assert_eq!(
+            row.kind.gutter_glyph(),
+            '/',
+            "a pinned worktree-less branch renders as a local branch-only `/` row"
+        );
     }
 
     #[test]

--- a/src/commands/list/layout.rs
+++ b/src/commands/list/layout.rs
@@ -520,6 +520,7 @@ pub struct ColumnLayout {
     pub format: ColumnFormat,
 }
 
+#[derive(Clone)]
 pub struct LayoutConfig {
     pub columns: Vec<ColumnLayout>,
     pub main_worktree_path: PathBuf,

--- a/src/commands/picker/items.rs
+++ b/src/commands/picker/items.rs
@@ -81,17 +81,19 @@ pub(super) type LocalContentSlot = Arc<Mutex<LocalContent>>;
 /// worktree path (which is unique) behind this prefix instead.
 pub(super) const WORKTREE_OUTPUT_PREFIX: &str = "worktree-path:";
 
-/// Per-row data the picker's `alt-y` (copy branch) and `alt-o` (open PR/MR URL)
-/// shortcuts need at key-press time, looked up by the row's `output()` token.
+/// Per-row data the picker needs at key-press time, looked up by the row's
+/// `output()` token: the `alt-y` (copy branch) / `alt-o` (open PR/MR URL)
+/// shortcuts, and the `alt-x` in-place branch morph (see [`MorphHandle`]).
 ///
-/// The shortcut callbacks read the *selected* `Arc<dyn SkimItem>` straight off
-/// skim's `App`, but skim's cross-thread `downcast_ref` is unreliable (see
-/// `picker_item_identifier`), so the row's typed fields aren't reachable that
-/// way. This table carries them instead, keyed by the same `output()` token
-/// both sides already share. It's filled where the rows are built —
-/// `progressive_handler::on_skeleton` for worktree/branch rows,
+/// The callbacks read the *selected* `Arc<dyn SkimItem>` straight off skim's
+/// `App`, but skim's cross-thread `downcast_ref` is unreliable (see
+/// `picker_item_identifier`), so the row's typed fields and shared slots aren't
+/// reachable that way. This table carries them instead, keyed by the same
+/// `output()` token both sides already share. It's filled where the rows are
+/// built — `progressive_handler::on_skeleton` for worktree/branch rows,
 /// `prs::stream_open_prs` for `--prs` rows — and read by the keybinding
-/// callbacks in `picker::install_shortcut_keybindings`.
+/// callbacks in `picker::install_shortcut_keybindings` and the `alt-x` removal
+/// in `picker::PickerCollector`.
 pub(super) struct RowShortcutData {
     /// The row's branch name — what `alt-y` copies. `None` for a detached
     /// worktree (no branch), which makes `alt-y` a no-op rather than copying
@@ -100,6 +102,36 @@ pub(super) struct RowShortcutData {
     pub branch: Option<String>,
     /// Where `alt-o` finds the row's PR/MR URL.
     pub url: RowUrl,
+    /// Handles for the `alt-x` in-place branch morph, when this row is a
+    /// linked worktree whose branch could outlive it. `None` for `--prs` rows
+    /// and the primary worktree (nothing to morph into). See [`MorphHandle`].
+    pub morph: Option<MorphHandle>,
+}
+
+/// Shared handles that let `alt-x` morph a worktree row into a `/ branch` row
+/// in place — no reload, no cursor move — when a removal keeps the (unmerged)
+/// branch. The collector rewrites the row's display through these slots and
+/// flips [`morphed`](Self::morphed); the same `Arc`s back the live
+/// [`WorktreeSkimItem`], so skim repaints the one row on the next `Event::Render`.
+///
+/// Reached by the collector through the shared [`RowShortcutData`] table (the
+/// `downcast_ref` route is unreliable cross-thread), so every field is an `Arc`
+/// the handler already built for the row in `on_skeleton`.
+pub(super) struct MorphHandle {
+    /// Worktree snapshot — the source the collector clones (flipping `kind` to
+    /// `Branch`) to render the `/ branch` line on the live layout.
+    pub item: Arc<ListItem>,
+    /// skim's display source for this row. The morph swaps the worktree line
+    /// for the rendered branch line here; the revert (failed removal) swaps it
+    /// back.
+    pub rendered: Arc<Mutex<String>>,
+    /// Dimmed to `working_tree: Some(false)` on morph so the `working_tree`
+    /// preview tab — there's no worktree left to diff — reads as empty.
+    pub local_content: LocalContentSlot,
+    /// Shared with [`WorktreeSkimItem::output`]: once set, the row's selection
+    /// token is the bare branch name (a branch-only row) instead of the
+    /// worktree path.
+    pub morphed: Arc<AtomicBool>,
 }
 
 /// Source of a row's PR/MR URL for the `alt-o` shortcut.
@@ -130,6 +162,14 @@ impl RowUrl {
 /// callbacks (which read it). Rebuilt on every skeleton, so a refresh re-collect
 /// repopulates it.
 pub(super) type ShortcutTable = Arc<Mutex<std::collections::HashMap<String, RowShortcutData>>>;
+
+/// The collect [`LayoutConfig`](crate::commands::list::layout::LayoutConfig),
+/// handed from the collect thread to the picker so `alt-x` can render a
+/// `/ branch` row on the same grid as the worktree rows (the in-place morph).
+/// `LayoutConfig` is `!Sync`, so it rides behind a lock; `None` until the first
+/// skeleton lands, overwritten on each refresh. Shared (like [`ShortcutTable`])
+/// between the per-spawn handler that fills it and the collector that reads it.
+pub(super) type LayoutSlot = Arc<Mutex<Option<crate::commands::list::layout::LayoutConfig>>>;
 
 /// The `output()` token for a worktree/branch row: the unique worktree path
 /// (behind [`WORKTREE_OUTPUT_PREFIX`]) for any worktree-backed row, else the
@@ -276,6 +316,13 @@ pub(super) struct WorktreeSkimItem {
     /// orchestrator pokes a repaint when that key's compute lands (see
     /// [`PreviewNotifier`]).
     pub notifier: Arc<PreviewNotifier>,
+    /// Set when an `alt-x` removal kept this row's branch and morphed the row
+    /// to `/ branch` in place: `output()` then yields the bare branch name
+    /// (a branch-only row) instead of the worktree path. Shared with the row's
+    /// [`MorphHandle`], which the collector flips. The frozen `item` snapshot
+    /// stays a worktree, but nothing reads it for identity once this is set —
+    /// `output()` short-circuits and `preview()` reads the live slots.
+    pub morphed: Arc<AtomicBool>,
 }
 
 impl SkimItem for WorktreeSkimItem {
@@ -291,6 +338,13 @@ impl SkimItem for WorktreeSkimItem {
     }
 
     fn output(&self) -> Cow<'_, str> {
+        // An `alt-x` morph turned this worktree row into a branch-only row: its
+        // selection token is the bare branch name, like any branch row (so a
+        // later switch/`alt-x` treats it as a branch, and `alt-y` finds it under
+        // the re-keyed token). Until then it's the unique worktree path.
+        if self.morphed.load(Ordering::Relaxed) {
+            return Cow::Owned(self.branch_name.clone());
+        }
         Cow::Owned(worktree_output_token(&self.item, &self.branch_name))
     }
 
@@ -1680,6 +1734,7 @@ mod tests {
                 pr_status: Arc::new(Mutex::new(None)),
                 local_content: Arc::new(Mutex::new(LocalContent::default())),
                 notifier: PreviewNotifier::detached(),
+                morphed: Arc::new(AtomicBool::new(false)),
             }
         };
 
@@ -1696,6 +1751,7 @@ mod tests {
                 pr_status: Arc::new(Mutex::new(None)),
                 local_content: Arc::new(Mutex::new(LocalContent::default())),
                 notifier: PreviewNotifier::detached(),
+                morphed: Arc::new(AtomicBool::new(false)),
             }
         };
 
@@ -1783,6 +1839,7 @@ mod tests {
                 pr_status: Arc::new(Mutex::new(pr_status)),
                 local_content: Arc::new(Mutex::new(LocalContent::default())),
                 notifier: PreviewNotifier::detached(),
+                morphed: Arc::new(AtomicBool::new(false)),
             }
         };
 
@@ -1891,6 +1948,7 @@ mod tests {
             pr_status: Arc::new(Mutex::new(slot)),
             local_content: Arc::new(Mutex::new(LocalContent::default())),
             notifier: PreviewNotifier::detached(),
+            morphed: Arc::new(AtomicBool::new(false)),
         };
 
         // CI hasn't reported (None) → the shared "Fetching PR status…" hint (it
@@ -1996,6 +2054,7 @@ mod tests {
             })))),
             local_content: Arc::new(Mutex::new(LocalContent::default())),
             notifier: PreviewNotifier::detached(),
+            morphed: Arc::new(AtomicBool::new(false)),
         };
 
         // In Pr mode, `render_preview` assembles the tab bar plus the worktree PR
@@ -2079,6 +2138,7 @@ mod tests {
             pr_status: Arc::clone(&slot),
             local_content: Arc::new(Mutex::new(LocalContent::default())),
             notifier: PreviewNotifier::detached(),
+            morphed: Arc::new(AtomicBool::new(false)),
         };
 
         // First render populates the shared cache.

--- a/src/commands/picker/items.rs
+++ b/src/commands/picker/items.rs
@@ -116,7 +116,7 @@ pub(super) struct RowShortcutData {
 /// in place — no reload, no cursor move — when a removal keeps the (unmerged)
 /// branch. The collector rewrites the row's display through these slots and
 /// flips [`morphed`](Self::morphed); the same `Arc`s back the live
-/// [`WorktreeSkimItem`], so skim repaints the one row on the next `Event::Render`.
+/// [`PickerRow`], so skim repaints the one row on the next `Event::Render`.
 ///
 /// Reached by the collector through the shared [`RowShortcutData`] table (the
 /// `downcast_ref` route is unreliable cross-thread), so every field is an `Arc`
@@ -132,7 +132,7 @@ pub(super) struct MorphHandle {
     /// Dimmed to `working_tree: Some(false)` on morph so the `working_tree`
     /// preview tab — there's no worktree left to diff — reads as empty.
     pub local_content: LocalContentSlot,
-    /// Shared with [`WorktreeSkimItem::output`]: once set, the row's selection
+    /// Shared with [`PickerRow::output`]: once set, the row's selection
     /// token is the bare branch name (a branch-only row) instead of the
     /// worktree path.
     pub morphed: Arc<AtomicBool>,

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -127,7 +127,7 @@ use super::hook_plan::{ApprovedHookPlan, HookPlanBuilder};
 use super::hooks::HookAnnouncer;
 use super::list::collect;
 use super::list::progressive::RenderTarget;
-use super::repository_ext::{RemoveTarget, RepositoryCliExt, compute_integration_reason};
+use super::repository_ext::{RemoveTarget, RepositoryCliExt};
 use super::worktree::{RemoveResult, SwitchPipeline};
 use crate::cli::SwitchFormat;
 use crate::output::{BackgroundFallbackMode, handle_remove_output};
@@ -259,6 +259,13 @@ struct PickerCollector {
     /// `worktree kept` warning here so the user learns the row that flickered
     /// back didn't actually go away. See [`restore_failed_removal`].
     stashed_warnings: Arc<Mutex<Vec<String>>>,
+    /// Branches whose worktree an `alt-x` removal removed while keeping the
+    /// (unmerged) branch. Shared (`Arc`) with [`PipelineFactory`]: the
+    /// background removal inserts the branch here and triggers a refresh, which
+    /// re-collects with these pinned into `collect`'s `pinned_branches` so the
+    /// row returns as a `/ branch` row (`+` worktree → `/` branch) instead of
+    /// vanishing. See [`PickerCollector::drop_and_remove_in_background`].
+    orphaned_branches: Arc<Mutex<std::collections::HashSet<String>>>,
 }
 
 impl PickerCollector {
@@ -405,12 +412,13 @@ impl PickerCollector {
     /// from showing a removal that didn't happen without ever resurrecting a row
     /// for a target that's actually gone.
     ///
-    /// When a worktree removal *succeeds* but leaves its unmerged branch behind
-    /// (`SafeDelete` won't delete unmerged work), the thread stashes the same
-    /// "retained; unmerged" message the branch-only keep path shows
-    /// ([`branch_retained_as_unmerged`] / [`stash_retained_unmerged_branch`]) —
-    /// the silent removal printed nothing, so this is the only place the user
-    /// learns the branch survived.
+    /// When a worktree removal *succeeds* but leaves its branch behind
+    /// (`SafeDelete` won't delete unmerged work), the thread pins the branch in
+    /// [`orphaned_branches`](PickerCollector::orphaned_branches) and sends a
+    /// `refresh` reload. The re-collect re-includes the now-worktree-less branch
+    /// (via `collect`'s `pinned_branches`), so the dropped row returns as a
+    /// `/ branch` row — the worktree is gone, the branch remains. This replaces
+    /// the silent removal's missing feedback with a live, accurate row.
     fn drop_and_remove_in_background(
         &mut self,
         selected_output: String,
@@ -461,6 +469,7 @@ impl PickerCollector {
         let items = Arc::clone(&self.items);
         let render_tx = Arc::clone(&self.render_tx);
         let stashed_warnings = Arc::clone(&self.stashed_warnings);
+        let orphaned_branches = Arc::clone(&self.orphaned_branches);
         let _ = std::thread::Builder::new()
             .name(format!("picker-remove-{selected_output}"))
             .spawn(move || {
@@ -481,16 +490,20 @@ impl PickerCollector {
                     }
                 } else if let RemoveResult::RemovedWorktree {
                     branch_name: Some(branch),
-                    target_branch,
                     ..
                 } = &result
-                    && branch_retained_as_unmerged(&repo, branch, target_branch.as_deref())
+                    && repo.branch(branch).exists_locally().unwrap_or(false)
                 {
-                    // The worktree is gone but its unmerged branch was kept (data
-                    // safety), and the silent removal couldn't say so. Stash the
-                    // same "retained; unmerged" pair the branch-only keep path
-                    // shows, drained once the picker exits.
-                    stash_retained_unmerged_branch(&stashed_warnings, branch);
+                    // The worktree is gone but its branch survived the removal
+                    // (`SafeDelete` keeps unmerged work). Pin the branch and
+                    // refresh so the dropped row returns as a `/ branch` row —
+                    // the worktree was removed, the branch remains. An integrated
+                    // branch `do_removal` already deleted fails `exists_locally`
+                    // here, so its row stays gone.
+                    orphaned_branches.lock().unwrap().insert(branch.clone());
+                    if let Some(event_tx) = render_tx.get() {
+                        let _ = event_tx.try_send(Event::Reload("refresh".to_string()));
+                    }
                 }
             });
 
@@ -763,12 +776,13 @@ fn removal_target_still_present(repo: &Repository, result: &RemoveResult) -> boo
 }
 
 /// Stash the canonical "retained; unmerged" info + hint pair (deduped), drained
-/// to stderr once the picker releases the terminal. Shared by
-/// [`PickerCollector::keep_unremovable_row`] (a branch-only row kept in place)
-/// and the background worktree removal (worktree removed, its unmerged branch
-/// kept) so the picker says the same thing however a branch came to be retained.
-/// The pair is the one `wt remove` itself prints — see
-/// [`crate::output::retained_unmerged_branch_messages`].
+/// to stderr once the picker releases the terminal. Used by
+/// [`PickerCollector::keep_unremovable_row`] — a branch-only row whose unmerged
+/// branch `SafeDelete` declines to delete stays put, and this explains the
+/// no-op. (A worktree removal that keeps its branch instead transforms the row
+/// to `/ branch` live — see [`PickerCollector::drop_and_remove_in_background`] —
+/// so it needs no stashed message.) The pair is the one `wt remove` itself
+/// prints — see [`crate::output::retained_unmerged_branch_messages`].
 fn stash_retained_unmerged_branch(stashed: &Mutex<Vec<String>>, branch_name: &str) {
     let (info, hint) = crate::output::retained_unmerged_branch_messages(branch_name);
     let mut stashed = stashed.lock().unwrap();
@@ -776,45 +790,6 @@ fn stash_retained_unmerged_branch(stashed: &Mutex<Vec<String>>, branch_name: &st
         stashed.push(info);
         stashed.push(hint);
     }
-}
-
-/// Whether a just-removed worktree left its branch behind because it's unmerged.
-///
-/// The picker removes with `SafeDelete`: an integrated branch is deleted along
-/// with its worktree, but an unmerged one is kept (data safety). The worktree is
-/// gone either way, so the row drops regardless — this decides whether to tell
-/// the user the *branch* survived, which the silent removal couldn't (skim owned
-/// the terminal). It observes the branch directly after the removal (still
-/// present, and no integration reason against its target) rather than trusting
-/// `do_removal`'s `Result`, the same way [`removal_target_still_present`] does.
-/// An integrated branch whose `git branch -d` failed still has an integration
-/// reason, so it's excluded — that's a delete error, not an unmerged retain.
-///
-/// The integration target defaults to `HEAD` when none is configured, mirroring
-/// the silent removal's own `delete_branch_if_safe(..., target.unwrap_or("HEAD"))`
-/// fallback — otherwise `compute_integration_reason` short-circuits to "no reason"
-/// for a `None` target and the check never runs, so every surviving branch would
-/// read as unmerged.
-fn branch_retained_as_unmerged(
-    repo: &Repository,
-    branch_name: &str,
-    target_branch: Option<&str>,
-) -> bool {
-    if !repo.branch(branch_name).exists_locally().unwrap_or(false) {
-        return false;
-    }
-    let Ok(snapshot) = repo.capture_refs() else {
-        return false;
-    };
-    compute_integration_reason(
-        repo,
-        &snapshot,
-        Some(branch_name),
-        Some(target_branch.unwrap_or("HEAD")),
-        BranchDeletionMode::SafeDelete,
-    )
-    .0
-    .is_none()
 }
 
 /// Put a row back after its background removal didn't happen, closing the alt-x
@@ -892,7 +867,7 @@ impl CommandCollector for PickerCollector {
         // are kept alive by those threads, so let them drop here. On a spawn
         // failure we fall through and re-stream the current items unchanged.
         if cmd.trim() == "refresh" {
-            match self.factory.spawn() {
+            match self.factory.spawn(true) {
                 Ok(SpawnedPipeline { rx, .. }) => {
                     let (tx_interrupt, _rx_interrupt) = bounded(1);
                     return (rx, tx_interrupt);
@@ -1007,6 +982,13 @@ struct PipelineFactory {
     preview_cache: PreviewCache,
     orchestrator: Arc<PreviewOrchestrator>,
     stashed_warnings: Arc<Mutex<Vec<String>>>,
+    /// Branches orphaned by an `alt-x` worktree removal that kept the (unmerged)
+    /// branch. Shared (`Arc`) with [`PickerCollector`], which inserts into it on
+    /// such a removal and triggers a refresh; [`spawn`](Self::spawn) reads it
+    /// into `collect`'s `pinned_branches` so the row returns as a `/ branch` row
+    /// instead of vanishing. Persists for the session, so it survives later
+    /// refreshes too.
+    orphaned_branches: Arc<Mutex<std::collections::HashSet<String>>>,
     grid_slot: Arc<prs::GridSlot>,
     preview_dims: (usize, usize),
     skim_list_width: usize,
@@ -1037,8 +1019,27 @@ impl PipelineFactory {
     /// once the spawned threads finish the channel closes and skim's reader sees
     /// EOF — the "background work done → picker idle" contract, which a refresh
     /// relies on to end its `reload`.
-    fn spawn(&self) -> anyhow::Result<SpawnedPipeline> {
+    ///
+    /// `fresh` controls the `Repository` the collect reads from. The initial
+    /// spawn passes `false` to reuse the prewarmed `self.repo` (its
+    /// `list_worktrees` / config caches are already warm, so the skeleton paints
+    /// fast). A refresh passes `true` to build a fresh `Repository::at(...)`:
+    /// `RepoCache` never invalidates (see the repository module's `# Caching`
+    /// spec — a post-mutation probe needs a fresh handle), so reusing `self.repo`
+    /// after an `alt-x` removal would re-collect a stale worktree list — the
+    /// removed worktree's branch would still read as "has a worktree" and never
+    /// surface as the `/ branch` row the pin intends. A fresh handle also lets a
+    /// refresh pick up worktrees added or removed outside the session.
+    fn spawn(&self, fresh: bool) -> anyhow::Result<SpawnedPipeline> {
         let (tx, rx): (SkimItemSender, SkimItemReceiver) = unbounded();
+
+        // The repo the collect (and `--prs`) thread reads from. Fresh on a
+        // refresh so post-removal worktree state is current (see the doc above).
+        let collect_repo = if fresh {
+            Repository::at(self.repo.discovery_path())?
+        } else {
+            self.repo.clone()
+        };
 
         // Fresh per spawn: the header shows a "loading…" marker keyed to this
         // flag while the forge call is in flight.
@@ -1068,10 +1069,15 @@ impl PipelineFactory {
             });
 
         let bg_handler: Arc<dyn collect::PickerProgressHandler> = handler.clone();
-        let bg_repo = self.repo.clone();
+        let bg_repo = collect_repo.clone();
         let bg_skip_tasks = self.skip_tasks.clone();
         let show_branches = self.show_branches;
         let show_remotes = self.show_remotes;
+        // Snapshot the branches orphaned by `alt-x` removals so this collect
+        // re-includes them as `/ branch` rows even with `show_branches` off
+        // (see `orphaned_branches`). Cloned per spawn: a later removal mutates
+        // the shared set and triggers another refresh.
+        let pinned_branches = self.orphaned_branches.lock().unwrap().clone();
         let command_timeout = self.command_timeout;
         let skim_list_width = self.skim_list_width;
         let collect_handle = std::thread::Builder::new()
@@ -1082,6 +1088,7 @@ impl PipelineFactory {
                     collect::ShowConfig::Resolved {
                         show_branches,
                         show_remotes,
+                        pinned_branches,
                         skip_tasks: bg_skip_tasks,
                         command_timeout,
                         collect_deadline: None,
@@ -1100,7 +1107,7 @@ impl PipelineFactory {
         // PR rows stream in (~1s) when the call returns.
         let prs_handle = if let Some(prs_loading) = prs_loading {
             let prs_tx = tx.clone();
-            let prs_repo = self.repo.clone();
+            let prs_repo = collect_repo.clone();
             let prs_warnings = Arc::clone(&self.stashed_warnings);
             let prs_orchestrator = Arc::clone(&self.orchestrator);
             let prs_render_tx = Arc::clone(&self.render_tx);
@@ -1371,6 +1378,13 @@ pub fn handle_picker(
     // again).
     let stashed_warnings: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
 
+    // Branches an alt-x removal orphaned (worktree gone, branch kept). Shared
+    // between the collector (which inserts on such a removal and refreshes) and
+    // the factory (which re-includes them on every collect). See
+    // `PickerCollector::orphaned_branches`.
+    let orphaned_branches: Arc<Mutex<std::collections::HashSet<String>>> =
+        Arc::new(Mutex::new(std::collections::HashSet::new()));
+
     // The collect pipeline, captured so the initial spawn below and every alt-r
     // refresh build it the same way. See `PipelineFactory`.
     let factory = Rc::new(PipelineFactory {
@@ -1381,6 +1395,7 @@ pub fn handle_picker(
         preview_cache: Arc::clone(&preview_cache),
         orchestrator: Arc::clone(&orchestrator),
         stashed_warnings: Arc::clone(&stashed_warnings),
+        orphaned_branches: Arc::clone(&orphaned_branches),
         // Column-geometry handoff: the collect thread fills it at skeleton time,
         // the `--prs` thread reads it to align PR rows with the worktree rows.
         grid_slot: Arc::new(prs::GridSlot::new()),
@@ -1403,6 +1418,7 @@ pub fn handle_picker(
         render_tx: Arc::clone(&render_tx),
         factory: Rc::clone(&factory),
         stashed_warnings: Arc::clone(&stashed_warnings),
+        orphaned_branches: Arc::clone(&orphaned_branches),
     };
 
     // Half-page preview scroll: half of skim's usable height.
@@ -1562,13 +1578,15 @@ pub fn handle_picker(
     // Spawn the collect pipeline (and the `--prs` thread when active). The
     // handler holds the only non-thread `tx` clone; when the bg threads exit,
     // `tx` drops, skim's reader sees EOF, and the picker goes idle. Every alt-r
-    // refresh re-runs this same `factory.spawn()` — see `PipelineFactory`.
+    // refresh re-runs this same `factory.spawn()` — see `PipelineFactory`. The
+    // initial spawn passes `fresh = false` to reuse the prewarmed repo caches;
+    // refreshes pass `true` for a fresh worktree view.
     let SpawnedPipeline {
         rx,
         handler,
         collect_handle,
         prs_handle,
-    } = factory.spawn()?;
+    } = factory.spawn(false)?;
     worktrunk::trace::instant("Picker collect spawned");
 
     // The dry run keeps the handler: skim never runs there, so the EOF contract
@@ -2479,6 +2497,7 @@ pub mod tests {
             preview_cache,
             orchestrator,
             stashed_warnings: Arc::new(Mutex::new(Vec::new())),
+            orphaned_branches: Arc::new(Mutex::new(std::collections::HashSet::new())),
             grid_slot: Arc::new(super::prs::GridSlot::new()),
             preview_dims: (80, 24),
             skim_list_width: 80,
@@ -2502,6 +2521,7 @@ pub mod tests {
     ) -> PickerCollector {
         let factory = test_factory(repo.clone());
         let stashed_warnings = Arc::clone(&factory.stashed_warnings);
+        let orphaned_branches = Arc::clone(&factory.orphaned_branches);
         PickerCollector {
             items,
             repo,
@@ -2509,6 +2529,7 @@ pub mod tests {
             render_tx: Arc::new(OnceLock::new()),
             factory,
             stashed_warnings,
+            orphaned_branches,
         }
     }
 
@@ -2824,6 +2845,7 @@ pub mod tests {
             approvals: Arc::new(approvals),
             render_tx: Arc::new(OnceLock::new()),
             stashed_warnings: Arc::clone(&stashed),
+            orphaned_branches: Arc::new(Mutex::new(std::collections::HashSet::new())),
         };
 
         let cmd = format!("remove '{token}'");
@@ -2861,9 +2883,9 @@ pub mod tests {
 
     /// End-to-end through `invoke`: removing a worktree whose branch is unmerged
     /// removes the worktree (the row drops) but keeps the branch — `SafeDelete`
-    /// won't delete unmerged work. The silent removal can't print, so the
-    /// background thread stashes the same "retained; unmerged" info + hint the
-    /// branch-only keep path shows, drained once the picker exits.
+    /// won't delete unmerged work. The background thread pins the surviving
+    /// branch in `orphaned_branches` and fires a refresh, so the next collect
+    /// re-includes it as a `/ branch` row instead of letting it vanish.
     #[test]
     fn test_invoke_removes_worktree_and_keeps_unmerged_branch() {
         let test = worktrunk::testing::TestRepo::with_initial_commit();
@@ -2905,36 +2927,23 @@ pub mod tests {
         let item = branched_picker_item("feature", &reported_path);
         let token = item.output().to_string();
         let items = Arc::new(Mutex::new(vec![Arc::clone(&item)]));
-        let stashed: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-        let mut collector = PickerCollector {
-            items: Arc::clone(&items),
-            repo: repo.clone(),
-            approvals: Arc::new(Approvals::default()),
-            render_tx: Arc::new(OnceLock::new()),
-            factory: test_factory(repo.clone()),
-            stashed_warnings: Arc::clone(&stashed),
-        };
+        let mut collector = test_collector(Arc::clone(&items), repo.clone());
+        let orphaned = Arc::clone(&collector.orphaned_branches);
 
         let cmd = format!("remove '{token}'");
         let (_rx, _interrupt) = collector.invoke(&cmd, Arc::new(AtomicUsize::new(0)));
 
-        // The worktree removal runs on a background thread that stashes the
-        // "retained; unmerged" pair on success — poll on the stash as the sync
-        // point (the same pattern as the failed-removal test).
+        // The worktree removal runs on a background thread that pins the
+        // surviving branch on success — poll on the pin as the sync point (the
+        // same pattern the failed-removal test uses for its stash).
         let deadline = Instant::now() + Duration::from_secs(5);
-        while stashed.lock().unwrap().is_empty() && Instant::now() < deadline {
+        while orphaned.lock().unwrap().is_empty() && Instant::now() < deadline {
             std::thread::sleep(Duration::from_millis(20));
         }
-        let warnings = stashed.lock().unwrap().clone();
         assert!(
-            warnings
-                .iter()
-                .any(|w| w.contains("unmerged") && w.contains("retained")),
-            "a removed worktree with an unmerged branch stashes a `retained` info line: {warnings:?}"
-        );
-        assert!(
-            warnings.iter().any(|w| w.contains("wt remove -D feature")),
-            "the stash includes the actionable `-D` hint: {warnings:?}"
+            orphaned.lock().unwrap().contains("feature"),
+            "the surviving branch is pinned so a refresh re-includes it as a `/ branch` row: {:?}",
+            orphaned.lock().unwrap()
         );
 
         assert!(!reported_path.exists(), "the worktree is removed");
@@ -2947,11 +2956,11 @@ pub mod tests {
 
     /// The negative of the above, end-to-end through `invoke`: removing a worktree
     /// whose branch is *integrated* deletes both the worktree and the branch, so
-    /// the `branch_retained_as_unmerged` guard must keep the keep-message path from
-    /// firing — nothing is stashed. Guards against a regression that drops the
-    /// guard and stashes a spurious "retained; unmerged" notice for every removal.
+    /// the `exists_locally` check finds no survivor and pins nothing — the row
+    /// stays gone instead of reappearing as a `/ branch` row. Guards against a
+    /// regression that pins (and resurrects) every removed branch.
     #[test]
-    fn test_invoke_removes_integrated_worktree_stashes_nothing() {
+    fn test_invoke_removes_integrated_worktree_pins_nothing() {
         let test = worktrunk::testing::TestRepo::with_initial_commit();
         let repo = worktrunk::git::Repository::at(test.path()).unwrap();
         let wt_dir = tempfile::tempdir().unwrap();
@@ -2977,23 +2986,16 @@ pub mod tests {
         let item = branched_picker_item("feature", &reported_path);
         let token = item.output().to_string();
         let items = Arc::new(Mutex::new(vec![Arc::clone(&item)]));
-        let stashed: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
-        let mut collector = PickerCollector {
-            items: Arc::clone(&items),
-            repo: repo.clone(),
-            approvals: Arc::new(Approvals::default()),
-            render_tx: Arc::new(OnceLock::new()),
-            factory: test_factory(repo.clone()),
-            stashed_warnings: Arc::clone(&stashed),
-        };
+        let mut collector = test_collector(Arc::clone(&items), repo.clone());
+        let orphaned = Arc::clone(&collector.orphaned_branches);
 
         let cmd = format!("remove '{token}'");
         let (_rx, _interrupt) = collector.invoke(&cmd, Arc::new(AtomicUsize::new(0)));
 
         // Sync on the branch being gone: that proves `do_removal` ran its branch
-        // delete, after which the thread runs the (no-op) retained-branch guard
-        // and exits. The grace window covers that guard — it can only stash if the
-        // guard regressed, so an empty stash after it is the real assertion.
+        // delete, after which the thread runs the (no-op) `exists_locally` check
+        // and exits. The grace window covers that check — it can only pin if the
+        // check regressed, so an empty pin set after it is the real assertion.
         let deadline = Instant::now() + Duration::from_secs(5);
         while !repo
             .run_command(&["branch", "--list", "feature"])
@@ -3006,9 +3008,9 @@ pub mod tests {
         assert!(!reported_path.exists(), "the worktree is removed");
         std::thread::sleep(Duration::from_millis(300));
         assert!(
-            stashed.lock().unwrap().is_empty(),
-            "an integrated worktree removal stashes no retained-branch message: {:?}",
-            stashed.lock().unwrap()
+            orphaned.lock().unwrap().is_empty(),
+            "an integrated worktree removal pins no branch (the row stays gone): {:?}",
+            orphaned.lock().unwrap()
         );
     }
 
@@ -3058,56 +3060,6 @@ pub mod tests {
             integration_reason: None,
         };
         assert!(!super::removal_target_still_present(&repo, &gone_branch));
-    }
-
-    /// `branch_retained_as_unmerged` observes the post-removal branch directly: an
-    /// integrated branch (same commit as the target) reads as deletable, not
-    /// retained; an unmerged branch (a commit the target lacks) reads as a
-    /// data-safety retain; a branch that's already gone reads as nothing to
-    /// surface.
-    #[test]
-    fn test_branch_retained_as_unmerged() {
-        let test = worktrunk::testing::TestRepo::with_initial_commit();
-        let repo = worktrunk::git::Repository::at(test.path()).unwrap();
-
-        // Integrated: a branch at main's commit — SafeDelete would delete it, so
-        // it isn't a retained-unmerged branch.
-        repo.run_command(&["branch", "integrated"]).unwrap();
-        assert!(!super::branch_retained_as_unmerged(
-            &repo,
-            "integrated",
-            Some("main")
-        ));
-
-        // Unmerged: a commit main doesn't have — SafeDelete keeps it.
-        repo.run_command(&["checkout", "-b", "unmerged"]).unwrap();
-        fs::write(test.path().join("new.txt"), "unmerged work").unwrap();
-        repo.run_command(&["add", "."]).unwrap();
-        repo.run_command(&["commit", "-m", "unmerged work"])
-            .unwrap();
-        repo.run_command(&["checkout", "main"]).unwrap();
-        assert!(super::branch_retained_as_unmerged(
-            &repo,
-            "unmerged",
-            Some("main")
-        ));
-
-        // A branch that no longer exists — nothing to surface.
-        assert!(!super::branch_retained_as_unmerged(
-            &repo,
-            "no-such-branch",
-            Some("main")
-        ));
-
-        // With no configured target the check falls back to HEAD (here `main`),
-        // matching the silent removal's own fallback — so it still distinguishes
-        // integrated from unmerged rather than reporting every survivor unmerged.
-        assert!(!super::branch_retained_as_unmerged(
-            &repo,
-            "integrated",
-            None
-        ));
-        assert!(super::branch_retained_as_unmerged(&repo, "unmerged", None));
     }
 
     /// `removal_will_remove_target` predicts removal from the prepared result
@@ -3199,6 +3151,7 @@ pub mod tests {
             approvals: Arc::new(Approvals::default()),
             render_tx: Arc::new(OnceLock::new()),
             stashed_warnings: Arc::clone(&stashed),
+            orphaned_branches: Arc::new(Mutex::new(std::collections::HashSet::new())),
         };
 
         let cmd = format!("remove '{token}'");

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -126,7 +126,7 @@ use super::hook_plan::{ApprovedHookPlan, HookPlanBuilder};
 use super::hooks::HookAnnouncer;
 use super::list::collect;
 use super::list::progressive::RenderTarget;
-use super::repository_ext::{RemoveTarget, RepositoryCliExt};
+use super::repository_ext::{RemoveTarget, RepositoryCliExt, compute_integration_reason};
 use super::worktree::{RemoveResult, SwitchPipeline};
 use crate::cli::SwitchFormat;
 use crate::output::{BackgroundFallbackMode, handle_remove_output};
@@ -396,6 +396,13 @@ impl PickerCollector {
     /// integrated→unmerged race leaves the branch in place. This keeps the list
     /// from showing a removal that didn't happen without ever resurrecting a row
     /// for a target that's actually gone.
+    ///
+    /// When a worktree removal *succeeds* but leaves its unmerged branch behind
+    /// (`SafeDelete` won't delete unmerged work), the thread stashes the same
+    /// "retained; unmerged" message the branch-only keep path shows
+    /// ([`branch_retained_as_unmerged`] / [`stash_retained_unmerged_branch`]) —
+    /// the silent removal printed nothing, so this is the only place the user
+    /// learns the branch survived.
     fn drop_and_remove_in_background(
         &mut self,
         selected_output: String,
@@ -452,18 +459,30 @@ impl PickerCollector {
                 if let Err(e) = Self::do_removal(&repo, &result, &approvals) {
                     log::warn!("picker: removal of '{selected_output}' errored: {e:#}");
                 }
-                if removal_target_still_present(&repo, &result)
-                    && let Some((item, pos)) = removed
+                if removal_target_still_present(&repo, &result) {
+                    if let Some((item, pos)) = removed {
+                        restore_failed_removal(
+                            &items,
+                            &render_tx,
+                            &stashed_warnings,
+                            item,
+                            pos,
+                            &removal_label,
+                            removal_noun,
+                        );
+                    }
+                } else if let RemoveResult::RemovedWorktree {
+                    branch_name: Some(branch),
+                    target_branch,
+                    ..
+                } = &result
+                    && branch_retained_as_unmerged(&repo, branch, target_branch.as_deref())
                 {
-                    restore_failed_removal(
-                        &items,
-                        &render_tx,
-                        &stashed_warnings,
-                        item,
-                        pos,
-                        &removal_label,
-                        removal_noun,
-                    );
+                    // The worktree is gone but its unmerged branch was kept (data
+                    // safety), and the silent removal couldn't say so. Stash the
+                    // same "retained; unmerged" pair the branch-only keep path
+                    // shows, drained once the picker exits.
+                    stash_retained_unmerged_branch(&stashed_warnings, branch);
                 }
             });
 
@@ -493,19 +512,11 @@ impl PickerCollector {
     fn keep_unremovable_row(&self, selected_output: &str, branch_name: &str) {
         // The canonical "retained; unmerged" info + hint `wt remove` prints,
         // shared so the picker copy can't drift (see
-        // `retained_unmerged_branch_messages`). Taking the branch name (not the
-        // whole `RemoveResult`) makes it unrepresentable for this keep path to be
-        // handed a `RemovedWorktree`, which always removes — see the dispatch in
-        // `invoke` and [`removal_will_remove_target`].
-        let (info, hint) = crate::output::retained_unmerged_branch_messages(branch_name);
-        {
-            let mut stashed = self.stashed_warnings.lock().unwrap();
-            // Dedup on repeated alt-r of the same kept row.
-            if !stashed.contains(&info) {
-                stashed.push(info);
-                stashed.push(hint);
-            }
-        }
+        // `stash_retained_unmerged_branch`). Taking the branch name (not the whole
+        // `RemoveResult`) makes it unrepresentable for this keep path to be handed
+        // a `RemovedWorktree`, which always removes — see the dispatch in `invoke`
+        // and [`removal_will_remove_target`].
+        stash_retained_unmerged_branch(&self.stashed_warnings, branch_name);
 
         // The row never moved, so land the cursor back on it (alt-r's reload reset
         // it to the top).
@@ -741,6 +752,61 @@ fn removal_target_still_present(repo: &Repository, result: &RemoveResult) -> boo
             repo.branch(branch_name).exists_locally().unwrap_or(false)
         }
     }
+}
+
+/// Stash the canonical "retained; unmerged" info + hint pair (deduped), drained
+/// to stderr once the picker releases the terminal. Shared by
+/// [`PickerCollector::keep_unremovable_row`] (a branch-only row kept in place)
+/// and the background worktree removal (worktree removed, its unmerged branch
+/// kept) so the picker says the same thing however a branch came to be retained.
+/// The pair is the one `wt remove` itself prints — see
+/// [`crate::output::retained_unmerged_branch_messages`].
+fn stash_retained_unmerged_branch(stashed: &Mutex<Vec<String>>, branch_name: &str) {
+    let (info, hint) = crate::output::retained_unmerged_branch_messages(branch_name);
+    let mut stashed = stashed.lock().unwrap();
+    if !stashed.contains(&info) {
+        stashed.push(info);
+        stashed.push(hint);
+    }
+}
+
+/// Whether a just-removed worktree left its branch behind because it's unmerged.
+///
+/// The picker removes with `SafeDelete`: an integrated branch is deleted along
+/// with its worktree, but an unmerged one is kept (data safety). The worktree is
+/// gone either way, so the row drops regardless — this decides whether to tell
+/// the user the *branch* survived, which the silent removal couldn't (skim owned
+/// the terminal). It observes the branch directly after the removal (still
+/// present, and no integration reason against its target) rather than trusting
+/// `do_removal`'s `Result`, the same way [`removal_target_still_present`] does.
+/// An integrated branch whose `git branch -d` failed still has an integration
+/// reason, so it's excluded — that's a delete error, not an unmerged retain.
+///
+/// The integration target defaults to `HEAD` when none is configured, mirroring
+/// the silent removal's own `delete_branch_if_safe(..., target.unwrap_or("HEAD"))`
+/// fallback — otherwise `compute_integration_reason` short-circuits to "no reason"
+/// for a `None` target and the check never runs, so every surviving branch would
+/// read as unmerged.
+fn branch_retained_as_unmerged(
+    repo: &Repository,
+    branch_name: &str,
+    target_branch: Option<&str>,
+) -> bool {
+    if !repo.branch(branch_name).exists_locally().unwrap_or(false) {
+        return false;
+    }
+    let Ok(snapshot) = repo.capture_refs() else {
+        return false;
+    };
+    compute_integration_reason(
+        repo,
+        &snapshot,
+        Some(branch_name),
+        Some(target_branch.unwrap_or("HEAD")),
+        BranchDeletionMode::SafeDelete,
+    )
+    .0
+    .is_none()
 }
 
 /// Put a row back after its background removal didn't happen, closing the alt-r
@@ -2481,6 +2547,157 @@ pub mod tests {
         );
     }
 
+    /// End-to-end through `invoke`: removing a worktree whose branch is unmerged
+    /// removes the worktree (the row drops) but keeps the branch — `SafeDelete`
+    /// won't delete unmerged work. The silent removal can't print, so the
+    /// background thread stashes the same "retained; unmerged" info + hint the
+    /// branch-only keep path shows, drained once the picker exits.
+    #[test]
+    fn test_invoke_removes_worktree_and_keeps_unmerged_branch() {
+        let test = worktrunk::testing::TestRepo::with_initial_commit();
+        let repo = worktrunk::git::Repository::at(test.path()).unwrap();
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("feature");
+        repo.run_command(&[
+            "worktree",
+            "add",
+            "-b",
+            "feature",
+            wt_path.to_str().unwrap(),
+        ])
+        .unwrap();
+
+        // Make `feature` unmerged: a commit on it that main doesn't have, so
+        // SafeDelete retains the branch when the worktree is removed.
+        fs::write(wt_path.join("new.txt"), "unmerged work").unwrap();
+        worktrunk::shell_exec::Cmd::new("git")
+            .args(["add", "."])
+            .current_dir(&wt_path)
+            .run()
+            .unwrap();
+        worktrunk::shell_exec::Cmd::new("git")
+            .args(["commit", "-m", "unmerged work"])
+            .current_dir(&wt_path)
+            .run()
+            .unwrap();
+
+        // Build the row from the git-reported path (macOS resolves the
+        // `/var`→`/private/var` symlink, which `prepare_removal`'s lookup matches).
+        let reported_path = repo
+            .list_worktrees()
+            .unwrap()
+            .iter()
+            .find(|wt| wt.branch.as_deref() == Some("feature"))
+            .map(|wt| wt.path.clone())
+            .expect("feature worktree is listed");
+        let item = branched_picker_item("feature", &reported_path);
+        let token = item.output().to_string();
+        let items = Arc::new(Mutex::new(vec![Arc::clone(&item)]));
+        let stashed: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let mut collector = PickerCollector {
+            items: Arc::clone(&items),
+            repo: repo.clone(),
+            approvals: Arc::new(Approvals::default()),
+            render_tx: Arc::new(OnceLock::new()),
+            stashed_warnings: Arc::clone(&stashed),
+        };
+
+        let cmd = format!("remove '{token}'");
+        let (_rx, _interrupt) = collector.invoke(&cmd, Arc::new(AtomicUsize::new(0)));
+
+        // The worktree removal runs on a background thread that stashes the
+        // "retained; unmerged" pair on success — poll on the stash as the sync
+        // point (the same pattern as the failed-removal test).
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while stashed.lock().unwrap().is_empty() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        let warnings = stashed.lock().unwrap().clone();
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("unmerged") && w.contains("retained")),
+            "a removed worktree with an unmerged branch stashes a `retained` info line: {warnings:?}"
+        );
+        assert!(
+            warnings.iter().any(|w| w.contains("wt remove -D feature")),
+            "the stash includes the actionable `-D` hint: {warnings:?}"
+        );
+
+        assert!(!reported_path.exists(), "the worktree is removed");
+        let branch_list = repo.run_command(&["branch", "--list", "feature"]).unwrap();
+        assert!(
+            !branch_list.is_empty(),
+            "the unmerged branch is retained after its worktree is removed"
+        );
+    }
+
+    /// The negative of the above, end-to-end through `invoke`: removing a worktree
+    /// whose branch is *integrated* deletes both the worktree and the branch, so
+    /// the `branch_retained_as_unmerged` guard must keep the keep-message path from
+    /// firing — nothing is stashed. Guards against a regression that drops the
+    /// guard and stashes a spurious "retained; unmerged" notice for every removal.
+    #[test]
+    fn test_invoke_removes_integrated_worktree_stashes_nothing() {
+        let test = worktrunk::testing::TestRepo::with_initial_commit();
+        let repo = worktrunk::git::Repository::at(test.path()).unwrap();
+        let wt_dir = tempfile::tempdir().unwrap();
+        let wt_path = wt_dir.path().join("feature");
+        // No extra commit → `feature` sits at main's commit (integrated), so
+        // SafeDelete deletes the branch along with the worktree.
+        repo.run_command(&[
+            "worktree",
+            "add",
+            "-b",
+            "feature",
+            wt_path.to_str().unwrap(),
+        ])
+        .unwrap();
+
+        let reported_path = repo
+            .list_worktrees()
+            .unwrap()
+            .iter()
+            .find(|wt| wt.branch.as_deref() == Some("feature"))
+            .map(|wt| wt.path.clone())
+            .expect("feature worktree is listed");
+        let item = branched_picker_item("feature", &reported_path);
+        let token = item.output().to_string();
+        let items = Arc::new(Mutex::new(vec![Arc::clone(&item)]));
+        let stashed: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+        let mut collector = PickerCollector {
+            items: Arc::clone(&items),
+            repo: repo.clone(),
+            approvals: Arc::new(Approvals::default()),
+            render_tx: Arc::new(OnceLock::new()),
+            stashed_warnings: Arc::clone(&stashed),
+        };
+
+        let cmd = format!("remove '{token}'");
+        let (_rx, _interrupt) = collector.invoke(&cmd, Arc::new(AtomicUsize::new(0)));
+
+        // Sync on the branch being gone: that proves `do_removal` ran its branch
+        // delete, after which the thread runs the (no-op) retained-branch guard
+        // and exits. The grace window covers that guard — it can only stash if the
+        // guard regressed, so an empty stash after it is the real assertion.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while !repo
+            .run_command(&["branch", "--list", "feature"])
+            .unwrap()
+            .is_empty()
+            && Instant::now() < deadline
+        {
+            std::thread::sleep(Duration::from_millis(20));
+        }
+        assert!(!reported_path.exists(), "the worktree is removed");
+        std::thread::sleep(Duration::from_millis(300));
+        assert!(
+            stashed.lock().unwrap().is_empty(),
+            "an integrated worktree removal stashes no retained-branch message: {:?}",
+            stashed.lock().unwrap()
+        );
+    }
+
     /// `removal_target_still_present` observes reality: a worktree dir or a
     /// branch ref that's gone reads as removed; one still on disk / in the
     /// ref store reads as present (the restore trigger).
@@ -2527,6 +2744,56 @@ pub mod tests {
             integration_reason: None,
         };
         assert!(!super::removal_target_still_present(&repo, &gone_branch));
+    }
+
+    /// `branch_retained_as_unmerged` observes the post-removal branch directly: an
+    /// integrated branch (same commit as the target) reads as deletable, not
+    /// retained; an unmerged branch (a commit the target lacks) reads as a
+    /// data-safety retain; a branch that's already gone reads as nothing to
+    /// surface.
+    #[test]
+    fn test_branch_retained_as_unmerged() {
+        let test = worktrunk::testing::TestRepo::with_initial_commit();
+        let repo = worktrunk::git::Repository::at(test.path()).unwrap();
+
+        // Integrated: a branch at main's commit — SafeDelete would delete it, so
+        // it isn't a retained-unmerged branch.
+        repo.run_command(&["branch", "integrated"]).unwrap();
+        assert!(!super::branch_retained_as_unmerged(
+            &repo,
+            "integrated",
+            Some("main")
+        ));
+
+        // Unmerged: a commit main doesn't have — SafeDelete keeps it.
+        repo.run_command(&["checkout", "-b", "unmerged"]).unwrap();
+        fs::write(test.path().join("new.txt"), "unmerged work").unwrap();
+        repo.run_command(&["add", "."]).unwrap();
+        repo.run_command(&["commit", "-m", "unmerged work"])
+            .unwrap();
+        repo.run_command(&["checkout", "main"]).unwrap();
+        assert!(super::branch_retained_as_unmerged(
+            &repo,
+            "unmerged",
+            Some("main")
+        ));
+
+        // A branch that no longer exists — nothing to surface.
+        assert!(!super::branch_retained_as_unmerged(
+            &repo,
+            "no-such-branch",
+            Some("main")
+        ));
+
+        // With no configured target the check falls back to HEAD (here `main`),
+        // matching the silent removal's own fallback — so it still distinguishes
+        // integrated from unmerged rather than reporting every survivor unmerged.
+        assert!(!super::branch_retained_as_unmerged(
+            &repo,
+            "integrated",
+            None
+        ));
+        assert!(super::branch_retained_as_unmerged(&repo, "unmerged", None));
     }
 
     /// `removal_will_remove_target` predicts removal from the prepared result

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -274,6 +274,15 @@ struct PickerCollector {
     /// back (or un-morphed) didn't actually go away. See [`restore_failed_removal`]
     /// and [`revert_morph`].
     stashed_warnings: Arc<Mutex<Vec<String>>>,
+    /// The `output()` token of the row displayed just below the selected one,
+    /// captured by the `alt-x` keybinding *before* its `reload(remove {})` resets
+    /// the cursor to the top. A drop consumes it to land the cursor on the row
+    /// that slides up — by identity, since the removed row's `shared_items` index
+    /// doesn't map to skim's filtered/reordered `item_list` (an active query made
+    /// an index land +N rows off). `None` when the selected row was last (no
+    /// successor → land on the new last row). See the `alt-x` bind in `handle_picker`
+    /// and [`reposition_cursor_action`].
+    drop_landing: Arc<Mutex<Option<String>>>,
 }
 
 impl PickerCollector {
@@ -427,23 +436,25 @@ impl PickerCollector {
         result: RemoveResult,
     ) {
         // Capture the removed row (and its position) before dropping it: the
-        // position restores the cursor to that slot (the row that slides up) after
-        // the reload — see `reposition_cursor_action` — and the row itself is
-        // handed to the background thread so it can put the row back if the removal
-        // fails (see `restore_failed_removal`).
-        let (removed, reposition_target) = {
+        // position is handed to the background thread so it can put the row back
+        // at its slot if the removal fails (see `restore_failed_removal`). The
+        // cursor lands by identity on the row that slid up — its token was
+        // captured before the reload by the `alt-x` binding (see
+        // `reposition_cursor_action`), since the removed row's `shared_items`
+        // index doesn't map to skim's filtered/reordered `item_list`.
+        let removed = {
             let mut items = self.items.lock().unwrap();
             let removed = items
                 .iter()
                 .position(|item| item.output().as_ref() == selected_output)
                 .map(|pos| (Arc::clone(&items[pos]), pos));
             items.retain(|item| item.output().as_ref() != selected_output);
-            let remaining_data_rows = items.len().saturating_sub(PICKER_HEADER_ROWS);
-            let target = removed
-                .as_ref()
-                .and_then(|(_, pos)| sticky_reposition_target(*pos, remaining_data_rows));
-            (removed, target)
+            removed
         };
+        // The row displayed just below the removed one, captured before this
+        // reload reset the cursor (`None` if the removed row was last — land on
+        // the new last row).
+        let reposition_target = self.drop_landing.lock().unwrap().take();
 
         // A user-facing (label, noun) for the `kept` message, taken from the result
         // before it moves into the background thread.
@@ -478,14 +489,12 @@ impl PickerCollector {
                 }
             });
 
-        // Restore the cursor near the removed row. skim resets it to the top on
-        // every reload; inject a Custom action that moves it back to the removed
-        // row's slot once the reloaded rows land (`render_tx` is skim's event
-        // sender, set once the TUI is up — always present by the time a reload
-        // fires).
-        if let Some(target) = reposition_target {
-            send_reposition(&self.render_tx, target);
-        }
+        // Restore the cursor onto the row that slid into the removed row's slot.
+        // skim resets it to the top on every reload; inject a Custom action that
+        // lands it on the captured row once the reloaded rows land (`render_tx` is
+        // skim's event sender, set once the TUI is up — always present by the time
+        // a reload fires).
+        send_reposition(&self.render_tx, reposition_target);
     }
 
     /// Keep the selected row in place and explain why its target wasn't removed.
@@ -533,19 +542,9 @@ impl PickerCollector {
     /// [`keep_current_worktree_row`](Self::keep_current_worktree_row)) re-anchor it
     /// on the row's slot.
     fn reposition_to_kept_row(&self, selected_output: &str) {
-        let reposition_target = {
-            let items = self.items.lock().unwrap();
-            items
-                .iter()
-                .position(|item| item.output().as_ref() == selected_output)
-                .and_then(|pos| {
-                    let remaining = items.len().saturating_sub(PICKER_HEADER_ROWS);
-                    sticky_reposition_target(pos, remaining)
-                })
-        };
-        if let Some(target) = reposition_target {
-            send_reposition(&self.render_tx, target);
-        }
+        // The row stayed put, so land back on it by its own token — identity, not
+        // an index, so it's right under an active query too.
+        send_reposition(&self.render_tx, Some(selected_output.to_string()));
     }
 
     /// Morph the selected worktree row into a `/ branch` row in place, then remove
@@ -610,18 +609,10 @@ impl PickerCollector {
             return;
         };
 
-        // Find the row's slot before flipping its identity (its `output()` token
-        // changes on morph). The row stays put, so the cursor lands right back.
-        let reposition_target = {
-            let items = self.items.lock().unwrap();
-            items
-                .iter()
-                .position(|item| item.output().as_ref() == selected_output)
-                .and_then(|pos| {
-                    let remaining = items.len().saturating_sub(PICKER_HEADER_ROWS);
-                    sticky_reposition_target(pos, remaining)
-                })
-        };
+        // The row stays put but flips its identity: after the morph its `output()`
+        // is the branch token. Land the cursor back on it by that token (captured
+        // here, before `branch` moves into the background thread below).
+        let reposition_target = Some(branch.clone());
 
         // Snapshot the pre-morph display for the revert, then apply the morph.
         let original_rendered = slots.rendered.lock().unwrap().clone();
@@ -669,9 +660,7 @@ impl PickerCollector {
 
         // alt-x's reload reset the cursor to the top; land it back on the row,
         // which is still in its original slot (morphed, not removed).
-        if let Some(target) = reposition_target {
-            send_reposition(&self.render_tx, target);
-        }
+        send_reposition(&self.render_tx, reposition_target);
     }
 }
 
@@ -814,30 +803,24 @@ const REPOSITION_SETTLED_RENDERS: usize = 3;
 /// guards against an unforeseen state where the matcher never settles.
 const REPOSITION_MAX_ATTEMPTS: usize = 1000;
 
-/// The `item_list` row the cursor should land on after an alt-x removal, given
-/// the removed row's position in `shared_items` (header included) and how many
-/// data rows remain.
+/// A skim `Custom` action that lands the cursor on the row whose `output()`
+/// token is `landing` once the reloaded item list is populated — or on the last
+/// row when `landing` is `None` or names a row the reload dropped.
 ///
-/// The removed row sat at `removed_pos`; the row that slides up into its slot is
-/// the next one, which lands at the same `item_list` index once the header is
-/// subtracted. Returns `None` when there's nothing to land on (the list is now
-/// header-only) or the position was the header itself. The caller clamps to the
-/// list's last row via `scroll_by`, so a removed-last-row target just overshoots
-/// and snaps back to the new last row.
-fn sticky_reposition_target(removed_pos: usize, remaining_data_rows: usize) -> Option<usize> {
-    if remaining_data_rows == 0 {
-        return None;
-    }
-    removed_pos.checked_sub(PICKER_HEADER_ROWS)
-}
-
-/// A skim `Custom` action that moves the cursor to `target` once the reloaded
-/// item list is populated.
+/// skim has no "select this item" action and resets the cursor to the top on
+/// reload, so this drives the move through `ItemList`'s public cursor API with
+/// `&mut App` in hand. It lands by **identity**, not by absolute index: a fuzzy
+/// query reorders and shrinks `item_list` relative to `shared_items`, so an
+/// index computed from a row's `shared_items` position would point at the wrong
+/// row (or past the filtered list's end) — the +N-row jump removals showed under
+/// an active query. Walking to the token is correct whether or not a query is
+/// live. `landing` is captured *before* the reload: the drop hands the token of
+/// the row displayed just below the removed one (see the `alt-x` binding), the
+/// keep / morph / restore paths the token of the row that stays or returns.
 ///
-/// skim has no "set cursor to index N" action and resets the cursor to the top
-/// on reload, so this drives the move through `ItemList`'s public cursor API
-/// with `&mut App` in hand: `jump_to_first` + `scroll_by(target)` lands on
-/// `target`, clamped to the last row.
+/// `None` (a removed *last* row, with no successor to slide up) and a token the
+/// reload dropped (also removed, or filtered out by the live query) both land on
+/// the new last row — for a removed last row, the row that was above it.
 ///
 /// The reload repopulates `item_list` asynchronously — the reader refills
 /// `item_pool`, then the matcher filters it into `item_list` — so the first
@@ -849,11 +832,6 @@ fn sticky_reposition_target(removed_pos: usize, remaining_data_rows: usize) -> O
 /// on. Sleeping instead of re-arming would hold `&mut App` across the await and
 /// starve the render that loads the rows.
 ///
-/// `target` is an `item_list` index (data rows only — see [`PICKER_HEADER_ROWS`])
-/// from [`sticky_reposition_target`]. Under an active fuzzy query the displayed
-/// order diverges from `shared_items` order, so the landing row is approximate
-/// (a valid nearby row) rather than the exact next row.
-///
 /// On landing, it returns [`Event::RunPreview`] so the preview pane repaints for
 /// the row the cursor settled on. skim only repaints the preview on a
 /// selection-*change* event (`on_selection_changed`), and moving the cursor
@@ -861,18 +839,34 @@ fn sticky_reposition_target(removed_pos: usize, remaining_data_rows: usize) -> O
 /// showing the row skim last previewed (the current worktree, which the reload
 /// briefly reset the cursor to) until the next keystroke.
 fn reposition_cursor_action(
-    target: usize,
+    landing: Option<String>,
     attempts: Arc<AtomicUsize>,
     settled_streak: Arc<AtomicUsize>,
 ) -> Action {
     Action::Custom(ActionCallback::new_sync(
         move |app| -> Result<Vec<Event>, Box<dyn std::error::Error + Send + Sync>> {
-            // Rows are in: land the cursor on the removed row's slot, then
+            // Rows are in: land the cursor on the target row by identity, then
             // repaint the preview for it (the cursor move alone doesn't).
-            if app.item_list.count() > 0 {
-                app.item_list.jump_to_first();
-                app.item_list
-                    .scroll_by(i32::try_from(target).unwrap_or(i32::MAX));
+            let count = app.item_list.count();
+            if count > 0 {
+                let mut landed = false;
+                if let Some(token) = landing.as_deref() {
+                    app.item_list.jump_to_first();
+                    for _ in 0..count {
+                        if app
+                            .item_list
+                            .selected()
+                            .is_some_and(|m| m.item.output().as_ref() == token)
+                        {
+                            landed = true;
+                            break;
+                        }
+                        app.item_list.select_next();
+                    }
+                }
+                if !landed {
+                    app.item_list.jump_to_last();
+                }
                 return Ok(vec![Event::RunPreview]);
             }
             // No rows yet. The matcher has "settled" once it has stopped with the
@@ -896,7 +890,7 @@ fn reposition_cursor_action(
                 return Ok(Vec::new());
             }
             Ok(vec![Event::Action(reposition_cursor_action(
-                target,
+                landing.clone(),
                 Arc::clone(&attempts),
                 Arc::clone(&settled_streak),
             ))])
@@ -904,13 +898,14 @@ fn reposition_cursor_action(
     ))
 }
 
-/// Inject a cursor reposition onto `target` through skim's event sender, with
-/// fresh attempt/streak counters (see [`reposition_cursor_action`]). The single
-/// path every alt-x outcome uses to move the cursor after its reload — the drop
-/// (cursor onto the slide-up row), the keep (back onto the row), and the restore
-/// (back onto the re-inserted row). A no-op before `render_tx` is set or once the
-/// receiver is gone (teardown); the queued action is dropped if the channel is
-/// full.
+/// Inject a cursor reposition onto the row whose `output()` token is `landing`
+/// through skim's event sender, with fresh attempt/streak counters (see
+/// [`reposition_cursor_action`]). `None` lands on the last row. The single path
+/// every alt-x outcome uses to move the cursor after its reload — the drop
+/// (cursor onto the row that slid up, captured before the reload), the keep /
+/// morph (back onto the row, which stays), and the restore (onto the re-inserted
+/// row). A no-op before `render_tx` is set or once the receiver is gone
+/// (teardown); the queued action is dropped if the channel is full.
 ///
 /// Rapid alt-r (or a background restore overtaking the optimistic drop) can leave
 /// more than one chain in flight. Each carries its own counters and self-terminates
@@ -919,10 +914,13 @@ fn reposition_cursor_action(
 /// render. Bounding this to only the newest reposition would take a generation
 /// token threaded through every chain (and every `PickerCollector` construction
 /// site); the self-correcting transient isn't worth that cross-chain state.
-fn send_reposition(render_tx: &OnceLock<tokio::sync::mpsc::Sender<Event>>, target: usize) {
+fn send_reposition(
+    render_tx: &OnceLock<tokio::sync::mpsc::Sender<Event>>,
+    landing: Option<String>,
+) {
     if let Some(event_tx) = render_tx.get() {
         let _ = event_tx.try_send(Event::Action(reposition_cursor_action(
-            target,
+            landing,
             Arc::new(AtomicUsize::new(0)),
             Arc::new(AtomicUsize::new(0)),
         )));
@@ -1135,8 +1133,9 @@ fn restore_failed_removal(
         // Another removal may have shrunk the list since the drop; clamp.
         let insert_at = removed_pos.min(items.len());
         items.insert(insert_at, removed_item);
-        let remaining_data_rows = items.len().saturating_sub(PICKER_HEADER_ROWS);
-        sticky_reposition_target(insert_at, remaining_data_rows)
+        // Land the cursor back on the restored row by its token — identity, not a
+        // `shared_items` index, so it's right even with a query reordering the list.
+        Some(token)
     };
 
     stashed_warnings.lock().unwrap().push(
@@ -1151,9 +1150,7 @@ fn restore_failed_removal(
     };
     // Re-stream the restored list, then land the cursor back on the row.
     let _ = event_tx.try_send(Event::Reload("restore".to_string()));
-    if let Some(target) = reposition_target {
-        send_reposition(render_tx, target);
-    }
+    send_reposition(render_tx, reposition_target);
 }
 
 impl CommandCollector for PickerCollector {
@@ -1754,6 +1751,11 @@ pub fn handle_picker(
         is_preview_bench,
     });
 
+    // Carries the drop's landing-row token from the `alt-x` keybinding (which sees
+    // skim's `App`, pre-reload) to the collector's `invoke` (reader thread,
+    // post-reload). See the `drop_landing` field and the `alt-x` bind below.
+    let drop_landing: Arc<Mutex<Option<String>>> = Arc::new(Mutex::new(None));
+
     let collector = PickerCollector {
         items: Arc::clone(&shared_items),
         repo: repo.clone(),
@@ -1761,6 +1763,7 @@ pub fn handle_picker(
         render_tx: Arc::clone(&render_tx),
         factory: Rc::clone(&factory),
         stashed_warnings: Arc::clone(&stashed_warnings),
+        drop_landing: Arc::clone(&drop_landing),
     };
 
     // Half-page preview scroll: half of skim's usable height.
@@ -1828,8 +1831,7 @@ pub fn handle_picker(
         // (or `--prs`) list scrolls with no position cue, made worse by
         // `no_info(true)` below hiding the matched/total counter.
         .scrollbar("▐".to_string())
-        // First line (header) non-selectable. `PICKER_HEADER_ROWS` mirrors this
-        // count so the alt-x cursor-reposition math stays in sync — keep them one.
+        // First line (header) non-selectable; `PICKER_HEADER_ROWS` names the count.
         .header_lines(PICKER_HEADER_ROWS)
         .multi(false)
         // The table is laid out at full terminal width (see `skim_list_width`
@@ -1870,18 +1872,10 @@ pub fn handle_picker(
             //
             // Create new worktree with query as branch name (alt-c for "create")
             "alt-c:accept(create)".to_string(),
-            // Remove selected worktree: `reload(remove {})` hands the selected
-            // row's output() token to PickerCollector, which performs the removal
-            // and streams updated items back — all without leaving the picker.
-            // Passing the token through the reload cmd (not an execute-silent +
-            // file write) sidesteps skim 4.x's fire-and-forget execute-silent,
-            // which raced the reader and removed nothing. The collector also
-            // re-positions the cursor onto the removed row's slot afterward —
-            // reload otherwise snaps it back to the top (see PickerCollector).
-            // alt-x for "remove" — alt-r is the refresh key (below), and putting
-            // the destructive action on a less-reflexive key guards against a
-            // mis-hit, the safe direction being a stray refresh.
-            "alt-x:reload(remove {})".to_string(),
+            // alt-x (remove) is installed natively below via
+            // `install_remove_keybinding` — it pairs a Custom callback (capture the
+            // landing row off skim's `App` before the reload resets the cursor)
+            // with `reload(remove {})`, which a string bind can't express.
             // Refresh the list (alt-r for "refresh"): `reload(refresh)` re-runs
             // collect through PickerCollector, picking up worktrees/branches
             // created outside the session (a teammate's push, a parallel agent)
@@ -1915,6 +1909,10 @@ pub fn handle_picker(
     // that read the selected row off skim's `App` and run the OS action on a
     // background thread. Like the preview-tab keys, they can't be string binds.
     install_shortcut_keybindings(&mut options.keymap, Arc::clone(&shortcut_table));
+    // alt-x (remove): a Custom callback that captures the would-be landing row
+    // off skim's `App`, then `reload(remove {})` — the same removal path as a
+    // string bind, fronted by the pre-reload capture a string bind can't run.
+    install_remove_keybinding(&mut options.keymap, Arc::clone(&drop_landing));
     worktrunk::trace::instant("Picker skim options built");
 
     // Spawn the collect pipeline (and the `--prs` thread when active). The
@@ -2185,6 +2183,60 @@ fn install_shortcut_keybindings(keymap: &mut skim::binds::KeyMap, shortcut_table
             }))],
         );
     }
+}
+
+/// Install `alt-x` (remove the selected row) as a native binding: a Custom
+/// callback that captures the drop's landing row, paired with `reload(remove {})`.
+///
+/// The capture has to run *before* the reload, which resets the cursor to the top.
+/// A drop's reposition needs to know which row should take the removed row's slot
+/// — the row displayed just below it — and only the live `App` knows skim's
+/// displayed order (a fuzzy query reorders and shrinks `item_list` relative to
+/// `shared_items`, so a `shared_items` index lands +N rows off). The callback
+/// peeks that neighbor, stashes its `output()` token in `drop_landing`, and the
+/// collector's drop path lands the cursor on it by identity. `None` means the
+/// selected row was last (no successor → land on the new last row).
+///
+/// skim runs a key's bound actions in order, so the callback restores the cursor
+/// to the selected row before `reload(remove {})` expands `{}` against it — the
+/// same removal the old string bind ran, fronted by a capture a string bind can't
+/// express (like the preview-tab and row shortcuts, hence a native keymap insert).
+fn install_remove_keybinding(
+    keymap: &mut skim::binds::KeyMap,
+    drop_landing: Arc<Mutex<Option<String>>>,
+) {
+    use skim::binds::parse_key;
+    let Ok(key) = parse_key("alt-x") else {
+        return;
+    };
+    let capture = Action::Custom(ActionCallback::new_sync(move |app| {
+        // Peek the row just below the selected one by stepping the cursor down and
+        // back. A clamp (the cursor doesn't move, so the peeked token equals the
+        // selected one) means the selected row is last — no successor, `None`. Any
+        // real move is restored so the paired `reload(remove {})` still expands
+        // `{}` against the selected row.
+        let landing = app.item_list.selected().and_then(|selected| {
+            let selected_token = selected.item.output().into_owned();
+            app.item_list.select_next();
+            let below = app
+                .item_list
+                .selected()
+                .map(|m| m.item.output().into_owned());
+            match below {
+                Some(token) if token != selected_token => {
+                    app.item_list.select_previous();
+                    Some(token)
+                }
+                _ => None,
+            }
+        });
+        *drop_landing.lock().unwrap() = landing;
+        Ok(Vec::new())
+    }));
+    keymap.insert(
+        key,
+        vec![capture, Action::Reload(Some("remove {}".to_string()))],
+    );
 }
 
 /// Run a row shortcut's OS action on a named background thread, logging any
@@ -2474,26 +2526,6 @@ pub mod tests {
         assert_eq!(parse_reload_remove_token("remove plain"), "plain");
     }
 
-    /// `sticky_reposition_target` maps a removed row's `shared_items` position
-    /// (header at index 0) to the `item_list` index the cursor should land on —
-    /// the data-row index of the slot the removed row vacated. It declines when
-    /// the list is now header-only (nothing to land on); `scroll_by` clamps the
-    /// removed-last-row overshoot, so the helper itself never caps the target.
-    #[test]
-    fn test_sticky_reposition_target() {
-        // First data row (shared_items index 1) → item_list index 0.
-        assert_eq!(super::sticky_reposition_target(1, 3), Some(0));
-        // Third data row (index 3) → item_list index 2, with rows remaining.
-        assert_eq!(super::sticky_reposition_target(3, 2), Some(2));
-        // Removed the only data row → header-only list, nothing to land on.
-        assert_eq!(super::sticky_reposition_target(1, 0), None);
-        // The header position itself never repositions.
-        assert_eq!(super::sticky_reposition_target(0, 2), None);
-        // Removed-last-row target may exceed the remaining rows; the helper
-        // returns it verbatim and leaves clamping to `scroll_by`.
-        assert_eq!(super::sticky_reposition_target(4, 3), Some(3));
-    }
-
     /// `send_reposition` (the single path the drop/keep/restore cursor moves
     /// share) queues an `Event::Action` through skim's sender when the TUI is up,
     /// and is a no-op before the sender is set.
@@ -2503,7 +2535,7 @@ pub mod tests {
         let (tx, mut rx) = tokio::sync::mpsc::channel(4);
         render_tx.set(tx).unwrap();
 
-        super::send_reposition(&render_tx, 2);
+        super::send_reposition(&render_tx, Some("worktree-path:/tmp/wt".to_string()));
         assert!(
             matches!(rx.try_recv(), Ok(skim::prelude::Event::Action(_))),
             "a set sender receives a reposition Action"
@@ -2511,7 +2543,7 @@ pub mod tests {
 
         // No sender set → no panic, nothing emitted.
         let empty: OnceLock<tokio::sync::mpsc::Sender<skim::prelude::Event>> = OnceLock::new();
-        super::send_reposition(&empty, 0);
+        super::send_reposition(&empty, None);
     }
 
     /// `from_signal` rejects tokens that carry no usable target: a blank or
@@ -2950,6 +2982,7 @@ pub mod tests {
             render_tx: Arc::new(OnceLock::new()),
             factory,
             stashed_warnings,
+            drop_landing: Arc::new(Mutex::new(None)),
         }
     }
 
@@ -3341,6 +3374,7 @@ pub mod tests {
             approvals: Arc::new(approvals),
             render_tx: Arc::new(OnceLock::new()),
             stashed_warnings: Arc::clone(&stashed),
+            drop_landing: Arc::new(Mutex::new(None)),
         };
 
         let cmd = format!("remove '{token}'");
@@ -3899,6 +3933,7 @@ pub mod tests {
             approvals: Arc::new(Approvals::default()),
             render_tx: Arc::new(OnceLock::new()),
             stashed_warnings: Arc::clone(&stashed),
+            drop_landing: Arc::new(Mutex::new(None)),
         };
 
         let cmd = format!("remove '{token}'");

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -122,19 +122,21 @@ use worktrunk::HookType;
 use worktrunk::config::Approvals;
 use worktrunk::git::{Repository, current_or_recover};
 use worktrunk::path::format_path_for_display;
-use worktrunk::styling::{eprintln, warning_message};
+use worktrunk::styling::{eprintln, strip_osc8_hyperlinks, warning_message};
 
 use super::hook_plan::{ApprovedHookPlan, HookPlanBuilder};
 use super::hooks::HookAnnouncer;
 use super::list::collect;
+use super::list::model::{BranchScope, ItemKind, ListItem};
 use super::list::progressive::RenderTarget;
+use super::list::render::PLACEHOLDER;
 use super::repository_ext::{RemoveTarget, RepositoryCliExt};
 use super::worktree::{RemoveResult, SwitchPipeline};
 use crate::cli::SwitchFormat;
 use crate::output::{BackgroundFallbackMode, handle_remove_output};
 use worktrunk::git::{BranchDeletionMode, delete_branch_if_safe};
 
-use items::{PreviewCache, ShortcutTable, WORKTREE_OUTPUT_PREFIX};
+use items::{LocalContent, LocalContentSlot, PreviewCache, ShortcutTable, WORKTREE_OUTPUT_PREFIX};
 use preview::{PreviewLayout, PreviewMode, PreviewState, PreviewStateData};
 use preview_orchestrator::PreviewOrchestrator;
 
@@ -258,15 +260,9 @@ struct PickerCollector {
     /// Same warning stash the progressive handler fills (drained to stderr once
     /// skim releases the terminal). A failed background removal pushes a
     /// `worktree kept` warning here so the user learns the row that flickered
-    /// back didn't actually go away. See [`restore_failed_removal`].
+    /// back (or un-morphed) didn't actually go away. See [`restore_failed_removal`]
+    /// and [`revert_morph`].
     stashed_warnings: Arc<Mutex<Vec<String>>>,
-    /// Branches whose worktree an `alt-x` removal removed while keeping the
-    /// (unmerged) branch. Shared (`Arc`) with [`PipelineFactory`]: the
-    /// background removal inserts the branch here and triggers a refresh, which
-    /// re-collects with these pinned into `collect`'s `pinned_branches` so the
-    /// row returns as a `/ branch` row (`+` worktree → `/` branch) instead of
-    /// vanishing. See [`PickerCollector::drop_and_remove_in_background`].
-    orphaned_branches: Arc<Mutex<std::collections::HashSet<String>>>,
 }
 
 impl PickerCollector {
@@ -398,28 +394,21 @@ impl PickerCollector {
 
     /// Drop the selected row and remove its target on a background thread.
     ///
-    /// For a removal [`removal_will_remove_target`] predicts will actually remove
-    /// the target (a clean worktree, or an integrated / force-deleted branch). The
-    /// `output()` token is unique per row (a `worktree-path:` path for worktrees),
-    /// so this drops exactly the selected row even when several detached rows share
-    /// the `(detached)` branch label.
+    /// For a removal that will remove the row entirely — a worktree whose branch
+    /// is *also* deleted (integrated, or force), or a force-deleted branch-only
+    /// row. A worktree removal that *keeps* its branch never reaches here; that's
+    /// the in-place morph ([`morph_and_remove_in_background`](Self::morph_and_remove_in_background)).
+    /// The `output()` token is unique per row (a `worktree-path:` path for
+    /// worktrees), so this drops exactly the selected row even when several
+    /// detached rows share the `(detached)` branch label.
     ///
     /// The row drops optimistically so the list stays snappy; the git work runs on
     /// a background thread off skim's event loop. The dropped row is restored only
     /// when the target survives — observed directly ([`removal_target_still_present`]),
     /// not inferred from `do_removal`'s `Result`, which is `Err` after a successful
-    /// removal whose `post-remove` hook fails to render/spawn, and `Ok` after an
-    /// integrated→unmerged race leaves the branch in place. This keeps the list
+    /// removal whose `post-remove` hook fails to render/spawn. This keeps the list
     /// from showing a removal that didn't happen without ever resurrecting a row
     /// for a target that's actually gone.
-    ///
-    /// When a worktree removal *succeeds* but leaves its branch behind
-    /// (`SafeDelete` won't delete unmerged work), the thread pins the branch in
-    /// [`orphaned_branches`](PickerCollector::orphaned_branches) and sends a
-    /// `refresh` reload. The re-collect re-includes the now-worktree-less branch
-    /// (via `collect`'s `pinned_branches`), so the dropped row returns as a
-    /// `/ branch` row — the worktree is gone, the branch remains. This replaces
-    /// the silent removal's missing feedback with a live, accurate row.
     fn drop_and_remove_in_background(
         &mut self,
         selected_output: String,
@@ -470,41 +459,27 @@ impl PickerCollector {
         let items = Arc::clone(&self.items);
         let render_tx = Arc::clone(&self.render_tx);
         let stashed_warnings = Arc::clone(&self.stashed_warnings);
-        let orphaned_branches = Arc::clone(&self.orphaned_branches);
         let _ = std::thread::Builder::new()
             .name(format!("picker-remove-{selected_output}"))
             .spawn(move || {
                 if let Err(e) = Self::do_removal(&repo, &result, &approvals) {
                     tracing::warn!(selected_output = %selected_output, error = %e, "picker: removal of '{selected_output}' errored: {e:#}");
                 }
-                if removal_target_still_present(&repo, &result) {
-                    if let Some((item, pos)) = removed {
-                        restore_failed_removal(
-                            &items,
-                            &render_tx,
-                            &stashed_warnings,
-                            item,
-                            pos,
-                            &removal_label,
-                            removal_noun,
-                        );
-                    }
-                } else if let RemoveResult::RemovedWorktree {
-                    branch_name: Some(branch),
-                    ..
-                } = &result
-                    && repo.branch(branch).exists_locally().unwrap_or(false)
+                // A removal that keeps its branch never reaches here — that's the
+                // morph path (`morph_and_remove_in_background`). So a surviving
+                // target means the removal itself failed: put the row back.
+                if removal_target_still_present(&repo, &result)
+                    && let Some((item, pos)) = removed
                 {
-                    // The worktree is gone but its branch survived the removal
-                    // (`SafeDelete` keeps unmerged work). Pin the branch and
-                    // refresh so the dropped row returns as a `/ branch` row —
-                    // the worktree was removed, the branch remains. An integrated
-                    // branch `do_removal` already deleted fails `exists_locally`
-                    // here, so its row stays gone.
-                    orphaned_branches.lock().unwrap().insert(branch.clone());
-                    if let Some(event_tx) = render_tx.get() {
-                        let _ = event_tx.try_send(Event::Reload("refresh".to_string()));
-                    }
+                    restore_failed_removal(
+                        &items,
+                        &render_tx,
+                        &stashed_warnings,
+                        item,
+                        pos,
+                        &removal_label,
+                        removal_noun,
+                    );
                 }
             });
 
@@ -555,6 +530,252 @@ impl PickerCollector {
         if let Some(target) = reposition_target {
             send_reposition(&self.render_tx, target);
         }
+    }
+
+    /// Morph the selected worktree row into a `/ branch` row in place, then remove
+    /// the worktree on a background thread.
+    ///
+    /// For a `RemovedWorktree` removal that [`worktree_removal_keeps_branch`]
+    /// predicts will keep its (unmerged) branch. The row never leaves its slot:
+    /// the morph rewrites the row's shared `rendered` line to the branch line
+    /// (rendered on the live layout — gutter `+` → `/`, path blank), flips the
+    /// row's [`morphed`](items::WorktreeSkimItem::morphed) flag (so `output()`
+    /// becomes the branch token), dims the `working_tree` preview tab (no worktree
+    /// left to diff), and re-keys the row's `alt-y`/`alt-o` shortcut entry to the
+    /// branch token. skim repaints just that row on the reload alt-x already
+    /// fires, and the cursor lands back on the same slot — no teleport, no reset.
+    ///
+    /// The morph is optimistic, like the drop path. The background thread runs the
+    /// git removal and, only if the worktree unexpectedly survives
+    /// ([`removal_target_still_present`] — a clean-check race, a locked dir, a
+    /// failing `pre-remove` hook), reverts the morph back to the worktree row via
+    /// [`revert_morph`] and surfaces why. (The branch can't flip integrated in the
+    /// millisecond between the prediction and the delete, so the only realistic
+    /// failure is the worktree removal itself.)
+    ///
+    /// Falls back to [`drop_and_remove_in_background`](Self::drop_and_remove_in_background)
+    /// when the row carries no [`MorphHandle`](items::MorphHandle) or the layout
+    /// hasn't landed — the worktree still removes, the row just drops instead of
+    /// morphing.
+    fn morph_and_remove_in_background(
+        &mut self,
+        selected_output: String,
+        branch: String,
+        planning_repo: Repository,
+        result: RemoveResult,
+    ) {
+        // Gather the row's shared morph handles and render the branch line on the
+        // live layout. Any gap (row not morphable, layout not yet handed over)
+        // means no clean in-place morph — drop the row instead, same end state.
+        let default_branch = self.repo.default_branch();
+        let prepared = {
+            let table = self.factory.shortcut_table.lock().unwrap();
+            let layout = self.factory.layout_slot.lock().unwrap();
+            match (
+                table.get(&selected_output).and_then(|d| d.morph.as_ref()),
+                layout.as_ref(),
+            ) {
+                (Some(handle), Some(layout)) => {
+                    let (branch_line, branch_local) =
+                        build_morph_branch_row(layout, &handle.item, default_branch.as_deref());
+                    Some(MorphSlots {
+                        rendered: Arc::clone(&handle.rendered),
+                        morphed: Arc::clone(&handle.morphed),
+                        local_content: Arc::clone(&handle.local_content),
+                        branch_line,
+                        branch_local,
+                    })
+                }
+                _ => None,
+            }
+        };
+        let Some(slots) = prepared else {
+            self.drop_and_remove_in_background(selected_output, planning_repo, result);
+            return;
+        };
+
+        // Find the row's slot before flipping its identity (its `output()` token
+        // changes on morph). The row stays put, so the cursor lands right back.
+        let reposition_target = {
+            let items = self.items.lock().unwrap();
+            items
+                .iter()
+                .position(|item| item.output().as_ref() == selected_output)
+                .and_then(|pos| {
+                    let remaining = items.len().saturating_sub(PICKER_HEADER_ROWS);
+                    sticky_reposition_target(pos, remaining)
+                })
+        };
+
+        // Snapshot the pre-morph display for the revert, then apply the morph.
+        let original_rendered = slots.rendered.lock().unwrap().clone();
+        let original_local = *slots.local_content.lock().unwrap();
+        *slots.rendered.lock().unwrap() = slots.branch_line;
+        slots.morphed.store(true, Ordering::Relaxed);
+        *slots.local_content.lock().unwrap() = slots.branch_local;
+
+        // Re-key the `alt-y`/`alt-o` lookup to the branch token (the row's new
+        // `output()`); the revert moves it back.
+        {
+            let mut table = self.factory.shortcut_table.lock().unwrap();
+            if let Some(data) = table.remove(&selected_output) {
+                table.insert(branch.clone(), data);
+            }
+        }
+
+        // If removing the current worktree, cd home so skim and git commands keep
+        // working after its directory disappears (as in the drop path).
+        if matches!(
+            &result,
+            RemoveResult::RemovedWorktree {
+                changed_directory: true,
+                ..
+            }
+        ) && let Some(home) = result.destination_path()
+        {
+            let _ = std::env::set_current_dir(home);
+            if let Ok(repo) = Repository::at(home) {
+                self.repo = repo;
+            }
+        }
+
+        let repo = planning_repo.clone();
+        let approvals = Arc::clone(&self.approvals);
+        let render_tx = Arc::clone(&self.render_tx);
+        let stashed_warnings = Arc::clone(&self.stashed_warnings);
+        let shortcut_table = Arc::clone(&self.factory.shortcut_table);
+        let revert = MorphRevert {
+            rendered: slots.rendered,
+            original_rendered,
+            morphed: slots.morphed,
+            local_content: slots.local_content,
+            original_local,
+            shortcut_table,
+            branch_token: branch.clone(),
+            worktree_token: selected_output.clone(),
+        };
+        let _ = std::thread::Builder::new()
+            .name(format!("picker-morph-{branch}"))
+            .spawn(move || {
+                if let Err(e) = Self::do_removal(&repo, &result, &approvals) {
+                    tracing::warn!(branch = %branch, error = %e, "picker: removal of '{branch}' worktree errored: {e:#}");
+                }
+                // Only the worktree removal can realistically fail here; if it did,
+                // the worktree dir survives — undo the morph and say so.
+                if removal_target_still_present(&repo, &result) {
+                    revert_morph(revert, &stashed_warnings, &render_tx);
+                }
+            });
+
+        // alt-x's reload reset the cursor to the top; land it back on the row,
+        // which is still in its original slot (morphed, not removed).
+        if let Some(target) = reposition_target {
+            send_reposition(&self.render_tx, target);
+        }
+    }
+}
+
+/// The row's shared display slots plus the pre-rendered branch line a morph
+/// swaps in (see [`PickerCollector::morph_and_remove_in_background`]).
+struct MorphSlots {
+    rendered: Arc<Mutex<String>>,
+    morphed: Arc<AtomicBool>,
+    local_content: LocalContentSlot,
+    branch_line: String,
+    branch_local: LocalContent,
+}
+
+/// Everything the background thread needs to undo a morph when the worktree
+/// removal failed (see [`revert_morph`]).
+struct MorphRevert {
+    rendered: Arc<Mutex<String>>,
+    original_rendered: String,
+    morphed: Arc<AtomicBool>,
+    local_content: LocalContentSlot,
+    original_local: LocalContent,
+    shortcut_table: ShortcutTable,
+    /// The branch token the morph re-keyed the shortcut entry to.
+    branch_token: String,
+    /// The worktree-path token the entry is keyed under before (and after) morph.
+    worktree_token: String,
+}
+
+/// Build the `/ branch` row a kept-branch `alt-x` morph swaps in — the rendered
+/// line (on the picker's live `layout`, the same grid the worktree rows use) and
+/// the diff-content signals for its preview tabs.
+///
+/// Clones the worktree row's model and demotes it to a local branch: `kind` →
+/// `Branch` blanks the path and worktree-status columns and switches the gutter
+/// to `/`, while counts / age / message carry over unchanged (the branch keeps
+/// the worktree's HEAD). Status symbols are reset and recomputed for the branch
+/// kind — `refresh_status_symbols` only fills empty slots, so the worktree's must
+/// be cleared first. The [`LocalContent`] is read off the demoted item, so its
+/// `working_tree` signal resolves empty (no worktree to diff) and the
+/// `working_tree` preview tab dims. OSC 8 hyperlinks are stripped to match the
+/// rows the handler builds (skim's pipeline mangles them).
+fn build_morph_branch_row(
+    layout: &crate::commands::list::layout::LayoutConfig,
+    worktree_item: &ListItem,
+    default_branch: Option<&str>,
+) -> (String, LocalContent) {
+    let mut branch_item = worktree_item.clone();
+    branch_item.kind = ItemKind::Branch(BranchScope::Local);
+    branch_item.status_symbols = Default::default();
+    branch_item.refresh_status_symbols(default_branch);
+    let line = strip_osc8_hyperlinks(
+        &layout
+            .render_list_item_line(&branch_item, PLACEHOLDER)
+            .render(),
+    );
+    (line, LocalContent::from_item(&branch_item))
+}
+
+/// Undo a morph after the worktree removal failed, restoring the worktree row in
+/// place and explaining why it didn't go away.
+///
+/// The mirror of [`PickerCollector::morph_and_remove_in_background`]'s apply
+/// step: restore the row's pre-morph display, clear the
+/// [`morphed`](items::WorktreeSkimItem::morphed) flag (so `output()` is the
+/// worktree token again), restore the diff-content slot, and move the
+/// `alt-y`/`alt-o` shortcut entry back to the worktree token. The row never left
+/// its slot, so a plain `Event::Render` repaints it — no reload, no cursor move
+/// (unlike [`restore_failed_removal`], which re-inserts a dropped row). The
+/// `kept … could not remove it` warning drains to stderr when the picker exits.
+fn revert_morph(
+    revert: MorphRevert,
+    stashed_warnings: &Mutex<Vec<String>>,
+    render_tx: &OnceLock<tokio::sync::mpsc::Sender<Event>>,
+) {
+    let MorphRevert {
+        rendered,
+        original_rendered,
+        morphed,
+        local_content,
+        original_local,
+        shortcut_table,
+        branch_token,
+        worktree_token,
+    } = revert;
+
+    *rendered.lock().unwrap() = original_rendered;
+    morphed.store(false, Ordering::Relaxed);
+    *local_content.lock().unwrap() = original_local;
+    {
+        let mut table = shortcut_table.lock().unwrap();
+        if let Some(data) = table.remove(&branch_token) {
+            table.insert(worktree_token, data);
+        }
+    }
+
+    stashed_warnings.lock().unwrap().push(
+        warning_message(cformat!(
+            "Kept <bold>{branch_token}</> worktree — could not remove it"
+        ))
+        .to_string(),
+    );
+
+    if let Some(tx) = render_tx.get() {
+        let _ = tx.try_send(Event::Render);
     }
 }
 
@@ -754,6 +975,42 @@ fn removal_will_remove_target(result: &RemoveResult) -> bool {
     }
 }
 
+/// The branch a `RemovedWorktree` removal will **keep** — worktree gone, branch
+/// retained — or `None` if the removal will delete the branch (or there's no
+/// branch). Drives the `alt-x` in-place morph: a kept branch turns the row into
+/// a `/ branch` row rather than dropping it.
+///
+/// Mirrors [`delete_branch_if_safe`] exactly so the prediction can't drift from
+/// the deletion the background `do_removal` performs: force always deletes; a
+/// `Keep` flag always retains; otherwise the branch is kept precisely when it is
+/// **not** integrated into the same `target_branch.unwrap_or("HEAD")` the actual
+/// delete checks (`Repository::integration_reason` → `None`). A `capture_refs`
+/// or integration error yields `None` (fall back to the drop path) — never a
+/// morph the removal won't back up. Runs a couple of git commands on skim's
+/// event loop, like `prepare_removal`'s own validation.
+fn worktree_removal_keeps_branch(repo: &Repository, result: &RemoveResult) -> Option<String> {
+    let RemoveResult::RemovedWorktree {
+        branch_name: Some(branch),
+        deletion_mode,
+        target_branch,
+        ..
+    } = result
+    else {
+        return None;
+    };
+    if deletion_mode.is_force() {
+        return None; // `-D` deletes regardless of integration.
+    }
+    if deletion_mode.should_keep() {
+        return Some(branch.clone()); // `Keep` retains regardless of integration.
+    }
+    // SafeDelete: kept iff unmerged — the exact check `delete_branch_if_safe` runs.
+    let snapshot = repo.capture_refs().ok()?;
+    let target = target_branch.as_deref().unwrap_or("HEAD");
+    let (_, reason) = repo.integration_reason(&snapshot, branch, target).ok()?;
+    reason.is_none().then(|| branch.clone())
+}
+
 /// Whether the row's underlying target still exists after `do_removal` ran — the
 /// primary evidence for "was this actually removed," used in place of inferring
 /// from `do_removal`'s `Result`.
@@ -764,12 +1021,24 @@ fn removal_will_remove_target(result: &RemoveResult) -> bool {
 /// and a `BranchOnly` safe-delete that raced from integrated to unmerged returns
 /// `Ok` while leaving the branch in place. (The *predictable* unmerged case never
 /// reaches here — [`removal_will_remove_target`] keeps that row without dropping
-/// it.) Observing the target directly handles both: the worktree dir is gone once
-/// removed (renamed into `.git/wt/trash/`), and the branch ref is gone once
-/// deleted. The check runs on the background thread, off skim's event loop.
+/// it.) Observing the target directly handles both: a removed worktree no longer
+/// has a `.git` entry at its path, and the branch ref is gone once deleted. The
+/// check runs on the background thread, off skim's event loop.
+///
+/// A bare `worktree_path.exists()` is *not* the signal: removing the **current**
+/// worktree leaves an empty placeholder directory at the original path so the
+/// shell's `$PWD` stays valid until the wrapper cd's away (see
+/// [`crate::output::handlers`] and `build_remove_command_staged`). That
+/// placeholder exists yet holds no worktree, so a successful removal would read as
+/// "still present" and spuriously restore the row. Probing the `.git` entry
+/// instead distinguishes a real worktree from the placeholder, and is also immune
+/// to a silently-failed `prune_worktrees` (the filesystem is ground truth; git's
+/// registration can lag) and to a stray `.DS_Store` landing in the placeholder
+/// during the cleanup race (the staging rename moves `.git` atomically with the
+/// rest of the tree, so the placeholder never has one).
 fn removal_target_still_present(repo: &Repository, result: &RemoveResult) -> bool {
     match result {
-        RemoveResult::RemovedWorktree { worktree_path, .. } => worktree_path.exists(),
+        RemoveResult::RemovedWorktree { worktree_path, .. } => worktree_path.join(".git").exists(),
         RemoveResult::BranchOnly { branch_name, .. } => {
             repo.branch(branch_name).exists_locally().unwrap_or(false)
         }
@@ -887,13 +1156,23 @@ impl CommandCollector for PickerCollector {
 
                 match preparation {
                     Ok((planning_repo, result)) => {
-                        // Decide up front, from the already-computed result, whether
-                        // this removal will actually remove the target. Only an
-                        // outcome that removes drops the row; a branch-only row whose
-                        // branch is unmerged stays put and is explained, so the list
-                        // never flickers a row off and back on (see
-                        // `removal_will_remove_target`).
-                        if removal_will_remove_target(&result) {
+                        // Decide up front, from the already-computed result, what
+                        // this removal does to the row:
+                        //   - keeps its (unmerged) branch → morph to `/ branch` in
+                        //     place (worktree gone, branch stays) — no row drop;
+                        //   - removes the target → drop the row;
+                        //   - branch-only row whose branch is unmerged → stays put,
+                        //     explained, so the list never flickers a row off and on.
+                        // See `worktree_removal_keeps_branch` / `removal_will_remove_target`.
+                        if let Some(branch) = worktree_removal_keeps_branch(&planning_repo, &result)
+                        {
+                            self.morph_and_remove_in_background(
+                                selected_output,
+                                branch,
+                                planning_repo,
+                                result,
+                            );
+                        } else if removal_will_remove_target(&result) {
                             self.drop_and_remove_in_background(
                                 selected_output,
                                 planning_repo,
@@ -983,14 +1262,11 @@ struct PipelineFactory {
     preview_cache: PreviewCache,
     orchestrator: Arc<PreviewOrchestrator>,
     stashed_warnings: Arc<Mutex<Vec<String>>>,
-    /// Branches orphaned by an `alt-x` worktree removal that kept the (unmerged)
-    /// branch. Shared (`Arc`) with [`PickerCollector`], which inserts into it on
-    /// such a removal and triggers a refresh; [`spawn`](Self::spawn) reads it
-    /// into `collect`'s `pinned_branches` so the row returns as a `/ branch` row
-    /// instead of vanishing. Persists for the session, so it survives later
-    /// refreshes too.
-    orphaned_branches: Arc<Mutex<std::collections::HashSet<String>>>,
     grid_slot: Arc<prs::GridSlot>,
+    /// Handoff of the collect layout to the collector, for rendering a
+    /// `/ branch` row on the same grid at `alt-x` time. Filled by the handler's
+    /// `provide_layout`, read by [`PickerCollector`]. See [`items::LayoutSlot`].
+    layout_slot: items::LayoutSlot,
     preview_dims: (usize, usize),
     skim_list_width: usize,
     command_timeout: Option<std::time::Duration>,
@@ -1028,9 +1304,9 @@ impl PipelineFactory {
     /// `local_branches` on the first-paint hot path (doubling them there slows
     /// the picker, worst on Windows).
     ///
-    /// The rebuild also makes the `alt-x` row transform work: the pinned branch
-    /// (see `orphaned_branches`) only reads as worktree-less — and so surfaces as
-    /// a `/ branch` row — when the refresh re-enumerates from a fresh handle.
+    /// The rebuild is also what lets `alt-r` drop a worktree an in-picker `alt-x`
+    /// removed: re-enumerating from a fresh handle skips the gone worktree, where
+    /// the startup cache would still list it.
     fn spawn(&self, rebuild_repo: bool) -> anyhow::Result<SpawnedPipeline> {
         let (tx, rx): (SkimItemSender, SkimItemReceiver) = unbounded();
 
@@ -1078,6 +1354,7 @@ impl PipelineFactory {
                 stashed_warnings: Arc::clone(&self.stashed_warnings),
                 deferred_items: OnceLock::new(),
                 grid_slot: Arc::clone(&self.grid_slot),
+                layout_slot: Arc::clone(&self.layout_slot),
                 prs_loading: prs_loading.clone(),
             });
 
@@ -1086,11 +1363,6 @@ impl PipelineFactory {
         let bg_skip_tasks = self.skip_tasks.clone();
         let show_branches = self.show_branches;
         let show_remotes = self.show_remotes;
-        // Snapshot the branches orphaned by `alt-x` removals so this collect
-        // re-includes them as `/ branch` rows even with `show_branches` off
-        // (see `orphaned_branches`). Cloned per spawn: a later removal mutates
-        // the shared set and triggers another refresh.
-        let pinned_branches = self.orphaned_branches.lock().unwrap().clone();
         let command_timeout = self.command_timeout;
         let skim_list_width = self.skim_list_width;
         let collect_handle = std::thread::Builder::new()
@@ -1101,7 +1373,6 @@ impl PipelineFactory {
                     collect::ShowConfig::Resolved {
                         show_branches,
                         show_remotes,
-                        pinned_branches,
                         skip_tasks: bg_skip_tasks,
                         command_timeout,
                         collect_deadline: None,
@@ -1398,13 +1669,6 @@ pub fn handle_picker(
     // again).
     let stashed_warnings: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
 
-    // Branches an alt-x removal orphaned (worktree gone, branch kept). Shared
-    // between the collector (which inserts on such a removal and refreshes) and
-    // the factory (which re-includes them on every collect). See
-    // `PickerCollector::orphaned_branches`.
-    let orphaned_branches: Arc<Mutex<std::collections::HashSet<String>>> =
-        Arc::new(Mutex::new(std::collections::HashSet::new()));
-
     // The collect pipeline, captured so the initial spawn below and every alt-r
     // refresh build it the same way. See `PipelineFactory`.
     let factory = Rc::new(PipelineFactory {
@@ -1415,10 +1679,12 @@ pub fn handle_picker(
         preview_cache: Arc::clone(&preview_cache),
         orchestrator: Arc::clone(&orchestrator),
         stashed_warnings: Arc::clone(&stashed_warnings),
-        orphaned_branches: Arc::clone(&orphaned_branches),
         // Column-geometry handoff: the collect thread fills it at skeleton time,
         // the `--prs` thread reads it to align PR rows with the worktree rows.
         grid_slot: Arc::new(prs::GridSlot::new()),
+        // Full-layout handoff: the handler fills it in `provide_layout`, the
+        // collector reads it to render the `alt-x` `/ branch` row on this grid.
+        layout_slot: Arc::new(Mutex::new(None)),
         preview_dims,
         skim_list_width,
         command_timeout,
@@ -1438,7 +1704,6 @@ pub fn handle_picker(
         render_tx: Arc::clone(&render_tx),
         factory: Rc::clone(&factory),
         stashed_warnings: Arc::clone(&stashed_warnings),
-        orphaned_branches: Arc::clone(&orphaned_branches),
     };
 
     // Half-page preview scroll: half of skim's usable height.
@@ -1969,7 +2234,7 @@ pub mod tests {
         install_preview_tab_keybindings, install_shortcut_keybindings, parse_reload_remove_token,
         picker_item_identifier, resolve_identifier, resolve_shortcut_branch, resolve_shortcut_url,
     };
-    use crate::commands::list::model::{ItemKind, ListItem, WorktreeData};
+    use crate::commands::list::model::{BranchScope, ItemKind, ListItem, WorktreeData};
     use crate::commands::worktree::RemoveResult;
     use skim::prelude::SkimItem;
     use skim::reader::CommandCollector;
@@ -2073,6 +2338,7 @@ pub mod tests {
                 RowShortcutData {
                     branch: Some("feat".into()),
                     url: RowUrl::Static(Some("https://example.test/pr/1".into())),
+                    morph: None,
                 },
             );
             t.insert(
@@ -2080,6 +2346,7 @@ pub mod tests {
                 RowShortcutData {
                     branch: None,
                     url: RowUrl::Static(None),
+                    morph: None,
                 },
             );
         }
@@ -2467,6 +2734,7 @@ pub mod tests {
             pr_status,
             local_content: Arc::new(Mutex::new(LocalContent::default())),
             notifier: super::preview_notify::PreviewNotifier::detached(),
+            morphed: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         }) as Arc<dyn SkimItem>
     }
 
@@ -2500,6 +2768,75 @@ pub mod tests {
         )
     }
 
+    /// Build a morphable worktree row and register everything `invoke`'s morph
+    /// path needs — a [`MorphHandle`](items::MorphHandle) in the factory's
+    /// shortcut table, keyed by the row's `output()` token, and a real layout in
+    /// its slot — so a kept-branch removal morphs in place instead of falling back
+    /// to a drop. Returns the row, its token, and the shared `rendered` / `morphed`
+    /// slots the morph mutates (so a test can assert on them).
+    fn setup_morphable_row(
+        factory: &std::rc::Rc<super::PipelineFactory>,
+        branch: &str,
+        path: &Path,
+    ) -> (
+        Arc<dyn SkimItem>,
+        String,
+        Arc<Mutex<String>>,
+        Arc<std::sync::atomic::AtomicBool>,
+    ) {
+        let mut item = ListItem::new_branch("abc123".to_string(), branch.to_string());
+        item.kind = ItemKind::Worktree(Box::new(WorktreeData {
+            path: path.to_path_buf(),
+            ..Default::default()
+        }));
+        let item_arc = Arc::new(item);
+        let rendered = Arc::new(Mutex::new(format!("+ {branch}")));
+        let local_content = Arc::new(Mutex::new(LocalContent::default()));
+        let morphed = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let row: Arc<dyn SkimItem> = Arc::new(WorktreeSkimItem {
+            search_text: branch.to_string(),
+            rendered: Arc::clone(&rendered),
+            branch_name: branch.to_string(),
+            item: Arc::clone(&item_arc),
+            preview_cache: Arc::new(dashmap::DashMap::new()),
+            has_upstream: false,
+            summaries_enabled: false,
+            pr_status: Arc::new(Mutex::new(None)),
+            local_content: Arc::clone(&local_content),
+            notifier: super::preview_notify::PreviewNotifier::detached(),
+            morphed: Arc::clone(&morphed),
+        });
+        let token = row.output().to_string();
+
+        factory.shortcut_table.lock().unwrap().insert(
+            token.clone(),
+            super::items::RowShortcutData {
+                branch: Some(branch.to_string()),
+                url: super::items::RowUrl::Static(None),
+                morph: Some(super::items::MorphHandle {
+                    item: Arc::clone(&item_arc),
+                    rendered: Arc::clone(&rendered),
+                    local_content,
+                    morphed: Arc::clone(&morphed),
+                }),
+            },
+        );
+        *factory.layout_slot.lock().unwrap() =
+            Some(crate::commands::list::layout::calculate_layout_with_width(
+                std::slice::from_ref(&*item_arc),
+                &std::collections::HashSet::new(),
+                80,
+                Path::new("/test"),
+                None,
+                None,
+                crate::commands::list::layout::ColumnSelection {
+                    custom: &[],
+                    selected: None,
+                },
+            ));
+        (row, token, rendered, morphed)
+    }
+
     /// A real [`PipelineFactory`] with empty config for the removal / `invoke`
     /// tests. Its `spawn()` is only reached by the refresh verb, which these
     /// tests don't exercise, so the minimal field set is enough to satisfy the
@@ -2519,8 +2856,8 @@ pub mod tests {
             preview_cache,
             orchestrator,
             stashed_warnings: Arc::new(Mutex::new(Vec::new())),
-            orphaned_branches: Arc::new(Mutex::new(std::collections::HashSet::new())),
             grid_slot: Arc::new(super::prs::GridSlot::new()),
+            layout_slot: Arc::new(Mutex::new(None)),
             preview_dims: (80, 24),
             skim_list_width: 80,
             command_timeout: None,
@@ -2543,7 +2880,6 @@ pub mod tests {
     ) -> PickerCollector {
         let factory = test_factory(repo.clone());
         let stashed_warnings = Arc::clone(&factory.stashed_warnings);
-        let orphaned_branches = Arc::clone(&factory.orphaned_branches);
         PickerCollector {
             items,
             repo,
@@ -2551,7 +2887,6 @@ pub mod tests {
             render_tx: Arc::new(OnceLock::new()),
             factory,
             stashed_warnings,
-            orphaned_branches,
         }
     }
 
@@ -2943,7 +3278,6 @@ pub mod tests {
             approvals: Arc::new(approvals),
             render_tx: Arc::new(OnceLock::new()),
             stashed_warnings: Arc::clone(&stashed),
-            orphaned_branches: Arc::new(Mutex::new(std::collections::HashSet::new())),
         };
 
         let cmd = format!("remove '{token}'");
@@ -2979,13 +3313,17 @@ pub mod tests {
         );
     }
 
-    /// End-to-end through `invoke`: removing a worktree whose branch is unmerged
-    /// removes the worktree (the row drops) but keeps the branch — `SafeDelete`
-    /// won't delete unmerged work. The background thread pins the surviving
-    /// branch in `orphaned_branches` and fires a refresh, so the next collect
-    /// re-includes it as a `/ branch` row instead of letting it vanish.
+    /// End-to-end through `invoke`: alt-x on a worktree whose branch is unmerged
+    /// morphs the row to `/ branch` in place. The worktree is removed but the
+    /// branch is kept (`SafeDelete` won't delete unmerged work), and the row
+    /// never leaves its slot — its `morphed` flag flips, its `output()` becomes
+    /// the bare branch token, and its display line is rewritten (no longer the
+    /// `+ worktree` line). The morph is applied synchronously in `invoke`; only
+    /// the git removal runs on the background thread.
     #[test]
-    fn test_invoke_removes_worktree_and_keeps_unmerged_branch() {
+    fn test_invoke_morphs_unmerged_worktree_to_branch_row() {
+        use std::sync::atomic::Ordering;
+
         let test = worktrunk::testing::TestRepo::with_initial_commit();
         let repo = worktrunk::git::Repository::at(test.path()).unwrap();
         let wt_dir = tempfile::tempdir().unwrap();
@@ -3022,43 +3360,60 @@ pub mod tests {
             .find(|wt| wt.branch.as_deref() == Some("feature"))
             .map(|wt| wt.path.clone())
             .expect("feature worktree is listed");
-        let item = branched_picker_item("feature", &reported_path);
-        let token = item.output().to_string();
-        let items = Arc::new(Mutex::new(vec![Arc::clone(&item)]));
+        let items = Arc::new(Mutex::new(Vec::new()));
         let mut collector = test_collector(Arc::clone(&items), repo.clone());
-        let orphaned = Arc::clone(&collector.orphaned_branches);
+        let (row, token, rendered, morphed) =
+            setup_morphable_row(&collector.factory, "feature", &reported_path);
+        items.lock().unwrap().push(Arc::clone(&row));
+        let original_line = rendered.lock().unwrap().clone();
 
         let cmd = format!("remove '{token}'");
         let (_rx, _interrupt) = collector.invoke(&cmd, Arc::new(AtomicUsize::new(0)));
 
-        // The worktree removal runs on a background thread that pins the
-        // surviving branch on success — poll on the pin as the sync point (the
-        // same pattern the failed-removal test uses for its stash).
-        let deadline = Instant::now() + Duration::from_secs(5);
-        while orphaned.lock().unwrap().is_empty() && Instant::now() < deadline {
-            std::thread::sleep(Duration::from_millis(20));
-        }
+        // The morph is synchronous, so it's already applied when `invoke` returns:
+        // the row is now a branch row in place — flag flipped, token rebranded,
+        // line rewritten.
         assert!(
-            orphaned.lock().unwrap().contains("feature"),
-            "the surviving branch is pinned so a refresh re-includes it as a `/ branch` row: {:?}",
-            orphaned.lock().unwrap()
+            morphed.load(Ordering::Relaxed),
+            "the kept-branch worktree row is morphed to a branch row"
+        );
+        assert_eq!(
+            row.output().as_ref(),
+            "feature",
+            "the morphed row's selection token is the bare branch name"
+        );
+        assert_ne!(
+            *rendered.lock().unwrap(),
+            original_line,
+            "the morphed row's display line is rewritten to the `/ branch` line"
         );
 
+        // The worktree removal itself runs in the background.
+        let deadline = Instant::now() + Duration::from_secs(5);
+        while reported_path.exists() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(20));
+        }
         assert!(!reported_path.exists(), "the worktree is removed");
         let branch_list = repo.run_command(&["branch", "--list", "feature"]).unwrap();
         assert!(
             !branch_list.is_empty(),
             "the unmerged branch is retained after its worktree is removed"
         );
+        // The removal succeeded, so the morph stands (no revert).
+        assert!(
+            morphed.load(Ordering::Relaxed),
+            "a successful removal leaves the row morphed"
+        );
     }
 
-    /// The negative of the above, end-to-end through `invoke`: removing a worktree
+    /// The negative of the above, end-to-end through `invoke`: alt-x on a worktree
     /// whose branch is *integrated* deletes both the worktree and the branch, so
-    /// the `exists_locally` check finds no survivor and pins nothing — the row
-    /// stays gone instead of reappearing as a `/ branch` row. Guards against a
-    /// regression that pins (and resurrects) every removed branch.
+    /// there's no branch to keep — the row drops (it's removed from the list)
+    /// rather than morphing. `worktree_removal_keeps_branch` returns `None`, so the
+    /// drop path runs, not the morph. Guards against morphing (and resurrecting) a
+    /// row whose branch is actually gone.
     #[test]
-    fn test_invoke_removes_integrated_worktree_pins_nothing() {
+    fn test_invoke_drops_integrated_worktree_row() {
         let test = worktrunk::testing::TestRepo::with_initial_commit();
         let repo = worktrunk::git::Repository::at(test.path()).unwrap();
         let wt_dir = tempfile::tempdir().unwrap();
@@ -3085,15 +3440,18 @@ pub mod tests {
         let token = item.output().to_string();
         let items = Arc::new(Mutex::new(vec![Arc::clone(&item)]));
         let mut collector = test_collector(Arc::clone(&items), repo.clone());
-        let orphaned = Arc::clone(&collector.orphaned_branches);
 
         let cmd = format!("remove '{token}'");
         let (_rx, _interrupt) = collector.invoke(&cmd, Arc::new(AtomicUsize::new(0)));
 
-        // Sync on the branch being gone: that proves `do_removal` ran its branch
-        // delete, after which the thread runs the (no-op) `exists_locally` check
-        // and exits. The grace window covers that check — it can only pin if the
-        // check regressed, so an empty pin set after it is the real assertion.
+        // The drop is synchronous (the row is removed before the background git
+        // work), so the list is already empty when `invoke` returns.
+        assert!(
+            items.lock().unwrap().is_empty(),
+            "the integrated worktree row drops instead of morphing"
+        );
+
+        // The background removal deletes both the worktree and the branch.
         let deadline = Instant::now() + Duration::from_secs(5);
         while !repo
             .run_command(&["branch", "--list", "feature"])
@@ -3104,17 +3462,126 @@ pub mod tests {
             std::thread::sleep(Duration::from_millis(20));
         }
         assert!(!reported_path.exists(), "the worktree is removed");
-        std::thread::sleep(Duration::from_millis(300));
         assert!(
-            orphaned.lock().unwrap().is_empty(),
-            "an integrated worktree removal pins no branch (the row stays gone): {:?}",
-            orphaned.lock().unwrap()
+            repo.run_command(&["branch", "--list", "feature"])
+                .unwrap()
+                .is_empty(),
+            "the integrated branch is deleted (nothing to keep)"
         );
     }
 
-    /// `removal_target_still_present` observes reality: a worktree dir or a
-    /// branch ref that's gone reads as removed; one still on disk / in the
-    /// ref store reads as present (the restore trigger).
+    /// `worktree_removal_keeps_branch` predicts the morph: a `RemovedWorktree`
+    /// whose `SafeDelete` would retain the branch (unmerged) yields the branch
+    /// name; an integrated one (deletes the branch) and a force-delete both yield
+    /// `None`. Built from real refs so the prediction runs the same
+    /// `integration_reason` the actual delete does.
+    #[test]
+    fn test_worktree_removal_keeps_branch() {
+        let test = worktrunk::testing::TestRepo::with_initial_commit();
+        let repo = worktrunk::git::Repository::at(test.path()).unwrap();
+        repo.run_command(&["branch", "integrated"]).unwrap();
+        // `unmerged` carries a commit main lacks.
+        repo.run_command(&["checkout", "-b", "unmerged"]).unwrap();
+        fs::write(test.path().join("new.txt"), "work").unwrap();
+        repo.run_command(&["add", "."]).unwrap();
+        repo.run_command(&["commit", "-m", "work"]).unwrap();
+        repo.run_command(&["checkout", "main"]).unwrap();
+
+        let result = |branch: &str, mode| RemoveResult::RemovedWorktree {
+            main_path: test.path().to_path_buf(),
+            worktree_path: test.path().join("gone"),
+            changed_directory: false,
+            branch_name: Some(branch.to_string()),
+            deletion_mode: mode,
+            target_branch: Some("main".to_string()),
+            force_worktree: false,
+            expected_path: None,
+            removed_commit: None,
+        };
+
+        assert_eq!(
+            super::worktree_removal_keeps_branch(
+                &repo,
+                &result("unmerged", BranchDeletionMode::SafeDelete)
+            )
+            .as_deref(),
+            Some("unmerged"),
+            "an unmerged branch is kept, so the row morphs"
+        );
+        assert_eq!(
+            super::worktree_removal_keeps_branch(
+                &repo,
+                &result("integrated", BranchDeletionMode::SafeDelete)
+            ),
+            None,
+            "an integrated branch is deleted, so the row drops"
+        );
+        assert_eq!(
+            super::worktree_removal_keeps_branch(
+                &repo,
+                &result("unmerged", BranchDeletionMode::ForceDelete)
+            ),
+            None,
+            "force-delete removes even an unmerged branch, so the row drops"
+        );
+    }
+
+    /// `build_morph_branch_row` renders the `/ branch` line a morph swaps in: the
+    /// worktree row's model demoted to a local branch on the live layout — gutter
+    /// `/`, no path — and a `LocalContent` whose `working_tree` reads empty (no
+    /// worktree to diff), which dims the `working_tree` preview tab.
+    #[test]
+    fn test_build_morph_branch_row() {
+        use ansi_str::AnsiStr;
+
+        let mut worktree_item = ListItem::new_branch("abc123".to_string(), "feature".to_string());
+        worktree_item.kind = ItemKind::Worktree(Box::new(WorktreeData {
+            path: Path::new("/tmp/wt.feature").to_path_buf(),
+            ..Default::default()
+        }));
+        let layout = crate::commands::list::layout::calculate_layout_with_width(
+            std::slice::from_ref(&worktree_item),
+            &std::collections::HashSet::new(),
+            80,
+            Path::new("/test"),
+            None,
+            None,
+            crate::commands::list::layout::ColumnSelection {
+                custom: &[],
+                selected: None,
+            },
+        );
+
+        let (line, local) = super::build_morph_branch_row(&layout, &worktree_item, Some("main"));
+        let plain = line.ansi_strip();
+        assert!(
+            plain.trim_start().starts_with('/'),
+            "the morphed line leads with the local-branch gutter `/`: {plain:?}"
+        );
+        assert!(
+            plain.contains("feature"),
+            "the morphed line shows the branch name: {plain:?}"
+        );
+        assert!(
+            !plain.contains("/tmp/wt.feature"),
+            "the morphed branch row has no worktree path: {plain:?}"
+        );
+        assert_eq!(
+            local,
+            LocalContent::from_item(&{
+                let mut b = ListItem::new_branch("abc123".to_string(), "feature".to_string());
+                b.kind = ItemKind::Branch(BranchScope::Local);
+                b
+            }),
+            "the morphed row's diff signals are the branch's (working_tree empty)"
+        );
+    }
+
+    /// `removal_target_still_present` observes reality: a worktree (a path with a
+    /// `.git` entry) or a branch ref that's gone reads as removed; one still on
+    /// disk / in the ref store reads as present (the restore trigger). The empty
+    /// placeholder left behind when removing the current worktree has no `.git`,
+    /// so it correctly reads as removed — not a spurious restore.
     #[test]
     fn test_removal_target_still_present() {
         let test = worktrunk::testing::TestRepo::with_initial_commit();
@@ -3133,11 +3600,21 @@ pub mod tests {
         };
         assert!(super::removal_target_still_present(
             &repo,
-            &worktree_result(test.path().to_path_buf()) // exists
+            &worktree_result(test.path().to_path_buf()) // a real worktree: has `.git`
         ));
         assert!(!super::removal_target_still_present(
             &repo,
             &worktree_result(test.path().join("does-not-exist"))
+        ));
+
+        // The empty placeholder left at the original path when removing the
+        // current worktree exists on disk but has no `.git` — it must read as
+        // removed, not trigger a spurious restore.
+        let placeholder = test.path().join("empty-placeholder");
+        std::fs::create_dir(&placeholder).unwrap();
+        assert!(!super::removal_target_still_present(
+            &repo,
+            &worktree_result(placeholder)
         ));
 
         repo.run_command(&["branch", "live-branch"]).unwrap();
@@ -3249,7 +3726,6 @@ pub mod tests {
             approvals: Arc::new(Approvals::default()),
             render_tx: Arc::new(OnceLock::new()),
             stashed_warnings: Arc::clone(&stashed),
-            orphaned_branches: Arc::new(Mutex::new(std::collections::HashSet::new())),
         };
 
         let cmd = format!("remove '{token}'");

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -554,7 +554,7 @@ impl PickerCollector {
     /// predicts will keep its (unmerged) branch. The row never leaves its slot:
     /// the morph rewrites the row's shared `rendered` line to the branch line
     /// (rendered on the live layout — gutter `+` → `/`, path blank), flips the
-    /// row's [`morphed`](items::WorktreeSkimItem::morphed) flag (so `output()`
+    /// row's [`morphed`](items::LocalCheckout::morphed) flag (so `output()`
     /// becomes the branch token), dims the `working_tree` preview tab (no worktree
     /// left to diff), and re-keys the row's `alt-y`/`alt-o` shortcut entry to the
     /// branch token. skim repaints just that row on the reload alt-x already
@@ -724,7 +724,7 @@ fn build_morph_branch_row(
 ///
 /// The mirror of [`PickerCollector::morph_and_remove_in_background`]'s apply
 /// step: restore the row's pre-morph display, clear the
-/// [`morphed`](items::WorktreeSkimItem::morphed) flag (so `output()` is the
+/// [`morphed`](items::LocalCheckout::morphed) flag (so `output()` is the
 /// worktree token again), restore the diff-content slot, and move the
 /// `alt-y`/`alt-o` shortcut entry back to the worktree token. The row never left
 /// its slot, so a plain `Event::Render` repaints it — no reload, no cursor move

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -120,9 +120,11 @@ use skim::reader::CommandCollector;
 use skim::tui::event::ActionCallback;
 use worktrunk::HookType;
 use worktrunk::config::Approvals;
-use worktrunk::git::{Repository, current_or_recover};
+use worktrunk::git::{ErrorExt, Repository, current_or_recover};
 use worktrunk::path::format_path_for_display;
-use worktrunk::styling::{eprintln, strip_osc8_hyperlinks, warning_message};
+use worktrunk::styling::{
+    eprintln, hint_message, info_message, strip_osc8_hyperlinks, warning_message,
+};
 
 use super::hook_plan::{ApprovedHookPlan, HookPlanBuilder};
 use super::hooks::HookAnnouncer;
@@ -144,6 +146,15 @@ use preview_orchestrator::PreviewOrchestrator;
 /// terminal (or in the dry-run path after the bg thread joins) — eprintln
 /// during the picker would corrupt skim's frame, so collect routes warnings
 /// through `PickerProgressHandler::stash_warning` and we emit them here.
+///
+/// TODO(picker-feedback): the declined-removal diagnostics (the main-worktree /
+/// dirty / unmerged "can't remove this row" messages from the `alt-x` keep paths)
+/// only surface here, on exit — the user presses `alt-x`, the row visibly stays,
+/// and the reason scrolls past after they quit. Consider a short in-picker message
+/// at `alt-x` time so the *why* lands immediately. skim has no footer slot (see the
+/// dropped Stall-indicator work), so the realistic slot is the header line — swap
+/// it to a transient "main worktree can't be removed" for a beat, then restore. The
+/// stash stays the fallback for background failures that surface after exit.
 fn drain_stashed_warnings(stash: &Mutex<Vec<String>>) {
     for line in stash.lock().unwrap().drain(..) {
         eprintln!("{line}");
@@ -434,22 +445,6 @@ impl PickerCollector {
             (removed, target)
         };
 
-        // If removing the current worktree, cd to home so skim and git commands
-        // continue to work after the directory disappears.
-        if matches!(
-            &result,
-            RemoveResult::RemovedWorktree {
-                changed_directory: true,
-                ..
-            }
-        ) && let Some(home) = result.destination_path()
-        {
-            let _ = std::env::set_current_dir(home);
-            if let Ok(repo) = Repository::at(home) {
-                self.repo = repo;
-            }
-        }
-
         // A user-facing (label, noun) for the `kept` message, taken from the result
         // before it moves into the background thread.
         let (removal_label, removal_noun) = removal_failure_subject(&result);
@@ -514,9 +509,30 @@ impl PickerCollector {
         // a `RemovedWorktree`, which always removes — see the dispatch in `invoke`
         // and [`removal_will_remove_target`].
         stash_retained_unmerged_branch(&self.stashed_warnings, branch_name);
+        self.reposition_to_kept_row(selected_output);
+    }
 
-        // The row never moved, so land the cursor back on it (alt-x's reload reset
-        // it to the top).
+    /// Keep the current worktree's row in place and explain why the picker won't
+    /// remove it.
+    ///
+    /// Called from `invoke` when [`removal_targets_current_worktree`] is true —
+    /// alt-x on the worktree the picker was launched from. Removing it would have
+    /// to switch the shell elsewhere first (see `removal_targets_current_worktree`
+    /// for why that's disruptive mid-picker), so the row stays put and a hint to
+    /// switch away first is stashed, drained to stderr when the picker exits. The
+    /// row never drops and no `do_removal` runs, so this is the only removal path
+    /// that never reaches a background thread.
+    fn keep_current_worktree_row(&self, selected_output: &str) {
+        stash_current_worktree_hint(&self.stashed_warnings);
+        self.reposition_to_kept_row(selected_output);
+    }
+
+    /// Land the cursor back on a row that stayed in place. alt-x's reload resets
+    /// the cursor to the top even when the row didn't move, so the keep-in-place
+    /// paths ([`keep_unremovable_row`](Self::keep_unremovable_row),
+    /// [`keep_current_worktree_row`](Self::keep_current_worktree_row)) re-anchor it
+    /// on the row's slot.
+    fn reposition_to_kept_row(&self, selected_output: &str) {
         let reposition_target = {
             let items = self.items.lock().unwrap();
             items
@@ -620,22 +636,6 @@ impl PickerCollector {
             let mut table = self.factory.shortcut_table.lock().unwrap();
             if let Some(data) = table.remove(&selected_output) {
                 table.insert(branch.clone(), data);
-            }
-        }
-
-        // If removing the current worktree, cd home so skim and git commands keep
-        // working after its directory disappears (as in the drop path).
-        if matches!(
-            &result,
-            RemoveResult::RemovedWorktree {
-                changed_directory: true,
-                ..
-            }
-        ) && let Some(home) = result.destination_path()
-        {
-            let _ = std::env::set_current_dir(home);
-            if let Ok(repo) = Repository::at(home) {
-                self.repo = repo;
             }
         }
 
@@ -975,6 +975,28 @@ fn removal_will_remove_target(result: &RemoveResult) -> bool {
     }
 }
 
+/// Whether the row's target is the worktree the picker was launched from — the
+/// `changed_directory` flag `prepare_worktree_removal` sets when the removed
+/// worktree is the caller's own.
+///
+/// The picker declines this case (see [`PickerCollector::keep_current_worktree_row`]):
+/// removing the current worktree would have to cd the shell elsewhere first, and
+/// that switch drags in `post-switch` hooks streaming into the picker, an empty
+/// placeholder directory swapped under the cursor mid-render, and a directory
+/// change the picker can't cleanly reflect. Switching away (Enter) and then
+/// removing the now-non-current row is the clean path, so alt-x on the current
+/// worktree keeps the row and explains. `BranchOnly` rows have no worktree to be
+/// standing in, so this is always `false` for them.
+fn removal_targets_current_worktree(result: &RemoveResult) -> bool {
+    matches!(
+        result,
+        RemoveResult::RemovedWorktree {
+            changed_directory: true,
+            ..
+        }
+    )
+}
+
 /// The branch a `RemovedWorktree` removal will **keep** — worktree gone, branch
 /// retained — or `None` if the removal will delete the branch (or there's no
 /// branch). Drives the `alt-x` in-place morph: a kept branch turns the row into
@@ -1021,24 +1043,20 @@ fn worktree_removal_keeps_branch(repo: &Repository, result: &RemoveResult) -> Op
 /// and a `BranchOnly` safe-delete that raced from integrated to unmerged returns
 /// `Ok` while leaving the branch in place. (The *predictable* unmerged case never
 /// reaches here — [`removal_will_remove_target`] keeps that row without dropping
-/// it.) Observing the target directly handles both: a removed worktree no longer
-/// has a `.git` entry at its path, and the branch ref is gone once deleted. The
-/// check runs on the background thread, off skim's event loop.
+/// it.) Observing the target directly handles both: the worktree dir is gone once
+/// removed (renamed into `.git/wt/trash/`), and the branch ref is gone once
+/// deleted. The check runs on the background thread, off skim's event loop.
 ///
-/// A bare `worktree_path.exists()` is *not* the signal: removing the **current**
-/// worktree leaves an empty placeholder directory at the original path so the
-/// shell's `$PWD` stays valid until the wrapper cd's away (see
-/// [`crate::output::handlers`] and `build_remove_command_staged`). That
-/// placeholder exists yet holds no worktree, so a successful removal would read as
-/// "still present" and spuriously restore the row. Probing the `.git` entry
-/// instead distinguishes a real worktree from the placeholder, and is also immune
-/// to a silently-failed `prune_worktrees` (the filesystem is ground truth; git's
-/// registration can lag) and to a stray `.DS_Store` landing in the placeholder
-/// during the cleanup race (the staging rename moves `.git` atomically with the
-/// rest of the tree, so the placeholder never has one).
+/// `worktree_path.exists()` is the right signal here because the picker only ever
+/// removes *non-current* worktrees — [`removal_targets_current_worktree`] keeps the
+/// current one in place rather than removing it. So no empty placeholder directory
+/// is ever left at `worktree_path` (that placeholder, which keeps `$PWD` valid, is
+/// created only when removing the worktree the shell is sitting in — see
+/// [`crate::output::handlers`]). A successful removal renames the whole tree away;
+/// a failed one leaves it intact.
 fn removal_target_still_present(repo: &Repository, result: &RemoveResult) -> bool {
     match result {
-        RemoveResult::RemovedWorktree { worktree_path, .. } => worktree_path.join(".git").exists(),
+        RemoveResult::RemovedWorktree { worktree_path, .. } => worktree_path.exists(),
         RemoveResult::BranchOnly { branch_name, .. } => {
             repo.branch(branch_name).exists_locally().unwrap_or(false)
         }
@@ -1055,6 +1073,21 @@ fn removal_target_still_present(repo: &Repository, result: &RemoveResult) -> boo
 /// prints — see [`crate::output::retained_unmerged_branch_messages`].
 fn stash_retained_unmerged_branch(stashed: &Mutex<Vec<String>>, branch_name: &str) {
     let (info, hint) = crate::output::retained_unmerged_branch_messages(branch_name);
+    let mut stashed = stashed.lock().unwrap();
+    if !stashed.contains(&info) {
+        stashed.push(info);
+        stashed.push(hint);
+    }
+}
+
+/// Stash the "can't remove the current worktree here" info + hint pair (deduped),
+/// drained to stderr once the picker releases the terminal. Used by
+/// [`PickerCollector::keep_current_worktree_row`] — alt-x on the worktree the
+/// picker was launched from keeps the row and explains, since removing it would
+/// have to switch the shell elsewhere first.
+fn stash_current_worktree_hint(stashed: &Mutex<Vec<String>>) {
+    let info = info_message("Can't remove the current worktree from the picker").to_string();
+    let hint = hint_message("Switch to another worktree first").to_string();
     let mut stashed = stashed.lock().unwrap();
     if !stashed.contains(&info) {
         stashed.push(info);
@@ -1158,13 +1191,20 @@ impl CommandCollector for PickerCollector {
                     Ok((planning_repo, result)) => {
                         // Decide up front, from the already-computed result, what
                         // this removal does to the row:
+                        //   - targets the current worktree → keep it; removing the
+                        //     worktree you're standing in has to switch you away
+                        //     first, which the picker declines (no row drop);
                         //   - keeps its (unmerged) branch → morph to `/ branch` in
                         //     place (worktree gone, branch stays) — no row drop;
                         //   - removes the target → drop the row;
                         //   - branch-only row whose branch is unmerged → stays put,
                         //     explained, so the list never flickers a row off and on.
-                        // See `worktree_removal_keeps_branch` / `removal_will_remove_target`.
-                        if let Some(branch) = worktree_removal_keeps_branch(&planning_repo, &result)
+                        // See `removal_targets_current_worktree` /
+                        // `worktree_removal_keeps_branch` / `removal_will_remove_target`.
+                        if removal_targets_current_worktree(&result) {
+                            self.keep_current_worktree_row(&selected_output);
+                        } else if let Some(branch) =
+                            worktree_removal_keeps_branch(&planning_repo, &result)
                         {
                             self.morph_and_remove_in_background(
                                 selected_output,
@@ -1189,6 +1229,18 @@ impl CommandCollector for PickerCollector {
                     }
                     Err(e) => {
                         tracing::info!(selected_output = %selected_output, error = %e, "picker: cannot remove '{selected_output}': {e:#}");
+                        // The target can't be removed — the main worktree, a dirty
+                        // worktree, a lock. Surface the *same* diagnostic `wt remove`
+                        // prints (drained to stderr on exit) instead of swallowing
+                        // it, so alt-x isn't a silent dead keypress. Nothing was
+                        // removed, so the row stays; re-anchor the cursor on it.
+                        if let Some(diagnostic) = e.render_diagnostic() {
+                            let mut stashed = self.stashed_warnings.lock().unwrap();
+                            if !stashed.contains(&diagnostic) {
+                                stashed.push(diagnostic);
+                            }
+                        }
+                        self.reposition_to_kept_row(&selected_output);
                     }
                 }
             }
@@ -3583,11 +3635,9 @@ pub mod tests {
         );
     }
 
-    /// `removal_target_still_present` observes reality: a worktree (a path with a
-    /// `.git` entry) or a branch ref that's gone reads as removed; one still on
-    /// disk / in the ref store reads as present (the restore trigger). The empty
-    /// placeholder left behind when removing the current worktree has no `.git`,
-    /// so it correctly reads as removed — not a spurious restore.
+    /// `removal_target_still_present` observes reality: a worktree dir or a branch
+    /// ref that's gone reads as removed; one still on disk / in the ref store reads
+    /// as present (the restore trigger).
     #[test]
     fn test_removal_target_still_present() {
         let test = worktrunk::testing::TestRepo::with_initial_commit();
@@ -3606,21 +3656,11 @@ pub mod tests {
         };
         assert!(super::removal_target_still_present(
             &repo,
-            &worktree_result(test.path().to_path_buf()) // a real worktree: has `.git`
+            &worktree_result(test.path().to_path_buf()) // still on disk
         ));
         assert!(!super::removal_target_still_present(
             &repo,
             &worktree_result(test.path().join("does-not-exist"))
-        ));
-
-        // The empty placeholder left at the original path when removing the
-        // current worktree exists on disk but has no `.git` — it must read as
-        // removed, not trigger a spurious restore.
-        let placeholder = test.path().join("empty-placeholder");
-        std::fs::create_dir(&placeholder).unwrap();
-        assert!(!super::removal_target_still_present(
-            &repo,
-            &worktree_result(placeholder)
         ));
 
         repo.run_command(&["branch", "live-branch"]).unwrap();
@@ -3699,6 +3739,128 @@ pub mod tests {
                 Some(IntegrationReason::SameCommit)
             )),
             "Keep never deletes, even when integrated"
+        );
+    }
+
+    /// `removal_targets_current_worktree` fires only for a `RemovedWorktree` whose
+    /// `changed_directory` flag is set (the worktree the picker was launched from);
+    /// a non-current worktree and any `BranchOnly` row read as `false`.
+    #[test]
+    fn test_removal_targets_current_worktree() {
+        let path = std::path::PathBuf::from("/repo.feature");
+        let worktree = |changed_directory| RemoveResult::RemovedWorktree {
+            main_path: std::path::PathBuf::from("/repo"),
+            worktree_path: path.clone(),
+            changed_directory,
+            branch_name: Some("feature".to_string()),
+            deletion_mode: BranchDeletionMode::SafeDelete,
+            target_branch: Some("main".to_string()),
+            force_worktree: false,
+            expected_path: None,
+            removed_commit: None,
+        };
+        assert!(
+            super::removal_targets_current_worktree(&worktree(true)),
+            "removing the worktree the picker was launched from"
+        );
+        assert!(
+            !super::removal_targets_current_worktree(&worktree(false)),
+            "removing some other worktree"
+        );
+        assert!(
+            !super::removal_targets_current_worktree(&RemoveResult::BranchOnly {
+                branch_name: "feature".to_string(),
+                deletion_mode: BranchDeletionMode::SafeDelete,
+                pruned: false,
+                target_branch: None,
+                integration_reason: None,
+            }),
+            "a branch-only row has no worktree to be standing in"
+        );
+    }
+
+    /// `keep_current_worktree_row` keeps the row in place and stashes the
+    /// can't-remove-current-worktree info + switch-away hint — alt-x on the current
+    /// worktree never removes it and never spawns a background removal.
+    #[test]
+    fn test_keep_current_worktree_row() {
+        let test = worktrunk::testing::TestRepo::with_initial_commit();
+        let repo = worktrunk::git::Repository::at(test.path()).unwrap();
+
+        let item = branched_picker_item("current", &test.path().join("current"));
+        let token = item.output().to_string();
+        let items = Arc::new(Mutex::new(vec![Arc::clone(&item)]));
+        let collector = test_collector(Arc::clone(&items), repo.clone());
+
+        collector.keep_current_worktree_row(&token);
+
+        assert_eq!(
+            items
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|item| item.output().into_owned())
+                .collect::<Vec<_>>(),
+            vec![token.clone()],
+            "the current worktree row is kept, not removed"
+        );
+        let warnings = collector.stashed_warnings.lock().unwrap().clone();
+        assert!(
+            warnings.iter().any(|w| w.contains("current worktree")),
+            "stashes the can't-remove-current-worktree info: {warnings:?}"
+        );
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("Switch to another worktree")),
+            "stashes the switch-away hint: {warnings:?}"
+        );
+
+        // A second alt-x on the same kept row dedups — the stash doesn't grow.
+        collector.keep_current_worktree_row(&token);
+        assert_eq!(
+            collector.stashed_warnings.lock().unwrap().len(),
+            warnings.len(),
+            "repeated alt-x on the current worktree stashes the hint only once"
+        );
+    }
+
+    /// alt-x on an unremovable target surfaces the same diagnostic `wt remove`
+    /// prints rather than swallowing it: `prepare_removal` errors (here the main
+    /// worktree can't be removed), so the dispatch's `Err` arm stashes the rendered
+    /// reason and keeps the row in place — no silent dead keypress.
+    #[test]
+    fn test_invoke_surfaces_unremovable_diagnostic() {
+        let test = worktrunk::testing::TestRepo::with_initial_commit();
+        let repo = worktrunk::git::Repository::at(test.path()).unwrap();
+
+        // The repo root is the main worktree — `prepare_worktree_removal` rejects it.
+        let item = branched_picker_item("main", test.path());
+        let token = item.output().to_string();
+        let items = Arc::new(Mutex::new(vec![Arc::clone(&item)]));
+        let mut collector = test_collector(Arc::clone(&items), repo.clone());
+
+        let cmd = format!("remove '{token}'");
+        let (_rx, _interrupt) = collector.invoke(&cmd, Arc::new(AtomicUsize::new(0)));
+
+        // Nothing was removed, so the row stays...
+        assert_eq!(
+            items
+                .lock()
+                .unwrap()
+                .iter()
+                .map(|item| item.output().into_owned())
+                .collect::<Vec<_>>(),
+            vec![token],
+            "an unremovable row is never dropped"
+        );
+        // ...and the reason is surfaced, not swallowed.
+        let warnings = collector.stashed_warnings.lock().unwrap().clone();
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.contains("main worktree cannot be removed")),
+            "the unremovable diagnostic is stashed for the user: {warnings:?}"
         );
     }
 

--- a/src/commands/picker/progressive_handler.rs
+++ b/src/commands/picker/progressive_handler.rs
@@ -52,8 +52,9 @@ use super::super::list::ci_status::PrStatus;
 const RENDER_THROTTLE: Duration = Duration::from_millis(16);
 
 use super::items::{
-    HeaderLoading, HeaderSkimItem, LocalContent, LocalContentSlot, PrStatusSlot, PreviewCache,
-    RowShortcutData, RowUrl, ShortcutTable, WorktreeSkimItem, worktree_output_token,
+    HeaderLoading, HeaderSkimItem, LayoutSlot, LocalContent, LocalContentSlot, MorphHandle,
+    PrStatusSlot, PreviewCache, RowShortcutData, RowUrl, ShortcutTable, WorktreeSkimItem,
+    worktree_output_token,
 };
 use super::preview::PreviewMode;
 use super::preview_orchestrator::PreviewOrchestrator;
@@ -137,6 +138,10 @@ pub(super) struct PickerHandler {
     /// Handoff of the layout's column geometry to the `--prs` thread, which
     /// renders PR rows on the same grid as the worktree rows.
     pub(super) grid_slot: Arc<super::prs::GridSlot>,
+    /// Handoff of the full collect layout to `PickerCollector`, filled in
+    /// `provide_layout` and read at `alt-x` time to render a `/ branch` row on
+    /// the same grid (the in-place morph). See [`LayoutSlot`].
+    pub(super) layout_slot: LayoutSlot,
     /// Shared with the header: `Some(true)` while the `--prs` forge call is in
     /// flight, so the header shows a "loading…" marker. The `--prs` thread
     /// clears it when the fetch resolves. `None` on non-`--prs` pickers.
@@ -344,6 +349,23 @@ impl PickerProgressHandler for PickerHandler {
                 Arc::new(Mutex::new(LocalContent::from_item(&item_arc)));
             local_content_slots.push(Arc::clone(&local_content_arc));
 
+            // `alt-x` morph handles: a non-primary worktree row with a branch
+            // can have that branch outlive a removal, so the row morphs to
+            // `/ branch` in place. The primary worktree (can't be removed),
+            // detached worktrees (no branch), and branch-only rows (nothing to
+            // morph from) carry no handle. Shares the row's live `Arc`s so the
+            // collector's mutation surfaces on the same item skim renders.
+            let morphed = Arc::new(AtomicBool::new(false));
+            let morph = (item_arc.worktree_data().is_some()
+                && item_arc.branch.is_some()
+                && !item_arc.is_main())
+            .then(|| MorphHandle {
+                item: Arc::clone(&item_arc),
+                rendered: Arc::clone(&rendered_arc),
+                local_content: Arc::clone(&local_content_arc),
+                morphed: Arc::clone(&morphed),
+            });
+
             // Shortcut lookup for this row: `alt-y` copies `branch`, `alt-o`
             // opens the URL once the live `pr_status` slot reports one. Carry the
             // raw `Option` (not `branch_name()`'s `"(detached)"` fallback) so
@@ -353,6 +375,7 @@ impl PickerProgressHandler for PickerHandler {
                 RowShortcutData {
                     branch: item_arc.branch.clone(),
                     url: RowUrl::Live(Arc::clone(&pr_status_arc)),
+                    morph,
                 },
             );
 
@@ -367,6 +390,7 @@ impl PickerProgressHandler for PickerHandler {
                 pr_status: pr_status_arc,
                 local_content: local_content_arc,
                 notifier: Arc::clone(self.orchestrator.notifier()),
+                morphed,
             }) as Arc<dyn SkimItem>);
         }
 
@@ -478,6 +502,12 @@ impl PickerProgressHandler for PickerHandler {
         self.stashed_warnings.lock().unwrap().push(line);
     }
 
+    fn provide_layout(&self, layout: &crate::commands::list::layout::LayoutConfig) {
+        // Stow a clone for `PickerCollector` to render the `alt-x` `/ branch`
+        // row on this grid. Overwritten each skeleton (a refresh re-collects).
+        *self.layout_slot.lock().unwrap() = Some(layout.clone());
+    }
+
     fn on_collect_complete(&self) {
         // Collection is done — `on_update` may have throttled away the last
         // row's repaint, so force one final frame that reflects every slot.
@@ -531,6 +561,7 @@ mod tests {
             stashed_warnings: Arc::new(Mutex::new(Vec::new())),
             deferred_items: OnceLock::new(),
             grid_slot: Arc::new(super::super::prs::GridSlot::new()),
+            layout_slot: Arc::new(Mutex::new(None)),
             prs_loading: None,
         }
     }

--- a/src/commands/picker/prs.rs
+++ b/src/commands/picker/prs.rs
@@ -285,6 +285,9 @@ fn fetch_and_stream(
                 RowShortcutData {
                     branch: Some(entry.head_branch.clone()),
                     url: RowUrl::Static(entry.url.clone()),
+                    // A `--prs` row has no local worktree to remove, so `alt-x`
+                    // can't morph it.
+                    morph: None,
                 },
             );
             Arc::new(PrSkimItem::new(

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -526,8 +526,10 @@ struct BranchDeletionDisplay {
 
 /// The canonical "branch retained because unmerged" info + hint lines, as an
 /// `(info, hint)` pair. [`print_retained_unmerged_branch`] prints them; the
-/// picker's `keep_unremovable_row` stashes them (it can't print mid-render).
-/// Shared so the two emit paths can't drift in wording, flag, or styling.
+/// picker stashes them via `stash_retained_unmerged_branch` (it can't print
+/// mid-render) — from both its branch-only keep path and its background
+/// worktree-removal path. Shared so the emit paths can't drift in wording, flag,
+/// or styling.
 pub(crate) fn retained_unmerged_branch_messages(branch_name: &str) -> (String, String) {
     let info = info_message(cformat!(
         "Branch <bold>{branch_name}</> retained; has unmerged changes"

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -527,9 +527,11 @@ struct BranchDeletionDisplay {
 /// The canonical "branch retained because unmerged" info + hint lines, as an
 /// `(info, hint)` pair. [`print_retained_unmerged_branch`] prints them; the
 /// picker stashes them via `stash_retained_unmerged_branch` (it can't print
-/// mid-render) — from both its branch-only keep path and its background
-/// worktree-removal path. Shared so the emit paths can't drift in wording, flag,
-/// or styling.
+/// mid-render) from its branch-only keep path — a `/ branch` row whose unmerged
+/// branch `SafeDelete` declines to delete stays put, so this explains the no-op.
+/// (A worktree removal that keeps its branch transforms the row to `/ branch`
+/// live instead, with no stashed message.) Shared so the emit paths can't drift
+/// in wording, flag, or styling.
 pub(crate) fn retained_unmerged_branch_messages(branch_name: &str) -> (String, String) {
     let info = info_message(cformat!(
         "Branch <bold>{branch_name}</> retained; has unmerged changes"

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -52,6 +52,15 @@ const READY_TIMEOUT: Duration = Duration::from_secs(30);
 /// in worst-case scenarios.
 const STABILIZE_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Maximum time to wait for the picker child to exit after the terminating
+/// keystroke (Enter to switch, Escape to abort) before force-killing it. A clean
+/// switch or abort exits in well under a second, but under heavy CI parallelism
+/// the final git work (or skim's Windows terminal teardown) can lag; killing a
+/// still-finishing child reports exit 1 on Windows, turning a successful-but-slow
+/// switch into a spurious failure. Generous like `READY_TIMEOUT`/`STABILIZE_TIMEOUT`
+/// for the same reason — fast polling means the common case still returns at once.
+const CHILD_EXIT_TIMEOUT: Duration = Duration::from_secs(30);
+
 /// How long screen must be unchanged to consider it "stable".
 /// Must be long enough for preview content to load (preview commands run async).
 /// 500ms balances reliability (allows preview to complete) with speed.
@@ -245,7 +254,7 @@ fn exec_in_pty_with_input_expectations(
 
     // Poll for process exit (fast polling, long timeout for CI)
     let start = std::time::Instant::now();
-    let timeout = Duration::from_secs(5);
+    let timeout = CHILD_EXIT_TIMEOUT;
     while start.elapsed() < timeout {
         if child.try_wait().unwrap().is_some() {
             break;
@@ -361,7 +370,7 @@ fn exec_in_pty_capture_before_abort(
 
     // Drain remaining output WITHOUT feeding to parser — preserves pre-abort screen
     let start = Instant::now();
-    let timeout = Duration::from_secs(5);
+    let timeout = CHILD_EXIT_TIMEOUT;
     loop {
         while rx.try_recv().is_ok() {} // discard chunks
         if child.try_wait().unwrap().is_some() {
@@ -2042,8 +2051,11 @@ fn drive_alt_r_then_switch(
     send(&writer, b"\r");
     drop(writer);
 
+    // Let the switch finish and the process exit on its own; the kill is a
+    // hung-child backstop. The wait is generous because a slow-but-successful
+    // exit that gets killed reports exit 1 on Windows — see `CHILD_EXIT_TIMEOUT`.
     let start = Instant::now();
-    while start.elapsed() < Duration::from_secs(5) {
+    while start.elapsed() < CHILD_EXIT_TIMEOUT {
         if child.try_wait().unwrap().is_some() {
             break;
         }

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -2930,3 +2930,105 @@ fn test_switch_picker_alt_x_unremovable_row_keeps_cursor(mut repo: TestRepo) {
 
     let _ = abort_and_exit_code(child, writer, rx);
 }
+
+/// alt-x under an active fuzzy query lands the cursor on the row displayed just
+/// below the removed one — the *filtered display* order, not the removed row's
+/// index in the full (unfiltered) `shared_items` list.
+///
+/// Typing a query both shrinks and reorders skim's `item_list` relative to
+/// `shared_items`. A reposition that scrolled to the removed row's `shared_items`
+/// index lands rows past the right one — the "+N down" jump a user sees when
+/// removing rows after filtering, where N is the count of filtered-out rows above
+/// the cursor. The other alt-x cursor tests type no query, so the two index spaces
+/// coincide and this regression hides. Here decoy worktrees the query filters out
+/// sit between the matching ones, inflating each keeper's `shared_items` index past
+/// its displayed index: an index-based reposition overshoots (and `scroll_by`
+/// clamps it to the last filtered row), an identity-based one lands on the neighbor.
+#[rstest]
+fn test_switch_picker_alt_x_lands_on_neighbor_under_filter(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["remote", "remove", "origin"]);
+    // Keepers (match the query `keep`) interleaved with decoys (don't), so each
+    // keeper carries decoys ahead of it in `shared_items` order. All sit at main's
+    // commit, so alt-x integrates-and-drops (the drop path).
+    for branch in [
+        "keep-1", "other-1", "keep-2", "other-2", "keep-3", "other-3", "keep-4",
+    ] {
+        repo.add_worktree(branch);
+    }
+
+    let env_vars = repo.test_env_vars();
+    let PickerSession {
+        child,
+        _master,
+        writer,
+        rx,
+        mut parser,
+    } = boot_picker_pty(
+        wt_bin().to_str().unwrap(),
+        &["switch", "--no-cd", "--format=json"],
+        repo.root_path(),
+        &env_vars,
+    );
+    let send = |bytes: &[u8]| {
+        let mut w = writer.lock().unwrap();
+        w.write_all(bytes).unwrap();
+        w.flush().unwrap();
+    };
+
+    wait_for_stable_with_content(&rx, &mut parser, Some("keep-4"));
+
+    // Type the query: only the four keepers survive (the current/main row and the
+    // decoys filter out), so the cursor starts on the top keeper.
+    send(b"keep");
+    wait_for_stable_with_content(&rx, &mut parser, Some("keep-1"));
+
+    // Learn the filtered display order — skim ranks the equal-scoring keepers, so
+    // read the rows top-to-bottom rather than assume one.
+    let order: Vec<String> = {
+        let list = list_pane_text(parser.screen());
+        let mut rows: Vec<(usize, String)> = ["keep-1", "keep-2", "keep-3", "keep-4"]
+            .iter()
+            .filter_map(|name| {
+                list.lines()
+                    .position(|l| l.contains(name))
+                    .map(|line| (line, (*name).to_string()))
+            })
+            .collect();
+        rows.sort_by_key(|(line, _)| *line);
+        rows.into_iter().map(|(_, name)| name).collect()
+    };
+    assert_eq!(
+        order.len(),
+        4,
+        "all four keepers shown under the `keep` filter"
+    );
+    // Remove the second displayed keeper (two still below it): the row directly
+    // below must catch the cursor, not one further down.
+    let remove_target = order[1].clone();
+    let expected_landing = order[2].clone();
+    let overshoot_row = order[3].clone();
+
+    // Down from the top filtered row onto the second keeper.
+    send(b"\x1b[B");
+    wait_for_cursor_on_row(&rx, &mut parser, &remove_target);
+
+    // alt-x drops it; the cursor must land on the row that slid up. An index-based
+    // reposition overshoots toward `overshoot_row` (clamped to the last filtered
+    // row) and times this out.
+    send(b"\x1bx");
+    wait_for_cursor_on_row(&rx, &mut parser, &expected_landing);
+
+    let pointer_line = list_pane_text(parser.screen())
+        .lines()
+        .find(|l| l.starts_with('>'))
+        .map(str::to_string)
+        .unwrap_or_default();
+    assert!(
+        !pointer_line.contains(&overshoot_row),
+        "alt-x under a filter overshot to `{overshoot_row}` instead of the \
+         immediate next row `{expected_landing}`.\nPointer line: {pointer_line:?}"
+    );
+
+    let _ = abort_and_exit_code(child, writer, rx);
+}

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -2311,6 +2311,102 @@ fn test_switch_picker_alt_x_keeps_cursor_sticky(mut repo: TestRepo) {
     );
 }
 
+/// alt-x lands the cursor on the row that slides up — the *immediate* next row —
+/// not one past it, even when the removed row has several rows below it.
+///
+/// [`test_switch_picker_alt_x_keeps_cursor_sticky`] removes the row directly below
+/// the pinned current worktree, leaving a single row beneath it. That can't tell a
+/// correct landing from a one-row overshoot: `scroll_by` clamps the cursor to the
+/// list's last row, so an off-by-one lands on the same (only) remaining row and the
+/// test passes anyway. This removes a *middle* row with two rows below it, where an
+/// overshoot lands one row too far instead of being clamped — the exact "jumps two
+/// down" a user sees with a long worktree list.
+#[rstest]
+fn test_switch_picker_alt_x_lands_on_immediate_next_row(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["remote", "remove", "origin"]);
+    // Four worktrees beneath the pinned current (main) row. All sit at main's
+    // commit, so each alt-x integrates-and-drops (no morph) — the drop path.
+    for branch in ["wt-a", "wt-b", "wt-c", "wt-d"] {
+        repo.add_worktree(branch);
+    }
+
+    let env_vars = repo.test_env_vars();
+    let PickerSession {
+        child,
+        _master,
+        writer,
+        rx,
+        mut parser,
+    } = boot_picker_pty(
+        wt_bin().to_str().unwrap(),
+        &["switch", "--no-cd", "--format=json"],
+        repo.root_path(),
+        &env_vars,
+    );
+    let send = |bytes: &[u8]| {
+        let mut w = writer.lock().unwrap();
+        w.write_all(bytes).unwrap();
+        w.flush().unwrap();
+    };
+
+    // One skeleton batch carries every worktree row, so waiting for one implies
+    // all are present.
+    wait_for_stable_with_content(&rx, &mut parser, Some("wt-a"));
+
+    // Learn the rendered order: the current worktree is pinned to the top, then the
+    // four worktrees by commit recency (a tie here, so insertion order). Read the
+    // four worktree rows top-to-bottom from the list pane.
+    let order: Vec<String> = {
+        let list = list_pane_text(parser.screen());
+        let mut rows: Vec<(usize, String)> = ["wt-a", "wt-b", "wt-c", "wt-d"]
+            .iter()
+            .filter_map(|name| {
+                list.lines()
+                    .position(|l| l.contains(name))
+                    .map(|line| (line, (*name).to_string()))
+            })
+            .collect();
+        rows.sort_by_key(|(line, _)| *line);
+        rows.into_iter().map(|(_, name)| name).collect()
+    };
+    assert_eq!(order.len(), 4, "all four worktree rows rendered");
+    // Remove the second worktree row (two rows still below it); the row directly
+    // below it must catch the cursor.
+    let remove_target = order[1].clone();
+    let expected_landing = order[2].clone();
+    let overshoot_row = order[3].clone();
+
+    // Down onto the second worktree row: one Down per row from the pinned current
+    // worktree at the top.
+    send(b"\x1b[B");
+    wait_for_cursor_on_row(&rx, &mut parser, &order[0]);
+    send(b"\x1b[B");
+    wait_for_cursor_on_row(&rx, &mut parser, &remove_target);
+
+    // alt-x drops it; the cursor must land on the row that slid up — the one
+    // directly below, not the one after it. A one-row overshoot lands on
+    // `overshoot_row` and times this out.
+    send(b"\x1bx");
+    wait_for_cursor_on_row(&rx, &mut parser, &expected_landing);
+
+    // Guard against the cursor having blown past to the next row: the pointer marks
+    // exactly one row, so a landing on `expected_landing` already excludes
+    // `overshoot_row`, but assert it explicitly for a clear failure message.
+    let pointer_line = list_pane_text(parser.screen())
+        .lines()
+        .find(|l| l.starts_with('>'))
+        .map(str::to_string)
+        .unwrap_or_default();
+    assert!(
+        !pointer_line.contains(&overshoot_row),
+        "alt-x overshot to `{overshoot_row}` instead of the immediate next row \
+         `{expected_landing}`.\nPointer line: {pointer_line:?}"
+    );
+
+    let _ = abort_and_exit_code(child, writer, rx);
+}
+
 /// Removing the sole row matching an active query leaves the filtered list empty,
 /// so the cursor-reposition gives up once the matcher settles empty rather than
 /// spinning the event loop. The picker stays responsive — its screen stabilizes,
@@ -2500,4 +2596,162 @@ fn test_switch_picker_alt_x_morphs_removed_worktree_in_place(mut repo: TestRepo)
         branches.contains("transform-me"),
         "the unmerged branch is retained after its worktree is removed: {branches:?}"
     );
+}
+
+/// alt-x on the *current* worktree — the one the picker was launched from — keeps
+/// the row in place rather than removing it. Removing the worktree the shell is
+/// sitting in would have to cd elsewhere first, which drags `post-switch` hooks
+/// into the picker and swaps an empty placeholder under the cursor mid-render, so
+/// the picker declines (`removal_targets_current_worktree`). End-to-end through
+/// real skim launched from inside the worktree: after alt-x the cursor stays on
+/// the unchanged `@ standing-here` row (gutter still `@` — not dropped, not
+/// morphed to `/`) and the worktree survives on disk. The branch is unmerged, so
+/// were the guard absent the row would morph; a surviving `@` proves the
+/// current-worktree check fires before the morph path.
+#[rstest]
+fn test_switch_picker_alt_x_keeps_current_worktree(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["remote", "remove", "origin"]);
+
+    let wt_path = repo.add_worktree("standing-here");
+    std::fs::write(wt_path.join("new.txt"), "unmerged work").unwrap();
+    repo.git_command()
+        .args(["-C", wt_path.to_str().unwrap(), "add", "new.txt"])
+        .run()
+        .unwrap();
+    repo.git_command()
+        .args([
+            "-C",
+            wt_path.to_str().unwrap(),
+            "commit",
+            "-m",
+            "unmerged work",
+        ])
+        .run()
+        .unwrap();
+
+    let env_vars = repo.test_env_vars();
+    let pair = crate::common::open_pty_with_size(TERM_ROWS, TERM_COLS);
+    let mut cmd = CommandBuilder::new(wt_bin().to_str().unwrap());
+    cmd.arg("switch");
+    cmd.cwd(&wt_path); // launched from inside the worktree → it's the current one
+    crate::common::configure_pty_command(&mut cmd);
+    cmd.env("CLICOLOR_FORCE", "1");
+    cmd.env("TERM", "xterm-256color");
+    for (key, value) in &env_vars {
+        cmd.env(key, value);
+    }
+    let mut child = pair.slave.spawn_command(cmd).unwrap();
+    drop(pair.slave);
+
+    let reader = pair.master.try_clone_reader().unwrap();
+    let writer: crate::common::pty::SharedPtyWriter =
+        Arc::new(Mutex::new(pair.master.take_writer().unwrap()));
+    let rx = crate::common::pty::spawn_pty_reader_answering_queries(reader, Arc::clone(&writer));
+    let mut parser = vt100::Parser::new(TERM_ROWS, TERM_COLS, 0);
+    let drain = |rx: &mpsc::Receiver<Vec<u8>>, parser: &mut vt100::Parser| {
+        while let Ok(chunk) = rx.try_recv() {
+            parser.process(&chunk);
+        }
+    };
+    let send = |writer: &crate::common::pty::SharedPtyWriter, bytes: &[u8]| {
+        let mut w = writer.lock().unwrap();
+        w.write_all(bytes).unwrap();
+        w.flush().unwrap();
+    };
+
+    let start = Instant::now();
+    loop {
+        drain(&rx, &mut parser);
+        if is_skim_ready(&parser.screen().contents()) || start.elapsed() > READY_TIMEOUT {
+            break;
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+    wait_for_stable_with_content(&rx, &mut parser, Some("standing-here"));
+
+    // Filter to the current-worktree row so the selection is deterministic, then
+    // confirm the cursor is on it — `> @ standing-here`, the `@` current gutter.
+    send(&writer, b"standing-here");
+    wait_for_cursor_on_row(&rx, &mut parser, "@ standing-here");
+
+    // alt-x is declined for the current worktree: the row neither drops (the
+    // filtered list would empty) nor morphs (the gutter would flip to `/`). After
+    // the reload settles the cursor is back on the unchanged `@ standing-here` row.
+    send(&writer, b"\x1bx");
+    wait_for_cursor_on_row(&rx, &mut parser, "@ standing-here");
+
+    send(&writer, b"\x1b"); // Esc to exit the picker.
+    drop(writer);
+    let start = Instant::now();
+    while start.elapsed() < CHILD_EXIT_TIMEOUT {
+        if child.try_wait().unwrap().is_some() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let _ = child.kill();
+    drain(&rx, &mut parser);
+    let _ = child.wait();
+
+    // The worktree survives — alt-x declined to remove the one we're standing in.
+    assert!(
+        wt_path.exists(),
+        "alt-x removed the current worktree.\nScreen:\n{}",
+        parser.screen().contents()
+    );
+}
+
+/// alt-x on an unremovable row (here the main worktree) keeps the cursor exactly on
+/// that row — it must not drift down — even with several rows below it.
+///
+/// This mirrors the keep paths a user hits most: alt-x on the main worktree or a
+/// dirty worktree surfaces a diagnostic and keeps the row. The single-row filtered
+/// case in [`test_switch_picker_alt_x_keeps_current_worktree`] can't catch a
+/// one-row drift (only one row matches the filter), so this drives a full,
+/// unfiltered list and removes nothing: the cursor has to come back to the *same*
+/// row, not the one below it.
+#[rstest]
+fn test_switch_picker_alt_x_unremovable_row_keeps_cursor(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["remote", "remove", "origin"]);
+    // Launch from `wt-a` so it's the pinned current row; `main` then sorts second,
+    // with `wt-b`/`wt-c`/`wt-d` below it — main is a mid-list unremovable row.
+    let wt_a = repo.add_worktree("wt-a");
+    for branch in ["wt-b", "wt-c", "wt-d"] {
+        repo.add_worktree(branch);
+    }
+
+    let env_vars = repo.test_env_vars();
+    let PickerSession {
+        child,
+        _master,
+        writer,
+        rx,
+        mut parser,
+    } = boot_picker_pty(
+        wt_bin().to_str().unwrap(),
+        &["switch", "--no-cd", "--format=json"],
+        &wt_a,
+        &env_vars,
+    );
+    let send = |bytes: &[u8]| {
+        let mut w = writer.lock().unwrap();
+        w.write_all(bytes).unwrap();
+        w.flush().unwrap();
+    };
+
+    wait_for_stable_with_content(&rx, &mut parser, Some("wt-d"));
+
+    // Down from the pinned current `wt-a` onto the `main` row (sorted second).
+    send(b"\x1b[B");
+    wait_for_cursor_on_row(&rx, &mut parser, "main");
+
+    // alt-x is declined for the main worktree (it can't be removed). The row stays
+    // and the cursor must land back on it — a one-row drift lands on the worktree
+    // below `main` and times this out.
+    send(b"\x1bx");
+    wait_for_cursor_on_row(&rx, &mut parser, "main");
+
+    let _ = abort_and_exit_code(child, writer, rx);
 }

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -2390,21 +2390,21 @@ fn test_switch_picker_alt_x_keeps_unmerged_branch_row(mut repo: TestRepo) {
     );
 }
 
-/// alt-x on a *worktree* row whose branch is unmerged removes the worktree but
-/// transforms the row in place: the worktree is gone, the local branch remains,
-/// so the row returns as a `/ branch` branch-only row (gutter `+` → `/`) instead
-/// of vanishing. End-to-end through real skim — the background removal pins the
-/// surviving branch and fires a `refresh` reload, and the re-collect re-includes
-/// it even though `show_branches` is off (the default picker). This covers the
-/// integration seam the unit tests can't reach: the `Event::Reload("refresh")`
-/// send and the live re-render.
+/// alt-x on a *worktree* row whose branch is unmerged morphs the row to
+/// `/ branch` **in place**: the worktree is removed, the local branch stays, and
+/// the row keeps its slot with the cursor on it — gutter `+` → `/`, no reload, no
+/// teleport. The cursor staying put is the whole point of the morph (the old
+/// re-collect re-sorted the row to the bottom and reset the cursor to the top).
+/// End-to-end through real skim: after alt-x, the list-pane cursor pointer (`>`)
+/// must land on the morphed `/ transform-me` row — proving both the in-place
+/// gutter flip and the sticky cursor in one assertion.
 #[rstest]
-fn test_switch_picker_alt_x_transforms_removed_worktree_to_branch_row(mut repo: TestRepo) {
+fn test_switch_picker_alt_x_morphs_removed_worktree_in_place(mut repo: TestRepo) {
     repo.remove_fixture_worktrees();
     repo.run_git(&["remote", "remove", "origin"]);
 
     // A worktree on a branch with a commit the default branch lacks, so
-    // `SafeDelete` keeps the branch when the worktree is removed.
+    // `SafeDelete` keeps the branch when the worktree is removed (→ morph, not drop).
     let wt_path = repo.add_worktree("transform-me");
     std::fs::write(wt_path.join("new.txt"), "unmerged work").unwrap();
     repo.git_command()
@@ -2423,32 +2423,81 @@ fn test_switch_picker_alt_x_transforms_removed_worktree_to_branch_row(mut repo: 
         .unwrap();
 
     let env_vars = repo.test_env_vars();
-    let result = exec_in_pty_capture_before_abort(
-        wt_bin().to_str().unwrap(),
-        &["switch"],
-        repo.root_path(),
-        &env_vars,
-        &[
-            // Filter to the worktree row (`> + transform-me`), then alt-x. The
-            // removal runs on a background thread (drop → pin → refresh →
-            // re-collect), so wait on the *post-transform* marker `/ transform-me`
-            // — the branch gutter that only appears once the row has transformed.
-            // Waiting on the bare name would match the pre-removal `+ ` row and
-            // capture before the transform rendered.
-            ("transform-me", Some("transform-me")),
-            ("\x1bx", Some("/ transform-me")),
-        ],
-    );
+    let pair = crate::common::open_pty_with_size(TERM_ROWS, TERM_COLS);
+    let mut cmd = CommandBuilder::new(wt_bin().to_str().unwrap());
+    cmd.arg("switch");
+    cmd.cwd(repo.root_path());
+    crate::common::configure_pty_command(&mut cmd);
+    cmd.env("CLICOLOR_FORCE", "1");
+    cmd.env("TERM", "xterm-256color");
+    for (key, value) in &env_vars {
+        cmd.env(key, value);
+    }
+    let mut child = pair.slave.spawn_command(cmd).unwrap();
+    drop(pair.slave);
 
-    assert_valid_abort_exit_code(result.exit_code);
-    let (list, _preview) = result.panels();
-    // `+ transform-me` (worktree) becomes `/ transform-me` (branch-only). The
-    // gutter glyph renders immediately before the branch name, so the `/ ` form
-    // appears only once the row has transformed — a worktree row (`+ `) or the
-    // prompt echo (`> transform-me`, no slash) never produces it.
+    let reader = pair.master.try_clone_reader().unwrap();
+    let writer: crate::common::pty::SharedPtyWriter =
+        Arc::new(Mutex::new(pair.master.take_writer().unwrap()));
+    let rx = crate::common::pty::spawn_pty_reader_answering_queries(reader, Arc::clone(&writer));
+    let mut parser = vt100::Parser::new(TERM_ROWS, TERM_COLS, 0);
+    let drain = |rx: &mpsc::Receiver<Vec<u8>>, parser: &mut vt100::Parser| {
+        while let Ok(chunk) = rx.try_recv() {
+            parser.process(&chunk);
+        }
+    };
+    let send = |writer: &crate::common::pty::SharedPtyWriter, bytes: &[u8]| {
+        let mut w = writer.lock().unwrap();
+        w.write_all(bytes).unwrap();
+        w.flush().unwrap();
+    };
+
+    // Wait for skim to be ready, then for the worktree row to land.
+    let start = Instant::now();
+    loop {
+        drain(&rx, &mut parser);
+        if is_skim_ready(&parser.screen().contents()) || start.elapsed() > READY_TIMEOUT {
+            break;
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+    wait_for_stable_with_content(&rx, &mut parser, Some("transform-me"));
+
+    // Filter to the single worktree row so the selection is deterministic
+    // regardless of commit-recency order, then confirm the cursor is on it. The
+    // row still reads `> + transform-me` — a linked worktree.
+    send(&writer, b"transform-me");
+    wait_for_cursor_on_row(&rx, &mut parser, "+ transform-me");
+
+    // alt-x morphs the row in place. The cursor must land back on the morphed
+    // row — `> / transform-me`, gutter flipped to the branch sigil. The morph
+    // leaves `search_text` untouched, so the row still matches the active filter;
+    // a drop would empty the list, and the old re-collect would reset the cursor.
+    send(&writer, b"\x1bx");
+    wait_for_cursor_on_row(&rx, &mut parser, "/ transform-me");
+
+    send(&writer, b"\x1b"); // Esc to exit the picker.
+    drop(writer);
+    let start = Instant::now();
+    while start.elapsed() < CHILD_EXIT_TIMEOUT {
+        if child.try_wait().unwrap().is_some() {
+            break;
+        }
+        std::thread::sleep(Duration::from_millis(10));
+    }
+    let _ = child.kill();
+    drain(&rx, &mut parser);
+    let _ = child.wait();
+
+    // The worktree is gone but its branch survives — the morph's premise.
     assert!(
-        list.contains("/ transform-me"),
-        "after alt-x the removed worktree's row returns as a `/ transform-me` \
-         branch-only row.\nList:\n{list}"
+        !wt_path.exists(),
+        "alt-x removed the worktree directory.\nScreen:\n{}",
+        parser.screen().contents()
+    );
+    let branches = repo.git_output(&["branch", "--list", "transform-me"]);
+    assert!(
+        branches.contains("transform-me"),
+        "the unmerged branch is retained after its worktree is removed: {branches:?}"
     );
 }

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -2181,3 +2181,66 @@ fn test_switch_picker_alt_x_keeps_unmerged_branch_row(mut repo: TestRepo) {
          both the prompt echo and a data row, got {occurrences} occurrence(s).\nList:\n{list}"
     );
 }
+
+/// alt-x on a *worktree* row whose branch is unmerged removes the worktree but
+/// transforms the row in place: the worktree is gone, the local branch remains,
+/// so the row returns as a `/ branch` branch-only row (gutter `+` → `/`) instead
+/// of vanishing. End-to-end through real skim — the background removal pins the
+/// surviving branch and fires a `refresh` reload, and the re-collect re-includes
+/// it even though `show_branches` is off (the default picker). This covers the
+/// integration seam the unit tests can't reach: the `Event::Reload("refresh")`
+/// send and the live re-render.
+#[rstest]
+fn test_switch_picker_alt_x_transforms_removed_worktree_to_branch_row(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    repo.run_git(&["remote", "remove", "origin"]);
+
+    // A worktree on a branch with a commit the default branch lacks, so
+    // `SafeDelete` keeps the branch when the worktree is removed.
+    let wt_path = repo.add_worktree("transform-me");
+    std::fs::write(wt_path.join("new.txt"), "unmerged work").unwrap();
+    repo.git_command()
+        .args(["-C", wt_path.to_str().unwrap(), "add", "new.txt"])
+        .run()
+        .unwrap();
+    repo.git_command()
+        .args([
+            "-C",
+            wt_path.to_str().unwrap(),
+            "commit",
+            "-m",
+            "unmerged work",
+        ])
+        .run()
+        .unwrap();
+
+    let env_vars = repo.test_env_vars();
+    let result = exec_in_pty_capture_before_abort(
+        wt_bin().to_str().unwrap(),
+        &["switch"],
+        repo.root_path(),
+        &env_vars,
+        &[
+            // Filter to the worktree row (`> + transform-me`), then alt-x. The
+            // removal runs on a background thread (drop → pin → refresh →
+            // re-collect), so wait on the *post-transform* marker `/ transform-me`
+            // — the branch gutter that only appears once the row has transformed.
+            // Waiting on the bare name would match the pre-removal `+ ` row and
+            // capture before the transform rendered.
+            ("transform-me", Some("transform-me")),
+            ("\x1bx", Some("/ transform-me")),
+        ],
+    );
+
+    assert_valid_abort_exit_code(result.exit_code);
+    let (list, _preview) = result.panels();
+    // `+ transform-me` (worktree) becomes `/ transform-me` (branch-only). The
+    // gutter glyph renders immediately before the branch name, so the `/ ` form
+    // appears only once the row has transformed — a worktree row (`+ `) or the
+    // prompt echo (`> transform-me`, no slash) never produces it.
+    assert!(
+        list.contains("/ transform-me"),
+        "after alt-x the removed worktree's row returns as a `/ transform-me` \
+         branch-only row.\nList:\n{list}"
+    );
+}

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -196,6 +196,8 @@ The CI column shows each row's PR/MR CI and review status, the same as [2mwt li
 
 [2mAlt-o[0m is a no-op on a row with no PR/MR (or whose status hasn't loaded yet).
 
+[2mAlt-x[0m is a no-op on the current worktree (the [2m@[0m row) — removing the worktree in use would have to switch elsewhere first, so switch away and remove it from there.
+
 Each row filters by its branch, path, and — when it has a PR/MR — the PR/MR's number, title, and author, the same fields whether the PR is checked out (a worktree row) or listed via [2m--prs[0m. Plain digits go to the filter, so a number can be typed directly and the preview tabs move to [2mAlt[0m.
 
 Typing a gutter sigil filters by row kind: [36m+[0m narrows to linked worktrees and [2m@[0m to the current worktree. The other sigils don't filter cleanly — [2m^[0m and [2m|[0m are skim's prefix-anchor and OR query operators (so [2m^[0m matches every row and [2m|[0m none), and [2m/[0m matches most rows because every worktree path contains it.


### PR DESCRIPTION
Overhauls the `wt switch` picker's `alt-x` (remove) so a removal updates the selected row in place instead of re-collecting the whole list, declines removals that can't safely happen with an explanation, and lands the cursor on the right row afterward — including under an active filter.

## What changes for the user

`alt-x` on a row now behaves by what the removal does:

- **Unmerged worktree** → the row morphs in place to a `/ branch` row (worktree gone, branch kept); the worktree removal runs in the background. No flicker, cursor stays put.
- **Merged worktree** → the row drops; the cursor lands on the row that slid up into its slot.
- **Current worktree (`@`), main, dirty, locked** → kept, with the same diagnostic `wt remove` prints (drained to stderr on picker exit) instead of a silent dead keypress or a disruptive cd-home.

Before, `alt-x` re-collected the entire list (a visible flicker, cursor reset to top), and removing the current worktree forced a `cd` elsewhere mid-render.

## The cursor fix (last commit)

The post-removal reposition scrolled to the removed row's index in the full `shared_items` list. Under a fuzzy query, skim's `item_list` is filtered and reordered, so that index pointed at the wrong row — the cursor jumped +N rows down (N = filtered-out rows above it), compounding on a second removal. Reposition is now by **row identity**: it walks `item_list` to the target row's `output()` token. The drop's landing row (the display-neighbor) is captured before the reload via a native `alt-x` binding (`[capture, reload]`); keep/morph/restore land on their own row's token.

## Reviewing

The bulk is `src/commands/picker/mod.rs`. Key pieces:
- `invoke` dispatch (`removal_targets_current_worktree` → `worktree_removal_keeps_branch` → `removal_will_remove_target`) decides keep / morph / drop.
- `morph_and_remove_in_background` does the in-place row morph (optimistic, reverted if the worktree unexpectedly survives).
- `reposition_cursor_action` / `install_remove_keybinding` are the identity-based cursor landing.

## Testing

Picker unit tests plus PTY integration tests through real skim, including the new `test_switch_picker_alt_x_lands_on_neighbor_under_filter` (removes a row with filtered-out decoys above it — confirmed to fail on the old index-based reposition and pass on identity). Multi-row cursor tests cover both drop and keep paths.

> _This was written by Claude Code on behalf of max_
