### PR TITLE
fix(list): rank Integrated (⊂) above WouldConflict (✗) in main-state

### DIFF
--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -182,10 +182,10 @@ The single highest-priority state describing the branch's relation to the defaul
 |--------|------------|---------|
 | `^` | `"is_main"` | The main worktree (the repo's home worktree) |
 | `∅` | `"orphan"` | No common ancestor with the default branch |
-| `✗` | `"would_conflict"` | Merging into the default branch would conflict (simulated with `git merge-tree`); with `--full`, the check includes uncommitted changes |
 | `_` | `"empty"` | Same commit as the default branch, working tree clean — safe to remove; row dimmed |
-| `–` | `"same_commit"` | Same commit as the default branch, but with uncommitted changes |
 | `⊂` | `"integrated"` | Content [integrated](@/remove.md#branch-cleanup) into the default branch or merge target via different history; the matching check is in `integration_reason`; row dimmed |
+| `✗` | `"would_conflict"` | Merging into the default branch would conflict (simulated with `git merge-tree`) and the branch isn't already integrated; with `--full`, the check includes uncommitted changes |
+| `–` | `"same_commit"` | Same commit as the default branch, but with uncommitted changes |
 | `↕` | `"diverged"` | Both ahead of and behind the default branch |
 | `↑` | `"ahead"` | Has commits the default branch doesn't |
 | `↓` | `"behind"` | Missing commits the default branch has |
@@ -328,7 +328,7 @@ Top-level `repo` describes the local checkout's repository as derived from the p
 
 ### main_state values
 
-The single highest-priority state describing the branch's relation to the default branch; absent when none applies (a normal up-to-date branch). Each value is one Default-branch symbol — see [Default branch](#default-branch) for the symbol and the full meaning of each value (`"is_main"`, `"orphan"`, `"would_conflict"`, `"empty"`, `"same_commit"`, `"integrated"`, `"diverged"`, `"ahead"`, `"behind"`).
+The single highest-priority state describing the branch's relation to the default branch; absent when none applies (a normal up-to-date branch). Each value is one Default-branch symbol — see [Default branch](#default-branch) for the symbol and the full meaning of each value (`"is_main"`, `"orphan"`, `"empty"`, `"integrated"`, `"would_conflict"`, `"same_commit"`, `"diverged"`, `"ahead"`, `"behind"`).
 
 ### integration_reason values
 

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -167,10 +167,10 @@ The single highest-priority state describing the branch's relation to the defaul
 |--------|------------|---------|
 | `^` | `"is_main"` | The main worktree (the repo's home worktree) |
 | `∅` | `"orphan"` | No common ancestor with the default branch |
-| `✗` | `"would_conflict"` | Merging into the default branch would conflict (simulated with `git merge-tree`); with `--full`, the check includes uncommitted changes |
 | `_` | `"empty"` | Same commit as the default branch, working tree clean — safe to remove; row dimmed |
-| `–` | `"same_commit"` | Same commit as the default branch, but with uncommitted changes |
 | `⊂` | `"integrated"` | Content [integrated](https://worktrunk.dev/remove/#branch-cleanup) into the default branch or merge target via different history; the matching check is in `integration_reason`; row dimmed |
+| `✗` | `"would_conflict"` | Merging into the default branch would conflict (simulated with `git merge-tree`) and the branch isn't already integrated; with `--full`, the check includes uncommitted changes |
+| `–` | `"same_commit"` | Same commit as the default branch, but with uncommitted changes |
 | `↕` | `"diverged"` | Both ahead of and behind the default branch |
 | `↑` | `"ahead"` | Has commits the default branch doesn't |
 | `↓` | `"behind"` | Missing commits the default branch has |
@@ -337,7 +337,7 @@ Top-level `repo` describes the local checkout's repository as derived from the p
 
 ### main_state values
 
-The single highest-priority state describing the branch's relation to the default branch; absent when none applies (a normal up-to-date branch). Each value is one Default-branch symbol — see [Default branch](#default-branch) for the symbol and the full meaning of each value (`"is_main"`, `"orphan"`, `"would_conflict"`, `"empty"`, `"same_commit"`, `"integrated"`, `"diverged"`, `"ahead"`, `"behind"`).
+The single highest-priority state describing the branch's relation to the default branch; absent when none applies (a normal up-to-date branch). Each value is one Default-branch symbol — see [Default branch](#default-branch) for the symbol and the full meaning of each value (`"is_main"`, `"orphan"`, `"empty"`, `"integrated"`, `"would_conflict"`, `"same_commit"`, `"diverged"`, `"ahead"`, `"behind"`).
 
 ### integration_reason values
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -910,10 +910,10 @@ The single highest-priority state describing the branch's relation to the defaul
 |--------|------------|---------|
 | `^` | `"is_main"` | The main worktree (the repo's home worktree) |
 | `∅` | `"orphan"` | No common ancestor with the default branch |
-| `✗` | `"would_conflict"` | Merging into the default branch would conflict (simulated with `git merge-tree`); with `--full`, the check includes uncommitted changes |
 | `_` | `"empty"` | Same commit as the default branch, working tree clean — safe to remove; row dimmed |
-| `–` | `"same_commit"` | Same commit as the default branch, but with uncommitted changes |
 | `⊂` | `"integrated"` | Content [integrated](@/remove.md#branch-cleanup) into the default branch or merge target via different history; the matching check is in `integration_reason`; row dimmed |
+| `✗` | `"would_conflict"` | Merging into the default branch would conflict (simulated with `git merge-tree`) and the branch isn't already integrated; with `--full`, the check includes uncommitted changes |
+| `–` | `"same_commit"` | Same commit as the default branch, but with uncommitted changes |
 | `↕` | `"diverged"` | Both ahead of and behind the default branch |
 | `↑` | `"ahead"` | Has commits the default branch doesn't |
 | `↓` | `"behind"` | Missing commits the default branch has |
@@ -1080,7 +1080,7 @@ Top-level `repo` describes the local checkout's repository as derived from the p
 
 ### main_state values
 
-The single highest-priority state describing the branch's relation to the default branch; absent when none applies (a normal up-to-date branch). Each value is one Default-branch symbol — see [Default branch](#default-branch) for the symbol and the full meaning of each value (`"is_main"`, `"orphan"`, `"would_conflict"`, `"empty"`, `"same_commit"`, `"integrated"`, `"diverged"`, `"ahead"`, `"behind"`).
+The single highest-priority state describing the branch's relation to the default branch; absent when none applies (a normal up-to-date branch). Each value is one Default-branch symbol — see [Default branch](#default-branch) for the symbol and the full meaning of each value (`"is_main"`, `"orphan"`, `"empty"`, `"integrated"`, `"would_conflict"`, `"same_commit"`, `"diverged"`, `"ahead"`, `"behind"`).
 
 ### integration_reason values
 

--- a/src/commands/list/collect/tasks.rs
+++ b/src/commands/list/collect/tasks.rs
@@ -558,8 +558,9 @@ impl Task for WorkingTreeDiffTask {
 /// **Skip-when-dirty optimization:** for worktree items, peek at the shared
 /// porcelain cache. When the worktree is dirty (and has no unmerged
 /// entries), `WorkingTreeConflictsTask` will produce a `Some(Some(_))`
-/// dirty-tree result that is authoritative for tier 3 (`tier_would_conflict`
-/// short-circuits on `Some(Some(_))` and ignores the HEAD probe). Returning
+/// dirty-tree result that is authoritative for the WouldConflict tier
+/// (`tier_would_conflict` short-circuits on `Some(Some(_))` and ignores the
+/// HEAD probe). Returning
 /// the redundant HEAD probe in that case would mean a second `git merge-tree`
 /// call against HEAD for the same row. Skip with a sentinel `false` —
 /// the value is ignored by the gate, and seeding `Some(false)` keeps the

--- a/src/commands/list/json_output.rs
+++ b/src/commands/list/json_output.rs
@@ -524,7 +524,7 @@ fn format_raw_symbols(symbols: &super::model::StatusSymbols) -> String {
         result.push_str(&wt.to_symbols());
     }
 
-    // Main state (gate 3) — merged column: ^✗_⊂↕↑↓
+    // Main state (gate 3) — merged column: ^_⊂✗↕↑↓
     if let Some(ms) = symbols.main_state {
         let s = ms.to_string();
         if !s.is_empty() {

--- a/src/commands/list/model/item.rs
+++ b/src/commands/list/model/item.rs
@@ -633,10 +633,17 @@ impl ListItem {
 
     /// Gate 3: main state. Walks the priority chain tier by tier, using
     /// the per-tier helpers from `state.rs`.
+    ///
+    /// Tier order: `IsMain > Orphan > integration (⊂/_) > WouldConflict (✗) >
+    /// same-commit-dirty / counts`. Integration outranks `WouldConflict`
+    /// because a branch whose content is already in the default branch is
+    /// safe to delete even if a naive re-merge would conflict (the conflict
+    /// is vacuous). To keep that from *delaying* the common `↑`/`↓`/`⊂`
+    /// cases, integration stays fire-or-continue (never blocks); only `✗` is
+    /// held back until the integration verdict is final, so an integrated
+    /// branch never momentarily flashes `✗` before settling to `⊂`.
     fn try_gate_main_state(&self, default_branch: Option<&str>) -> Option<MainState> {
-        use super::state::{
-            Tier, tier_integration_or_counts, tier_is_main, tier_orphan, tier_would_conflict,
-        };
+        use super::state::{Tier, tier_counts, tier_is_main, tier_orphan, tier_would_conflict};
 
         let is_main = matches!(&self.kind, ItemKind::Worktree(data) if data.is_main);
 
@@ -654,43 +661,78 @@ impl ListItem {
             Tier::Wait => return None,
         }
 
-        // Tier 3: WouldConflict. For branches, there's no working-tree
-        // conflict probe, so we substitute `Some(None)` (the "task ran
-        // but working tree is clean / N/A" sentinel).
+        // `is_clean` feeds both the integration verdict (only a clean tree
+        // can be shown as integrated) and the `✗` guard (we can rule out
+        // "clean & integrated" only once cleanliness is known). It comes
+        // from the cheap local `WorkingTreeDiff`, which lands well before
+        // the merge-tree probes, so requiring it here rarely delays a cell.
+        let is_clean = match &self.kind {
+            ItemKind::Worktree(data) => {
+                let diff = data.working_tree_diff.as_ref()?;
+                let status = data.working_tree_status?;
+                diff.is_empty() && !status.untracked
+            }
+            // Branches have no working tree; trivially clean.
+            ItemKind::Branch(_) => true,
+        };
+
+        // Tier 3: Integration (`⊂`/`_`). Fire when the content is known to be
+        // in the default branch; otherwise fall through (the gate re-evaluates,
+        // so a later pass can still upgrade `↑` to `⊂`). `is_main` is already
+        // `false` here (tier 1 returned otherwise).
+        if let Some(state) = self.check_integration_state(is_main, default_branch, is_clean) {
+            return Some(state);
+        }
+
+        // Tier 4: WouldConflict (`✗`). Held until the integration verdict is
+        // final (`integration_resolved`) so an integrated-but-stale branch
+        // never flashes `✗` before tier 3 settles it to `⊂`. For branches
+        // there's no working-tree conflict probe, so substitute `Some(None)`
+        // (the "task ran but working tree is clean / N/A" sentinel).
         let has_working_tree_conflicts = match &self.kind {
             ItemKind::Worktree(data) => data.has_working_tree_conflicts,
             ItemKind::Branch(_) => Some(None),
         };
-        match tier_would_conflict(self.has_merge_tree_conflicts, has_working_tree_conflicts) {
+        let integration_resolved = self.integration_resolved(default_branch, is_clean);
+        match tier_would_conflict(
+            self.has_merge_tree_conflicts,
+            has_working_tree_conflicts,
+            integration_resolved,
+        ) {
             Tier::Fired(s) => return Some(s),
             Tier::RuledOut => {}
             Tier::Wait => return None,
         }
 
-        // Tiers 4-6: integration / same-commit-dirty / counts-based. Needs
-        // `counts` and `is_clean`, plus the integration signals fed
-        // through `check_integration_state` (which is short-circuiting and
-        // treats missing integration signals as "no info, fall through").
-        let is_clean = match &self.kind {
-            ItemKind::Worktree(data) => {
-                let diff = data.working_tree_diff.as_ref()?;
-                let status = data.working_tree_status?;
-                Some(diff.is_empty() && !status.untracked)
-            }
-            // Branches have no working tree; trivially clean.
-            ItemKind::Branch(_) => Some(true),
-        };
-        let integration = match &self.kind {
-            ItemKind::Worktree(data) => {
-                self.check_integration_state(data.is_main, default_branch, is_clean?)
-            }
-            ItemKind::Branch(_) => self.check_integration_state(false, default_branch, true),
-        };
-
-        match tier_integration_or_counts(self.counts, is_clean, integration) {
+        // Tiers 5-6: same-commit-dirty / counts-based fallback.
+        match tier_counts(self.counts, Some(is_clean)) {
             Tier::Fired(s) => Some(s),
             Tier::RuledOut | Tier::Wait => None,
         }
+    }
+
+    /// Whether the integration verdict for this item is final — i.e. it will
+    /// not later flip to "integrated". Used by gate 3 to decide when `✗`
+    /// (WouldConflict) is safe to render: a detected conflict only means `✗`
+    /// for a branch that isn't already in the default branch, so `✗` holds
+    /// until this returns `true`.
+    ///
+    /// The verdict is final immediately when integration can't apply (no
+    /// default branch, or a dirty tree — integration states require a clean
+    /// tree). Otherwise it can still resolve to integrated until every feeder
+    /// signal of `check_integration_state` has reported. Those signals are
+    /// seeded on skip (see `seed_skipped_task_defaults`), so this converges
+    /// for every item — including branches, which schedule the same probes.
+    fn integration_resolved(&self, default_branch: Option<&str>, is_clean: bool) -> bool {
+        if default_branch.is_none() || !is_clean {
+            return true;
+        }
+        self.counts.is_some()
+            && self.is_ancestor.is_some()
+            && self.has_file_changes.is_some()
+            && self.committed_trees_match.is_some()
+            && self.would_merge_add.is_some()
+            && self.is_patch_id_match.is_some()
     }
 
     /// Gate 4: upstream divergence. Resolves once `upstream` is loaded.
@@ -1036,31 +1078,42 @@ mod tests {
         assert_eq!(item.status_symbols.main_state, Some(MainState::Orphan));
     }
 
+    /// Mark `item`'s working tree clean (so `is_clean` resolves) by seeding
+    /// the cheap local probes the gate reads for cleanliness.
+    fn mark_working_tree_clean(item: &mut ListItem) {
+        use super::super::super::model::WorkingTreeStatus;
+        use worktrunk::git::LineDiff;
+        if let ItemKind::Worktree(ref mut data) = item.kind {
+            data.working_tree_diff = Some(LineDiff::default());
+            data.working_tree_status = Some(WorkingTreeStatus::default());
+            data.has_working_tree_conflicts = Some(None); // clean: defer to HEAD probe
+        }
+    }
+
     #[test]
     fn gate_main_state_would_conflict_requires_both_conflict_signals() {
-        // `has_merge_tree_conflicts = None` → tier 3 waits even with
+        // Clean tree + no default branch ⇒ integration can't apply, so the
+        // WouldConflict tier is reached and gated only by the conflict probes.
+        // `has_merge_tree_conflicts = None` → the tier waits even with
         // `has_working_tree_conflicts` saying "clean."
         let mut item = make_worktree_item();
         item.is_orphan = Some(false);
+        mark_working_tree_clean(&mut item);
         item.has_merge_tree_conflicts = None;
-        if let ItemKind::Worktree(ref mut data) = item.kind {
-            data.has_working_tree_conflicts = Some(None); // clean working tree
-        }
         item.refresh_status_symbols(None);
         assert_eq!(item.status_symbols.main_state, None);
 
-        // Set the merge-tree probe to "no conflict" → tier 3 rules out,
-        // fall through to lower tiers. But counts is still None, so
-        // tier 4 waits and gate stays None.
+        // Set the merge-tree probe to "no conflict" → the tier rules out and
+        // falls through. But counts is still None, so the counts tier waits
+        // and the gate stays None.
         item.has_merge_tree_conflicts = Some(false);
         item.refresh_status_symbols(None);
         assert_eq!(item.status_symbols.main_state, None);
     }
 
     #[test]
-    fn gate_main_state_tier4_waits_for_counts_and_clean() {
-        use super::super::super::model::{AheadBehind, WorkingTreeStatus};
-        use worktrunk::git::LineDiff;
+    fn gate_main_state_counts_tier_waits_for_counts_and_clean() {
+        use super::super::super::model::AheadBehind;
 
         let mut item = make_worktree_item();
         item.is_orphan = Some(false);
@@ -1068,7 +1121,8 @@ mod tests {
         if let ItemKind::Worktree(ref mut data) = item.kind {
             data.has_working_tree_conflicts = Some(None);
         }
-        // counts set but is_clean inputs missing → Wait.
+        // counts set but is_clean inputs missing → the gate can't even
+        // compute `is_clean`, so it waits.
         item.counts = Some(AheadBehind {
             ahead: 3,
             behind: 2,
@@ -1076,13 +1130,83 @@ mod tests {
         item.refresh_status_symbols(None);
         assert_eq!(item.status_symbols.main_state, None);
 
-        // Fill in the is_clean inputs → gate resolves.
-        if let ItemKind::Worktree(ref mut data) = item.kind {
-            data.working_tree_diff = Some(LineDiff::default());
-            data.working_tree_status = Some(WorkingTreeStatus::default());
-        }
+        // Fill in the is_clean inputs → gate resolves to Diverged.
+        mark_working_tree_clean(&mut item);
         item.refresh_status_symbols(None);
         assert_eq!(item.status_symbols.main_state, Some(MainState::Diverged));
+    }
+
+    /// Seed the integration feeder signals for a branch whose squashed diff
+    /// matches a commit already on the default branch (patch-id match), with
+    /// ahead/behind counts so it isn't same-commit. `patch_id` and
+    /// `would_merge_add` are left to the caller to model the loading state.
+    fn seed_patch_id_integration(item: &mut ListItem) {
+        use super::super::super::model::AheadBehind;
+        item.is_orphan = Some(false);
+        item.counts = Some(AheadBehind {
+            ahead: 1,
+            behind: 11,
+        });
+        item.is_ancestor = Some(false);
+        item.has_file_changes = Some(true); // has added changes (not NoAddedChanges)
+        item.committed_trees_match = Some(false);
+        // A real merge-tree conflict against today's default branch.
+        item.has_merge_tree_conflicts = Some(true);
+        mark_working_tree_clean(item);
+    }
+
+    #[test]
+    fn gate_main_state_integration_outranks_would_conflict() {
+        // The squash-merged-then-base-moved-on case: content is in the
+        // default branch (patch-id match) AND a naive re-merge conflicts.
+        // The row must show ⊂ (Integrated), never ✗ — matching what
+        // `wt step prune` reports.
+        let mut item = make_worktree_item();
+        seed_patch_id_integration(&mut item);
+        item.would_merge_add = Some(true); // merge-tree conflicted, can't tell
+        item.is_patch_id_match = Some(true); // …but the patch-id matches
+        item.refresh_status_symbols(Some("main"));
+        assert_eq!(
+            item.status_symbols.main_state,
+            Some(MainState::Integrated(IntegrationReason::PatchIdMatch))
+        );
+    }
+
+    #[test]
+    fn gate_main_state_conflict_holds_until_integration_resolves() {
+        // While the patch-id probe is still loading, a detected conflict must
+        // NOT flash ✗ — the gate holds at `·` (None) so an integrated branch
+        // never momentarily alarms before settling to ⊂.
+        let mut item = make_worktree_item();
+        seed_patch_id_integration(&mut item);
+        item.would_merge_add = None; // integration verdict not yet final
+        item.is_patch_id_match = None;
+        item.refresh_status_symbols(Some("main"));
+        assert_eq!(item.status_symbols.main_state, None);
+
+        // Once the probe lands as a patch-id match, it settles to ⊂.
+        item.would_merge_add = Some(true);
+        item.is_patch_id_match = Some(true);
+        item.refresh_status_symbols(Some("main"));
+        assert_eq!(
+            item.status_symbols.main_state,
+            Some(MainState::Integrated(IntegrationReason::PatchIdMatch))
+        );
+    }
+
+    #[test]
+    fn gate_main_state_genuine_conflict_shows_would_conflict() {
+        // Not integrated (patch-id resolves negative) AND a real conflict →
+        // ✗ is correct and still rendered.
+        let mut item = make_worktree_item();
+        seed_patch_id_integration(&mut item);
+        item.would_merge_add = Some(true);
+        item.is_patch_id_match = Some(false); // resolved: NOT integrated
+        item.refresh_status_symbols(Some("main"));
+        assert_eq!(
+            item.status_symbols.main_state,
+            Some(MainState::WouldConflict)
+        );
     }
 
     // ---- Gate 4: upstream divergence (position 5) ----

--- a/src/commands/list/model/state.rs
+++ b/src/commands/list/model/state.rs
@@ -111,13 +111,23 @@ impl std::fmt::Display for WorktreeState {
 /// Priority order determines which symbol is shown:
 /// 1. IsMain (^) - this IS the main worktree
 /// 2. Orphan (∅) - no common ancestor with default branch
-/// 3. WouldConflict (✗) - merge-tree simulation shows conflicts
-/// 4. Empty (_) - same commit as default branch AND clean working tree (safe to delete)
-/// 5. SameCommit (–) - same commit as default branch with uncommitted changes
-/// 6. Integrated (⊂) - content is in default branch via different history
+/// 3. Empty (_) - same commit as default branch AND clean working tree (safe to delete)
+/// 4. Integrated (⊂) - content is in default branch via different history (safe to delete)
+/// 5. WouldConflict (✗) - merge-tree simulation shows conflicts AND not already integrated
+/// 6. SameCommit (–) - same commit as default branch with uncommitted changes
 /// 7. Diverged (↕) - both ahead and behind default branch
 /// 8. Ahead (↑) - has commits default branch doesn't have
 /// 9. Behind (↓) - missing commits from default branch
+///
+/// `Empty`/`Integrated` rank above `WouldConflict`: a branch whose content is
+/// already in the default branch is safe to delete regardless of whether a
+/// naive re-merge would conflict. Such a conflict is vacuous — it happens when
+/// the default branch squash-merged the branch and then re-edited the same
+/// lines, so resolving it just reproduces the default branch's tree (nothing
+/// added). `wt step prune` reaches the same verdict via the same patch-id
+/// check, so the list symbol and the prune message agree. (Same rationale as
+/// `Orphan` outranking `WouldConflict`: show the root-cause state, not the
+/// downstream conflict.)
 ///
 /// The `Integrated` variant carries an [`IntegrationReason`] explaining how the
 /// content was integrated (ancestor, trees match, no added changes, or merge adds nothing).
@@ -198,18 +208,21 @@ impl MainState {
 
     /// Compute from divergence counts, integration state, and same-commit-dirty flag.
     ///
-    /// Priority: IsMain > Orphan > WouldConflict > integration > SameCommit > Diverged > Ahead > Behind
+    /// Priority: IsMain > Orphan > integration > WouldConflict > SameCommit > Diverged > Ahead > Behind
     ///
-    /// Orphan takes priority over WouldConflict because:
-    /// - Orphan is a fundamental property (no common ancestor)
-    /// - Merge conflicts for orphan branches are expected but not actionable normally
-    /// - Users should understand "this is an orphan branch" rather than "this would conflict"
+    /// Both Orphan and integration take priority over WouldConflict because:
+    /// - Each is a more fundamental property (no common ancestor / content
+    ///   already in the default branch)
+    /// - The merge conflict they imply is expected and not actionable —
+    ///   an orphan can't be merged cleanly, and an integrated branch has
+    ///   nothing left to merge (its conflict is vacuous)
+    /// - Users should see "this is an orphan branch" / "this is integrated
+    ///   (safe to delete)" rather than the downstream "this would conflict"
     ///
     /// This function takes every input up front — it's the "all data is
     /// available" path. For the per-gate resolver that walks tiers with
     /// partial data, see [`tier_is_main`], [`tier_orphan`],
-    /// [`tier_would_conflict`], [`tier_integration_or_counts`], and the
-    /// [`Tier`] helper below.
+    /// [`tier_would_conflict`], [`tier_counts`], and the [`Tier`] helper below.
     pub fn from_integration_and_counts(
         is_main: bool,
         would_conflict: bool,
@@ -223,10 +236,10 @@ impl MainState {
             Self::IsMain
         } else if is_orphan {
             Self::Orphan
-        } else if would_conflict {
-            Self::WouldConflict
         } else if let Some(state) = integration {
             state
+        } else if would_conflict {
+            Self::WouldConflict
         } else if is_same_commit_dirty {
             Self::SameCommit
         } else {
@@ -289,8 +302,9 @@ pub fn tier_orphan(is_orphan: Option<bool>) -> Tier<MainState> {
     }
 }
 
-/// Tier 3: `WouldConflict`. Authoritative source depends on which probe
-/// landed.
+/// Tier 4: `WouldConflict`. Runs *after* the integration tier, because a
+/// merge-tree conflict only means `✗` for a branch that isn't already
+/// integrated into the default branch.
 ///
 /// `has_merge_tree_conflicts` is the committed-HEAD probe (from
 /// `MergeTreeConflicts`). `has_working_tree_conflicts` is the dirty-tree
@@ -308,53 +322,69 @@ pub fn tier_orphan(is_orphan: Option<bool>) -> Tier<MainState> {
 /// avoid a redundant subprocess (returning a sentinel `false` that this
 /// gate ignores).
 ///
-/// Behavior:
-/// - `has_working_tree_conflicts == Some(Some(true))` → fire (dirty
-///   conflict, authoritative).
-/// - `has_working_tree_conflicts == Some(Some(false))` → rule out (dirty
-///   no-conflict, authoritative).
+/// **The conflict verdict (from the two probes):**
+/// - `has_working_tree_conflicts == Some(Some(true))` → conflict.
+/// - `has_working_tree_conflicts == Some(Some(false))` → no conflict.
 /// - Otherwise consult the HEAD probe:
-///   - `Some(true)` → fire.
+///   - `Some(true)` → conflict.
 ///   - `Some(false)` and working-tree probe loaded (`Some(None)`, i.e.,
-///     clean or unmerged) → rule out.
-///   - `Some(false)` and working-tree probe still `None` → wait (the
+///     clean or unmerged) → no conflict.
+///   - `Some(false)` and working-tree probe still `None` → unknown (the
 ///     working-tree probe could still flip us).
-///   - `None` → wait.
+///   - `None` → unknown.
+///
+/// **Then the integration gate:** a conflict fires `✗` only once
+/// `integration_resolved` is true (the integration verdict is final and
+/// negative — a positive verdict already fired `⊂`/`_` in the earlier
+/// tier). While the verdict is still pending, a detected conflict holds at
+/// `Wait` rather than flashing `✗` for a branch that may settle to `⊂`.
+/// No conflict rules out; an unknown conflict waits.
 pub fn tier_would_conflict(
     has_merge_tree_conflicts: Option<bool>,
     has_working_tree_conflicts: Option<Option<bool>>,
+    integration_resolved: bool,
 ) -> Tier<MainState> {
     use Tier::*;
-    match (has_merge_tree_conflicts, has_working_tree_conflicts) {
+    let conflict = match (has_merge_tree_conflicts, has_working_tree_conflicts) {
         // Working-tree probe is authoritative when it reports a dirty result.
-        (_, Some(Some(true))) => Fired(MainState::WouldConflict),
-        (_, Some(Some(false))) => RuledOut,
+        (_, Some(Some(true))) => Some(true),
+        (_, Some(Some(false))) => Some(false),
         // Otherwise consult HEAD probe.
-        (Some(true), _) => Fired(MainState::WouldConflict),
-        (Some(false), Some(None)) => RuledOut,
-        // HEAD says "no conflict" but WT hasn't reported — wait.
-        (Some(false), None) => Wait,
-        (None, _) => Wait,
+        (Some(true), _) => Some(true),
+        (Some(false), Some(None)) => Some(false),
+        // HEAD says "no conflict" but WT hasn't reported — unknown.
+        (Some(false), None) => None,
+        (None, _) => None,
+    };
+    match conflict {
+        // A conflict is only `✗` for a branch that isn't already integrated.
+        // Hold until the integration verdict is final so we never flash `✗`
+        // for a branch that will settle to `⊂`.
+        Some(true) if integration_resolved => Fired(MainState::WouldConflict),
+        Some(true) => Wait,
+        Some(false) => RuledOut,
+        None => Wait,
     }
 }
 
-/// Tiers 4–6: integration / same-commit-dirty / counts-based fallback.
+/// Tiers 5–6: same-commit-dirty / counts-based fallback.
 ///
-/// Once tiers 1–3 have been ruled out, the gate needs `counts` and
-/// `is_clean`, plus whatever integration signals the caller can provide.
-/// This delegates to [`MainState::from_integration_and_counts`] with
-/// `is_main = false`, `would_conflict = false`, `is_orphan = false`
-/// (callers enforce those invariants via the earlier tiers).
+/// Reached once tiers 1–4 have been ruled out (not main, not orphan, not
+/// integrated, no un-integrated conflict). The gate needs `counts` and
+/// `is_clean`. Integration is resolved in the earlier integration tier, so
+/// this delegates to [`MainState::from_integration_and_counts`] with
+/// `is_main = false`, `would_conflict = false`, `integration = None`,
+/// `is_orphan = false` (callers enforce those invariants via the earlier
+/// tiers).
 ///
 /// Returns:
 /// - `Fired(state)` if `counts` and `is_clean` are both known. (`state`
 ///   may be `MainState::None` when there's nothing to display, which
 ///   callers should still treat as a resolved gate.)
 /// - `Wait` if either `counts` or `is_clean` is still loading.
-pub fn tier_integration_or_counts(
+pub fn tier_counts(
     counts: Option<super::stats::AheadBehind>,
     is_clean: Option<bool>,
-    integration: Option<MainState>,
 ) -> Tier<MainState> {
     let Some(counts) = counts else {
         return Tier::Wait;
@@ -366,8 +396,8 @@ pub fn tier_integration_or_counts(
     let is_same_commit_dirty = !is_clean && counts.ahead == 0 && counts.behind == 0;
     Tier::Fired(MainState::from_integration_and_counts(
         false, // is_main — tier 1 ruled this out
-        false, // would_conflict — tier 3 ruled this out
-        integration,
+        false, // would_conflict — tier 4 ruled this out
+        None,  // integration — resolved in the integration tier
         is_same_commit_dirty,
         false, // is_orphan — tier 2 ruled this out
         counts.ahead,
@@ -616,10 +646,41 @@ mod tests {
             MainState::Orphan
         ));
 
-        // WouldConflict when not orphan
+        // WouldConflict when not orphan and not integrated
         assert!(matches!(
             MainState::from_integration_and_counts(false, true, None, false, false, 5, 3),
             MainState::WouldConflict
+        ));
+
+        // Integration outranks WouldConflict: a branch whose content is
+        // already in the default branch shows ⊂, not ✗, even though a naive
+        // re-merge would conflict (the conflict is vacuous). This is the
+        // squash-merged-then-base-moved-on case.
+        assert!(matches!(
+            MainState::from_integration_and_counts(
+                false, // is_main
+                true,  // would_conflict
+                Some(MainState::Integrated(IntegrationReason::PatchIdMatch)),
+                false, // is_same_commit_dirty
+                false, // is_orphan
+                1,
+                11,
+            ),
+            MainState::Integrated(IntegrationReason::PatchIdMatch)
+        ));
+
+        // Empty (same commit, clean) also outranks WouldConflict.
+        assert!(matches!(
+            MainState::from_integration_and_counts(
+                false,
+                true,
+                Some(MainState::Empty),
+                false,
+                false,
+                0,
+                0
+            ),
+            MainState::Empty
         ));
 
         // Empty (passed as integration state - same commit with clean working tree)
@@ -706,35 +767,45 @@ mod tests {
 
     #[test]
     fn test_tier_would_conflict() {
+        // The integration verdict is resolved-negative (`true`) in these
+        // cases, so the conflict verdict alone decides the tier — the
+        // historical contract for the two probes is unchanged.
+
         // HEAD probe says conflict → fire, even if working-tree probe
         // hasn't reported.
         assert_eq!(
-            tier_would_conflict(Some(true), None),
+            tier_would_conflict(Some(true), None, true),
             Tier::Fired(MainState::WouldConflict)
         );
         // Working-tree probe says dirty conflict → fire, even if HEAD
         // probe hasn't reported.
         assert_eq!(
-            tier_would_conflict(None, Some(Some(true))),
+            tier_would_conflict(None, Some(Some(true)), true),
             Tier::Fired(MainState::WouldConflict)
         );
         // Both probes report "no conflict" (HEAD: Some(false), WT:
         // Some(None) meaning "working tree is clean, no dirty-tree
         // result") → rule out.
-        assert_eq!(tier_would_conflict(Some(false), Some(None)), Tier::RuledOut);
+        assert_eq!(
+            tier_would_conflict(Some(false), Some(None), true),
+            Tier::RuledOut
+        );
         // WT probe reports a clean dirty-tree result (Some(Some(false)))
         // → rule out, regardless of HEAD probe.
         assert_eq!(
-            tier_would_conflict(Some(false), Some(Some(false))),
+            tier_would_conflict(Some(false), Some(Some(false)), true),
             Tier::RuledOut
         );
         // WT probe is authoritative: rule out even when HEAD probe was
         // skipped (None) because MergeTreeConflictsTask deferred to it.
-        assert_eq!(tier_would_conflict(None, Some(Some(false))), Tier::RuledOut);
+        assert_eq!(
+            tier_would_conflict(None, Some(Some(false)), true),
+            Tier::RuledOut
+        );
         // WT probe is authoritative: fire even when HEAD probe says no
         // conflict (the dirty tree's merge result wins).
         assert_eq!(
-            tier_would_conflict(Some(false), Some(Some(true))),
+            tier_would_conflict(Some(false), Some(Some(true)), true),
             Tier::Fired(MainState::WouldConflict)
         );
         // WT probe is authoritative: rule out even when HEAD probe says
@@ -745,103 +816,98 @@ mod tests {
         // contract so a future refactor that reorders the matches
         // doesn't silently regress.
         assert_eq!(
-            tier_would_conflict(Some(true), Some(Some(false))),
+            tier_would_conflict(Some(true), Some(Some(false)), true),
             Tier::RuledOut
         );
         // HEAD probe hasn't reported → wait (could flip us to conflict).
-        assert_eq!(tier_would_conflict(None, None), Tier::Wait);
-        assert_eq!(tier_would_conflict(None, Some(None)), Tier::Wait);
+        assert_eq!(tier_would_conflict(None, None, true), Tier::Wait);
+        assert_eq!(tier_would_conflict(None, Some(None), true), Tier::Wait);
         // HEAD probe says "no conflict" but WT probe hasn't reported →
         // wait (WT could still flip us).
-        assert_eq!(tier_would_conflict(Some(false), None), Tier::Wait);
+        assert_eq!(tier_would_conflict(Some(false), None, true), Tier::Wait);
+
+        // Integration gate: a detected conflict holds at Wait until the
+        // integration verdict is final, so an integrated-but-stale branch
+        // never flashes ✗ before tier 3 settles it to ⊂.
+        assert_eq!(tier_would_conflict(Some(true), None, false), Tier::Wait);
+        assert_eq!(
+            tier_would_conflict(None, Some(Some(true)), false),
+            Tier::Wait
+        );
+        // The integration gate doesn't change a "no conflict" or "unknown"
+        // verdict — only a detected conflict is held.
+        assert_eq!(
+            tier_would_conflict(Some(false), Some(None), false),
+            Tier::RuledOut
+        );
+        assert_eq!(tier_would_conflict(None, None, false), Tier::Wait);
     }
 
     #[test]
-    fn test_tier_integration_or_counts() {
+    fn test_tier_counts() {
         use super::super::stats::AheadBehind;
 
         // counts missing → wait
-        assert_eq!(
-            tier_integration_or_counts(None, Some(true), None),
-            Tier::Wait
-        );
+        assert_eq!(tier_counts(None, Some(true)), Tier::Wait);
 
         // is_clean missing → wait
         assert_eq!(
-            tier_integration_or_counts(
+            tier_counts(
                 Some(AheadBehind {
                     ahead: 0,
                     behind: 0
                 }),
                 None,
-                None
             ),
             Tier::Wait
         );
 
         // in-sync clean → Fired(None)
         assert_eq!(
-            tier_integration_or_counts(
+            tier_counts(
                 Some(AheadBehind {
                     ahead: 0,
                     behind: 0
                 }),
                 Some(true),
-                None
             ),
             Tier::Fired(MainState::None)
         );
 
         // in-sync dirty → SameCommit
         assert_eq!(
-            tier_integration_or_counts(
+            tier_counts(
                 Some(AheadBehind {
                     ahead: 0,
                     behind: 0
                 }),
                 Some(false),
-                None
             ),
             Tier::Fired(MainState::SameCommit)
         );
 
         // Ahead only
         assert_eq!(
-            tier_integration_or_counts(
+            tier_counts(
                 Some(AheadBehind {
                     ahead: 3,
                     behind: 0
                 }),
                 Some(true),
-                None
             ),
             Tier::Fired(MainState::Ahead)
         );
 
         // Diverged
         assert_eq!(
-            tier_integration_or_counts(
+            tier_counts(
                 Some(AheadBehind {
                     ahead: 3,
                     behind: 2
                 }),
                 Some(true),
-                None
             ),
             Tier::Fired(MainState::Diverged)
-        );
-
-        // Integration state wins over counts
-        assert_eq!(
-            tier_integration_or_counts(
-                Some(AheadBehind {
-                    ahead: 5,
-                    behind: 0
-                }),
-                Some(true),
-                Some(MainState::Integrated(IntegrationReason::Ancestor)),
-            ),
-            Tier::Fired(MainState::Integrated(IntegrationReason::Ancestor))
         );
     }
 

--- a/src/commands/list/model/status_symbols.rs
+++ b/src/commands/list/model/status_symbols.rs
@@ -23,7 +23,7 @@
 //! | 1 | `MODIFIED`          | `!`                  | Are there unstaged modifications?     |
 //! | 2 | `UNTRACKED`         | `?`                  | Are there untracked files?            |
 //! | 3 | `WORKTREE_STATE`    | `✘ ⤴ ⤵ ⚑ ⊟ ⊞ /`      | Operation / worktree attribute        |
-//! | 4 | `MAIN_STATE`        | `^ ✗ _ – ⊂ ↕ ↑ ↓`    | Relationship to the default branch    |
+//! | 4 | `MAIN_STATE`        | `^ _ ⊂ ✗ – ↕ ↑ ↓`    | Relationship to the default branch    |
 //! | 5 | `UPSTREAM_DIVERGENCE` | \| ⇅ ⇡ ⇣           | Relationship to the tracked remote    |
 //! | 6 | `USER_MARKER`       | emoji / text         | User-defined annotation               |
 //!
@@ -85,7 +85,7 @@
 //!
 //! # Gate 3: Main state (position 4)
 //!
-//! **Renders:** at most one of `^ ✗ _ – ⊂ ↕ ↑ ↓`. Priority:
+//! **Renders:** at most one of `^ _ ⊂ ✗ – ↕ ↑ ↓`. Priority:
 //! `IsMain > Orphan > Empty(_) > Integrated(⊂) > WouldConflict(✗) >
 //! SameCommitDirty(–) > Diverged(↕) > Ahead(↑) > Behind(↓) > None`.
 //!
@@ -263,7 +263,7 @@ impl PositionMask {
     pub(crate) const MODIFIED: usize = 1; // ! (modified files)
     pub(crate) const UNTRACKED: usize = 2; // ? (untracked files)
     pub(crate) const WORKTREE_STATE: usize = 3; // Worktree: ✘⤴⤵/⚑⊟⊞
-    pub(crate) const MAIN_STATE: usize = 4; // Main relationship: ^✗_⊂↕↑↓
+    pub(crate) const MAIN_STATE: usize = 4; // Main relationship: ^_⊂✗↕↑↓
     pub(crate) const UPSTREAM_DIVERGENCE: usize = 5; // Remote: |⇅⇡⇣
     pub(crate) const USER_MARKER: usize = 6;
 
@@ -275,7 +275,7 @@ impl PositionMask {
             1, // MODIFIED: ! (1 char)
             1, // UNTRACKED: ? (1 char)
             1, // WORKTREE_STATE: ✘⤴⤵/⚑⊟⊞ (1 char, priority: conflicts > rebase > merge > branch_worktree_mismatch > prunable > locked > branch)
-            1, // MAIN_STATE: ^✗_–⊂↕↑↓ (1 char, priority: is_main > orphan > empty > integrated > would_conflict > same_commit > diverged > ahead > behind)
+            1, // MAIN_STATE: ^_⊂✗–↕↑↓ (1 char, priority: is_main > orphan > empty > integrated > would_conflict > same_commit > diverged > ahead > behind)
             1, // UPSTREAM_DIVERGENCE: |⇡⇣⇅ (1 char)
             2, // USER_MARKER: single emoji or two chars (allocate 2)
         ],

--- a/src/commands/list/model/status_symbols.rs
+++ b/src/commands/list/model/status_symbols.rs
@@ -86,19 +86,19 @@
 //! # Gate 3: Main state (position 4)
 //!
 //! **Renders:** at most one of `^ ✗ _ – ⊂ ↕ ↑ ↓`. Priority:
-//! `IsMain > Orphan > WouldConflict > Empty(_) > SameCommitDirty(–) >
-//! Integrated(⊂) > Diverged(↕) > Ahead(↑) > Behind(↓) > None`.
+//! `IsMain > Orphan > Empty(_) > Integrated(⊂) > WouldConflict(✗) >
+//! SameCommitDirty(–) > Diverged(↕) > Ahead(↑) > Behind(↓) > None`.
 //!
 //! **Inputs:**
 //! - `is_main` (metadata)
 //! - `is_orphan` (from `AheadBehind`)
-//! - `has_merge_tree_conflicts` (from `MergeTreeConflicts`)
-//! - `has_working_tree_conflicts` (from `WorkingTreeConflicts`)
 //! - Integration signals: `is_ancestor`, `committed_trees_match`,
 //!   `has_file_changes`, `would_merge_add`, `is_patch_id_match`
+//! - `has_merge_tree_conflicts` (from `MergeTreeConflicts`)
+//! - `has_working_tree_conflicts` (from `WorkingTreeConflicts`)
 //! - `counts` (from `AheadBehind`)
 //! - `working_tree_diff` + `working_tree_status` (used for `is_clean`, which
-//!   distinguishes `Empty(_)` from `SameCommitDirty(–)`)
+//!   distinguishes `Empty(_)` from `SameCommitDirty(–)` and gates `✗`)
 //!
 //! **Rule — short-circuit on priority (same pattern as gate 2):** render as
 //! soon as the priority-winning signal can be identified.
@@ -106,16 +106,19 @@
 //! 1. `is_main == true` (metadata) → `^`. Always immediate for the main
 //!    worktree, regardless of any other field.
 //! 2. `is_orphan == Some(true)` → orphan display.
-//! 3. `has_working_tree_conflicts == Some(Some(true))` (dirty-tree probe
-//!    is authoritative when present) or `has_merge_tree_conflicts == Some(true)`
-//!    → `✗`. When the dirty-tree probe says `Some(Some(false))` it rules
-//!    out tier 3 even if the HEAD probe was skipped (see
-//!    [`tier_would_conflict`](super::state::tier_would_conflict)).
-//! 4. Distinguish Empty / SameCommitDirty / Integrated — requires `counts`,
-//!    `is_clean` (from `working_tree_diff` + `working_tree_status` for
-//!    worktrees; trivially clean for branches), and the integration signals.
-//!    Render as soon as all signals needed to pick a row have landed.
-//! 5. Otherwise fall through to `↕/↑/↓/None` from `counts`.
+//! 3. Integration (`⊂`/`_`): once `is_clean` is known, the integration
+//!    signals can fire `Empty(_)` (same commit, clean) or `Integrated(⊂)`
+//!    (content already in the default branch). This is fire-or-continue —
+//!    a not-yet-integrated branch falls through without waiting, so the gate
+//!    can still upgrade an `↑` to `⊂` on a later pass.
+//! 4. `✗` (WouldConflict): `has_working_tree_conflicts == Some(Some(true))`
+//!    (dirty-tree probe is authoritative) or `has_merge_tree_conflicts ==
+//!    Some(true)` → `✗`, but only once the integration verdict is final and
+//!    negative (`integration_resolved`). While integration is still pending,
+//!    a detected conflict holds at `·` rather than flashing `✗` for a branch
+//!    that may settle to `⊂`. See
+//!    [`tier_would_conflict`](super::state::tier_would_conflict).
+//! 5. Otherwise fall through to `–/↕/↑/↓/None` from `counts` + `is_clean`.
 //!
 //! **Exception — unborn items (`HEAD == NULL_OID`):** all commit-dependent
 //! tasks are skipped at spawn time. Their fields are seeded with "no commits"
@@ -272,7 +275,7 @@ impl PositionMask {
             1, // MODIFIED: ! (1 char)
             1, // UNTRACKED: ? (1 char)
             1, // WORKTREE_STATE: ✘⤴⤵/⚑⊟⊞ (1 char, priority: conflicts > rebase > merge > branch_worktree_mismatch > prunable > locked > branch)
-            1, // MAIN_STATE: ^✗_–⊂↕↑↓ (1 char, priority: is_main > orphan > would_conflict > empty > same_commit > integrated > diverged > ahead > behind)
+            1, // MAIN_STATE: ^✗_–⊂↕↑↓ (1 char, priority: is_main > orphan > empty > integrated > would_conflict > same_commit > diverged > ahead > behind)
             1, // UPSTREAM_DIVERGENCE: |⇡⇣⇅ (1 char)
             2, // USER_MARKER: single emoji or two chars (allocate 2)
         ],
@@ -366,12 +369,12 @@ impl WorkingTreeStatus {
 /// - /: Branch without worktree
 ///
 /// **Main state (single position with priority):**
-/// Priority: ^ > ✗ > _ > – > ⊂ > ↕ > ↑ > ↓
+/// Priority: ^ > _ > ⊂ > ✗ > – > ↕ > ↑ > ↓
 /// - ^: This IS the main worktree
-/// - ✗: Would conflict if merged to default branch
 /// - _: Same commit as default branch, clean working tree (removable)
-/// - –: Same commit as default branch, uncommitted changes (NOT removable)
 /// - ⊂: Content integrated (removable)
+/// - ✗: Would conflict if merged to default branch, and NOT already integrated
+/// - –: Same commit as default branch, uncommitted changes (NOT removable)
 /// - ↕: Diverged from default branch
 /// - ↑: Ahead of default branch
 /// - ↓: Behind default branch

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -232,17 +232,17 @@ An in-progress git operation, a worktree-location attribute, or a branch with no
 
 The single highest-priority state describing the branch's relation to the default branch; blank when none applies (a normal up-to-date branch). Each symbol is one [2mmain_state[0m value:
 
- Symbol    main_state                                                                     Meaning                                                                  
- ────── ──────────────── ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
- [2m^[0m      [2m"is_main"[0m        The main worktree (the repo's home worktree)                                                                                              
- [2m∅[0m      [2m"orphan"[0m         No common ancestor with the default branch                                                                                                
- [33m✗[0m      [2m"would_conflict"[0m Merging into the default branch would conflict (simulated with [2mgit merge-tree[0m); with [2m--full[0m, the check includes uncommitted changes       
- [2m_[0m      [2m"empty"[0m          Same commit as the default branch, working tree clean — safe to remove; row dimmed                                                        
- [2m–[0m      [2m"same_commit"[0m    Same commit as the default branch, but with uncommitted changes                                                                           
- [2m⊂[0m      [2m"integrated"[0m     Content integrated into the default branch or merge target via different history; the matching check is in [2mintegration_reason[0m; row dimmed 
- [2m↕[0m      [2m"diverged"[0m       Both ahead of and behind the default branch                                                                                               
- [2m↑[0m      [2m"ahead"[0m          Has commits the default branch doesn't                                                                                                    
- [2m↓[0m      [2m"behind"[0m         Missing commits the default branch has                                                                                                    
+ Symbol    main_state                                                                                      Meaning                                                                                   
+ ────── ──────────────── ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
+ [2m^[0m      [2m"is_main"[0m        The main worktree (the repo's home worktree)                                                                                                                                
+ [2m∅[0m      [2m"orphan"[0m         No common ancestor with the default branch                                                                                                                                  
+ [2m_[0m      [2m"empty"[0m          Same commit as the default branch, working tree clean — safe to remove; row dimmed                                                                                          
+ [2m⊂[0m      [2m"integrated"[0m     Content integrated into the default branch or merge target via different history; the matching check is in [2mintegration_reason[0m; row dimmed                                   
+ [33m✗[0m      [2m"would_conflict"[0m Merging into the default branch would conflict (simulated with [2mgit merge-tree[0m) and the branch isn't already integrated; with [2m--full[0m, the check includes uncommitted changes 
+ [2m–[0m      [2m"same_commit"[0m    Same commit as the default branch, but with uncommitted changes                                                                                                             
+ [2m↕[0m      [2m"diverged"[0m       Both ahead of and behind the default branch                                                                                                                                 
+ [2m↑[0m      [2m"ahead"[0m          Has commits the default branch doesn't                                                                                                                                      
+ [2m↓[0m      [2m"behind"[0m         Missing commits the default branch has                                                                                                                                      
 
 Rows are dimmed when safe to delete — [2m_[0m ([2m"empty"[0m) or [2m⊂[0m ([2m"integrated"[0m).
 
@@ -404,7 +404,7 @@ Top-level [2mrepo[0m describes the local checkout's repository as derived from
 
 [32mmain_state values[0m
 
-The single highest-priority state describing the branch's relation to the default branch; absent when none applies (a normal up-to-date branch). Each value is one Default-branch symbol — see Default branch for the symbol and the full meaning of each value ([2m"is_main"[0m, [2m"orphan"[0m, [2m"would_conflict"[0m, [2m"empty"[0m, [2m"same_commit"[0m, [2m"integrated"[0m, [2m"diverged"[0m, [2m"ahead"[0m, [2m"behind"[0m).
+The single highest-priority state describing the branch's relation to the default branch; absent when none applies (a normal up-to-date branch). Each value is one Default-branch symbol — see Default branch for the symbol and the full meaning of each value ([2m"is_main"[0m, [2m"orphan"[0m, [2m"empty"[0m, [2m"integrated"[0m, [2m"would_conflict"[0m, [2m"same_commit"[0m, [2m"diverged"[0m, [2m"ahead"[0m, [2m"behind"[0m).
 
 [32mintegration_reason values[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -287,16 +287,16 @@ symbol is one [2mmain_state[0m value:
  ──── ────────── ────────────────────────────────────────────────────────────── 
  [2m^[0m    [2m"is_main"[0m  The main worktree (the repo's home worktree)                   
  [2m∅[0m    [2m"orphan"[0m   No common ancestor with the default branch                     
- [33m✗[0m    [2m"would_con[0m Merging into the default branch would conflict (simulated with 
-      [2mflict"[0m     [2mgit merge-tree[0m); with [2m--full[0m, the check includes uncommitted   
-                 changes                                                        
  [2m_[0m    [2m"empty"[0m    Same commit as the default branch, working tree clean — safe   
                  to remove; row dimmed                                          
- [2m–[0m    [2m"same_comm[0m Same commit as the default branch, but with uncommitted        
-      [2mit"[0m        changes                                                        
  [2m⊂[0m    [2m"integrate[0m Content integrated into the default branch or merge target via 
       [2md"[0m         different history; the matching check is in [2mintegration_reason[0m 
                  ; row dimmed                                                   
+ [33m✗[0m    [2m"would_con[0m Merging into the default branch would conflict (simulated with 
+      [2mflict"[0m     [2mgit merge-tree[0m) and the branch isn't already integrated; with  
+                 [2m--full[0m, the check includes uncommitted changes                 
+ [2m–[0m    [2m"same_comm[0m Same commit as the default branch, but with uncommitted        
+      [2mit"[0m        changes                                                        
  [2m↕[0m    [2m"diverged"[0m Both ahead of and behind the default branch                    
  [2m↑[0m    [2m"ahead"[0m    Has commits the default branch doesn't                         
  [2m↓[0m    [2m"behind"[0m   Missing commits the default branch has                         
@@ -494,8 +494,8 @@ primary remote. [2mci.repo[0m describes the repository targeted by the PR/MR U
 The single highest-priority state describing the branch's relation to the 
 default branch; absent when none applies (a normal up-to-date branch). Each 
 value is one Default-branch symbol — see Default branch for the symbol and the 
-full meaning of each value ([2m"is_main"[0m, [2m"orphan"[0m, [2m"would_conflict"[0m, [2m"empty"[0m, 
-[2m"same_commit"[0m, [2m"integrated"[0m, [2m"diverged"[0m, [2m"ahead"[0m, [2m"behind"[0m).
+full meaning of each value ([2m"is_main"[0m, [2m"orphan"[0m, [2m"empty"[0m, [2m"integrated"[0m, 
+[2m"would_conflict"[0m, [2m"same_commit"[0m, [2m"diverged"[0m, [2m"ahead"[0m, [2m"behind"[0m).
 
 [32mintegration_reason values[0m
 


### PR DESCRIPTION
A squash-merged branch whose default branch later re-edited the same lines showed `✗` (WouldConflict) in `wt list`, while `wt step prune` correctly classified it as `⊂` (all changes in main) and removed it. The list and the prune verdict disagreed on the same branch, so `✗` read as "unmerged work that conflicts" when the branch was in fact fully integrated and safe to delete.

The conflict is real but vacuous: a 3-way re-merge collides on the lines the default branch re-touched, yet the branch's whole diff already matches a commit on the default branch (patch-id), so resolving the merge just reproduces the default branch's tree — nothing added. That patch-id check is exactly how `prune` reaches `⊂`; the list simply ranked the downstream conflict above the integration verdict.

This reorders gate 3 of the main-state column so the integration family (`⊂`/`_`) outranks `WouldConflict`, mirroring the existing rule that `Orphan` outranks it — show the root-cause state, not the downstream conflict. Integration stays fire-or-continue so the common `↑`/`↓`/`⊂` cases still render promptly; only `✗` is held until the integration verdict is final, so an integrated-but-stale branch never flashes `✗` before settling to `⊂`. A genuinely un-integrated conflict still shows `✗`.

Well covered by unit tests on the priority logic and three new gate tests pinning the integrated-outranks-conflict, no-flash-while-loading, and genuine-conflict cases. The list's rendered table output is unchanged (the integrated-and-conflicting combination doesn't occur in existing fixtures); a follow-up commit reorders the `wt list` default-branch symbol docs and regenerates the `--help` snapshots to match the new priority.

> _This was written by Claude Code on behalf of max_
