### PR TITLE
fix(list): diff branches against the default branch's upstream tip

### DIFF
--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -91,6 +91,8 @@ Output as JSON for scripting:
 
 The `main` header label is used regardless of the default branch's actual name.
 
+`main↕` and `main…±` measure against the default branch's upstream tip when the local copy lags it — so in a fork whose local `main` trails `origin/main`, a branch reads as ahead of the real mainline, not of a stale local checkout. The `↑`/`↓`/`↕` Status symbols derive from these counts, so they track the upstream tip too.
+
 ### Gutter
 
 The leftmost column marks each row by physical presence, from most present to least:

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -80,6 +80,8 @@ $ wt list --format=json
 
 The `main` header label is used regardless of the default branch's actual name.
 
+`main↕` and `main…±` measure against the default branch's upstream tip when the local copy lags it — so in a fork whose local `main` trails `origin/main`, a branch reads as ahead of the real mainline, not of a stale local checkout. The `↑`/`↓`/`↕` Status symbols derive from these counts, so they track the upstream tip too.
+
 ### Gutter
 
 The leftmost column marks each row by physical presence, from most present to least:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -823,6 +823,8 @@ $ wt list --format=json
 
 The `main` header label is used regardless of the default branch's actual name.
 
+`main↕` and `main…±` measure against the default branch's upstream tip when the local copy lags it — so in a fork whose local `main` trails `origin/main`, a branch reads as ahead of the real mainline, not of a stale local checkout. The `↑`/`↓`/`↕` Status symbols derive from these counts, so they track the upstream tip too.
+
 ### Gutter
 
 The leftmost column marks each row by physical presence, from most present to least:

--- a/src/commands/list/collect/tasks.rs
+++ b/src/commands/list/collect/tasks.rs
@@ -97,11 +97,39 @@ impl TaskContext {
 
     /// Get the default branch resolved for this list invocation.
     ///
-    /// Used for informational stats (ahead/behind, branch diff). Returns
-    /// `None` if default branch cannot be determined, or if the persisted
-    /// value is stale (see `TaskContext::default_branch` docs).
+    /// The conflict columns (`WouldConflict`) compare against this local
+    /// ref because it is the branch `wt merge` actually targets. The
+    /// informational stat columns go through [`Self::comparison_base`]
+    /// instead, which prefers the upstream tip. Returns `None` if the
+    /// default branch cannot be determined, or if the persisted value is
+    /// stale (see `TaskContext::default_branch` docs).
     pub(super) fn default_branch(&self) -> Option<String> {
         self.default_branch.clone()
+    }
+
+    /// The base ref the informational comparison columns — ahead/behind
+    /// (`main↕`) and branch diff (`main…±`) — measure a branch against.
+    ///
+    /// This is the same upstream-aware "superset" mainline ref the
+    /// integration column already uses ([`IntegrationTargets::primary`]):
+    /// the local default branch when it is up to date with (or ahead of)
+    /// its upstream or has no upstream, and the upstream ref when the local
+    /// default *lags* it. The lagging case is the one that matters — a fork
+    /// whose local `master` sits dozens of commits behind `origin/master`
+    /// would otherwise make every feature read as dozens of commits and
+    /// thousands of lines ahead of "main", measuring each branch against a
+    /// stale base instead of the real mainline tip. Routing these columns
+    /// through `primary` keeps them consistent with the integration symbol
+    /// and immune to a stale local default.
+    ///
+    /// Falls back to the raw default branch name when integration targets
+    /// could not be resolved (snapshot capture failed) so the columns still
+    /// render in that degraded mode.
+    pub(super) fn comparison_base(&self) -> Option<&str> {
+        self.integration_targets
+            .as_ref()
+            .map(|t| t.primary.as_str())
+            .or(self.default_branch.as_deref())
     }
 
     /// Get the integration targets resolved for this list invocation.
@@ -172,15 +200,18 @@ pub trait Task: Send + Sync + 'static {
 // Task Implementations
 // ============================================================================
 
-/// Task: Ahead/behind counts vs local default branch (informational stats)
+/// Task: Ahead/behind counts vs the mainline tip (informational stats).
+///
+/// Measures against [`TaskContext::comparison_base`] — the upstream-aware
+/// default-branch tip — so a stale local default doesn't inflate the counts.
 pub struct AheadBehindTask;
 
 impl Task for AheadBehindTask {
     const KIND: TaskKind = TaskKind::AheadBehind;
 
     fn compute(ctx: TaskContext) -> Result<TaskResult, TaskError> {
-        // When default_branch is None, return zero counts (cells show empty)
-        let Some(base) = ctx.default_branch() else {
+        // When no comparison base resolves, return zero counts (cells show empty)
+        let Some(base) = ctx.comparison_base() else {
             return Ok(TaskResult::AheadBehind {
                 item_idx: ctx.item_idx,
                 counts: AheadBehind::default(),
@@ -190,7 +221,7 @@ impl Task for AheadBehindTask {
         let repo = &ctx.repo;
 
         let base_sha = ctx
-            .resolve_sha(&base)
+            .resolve_sha(base)
             .map_err(|e| ctx.error(Self::KIND, &e))?;
         // Compare against the branch tip via its full ref when present —
         // see `branch_check_sha` for the rebase-in-progress rationale.
@@ -220,7 +251,7 @@ impl Task for AheadBehindTask {
             .unwrap_or(&ctx.branch_ref.commit_sha);
         let counts = ctx
             .snapshot()
-            .and_then(|s| s.ahead_behind(&base, head_ref))
+            .and_then(|s| s.ahead_behind(base, head_ref))
             .map(Ok)
             .unwrap_or_else(|| repo.ahead_behind_by_sha(&base_sha, &head_sha))
             .map_err(|e| ctx.error(Self::KIND, &e))?;
@@ -466,15 +497,18 @@ impl Task for IsAncestorTask {
     }
 }
 
-/// Task 4: Branch diff stats vs local default branch (informational stats)
+/// Task 4: Branch diff stats vs the mainline tip (informational stats).
+///
+/// Measures against [`TaskContext::comparison_base`] — the upstream-aware
+/// default-branch tip — so a stale local default doesn't inflate the diff.
 pub struct BranchDiffTask;
 
 impl Task for BranchDiffTask {
     const KIND: TaskKind = TaskKind::BranchDiff;
 
     fn compute(ctx: TaskContext) -> Result<TaskResult, TaskError> {
-        // When default_branch is None, return empty diff (cells show empty)
-        let Some(base) = ctx.default_branch() else {
+        // When no comparison base resolves, return empty diff (cells show empty)
+        let Some(base) = ctx.comparison_base() else {
             return Ok(TaskResult::BranchDiff {
                 item_idx: ctx.item_idx,
                 branch_diff: BranchDiffTotals::default(),
@@ -484,7 +518,7 @@ impl Task for BranchDiffTask {
         // Resolve via snapshot — see `branch_check_sha` for the
         // rebase-in-progress rationale.
         let base_sha = ctx
-            .resolve_sha(&base)
+            .resolve_sha(base)
             .map_err(|e| ctx.error(Self::KIND, &e))?;
         let head_sha = ctx
             .branch_check_sha()

--- a/src/commands/list/collect/tasks.rs
+++ b/src/commands/list/collect/tasks.rs
@@ -27,6 +27,28 @@ use super::types::{ErrorCause, TaskError, TaskKind, TaskResult};
 /// across all clones via `Arc<RepoCache>`, so parallel tasks benefit from
 /// cached merge-base results, ahead/behind counts, default branch, and
 /// integration targets.
+///
+/// # Comparison bases
+///
+/// Three accessors expose "the mainline ref" a task compares against, and
+/// which one to use is decided by the question the task answers:
+///
+/// - [`default_branch`](Self::default_branch) is the local ref. Conflict
+///   prediction (`WouldConflict`) and the `wt merge` / `wt switch --base`
+///   writes use it, since that is the branch the merge actually updates and
+///   a remote-tracking ref is not writable.
+/// - [`comparison_base`](Self::comparison_base) is the upstream-aware
+///   superset tip. The ahead/behind (`main↕`) and branch-diff (`main…±`)
+///   columns measure against it, so a local default that lags its upstream
+///   does not inflate the distance from the real mainline.
+/// - [`integration_targets`](Self::integration_targets) is that superset
+///   plus, when local and upstream diverge, both sides. Integration status
+///   checks whether the work has landed in the mainline on either.
+///
+/// All three resolve the upstream from the default branch's configured
+/// `@{upstream}` alone ([`RefSnapshot::upstream_of`]); there is no
+/// remote-name heuristic. The superset selection itself lives on
+/// [`Repository::integration_targets`].
 #[derive(Clone)]
 pub struct TaskContext {
     /// Shared repository handle. All clones share the same cache via Arc.
@@ -95,14 +117,11 @@ impl TaskContext {
         TaskError::new(self.item_idx, kind, message, cause)
     }
 
-    /// Get the default branch resolved for this list invocation.
-    ///
-    /// The conflict columns (`WouldConflict`) compare against this local
-    /// ref because it is the branch `wt merge` actually targets. The
-    /// informational stat columns go through [`Self::comparison_base`]
-    /// instead, which prefers the upstream tip. Returns `None` if the
-    /// default branch cannot be determined, or if the persisted value is
-    /// stale (see `TaskContext::default_branch` docs).
+    /// Get the default branch resolved for this list invocation: the local
+    /// ref, used by conflict prediction and the merge/`--base` writes (see
+    /// the type-level "Comparison bases" note). Returns `None` if the default
+    /// branch cannot be determined, or if the persisted value is stale (see
+    /// the `default_branch` field docs).
     pub(super) fn default_branch(&self) -> Option<String> {
         self.default_branch.clone()
     }

--- a/tests/integration_tests/list.rs
+++ b/tests/integration_tests/list.rs
@@ -715,6 +715,117 @@ fn test_list_with_upstream_tracking(mut repo: TestRepo) {
     });
 }
 
+/// When the local default branch lags its upstream (a fork whose `main` sits
+/// behind `origin/main`), the `main↕`/`main…±` columns must measure each
+/// branch against the upstream tip, not the stale local tip. Otherwise every
+/// branch reads as ahead by every commit the local default is missing.
+#[rstest]
+fn test_list_branch_stats_use_upstream_when_local_default_lags(mut repo: TestRepo) {
+    repo.commit("c0");
+    repo.setup_remote("main");
+    // Persist the default branch so detection is deterministic.
+    repo.run_git(&["config", "worktrunk.default-branch", "main"]);
+
+    // Advance origin/main three commits ahead, then pin local main back so it
+    // lags its upstream by three commits (the stale-fork shape).
+    repo.commit("upstream 1");
+    repo.commit("upstream 2");
+    repo.commit("upstream 3");
+    repo.run_git(&["push", "origin", "main"]);
+    repo.run_git(&["reset", "--hard", "HEAD~3"]);
+    repo.run_git(&["fetch", "origin"]);
+
+    // Feature branch off the real upstream tip, two commits ahead.
+    let feature_wt = repo.add_worktree("feature");
+    repo.run_git_in(&feature_wt, &["reset", "--hard", "origin/main"]);
+    std::fs::write(feature_wt.join("feat.txt"), "a\n").unwrap();
+    repo.run_git_in(&feature_wt, &["add", "."]);
+    repo.run_git_in(&feature_wt, &["commit", "-m", "feature commit 1"]);
+    std::fs::write(feature_wt.join("feat.txt"), "a\nb\n").unwrap();
+    repo.run_git_in(&feature_wt, &["add", "."]);
+    repo.run_git_in(&feature_wt, &["commit", "-m", "feature commit 2"]);
+
+    let output = repo
+        .wt_command()
+        .args(["list", "--branches", "--format=json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "wt list should succeed");
+
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    let feature = json
+        .iter()
+        .find(|w| w["branch"] == "feature")
+        .expect("feature row should be present");
+
+    // Two commits ahead of the upstream tip — not five (3 stale + 2 feature).
+    assert_eq!(
+        feature["main"]["ahead"].as_u64(),
+        Some(2),
+        "ahead must be measured against origin/main, not the stale local main: {feature:#?}"
+    );
+    assert_eq!(feature["main"]["behind"].as_u64(), Some(0));
+    // The diff reflects only the feature's own additions, not the three
+    // upstream commits the local default is missing.
+    assert_eq!(
+        feature["main"]["diff"]["added"].as_u64(),
+        Some(2),
+        "branch diff must be measured against origin/main: {feature:#?}"
+    );
+}
+
+/// The mirror of the lagging-fork case: when the local default branch is
+/// *ahead* of its upstream (local commits not yet pushed, e.g. just after a
+/// local `wt merge`), the base must stay local. Otherwise a sibling branch
+/// would show those unpushed default-branch commits in its own counts. This
+/// pins the contract that `comparison_base` reuses `integration_targets`'
+/// superset selection rather than naively preferring the upstream ref.
+#[rstest]
+fn test_list_branch_stats_stay_local_when_default_ahead_of_upstream(mut repo: TestRepo) {
+    repo.commit("c0");
+    repo.setup_remote("main");
+    repo.run_git(&["config", "worktrunk.default-branch", "main"]);
+
+    // Advance local main three commits past origin/main, leaving them unpushed
+    // so the local default is ahead of its upstream.
+    repo.commit("local main 1");
+    repo.commit("local main 2");
+    repo.commit("local main 3");
+    repo.run_git(&["fetch", "origin"]);
+
+    // Feature off the local default tip, two commits ahead.
+    let feature_wt = repo.add_worktree("feature");
+    std::fs::write(feature_wt.join("feat.txt"), "a\n").unwrap();
+    repo.run_git_in(&feature_wt, &["add", "."]);
+    repo.run_git_in(&feature_wt, &["commit", "-m", "feature commit 1"]);
+    std::fs::write(feature_wt.join("feat.txt"), "a\nb\n").unwrap();
+    repo.run_git_in(&feature_wt, &["add", "."]);
+    repo.run_git_in(&feature_wt, &["commit", "-m", "feature commit 2"]);
+
+    let output = repo
+        .wt_command()
+        .args(["list", "--branches", "--format=json"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "wt list should succeed");
+
+    let json: Vec<serde_json::Value> = serde_json::from_slice(&output.stdout).unwrap();
+    let feature = json
+        .iter()
+        .find(|w| w["branch"] == "feature")
+        .expect("feature row should be present");
+
+    // Two commits ahead of the LOCAL default tip — not five (which would
+    // wrongly fold in the three unpushed local-main commits by measuring
+    // against origin/main).
+    assert_eq!(
+        feature["main"]["ahead"].as_u64(),
+        Some(2),
+        "ahead must stay measured against local main when it leads origin/main: {feature:#?}"
+    );
+    assert_eq!(feature["main"]["behind"].as_u64(), Some(0));
+}
+
 #[rstest]
 fn test_list_primary_on_different_branch(mut repo: TestRepo) {
     repo.switch_primary_to("develop");

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -150,6 +150,8 @@ Output as JSON for scripting:
 
 The [2mmain[0m header label is used regardless of the default branch's actual name.
 
+[2mmain↕[0m and [2mmain…±[0m measure against the default branch's upstream tip when the local copy lags it — so in a fork whose local [2mmain[0m trails [2morigin/main[0m, a branch reads as ahead of the real mainline, not of a stale local checkout. The [2m↑[0m/[2m↓[0m/[2m↕[0m Status symbols derive from these counts, so they track the upstream tip too.
+
 [32mGutter[0m
 
 The leftmost column marks each row by physical presence, from most present to least:

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -163,6 +163,11 @@ Output as JSON for scripting:
 
 The [2mmain[0m header label is used regardless of the default branch's actual name.
 
+[2mmain↕[0m and [2mmain…±[0m measure against the default branch's upstream tip when the 
+local copy lags it — so in a fork whose local [2mmain[0m trails [2morigin/main[0m, a branch 
+reads as ahead of the real mainline, not of a stale local checkout. The [2m↑[0m/[2m↓[0m/[2m↕[0m 
+Status symbols derive from these counts, so they track the upstream tip too.
+
 [32mGutter[0m
 
 The leftmost column marks each row by physical presence, from most present to 


### PR DESCRIPTION
## Problem

`wt list`'s `main↕` (ahead/behind) and `main…±` (branch diff) columns measured every branch against the **local** default-branch tip. In a fork whose local `main`/`master` lags its upstream, those columns reported garbage. Local default branches go stale routinely: you fetch far more often than you fast-forward local `main`, while the remote-tracking ref refreshes on every fetch.

Concretely, in a fork of `skim-rs/skim` whose local `master` sat 42 commits behind `origin/master`, every feature branch displayed as `↑44` ahead and `+∞ / -5K`, when each was only ~2 commits past the real upstream tip. The workaround was a manual `git merge --ff-only upstream/master` to un-stale the local base before `wt list` made sense again.

## Root cause

`wt list` already carried two notions of "the mainline ref":

- **Integration status** (`⊂` / `↑` / `↓` …) resolves the default branch's upstream and compares against the *superset* of `{local default, its upstream}` via `Repository::integration_targets()`.
- **The two stat columns** ignored that and diffed against the raw local `default_branch`.

That inconsistency is the bug. A stale local default inflated the counts by every commit it was missing, and the integration symbol and the numbers next to it could disagree.

## Fix

Route the two informational stat tasks through the same upstream-aware superset ref the integration column already uses. A new `TaskContext::comparison_base()` returns `integration_targets.primary` (the superset side), falling back to the raw `default_branch` only when integration targets could not be resolved (snapshot capture failed). `AheadBehindTask` and `BranchDiffTask` now consume it instead of `default_branch()`.

This reuses one mechanism rather than adding a second upstream resolver, and is correct across all four local-vs-upstream relationships:

| Relationship | base | vs. before |
|---|---|---|
| no upstream / local == upstream | local | unchanged |
| local behind upstream (stale fork) | **upstream** | **fixed** |
| upstream behind local (unpushed local merge) | local | unchanged |
| diverged | local | unchanged |

The "upstream behind local" row is why naively preferring the upstream ref would be wrong. After a local `wt merge` that has not been pushed, the default branch leads its upstream, and sibling branches must still measure against the local tip so the unpushed merge commits do not leak into their counts. Reusing `integration_targets.primary` gets this case right for free, because its superset selection already keeps the local ref there.

### Deliberately unchanged

- **Conflict columns** (`✗ WouldConflict`, via `MergeTreeConflictsTask` / `WorkingTreeConflictsTask`) keep using the local default branch. They predict the local `wt merge`, which targets the local ref.
- **`wt merge` target** and **`wt switch --base`** (writes) keep using the local branch. You merge into and update a local ref, and a new branch defaults onto a writable local branch; a remote-tracking ref is neither.

### Side effect

The `↑`/`↓`/`↕` gutter symbols derive from these counts (`is_same_commit` in `model/item.rs`), so they now also track the upstream tip in a lagging fork. A branch sitting at the stale local-main tip renders `⊂` (its content is already in the real mainline) rather than `_`. Removal safety is unchanged: the safe-to-remove signals (`is_ancestor`, `trees_match`) were already upstream-aware.

## Performance

The snapshot's batched `%(ahead-behind)` walk is keyed on the local default-branch name, so the common case (superset == local) keeps the batch. Only the lagging-fork case falls back to a per-pair `ahead_behind_by_sha`, which is SHA-cache-backed, and that case had wrong numbers before. The diverged case stays local, so it keeps the batch too.

## Tests

Two regression tests in `tests/integration_tests/list.rs`:

- `test_list_branch_stats_use_upstream_when_local_default_lags` covers the fix. It fails on `main` with `ahead 5` against the expected `2`.
- `test_list_branch_stats_stay_local_when_default_ahead_of_upstream` pins that the base stays local when the default leads its upstream.

The full `wt hook pre-merge` gate is green (4262 tests, clippy, docs-sync, rustdoc).

> _This was written by Claude Code on behalf of max_
