### PR TITLE
fix(list): paint Age/Message columns once the commit batch lands

### DIFF
--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -127,7 +127,21 @@
 //! │  )                                          // ~10ms total (max of all spawns)
 //! ├─ populate ListItem.commit from cache        (cache-hit lookups, sub-ms)
 //! Worker thread spawns
+//! └─ paint Age/Message columns                  (workers already running)
 //! ```
+//!
+//! **Why the Age/Message paint:** those two columns carry no task — their
+//! data is the `ListItem.commit` populated above — so without an explicit
+//! repaint they'd sit on the skeleton placeholder until the row's first *task*
+//! result happened to redraw it, lagging behind the slower task-driven columns
+//! (and a cache-warm Summary preview). The paint runs *after* the worker pool
+//! is spawned — so the slow git subprocesses (the long pole) aren't delayed by
+//! it — but *before* the drain renders any result, so Age/Message still reach
+//! the screen ahead of every task-driven column. Reading `all_items` here is
+//! race-free: the worker thread only sends results through the channel, and the
+//! drain (the sole `all_items` mutator) hasn't started. `render_skeleton_row`
+//! fills Age/Message from `item.commit` while every task column keeps its
+//! placeholder.
 //!
 //! **Why fsmonitor check is sequential:** It gates whether daemon starts are needed.
 //! The check is fast (~5ms) and must complete before we know which spawns to add.
@@ -484,12 +498,16 @@ pub trait PickerProgressHandler: Send + Sync {
     /// the frozen skeleton snapshot.
     fn on_update(&self, idx: usize, rendered: String, item: &super::model::ListItem);
 
-    /// Fired at the 200ms reveal deadline. One pre-rendered line per row,
-    /// with the placeholder promoted from blank to `·`: rows that have
-    /// received real data use `format_list_item_line`, rows still at
-    /// skeleton state use the skeleton renderer. The handler writes every
-    /// slot — slot writes are idempotent.
-    fn on_reveal(&self, rendered: Vec<String>);
+    /// Rewrite every row's rendered line from `rendered` and repaint. The
+    /// handler writes one slot per row — slot writes are idempotent — then
+    /// pokes skim. Two callers, both handing over a full set of freshly
+    /// rendered rows:
+    /// - the post-skeleton commit paint (Age/Message filled from the
+    ///   pre-skeleton batch, every task column still on its placeholder),
+    /// - the 200ms reveal (placeholder promoted from blank to `·`: rows that
+    ///   have data use `format_list_item_line`, rows still at skeleton state
+    ///   use the skeleton renderer).
+    fn repaint_rows(&self, rendered: Vec<String>);
 
     /// Stash a pre-formatted warning line. Skim owns the terminal while
     /// collect runs on the picker's bg thread, so eprintln from collect
@@ -1591,6 +1609,37 @@ pub fn collect(
     // Drop the original sender so drain_results knows when all spawned threads are done
     drop(tx);
 
+    // Workers are running now — paint the commit-derived columns (Age,
+    // Message) while the git subprocesses spin up. They carry no task, so
+    // without this they'd sit on the skeleton placeholder until the row's
+    // first task result happened to redraw it, lagging behind the slower
+    // task-driven columns (and the cache-warm Summary preview, the symptom
+    // this addresses). Spawning the workers first means the slow git work (the
+    // long pole) isn't delayed by this paint, and reading `all_items` here is
+    // race-free: the worker thread only sends results through the channel —
+    // the drain below is the sole `all_items` mutator and hasn't started. The
+    // paint still lands before the drain renders any result, so Age/Message
+    // reach the screen ahead of every task-driven column. `render_skeleton_row`
+    // fills them from `item.commit` while each task column keeps its blank
+    // placeholder.
+    if progressive_table.is_some() || progressive_handler.is_some() {
+        let commit_rows: Vec<String> = all_items
+            .iter()
+            .map(|item| layout.render_skeleton_row(item, placeholder).render())
+            .collect();
+        if let Some(table) = progressive_table.as_mut() {
+            for (idx, row) in commit_rows.iter().enumerate() {
+                table.update_row(idx, row.clone());
+            }
+            if let Err(e) = table.flush() {
+                tracing::debug!(error = %e, "Progressive table commit-column paint flush failed: {}", e);
+            }
+        }
+        if let Some(handler) = progressive_handler.as_ref() {
+            handler.repaint_rows(commit_rows);
+        }
+    }
+
     // Drain task results with conditional progressive rendering.
     //
     // Progressive mutable state (table, row cache, counters) is owned by a
@@ -1707,7 +1756,7 @@ pub fn collect(
                     }
 
                     if let Some(handler) = progressive_handler.as_ref() {
-                        handler.on_reveal(updates);
+                        handler.repaint_rows(updates);
                     }
                 }
                 results::DrainEvent::Stall {

--- a/src/commands/list/render.rs
+++ b/src/commands/list/render.rs
@@ -351,6 +351,25 @@ impl LayoutConfig {
                         _ => StyledLine::new(),
                     };
                 }
+                // Age (Time) and Message carry no task — their data arrives in
+                // `item.commit` from the pre-skeleton commit batch, not from a
+                // task result. Render them through the canonical cell renderer
+                // so the post-skeleton commit paint (and the 200ms reveal) fill
+                // them the moment that batch is folded in, instead of leaving
+                // them on the placeholder until the row's first task result
+                // happens to redraw it. Before the batch lands (the very first
+                // skeleton paint) `item.commit` is `None`, and `render_cell`
+                // returns the same placeholder the `_` arm below would.
+                ColumnKind::Time | ColumnKind::Message => {
+                    return col.render_cell(
+                        item,
+                        &self.status_position_mask,
+                        &self.main_worktree_path,
+                        self.max_message_len,
+                        self.max_summary_len,
+                        spinner,
+                    );
+                }
                 _ => {
                     // Show spinner for data columns (placeholder_cell handles alignment)
                     return col.placeholder_cell(spinner);
@@ -1336,6 +1355,72 @@ mod tests {
         item.summary = Some(Some("Add user authentication".into()));
         let cell = summary_col.render_cell(&item, &mask, &main_path, 50, 40, PLACEHOLDER);
         insta::assert_snapshot!(cell.render(), @"Add user authentication");
+    }
+
+    /// The skeleton renders the task-free Age/Message columns from
+    /// `item.commit` the moment the pre-skeleton commit batch is folded in,
+    /// rather than leaving them on the placeholder until the row's first task
+    /// result. Before the batch lands (`commit = None`, the very first paint)
+    /// both columns show the loading placeholder, exactly as the catch-all arm
+    /// did — so the first frame is unchanged.
+    #[test]
+    fn test_skeleton_renders_commit_columns_when_loaded() {
+        use super::super::layout::{ColumnLayout, LayoutConfig};
+        use super::super::model::{CommitDetails, ListItem, PositionMask};
+        use std::path::PathBuf;
+
+        let layout = LayoutConfig {
+            columns: vec![
+                ColumnLayout {
+                    kind: ColumnKind::Time,
+                    header: std::borrow::Cow::Borrowed("Age"),
+                    start: 0,
+                    width: 6,
+                    format: ColumnFormat::Text,
+                },
+                ColumnLayout {
+                    kind: ColumnKind::Message,
+                    header: std::borrow::Cow::Borrowed("Message"),
+                    start: 7,
+                    width: 20,
+                    format: ColumnFormat::Text,
+                },
+            ],
+            main_worktree_path: PathBuf::from("/tmp"),
+            max_message_len: 20,
+            max_summary_len: 10,
+            hidden_column_count: 0,
+            status_position_mask: PositionMask::FULL,
+        };
+
+        // commit = None (first skeleton paint, before the batch) → placeholders.
+        let mut item = ListItem::new_branch("abc123".into(), "feat".into());
+        item.commit = None;
+        let line = layout.render_skeleton_row(&item, PLACEHOLDER).render();
+        assert!(
+            line.contains('·'),
+            "Age/Message are placeholders before the commit batch: {line}"
+        );
+        assert!(
+            !line.contains("Fix the parser"),
+            "no commit subject before the batch: {line}"
+        );
+
+        // commit = Some (post-skeleton commit paint) → the subject and a
+        // relative age render without waiting for any task result.
+        item.commit = Some(CommitDetails {
+            timestamp: 1_700_000_000,
+            commit_message: "Fix the parser".into(),
+        });
+        let line = layout.render_skeleton_row(&item, PLACEHOLDER).render();
+        assert!(
+            line.contains("Fix the parser"),
+            "commit subject paints in the skeleton once the batch is in: {line}"
+        );
+        assert!(
+            !line.contains('·'),
+            "no loading placeholder once commit data is in: {line}"
+        );
     }
 
     #[test]

--- a/src/commands/picker/progressive_handler.rs
+++ b/src/commands/picker/progressive_handler.rs
@@ -540,7 +540,7 @@ impl PickerProgressHandler for PickerHandler {
         self.request_render(false);
     }
 
-    fn on_reveal(&self, rendered: Vec<String>) {
+    fn repaint_rows(&self, rendered: Vec<String>) {
         let Some(slots) = self.rendered_slots.get() else {
             return;
         };
@@ -772,9 +772,9 @@ mod tests {
             "row 0 diff-content untouched"
         );
 
-        // on_reveal rewrites every slot — slot writes are idempotent
+        // repaint_rows rewrites every slot — slot writes are idempotent
         // through `Mutex<String>`, so unconditional updates are safe.
-        handler.on_reveal(vec!["rev-one".into(), "rev-two".into()]);
+        handler.repaint_rows(vec!["rev-one".into(), "rev-two".into()]);
         assert_eq!(*slots[0].lock().unwrap(), "rev-one");
         assert_eq!(*slots[1].lock().unwrap(), "rev-two");
     }


### PR DESCRIPTION
## Summary

The **Age** and **Message** columns in `wt list` / the `wt switch` picker carry no async task — their data is the pre-skeleton `git log` batch folded into `item.commit`. But the skeleton renderer left them on the loading placeholder (`·`) until the row's *first task result* happened to redraw it, so already-in-hand data lagged behind the slower task-driven columns and a cache-warm Summary preview. That's the "summary renders before the commit message" effect.

The fix paints those columns from `item.commit` the moment the batch lands, without delaying the skeleton:

- `render_skeleton_row` now renders Age/Message via the canonical `render_cell` (byte-identical placeholder when `item.commit` is `None`, so the first skeleton frame is unchanged).
- `collect()` does a one-shot repaint of those columns **right after the worker pool is spawned** — so the slow git subprocesses (the long pole, ~436ms of parallel work) start first and the paint lands in their shadow, still ahead of the drain rendering any task result. Reading `all_items` there is race-free: the worker only sends results through the channel, and the drain (the sole `all_items` mutator) hasn't started.
- The picker's `on_reveal` handler is renamed `repaint_rows` — it now has two callers (the commit paint and the 200ms reveal) sharing one "rewrite all rows + repaint" contract.

The `collect/mod.rs` module docstring's post-skeleton phase diagram and rationale are updated to match.

## Testing

Full pre-merge gate green (4269 tests + lints, rustdoc `-Dwarnings`). Added a unit test (`test_skeleton_renders_commit_columns_when_loaded`) covering both states: placeholder when `commit` is `None`, subject + relative age once it's populated. The `_list` PTY snapshots are unaffected (Age/Message sit right of the picker's col-59 split).

> _This was written by Claude Code on behalf of max_
