### PR TITLE
perf(list): dedup commit→tree resolution via in-memory cache

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,7 +193,7 @@ No `get_*` — bare nouns follow Rust stdlib convention.
 
 ## Repository Caching
 
-`Repository` caches read-only values via `Arc<RepoCache>` (cloning shares it). What is and isn't cached, the `list_worktrees()` post-mutation invariant, and the two storage patterns: the `# Caching` section in `src/git/repository/mod.rs`.
+`Repository` caches read-only values via `Arc<RepoCache>` (cloning shares it). What is and isn't cached, the `list_worktrees()` post-mutation invariant, the two storage patterns, and the in-memory-`RepoCache`-vs-persistent-`sha_cache` decision (cheap-and-hot → in-memory get-or-create; expensive → disk; both → in-memory front over disk back): the `# Caching` section in `src/git/repository/mod.rs`.
 
 ## Releases
 

--- a/src/git/repository/integration.rs
+++ b/src/git/repository/integration.rs
@@ -138,23 +138,13 @@ impl Repository {
     /// Useful for detecting squash merges or rebases where the content has been
     /// integrated but commit ancestry doesn't show the relationship.
     ///
-    /// Resolves each commit SHA to its tree SHA in a single `git rev-parse`
-    /// call and compares. The commit→tree resolution is itself uncached
-    /// (trees are cheap and not stale-prone), but the inputs are SHAs so
-    /// the call is immune to ref-name staleness.
+    /// Both commit→tree resolutions go through `commit_to_tree_sha`, so the
+    /// shared target side (the default-branch tip, identical across every
+    /// `wt list` row) is peeled once per process and shared with
+    /// `would_merge_add_to_target`'s lookup. Inputs are commit SHAs, so the
+    /// mapping is content-addressed and immune to ref-name staleness.
     pub fn trees_match_by_sha(&self, commit_sha1: &str, commit_sha2: &str) -> anyhow::Result<bool> {
-        let output = self.run_command(&[
-            "rev-parse",
-            &format!("{commit_sha1}^{{tree}}"),
-            &format!("{commit_sha2}^{{tree}}"),
-        ])?;
-        let mut lines = output.lines();
-        let tree1 = lines.next().context("rev-parse returned no output")?.trim();
-        let tree2 = lines
-            .next()
-            .context("rev-parse returned only one line")?
-            .trim();
-        Ok(tree1 == tree2)
+        Ok(self.commit_to_tree_sha(commit_sha1)? == self.commit_to_tree_sha(commit_sha2)?)
     }
 
     /// Check if merging `head_sha` into `base_sha` would result in conflicts.
@@ -271,8 +261,11 @@ impl Repository {
             MergeTreeOutcome::Conflict => Ok(None),
             MergeTreeOutcome::Clean { tree } => {
                 // If the merge result differs from target's tree, merging would
-                // add something (the branch is not already integrated).
-                let target_tree = self.rev_parse_tree(&format!("{target}^{{tree}}"))?;
+                // add something (the branch is not already integrated). The
+                // target is shared across every `wt list` row, so resolve its
+                // tree through the in-memory repo cache — peeled once, not once
+                // per row (see [`Self::commit_to_tree_sha`]).
+                let target_tree = self.commit_to_tree_sha(target)?;
                 Ok(Some(tree != target_tree))
             }
         }
@@ -497,12 +490,43 @@ impl Repository {
 
     /// Resolve a tree spec (e.g. `"refs/heads/main^{tree}"`) to its tree SHA.
     /// Uncached — tree resolution is cheap (~1 ms) and stale-prone if memoized
-    /// against a moving ref name.
+    /// against a moving ref name. When the input is a commit SHA, prefer
+    /// [`Self::commit_to_tree_sha`], which memoizes the immutable commit→tree
+    /// mapping.
     pub(super) fn rev_parse_tree(&self, spec: &str) -> anyhow::Result<String> {
         Ok(self
             .run_command(&["rev-parse", "--verify", "--end-of-options", spec])?
             .trim()
             .to_string())
+    }
+
+    /// Resolve a commit SHA to its tree SHA, memoized in the in-memory repo
+    /// cache (get-or-create — the same lock-free pattern as
+    /// [`Self::merge_base_by_sha`]).
+    ///
+    /// Unlike [`Self::rev_parse_tree`], the input is a commit SHA, so the
+    /// commit→tree mapping is content-addressed and never stale within a
+    /// process — a `git` object's tree is immutable. Caching it dedups the
+    /// `wt list` hot path, where every branch row peels the *same*
+    /// default-branch tip to its tree inside
+    /// [`Self::would_merge_add_to_target`]; without the cache that is one
+    /// identical `rev-parse` subprocess per row.
+    ///
+    /// In-memory rather than the persistent `sha_cache`: the resolution is
+    /// ~1 ms, so cross-run persistence saves almost nothing, while the `Entry`
+    /// match holds the shard lock across check-and-insert so the first miss
+    /// computes once and every concurrent row reads it — no cold-start race.
+    /// The disk cache is reserved for results expensive enough that persisting
+    /// them across invocations outweighs a one-off recompute.
+    fn commit_to_tree_sha(&self, commit_sha: &str) -> anyhow::Result<String> {
+        use dashmap::mapref::entry::Entry;
+        match self.cache.commit_tree.entry(commit_sha.to_string()) {
+            Entry::Occupied(e) => Ok(e.get().clone()),
+            Entry::Vacant(e) => {
+                let tree = self.rev_parse_tree(&format!("{commit_sha}^{{tree}}"))?;
+                Ok(e.insert(tree).clone())
+            }
+        }
     }
 
     /// Resolve a ref to its commit SHA. Uncached — callers that want
@@ -683,6 +707,50 @@ mod snapshot_resolve_tests {
         // Bogus ref → error (not a confusing "unknown option" — `--verify`
         // surfaces a clean "Needed a single revision" / "bad revision").
         assert!(snapshot_resolve(&repo, &snapshot, "no-such-ref").is_err());
+    }
+}
+
+#[cfg(test)]
+mod commit_tree_cache_tests {
+    use super::*;
+    use crate::testing::TestRepo;
+
+    /// The integration probe peels the target commit to its tree once and
+    /// memoizes it in the in-memory repo cache, keyed by the target commit
+    /// SHA — so the many `wt list` rows sharing one target don't each spawn
+    /// `git rev-parse <target>^{tree}`.
+    #[test]
+    fn probe_caches_target_tree_in_memory() {
+        let test = TestRepo::with_initial_commit();
+
+        // Feature adds a file; main is unchanged. The merge is clean but adds
+        // changes, so the probe reaches the Clean arm of
+        // would_merge_add_to_target and resolves the target (main) tree.
+        test.run_git(&["checkout", "-b", "feature"]);
+        std::fs::write(test.root_path().join("new.txt"), "content\n").unwrap();
+        test.run_git(&["add", "new.txt"]);
+        test.run_git(&["commit", "-m", "Feature"]);
+        test.run_git(&["checkout", "main"]);
+
+        let feature_sha = test.git_output(&["rev-parse", "feature"]);
+        let main_sha = test.git_output(&["rev-parse", "main"]);
+        let main_tree = test.git_output(&["rev-parse", "main^{tree}"]);
+
+        let repo = Repository::at(test.root_path()).unwrap();
+        assert!(!repo.cache.commit_tree.contains_key(&main_sha));
+
+        let probe = repo
+            .merge_integration_probe_by_sha(&feature_sha, &main_sha)
+            .unwrap();
+        assert!(probe.would_merge_add, "clean merge adds the new file");
+
+        // Target tree resolved once and cached under the target commit SHA.
+        let cached = repo
+            .cache
+            .commit_tree
+            .get(&main_sha)
+            .map(|e| e.value().clone());
+        assert_eq!(cached, Some(main_tree));
     }
 }
 

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -33,7 +33,25 @@
 //!   of `main` and have every later `Repository::current()` (each builds a
 //!   fresh `RepoCache`) reuse the result.
 //!
-//! **Lifetime.** Neither layer is ever invalidated. `RepoCache` lives as
+//! **Persistence: in-memory vs on-disk.** Both layers above are in-memory and
+//! die with the process. A third store — the persistent on-disk [`sha_cache`]
+//! (SHA-keyed JSON under `.git/wt/cache/`) — survives across invocations.
+//! Which store a git result belongs in turns on recompute cost and parallelism:
+//! - *Cheap, resolved many times per run* (commit→tree, merge-base) → in-memory
+//!   `RepoCache` `DashMap`, get-or-create. The `Entry` match holds the shard
+//!   lock across check-and-insert, so parallel `wt list` rows sharing a key
+//!   spawn one git process, not one each; recompute is ~1 ms, so cross-run
+//!   persistence isn't worth a file. Exemplars:
+//!   [`Repository::merge_base_by_sha`], [`Repository::commit_to_tree_sha`].
+//! - *Expensive, worth persisting across invocations* (merge-tree, patch-id,
+//!   diff stats, ahead/behind) → the disk [`sha_cache`]; content-addressed by
+//!   SHA, so never stale.
+//! - *Both expensive and hot-in-parallel* → an in-memory `DashMap` front over
+//!   the disk back, so parallel tasks don't race through the file cache for the
+//!   same key (the in-memory layer pays the first miss once; the disk layer
+//!   persists it). Exemplar: the `diff_stats` field below.
+//!
+//! **Lifetime.** Neither in-memory layer is ever invalidated. `RepoCache` lives as
 //! long as the `Repository` it's attached to (typically the command).
 //! Process-wide statics live for the process. For the CLI that's the same
 //! thing — one command per process — but tests run many commands in one
@@ -221,6 +239,12 @@ pub(super) struct RepoCache {
     /// a [`RefSnapshot`] before consulting. The key order is normalized
     /// (`(min, max)`) since merge-base is symmetric.
     pub(super) merge_base: DashMap<(String, String), Option<String>>,
+    /// Commit→tree cache: commit_sha -> tree_sha. Keys are commit SHAs by
+    /// contract; a commit's tree is immutable, so the mapping is never stale
+    /// within a process. Dedups the `wt list` integration probe, where every
+    /// branch row peels the same default-branch tip to its tree. Resolved via
+    /// [`Repository::commit_to_tree_sha`].
+    pub(super) commit_tree: DashMap<String, String>,
     /// Effective remote URLs: remote_name -> effective URL (with `url.insteadOf` applied).
     /// Separate from `all_config` because `git remote get-url` applies
     /// `url.insteadOf` rewrites that aren't visible in raw config.

--- a/tests/snapshots/integration__integration_tests__list__list_warns_when_commit_details_batch_fails.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_warns_when_commit_details_batch_fails.snap
@@ -57,7 +57,7 @@ exit_code: 0
 [33m▲[39m [33mFailed to batch-fetch commit details: fatal: bad object 0000000000000000000000000000000000000001[39m
 [33m▲[39m [33mSome git operations failed:
 [107m [0m [1m(detached)[22m: ahead-behind (git merge-base failed for 05a4a45d0b981dad5c27db59dca482836d59f89e 0000000000000000000000000000000000000001: fatal: Not a valid commit name 0000000000000000000000000000000000000001)
-[107m [0m [1m(detached)[22m: committed-trees-match (fatal: ambiguous argument '0000000000000000000000000000000000000001^{tree}': unknown revision or path not in the working tree.)
+[107m [0m [1m(detached)[22m: committed-trees-match (fatal: Needed a single revision)
 [107m [0m [1m(detached)[22m: branch-diff (git merge-base failed for 05a4a45d0b981dad5c27db59dca482836d59f89e 0000000000000000000000000000000000000001: fatal: Not a valid commit name 0000000000000000000000000000000000000001)
 [107m [0m [1m(detached)[22m: working-tree-diff (fatal: bad object HEAD)
 [107m [0m [1m(detached)[22m: merge-tree-conflicts (fatal: bad object HEAD)


### PR DESCRIPTION
`wt list --full` peeled the shared default-branch tip to its tree once per worktree/branch row inside the integration probe — N identical `git rev-parse <sha>^{tree}` subprocesses for one value (the largest duplicate-call line in a profiled run).

This adds a commit→tree memo to the in-memory `RepoCache` (a `DashMap` get-or-create, mirroring `merge_base_by_sha`): the `Entry` match holds the shard lock across check-and-insert, so parallel rows sharing the target spawn one process, not one each. Both `would_merge_add_to_target` and `trees_match_by_sha` now resolve commit→tree through it, so the shared target tree resolves exactly once per run (verified against `[wt-trace]` records).

In-memory rather than the persistent `sha_cache`: the resolution is ~1 ms, so cross-run persistence buys little, while the in-memory layer eliminates the cold-run race the disk cache would have. The codebase already had this pattern (`merge_base`, `diff_stats`) but the in-memory-vs-disk decision was implicit — so this also documents it in the `# Caching` module section, with the three exemplars.

The one snapshot change is an improvement: the `committed-trees-match` failure now surfaces the clean `--verify` error (`Needed a single revision`) instead of the confusing `ambiguous argument …`, matching every other `rev-parse` call site.

> _This was written by Claude Code on behalf of max_
