### PR TITLE
perf(list): dedup merge-tree spawns shared by the two integration probes

### DIFF
--- a/src/git/repository/integration.rs
+++ b/src/git/repository/integration.rs
@@ -76,7 +76,10 @@ const PATCH_ID_SCAN_MAX_COMMITS: usize = 500;
 /// Exit 0 → `Clean` carrying the resulting tree SHA; exit 1 → `Conflict`;
 /// anything else is an error (the helper bails). Both merge-tree callers
 /// share this dispatch; they differ only in what they do with a clean tree.
-enum MergeTreeOutcome {
+/// `Clone` + `Debug` so the outcome can be memoized in
+/// [`RepoCache::merge_tree`](super::RepoCache::merge_tree).
+#[derive(Debug, Clone)]
+pub(in crate::git) enum MergeTreeOutcome {
     Clean { tree: String },
     Conflict,
 }
@@ -205,11 +208,39 @@ impl Repository {
         self.run_merge_tree(base_sha, head_commit, base_sha, &cache_head)
     }
 
-    /// Run `git merge-tree --write-tree <a> <b>` and classify the outcome by
-    /// exit code. Exit 1 → [`MergeTreeOutcome::Conflict`]; anything other than
-    /// success is an error; exit 0 → [`MergeTreeOutcome::Clean`] with the
-    /// resulting tree SHA (first line of stdout).
+    /// Run `git merge-tree --write-tree <a> <b>`, memoizing the outcome in the
+    /// in-memory [`RepoCache::merge_tree`](super::RepoCache::merge_tree) cache.
+    ///
+    /// `git merge-tree` is the costliest operation in `wt list`, and the two
+    /// integration probes ask it the same question per row:
+    /// [`Self::run_merge_tree`] wants the conflict bit (for the `WouldConflict`
+    /// column) and [`Self::would_merge_add_to_target`] wants the resulting tree
+    /// (for the integration column) — both run `merge-tree --write-tree
+    /// <target> <branch>`. Their persistent caches (`merge-tree-conflicts` vs
+    /// `merge-add-probe`) are keyed separately, so on a cold run neither sees
+    /// the other and the subprocess fires twice. The shared entry lock
+    /// collapses both — and any cross-row repeat of the same pair — to a single
+    /// spawn, mirroring [`Self::merge_base_by_sha`].
     fn merge_tree_outcome(&self, a: &str, b: &str) -> anyhow::Result<MergeTreeOutcome> {
+        use dashmap::mapref::entry::Entry;
+
+        // Asymmetric key: both call sites pass arguments in `(target, branch)`
+        // order, and a swapped merge can differ in conflict-hunk content, so
+        // the order is preserved rather than normalized.
+        match self.cache.merge_tree.entry((a.to_string(), b.to_string())) {
+            Entry::Occupied(e) => Ok(e.get().clone()),
+            Entry::Vacant(e) => {
+                let outcome = self.compute_merge_tree_outcome(a, b)?;
+                Ok(e.insert(outcome).clone())
+            }
+        }
+    }
+
+    /// Compute a fresh `git merge-tree --write-tree <a> <b>` outcome, classified
+    /// by exit code. Exit 1 → [`MergeTreeOutcome::Conflict`]; anything other
+    /// than success is an error; exit 0 → [`MergeTreeOutcome::Clean`] with the
+    /// resulting tree SHA (first line of stdout).
+    fn compute_merge_tree_outcome(&self, a: &str, b: &str) -> anyhow::Result<MergeTreeOutcome> {
         // Exit codes: 0 = clean merge, 1 = conflicts, 128+ = error (invalid ref, corrupt repo)
         let output = self.run_command_output(&["merge-tree", "--write-tree", a, b])?;
 
@@ -880,6 +911,65 @@ mod patch_id_tests {
             check_integration(&signals),
             Some(IntegrationReason::PatchIdMatch),
             "squash merge must be detected via patch-id regardless of diff.* config"
+        );
+    }
+}
+
+#[cfg(test)]
+mod merge_tree_cache_tests {
+    use super::*;
+    use crate::testing::TestRepo;
+
+    /// The conflict probe ([`Repository::has_merge_conflicts_by_sha`], driving
+    /// the `WouldConflict` column) and the integration probe
+    /// ([`Repository::merge_integration_probe_by_sha`], driving the
+    /// integration column) both run `git merge-tree --write-tree <target>
+    /// <branch>` for the same row but extract different answers — the conflict
+    /// bit versus the resulting tree. They must key the in-memory cache
+    /// identically, in `(target, branch)` order, so the subprocess fires once
+    /// per row rather than once per probe. An argument-order regression on
+    /// either call site would split this into two entries (two spawns); this
+    /// pins it at one.
+    #[test]
+    fn conflict_and_integration_probes_share_one_merge_tree_spawn() {
+        let test = TestRepo::with_initial_commit();
+
+        // feature: one commit ahead of main, clean-mergeable, not integrated.
+        test.run_git(&["checkout", "-b", "feature"]);
+        std::fs::write(test.root_path().join("new.txt"), "content\n").unwrap();
+        test.run_git(&["add", "new.txt"]);
+        test.run_git(&["commit", "-m", "feature"]);
+        test.run_git(&["checkout", "main"]);
+
+        let main_sha = test.git_output(&["rev-parse", "main"]);
+        let feature_sha = test.git_output(&["rev-parse", "feature"]);
+
+        let repo = Repository::at(test.root_path()).unwrap();
+
+        // Conflict probe: a clean merge has no conflicts.
+        assert!(
+            !repo
+                .has_merge_conflicts_by_sha(&main_sha, &feature_sha)
+                .unwrap()
+        );
+        // Integration probe: merging adds new.txt, so it would change main —
+        // not yet integrated, and no patch-id fallback (merge was clean).
+        let probe = repo
+            .merge_integration_probe_by_sha(&feature_sha, &main_sha)
+            .unwrap();
+        assert!(probe.would_merge_add);
+        assert!(!probe.is_patch_id_match);
+
+        // Both probes resolved through a single shared merge-tree entry, keyed
+        // (target, branch) = (main, feature).
+        assert_eq!(
+            repo.cache.merge_tree.len(),
+            1,
+            "conflict + integration probes must share one merge-tree cache entry"
+        );
+        assert!(
+            repo.cache.merge_tree.contains_key(&(main_sha, feature_sha)),
+            "the shared entry must be keyed (target, branch)"
         );
     }
 }

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -221,6 +221,17 @@ pub(super) struct RepoCache {
     /// a [`RefSnapshot`] before consulting. The key order is normalized
     /// (`(min, max)`) since merge-base is symmetric.
     pub(super) merge_base: DashMap<(String, String), Option<String>>,
+    /// In-memory merge-tree outcome cache: (a_sha, b_sha) -> outcome.
+    /// `git merge-tree --write-tree` is the costliest op in `wt list`, and the
+    /// conflict probe (`has_merge_conflicts_by_sha`) and the integration probe
+    /// (`merge_integration_probe_by_sha` via `would_merge_add_to_target`) run
+    /// the identical `(target, branch)` merge per row for two different
+    /// answers. Their persistent caches (`merge-tree-conflicts` vs
+    /// `merge-add-probe`) are keyed separately, so a cold run would spawn the
+    /// subprocess twice; this front collapses both to one via the entry-lock
+    /// pattern (same as [`Self::merge_base`]). Keys are commit SHAs in call
+    /// order — see `Repository::merge_tree_outcome`.
+    pub(super) merge_tree: DashMap<(String, String), integration::MergeTreeOutcome>,
     /// Effective remote URLs: remote_name -> effective URL (with `url.insteadOf` applied).
     /// Separate from `all_config` because `git remote get-url` applies
     /// `url.insteadOf` rewrites that aren't visible in raw config.


### PR DESCRIPTION
## What

A cold `wt list` runs `git merge-tree --write-tree <target> <branch>` **twice per row**: once from `MergeTreeConflictsTask` (which wants the conflict bit, for the `WouldConflict` column, via `has_merge_conflicts_by_sha` → `run_merge_tree`) and once from `WouldMergeAddTask` (which wants the resulting tree, for the integration column, via `merge_integration_probe_by_sha` → `would_merge_add_to_target`). When the local default branch is also the integration primary — the common case — both calls are the *byte-identical* subprocess `git merge-tree --write-tree <default> <branch>`. They differ only in which field of the outcome each reads (conflict flag vs. clean-merge tree).

The two answers are cached in two different persistent kinds (`merge-tree-conflicts` vs. `merge-add-probe`), keyed separately, and the persistent caches don't hold a lock across compute, so on a cold run neither probe sees the other's spawn — the same merge fires twice. `git merge-tree` is the single most expensive command in `wt list` (in a busy-repo profile: 156 calls, ~25 s total, ~162 ms avg).

## Fix

Add an in-memory `RepoCache::merge_tree` cache and route `Repository::merge_tree_outcome` through it with the entry-lock get-or-create pattern — the same shape `merge_base_by_sha` already uses. The shard lock is held across the subprocess, so parallel rows sharing a `(target, branch)` pair (and, crucially, the two probes on the *same* row) collapse to one spawn. The key is `(a, b)` in call order; both dedup sites pass `(target, branch)`, and the cached outcome doesn't depend on argument order, so a symmetric key would add nothing.

Scope: in-memory, command-lifetime only — warm runs already short-circuit at the higher-level persistent caches (`merge-tree-conflicts` / `merge-add-probe`) and never reach `merge_tree_outcome`. This only removes the cold-run duplicate.

## Evidence

Cold `wt list --full` on a 16-worktree repo, counting authoritative `[wt-trace] cmd=` records:

```
before:  33 merge-tree spawns,  18 distinct pairs  (15 exact duplicates)
after:   18 merge-tree spawns,  18 distinct pairs  (0 duplicates)
```

Every duplicated pair was `(main_HEAD, <branch>)` — confirming the two probes, not a cold-run race. Output (integration symbols, conflict markers) is unchanged: the cached `MergeTreeOutcome` is identical to a fresh compute.

This is orthogonal to and composes with #3288 (which dedups commit→tree resolution): that change caches `commit_to_tree_sha`; this one caches the `merge-tree` outcome itself.

## Testing

Added `conflict_and_integration_probes_share_one_merge_tree_spawn`, which pins the load-bearing invariant: after running both probes for one row, exactly one `merge_tree` entry exists, keyed `(target, branch)`. An argument-order regression on either call site would split it into two entries (two spawns) and fail the test. Full pre-merge gate green (4273 tests).

> _This was written by Claude Code on behalf of max_
