### PR TITLE
fix(picker): show the resolved config path in disabled-summary hints

### DIFF
--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -1648,19 +1648,30 @@ pub fn handle_picker(
         if config.list.summary() && config.commit_generation.is_configured() {
             (config.commit_generation.command.clone(), None)
         } else {
+            // Point at the config file wt actually loads from — respecting
+            // --config, WORKTRUNK_CONFIG_PATH, and $XDG_CONFIG_HOME — rather
+            // than a hardcoded default. Fall back to the canonical path on the
+            // rare occasion no location can be determined.
+            let config_path = worktrunk::config::config_path()
+                .map(|p| format_path_for_display(&p))
+                .unwrap_or_else(|| "~/.config/worktrunk/config.toml".to_string());
             let hint = if !config.commit_generation.is_configured() {
-                "Configure [commit.generation] command to enable LLM summaries.\n\n\
-                 Example in ~/.config/worktrunk/config.toml:\n\n\
-                 [commit.generation]\n\
-                 command = \"llm -m haiku\"\n\n\
-                 [list]\n\
-                 summary = true\n"
+                format!(
+                    "Configure [commit.generation] command to enable LLM summaries.\n\n\
+                     Example in {config_path}:\n\n\
+                     [commit.generation]\n\
+                     command = \"llm -m haiku\"\n\n\
+                     [list]\n\
+                     summary = true\n"
+                )
             } else {
-                "Enable summaries in ~/.config/worktrunk/config.toml:\n\n\
-                 [list]\n\
-                 summary = true\n"
+                format!(
+                    "Enable summaries in {config_path}:\n\n\
+                     [list]\n\
+                     summary = true\n"
+                )
             };
-            (None, Some(hint.to_string()))
+            (None, Some(hint))
         };
 
     // The picker's full row list — header, worktree/branch rows, and (in `--prs`

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -1644,28 +1644,32 @@ pub fn handle_picker(
     // Summary hint: when summaries are disabled, prime the Summary cache
     // with config guidance instead of showing a perpetual "Generating…"
     // placeholder.
-    let (llm_command, summary_hint) = if config.list.summary()
-        && config.commit_generation.is_configured()
-    {
-        (config.commit_generation.command.clone(), None)
-    } else {
-        // Point at the config file wt actually loads from — respecting
-        // --config, WORKTRUNK_CONFIG_PATH, and $XDG_CONFIG_HOME — rather
-        // than a hardcoded default. Fall back to the canonical path on the
-        // rare occasion no location can be determined.
-        let config_path = worktrunk::config::config_path()
-            .map(|p| format_path_for_display(&p))
-            .unwrap_or_else(|| "~/.config/worktrunk/config.toml".to_string());
-        // A short first line stays the bold H4 subject (`render_summary`
-        // promotes it and never wraps it, so a long sentence would clip on
-        // a narrow pane); the instruction and the resolved path live in the
-        // wrapping body, and the config block is fenced so it renders in the
-        // house gutter rather than as loose prose.
-        let hint = if !config.commit_generation.is_configured() {
-            format!(
-                r#"Summaries not configured
+    let (llm_command, summary_hint) =
+        if config.list.summary() && config.commit_generation.is_configured() {
+            (config.commit_generation.command.clone(), None)
+        } else {
+            // Point at the config file wt actually loads from — respecting
+            // --config, WORKTRUNK_CONFIG_PATH, and $XDG_CONFIG_HOME — rather
+            // than a hardcoded default. Fall back to the canonical path on the
+            // rare occasion no location can be determined.
+            let config_path = worktrunk::config::config_path()
+                .map(|p| format_path_for_display(&p))
+                .unwrap_or_else(|| "~/.config/worktrunk/config.toml".to_string());
+            // Keep every prose line short and put the resolved path on its own
+            // line. `render_summary` word-wraps prose to the preview width, and
+            // that width is a column narrower under Windows' PTY — so a sentence
+            // long enough to wrap lands its break on a different word there, and
+            // the single cross-platform snapshot can't match. A short lead line,
+            // the path alone (one unbreakable token, no wrap boundary to shift),
+            // and the fenced config block (code blocks are never wrapped) all
+            // render identically on every platform. The first line stays the bold
+            // H4 subject, which `render_summary` promotes and never wraps.
+            let hint = if !config.commit_generation.is_configured() {
+                format!(
+                    r#"Summaries not configured
 
-LLM branch summaries need a [commit.generation] command. Add one in {config_path}, then enable summaries:
+Add a [commit.generation] command in:
+{config_path}
 
 ```toml
 [commit.generation]
@@ -1675,22 +1679,23 @@ command = "llm -m haiku"
 summary = true
 ```
 "#
-            )
-        } else {
-            format!(
-                r#"Summaries off
+                )
+            } else {
+                format!(
+                    r#"Summaries off
 
-A [commit.generation] command is configured. Enable summaries in {config_path}:
+Enable summaries in:
+{config_path}
 
 ```toml
 [list]
 summary = true
 ```
 "#
-            )
+                )
+            };
+            (None, Some(hint))
         };
-        (None, Some(hint))
-    };
 
     // The picker's full row list — header, worktree/branch rows, and (in `--prs`
     // mode) PR/MR rows. `on_skeleton` fills it with the header + worktree/branch

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -1644,35 +1644,53 @@ pub fn handle_picker(
     // Summary hint: when summaries are disabled, prime the Summary cache
     // with config guidance instead of showing a perpetual "Generating…"
     // placeholder.
-    let (llm_command, summary_hint) =
-        if config.list.summary() && config.commit_generation.is_configured() {
-            (config.commit_generation.command.clone(), None)
+    let (llm_command, summary_hint) = if config.list.summary()
+        && config.commit_generation.is_configured()
+    {
+        (config.commit_generation.command.clone(), None)
+    } else {
+        // Point at the config file wt actually loads from — respecting
+        // --config, WORKTRUNK_CONFIG_PATH, and $XDG_CONFIG_HOME — rather
+        // than a hardcoded default. Fall back to the canonical path on the
+        // rare occasion no location can be determined.
+        let config_path = worktrunk::config::config_path()
+            .map(|p| format_path_for_display(&p))
+            .unwrap_or_else(|| "~/.config/worktrunk/config.toml".to_string());
+        // A short first line stays the bold H4 subject (`render_summary`
+        // promotes it and never wraps it, so a long sentence would clip on
+        // a narrow pane); the instruction and the resolved path live in the
+        // wrapping body, and the config block is fenced so it renders in the
+        // house gutter rather than as loose prose.
+        let hint = if !config.commit_generation.is_configured() {
+            format!(
+                r#"Summaries not configured
+
+LLM branch summaries need a [commit.generation] command. Add one in {config_path}, then enable summaries:
+
+```toml
+[commit.generation]
+command = "llm -m haiku"
+
+[list]
+summary = true
+```
+"#
+            )
         } else {
-            // Point at the config file wt actually loads from — respecting
-            // --config, WORKTRUNK_CONFIG_PATH, and $XDG_CONFIG_HOME — rather
-            // than a hardcoded default. Fall back to the canonical path on the
-            // rare occasion no location can be determined.
-            let config_path = worktrunk::config::config_path()
-                .map(|p| format_path_for_display(&p))
-                .unwrap_or_else(|| "~/.config/worktrunk/config.toml".to_string());
-            let hint = if !config.commit_generation.is_configured() {
-                format!(
-                    "Configure [commit.generation] command to enable LLM summaries.\n\n\
-                     Example in {config_path}:\n\n\
-                     [commit.generation]\n\
-                     command = \"llm -m haiku\"\n\n\
-                     [list]\n\
-                     summary = true\n"
-                )
-            } else {
-                format!(
-                    "Enable summaries in {config_path}:\n\n\
-                     [list]\n\
-                     summary = true\n"
-                )
-            };
-            (None, Some(hint))
+            format!(
+                r#"Summaries off
+
+A [commit.generation] command is configured. Enable summaries in {config_path}:
+
+```toml
+[list]
+summary = true
+```
+"#
+            )
         };
+        (None, Some(hint))
+    };
 
     // The picker's full row list — header, worktree/branch rows, and (in `--prs`
     // mode) PR/MR rows. `on_skeleton` fills it with the header + worktree/branch

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -1311,8 +1311,8 @@ fn test_switch_picker_preview_panel_summary(mut repo: TestRepo) {
         &[
             // Cursor-navigation select: see test_switch_picker_preview_panel_uncommitted
             // for the matcher-lag rationale.
-            ("\x1b[B", None),             // Down: move cursor to `feature`
-            ("\x1b5", Some("Configure")), // Alt-5: summary panel; wait for hint
+            ("\x1b[B", None),                     // Down: move cursor to `feature`
+            ("\x1b5", Some("commit.generation")), // Alt-5: summary panel; wait for hint
         ],
     );
 
@@ -1323,6 +1323,49 @@ fn test_switch_picker_preview_panel_summary(mut repo: TestRepo) {
     settings.bind(|| {
         assert_snapshot!("switch_picker_preview_summary_list", list);
         assert_snapshot!("switch_picker_preview_summary_preview", preview);
+    });
+}
+
+/// The summary panel's "enable summaries" hint — shown when commit.generation
+/// IS configured but `[list] summary = false`. Covers the second hint arm (the
+/// first is exercised by `test_switch_picker_preview_panel_summary`), and pins
+/// that both hints point at the resolved config path: under the test's
+/// `WORKTRUNK_CONFIG_PATH` isolation that path redacts to `[TEST_CONFIG]`, not
+/// a hardcoded `~/.config/worktrunk/config.toml`.
+#[rstest]
+fn test_switch_picker_preview_panel_summary_disabled(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    // Remove origin so snapshots don't show origin/main
+    repo.run_git(&["remote", "remove", "origin"]);
+    repo.add_worktree("feature");
+
+    // commit.generation configured, but summaries off — the picker seeds the
+    // Summary tab with the "enable summaries" hint rather than generating one.
+    repo.write_test_config(
+        "[commit.generation]\ncommand = \"llm -m haiku\"\n\n[list]\nsummary = false\n",
+    );
+
+    let env_vars = repo.test_env_vars();
+    // Select `feature`, then Alt-5 for the summary panel. Wait for the hint.
+    let result = exec_in_pty_capture_before_abort(
+        wt_bin().to_str().unwrap(),
+        &["switch"],
+        repo.root_path(),
+        &env_vars,
+        &[
+            // Cursor-navigation select: see test_switch_picker_preview_panel_uncommitted
+            // for the matcher-lag rationale.
+            ("\x1b[B", None),          // Down: move cursor to `feature`
+            ("\x1b5", Some("Enable")), // Alt-5: summary panel; wait for hint
+        ],
+    );
+
+    assert_valid_abort_exit_code(result.exit_code);
+
+    let (_, preview) = result.panels();
+    let settings = switch_picker_settings(&repo);
+    settings.bind(|| {
+        assert_snapshot!("switch_picker_preview_summary_disabled_preview", preview);
     });
 }
 

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_summary_disabled_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_summary_disabled_preview.snap
@@ -5,13 +5,10 @@ expression: preview
 1 2 3 4 5: summary 6 7
 Enter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | a
 
-Summaries not configured
+Summaries off
 
-LLM branch summaries need a [commit.generation] command. Ad
- one in [TEST_CONFIG], then enable summaries:
-
-  [commit.generation]
-  command = "llm -m haiku"
+A [commit.generation] command is configured. Enable
+summaries in [TEST_CONFIG]:
 
   [list]
   summary = true

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_summary_disabled_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_summary_disabled_preview.snap
@@ -7,8 +7,8 @@ Enter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | a
 
 Summaries off
 
-A [commit.generation] command is configured. Enable
-summaries in [TEST_CONFIG]:
+Enable summaries in:
+[TEST_CONFIG]
 
   [list]
   summary = true

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_summary_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_summary_preview.snap
@@ -7,8 +7,8 @@ Enter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | a
 
 Summaries not configured
 
-LLM branch summaries need a [commit.generation] command. Ad
- one in [TEST_CONFIG], then enable summaries:
+Add a [commit.generation] command in:
+[TEST_CONFIG]
 
   [commit.generation]
   command = "llm -m haiku"

--- a/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_summary_preview.snap
+++ b/tests/snapshots/integration__integration_tests__switch_picker__switch_picker_preview_summary_preview.snap
@@ -7,7 +7,7 @@ Enter: switch | ctrl-u/d: scroll | Tab/alt-1…7: preview | a
 
 Configure [commit.generation] command to enable LLM summari
 
-Example in ~/.config/worktrunk/config.toml:
+Example in [TEST_CONFIG]:
 
 [commit.generation]
 command = "llm -m haiku"


### PR DESCRIPTION
When LLM summaries are disabled, the `wt switch` picker's Summary tab is seeded with one of two hints — "Summaries not configured" when there's no `[commit.generation]` command, or "Summaries off" when `[list] summary = false`. Both previously told the user to edit a hardcoded `~/.config/worktrunk/config.toml`, which is wrong whenever wt loads config from elsewhere: a `--config` flag, the `WORKTRUNK_CONFIG_PATH` env var, or a non-default `$XDG_CONFIG_HOME`. A user following the hint would edit a file wt never reads.

Both hints now show the path wt actually loads from, resolved once at picker startup via `worktrunk::config::config_path()` (priority: `--config` → `WORKTRUNK_CONFIG_PATH` → platform default) and rendered through `format_path_for_display` so it shows `~/…`. When no location can be determined, it falls back to the canonical literal. This mirrors the resolved-path idiom already in `src/commands/worktree/resolve.rs`.

The hints are also reshaped into the gutter house style — a bold H4-subject first line and a fenced ` ```toml ` config block — structured so the PTY snapshot is platform-stable. `render_summary` word-wraps prose to the preview width, which is one column narrower under Windows' PTY, so any prose body long enough to wrap breaks on a different word there and a single cross-platform snapshot can't match. To avoid that, the only prose is a short lead line that can't wrap, the resolved path sits alone on its own line (one unbreakable token, so there's no wrap boundary to shift), and the config block is never wrapped (code blocks aren't). The H4 subject is never wrapped either.

## Tests

`test_switch_picker_preview_panel_summary_disabled` is added to cover the "configured but `summary = false`" arm, which had no test before (the existing summary test only exercises the not-configured arm) — closing a `codecov/patch` gap. Both arms' PTY snapshots render the resolved path; under the tests' `WORKTRUNK_CONFIG_PATH` isolation that path is a per-run temp file, which the existing snapshot filter redacts to a stable `[TEST_CONFIG]` placeholder, so the snapshots stay host-independent and `test_no_host_specific_paths_in_snapshots` is satisfied.

> _This was written by Claude Code on behalf of max_
