### PR TITLE
feat(list): force a listed column on past the --full preset gate

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,7 +105,7 @@ Why: silent "lookup" paths that walk to the wire (alias dispatch, hook context b
 
 What currently reaches the wire:
 
-- `wt list --full`, `wt list statusline` — CI status
+- `wt list --full`, `wt list statusline` — CI status; also plain `wt list` when `[list] columns` names `ci`, which forces the column (and its fetch) on without `--full`
 - `wt switch` (interactive picker, no target) — per-row CI status, primed from the local cache then fetched live and streamed into the rows; once a row's CI fetch surfaces an open PR/MR, a per-row background `gh pr view <n> --json comments` (`glab api …/notes` on GitLab) fills that row's `comments` preview tab — the same fetch a `--prs` row makes, spawned once per row from `progressive_handler` (see `picker::prs::spawn_comments_fetch`). The `comments` tab is the only PR data fetched lazily here; `pr` rides the CI call and `log` is the local `git log`
 - generating a branch summary with a `commit.generation` command
 - generating a commit message with a `commit.generation` command

--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -132,8 +132,11 @@
 # default set, where custom columns append automatically. A built-in name wins a
 # header collision; the gutter type indicator always shows.
 #
-# Listing a column requests it but cannot force it on: a gated column stays hidden
-# (`ci` needs `--full`, `summary` needs `[commit.generation]`).
+# Listing a column forces it on, space permitting: `ci` shows without `--full`,
+# since `--full` only bundles columns into the default table rather than gating a
+# named one. A column whose data source is missing still stays hidden — `summary`
+# needs an LLM command (`[commit.generation]`), `url` needs a `[list] url`
+# template — since listing can't supply the data.
 #
 # The selection drives the table and the `wt switch` picker; `wt list --format
 # json` ignores it and emits every field.

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -220,8 +220,11 @@ and is exhaustive: only the listed columns render. Omit `columns` to keep the
 default set, where custom columns append automatically. A built-in name wins a
 header collision; the gutter type indicator always shows.
 
-Listing a column requests it but cannot force it on: a gated column stays hidden
-(`ci` needs `--full`, `summary` needs `[commit.generation]`).
+Listing a column forces it on, space permitting: `ci` shows without `--full`,
+since `--full` only bundles columns into the default table rather than gating a
+named one. A column whose data source is missing still stays hidden — `summary`
+needs an LLM command (`[commit.generation]`), `url` needs a `[list] url`
+template — since listing can't supply the data.
 
 The selection drives the table and the `wt switch` picker; `wt list --format
 json` ignores it and emits every field.

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -219,8 +219,11 @@ and is exhaustive: only the listed columns render. Omit `columns` to keep the
 default set, where custom columns append automatically. A built-in name wins a
 header collision; the gutter type indicator always shows.
 
-Listing a column requests it but cannot force it on: a gated column stays hidden
-(`ci` needs `--full`, `summary` needs `[commit.generation]`).
+Listing a column forces it on, space permitting: `ci` shows without `--full`,
+since `--full` only bundles columns into the default table rather than gating a
+named one. A column whose data source is missing still stays hidden — `summary`
+needs an LLM command (`[commit.generation]`), `url` needs a `[list] url`
+template — since listing can't supply the data.
 
 The selection drives the table and the `wt switch` picker; `wt list --format
 json` ignores it and emits every field.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1946,8 +1946,11 @@ and is exhaustive: only the listed columns render. Omit `columns` to keep the
 default set, where custom columns append automatically. A built-in name wins a
 header collision; the gutter type indicator always shows.
 
-Listing a column requests it but cannot force it on: a gated column stays hidden
-(`ci` needs `--full`, `summary` needs `[commit.generation]`).
+Listing a column forces it on, space permitting: `ci` shows without `--full`,
+since `--full` only bundles columns into the default table rather than gating a
+named one. A column whose data source is missing still stays hidden — `summary`
+needs an LLM command (`[commit.generation]`), `url` needs a `[list] url`
+template — since listing can't supply the data.
 
 The selection drives the table and the `wt switch` picker; `wt list --format
 json` ignores it and emits every field.

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -476,13 +476,19 @@ impl CollectOptions {
     /// need (e.g. `CollectOptions { url_template, ..for_columns(cols, &gates) }`).
     ///
     /// `collect` builds its options directly — it has the context fields already
-    /// resolved — so this is for the single-item callers (statusline).
+    /// resolved — so this is for the single-item callers (statusline). They
+    /// render the default column set, not a `[list] columns` selection, so the
+    /// plan uses [`ColumnSource::Default`](super::columns::ColumnSource).
     pub fn for_columns(
         rendered: impl IntoIterator<Item = super::columns::ColumnKind>,
         gates: &super::columns::ColumnGates,
     ) -> Self {
         Self {
-            tasks: super::columns::required_tasks_for_render(rendered, gates),
+            tasks: super::columns::required_tasks_for_render(
+                rendered,
+                super::columns::ColumnSource::Default,
+                gates,
+            ),
             url_template: None,
             llm_command: None,
             default_branch: None,
@@ -1184,32 +1190,57 @@ pub fn collect(
         };
 
     // Decide, in one place, which background tasks to run: the union of the
-    // tasks every column the table will render needs. This is the canonical
-    // "what do we need" stage — the spawn loop fires exactly this set, and the
-    // layout filter renders exactly the columns it feeds.
+    // tasks every column the rendered table needs. This is the canonical "what
+    // do we need" stage — the spawn loop fires exactly this set, and the layout
+    // filter renders exactly the columns it feeds. Three shapes:
     //
-    // The rendered set is the `[list] columns` selection for the table; the
-    // picker and JSON ignore it (`all_columns`) because their consumers — the
-    // picker's preview tabs, JSON's every-field contract in `src/cli/mod.rs` —
-    // need the full data set, not just what renders. The gates (`--full`,
-    // `[list] summary` + `[commit.generation]`, a url template) then drop a
-    // column and its tasks regardless of selection.
+    // - `wt list` table → the `[list] columns` selection (source `Listed`), or
+    //   `all_columns` (source `Default`) when nothing narrows it. The `Listed`
+    //   source lets an explicit selection override the preset gates (`--full`,
+    //   `[list] summary`): listing `ci` runs its task without `--full`. The
+    //   data-source gates (`[commit.generation]`, a url template) still drop a
+    //   column whose data can't be produced, however it was requested.
+    // - picker → `all_columns` for its preview tabs, unioned with the selection's
+    //   forced-on columns so its table matches `wt list`'s. The union matters for
+    //   a listed `summary` that `Default` alone wouldn't plan (LLM command set,
+    //   `[list] summary` off): without it the picker would hide a column `wt list`
+    //   shows. CI is already covered — the picker is always `show_full`.
+    // - `--format json` → `all_columns` (source `Default`), ignoring the
+    //   selection: its every-field contract (`src/cli/mod.rs`) needs the full set.
     //
     // So a branch/path `ls` alias over many dirty worktrees runs no `git status`
-    // / diffs / ahead-behind walks (#3133), while a column gated off elsewhere
-    // stays off — selection narrows the work, never forces it on.
+    // / diffs / ahead-behind walks (#3133), while a default column gated off by
+    // `--full` stays off until the user passes `--full` or lists it.
     let gates = super::columns::ColumnGates {
         show_full,
         summary_enabled: config.list.summary(),
         has_llm_command: llm_command.is_some(),
         has_url_template: url_template.is_some(),
     };
+    let listed_plan = || {
+        super::columns::required_tasks_for_render(
+            selected_columns.iter().copied(),
+            super::columns::ColumnSource::Listed,
+            &gates,
+        )
+    };
+    let full_plan = || {
+        super::columns::required_tasks_for_render(
+            super::columns::all_columns(),
+            super::columns::ColumnSource::Default,
+            &gates,
+        )
+    };
     let prune_to_selection =
         render_table && progressive_handler.is_none() && !selected_columns.is_empty();
     let tasks = if prune_to_selection {
-        super::columns::required_tasks_for_render(selected_columns.iter().copied(), &gates)
+        listed_plan()
+    } else if progressive_handler.is_some() {
+        let mut tasks = full_plan();
+        tasks.extend(listed_plan());
+        tasks
     } else {
-        super::columns::required_tasks_for_render(super::columns::all_columns(), &gates)
+        full_plan()
     };
 
     // The picker primes its CI cells from the local cache so the column paints

--- a/src/commands/list/columns.rs
+++ b/src/commands/list/columns.rs
@@ -167,10 +167,10 @@ impl ColumnKind {
     /// A column renders when it consumes no task (identity columns, Gutter,
     /// custom — always shown) or at least one of its tasks is in the run set.
     /// The layout filter applies this to every built-in, dropping any whose
-    /// tasks were all left out of the plan: a column gated off (`--full`, a
-    /// missing template/LLM), or — under a `[list] columns` selection — an
-    /// unselected column (whose tasks aren't planned either, though the separate
-    /// selection filter also removes it).
+    /// tasks the planner left out: a default-set column gated off by `--full`,
+    /// any column whose data source is missing (no template/LLM), or — under a
+    /// `[list] columns` selection — an unselected column (whose tasks aren't
+    /// planned either, though the separate selection filter also removes it).
     pub fn renders_given_run(self, run: &std::collections::HashSet<TaskKind>) -> bool {
         let required = self.required_tasks();
         required.is_empty() || required.iter().any(|task| run.contains(task))
@@ -195,28 +195,54 @@ pub fn all_tasks() -> std::collections::HashSet<TaskKind> {
     TaskKind::iter().collect()
 }
 
-/// Gates that hide a column independent of the `[list] columns` selection — the
-/// data source is off, so neither the column nor its tasks appear.
+/// Gates that hide a column independent of the `[list] columns` selection.
+///
+/// Two kinds, distinguished by [`column_renders`]. *Preset* gates (`show_full`,
+/// `summary_enabled`) bundle columns into the default table; a column named
+/// outright in `[list] columns` overrides them. *Data-source* gates
+/// (`has_llm_command`, `has_url_template`) are hard: without the command or
+/// template there's nothing to render, so they hold even for a listed column.
 #[derive(Clone, Copy, Debug)]
 pub struct ColumnGates {
-    /// `--full` (or `[list] full`): CI status and LLM summaries are off without it.
+    /// `--full` (or `[list] full`): CI status and LLM summaries join the default
+    /// table only with it. A preset — a listed `ci`/`summary` ignores it.
     pub show_full: bool,
-    /// `[list] summary`: the summary column is opt-in even under `--full`.
+    /// `[list] summary`: the summary column is opt-in for the default table even
+    /// under `--full`. A preset — a listed `summary` ignores it.
     pub summary_enabled: bool,
-    /// An LLM command is configured (`[commit.generation]`).
+    /// An LLM command is configured (`[commit.generation]`). A data source: no
+    /// command, no summary, however the column was requested.
     pub has_llm_command: bool,
-    /// A `[list] url` template is configured.
+    /// A `[list] url` template is configured. A data source: no template, no url.
     pub has_url_template: bool,
 }
 
-/// Whether a column's data source is available under `gates`. `false` hides the
-/// column and skips its tasks regardless of selection: `ci` and `summary` need
-/// `--full`; `summary` additionally needs an LLM command and `[list] summary`;
-/// `url` needs a template. Every other column always renders.
-fn column_renders(kind: ColumnKind, gates: &ColumnGates) -> bool {
+/// How a column entered the rendered set, which decides whether the preset gates
+/// apply to it (see [`ColumnGates`]).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ColumnSource {
+    /// Part of the default set: no `[list] columns`, or the picker/JSON plan over
+    /// every column. Every gate applies.
+    Default,
+    /// Named explicitly in `[list] columns`. The preset gates don't apply; the
+    /// data-source gates still do.
+    Listed,
+}
+
+/// Whether a column renders under `gates`, given how it entered the set.
+///
+/// A `Listed` column overrides the preset gates (`--full`, `[list] summary`):
+/// listing `ci` shows it without `--full`, listing `summary` shows it whenever an
+/// LLM command exists. The data-source gates always apply — `summary` needs an
+/// LLM command, `url` needs a template — since listing can't supply data that
+/// isn't configured. Every other column always renders.
+fn column_renders(kind: ColumnKind, source: ColumnSource, gates: &ColumnGates) -> bool {
+    let listed = source == ColumnSource::Listed;
     match kind {
-        ColumnKind::CiStatus => gates.show_full,
-        ColumnKind::Summary => gates.show_full && gates.summary_enabled && gates.has_llm_command,
+        ColumnKind::CiStatus => listed || gates.show_full,
+        ColumnKind::Summary => {
+            gates.has_llm_command && (listed || (gates.show_full && gates.summary_enabled))
+        }
         ColumnKind::Url => gates.has_url_template,
         _ => true,
     }
@@ -224,19 +250,23 @@ fn column_renders(kind: ColumnKind, gates: &ColumnGates) -> bool {
 
 /// The one place that decides which background tasks `wt list` runs.
 ///
-/// `rendered` is the column set the table will lay out — the `[list] columns`
-/// selection, or [`all_columns`] when nothing narrows it. The task set is
-/// exactly the union of the [`required_tasks`](ColumnKind::required_tasks) of
-/// the columns that survive the gates (`column_renders`). `collect` stores this
-/// set directly on [`CollectOptions::tasks`](super::collect::CollectOptions::tasks); the spawn loops and layout filter
-/// consume it as-is, so a task runs iff some rendered column needs it.
+/// `rendered` is the column set the table will lay out, paired with its `source`:
+/// the `[list] columns` selection (`Listed`), or [`all_columns`] when nothing
+/// narrows it (`Default`). The task set is exactly the union of the
+/// [`required_tasks`](ColumnKind::required_tasks) of the columns that survive the
+/// gates (`column_renders`) — so a `Listed` `ci` enrols its task without `--full`,
+/// while a column whose data source is missing enrols nothing. `collect` stores
+/// this set directly on [`CollectOptions::tasks`](super::collect::CollectOptions::tasks);
+/// the spawn loops and layout filter consume it as-is, so a task runs iff some
+/// rendered column needs it.
 pub fn required_tasks_for_render(
     rendered: impl IntoIterator<Item = ColumnKind>,
+    source: ColumnSource,
     gates: &ColumnGates,
 ) -> std::collections::HashSet<TaskKind> {
     rendered
         .into_iter()
-        .filter(|&kind| column_renders(kind, gates))
+        .filter(|&kind| column_renders(kind, source, gates))
         .flat_map(|kind| kind.required_tasks().iter().copied())
         .collect()
 }
@@ -578,6 +608,7 @@ mod tests {
 
     #[test]
     fn test_required_tasks_for_render() {
+        use ColumnSource::{Default, Listed};
         use strum::IntoEnumIterator;
 
         // Every gate open: every column can render.
@@ -591,56 +622,50 @@ mod tests {
 
         // The default set (all built-ins) under open gates needs every task —
         // the planner is exhaustive, so nothing falls out silently.
-        assert_eq!(required_tasks_for_render(all_columns(), &open), all);
+        assert_eq!(
+            required_tasks_for_render(all_columns(), Default, &open),
+            all
+        );
 
         // A branch/path `ls` view needs no background task at all.
         assert!(
-            required_tasks_for_render([ColumnKind::Branch, ColumnKind::Path], &open).is_empty(),
+            required_tasks_for_render([ColumnKind::Branch, ColumnKind::Path], Default, &open)
+                .is_empty(),
             "identity columns need no task"
         );
 
         // Selecting Status keeps every status-feeding task; the independent
         // columns' tasks are not pulled in.
-        let status = required_tasks_for_render([ColumnKind::Status], &open);
+        let status = required_tasks_for_render([ColumnKind::Status], Listed, &open);
         assert!(status.contains(&TaskKind::AheadBehind));
         assert!(status.contains(&TaskKind::WorkingTreeDiff));
         assert!(!status.contains(&TaskKind::BranchDiff));
         assert!(!status.contains(&TaskKind::CiStatus));
 
         // A custom column consumes no task, like the identity columns.
-        assert!(required_tasks_for_render([ColumnKind::Custom(0)], &open).is_empty());
+        assert!(required_tasks_for_render([ColumnKind::Custom(0)], Listed, &open).is_empty());
 
-        // Gates drop a column's tasks even when it is explicitly selected —
-        // "select narrows the work, never forces it on".
-        assert_eq!(
-            required_tasks_for_render([ColumnKind::CiStatus], &open),
-            HashSet::from([TaskKind::CiStatus]),
-            "ci runs under --full"
-        );
+        // `ci`'s only gate is the `--full` preset: hidden in the default set
+        // without it, forced on when listed.
         let no_full = ColumnGates {
             show_full: false,
             ..open
         };
         assert!(
-            required_tasks_for_render([ColumnKind::CiStatus], &no_full).is_empty(),
-            "ci is gated off without --full"
+            required_tasks_for_render([ColumnKind::CiStatus], Default, &no_full).is_empty(),
+            "ci stays off in the default set without --full"
         );
-        let no_template = ColumnGates {
-            has_url_template: false,
-            ..open
-        };
-        assert!(
-            required_tasks_for_render([ColumnKind::Url], &no_template).is_empty(),
-            "url needs a template"
+        assert_eq!(
+            required_tasks_for_render([ColumnKind::CiStatus], Listed, &no_full),
+            HashSet::from([TaskKind::CiStatus]),
+            "listing ci forces it on without --full"
         );
-        // Summary needs --full AND an LLM command AND [list] summary.
-        for gates in [
+
+        // `summary`'s presets (`--full`, `[list] summary`) gate the default set
+        // but yield to a listing; its LLM command is a data source that doesn't.
+        for preset_off in [
             ColumnGates {
                 show_full: false,
-                ..open
-            },
-            ColumnGates {
-                has_llm_command: false,
                 ..open
             },
             ColumnGates {
@@ -649,12 +674,37 @@ mod tests {
             },
         ] {
             assert!(
-                required_tasks_for_render([ColumnKind::Summary], &gates).is_empty(),
-                "summary is gated off when a precondition is missing"
+                required_tasks_for_render([ColumnKind::Summary], Default, &preset_off).is_empty(),
+                "summary stays off in the default set when a preset is off"
+            );
+            assert_eq!(
+                required_tasks_for_render([ColumnKind::Summary], Listed, &preset_off),
+                HashSet::from([TaskKind::SummaryGenerate]),
+                "listing summary overrides the preset gate"
             );
         }
+        let no_llm = ColumnGates {
+            has_llm_command: false,
+            ..open
+        };
+        assert!(
+            required_tasks_for_render([ColumnKind::Summary], Listed, &no_llm).is_empty(),
+            "summary needs an LLM command even when listed"
+        );
+
+        // `url`'s template is a data source, gating even a listed column.
+        let no_template = ColumnGates {
+            has_url_template: false,
+            ..open
+        };
+        assert!(
+            required_tasks_for_render([ColumnKind::Url], Listed, &no_template).is_empty(),
+            "url needs a template even when listed"
+        );
+
+        // Every precondition holding, a listed summary runs.
         assert_eq!(
-            required_tasks_for_render([ColumnKind::Summary], &open),
+            required_tasks_for_render([ColumnKind::Summary], Listed, &open),
             HashSet::from([TaskKind::SummaryGenerate]),
             "summary runs when every precondition holds"
         );

--- a/src/commands/list/layout.rs
+++ b/src/commands/list/layout.rs
@@ -105,12 +105,13 @@
 //!
 //! Some columns have non-standard behavior that extends beyond the basic two-tier model:
 //!
-//! 1. **CiStatus** and **Summary** - Visibility gate (`show_full` flag)
-//!    - Both require `show_full=true` — they reach off-machine (CI status over
-//!      the network, branch summaries via the LLM), so they're hidden by default
-//!    - Gated via the run plan (`tasks`): when `show_full=false`, their
-//!      `TaskKind` is absent from `tasks`, so `renders_given_run` filters the
-//!      column out entirely (bypasses the tier system)
+//! 1. **CiStatus** and **Summary** - Hidden in the default table without `--full`
+//!    - Both reach off-machine (CI status over the network, branch summaries via
+//!      the LLM), so the default table hides them until `--full`
+//!    - Gated via the run plan (`tasks`): the planner omits their `TaskKind` when
+//!      they're gated off, so `renders_given_run` filters the column out entirely
+//!      (bypasses the tier system). A `[list] columns` listing forces them on —
+//!      the planner then includes the task and the column renders
 //!    - **BranchDiff** (`main…±`) is pure local git, so it is *not* gated — it
 //!      shows by default and follows the normal two-tier priority (6/16);
 //!      CiStatus is 5/15
@@ -784,10 +785,11 @@ fn allocate_columns_with_priority(
         .collect();
 
     // Build candidates with priorities.
-    // - Filter out columns whose tasks were all left out of the run plan (gated
-    //   off by `--full`, a missing template/LLM). `renders_given_run` reads the
-    //   same `required_tasks()` map that chose the plan, so a rendered column's
-    //   tasks always ran and only a gated-off column drops here.
+    // - Filter out columns whose tasks were all left out of the run plan (a
+    //   default-set column gated off by `--full`, or a missing template/LLM).
+    //   `renders_given_run` reads the same `required_tasks()` map that chose the
+    //   plan, so a rendered column's tasks always ran and only a gated-off column
+    //   drops here.
     // - When `[list] columns` selects a subset, keep only the chosen built-ins
     //   (Gutter is structural — always kept). This filters WITHOUT renumbering
     //   base_priority, so the Summary drop loop and EMPTY_PENALTY tiers below
@@ -1937,14 +1939,18 @@ mod tests {
     }
 
     #[test]
-    fn test_selected_columns_cannot_force_a_gated_column() {
-        // Selection narrows the candidate set; it can't force on a column gated
-        // off by the run plan. `ci` needs --full: with CiStatus absent from the
-        // plan, selecting it leaves a gutter-only table (renders_given_run runs
-        // first).
+    fn test_layout_renders_column_iff_task_planned() {
+        // The layout stage honors the run plan literally: a column renders iff one
+        // of its tasks is planned, whatever the selection. Policy — which tasks to
+        // plan, including forcing a listed `ci` on without `--full` — lives in the
+        // planner (`required_tasks_for_render`); here we feed the layout a plan
+        // directly to test the filter in isolation.
         let items = vec![make_test_item("feature-branch")];
         let selected = [ColumnKind::CiStatus];
-        let gated = calculate_layout_with_width(
+
+        // CiStatus absent from the plan: the column drops even though it's
+        // selected, leaving a gutter-only table.
+        let unplanned = calculate_layout_with_width(
             &items,
             &non_full_run_tasks(),
             200,
@@ -1957,15 +1963,14 @@ mod tests {
             },
         );
         assert!(
-            find_column(&gated, ColumnKind::CiStatus).is_none(),
-            "a gated column stays hidden even when selected"
+            find_column(&unplanned, ColumnKind::CiStatus).is_none(),
+            "a column whose task wasn't planned stays hidden, even when selected"
         );
-        let kinds: Vec<ColumnKind> = gated.columns.iter().map(|c| c.kind).collect();
+        let kinds: Vec<ColumnKind> = unplanned.columns.iter().map(|c| c.kind).collect();
         assert_eq!(kinds, vec![ColumnKind::Gutter], "only the gutter survives");
 
-        // Once the gate opens (full mode, nothing skipped), the same selection
-        // renders CI.
-        let full = calculate_layout_with_width(
+        // CiStatus in the plan: the same selection renders it.
+        let planned = calculate_layout_with_width(
             &items,
             &full_run_tasks(),
             200,
@@ -1978,8 +1983,8 @@ mod tests {
             },
         );
         assert!(
-            find_column(&full, ColumnKind::CiStatus).is_some(),
-            "the selected column renders once its task is no longer skipped"
+            find_column(&planned, ColumnKind::CiStatus).is_some(),
+            "the selected column renders once its task is planned"
         );
     }
 

--- a/tests/integration_tests/list_config.rs
+++ b/tests/integration_tests/list_config.rs
@@ -1048,6 +1048,55 @@ columns = ["branch", "age"]
     );
 }
 
+/// A listed column overrides the `--full` preset gate — the positive counterpart
+/// to the prune above. `--full` bundles `ci`/`summary` into the default table; it
+/// doesn't gate a column named outright. So `columns = ["branch", "ci"]` renders
+/// the CI column with no `--full`, where the default set hides it. Asserted on the
+/// rendered header row (column enrolment, independent of whether `gh` is on PATH).
+#[rstest]
+fn test_list_config_listed_column_overrides_full_gate(repo: TestRepo) {
+    let header_of = |config: &str| -> String {
+        if config.is_empty() {
+            let _ = fs::remove_file(repo.test_config_path());
+        } else {
+            fs::write(repo.test_config_path(), config).unwrap();
+        }
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        cmd.arg("list").current_dir(repo.root_path());
+        let output = cmd.output().unwrap();
+        assert!(
+            output.status.success(),
+            "exit code should be 0 for config {config:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        // The header row is the line naming the Branch column.
+        stdout
+            .lines()
+            .find(|line| line.contains("Branch"))
+            .unwrap_or_default()
+            .to_string()
+    };
+
+    // Control: the default set without `--full` hides CI.
+    assert!(
+        !header_of("").contains("CI"),
+        "the default non-full table should not show the CI column"
+    );
+
+    // Listing `ci` forces the column on without `--full`.
+    let listed = header_of(
+        r#"[list]
+columns = ["branch", "ci"]
+"#,
+    );
+    assert!(
+        listed.contains("CI"),
+        "listing `ci` should render the CI column without --full:\n{listed:?}"
+    );
+}
+
 /// The task prune must not reach the JSON path. `wt list --format json` ignores
 /// `[list] columns` and always emits every field (the `after_long_help`
 /// contract in `src/cli/mod.rs`), so a narrowed selection that drops the Status

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -198,8 +198,11 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# default set, where custom columns append automatically. A built-in name wins a[0m
 [107m [0m [2m# header collision; the gutter type indicator always shows.[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# Listing a column requests it but cannot force it on: a gated column stays hidden[0m
-[107m [0m [2m# (`ci` needs `--full`, `summary` needs `[commit.generation]`).[0m
+[107m [0m [2m# Listing a column forces it on, space permitting: `ci` shows without `--full`,[0m
+[107m [0m [2m# since `--full` only bundles columns into the default table rather than gating a[0m
+[107m [0m [2m# named one. A column whose data source is missing still stays hidden — `summary`[0m
+[107m [0m [2m# needs an LLM command (`[commit.generation]`), `url` needs a `[list] url`[0m
+[107m [0m [2m# template — since listing can't supply the data.[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# The selection drives the table and the `wt switch` picker; `wt list --format[0m
 [107m [0m [2m# json` ignores it and emits every field.[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -246,8 +246,11 @@ and is exhaustive: only the listed columns render. Omit [2mcolumns[0m to keep 
 default set, where custom columns append automatically. A built-in name wins a
 header collision; the gutter type indicator always shows.
 
-Listing a column requests it but cannot force it on: a gated column stays hidden
-([2mci[0m needs [2m--full[0m, [2msummary[0m needs [2m[commit.generation][0m).
+Listing a column forces it on, space permitting: [2mci[0m shows without [2m--full[0m,
+since [2m--full[0m only bundles columns into the default table rather than gating a
+named one. A column whose data source is missing still stays hidden — [2msummary[0m
+needs an LLM command ([2m[commit.generation][0m), [2murl[0m needs a [2m[list] url[0m
+template — since listing can't supply the data.
 
 The selection drives the table and the [2mwt switch[0m picker; [2mwt list --format[0m
 json[2m ignores it and emits every field.[0m


### PR DESCRIPTION
## Problem

A `[list] columns` entry could narrow the table but never *force a column on* past its gate. Listing `ci` without `--full` still hid the CI column; the gate won. But `--full` is a column-selection preset — it bundles CI/summaries into the default table — not a feature-approval switch, so "I listed `ci`" being silently overridden by "you didn't pass `--full`" is surprising.

## Solution

A listed column now overrides the **preset** gates while still respecting the **data-source** gates. The distinction is a new `ColumnSource` (`Default` | `Listed`) threaded through the task planner:

- **Preset gates** — `--full` (`show_full`), `[list] summary` (`summary_enabled`) — bundle columns into the *default* table. A `Listed` column overrides them: listing `ci` shows it without `--full`; listing `summary` shows it whenever an LLM command exists.
- **Data-source gates** — `[commit.generation]` (`has_llm_command`), `[list] url` (`has_url_template`) — are hard prerequisites. They apply even to a `Listed` column: a listed `summary` with no LLM command, or `url` with no template, stays hidden, because listing can't conjure data that isn't configured.

`Default`-source behavior (the default table, the picker, and `--format json`, which all plan over `all_columns`) is byte-for-byte unchanged — `column_renders(kind, Default, gates)` reduces to the old function.

### Before / after

`columns = ["branch", "ci"]`, no `--full`:

```
before:  Branch              # ci dropped — gated by --full
after:   Branch   CI         # listed → forced on
```

### Picker consistency

The picker plans tasks from `all_columns` (it needs every column's data for its preview tabs) but renders the `[list] columns` selection. So it now plans the **union** of its preview set and the selection's forced-on columns, keeping its table identical to `wt list`'s. This matters for one case: a listed `summary` with an LLM command configured but `[list] summary` off — `wt list` shows it, and without the union the picker would have hidden it.

## Testing

- **Unit** (`test_required_tasks_for_render`): both sources × every gate combination — listed-`ci`-without-`--full`, listed-`summary` overriding the presets, listed-`summary` still needing an LLM command, listed-`url` still needing a template, and `Default`-source parity.
- **Integration** (`test_list_config_listed_column_overrides_full_gate`): end-to-end — `columns = ["branch", "ci"]` renders the `CI` header with no `--full`, where the default set hides it. Asserts on column enrolment (the rendered header), independent of whether `gh` is on `PATH`.
- **Layout**: the filter test was repurposed (`test_layout_renders_column_iff_task_planned`) to test "render iff task planned" in isolation, since the planner no longer produces the old "listed but unplanned `ci`" pairing.
- Full `pre-merge` gate (all suites, fmt, clippy, docs-sync, PTY picker snapshots) green after merging `main`. The picker's 44 PTY tests pass with no snapshot churn.

## Docs

The `[list] columns` help prose was rewritten ("Listing a column forces it on, space permitting…") in the `src/cli/mod.rs` source and regenerated across all four render contexts (terminal `--help`, `config.example.toml`, `docs/content/config.md`, skills reference). The `CLAUDE.md` network-access inventory also now notes that a listed `ci` column reaches the wire without `--full`.

> _This was written by Claude Code on behalf of max_

