### PR TITLE
fix(commit-gen): show the resolved config path in setup-prompt hints

### DIFF
--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -1666,13 +1666,9 @@ pub fn handle_picker(
         if config.list.summary() && config.commit_generation.is_configured() {
             (config.commit_generation.command.clone(), None)
         } else {
-            // Point at the config file wt actually loads from — respecting
-            // --config, WORKTRUNK_CONFIG_PATH, and $XDG_CONFIG_HOME — rather
-            // than a hardcoded default. Fall back to the canonical path on the
-            // rare occasion no location can be determined.
-            let config_path = worktrunk::config::config_path()
-                .map(|p| format_path_for_display(&p))
-                .unwrap_or_else(|| "~/.config/worktrunk/config.toml".to_string());
+            // Point at the config file wt actually loads from, not a hardcoded
+            // default (resolution + fallback live in `config_path_for_display`).
+            let config_path = worktrunk::config::config_path_for_display();
             // Keep every prose line short and put the resolved path on its own
             // line. `render_summary` word-wraps prose to the preview width, and
             // that width is a column narrower under Windows' PTY — so a sentence

--- a/src/commands/worktree/resolve.rs
+++ b/src/commands/worktree/resolve.rs
@@ -246,9 +246,7 @@ pub fn offer_bare_repo_worktree_path_fix(
     let example_bad = format!("{parent_name}/{repo_name}.{sanitized}");
     let example_good = format!("{parent_name}/{sanitized}");
 
-    let config_path_display = worktrunk::config::config_path()
-        .map(|p| format_path_for_display(&p).to_string())
-        .unwrap_or_else(|| "~/.config/worktrunk/config.toml".to_string());
+    let config_path_display = worktrunk::config::config_path_for_display();
 
     // Non-interactive: warn and show the config to add.
     if !std::io::stdin().is_terminal() {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -163,9 +163,9 @@ pub(crate) use user::LoadError;
 pub use user::{
     CommitConfig, CommitGenerationConfig, CopyIgnoredConfig, ListColumnConfig, ListConfig,
     MergeConfig, RemoveConfig, ResolvedConfig, StageMode, StepConfig, SwitchConfig,
-    SwitchPickerConfig, UserConfig, UserProjectOverrides, config_path, default_config_path,
-    default_system_config_path, require_config_path, set_config_overrides, set_config_path,
-    system_config_path, valid_user_config_keys,
+    SwitchPickerConfig, UserConfig, UserProjectOverrides, config_path, config_path_for_display,
+    default_config_path, default_system_config_path, require_config_path, set_config_overrides,
+    set_config_path, system_config_path, valid_user_config_keys,
 };
 
 #[cfg(test)]

--- a/src/config/user/mod.rs
+++ b/src/config/user/mod.rs
@@ -44,8 +44,8 @@ fn cli_config_overrides() -> &'static [String] {
 // Re-export public types
 pub use merge::Merge;
 pub use path::{
-    config_path, default_config_path, default_system_config_path, require_config_path,
-    set_config_path, system_config_path,
+    config_path, config_path_for_display, default_config_path, default_system_config_path,
+    require_config_path, set_config_path, system_config_path,
 };
 pub use resolved::ResolvedConfig;
 pub use schema::valid_user_config_keys;

--- a/src/config/user/path.rs
+++ b/src/config/user/path.rs
@@ -59,6 +59,20 @@ pub fn require_config_path() -> Result<PathBuf, ConfigError> {
     })
 }
 
+/// Resolve the user config path for display, formatted with `~` and falling
+/// back to the canonical location when none can be determined.
+///
+/// The display counterpart of [`config_path`]: user-facing messages that name
+/// "the config file wt would load or write" route through this, so the
+/// `--config` / `WORKTRUNK_CONFIG_PATH` / `$XDG_CONFIG_HOME` resolution and the
+/// fallback literal live in one place. Use [`require_config_path`] for the
+/// actual mutation; this is display-only.
+pub fn config_path_for_display() -> String {
+    config_path()
+        .map(|p| crate::path::format_path_for_display(&p))
+        .unwrap_or_else(|| "~/.config/worktrunk/config.toml".to_string())
+}
+
 /// Platform-specific default config path, without CLI or env var overrides.
 ///
 /// Returns the etcetera-based platform default. Called by `config_path()`

--- a/src/output/commit_generation.rs
+++ b/src/output/commit_generation.rs
@@ -190,15 +190,18 @@ pub fn prompt_commit_generation(config: &mut UserConfig) -> anyhow::Result<bool>
     let formatted_command = format_command_for_display(command);
     let config_preview = format!("[commit.generation]\ncommand = {formatted_command}");
 
+    // Point at the config file wt actually writes to — respecting --config,
+    // WORKTRUNK_CONFIG_PATH, and $XDG_CONFIG_HOME — rather than a hardcoded
+    // default. The save below resolves the same path via require_config_path.
+    let config_path = worktrunk::config::config_path_for_display();
+
     // Show prompt with preview on ?
     let response = prompt_yes_no_preview(
         &cformat!("Configure <bold>{tool}</> for commit messages?"),
         || {
             eprintln!(
                 "{}",
-                info_message(cformat!(
-                    "Would add to <bold>~/.config/worktrunk/config.toml</>:"
-                ))
+                info_message(cformat!("Would add to <bold>{config_path}</>:"))
             );
             eprintln!("{}", format_toml(&config_preview));
             eprintln!();
@@ -216,7 +219,7 @@ pub fn prompt_commit_generation(config: &mut UserConfig) -> anyhow::Result<bool>
                 eprintln!(
                     "{}",
                     hint_message(cformat!(
-                        "Config save failed; add manually to <underline>~/.config/worktrunk/config.toml</>"
+                        "Config save failed; add manually to <underline>{config_path}</>"
                     ))
                 );
                 return Ok(false);

--- a/tests/integration_tests/shell_integration_prompt.rs
+++ b/tests/integration_tests/shell_integration_prompt.rs
@@ -672,4 +672,52 @@ mod commit_generation_prompt_tests {
             "Should show preview: {output}"
         );
     }
+
+    /// Test: LLM tool available, user accepts, but the config save fails
+    ///
+    /// Points WORKTRUNK_CONFIG_PATH at a path whose parent is a regular file,
+    /// so the write fails with ENOTDIR — exercising the save-failure hint,
+    /// which names the resolved config path via `config_path_for_display`.
+    #[rstest]
+    fn test_user_accepts_but_save_fails_shows_manual_hint(repo: TestRepo) {
+        let temp_home = TempDir::new().unwrap();
+        let bin_dir = setup_fake_claude(temp_home.path());
+
+        // Stage a change
+        let test_file = repo.root_path().join("test.txt");
+        fs::write(&test_file, "test content\n").unwrap();
+        repo.run_git(&["add", "test.txt"]);
+
+        // A regular file standing in for the config's parent directory makes
+        // every write under it fail with ENOTDIR — root-proof, unlike chmod.
+        let blocker = temp_home.path().join("blocker");
+        fs::write(&blocker, "x").unwrap();
+        let unwritable_config = blocker.join("config.toml");
+
+        let mut env_vars = repo.test_env_vars();
+        let path = format!("{}:/usr/bin:/bin", bin_dir.display());
+        env_vars.push(("PATH".to_string(), path));
+        // Overrides the WORKTRUNK_CONFIG_PATH from test_env_vars (last wins).
+        env_vars.push((
+            "WORKTRUNK_CONFIG_PATH".to_string(),
+            unwritable_config.to_string_lossy().to_string(),
+        ));
+
+        let cmd = build_pty_command(
+            wt_bin().to_str().unwrap(),
+            &["step", "commit"],
+            repo.root_path(),
+            &env_vars,
+            Some(temp_home.path()),
+        );
+        let (output, exit_code) = exec_cmd_in_pty_prompted(cmd, &["y\n"], "[y/N");
+
+        // The commit still completes with a fallback message; only the config
+        // save fails, so the manual-add hint fires.
+        assert_eq!(exit_code, 0, "Command should succeed: {output}");
+        assert!(
+            output.contains("Config save failed"),
+            "Should show manual-add hint on save failure: {output}"
+        );
+    }
 }


### PR DESCRIPTION
The first-time commit-generation setup prompt (`wt step commit` / `wt merge` / `wt step squash` with no `[commit.generation]` configured) hardcoded `~/.config/worktrunk/config.toml` in two user-facing hints — the `?`-preview ("Would add to …") and the save-failure hint ("add manually to …") — while the actual save resolves the path via `require_config_path()`. So the displayed path was wrong whenever `--config`, `WORKTRUNK_CONFIG_PATH`, or `$XDG_CONFIG_HOME` redirected the real config location. Same bug class as #3290 (the picker's disabled-summary hint).

Rather than add a third inline copy of the `config_path() → format_path_for_display → fallback-literal` dance — the picker and the bare-repo `resolve.rs` warning each already carried one — this extracts a single helper, `config_path_for_display()`, the display-only counterpart of `config_path()`. The `--config` / `WORKTRUNK_CONFIG_PATH` / `$XDG_CONFIG_HOME` resolution and the one canonical fallback literal now live in one place, and all three sites route through it (the inline at `resolve.rs` also dropped a redundant `.to_string()`). The helper's doc points callers at `require_config_path()` for the actual mutation.

## Testing

The helper is covered three ways over by existing integration tests (the picker summary-preview PTY snapshot, the bare-repo prompt snapshot, and the commit-generation prompt PTY tests). The commit-gen prompt's preview line was already covered by `test_user_requests_preview`; this PR adds `test_user_accepts_but_save_fails_shows_manual_hint` to cover the save-failure hint — it points `WORKTRUNK_CONFIG_PATH` at a path whose parent is a regular file, so the write fails with `ENOTDIR` (root-proof, unlike a chmod). No snapshot drift: the picker/resolve conversions emit byte-identical output.

> _This was written by Claude Code on behalf of max_
