### PR TITLE
fix(picker): keep the empty-query list in collect order

### DIFF
--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -1791,31 +1791,29 @@ summary = true
     let mut options = SkimOptionsBuilder::default()
         .height("90%".to_string())
         .reverse(true)
-        // Rank matches by a row's *distinguishing* tail, not the shared
-        // `~/workspace/` prefix every worktree path carries. `last_match` makes
-        // the matcher prefer the query's rightmost occurrence, and front-loading
-        // `PathName` in the tiebreak ranks leaf-segment matches (at/after the
-        // last `/`) above parent-directory ones — so `feature/auth` ranks on
-        // `auth`, and the worktree folder name ranks on its tail. This is skim's
-        // `Path` scheme spelled out as its two underlying knobs: a
-        // `.scheme(MatchScheme::Path)` call would also expand here (the builder's
-        // `build()` runs `SkimOptions::build`, which expands the scheme — unlike
-        // the clap-only `scrollbar` default), but it injects a duplicate `Score`
-        // criterion, so setting the knobs directly is the same effect without the
-        // artifact. (Default tiebreak is `[Score, Begin, End]`.) Paired with the
-        // distinct-path `search_text` built in `progressive_handler::on_skeleton`.
+        // skim 4.8's default tiebreak, kept explicit so a future edit can't
+        // quietly reintroduce `PathName` here. The empty-query view (no characters typed)
+        // is the picker's default frame, and it must show rows in the order
+        // `collect` produced them: current, main, newest-first worktrees, then
+        // branches, then the appended `--prs` rows. skim's empty-query engine
+        // (`MatchAllEngine`) scores every row `(score=0, begin=0)`, so with all
+        // scores tied the *whole* list is ordered by the second criterion. A
+        // `PathName` there degenerates: its key is `path_name_offset - begin`, so
+        // at `begin=0` it collapses to `path_name_offset` — sorting every row by
+        // where its last `/` sits. That pulls any slash-bearing name out of
+        // collect order regardless of row kind: a `feature/…` PR head branch, a
+        // `perf/…` worktree branch, and the `/`-gutter local-branch rows all sink
+        // together. `Begin`/`End` are `0` on the empty query, so they don't
+        // perturb it, leaving collect's input order intact.
         //
-        // `PathName` reads the whole `search_text`, including the trailing gutter
-        // glyph. Local-branch rows fold in `/` as that glyph (the gutter sigil),
-        // which `PathName` then reads as a path separator, so on a *score tie* a
-        // local-branch row sorts just under a worktree/remote row whose glyph
-        // (`+`/`@`/`^`/`|`) isn't a separator. The effect is confined to exact
-        // ties (`PathName` is the 2nd criterion) and only reorders rows, so it
-        // rides along rather than warranting a change to the gutter sigils.
-        .last_match(true)
+        // The cost of omitting `PathName` is confined to typed queries (scores
+        // only tie once a query matches): leaf-segment matches no longer win an
+        // exact tie. Two existing mechanisms already cover most of that — the
+        // shared `~/workspace/` prefix is stripped from each row's `search_text`
+        // in `progressive_handler::on_skeleton`, and frizbee penalizes
+        // non-boundary matches — so `feature/auth` still ranks well on `auth`.
         .tiebreak(vec![
             RankCriteria::Score,
-            RankCriteria::PathName,
             RankCriteria::Begin,
             RankCriteria::End,
         ])

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -878,6 +878,50 @@ fn test_switch_picker_with_multiple_worktrees(mut repo: TestRepo) {
     });
 }
 
+/// A branch name containing `/` (`feature/auth`) must keep its place in collect
+/// order on the empty-query view — it must not sink below plainer names. skim's
+/// empty-query engine scores every row `(score=0, begin=0)`, so a `PathName`
+/// tiebreak would collapse to `path_name_offset` there and demote every
+/// slash-bearing row (a `feature/…` branch, a `/`-gutter row). The picker uses
+/// the default `[Score, Begin, End]` tiebreak precisely so the empty query keeps
+/// the order `collect` produced (current, main, newest-first). Created
+/// `feature/auth` first so collect ranks it ahead of `plain-branch` (equal test
+/// timestamps fall back to worktree-creation order). Asserts the relative order
+/// directly rather than freezing a frame, so column-layout and async-render
+/// timing can't drift it.
+#[rstest]
+fn test_switch_picker_slashed_branch_keeps_collect_order(mut repo: TestRepo) {
+    repo.remove_fixture_worktrees();
+    // Remove origin so the list doesn't show origin/main
+    repo.run_git(&["remote", "remove", "origin"]);
+    repo.add_worktree("feature/auth");
+    repo.add_worktree("plain-branch");
+
+    let env_vars = repo.test_env_vars();
+    let result = exec_in_pty_capture_before_abort(
+        wt_bin().to_str().unwrap(),
+        &["switch"],
+        repo.root_path(),
+        &env_vars,
+        // Settle: wait for the last row to render before capturing.
+        &[("", Some("plain-branch"))],
+    );
+
+    assert_valid_abort_exit_code(result.exit_code);
+
+    let (list, _preview) = result.panels();
+    let auth = list
+        .find("feature/auth")
+        .unwrap_or_else(|| panic!("feature/auth row missing:\n{list}"));
+    let plain = list
+        .find("plain-branch")
+        .unwrap_or_else(|| panic!("plain-branch row missing:\n{list}"));
+    assert!(
+        auth < plain,
+        "slashed branch must keep collect order (feature/auth before plain-branch):\n{list}"
+    );
+}
+
 /// Alt-l / alt-h are skim's built-in horizontal-scroll keys (ScrollRight /
 /// ScrollLeft). The picker binds both to `ignore` because each row's `display()`
 /// owns its layout with a leading worktree-status sigil; an unbound alt-l slides


### PR DESCRIPTION
The `wt switch` picker's default view (no query typed) reordered rows by where each name's last `/` falls, instead of showing them in collect order. Any slash-bearing row — a `feature/…` PR head branch, a `perf/…` worktree branch, or a `/`-gutter local branch — sank toward the bottom and intermixed with rows of other kinds. A worktree like `perf/list-prune-…` would appear stranded among the `#` PR rows rather than up with the other worktrees.

**Cause.** The picker set a custom skim tiebreak `[Score, PathName, Begin, End]` (plus `last_match(true)`). On an empty query skim's `MatchAllEngine` scores every row `(score=0, begin=0)`, so with all scores tied the whole list is ordered by the second criterion. `PathName`'s key is `path_name_offset - begin`, which at `begin=0` collapses to `path_name_offset` — the byte offset after the last `/`. Names without a slash get `0` (kept in input order); names with one get a positive offset and sink. `PathName` was added to rank typed-query matches on their leaf segment (`feature/auth` on `auth`), but skim is a plain crates.io dependency with no engine-injection hook, so it can't be made inert on an empty query without forking skim — which this project deliberately avoids.

**Fix.** Revert to skim's default `[Score, Begin, End]` and drop `last_match(true)`. On an empty query every row ties on `[0,0,0]`, so skim's stable sort preserves input order, which is collect's order: current, main, newest-first worktrees, then branches, then the appended `--prs` rows. The cost is confined to typed queries — leaf-segment matches no longer win a *score tie* — but the shared `~/workspace/` prefix is already stripped from each row's match text in `progressive_handler::on_skeleton`, and the frizbee matcher penalizes non-boundary matches, so `feature/auth` still ranks well on `auth`.

A regression test creates a `feature/auth` worktree before a `plain-branch` one and asserts `feature/auth` stays ahead on the empty-query view; it was confirmed to fail on the old tiebreak and pass on the new one.

> _This was written by Claude Code on behalf of max_
