### PR TITLE
skills(release): document a buildable baseline for semver-checks

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -293,6 +293,13 @@ Interpreting results:
 
 - **No issues reported**: any bump level is valid from the library's perspective. Choose based on CLI changes and new features.
 - **Breaking changes reported**: while pre-1.0, these require at minimum a minor bump (e.g., 0.37.0 → 0.38.0). A patch release is not allowed.
-- **Tool fails to run** (e.g., missing baseline): likely the crate hasn't been published yet or the registry cache is stale. Try `cargo semver-checks check-release -p worktrunk --baseline-version <last-published>`.
+- **No baseline found**: the last version isn't on crates.io yet, or the registry index is stale. Add `--baseline-version <last-published>`.
+- **Baseline fails to build** (`failed to build rustdoc for crate worktrunk v<last>`): a pin this release added to fix a broken transitive dep isn't in the published baseline, which resolves its dependencies fresh. Build the baseline from the published source with the pin applied (currently `petname-macros`; see `Cargo.toml`):
+
+  ```bash
+  B="$(mktemp -d)/base"; cp -R ~/.cargo/registry/src/*/worktrunk-<last> "$B"; chmod -R u+w "$B"
+  printf '\n[dependencies.petname-macros]\nversion = "=3.0.0"\n' >> "$B/Cargo.toml"
+  cargo semver-checks check-release -p worktrunk --baseline-root "$B"
+  ```
 
 This check validates the chosen bump — it doesn't distinguish patch vs. minor when no breakage exists. Continue using the commit review to decide between patch (fixes only) and minor (new features).


### PR DESCRIPTION
## Problem

While prepping the 0.63.0 release, release step 5 — `cargo semver-checks check-release -p worktrunk` — failed before producing any verdict:

```
error[E0433]: cannot find `lang` in `petname`
   --> .../petname-3.0.0/src/lib.rs:282:9
error: failed to build rustdoc for crate worktrunk v0.62.0
```

`cargo-semver-checks` builds the last-published baseline (worktrunk 0.62.0) to diff the public API against the working tree. It resolves that baseline's dependencies **fresh from its published manifest**, so the working tree's pins don't reach the build.

## Root cause

`petname` 3.0.0 declares `petname-macros = "^3.0.0"`. crates.io has `petname-macros` 3.0.0, 3.0.1, and 3.1.0 — none yanked — so the caret resolves to **3.1.0**, whose `petnames!` macro emits `::petname::lang::…` references that don't exist in petname 3.0.0 (`E0433`).

The working tree pins `petname-macros = "=3.0.0"` to constrain this (landed for 0.63.0 in #3283). The **0.62.0 baseline manifest predates that pin**, so semver-checks' fresh baseline resolution pulls the broken 3.1.0 and the baseline can't compile. `--baseline-version 0.62.0` and `--baseline-rev v0.62.0` both build the baseline's own (unpinned) manifest, so both fail the same way. The library-API check is then silently skipped exactly when a dependency problem is in flight.

This is partly transient — 0.63.0's published baseline will carry the pin, so the next release's plain command builds again. The deeper cause is upstream (the incompatible `petname-macros` 3.0.1/3.1.0 are not yanked, and petname 3.0.0's caret range admits them); our `=3.0.0` pin is the correct local mitigation and is unchanged here.

## Fix

The only baseline knob that can carry the working tree's pin into the baseline build is `--baseline-root` (provide your own baseline source). The release skill's "Library API Compatibility" section now documents a recipe: copy the published baseline source out of the registry cache, append the same pin, and point semver-checks at it.

## Demonstration

Running the documented recipe against 0.62.0 builds the baseline and reports a real verdict instead of failing to build:

```
Building worktrunk v0.62.0 (baseline)
   Built [ 16.877s] (baseline)
Checking worktrunk v0.62.0 -> v0.62.0
 Checked 196 checks: 193 pass, 3 fail, 0 warn, 56 skip
 Summary semver requires new major version: 3 major and 0 minor checks failed
```

Docs-only change to `.claude/skills/release/SKILL.md`; no code or dependency change. The 0.63.0 release itself (#3300) is handled separately.

> _This was written by Claude Code on behalf of Maximilian Roos_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
