### PR TITLE
fix(picker): un-nest the code-block gutter in comment previews

### DIFF
--- a/src/commands/picker/pr_pane.rs
+++ b/src/commands/picker/pr_pane.rs
@@ -114,15 +114,55 @@ pub(super) fn description(body: &str, width: usize) -> String {
 /// off from its author header. The markdown wraps to the gutter's inner width
 /// (the bar plus its pad take two columns) so the gutter's own wrap is a no-op
 /// rather than re-breaking the already-styled lines.
+///
+/// The body renders *flush* ([`render_markdown_flush`](crate::md_help::render_markdown_flush)),
+/// not gutter-quoted: a comment's own fenced code block would otherwise get its
+/// own house gutter from the markdown renderer, and quoting that inside this
+/// gutter nests two bars — the outer re-wrap then strands continuation lines
+/// without a bar and drops their dim. Flush keeps a single gutter, and flush
+/// code blocks pre-wrap to the inner width so this gutter's wrap stays a no-op.
 pub(super) fn markdown_in_gutter(body: &str, width: usize) -> String {
-    let rendered =
-        crate::md_help::render_markdown_in_help_with_width(body, Some(width.saturating_sub(2)));
+    let rendered = crate::md_help::render_markdown_flush(body, Some(width.saturating_sub(2)));
     format_with_gutter(&rendered, Some(width))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn markdown_in_gutter_code_block_stays_single_guttered_and_dim() {
+        use worktrunk::styling::GUTTER;
+        // A comment whose body wraps a long line in a fenced code block. The
+        // renderer must not nest a second house bar (the code block's own gutter
+        // inside this one), which used to strand continuation lines bar-less and
+        // un-dimmed and break the alignment.
+        let body = "Some intro prose.\n\n```\nfirst second third fourth fifth sixth seventh eighth ninth tenth eleventh twelfth\n```";
+        let out = markdown_in_gutter(body, 40);
+        let bar = format!("{GUTTER}"); // the house bar's opening SGR
+
+        for line in out.lines() {
+            // Exactly one gutter bar per rendered line: the screenshot bug put two
+            // on some lines (nested) and zero on the stranded continuations.
+            assert_eq!(
+                line.matches(&bar).count(),
+                1,
+                "every line carries exactly one gutter bar: {line:?}"
+            );
+        }
+
+        // Every wrapped piece of the code block stays dim — the bug dropped the
+        // dim on every line after the first.
+        let dim = anstyle::Style::new().dimmed();
+        let dim_open = format!("{dim}");
+        for word in ["first", "seventh", "twelfth"] {
+            let line = out
+                .lines()
+                .find(|l| l.contains(word))
+                .unwrap_or_else(|| panic!("code word {word:?} present in {out:?}"));
+            assert!(line.contains(&dim_open), "code line stays dim: {line:?}");
+        }
+    }
 
     #[test]
     fn header_with_and_without_title() {

--- a/src/md_help.rs
+++ b/src/md_help.rs
@@ -111,10 +111,19 @@ fn render_markdown(help: &str, width: Option<usize>, code_blocks: CodeBlocks) ->
                 // flush-left; the gutter mode quotes it in the house bar.
                 let content = code_block_lines.join("\n");
                 let formatted = if code_blocks == CodeBlocks::Flush {
+                    // Flush code feeds the gutter-free `pr`/comments panes. Wrap each
+                    // line to width (word-wrap, preserving indent) and dim every
+                    // resulting piece, so a long line doesn't overflow the pane — and,
+                    // when the comments pane re-quotes this in the house gutter, every
+                    // wrapped piece already fits, keeping the gutter's own wrap a no-op
+                    // and the dim consistent rather than landing only on the first line.
                     let dim = Style::new().dimmed();
                     code_block_lines
                         .iter()
-                        .map(|l| format!("{dim}{l}{dim:#}"))
+                        .flat_map(|l| {
+                            width.map_or_else(|| vec![l.to_string()], |w| wrap_styled_text(l, w))
+                        })
+                        .map(|piece| format!("{dim}{piece}{dim:#}"))
                         .collect::<Vec<_>>()
                         .join("\n")
                 } else {


### PR DESCRIPTION
A fenced code block inside a PR/MR comment rendered as a garbled double gutter in the `wt switch` comments/feedback preview — alternating bar/no-bar lines, dim dropping out after the first line, and words stranded flush-left with broken alignment.

The comments pane rendered each comment body through md_help's *gutter* mode, which gives a fenced code block its own house bar and leaves it unwrapped, and then quoted the whole thing in a *second* house gutter. The outer, ANSI-naive re-wrap stranded the inner bar on each line's first piece and dropped the dim on the continuations.

The fix renders the comment body *flush* — the same gutter-free path the `pr` description pane already uses — so a code block gets no nested bar and there is exactly one gutter. Flush-mode code blocks now also pre-wrap to the pane width with per-line dim, which keeps the single gutter's own wrap a no-op (the pane's invariant), keeps the dim consistent on every line, and stops long code lines from overflowing the `pr` description pane. Flush mode is used only by these two picker panes; `--help` pages use gutter mode and are untouched.

**Before** (`▌` = a house gutter bar):

```
▌ ▌ positive-priority tasks are eligible victims only while
▌ their runtime is under
▌ ▌ `--preempt_elapsed_time`, default 12h — past that they
carry
```

**After**:

```
▌ positive-priority tasks are eligible victims only while
▌ their runtime is under `--preempt_elapsed_time`, default
▌ 12h — past that they gain elapsed-time protection), and
```

A renderer-level regression test asserts exactly one gutter bar per line and that every wrapped code piece stays dim. No existing fixtures carry fenced code in a comment body, so no snapshots shift. Verified at the renderer level; there is no end-to-end PTY fixture with a code-block comment body yet.

> _This was written by Claude Code on behalf of max_
