### PR TITLE
perf(switch): reuse the list collector's ref scan for the preview comparison base

### DIFF
--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -1546,6 +1546,14 @@ pub fn collect(
         .as_deref()
         .and_then(|s| repo.integration_targets(s));
 
+    // Seed the repo-wide comparison-base cache from this snapshot so the
+    // diff/summary preview panes reuse this ref scan instead of capturing their
+    // own. They run on `repo` (`wt list --full`'s summary column) or a clone of
+    // it (the picker's panes), both sharing this `Arc<RepoCache>`.
+    if let Some(s) = snapshot.as_deref() {
+        repo.prime_comparison_base(s);
+    }
+
     // Patch integration_targets and snapshot into options. When
     // default_branch is None (unset or stale), null integration_targets
     // out — tasks otherwise see a target derived from the stale value

--- a/src/commands/picker/items.rs
+++ b/src/commands/picker/items.rs
@@ -2673,6 +2673,44 @@ mod tests {
     }
 
     #[test]
+    fn prime_comparison_base_feeds_branch_diff_spec() {
+        // Priming the comparison base from the collector's already-captured
+        // snapshot must seed the same upstream-aware base the lazy path would
+        // resolve, so the preview pane reuses that scan instead of capturing
+        // its own. Same upstream-aware setup as the test above: local main
+        // lags origin-main, so the base is origin-main, not the stale local.
+        let (t, repo) = repo_with_main();
+        repo.run_command(&["branch", "origin-main"]).unwrap();
+        repo.run_command(&["checkout", "origin-main"]).unwrap();
+        std::fs::write(t.path().join("upstream.txt"), "from upstream\n").unwrap();
+        repo.run_command(&["add", "upstream.txt"]).unwrap();
+        repo.run_command(&["commit", "-m", "upstream commit"])
+            .unwrap();
+        repo.run_command(&["checkout", "-b", "feature"]).unwrap();
+        std::fs::write(t.path().join("feature.txt"), "feature work\n").unwrap();
+        repo.run_command(&["add", "feature.txt"]).unwrap();
+        repo.run_command(&["commit", "-m", "feature commit"])
+            .unwrap();
+        repo.run_command(&["branch", "--set-upstream-to=origin-main", "main"])
+            .unwrap();
+
+        let head = repo
+            .run_command(&["rev-parse", "refs/heads/feature"])
+            .unwrap();
+        let snapshot = repo.capture_refs().unwrap();
+        repo.prime_comparison_base(&snapshot);
+
+        let spec = repo
+            .branch_diff_spec(head.trim())
+            .expect("primed base resolves a spec");
+        assert_eq!(
+            spec.base_name, "origin-main",
+            "primed base must be the upstream-aware comparison base, got: {:?}",
+            spec.base_name
+        );
+    }
+
+    #[test]
     fn branch_diff_cache_short_circuits_recompute() {
         // Pre-populate the disk cache with a sentinel value, then call
         // compute — a hit must return the sentinel verbatim instead of

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -1544,12 +1544,11 @@ pub fn handle_picker(
     // Wrapped in `Arc` because the progressive handler (running on the
     // collect background thread) also calls `spawn_preview`.
     //
-    // BranchDiff previews resolve the default branch's SHA via
-    // `Repository::default_branch_sha`, which sources it from the
-    // local-branch inventory cached on the shared `RepoCache`. N parallel
-    // preview tasks share one inventory scan instead of each forking
-    // `git rev-parse`. Read-only for the picker session — see the
-    // accessor's docstring for the staleness contract.
+    // BranchDiff previews resolve the upstream-aware comparison base via
+    // `Repository::branch_diff_spec`, memoized on the shared `RepoCache` and
+    // primed by `collect::collect` from its ref scan, so N parallel preview
+    // tasks share one resolution instead of each capturing refs. Read-only for
+    // the picker session — see `branch_diff_spec` for the staleness contract.
     //
     // skim 4.x repaints on demand, so the orchestrator needs a handle to skim's
     // event loop to surface a preview compute that lands after the keystroke that

--- a/src/git/repository/integration.rs
+++ b/src/git/repository/integration.rs
@@ -586,9 +586,9 @@ impl Repository {
     /// Selects the base via the shared [`select_comparison_base`] rule
     /// ([`IntegrationTargets::primary`] else the raw local default), so the
     /// preview panes and the `wt list` columns can't pick different bases.
-    /// Captures a [`RefSnapshot`] on first call; safe in the read-only preview
-    /// contexts that use it (wt doesn't move refs there). Fully local — no
-    /// network.
+    /// Captures a [`RefSnapshot`] on first call unless already primed via
+    /// [`Self::prime_comparison_base`]; safe in the read-only preview contexts
+    /// that use it (wt doesn't move refs there). Fully local — no network.
     fn comparison_base(&self) -> Option<&ComparisonBase> {
         self.cache
             .comparison_base
@@ -596,18 +596,38 @@ impl Repository {
             .as_ref()
     }
 
+    /// Seed the memoized comparison base from an already-captured snapshot, so
+    /// the diff/summary preview panes reuse the `wt list` collector's ref scan
+    /// instead of capturing their own (both share one `Arc<RepoCache>`).
+    /// Idempotent — a no-op once the base is resolved; the lazy
+    /// `comparison_base` path remains the fallback for callers that preview
+    /// without collecting first.
+    pub fn prime_comparison_base(&self, snapshot: &RefSnapshot) {
+        self.cache
+            .comparison_base
+            .get_or_init(|| self.comparison_base_from(snapshot));
+    }
+
     fn resolve_comparison_base(&self) -> Option<ComparisonBase> {
         // No default branch → no comparison base; skip the ref scan entirely.
         self.default_branch()?;
         let snapshot = self.capture_refs().ok()?;
-        let targets = self.integration_targets(&snapshot);
+        self.comparison_base_from(&snapshot)
+    }
+
+    /// Resolve the comparison base from a captured snapshot. The shared core of
+    /// the lazy [`Self::resolve_comparison_base`] (captures its own snapshot)
+    /// and [`Self::prime_comparison_base`] (reuses the collector's), so both
+    /// select the base by the same [`select_comparison_base`] rule.
+    fn comparison_base_from(&self, snapshot: &RefSnapshot) -> Option<ComparisonBase> {
+        let targets = self.integration_targets(snapshot);
         let default_branch = self.default_branch();
         let name = select_comparison_base(targets.as_ref(), default_branch.as_deref())?.to_string();
         // No usable base if the name won't resolve (a stale
         // `worktrunk.default-branch` pointing at a deleted branch) — return
         // `None` so the panes skip the branch diff rather than render a
         // guaranteed-empty range against a missing ref.
-        let sha = snapshot_resolve(self, &snapshot, &name).ok()?;
+        let sha = snapshot_resolve(self, snapshot, &name).ok()?;
         Some(ComparisonBase { name, sha })
     }
 


### PR DESCRIPTION
Follow-up to #3305. That PR routed the picker's diff/summary preview panes through the upstream-aware comparison base, which is resolved from a `RefSnapshot` and memoized on the repo's `RepoCache`. But the preview path captured its *own* snapshot — a second `git for-each-ref` scan duplicating the one the `wt list` collector already runs a moment earlier.

This primes that memoized base from the collector's snapshot. `resolve_comparison_base` splits into a snapshot-taking core (`comparison_base_from`) shared by the lazy path and a new `prime_comparison_base`; the collector calls the latter once from the snapshot it already holds. The picker's preview panes run on a clone of the collector's `Repository` (shared `Arc<RepoCache>`) and `wt list --full`'s summary column runs on it directly, so both read the primed base instead of re-scanning. The lazy capture remains as the fallback for any caller that previews without collecting first.

No behavior change — the base value and its staleness characteristics are identical; only the scan that resolves it is shared instead of repeated.

**Testing**: new `prime_comparison_base_feeds_branch_diff_spec` exercises the prime path and asserts it feeds `branch_diff_spec` the upstream-aware base; the existing branch-diff and summary tests cover the lazy path. Feature-gated clippy and the rustdoc `-Dwarnings` gate are clean.

> _This was written by Claude Code on behalf of max_
