### PR TITLE
fix: fence user-controlled refs against git flag injection

### DIFF
--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -194,6 +194,9 @@ pub(crate) fn show_diffstat(repo: &worktrunk::git::Repository, range: &str) -> a
         stat_width_arg = format!("--stat-width={stat_width}");
         args.push(&stat_width_arg);
     }
+    // Fence the range positional so a target branch named like a flag
+    // (`-x..HEAD`) can't be misparsed as an option.
+    args.push("--end-of-options");
     args.push(range);
     let diff_stat = repo.run_command(&args)?.trim_end().to_string();
 

--- a/src/commands/picker/items.rs
+++ b/src/commands/picker/items.rs
@@ -282,29 +282,44 @@ impl SkimItem for HeaderSkimItem {
 }
 
 /// Common diff rendering: check stat, show stat + full diff if non-empty.
+/// Render a `git diff` preview (stat header, then the colored diff). `prefix`
+/// is the command through the `diff` subcommand (e.g. `["diff"]` or
+/// `["-C", path, "diff"]`); `revs` are the positional revisions.
+///
+/// The diff options precede an `--end-of-options` sentinel, which fences the
+/// positional `revs` so a ref that looks like a flag (a branch literally named
+/// `-x` or `--foo`) can't be misparsed as an option. Today's callers pass
+/// resolved SHAs and `HEAD`, but the fence keeps the helper safe for any future
+/// caller that passes a raw name.
 fn compute_diff_preview(
     repo: &Repository,
-    args: &[&str],
+    prefix: &[&str],
+    revs: &[&str],
     no_changes_msg: &str,
     width: usize,
 ) -> String {
     let mut output = String::new();
+    let stat_width_arg = format!("--stat-width={width}");
 
-    // Check stat output first
-    let mut stat_args = args.to_vec();
-    stat_args.push("--stat");
-    stat_args.push("--color=always");
-    let stat_width_arg = format!("--stat-width={}", width);
-    stat_args.push(&stat_width_arg);
+    // Check stat output first.
+    let mut stat_args = prefix.to_vec();
+    stat_args.extend([
+        "--stat",
+        "--color=always",
+        stat_width_arg.as_str(),
+        "--end-of-options",
+    ]);
+    stat_args.extend_from_slice(revs);
 
     if let Ok(stat) = repo.run_command(&stat_args)
         && !stat.trim().is_empty()
     {
         output.push_str(&stat);
 
-        // Build diff args with color
-        let mut diff_args = args.to_vec();
-        diff_args.push("--color=always");
+        // Build diff args with color.
+        let mut diff_args = prefix.to_vec();
+        diff_args.extend(["--color=always", "--end-of-options"]);
+        diff_args.extend_from_slice(revs);
 
         if let Ok(diff) = repo.run_command(&diff_args) {
             output.push_str(&diff);
@@ -1269,7 +1284,8 @@ impl PickerRow {
         let reset = Reset;
         compute_diff_preview(
             repo,
-            &["-C", &path, "diff", "HEAD"],
+            &["-C", &path, "diff"],
+            &["HEAD"],
             &cformat!("{INFO_SYMBOL}{reset} <bold>{branch}</>{reset} has no uncommitted changes"),
             width,
         )
@@ -1303,12 +1319,12 @@ impl PickerRow {
             return cached;
         }
 
-        let mut diff_args = vec!["diff"];
-        diff_args.extend(spec.revs.iter().map(String::as_str));
+        let revs: Vec<&str> = spec.revs.iter().map(String::as_str).collect();
         let base_name = &spec.base_name;
         let result = compute_diff_preview(
             repo,
-            &diff_args,
+            &["diff"],
+            &revs,
             &cformat!(
                 "{INFO_SYMBOL}{reset} <bold>{branch}</>{reset} has no file changes vs <bold>{base_name}</>{reset}"
             ),
@@ -1380,7 +1396,8 @@ impl PickerRow {
             let range = format!("{upstream_sha}...{}", item.head());
             compute_diff_preview(
                 repo,
-                &["diff", &range],
+                &["diff"],
+                &[&range],
                 &cformat!(
                     "{INFO_SYMBOL}{reset} <bold>{branch}</>{reset} has diverged (⇡{ahead} ⇣{behind}) but no unique file changes"
                 ),
@@ -1390,7 +1407,8 @@ impl PickerRow {
             let range = format!("{upstream_sha}...{}", item.head());
             compute_diff_preview(
                 repo,
-                &["diff", &range],
+                &["diff"],
+                &[&range],
                 &cformat!(
                     "{INFO_SYMBOL}{reset} <bold>{branch}</>{reset} has no unpushed file changes"
                 ),
@@ -1400,7 +1418,8 @@ impl PickerRow {
             let range = format!("{}...{upstream_sha}", item.head());
             compute_diff_preview(
                 repo,
-                &["diff", &range],
+                &["diff"],
+                &[&range],
                 &cformat!(
                     "{INFO_SYMBOL}{reset} <bold>{branch}</>{reset} is behind upstream (⇣{behind}) but no file changes"
                 ),
@@ -2707,6 +2726,31 @@ mod tests {
             spec.base_name, "origin-main",
             "primed base must be the upstream-aware comparison base, got: {:?}",
             spec.base_name
+        );
+    }
+
+    #[test]
+    fn diff_preview_fences_flag_like_refs() {
+        // A ref whose name starts with `-` must reach git as a positional, not
+        // an option. Without the `--end-of-options` fence, `git diff <sha>
+        // -weird` misparses `-weird` as a flag and errors out; the fence lets
+        // it resolve as a ref. `git branch` rejects leading-dash names, so the
+        // ref is created via `update-ref`.
+        let (t, repo) = repo_with_main();
+        std::fs::write(t.path().join("fenced.txt"), "fenced\n").unwrap();
+        repo.run_command(&["add", "fenced.txt"]).unwrap();
+        repo.run_command(&["commit", "-m", "fenced commit"])
+            .unwrap();
+        let head = repo.run_command(&["rev-parse", "HEAD"]).unwrap();
+        let root = repo.run_command(&["rev-parse", "HEAD~1"]).unwrap();
+        repo.run_command(&["update-ref", "refs/heads/-weird", head.trim()])
+            .unwrap();
+
+        let out =
+            compute_diff_preview(&repo, &["diff"], &[root.trim(), "-weird"], "NO CHANGES", 80);
+        assert!(
+            out.contains("fenced.txt"),
+            "the --end-of-options fence must let `-weird` resolve as a ref; got: {out:?}"
         );
     }
 

--- a/src/commands/worktree/push.rs
+++ b/src/commands/worktree/push.rs
@@ -127,7 +127,12 @@ impl MergeContext {
         let commit_count = repo.count_commits(&target_branch, "HEAD")?;
 
         let stats_summary = if commit_count > 0 {
-            repo.diff_stats_summary(&["diff", "--shortstat", &format!("{}..HEAD", target_branch)])
+            repo.diff_stats_summary(&[
+                "diff",
+                "--shortstat",
+                "--end-of-options",
+                &format!("{}..HEAD", target_branch),
+            ])
         } else {
             Vec::new()
         };
@@ -183,6 +188,7 @@ impl MergeContext {
             "--color=always",
             "--graph",
             "--oneline",
+            "--end-of-options",
             &format!("{}..HEAD", self.target_branch),
         ])?;
         eprintln!("{}", format_with_gutter(&log_output, None));

--- a/src/git/remove.rs
+++ b/src/git/remove.rs
@@ -407,7 +407,7 @@ pub fn delete_branch_if_safe(
     // Force-delete: skip integration check entirely (matches compute_integration_reason
     // behavior for the Worktree path). The user explicitly chose -D.
     if force_delete {
-        repo.run_command(&["branch", "-D", branch_name])?;
+        repo.run_command(&["branch", "-D", "--", branch_name])?;
         return Ok(BranchDeletionResult {
             outcome: BranchDeletionOutcome::ForceDeleted,
             integration_target: target.to_string(),
@@ -436,7 +436,7 @@ pub fn delete_branch_if_safe(
                 // pre-CAS behavior in a corner case rather than introducing a
                 // new error class.
                 None => {
-                    repo.run_command(&["branch", "-D", branch_name])?;
+                    repo.run_command(&["branch", "-D", "--", branch_name])?;
                     BranchDeletionOutcome::Integrated(r)
                 }
             }
@@ -580,6 +580,30 @@ mod tests {
             .status()
             .unwrap();
         assert!(!exit.success(), "branch should have been deleted");
+    }
+
+    /// A branch whose name starts with `-` must still force-delete: the
+    /// `git branch -D -- <name>` separator stops git from parsing `-x` as an
+    /// option. Created via `update-ref` since `git branch` rejects leading-dash
+    /// names.
+    #[test]
+    fn force_delete_handles_flag_like_branch_name() {
+        let test = TestRepo::with_initial_commit();
+        let repo = Repository::at(test.root_path()).unwrap();
+        let head = repo.run_command(&["rev-parse", "HEAD"]).unwrap();
+        test.run_git(&["update-ref", "refs/heads/-x", head.trim()]);
+
+        let snapshot = repo.capture_refs().unwrap();
+        let result = delete_branch_if_safe(&repo, &snapshot, "-x", "main", true).unwrap();
+        assert!(
+            matches!(result.outcome, BranchDeletionOutcome::ForceDeleted),
+            "expected ForceDeleted, got a different outcome"
+        );
+        assert!(
+            repo.run_command(&["rev-parse", "--verify", "--quiet", "refs/heads/-x"])
+                .is_err(),
+            "flag-like branch should have been force-deleted"
+        );
     }
 
     /// When the branch ref vanishes between snapshot capture and the CAS

--- a/src/output/handlers.rs
+++ b/src/output/handlers.rs
@@ -1126,7 +1126,7 @@ fn handle_branch_only_output(
         handle_branch_deletion_result(result, branch_name)?
     } else if deletion_mode.is_force() {
         let repo = worktrunk::git::Repository::current()?;
-        let result = repo.run_command(&["branch", "-D", branch_name]);
+        let result = repo.run_command(&["branch", "-D", "--", branch_name]);
         handle_branch_deletion_result(
             result.map(|_| BranchDeletionResult {
                 outcome: BranchDeletionOutcome::ForceDeleted,


### PR DESCRIPTION
A branch or ref name can begin with `-` (creatable out-of-band via `git update-ref`, since `git branch` rejects leading-dash names). Git then misparses such a name as an *option* rather than a ref. The project already defends against this with `--end-of-options` (for ranges) and `--` (for branch names) in several places — `repository/diff.rs`, `worktree/switch.rs` — but a few callsites didn't. This closes them.

## The preview helper

`compute_diff_preview` (picker diff/summary panes) appended its `--stat`/`--color` options *after* the positional revs, so it structurally couldn't place an `--end-of-options` fence (git requires all options before it). Restructured to `prefix` + options + `--end-of-options` + `revs` — the only ordering git accepts. Today's callers pass resolved SHAs (which can't lead with `-`), but the helper is now safe for any future caller that passes a raw name.

## Audit findings

A sweep of every git-subprocess callsite found six more gaps, all fixed to match the existing convention:

| Site | Was | Now | Severity |
|------|-----|-----|----------|
| `remove.rs` force-delete | `branch -D <name>` | `branch -D -- <name>` | high — destructive |
| `remove.rs` non-CAS fallback | `branch -D <name>` | `branch -D -- <name>` | high — destructive |
| `handlers.rs` force handler | `branch -D <name>` | `branch -D -- <name>` | high — destructive |
| `push.rs` shortstat | `<target>..HEAD` | `--end-of-options <target>..HEAD` | read-only |
| `push.rs` commit-graph log | `<target>..HEAD` | `--end-of-options <target>..HEAD` | read-only |
| `show_diffstat` helper | `<range>` | `--end-of-options <range>` | read-only |

The three `branch -D` sites are the most serious — a branch named `-d`/`-r` could redirect a destructive delete. The `push.rs` ranges take the user's `wt merge [TARGET]` positional, so `wt merge -- -x` produces a `-x..HEAD` token that leads with `-`.

Everything else the audit traced was already safe (SHA positionals, `refs/heads/…` prefixes, option-argument values, `--`-guarded calls). One borderline case (`{remote}/HEAD`) was excluded — git won't let a remote name begin with `-`.

## Testing

Two regression tests that fail under the old code: `diff_preview_fences_flag_like_refs` (creates `refs/heads/-weird`, asserts it resolves through the fence) and `force_delete_handles_flag_like_branch_name` (force-deletes a `-x` branch). Full local gate green (4296 tests), clippy + rustdoc clean.

> _This was written by Claude Code on behalf of max_
