### PR TITLE
feat(list): add git.branch.* template namespace for custom columns

### DIFF
--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -154,19 +154,29 @@
 #                                  # lower = kept longer (default: 9, the URL band)
 #
 # Templates may reference `{{ branch }}`, `{{ worktree_path }}`,
-# `{{ worktree_name }}` (empty for branch-only rows), and `{{ vars.* }}` —
-# per-branch values stored with
-# `wt config state vars set` (https://worktrunk.dev/config/#wt-config-state-vars).
+# `{{ worktree_name }}` (empty for branch-only rows), and two per-branch
+# namespaces:
+#
+# - `{{ vars.* }}` — values stored with
+#   `wt config state vars set` (https://worktrunk.dev/config/#wt-config-state-vars).
+# - `{{ git.branch.* }}` — the branch's own git config under `branch.<name>.*`,
+#   read straight from `git config` (e.g. `{{ git.branch.jira }}` for a key you
+#   set yourself, or the git-native `description`). Git lowercases config variable
+#   names, so `branch.<name>.nvciShelf` reads as `{{ git.branch.nvcishelf }}`.
+#
 # All standard filters work (`sanitize`, `hash_port`, `codename`, …). A row
-# where the template renders empty (e.g. a branch without the vars key) shows an
+# where the template renders empty (e.g. a branch without the key) shows an
 # empty cell; a column that is empty for every row is dropped from the table.
 # `wt list --format json` includes the rendered values under `columns`.
 #
-# A `Note` column showing free-form descriptions, set per branch with
-# `wt config state vars set note "Bug fix for production fire"`:
+# A `Jira` column reading a key kept in git config, and a `Summary` column
+# showing just the first line of the git-native branch description:
 #
-# [list.custom-columns.Note]
-# template = "{{ vars.note }}"
+# [list.custom-columns.Jira]
+# template = "{{ git.branch.jira }}"
+#
+# [list.custom-columns.Summary]
+# template = "{{ git.branch.description | lines | first }}"
 #
 # ### Commit
 #

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -246,20 +246,30 @@ priority = 9                     # Optional drop order when the terminal narrows
 ```
 
 Templates may reference `{{ branch }}`, `{{ worktree_path }}`,
-`{{ worktree_name }}` (empty for branch-only rows), and `{{ vars.* }}` —
-per-branch values stored with
-[`wt config state vars set`](@/config.md#wt-config-state-vars).
+`{{ worktree_name }}` (empty for branch-only rows), and two per-branch
+namespaces:
+
+- `{{ vars.* }}` — values stored with
+  [`wt config state vars set`](@/config.md#wt-config-state-vars).
+- `{{ git.branch.* }}` — the branch's own git config under `branch.<name>.*`,
+  read straight from `git config` (e.g. `{{ git.branch.jira }}` for a key you
+  set yourself, or the git-native `description`). Git lowercases config variable
+  names, so `branch.<name>.nvciShelf` reads as `{{ git.branch.nvcishelf }}`.
+
 All standard filters work (`sanitize`, `hash_port`, `codename`, …). A row
-where the template renders empty (e.g. a branch without the vars key) shows an
+where the template renders empty (e.g. a branch without the key) shows an
 empty cell; a column that is empty for every row is dropped from the table.
 `wt list --format json` includes the rendered values under `columns`.
 
-A `Note` column showing free-form descriptions, set per branch with
-`wt config state vars set note "Bug fix for production fire"`:
+A `Jira` column reading a key kept in git config, and a `Summary` column
+showing just the first line of the git-native branch description:
 
 ```toml
-[list.custom-columns.Note]
-template = "{{ vars.note }}"
+[list.custom-columns.Jira]
+template = "{{ git.branch.jira }}"
+
+[list.custom-columns.Summary]
+template = "{{ git.branch.description | lines | first }}"
 ```
 
 ### Commit

--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -137,7 +137,7 @@ Reuses the [`commit.generation`](@/config.md#commit) command — the same LLM th
 
 <span class="badge-experimental"></span>
 
-Each `[list.custom-columns]` entry in user config adds a column: the key is the header, the template renders each row's cell. Templates can reference per-branch `{{ vars.* }}` stored with [`wt config state vars set`](@/config.md#wt-config-state-vars) — useful for tracking what each of many (often agent-driven) branches is for:
+Each `[list.custom-columns]` entry in user config adds a column: the key is the header, the template renders each row's cell. Templates read two per-branch namespaces — `{{ vars.* }}`, stored with [`wt config state vars set`](@/config.md#wt-config-state-vars), and `{{ git.branch.* }}`, the branch's own git config under `branch.<name>.*` (a `jira` key you set yourself, or the git-native `description`) — useful for tracking what each of many (often agent-driven) branches is for:
 
 ```toml
 [list.custom-columns.Ticket]

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -243,20 +243,30 @@ priority = 9                     # Optional drop order when the terminal narrows
 ```
 
 Templates may reference `{{ branch }}`, `{{ worktree_path }}`,
-`{{ worktree_name }}` (empty for branch-only rows), and `{{ vars.* }}` —
-per-branch values stored with
-[`wt config state vars set`](https://worktrunk.dev/config/#wt-config-state-vars).
+`{{ worktree_name }}` (empty for branch-only rows), and two per-branch
+namespaces:
+
+- `{{ vars.* }}` — values stored with
+  [`wt config state vars set`](https://worktrunk.dev/config/#wt-config-state-vars).
+- `{{ git.branch.* }}` — the branch's own git config under `branch.<name>.*`,
+  read straight from `git config` (e.g. `{{ git.branch.jira }}` for a key you
+  set yourself, or the git-native `description`). Git lowercases config variable
+  names, so `branch.<name>.nvciShelf` reads as `{{ git.branch.nvcishelf }}`.
+
 All standard filters work (`sanitize`, `hash_port`, `codename`, …). A row
-where the template renders empty (e.g. a branch without the vars key) shows an
+where the template renders empty (e.g. a branch without the key) shows an
 empty cell; a column that is empty for every row is dropped from the table.
 `wt list --format json` includes the rendered values under `columns`.
 
-A `Note` column showing free-form descriptions, set per branch with
-`wt config state vars set note "Bug fix for production fire"`:
+A `Jira` column reading a key kept in git config, and a `Summary` column
+showing just the first line of the git-native branch description:
 
 ```toml
-[list.custom-columns.Note]
-template = "{{ vars.note }}"
+[list.custom-columns.Jira]
+template = "{{ git.branch.jira }}"
+
+[list.custom-columns.Summary]
+template = "{{ git.branch.description | lines | first }}"
 ```
 
 ### Commit

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -122,7 +122,7 @@ Reuses the [`commit.generation`](https://worktrunk.dev/config/#commit) command �
 
 ### Custom columns [experimental]
 
-Each `[list.custom-columns]` entry in user config adds a column: the key is the header, the template renders each row's cell. Templates can reference per-branch `{{ vars.* }}` stored with [`wt config state vars set`](https://worktrunk.dev/config/#wt-config-state-vars) — useful for tracking what each of many (often agent-driven) branches is for:
+Each `[list.custom-columns]` entry in user config adds a column: the key is the header, the template renders each row's cell. Templates read two per-branch namespaces — `{{ vars.* }}`, stored with [`wt config state vars set`](https://worktrunk.dev/config/#wt-config-state-vars), and `{{ git.branch.* }}`, the branch's own git config under `branch.<name>.*` (a `jira` key you set yourself, or the git-native `description`) — useful for tracking what each of many (often agent-driven) branches is for:
 
 ```toml
 [list.custom-columns.Ticket]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -865,7 +865,7 @@ Reuses the [`commit.generation`](@/config.md#commit) command — the same LLM th
 
 ### Custom columns [experimental]
 
-Each `[list.custom-columns]` entry in user config adds a column: the key is the header, the template renders each row's cell. Templates can reference per-branch `{{ vars.* }}` stored with [`wt config state vars set`](@/config.md#wt-config-state-vars) — useful for tracking what each of many (often agent-driven) branches is for:
+Each `[list.custom-columns]` entry in user config adds a column: the key is the header, the template renders each row's cell. Templates read two per-branch namespaces — `{{ vars.* }}`, stored with [`wt config state vars set`](@/config.md#wt-config-state-vars), and `{{ git.branch.* }}`, the branch's own git config under `branch.<name>.*` (a `jira` key you set yourself, or the git-native `description`) — useful for tracking what each of many (often agent-driven) branches is for:
 
 ```toml
 [list.custom-columns.Ticket]
@@ -1970,20 +1970,30 @@ priority = 9                     # Optional drop order when the terminal narrows
 ```
 
 Templates may reference `{{ branch }}`, `{{ worktree_path }}`,
-`{{ worktree_name }}` (empty for branch-only rows), and `{{ vars.* }}` —
-per-branch values stored with
-[`wt config state vars set`](@/config.md#wt-config-state-vars).
+`{{ worktree_name }}` (empty for branch-only rows), and two per-branch
+namespaces:
+
+- `{{ vars.* }}` — values stored with
+  [`wt config state vars set`](@/config.md#wt-config-state-vars).
+- `{{ git.branch.* }}` — the branch's own git config under `branch.<name>.*`,
+  read straight from `git config` (e.g. `{{ git.branch.jira }}` for a key you
+  set yourself, or the git-native `description`). Git lowercases config variable
+  names, so `branch.<name>.nvciShelf` reads as `{{ git.branch.nvcishelf }}`.
+
 All standard filters work (`sanitize`, `hash_port`, `codename`, …). A row
-where the template renders empty (e.g. a branch without the vars key) shows an
+where the template renders empty (e.g. a branch without the key) shows an
 empty cell; a column that is empty for every row is dropped from the table.
 `wt list --format json` includes the rendered values under `columns`.
 
-A `Note` column showing free-form descriptions, set per branch with
-`wt config state vars set note "Bug fix for production fire"`:
+A `Jira` column reading a key kept in git config, and a `Summary` column
+showing just the first line of the git-native branch description:
 
 ```toml
-[list.custom-columns.Note]
-template = "{{ vars.note }}"
+[list.custom-columns.Jira]
+template = "{{ git.branch.jira }}"
+
+[list.custom-columns.Summary]
+template = "{{ git.branch.description | lines | first }}"
 ```
 
 ### Commit

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -1145,9 +1145,10 @@ pub fn collect(
     let llm_command = config.commit_generation.command.clone();
 
     // Custom [list.custom-columns] values expand before layout: their inputs
-    // (branch, worktree identity, vars from the bulk config snapshot) are
-    // already in memory, so cells paint with the skeleton and column widths
-    // are measured from content like Branch/Path. Pure CPU — no subprocess.
+    // (branch, worktree identity, vars and branch_config from the bulk config
+    // snapshot) are already in memory, so cells paint with the skeleton and
+    // column widths are measured from content like Branch/Path. Pure CPU — no
+    // subprocess.
     //
     // A broken column definition aborts `wt list` with the error. The picker
     // shares this path but runs collect on a background thread while skim
@@ -1164,10 +1165,12 @@ pub fn collect(
         };
     if !custom_columns.is_empty() {
         let all_vars = repo.all_vars_from_snapshot()?;
+        let all_branch_config = repo.all_branch_config_from_snapshot()?;
         super::custom_columns::expand_custom_columns(
             &custom_columns,
             &mut all_items,
             &all_vars,
+            &all_branch_config,
             repo,
         );
     }

--- a/src/commands/list/custom_columns.rs
+++ b/src/commands/list/custom_columns.rs
@@ -2,15 +2,16 @@
 //!
 //! Resolved once per invocation, then expanded eagerly for every row before
 //! the table skeleton renders: the template inputs (branch, worktree
-//! identity, per-branch vars from the bulk config snapshot) are all in memory
-//! by then, so cells paint with the skeleton, widths are measured from
-//! content like Branch/Path, and a column that renders empty for every row is
-//! dropped by the regular empty-column penalty. Layout participation lives in
-//! `columns.rs` / `layout.rs` via `ColumnKind::Custom`.
+//! identity, per-branch `vars` and `git.branch` config from the bulk config
+//! snapshot) are all in memory by then, so cells paint with the skeleton,
+//! widths are measured from content like Branch/Path, and a column that
+//! renders empty for every row is dropped by the regular empty-column penalty.
+//! Layout participation lives in `columns.rs` / `layout.rs` via
+//! `ColumnKind::Custom`.
 //!
 //! Expansion stays off the skeleton's critical costs: one minijinja
-//! environment and one parse per column per invocation, one vars conversion
-//! per branch, zero subprocesses per cell.
+//! environment and one parse per column per invocation, one value conversion
+//! per branch per namespace, zero subprocesses per cell.
 
 use std::collections::{BTreeMap, HashMap};
 
@@ -88,15 +89,18 @@ pub fn resolve_custom_columns(
 /// Expand every custom column for every item, populating
 /// `ListItem::custom_values`.
 ///
-/// `all_vars` is the pre-fetched vars map for all branches (one snapshot
-/// read covers the whole table — no subprocess per cell). Render errors
-/// produce an empty cell, logged at `-vv`: a vars key absent on this branch
-/// is the expected sparse-column shape, and config-level typos were already
-/// rejected at resolution.
+/// `all_vars` and `all_branch_config` are the pre-fetched per-branch maps for
+/// the whole table (one snapshot read each — no subprocess per cell); the
+/// former backs `{{ vars.* }}` (worktrunk's `wt config state vars`), the
+/// latter `{{ git.branch.* }}` (the branch's own `branch.<name>.*` git
+/// config). Render errors produce an empty cell, logged at `-vv`: a key absent
+/// on this branch is the expected sparse-column shape, and config-level typos
+/// were already rejected at resolution.
 pub fn expand_custom_columns(
     columns: &[ResolvedCustomColumn],
     items: &mut [ListItem],
     all_vars: &HashMap<String, BTreeMap<String, String>>,
+    all_branch_config: &HashMap<String, BTreeMap<String, String>>,
     repo: &Repository,
 ) {
     let env = template_environment(repo);
@@ -120,12 +124,17 @@ pub fn expand_custom_columns(
         )
         .collect();
 
-    // Convert each branch's vars to a template value once, not per cell
+    // Convert each branch's vars / branch_config to a template value once, not
+    // per cell. Both namespaces share the same empty value for unknown branches.
     let branch_values: HashMap<&str, Value> = all_vars
         .iter()
         .map(|(branch, entries)| (branch.as_str(), vars_map_to_value(entries)))
         .collect();
-    let empty_vars = vars_map_to_value(&BTreeMap::new());
+    let branch_config_values: HashMap<&str, Value> = all_branch_config
+        .iter()
+        .map(|(branch, entries)| (branch.as_str(), vars_map_to_value(entries)))
+        .collect();
+    let empty = vars_map_to_value(&BTreeMap::new());
 
     // Worktree identity is only computed when a template references it:
     // `to_posix_path` shells out to cygpath per call on Windows (Git Bash),
@@ -158,10 +167,15 @@ pub fn expand_custom_columns(
         context.insert("branch".to_string(), Value::from(branch));
         context.insert("worktree_path".to_string(), Value::from(worktree_path));
         context.insert("worktree_name".to_string(), Value::from(worktree_name));
-        // Always inject vars (empty for unknown branches) so
-        // `{{ vars.key | default(...) }}` works in SemiStrict mode
-        let vars = branch_values.get(branch).unwrap_or(&empty_vars).clone();
+        // Always inject vars / git.branch (empty for unknown branches) so
+        // `{{ vars.key | default(...) }}` works in SemiStrict mode. The branch's
+        // git config nests under `git` so the namespace can grow (git.remote,
+        // git.upstream, …) without claiming a new top-level name per field.
+        let vars = branch_values.get(branch).unwrap_or(&empty).clone();
         context.insert("vars".to_string(), vars);
+        let branch_config = branch_config_values.get(branch).unwrap_or(&empty).clone();
+        let git = Value::from_object(HashMap::from([("branch".to_string(), branch_config)]));
+        context.insert("git".to_string(), git);
         let context = Value::from_object(context);
 
         item.custom_values = templates
@@ -322,7 +336,7 @@ mod tests {
             ListItem::new_branch("abc12345".to_string(), "feature".to_string()),
             ListItem::new_branch("abc12345".to_string(), "other".to_string()),
         ];
-        expand_custom_columns(&columns, &mut items, &all_vars, &test.repo);
+        expand_custom_columns(&columns, &mut items, &all_vars, &HashMap::new(), &test.repo);
 
         // Vars-backed cells are sanitized to one line; nested JSON access
         // works; identity vars expand
@@ -332,5 +346,55 @@ mod tests {
         );
         // A branch without the vars keys renders empty cells, not errors
         assert_eq!(items[1].custom_values, ["", "", "other!"]);
+    }
+
+    #[test]
+    fn test_expand_custom_columns_git_branch() {
+        let test = TestRepo::new();
+        let columns = vec![
+            ResolvedCustomColumn {
+                name: "Ticket".to_string(),
+                template: "{{ git.branch.jira }}".to_string(),
+                max_width: 40,
+                priority: 9,
+            },
+            // The git-native description is multi-line; `lines | first` keeps
+            // just the summary line the use case wants.
+            ResolvedCustomColumn {
+                name: "Summary".to_string(),
+                template: "{{ git.branch.description | lines | first }}".to_string(),
+                max_width: 40,
+                priority: 9,
+            },
+        ];
+        let mut all_branch_config = HashMap::new();
+        all_branch_config.insert(
+            "feature".to_string(),
+            BTreeMap::from([
+                ("jira".to_string(), "PROJ-1".to_string()),
+                (
+                    "description".to_string(),
+                    "Add telemetry\n\n# Details\nlong body".to_string(),
+                ),
+            ]),
+        );
+
+        let mut items = vec![
+            ListItem::new_branch("abc12345".to_string(), "feature".to_string()),
+            ListItem::new_branch("abc12345".to_string(), "other".to_string()),
+        ];
+        expand_custom_columns(
+            &columns,
+            &mut items,
+            &HashMap::new(),
+            &all_branch_config,
+            &test.repo,
+        );
+
+        // The branch's own git config surfaces; the multi-line description is
+        // reduced to its first line.
+        assert_eq!(items[0].custom_values, ["PROJ-1", "Add telemetry"]);
+        // A branch without the keys renders empty cells, not errors.
+        assert_eq!(items[1].custom_values, ["", ""]);
     }
 }

--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -1073,13 +1073,15 @@ pub fn vars_map_to_value(entries: &std::collections::BTreeMap<String, String>) -
     Value::from_serialize(&vars_map)
 }
 
-/// A vars stand-in that answers every key with a placeholder string.
+/// A stand-in for the `vars` / `git.branch` maps that answers every key
+/// with a placeholder string.
 ///
 /// Used only by [`validate_list_column_template`]'s trial render: list
-/// columns lean on `{{ vars.key }}` for keys that only some branches set, so
-/// validating against an empty map (as [`validate_template`] does) would
-/// wrongly reject the dominant pattern. Answering every key keeps the trial
-/// render exercising filters without constraining which keys exist.
+/// columns lean on `{{ vars.key }}` / `{{ git.branch.key }}` for keys that
+/// only some branches set, so validating against an empty map (as
+/// [`validate_template`] does) would wrongly reject the dominant pattern.
+/// Answering every key keeps the trial render exercising filters without
+/// constraining which keys exist.
 #[derive(Debug)]
 struct AnyKeyVars;
 
@@ -1092,10 +1094,10 @@ impl Object for AnyKeyVars {
 /// Validate a `wt list` custom-column template.
 ///
 /// Checks syntax, restricts top-level variables to `LIST_COLUMN_VARS` ∪
-/// `vars`, and trial-renders with placeholder values so filter errors (e.g. a
-/// misspelled filter name) surface at config resolution rather than as
-/// silently empty cells. `vars.*` access is unconstrained — any key
-/// validates, since which keys exist is per-branch runtime state.
+/// `{vars, git}`, and trial-renders with placeholder values so filter errors
+/// (e.g. a misspelled filter name) surface at config resolution rather than as
+/// silently empty cells. `vars.*` and `git.branch.*` access is unconstrained —
+/// any key validates, since which keys exist is per-branch runtime state.
 pub fn validate_list_column_template(
     template: &str,
     repo: &Repository,
@@ -1109,12 +1111,13 @@ pub fn validate_list_column_template(
     let mut undefined: Vec<String> = tmpl
         .undeclared_variables(false)
         .into_iter()
-        .filter(|var| var != "vars" && !LIST_COLUMN_VARS.contains(&var.as_str()))
+        .filter(|var| var != "vars" && var != "git" && !LIST_COLUMN_VARS.contains(&var.as_str()))
         .collect();
     undefined.sort();
     if !undefined.is_empty() {
         let mut available = LIST_COLUMN_VARS.to_vec();
         available.push("vars.<key>");
+        available.push("git.branch.<key>");
         return Err(build_undefined_vars_error(
             name,
             &undefined,
@@ -1127,6 +1130,10 @@ pub fn validate_list_column_template(
         .map(|&k| (k.to_string(), Value::from("PLACEHOLDER")))
         .collect();
     context.insert("vars".to_string(), Value::from_object(AnyKeyVars));
+    // git.branch.<key> resolves to a placeholder; nesting AnyKeyVars under
+    // `branch` lets the trial render exercise `{{ git.branch.* }}` filters.
+    let git = HashMap::from([("branch".to_string(), Value::from_object(AnyKeyVars))]);
+    context.insert("git".to_string(), Value::from_object(git));
     match tmpl.render(Value::from_object(context)) {
         Ok(_) => Ok(()),
         // At runtime an undefined value renders as an empty cell by design
@@ -3016,13 +3023,27 @@ mod tests {
         // Nested vars access (JSON values at runtime) must not be rejected
         // even though the trial render's placeholder vars are flat strings
         validate_list_column_template("{{ vars.config.port }}", &test.repo, "t").unwrap();
+        // git.branch.* mirrors vars.*: any key validates, filters apply
+        validate_list_column_template("{{ git.branch.jira }}", &test.repo, "t").unwrap();
+        validate_list_column_template(
+            "{{ git.branch.description | lines | first }}",
+            &test.repo,
+            "t",
+        )
+        .unwrap();
 
-        // Unknown top-level variables list the available set, vars included
+        // Unknown top-level variables list the available set, both namespaces included
         let err = validate_list_column_template("{{ branhc }}", &test.repo, "t").unwrap_err();
         assert!(err.message.contains("branhc"), "got: {}", err.message);
         assert_eq!(
             err.available_vars,
-            vec!["branch", "vars.<key>", "worktree_name", "worktree_path"]
+            vec![
+                "branch",
+                "git.branch.<key>",
+                "vars.<key>",
+                "worktree_name",
+                "worktree_path"
+            ]
         );
 
         // Syntax errors fail

--- a/src/git/repository/config.rs
+++ b/src/git/repository/config.rs
@@ -198,22 +198,50 @@ impl Repository {
         &self,
     ) -> anyhow::Result<std::collections::HashMap<String, std::collections::BTreeMap<String, String>>>
     {
+        self.subsection_map_from_snapshot(parse_vars_config_key)
+    }
+
+    /// Get all `branch.<name>.*` git config entries across all branches from
+    /// the bulk config snapshot.
+    ///
+    /// Returns a map of branch → (key → value), reading the in-memory
+    /// `Repository::all_config` map with no subprocess (see
+    /// [`Self::all_vars_from_snapshot`] for the snapshot's coherence model).
+    /// This surfaces the keys a user already stores under `branch.<name>.*` in
+    /// git config — both convention keys (`branch.<name>.jira`) and the
+    /// git-native `branch.<name>.description` — in `wt list` custom columns via
+    /// `{{ git.branch.* }}`, the parallel namespace to `{{ vars.* }}`.
+    pub fn all_branch_config_from_snapshot(
+        &self,
+    ) -> anyhow::Result<std::collections::HashMap<String, std::collections::BTreeMap<String, String>>>
+    {
+        self.subsection_map_from_snapshot(parse_branch_config_key)
+    }
+
+    /// Build a branch → (key → value) map from the bulk config snapshot,
+    /// splitting each config key with `parse` (which returns `None` to skip a
+    /// key). Backs both [`Self::all_vars_from_snapshot`] and
+    /// [`Self::all_branch_config_from_snapshot`]. `parse_config_list_z`
+    /// guarantees at least one value per key, so the last one is authoritative.
+    fn subsection_map_from_snapshot(
+        &self,
+        parse: fn(&str) -> Option<(&str, &str)>,
+    ) -> anyhow::Result<std::collections::HashMap<String, std::collections::BTreeMap<String, String>>>
+    {
         let guard = self.all_config()?.read().unwrap();
         let mut result: std::collections::HashMap<
             String,
             std::collections::BTreeMap<String, String>,
         > = std::collections::HashMap::new();
         for (config_key, values) in guard.iter() {
-            let Some((branch, key)) = parse_vars_config_key(config_key) else {
+            let Some((branch, key)) = parse(config_key) else {
                 continue;
             };
-            let Some(value) = values.last() else {
-                continue;
-            };
+            let value = values.last().cloned().unwrap_or_default();
             result
                 .entry(branch.to_string())
                 .or_default()
-                .insert(key.to_string(), value.clone());
+                .insert(key.to_string(), value);
         }
         Ok(result)
     }
@@ -692,6 +720,18 @@ fn parse_vars_config_key(config_key: &str) -> Option<(&str, &str)> {
         .rsplit_once(".vars.")
 }
 
+/// Split a `branch.<name>.<key>` config key into `(branch, key)`.
+///
+/// Uses `rsplit_once`: git config variable names cannot contain dots, so the
+/// last `.` always separates the branch subsection (which may itself contain
+/// dots or slashes, e.g. `feature.foo`, `feature/bar`) from the variable name.
+/// Git's own section-level branch settings have no subsection and so flatten to
+/// two segments (`branch.sort`, `branch.autoSetupMerge`); after stripping the
+/// prefix they hold no `.`, so `rsplit_once` yields `None` and they're skipped.
+fn parse_branch_config_key(config_key: &str) -> Option<(&str, &str)> {
+    config_key.strip_prefix("branch.")?.rsplit_once('.')
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -800,5 +840,35 @@ mod tests {
         assert_eq!(snapshot["feature"]["ticket"], "JIRA-1");
         assert_eq!(snapshot["feature"]["note"], "a note");
         assert_eq!(snapshot["weird.vars.branch"]["key"], "v");
+    }
+
+    /// The branch-config snapshot read parses `branch.<name>.*` keys, including
+    /// branch names containing dots or slashes, lowercases the variable name as
+    /// git does, and skips git's own section-level branch settings
+    /// (`branch.sort`), which have no subsection.
+    #[test]
+    fn test_all_branch_config_from_snapshot() {
+        let test = TestRepo::with_initial_commit();
+        let repo = Repository::at(test.root_path()).unwrap();
+
+        repo.set_config("branch.feature.jira", "PROJ-1").unwrap();
+        repo.set_config("branch.feature.foo.jira", "PROJ-2")
+            .unwrap();
+        repo.set_config("branch.feature/bar.jira", "PROJ-3")
+            .unwrap();
+        // Git lowercases variable names; a mixed-case key reads back lowered.
+        repo.set_config("branch.feature.nvciShelf", "64645277")
+            .unwrap();
+        // A section-level branch setting has no subsection — must be skipped.
+        repo.set_config("branch.sort", "-committerdate").unwrap();
+
+        let snapshot = repo.all_branch_config_from_snapshot().unwrap();
+        assert_eq!(snapshot["feature"]["jira"], "PROJ-1");
+        assert_eq!(snapshot["feature"]["nvcishelf"], "64645277");
+        // Dotted and slashed branch names keep their full subsection.
+        assert_eq!(snapshot["feature.foo"]["jira"], "PROJ-2");
+        assert_eq!(snapshot["feature/bar"]["jira"], "PROJ-3");
+        // `branch.sort` is git's own key, not a per-branch entry.
+        assert!(!snapshot.contains_key("sort"));
     }
 }

--- a/tests/integration_tests/list_config.rs
+++ b/tests/integration_tests/list_config.rs
@@ -828,6 +828,51 @@ template = "{{ vars.ticket }}"
 }
 
 #[rstest]
+fn test_list_custom_column_git_branch(repo: TestRepo) {
+    // A git.branch column reads the branch's own git config under
+    // branch.<name>.*, with no `wt config state vars set` round-trip. The
+    // git-native multi-line description is reduced to its first line.
+    fs::write(
+        repo.test_config_path(),
+        r#"[list.custom-columns.Jira]
+template = "{{ git.branch.jira }}"
+
+[list.custom-columns.Summary]
+template = "{{ git.branch.description | lines | first }}"
+"#,
+    )
+    .unwrap();
+    repo.run_git(&["config", "branch.feature-a.jira", "HWINFCI-2810"]);
+    repo.run_git(&[
+        "config",
+        "branch.feature-a.description",
+        "Add telemetry\n\n# Description\nlong body",
+    ]);
+
+    let mut cmd = wt_command();
+    repo.configure_wt_cmd(&mut cmd);
+    cmd.args(["list", "--format=json"])
+        .current_dir(repo.root_path());
+
+    let output = cmd.output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let json: serde_json::Value = serde_json::from_str(&stdout).unwrap();
+    let items = json.as_array().unwrap();
+    let by_branch = |branch: &str| {
+        items
+            .iter()
+            .find(|item| item["branch"] == branch)
+            .unwrap_or_else(|| panic!("no item for branch {branch}"))
+    };
+
+    let cols = &by_branch("feature-a")["columns"];
+    assert_eq!(cols["Jira"], "HWINFCI-2810");
+    assert_eq!(cols["Summary"], "Add telemetry");
+    // A branch without any branch.<name>.* keys renders no custom cells.
+    assert!(by_branch("feature-b")["columns"].is_null());
+}
+
+#[rstest]
 fn test_list_custom_column_invalid_template(repo: TestRepo) {
     // An unknown top-level variable aborts wt list with the available set
     fs::write(

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -220,19 +220,29 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m#                                  # lower = kept longer (default: 9, the URL band)[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# Templates may reference `{{ branch }}`, `{{ worktree_path }}`,[0m
-[107m [0m [2m# `{{ worktree_name }}` (empty for branch-only rows), and `{{ vars.* }}` —[0m
-[107m [0m [2m# per-branch values stored with[0m
-[107m [0m [2m# `wt config state vars set` (https://worktrunk.dev/config/#wt-config-state-vars).[0m
+[107m [0m [2m# `{{ worktree_name }}` (empty for branch-only rows), and two per-branch[0m
+[107m [0m [2m# namespaces:[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# - `{{ vars.* }}` — values stored with[0m
+[107m [0m [2m#   `wt config state vars set` (https://worktrunk.dev/config/#wt-config-state-vars).[0m
+[107m [0m [2m# - `{{ git.branch.* }}` — the branch's own git config under `branch.<name>.*`,[0m
+[107m [0m [2m#   read straight from `git config` (e.g. `{{ git.branch.jira }}` for a key you[0m
+[107m [0m [2m#   set yourself, or the git-native `description`). Git lowercases config variable[0m
+[107m [0m [2m#   names, so `branch.<name>.nvciShelf` reads as `{{ git.branch.nvcishelf }}`.[0m
+[107m [0m [2m#[0m
 [107m [0m [2m# All standard filters work (`sanitize`, `hash_port`, `codename`, …). A row[0m
-[107m [0m [2m# where the template renders empty (e.g. a branch without the vars key) shows an[0m
+[107m [0m [2m# where the template renders empty (e.g. a branch without the key) shows an[0m
 [107m [0m [2m# empty cell; a column that is empty for every row is dropped from the table.[0m
 [107m [0m [2m# `wt list --format json` includes the rendered values under `columns`.[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# A `Note` column showing free-form descriptions, set per branch with[0m
-[107m [0m [2m# `wt config state vars set note "Bug fix for production fire"`:[0m
+[107m [0m [2m# A `Jira` column reading a key kept in git config, and a `Summary` column[0m
+[107m [0m [2m# showing just the first line of the git-native branch description:[0m
 [107m [0m [2m#[0m
-[107m [0m [2m# [list.custom-columns.Note][0m
-[107m [0m [2m# template = "{{ vars.note }}"[0m
+[107m [0m [2m# [list.custom-columns.Jira][0m
+[107m [0m [2m# template = "{{ git.branch.jira }}"[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# [list.custom-columns.Summary][0m
+[107m [0m [2m# template = "{{ git.branch.description | lines | first }}"[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# ### Commit[0m
 [107m [0m [2m#[0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -268,19 +268,29 @@ renders each row's cell.
 [107m [0m [2m                                 [0m[2m# lower = kept longer (default: 9, the URL band)[0m
 
 Templates may reference [2m{{ branch }}[0m, [2m{{ worktree_path }}[0m,
-[2m{{ worktree_name }}[0m (empty for branch-only rows), and [2m{{ vars.* }}[0m —
-per-branch values stored with
-[2mwt config state vars set[0m.
+[2m{{ worktree_name }}[0m (empty for branch-only rows), and two per-branch
+namespaces:
+
+- [2m{{ vars.* }}[0m — values stored with
+  [2mwt config state vars set[0m.
+- [2m{{ git.branch.* }}[0m — the branch's own git config under [2mbranch.<name>.*[0m,
+  read straight from [2mgit config[0m (e.g. [2m{{ git.branch.jira }}[0m for a key you
+  set yourself, or the git-native [2mdescription[0m). Git lowercases config variable
+  names, so [2mbranch.<name>.nvciShelf[0m reads as [2m{{ git.branch.nvcishelf }}[0m.
+
 All standard filters work ([2msanitize[0m, [2mhash_port[0m, [2mcodename[0m, …). A row
-where the template renders empty (e.g. a branch without the vars key) shows an
+where the template renders empty (e.g. a branch without the key) shows an
 empty cell; a column that is empty for every row is dropped from the table.
 [2mwt list --format json[0m includes the rendered values under [2mcolumns[0m.
 
-A [2mNote[0m column showing free-form descriptions, set per branch with
-[2mwt config state vars set note "Bug fix for production fire"[0m:
+A [2mJira[0m column reading a key kept in git config, and a [2mSummary[0m column
+showing just the first line of the git-native branch description:
 
-[107m [0m [2m[36m[list.custom-columns.Note][0m
-[107m [0m [2mtemplate = [0m[2m[32m"{{ vars.note }}"[0m
+[107m [0m [2m[36m[list.custom-columns.Jira][0m
+[107m [0m [2mtemplate = [0m[2m[32m"{{ git.branch.jira }}"[0m
+[107m [0m 
+[107m [0m [2m[36m[list.custom-columns.Summary][0m
+[107m [0m [2mtemplate = [0m[2m[32m"{{ git.branch.description | lines | first }}"[0m
 
 [32mCommit[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -193,7 +193,7 @@ Reuses the [2mcommit.generation[0m command — the same LLM that generates com
 
 [32mCustom columns [experimental][0m
 
-Each [2m[list.custom-columns][0m entry in user config adds a column: the key is the header, the template renders each row's cell. Templates can reference per-branch [2m{{ vars.* }}[0m stored with [2mwt config state vars set[0m — useful for tracking what each of many (often agent-driven) branches is for:
+Each [2m[list.custom-columns][0m entry in user config adds a column: the key is the header, the template renders each row's cell. Templates read two per-branch namespaces — [2m{{ vars.* }}[0m, stored with [2mwt config state vars set[0m, and [2m{{ git.branch.* }}[0m, the branch's own git config under [2mbranch.<name>.*[0m (a [2mjira[0m key you set yourself, or the git-native [2mdescription[0m) — useful for tracking what each of many (often agent-driven) branches is for:
 
 [107m [0m [2m[36m[list.custom-columns.Ticket][0m
 [107m [0m [2mtemplate = [0m[2m[32m"{{ vars.ticket }}"[0m

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -231,9 +231,11 @@ are cached until the branch's diff changes.
 [32mCustom columns [experimental][0m
 
 Each [2m[list.custom-columns][0m entry in user config adds a column: the key is the 
-header, the template renders each row's cell. Templates can reference per-branch
- [2m{{ vars.* }}[0m stored with [2mwt config state vars set[0m — useful for tracking what 
-each of many (often agent-driven) branches is for:
+header, the template renders each row's cell. Templates read two per-branch 
+namespaces — [2m{{ vars.* }}[0m, stored with [2mwt config state vars set[0m, and [2m{{ 
+[2mgit.branch.* }}[0m, the branch's own git config under [2mbranch.<name>.*[0m (a [2mjira[0m key 
+you set yourself, or the git-native [2mdescription[0m) — useful for tracking what each
+ of many (often agent-driven) branches is for:
 
 [107m [0m [2m[36m[list.custom-columns.Ticket][0m
 [107m [0m [2mtemplate = [0m[2m[32m"{{ vars.ticket }}"[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_custom_column_invalid_template.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_custom_column_invalid_template.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -46,4 +47,4 @@ exit_code: 1
 
 ----- stderr -----
 [31m✗[39m [31mFailed to expand list.custom-columns.Ticket: undefined value: `branhc`[39m
-[2m↳[22m [2mAvailable variables: [4mbranch[24m, [4mvars.<key>[24m, [4mworktree_name[24m, [4mworktree_path[24m[22m
+[2m↳[22m [2mAvailable variables: [4mbranch[24m, [4mgit.branch.<key>[24m, [4mvars.<key>[24m, [4mworktree_name[24m, [4mworktree_path[24m[22m


### PR DESCRIPTION
Adds a `{{ git.branch.* }}` template namespace for `wt list` custom columns, parallel to `{{ vars.* }}`. It surfaces a branch's own git config under `branch.<name>.*` — both convention keys you set yourself (`branch.<name>.jira`) and the git-native `branch.<name>.description` — without re-storing the values through `wt config state vars set`. This is the gap left open in #3258: `vars.*` only reads worktrunk's `worktrunk.state.<branch>.vars.*` namespace, so keys a user already keeps in git config were invisible to the list.

## Before / after

With `branch.feature.jira` and `branch.feature.description` already in `.git/config`:

```toml
[list.custom-columns.Jira]
template = "{{ git.branch.jira }}"
[list.custom-columns.Summary]
template = "{{ git.branch.description | lines | first }}"
```

```
Branch     …  Jira          Summary
feature    …  HWINFCI-2810  Add telemetry instrumentation
main       …                                                 ← no branch.main.*, empty cells
```

Previously the only way to populate these columns was to re-enter the data via `wt config state vars set`; now the branch's own config is read directly.

## Design

- A new `git` top-level namespace (rather than a flat `branch_config`) so it can grow other git-derived per-branch fields later (`git.upstream`, `git.remote`, …) without claiming a new top-level name each time. Today it holds `git.branch.*`.
- `git.branch.<key>` maps 1:1 to `git config branch.<name>.<key>`. Note git lowercases config variable names, so `branch.<name>.nvciShelf` reads as `{{ git.branch.nvcishelf }}`; the git-native `description` is multi-line, so `| lines | first` gives the summary line.
- Data comes from the existing in-memory bulk config snapshot — one read, zero subprocesses per cell, on the same skeleton-first path as `vars`. The reader shares a `subsection_map_from_snapshot(parse)` helper with the existing `all_vars_from_snapshot`.
- Parsing splits `branch.<name>.<key>` with `rsplit_once('.')`, which is correct because git variable names can't contain dots: dotted/slashed branch names (`feature.foo`, `feature/bar`) keep their full subsection, and git's section-level keys (`branch.sort`, `branch.autoSetupMerge`) flatten to two segments and are skipped.
- Scoped to list custom columns only — no leakage into hook/alias/pipeline template contexts.

## Testing

Unit tests for the parser/reader (dotted + slashed branch names, variable-name lowercasing, `branch.sort` skip) and for rendering (including `description | lines | first`); a JSON integration test exercises the full `wt list` path end-to-end. Verified manually against a scratch repo. Full pre-merge gate green (4297 tests, clippy, fmt, rustdoc, docs-in-sync).

Closes #3258. Thanks to @cazador481 for the request.

> _This was written by Claude Code on behalf of max_
