### PR TITLE
ci: gate rust caches to main and share one per OS to fit the 10 GB cap

### DIFF
--- a/.github/actions/test-setup/action.yaml
+++ b/.github/actions/test-setup/action.yaml
@@ -4,6 +4,17 @@ description: |
   Used by the test matrix and the cargo-affected jobs (which add their own
   cargo-affected + llvm-tools steps after this).
 
+inputs:
+  save-cache:
+    description: >-
+      Whether this job may save the shared rust cache (and then only on main).
+      `test` is the canonical saver and leaves this at the default; everyone
+      else (collect-affected, affected-tests, release-target) passes 'false' so
+      they restore main's cache but never write — keeps instrumented
+      (collect-affected) and cross-compiled (release-target) artifacts out of
+      the shared cache, and stops PR runs depositing single-use caches.
+    default: "true"
+
 runs:
   using: composite
   steps:
@@ -31,6 +42,16 @@ runs:
         cache-bin: false
         # Bumped to invalidate caches that already include the stale bin.
         prefix-key: v1-rust
+        # One shared cache per OS (rust-cache appends os/arch) across the test
+        # family — `test`, `affected-tests`, `collect-affected`. The PR-only
+        # `affected-tests` job restores `test`'s main cache instead of a cache
+        # of its own (it never runs on main, so a per-job key would have no
+        # baseline and miss every time).
+        shared-key: shared
+        # Only `test` on main writes the shared cache; see the `save-cache`
+        # input. PRs restore main's cache and never deposit single-use ones,
+        # which is what keeps the repo under the 10 GB cache cap.
+        save-if: ${{ inputs.save-cache == 'true' && github.ref == 'refs/heads/main' }}
 
     - name: Install shells (zsh, fish) - Ubuntu
       if: runner.os == 'Linux'

--- a/.github/actions/test-setup/action.yaml
+++ b/.github/actions/test-setup/action.yaml
@@ -55,10 +55,13 @@ runs:
 
     - name: Install shells (zsh, fish) - Ubuntu
       if: runner.os == 'Linux'
-      uses: awalsh128/cache-apt-pkgs-action@v1.6.1
-      with:
-        packages: zsh fish
-        version: 1.0
+      shell: bash
+      # Direct apt rather than awalsh128/cache-apt-pkgs-action: the action's
+      # `v1.6.1` tag was force-moved onto a broken `v1.6.2` that exits 3 in its
+      # pre-cache step, failing every Linux job repo-wide. Two small packages
+      # install in seconds, so the apt-package cache it provided isn't worth a
+      # flaky dependency (or its slot against the 10 GB cache cap).
+      run: sudo apt-get update && sudo apt-get install -y zsh fish
 
     - name: Install shells (fish) - macOS
       if: runner.os == 'macOS'

--- a/.github/actions/test-setup/action.yaml
+++ b/.github/actions/test-setup/action.yaml
@@ -55,13 +55,10 @@ runs:
 
     - name: Install shells (zsh, fish) - Ubuntu
       if: runner.os == 'Linux'
-      shell: bash
-      # Direct apt rather than awalsh128/cache-apt-pkgs-action: the action's
-      # `v1.6.1` tag was force-moved onto a broken `v1.6.2` that exits 3 in its
-      # pre-cache step, failing every Linux job repo-wide. Two small packages
-      # install in seconds, so the apt-package cache it provided isn't worth a
-      # flaky dependency (or its slot against the 10 GB cache cap).
-      run: sudo apt-get update && sudo apt-get install -y zsh fish
+      uses: awalsh128/cache-apt-pkgs-action@v1.6.1
+      with:
+        packages: zsh fish
+        version: 1.0
 
     - name: Install shells (fish) - macOS
       if: runner.os == 'macOS'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -469,9 +469,10 @@ jobs:
         save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Install shells (zsh, fish)
-      # Direct apt — the cached-apt action's tag moved onto a broken release
-      # (see .github/actions/test-setup for the full note).
-      run: sudo apt-get update && sudo apt-get install -y zsh fish
+      uses: awalsh128/cache-apt-pkgs-action@v1.6.1
+      with:
+        packages: zsh fish
+        version: 1.0
 
     - name: Install nushell
       uses: hustcer/setup-nu@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -469,10 +469,9 @@ jobs:
         save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Install shells (zsh, fish)
-      uses: awalsh128/cache-apt-pkgs-action@v1.6.1
-      with:
-        packages: zsh fish
-        version: 1.0
+      # Direct apt — the cached-apt action's tag moved onto a broken release
+      # (see .github/actions/test-setup for the full note).
+      run: sudo apt-get update && sudo apt-get install -y zsh fish
 
     - name: Install nushell
       uses: hustcer/setup-nu@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -35,6 +35,11 @@ jobs:
 
     - name: 💰 Cache
       uses: Swatinem/rust-cache@v2
+      with:
+        # Own cache (clippy builds check artifacts the shared test cache can't
+        # supply), gated to main so PRs restore but never write.
+        cache-bin: "false"
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Install lychee
       uses: baptiste0928/cargo-install@v3
@@ -58,6 +63,11 @@ jobs:
 
     - name: 💰 Cache
       uses: Swatinem/rust-cache@v2
+      with:
+        # Own cache (its `--no-default-features` builds want a smaller dep set
+        # than the shared test cache), gated to main.
+        cache-bin: "false"
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Library builds without any features
       run: cargo check --lib --no-default-features
@@ -168,6 +178,12 @@ jobs:
 
     - name: 💰 Cache
       uses: Swatinem/rust-cache@v2
+      with:
+        # Own cache — `cargo msrv verify` builds with older toolchains whose
+        # rustc hash never matches the shared (stable) test cache. Gated to
+        # main; this job only runs when Cargo/toolchain files change.
+        cache-bin: "false"
+        save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - uses: baptiste0928/cargo-install@v3
       with:
@@ -272,6 +288,11 @@ jobs:
         fetch-depth: 0
 
     - uses: ./.github/actions/test-setup
+      with:
+        # Restore-only: collect builds coverage-instrumented artifacts (it adds
+        # llvm-tools below), which must not overwrite the shared cache that
+        # `test` saves for everyone else.
+        save-cache: "false"
 
     - name: "Use fast D: drive for temp files (Windows)"
       if: runner.os == 'Windows'
@@ -362,6 +383,11 @@ jobs:
         echo "merge-base with origin/main: $sha"
 
     - uses: ./.github/actions/test-setup
+      with:
+        # PR-only job: restore `test`'s shared main cache, never save. This is
+        # the job that most needs the shared key — a per-job cache would have
+        # no main baseline (it never runs on main) and cold-build every PR.
+        save-cache: "false"
 
     - name: "Use fast D: drive for temp files (Windows)"
       if: runner.os == 'Windows'
@@ -437,6 +463,9 @@ jobs:
     - name: 💰 Cache
       uses: Swatinem/rust-cache@v2
       with:
+        # Own cache — coverage-instrumented builds differ from the shared test
+        # cache. Already main-gated; cache-bin:false matches everywhere else.
+        cache-bin: "false"
         save-if: ${{ github.ref == 'refs/heads/main' }}
 
     - name: Install shells (zsh, fish)

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -128,9 +128,10 @@ jobs:
     # zsh/fish and probe nushell; match the test matrix's shell setup
     # (.github/actions/test-setup) so those combinations run, not just compile.
     - name: Install shells (zsh, fish)
-      # Direct apt — the cached-apt action's tag moved onto a broken release
-      # (see .github/actions/test-setup for the full note).
-      run: sudo apt-get update && sudo apt-get install -y zsh fish
+      uses: awalsh128/cache-apt-pkgs-action@v1.6.1
+      with:
+        packages: zsh fish
+        version: 1.0
 
     - name: Install nushell
       uses: hustcer/setup-nu@v3
@@ -218,9 +219,10 @@ jobs:
         save-if: false
 
     - name: Install shells (zsh, fish)
-      # Direct apt — the cached-apt action's tag moved onto a broken release
-      # (see .github/actions/test-setup for the full note).
-      run: sudo apt-get update && sudo apt-get install -y zsh fish
+      uses: awalsh128/cache-apt-pkgs-action@v1.6.1
+      with:
+        packages: zsh fish
+        version: 1.0
 
     - name: Install nushell
       uses: hustcer/setup-nu@v3

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -110,6 +110,14 @@ jobs:
 
     - name: 💰 Cache
       uses: Swatinem/rust-cache@v2
+      with:
+        # Restore the shared `test` cache (registry + deps), never save.
+        # Nightly-only jobs riding main's cache aren't worth their own entry
+        # against the 10 GB repo cap.
+        prefix-key: v1-rust
+        shared-key: shared
+        cache-bin: "false"
+        save-if: false
 
     - name: Install cargo-hack
       uses: taiki-e/install-action@v2.82.4
@@ -173,6 +181,11 @@ jobs:
       run: sudo apt-get update && sudo apt-get install -y musl-tools
 
     - uses: ./.github/actions/test-setup
+      with:
+        # Cross-compiles musl/Intel targets the shared cache never builds, so
+        # it restore-misses anyway — and we don't want these one-off release
+        # triples writing their own caches against the 10 GB cap.
+        save-cache: "false"
 
     - name: Add target
       run: rustup target add ${{ matrix.target }}
@@ -196,6 +209,14 @@ jobs:
 
     - name: 💰 Cache
       uses: Swatinem/rust-cache@v2
+      with:
+        # Restore the shared `test` cache (registry + deps), never save —
+        # `cargo bench` is release-profile so it rebuilds its own artifacts,
+        # but the dependency download/extract is still worth restoring.
+        prefix-key: v1-rust
+        shared-key: shared
+        cache-bin: "false"
+        save-if: false
 
     - name: Install shells (zsh, fish)
       uses: awalsh128/cache-apt-pkgs-action@v1.6.1
@@ -260,6 +281,13 @@ jobs:
 
     - name: 💰 Cache
       uses: Swatinem/rust-cache@v2
+      with:
+        # Never save. Runs on the nightly toolchain, whose rustc hash can't
+        # match the shared (stable) cache, so a per-job cache would only ever
+        # serve the next nightly — near-zero hit under the 10 GB cap. Cold
+        # builds here are absorbed by the nightly cadence.
+        cache-bin: "false"
+        save-if: false
 
     - uses: baptiste0928/cargo-install@v3
       with:
@@ -289,7 +317,11 @@ jobs:
     - name: 💰 Cache
       uses: Swatinem/rust-cache@v2
       with:
-        key: minimal-versions
+        # Never save — nightly toolchain (can't match the shared stable cache)
+        # plus a minimized lockfile that's unique to this run, so a saved cache
+        # would never be reused.
+        cache-bin: "false"
+        save-if: false
 
     - name: Resolve to minimum versions
       # `direct`, not full `-Z minimal-versions`: minimize only worktrunk's own
@@ -324,6 +356,12 @@ jobs:
 
     - name: 💰 Cache
       uses: Swatinem/rust-cache@v2
+      with:
+        # Restore the shared `test` cache (registry + deps), never save.
+        prefix-key: v1-rust
+        shared-key: shared
+        cache-bin: "false"
+        save-if: false
 
     - name: 🧪 Build crates.io archive without .git
       run: cargo test --test integration crate_io_archive_builds_and_versions_without_git -- --ignored

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -128,10 +128,9 @@ jobs:
     # zsh/fish and probe nushell; match the test matrix's shell setup
     # (.github/actions/test-setup) so those combinations run, not just compile.
     - name: Install shells (zsh, fish)
-      uses: awalsh128/cache-apt-pkgs-action@v1.6.1
-      with:
-        packages: zsh fish
-        version: 1.0
+      # Direct apt — the cached-apt action's tag moved onto a broken release
+      # (see .github/actions/test-setup for the full note).
+      run: sudo apt-get update && sudo apt-get install -y zsh fish
 
     - name: Install nushell
       uses: hustcer/setup-nu@v3
@@ -219,10 +218,9 @@ jobs:
         save-if: false
 
     - name: Install shells (zsh, fish)
-      uses: awalsh128/cache-apt-pkgs-action@v1.6.1
-      with:
-        packages: zsh fish
-        version: 1.0
+      # Direct apt — the cached-apt action's tag moved onto a broken release
+      # (see .github/actions/test-setup for the full note).
+      run: sudo apt-get update && sudo apt-get install -y zsh fish
 
     - name: Install nushell
       uses: hustcer/setup-nu@v3


### PR DESCRIPTION
## What

The Actions cache sat at **11.1 GB across 57 caches** against GitHub's hard **10 GB per-repo cap**, so every run was evicting older caches LRU-style — constant churn. ~57% of that was single-PR caches (`refs/pull/N/merge`) that no other PR can ever restore, depositing budget that evicted the reusable `main` caches.

## Changes

- **`save-if` gated to `main` on every rust-cache call.** PRs restore `main`'s cache via the restore-key fallback and never deposit their own. This alone drops the footprint under the cap.
- **One shared cache per OS for the test family.** `test-setup` now sets `shared-key`, with `test` as the sole saver (new `save-cache` input, default `true`); `affected-tests` / `collect-affected` / `release-target` pass `save-cache: "false"`. The PR-only `affected-tests` job needed this most — it never runs on `main`, so a per-job key had no baseline and cold-built every PR; it now rides `test`'s `main` cache.
- **Nightly/release jobs stop saving.** Stable ones (`feature-powerset`, `benchmarks`, `crate-build`) restore the shared cache read-only; the nightly-toolchain ones (`check-unused`, `minimal-versions`) and the cross-target `release-target` just don't save — near-zero reuse against the cap.
- **`cache-bin: false` applied to the v0 jobs too** (`lint`, `feature-check`, `msrv`, `code-coverage`), closing the latent rustup-proxy bug that `test-setup` already guarded against.

## Deliberate non-changes

- `lint` / `feature-check` / `code-coverage` keep their own `main`-gated caches rather than joining the shared one. They build divergent artifacts (clippy-check, `--no-default-features`, coverage-instrumented), and we're no longer space-constrained after the above — a right-sized own cache beats a 1.3 GB restore for partial reuse.
- Did **not** add PRQL's `Cargo.lock`-hash-in-prefix-key: rust-cache already keys on the lockfile, and `save-if: main` already prevents the PR-junk accumulation that trick fights (one mechanism per guarantee).
- The `awalsh128/cache-apt-pkgs-action` stays pinned at `v1.6.1` (per #3321, merged into this branch) — not replaced. Only `Swatinem/rust-cache` config changes here.

Projected active cache: **~3–5 GB**, all `main`-scoped. No `wt` behavior change, so no changelog entry.

> _This was written by Claude Code on behalf of max_
