### PR TITLE
ci: split fast checks from the full suite; add nightly full-tests safety net

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -102,8 +102,15 @@ jobs:
         echo "TEMP=D:\tmp" >> $env:GITHUB_ENV
         echo "TMP=D:\tmp" >> $env:GITHUB_ENV
 
-    - name: 🧪 Pre-merge hooks
-      run: wt hook pre-merge --yes lockfile insta doctest doc
+    # The full nextest suite (snapshots included) — CI's long-pole. The fast
+    # pre-merge gates (lockfile/doctest/rustdoc) live in the `fast-checks` job,
+    # so this job is now just the suite and can later be swapped for the
+    # cargo-affected legs on PRs without disturbing those gates. The `insta`
+    # step runs `--unreferenced reject` on Linux (orphan-snapshot detection) —
+    # an intrinsically full-suite check that rides this job on push-to-main and,
+    # after the flip, stays there.
+    - name: 🧪 Full test suite
+      run: wt hook pre-merge --yes insta
 
     # Anything tests leave behind in the working tree is a leak we want to see
     # before it lands. `target/` is gitignored, so a normal run is clean —
@@ -132,6 +139,31 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: target/nextest/default/junit.xml
         report_type: test_results
+
+  # The pre-merge gates that aren't the nextest suite: Cargo.lock freshness,
+  # doctests, and the rustdoc `-Dwarnings` build. Split out of `test` so the
+  # full suite (the long-pole) can later be replaced on PRs by the
+  # cargo-affected legs without dropping these — they stay required and
+  # untouched by that flip. Linux-only: all three are platform-independent. The
+  # one blind spot is doc/doctest inside `#[cfg(windows)]` / `#[cfg(target_os
+  # = …)]` code, which only the full `test` matrix compiles; acceptable for a
+  # gate whose job is broken links and stale locks, not platform behavior.
+  fast-checks:
+    runs-on: ubuntu-24.04
+    steps:
+    - name: 📂 Checkout code
+      uses: actions/checkout@v7
+
+    - uses: ./.github/actions/test-setup
+
+    - name: Install wt
+      uses: baptiste0928/cargo-install@v3
+      with:
+        crate: worktrunk
+        version: "=0.62.0"
+
+    - name: 🧪 Lockfile, doctests, rustdoc
+      run: wt hook pre-merge --yes lockfile doctest doc
 
   # Check if Cargo/CI files changed (for conditional jobs below)
   changes:
@@ -204,12 +236,16 @@ jobs:
   # cache-misses on the others — each OS's `affected-tests` leg pairs with a
   # `collect-affected` DB from the same OS via the `runner.os` cache key.
   #
-  # TODO(affected-only PRs): once `affected tests (linux/macos/windows)` has a
-  # track record of catching every failure the required full suite catches on
-  # all three OSes, drop the full `test` matrix from PRs and let cargo-affected
-  # be the PR test path. Confidence bar: a sustained stretch of PRs where the
-  # advisory legs and the required full matrix agree — no failure the full
-  # suite caught that affected selection missed.
+  # TODO(affected-only PRs): the fast pre-merge gates are already split into the
+  # `fast-checks` job, so `test (linux/macos/windows)` is now purely the full
+  # nextest suite — the long-pole, and a drop-in shape for the affected legs.
+  # Once `affected tests (*)` has a track record of catching every failure the
+  # full suite catches on all three OSes, flip: make the affected legs required
+  # and delete this PR `test` job — its full-matrix coverage already runs as
+  # `full-tests` in the `nightly` workflow. `fast-checks` stays required and
+  # unchanged. Confidence bar: a sustained stretch of PRs where the advisory
+  # legs and the required full matrix agree — no failure the full suite caught
+  # that affected selection missed.
   #
   # Until then the full `test` matrix stays required and runs on every PR,
   # unchanged. Do NOT reach affected-only by making the required `test (*)`
@@ -217,11 +253,15 @@ jobs:
   # branch-protection change owned by the repo admin (see `.github/CLAUDE.md`),
   # not a silent workflow skip.
   #
-  # When the gate is flipped, keep periodic full runs (push-to-main, and fold
-  # into the `nightly` workflow, which already hosts slower checks) —
-  # cargo-affected misses non-Rust inputs (`include_str!`, templates, SQL),
-  # build-time inputs not in its fingerprint (build.rs, rust-toolchain.toml,
-  # .cargo/config.toml), and proc-macro source edits.
+  # The full suite must keep running after the flip, because cargo-affected
+  # misses non-Rust inputs (`include_str!`, templates, SQL), build-time inputs
+  # not in its fingerprint (build.rs, rust-toolchain.toml, .cargo/config.toml),
+  # and proc-macro source edits. Its home is the `full-tests` matrix in the
+  # `nightly` workflow (nightly cron, the `nightly` label, and before a
+  # release) — NOT push-to-main: a failure there means affected under-selected,
+  # and that must not redden main. Nightly failures are non-blocking and
+  # Tend-fixable. The Linux `--unreferenced reject` orphan check, intrinsically
+  # full-suite, rides `full-tests` too.
   #
   # Cache strategy:
   # - `collect-affected` (push to main) saves `target/affected/coverage.db`

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -2,6 +2,8 @@ name: nightly
 # Slower checks that aren't worth running on every PR but should run before a
 # release. Jobs:
 #   - feature-powerset: feature-flag unification, check + test suite (motivated by #2442)
+#   - full-tests: full nextest suite on the linux/macos/windows matrix — the
+#     cargo-affected safety net (see the job comment and ci.yaml's affected block)
 #   - release-target: PTY+shell suite on the release triples ci.yaml doesn't cover
 #   - benchmarks: full criterion suite + time-series gist append (cron only)
 #   - check-unused-dependencies: cargo-udeps on nightly toolchain
@@ -133,6 +135,64 @@ jobs:
     - run: cargo hack check --feature-powerset --no-dev-deps
 
     - run: cargo hack test --feature-powerset
+
+  full-tests:
+    # The full nextest suite on the standard linux/macos/windows matrix —
+    # mirrors ci.yaml's PR `test` job. This is the safety net for the gaps
+    # cargo-affected can't cover: tests it under-selects, plus the non-Rust /
+    # build inputs it can't trace (`include_str!`, templates, build.rs,
+    # rust-toolchain.toml, proc-macros). It also hosts the Linux
+    # `--unreferenced reject` orphan check, which is intrinsically full-suite.
+    # It lives in `nightly`, NOT on push-to-main, on purpose: a failure here
+    # means affected missed something, and that must not redden main — nightly
+    # failures are non-blocking and Tend-fixable. Complements feature-powerset
+    # (Linux, feature combos) and release-target (cross triples) by covering
+    # the standard 3-OS matrix that neither runs. At the affected-only flip,
+    # ci.yaml's `test` job is deleted and this becomes the sole full run.
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-24.04
+            name: linux
+          - os: macos-15
+            name: macos
+          - os: windows-2022
+            name: windows
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: 📂 Checkout code
+      uses: actions/checkout@v7
+
+    - uses: ./.github/actions/test-setup
+
+    - name: Install wt
+      uses: baptiste0928/cargo-install@v3
+      with:
+        crate: worktrunk
+        version: "=0.62.0"
+
+    - name: "Use fast D: drive for temp files (Windows)"
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        New-Item -ItemType Directory -Force -Path "D:\tmp" | Out-Null
+        echo "TEMP=D:\tmp" >> $env:GITHUB_ENV
+        echo "TMP=D:\tmp" >> $env:GITHUB_ENV
+
+    - name: 🧪 Full test suite
+      run: wt hook pre-merge --yes insta
+
+    - name: 🧹 Verify clean working tree
+      shell: bash
+      run: |
+        if [ -n "$(git status --porcelain)" ]; then
+          echo "::error::tests left files behind in the working tree:"
+          git status --porcelain
+          exit 1
+        fi
 
   release-target:
     # Build and run the test suite on the release triples that ci.yaml's


### PR DESCRIPTION
Prep work toward making the advisory `cargo-affected` legs the PR test path, without flipping any merge gate yet.

## What changed

- **`ci.yaml`** — the `test (linux/macos/windows)` job bundled five gates through one `wt hook pre-merge` call. Split the platform-independent ones — `Cargo.lock` freshness, doctests, and the rustdoc `-Dwarnings` build — into a new Linux-only `fast-checks` job. `test` now runs *only* the full nextest suite (`insta`), so it's a clean drop-in shape for the affected legs later. `fast-checks` stays required and unchanged across the eventual flip.
- **`nightly.yaml`** — added a `full-tests` matrix job (linux/macos/windows, the full suite). This is the safety net for what cargo-affected can't cover: tests it under-selects, plus non-Rust/build inputs it can't trace (`include_str!`, templates, `build.rs`, toolchain, proc-macros). It also hosts the Linux `--unreferenced reject` orphan check. It runs on nightly cron, the `nightly` label, dispatch, and dep-pushes — deliberately **not** on the main-gating path, so a cargo-affected miss surfaces in nightly (non-blocking, Tend-fixable) rather than reddening main.

Nothing is gated by the affected legs yet; `test (*)` stays the required PR gate during calibration. The flip (make affected required, delete the PR `test` job) is a later, separate change — documented in the `ci.yaml` comment block.

## ⚠️ Branch-protection follow-up

Splitting `lockfile`/`doctest`/`doc` out of the required `test` job means **`fast-checks` must be added to the required status checks** (the "Merge access" ruleset). Until it is, those three gates don't block PRs. This is an admin action that should accompany the merge.

## Testing

CI-config only; validated with `actionlint` and pre-commit (yaml/eof/whitespace/typos). The workflow behavior itself validates on this PR's run.

> _This was written by Claude Code on behalf of max_
