### PR TITLE
perf(list): cut warm-cache `wt list` re-run ~36% by killing redundant per-row git forks

### DIFF
--- a/benches/list.rs
+++ b/benches/list.rs
@@ -25,8 +25,8 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use worktrunk::testing::isolate_subprocess_env;
 use wt_perf::{
-    RepoConfig, add_history_spread_branches, add_worktrees, clone_rust_repo, create_repo,
-    invalidate_caches_auto, run_git, setup_fake_remote,
+    RepoConfig, add_history_spread_branches, add_worktrees, clone_rust_repo, create_mixed_repo,
+    create_repo, invalidate_caches_auto, run_git, setup_fake_remote,
 };
 
 /// Benchmark configuration wrapping RepoConfig with cache state.
@@ -382,12 +382,68 @@ fn bench_real_repo_many_branches(c: &mut Criterion) {
     group.finish();
 }
 
+// TODO(bench-full-combined): promote this into one canonical "full"-scenario
+// benchmark covering lots of worktrees AND branches across cold + warm cache
+// (the existing `full` group is worktrees-only despite its name; the branch
+// groups have no worktrees). With a combined fixture, use the trace attribution
+// to isolate where the cost lands — the per-command `args.context` grouping in
+// `benches/CLAUDE.md` (query #3) buckets time per worktree, and worktree-only
+// vs branch-only variants separate worktree-side tasks (status/diff/write-tree)
+// from branch-side tasks (ahead-behind/merge-tree/integration), so a regression
+// can be pinned to a feature rather than the whole command. `rerun_warm` below
+// is the warm seed of that.
+
+/// Warm-cache re-run: many worktrees AND many branches in varied states, with
+/// `.git/wt/cache/` already populated — the steady-state "re-run `wt list`"
+/// cost a user pays on every invocation once the persistent SHA cache is warm.
+///
+/// Unlike the cold variants, this measures *irreducible per-invocation* work:
+/// the in-memory caches (`Arc<RepoCache>`, `WORKTREE_ROOTS`, `GIT_DIRS`,
+/// `commit_tree`, `merge_base`) die with each `wt` process, so every re-run
+/// re-forks whatever those cover, while the disk SHA cache (ahead-behind,
+/// is-ancestor, merge-tree, diff-stats) serves from file reads. `b.iter`
+/// (no cache invalidation) keeps the disk cache warm across iterations; the
+/// criterion warm-up populates it before the first measured run.
+///
+/// Runs `list --branches --progressive` to exercise both worktree and branch
+/// rows on the progressive render path (matching real TTY use), without the
+/// network-touching `ci` column that `--full` would add.
+fn bench_rerun_warm(c: &mut Criterion) {
+    let mut group = c.benchmark_group("rerun_warm");
+    // ~24 worktrees + 120 branches runs ~300ms/iter; the inherited 30-sample /
+    // 15s budget can't fit 30, so cap samples at criterion's minimum and give
+    // a 20s window (≈ a few iters per sample).
+    group.measurement_time(std::time::Duration::from_secs(20));
+    group.sample_size(10);
+
+    let binary = Path::new(env!("CARGO_BIN_EXE_wt"));
+
+    let (worktrees, branches) = (24usize, 120usize);
+    group.bench_with_input(
+        BenchmarkId::from_parameter(format!("{worktrees}wt_{branches}br")),
+        &(worktrees, branches),
+        |b, &(worktrees, branches)| {
+            let temp = create_mixed_repo(worktrees, branches);
+            let repo_path = temp.path().join("repo");
+            b.iter(|| {
+                let mut cmd = Command::new(binary);
+                cmd.args(["list", "--branches", "--progressive"])
+                    .current_dir(&repo_path);
+                isolate_subprocess_env(&mut cmd, None);
+                cmd.output().unwrap();
+            });
+        },
+    );
+
+    group.finish();
+}
+
 criterion_group! {
     name = benches;
     config = Criterion::default()
         .sample_size(30)
         .measurement_time(std::time::Duration::from_secs(15))
         .warm_up_time(std::time::Duration::from_secs(3));
-    targets = bench_skeleton, bench_full, bench_worktree_scaling, bench_real_repo, bench_many_branches, bench_divergent_branches, bench_real_repo_many_branches
+    targets = bench_skeleton, bench_full, bench_worktree_scaling, bench_real_repo, bench_many_branches, bench_divergent_branches, bench_real_repo_many_branches, bench_rerun_warm
 }
 criterion_main!(benches);

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -153,7 +153,7 @@ Worktrunk stores small amounts of cache and log data in the repository's `.git/`
 | Location | Purpose | Created by |
 |----------|---------|------------|
 | `git config worktrunk.*` | Cached default branch, switch history, branch markers, custom variables | Various commands |
-| `.git/wt/cache/{kind}/*.json` | Cached CI status, the largest PR/MR number seen (sizes the `wt list` CI column), and git command results (merge-tree, integration probes, diff stats, ancestry checks, ahead/behind counts) | `wt list`, `wt merge`, `wt remove` |
+| `.git/wt/cache/{kind}/*.json` | Cached CI status, the largest PR/MR number seen (sizes the `wt list` CI column), and git command results (merge-tree, integration probes, diff stats, ancestry checks, ahead/behind counts, merge bases) | `wt list`, `wt merge`, `wt remove` |
 | `.git/wt/cache/summary/{branch}/{hash}.json` | Cached LLM branch summaries, content-addressed by diff hash | `wt list --full`, `wt switch` (when `[list] summary = true`) |
 | `.git/wt/logs/{branch}/**/*.log` | Background hook output (nested per branch) | Hooks, background `wt remove` |
 | `.git/wt/logs/commands.jsonl` | Command audit log (~2MB max) | Hooks, LLM commands |

--- a/skills/worktrunk/reference/faq.md
+++ b/skills/worktrunk/reference/faq.md
@@ -146,7 +146,7 @@ Worktrunk stores small amounts of cache and log data in the repository's `.git/`
 | Location | Purpose | Created by |
 |----------|---------|------------|
 | `git config worktrunk.*` | Cached default branch, switch history, branch markers, custom variables | Various commands |
-| `.git/wt/cache/{kind}/*.json` | Cached CI status, the largest PR/MR number seen (sizes the `wt list` CI column), and git command results (merge-tree, integration probes, diff stats, ancestry checks, ahead/behind counts) | `wt list`, `wt merge`, `wt remove` |
+| `.git/wt/cache/{kind}/*.json` | Cached CI status, the largest PR/MR number seen (sizes the `wt list` CI column), and git command results (merge-tree, integration probes, diff stats, ancestry checks, ahead/behind counts, merge bases) | `wt list`, `wt merge`, `wt remove` |
 | `.git/wt/cache/summary/{branch}/{hash}.json` | Cached LLM branch summaries, content-addressed by diff hash | `wt list --full`, `wt switch` (when `[list] summary = true`) |
 | `.git/wt/logs/{branch}/**/*.log` | Background hook output (nested per branch) | Hooks, background `wt remove` |
 | `.git/wt/logs/commands.jsonl` | Command audit log (~2MB max) | Hooks, LLM commands |

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -51,7 +51,7 @@
 //!
 //! ```text
 //! git log --no-walk --no-show-signature \
-//!   --format=%H%x00%h%x00%ct%x00%s \
+//!   --format=%H%x00%h%x00%ct%x00%T%x00%s \
 //!   SHA₁ SHA₂ … SHA_N
 //! ```
 //!
@@ -62,10 +62,10 @@
 //! - `--no-show-signature` — skip GPG verification. If `gpg.program` is set
 //!   and any of these commits are signed, the default forks `gpg` per
 //!   commit; disabled here.
-//! - `--format=%H%x00%h%x00%ct%x00%s` — four fields per commit,
+//! - `--format=%H%x00%h%x00%ct%x00%T%x00%s` — five fields per commit,
 //!   NUL-separated because subjects can contain anything except NUL:
 //!   - `%H` full SHA, `%h` abbreviated SHA, `%ct` committer date (Unix
-//!     epoch), `%s` subject (first line of message).
+//!     epoch), `%T` tree SHA, `%s` subject (first line of message).
 //!
 //! SHAs come from #4 (worktree HEADs) ∪ #5 (branch tips), deduplicated.
 //! Argv length scales with N — Linux `ARG_MAX` (~128 KB) bounds the
@@ -77,13 +77,16 @@
 //! - `%ct` again, post-skeleton — Age column ("3 hours ago").
 //! - `%s` post-skeleton — Message column.
 //! - `%h` post-skeleton — abbreviated-SHA cell.
+//! - `%T` post-skeleton — primes the `commit_tree` cache so the per-row
+//!   `CommittedTreesMatch` / `WouldMergeAdd` tree lookups never fork
+//!   `git rev-parse <sha>^{tree}` (see [`Repository::commit_details_many`]).
 //!
-//! Subjects and abbreviated SHAs ride along for free: git resolves each
-//! commit object to read its timestamp anyway, so the extra bytes add no
-//! measurable latency to the round trip. Without this batch you'd be
-//! forking `git log -1` per SHA later — same data, N forks instead of one.
-//! The full `(timestamp, subject)` map is handed to the post-skeleton loop
-//! that populates `ListItem.commit` directly.
+//! Tree SHAs, subjects, and abbreviated SHAs ride along for free: git resolves
+//! each commit object to read its timestamp anyway, so the extra bytes add no
+//! measurable latency to the round trip. Without this batch you'd be forking
+//! `git log -1` (and `rev-parse ^{tree}`) per SHA later — same data, N forks
+//! instead of one. The full `(timestamp, subject)` map is handed to the
+//! post-skeleton loop that populates `ListItem.commit` directly.
 //!
 //! When the batch fails (e.g., a listed SHA was deleted mid-run), the
 //! failure is surfaced once and Age/Message cells render placeholders for
@@ -223,6 +226,7 @@
 //! | `has-added-changes/` | `git::repository::sha_cache` | `{branch_sha}-{target_sha}.json` | Never — content-addressed |
 //! | `diff-stats/` | `git::repository::sha_cache` | `{base_sha}-{head_sha}.json` | Never — content-addressed |
 //! | `ahead-behind/` | `git::repository::sha_cache` | `{base_sha}-{head_sha}.json` | Never — content-addressed |
+//! | `merge-base/` | `git::repository::sha_cache` | `{sha1}-{sha2}.json` (sorted) | Never — content-addressed |
 //! | `ci-status/` | `commands::list::ci_status::cache` | `{branch}.json` | TTL 30–60s + HEAD SHA check |
 //! | `summary/{branch}/` | `summary` | `{diff_hash}.json` | Miss if no file exists for the current hash; siblings pruned on write |
 //!
@@ -230,7 +234,7 @@
 //!
 //! - **SHA-pair**: pure function of two commit SHAs. Never stale, no TTL, no invalidation.
 //!   Used by all `sha_cache` kinds (merge-tree conflicts, merge-add probes, ancestry
-//!   checks, file-change probes, diff stats, ahead/behind counts).
+//!   checks, file-change probes, diff stats, ahead/behind counts, merge-base).
 //! - **Branch + TTL + HEAD**: external mutable state (CI API, remote refs). TTL bounds
 //!   staleness; the HEAD check invalidates early when the branch moves.
 //! - **Branch + content-addressed hash in filename**: content hash (SHA-256
@@ -249,7 +253,7 @@
 //! | `IsAncestor` | `sha_cache` (is-ancestor) |
 //! | `HasFileChanges` | `sha_cache` (has-added-changes) |
 //! | `BranchDiff` | `sha_cache` (diff-stats, skipped when sparse checkout is active) |
-//! | `AheadBehind`, `Upstream` | `sha_cache` (ahead-behind); on a cold cache both columns are pre-filled from `for-each-ref %(ahead-behind:SHA)` walks — one against the default branch (`main↕`, in `RefSnapshot::capture_ahead_behind`) and one per unique upstream SHA (`Remote⇅`, in `Repository::prime_upstream_ahead_behind_cache`) |
+//! | `AheadBehind`, `Upstream` | `sha_cache` (ahead-behind for counts, merge-base for the orphan check); on a cold cache both columns are pre-filled from `for-each-ref %(ahead-behind:SHA)` walks — one against the default branch (`main↕`, in `RefSnapshot::capture_ahead_behind`) and one per unique upstream SHA (`Remote⇅`, in `Repository::prime_upstream_ahead_behind_cache`) |
 //! | `CiStatus` | `ci_status::cache` |
 //! | `SummaryGenerate` | `summary` |
 //!
@@ -257,7 +261,11 @@
 //!
 //! ### Already optimized (not cache candidates)
 //!
-//! - `CommittedTreesMatch` — single `git rev-parse` resolving both tree SHAs (~1ms)
+//! - `CommittedTreesMatch` — resolves both commit→tree SHAs through the
+//!   in-memory `commit_tree` cache, which the pre-skeleton commit-details
+//!   `git log` batch primes via `%T` (see [`Repository::commit_details_many`]).
+//!   So on the `wt list` path it forks nothing per row — the tree SHAs are
+//!   already in memory.
 //!
 //! ### Cached via tree SHA
 //!
@@ -1415,6 +1423,15 @@ pub fn collect(
     //
     // These operations run in parallel using rayon::scope with single-level parallelism.
     // See module docs for the timing diagram.
+
+    // Seed root/git-dir for every worktree from the list we already fetched, so
+    // the per-worktree tasks below don't each fork `git rev-parse
+    // --show-toplevel` / `--git-dir`. Deferred to post-skeleton: only the
+    // worker-pool tasks consume these (the pre-skeleton current-worktree probe
+    // uses the prewarmed discovery-worktree root), so seeding here keeps the
+    // local fs reads off the skeleton critical path — and skips them entirely
+    // on the `WORKTRUNK_SKELETON_ONLY` exit above, which runs no tasks.
+    repo.prime_worktree_path_caches(worktrees);
 
     // Collect worktree paths for fsmonitor starts (macOS only, fast, no git commands).
     // Git's builtin fsmonitor has race conditions under parallel load - pre-starting

--- a/src/git/repository/diff.rs
+++ b/src/git/repository/diff.rs
@@ -95,6 +95,16 @@ impl Repository {
     /// other whitespace parse unambiguously. `%s` is the subject line only, so
     /// no multi-line handling is needed.
     ///
+    /// **Primes the commit→tree cache.** The format also reads `%T` (the
+    /// commit's tree SHA) and stores it in the in-memory `commit_tree` cache
+    /// that `commit_to_tree_sha` reads. git resolves the commit object
+    /// to read `%ct` anyway, so the tree SHA rides along for free in the same
+    /// round trip — turning the `wt list` per-row `CommittedTreesMatch` /
+    /// `WouldMergeAdd` tree lookups (every item head + the default-branch tip
+    /// are in this batch) from one `rev-parse <sha>^{tree}` fork each into
+    /// memory hits. The mapping is content-addressed (a commit's tree is
+    /// immutable), so priming it from the authoritative batch is never stale.
+    ///
     /// Fails if any SHA is invalid — `git log --no-walk` refuses the whole
     /// batch on a single bad ref. Callers should surface the error rather
     /// than fall back to per-SHA fetches: the batch is the only commit-detail
@@ -111,11 +121,13 @@ impl Repository {
         // --no-walk shows exactly the named commits without DAG walking.
         // --no-show-signature suppresses GPG verification output that otherwise
         // contaminates stdout when log.showSignature is set.
+        // %T (tree SHA) rides along to prime the commit→tree cache; it's placed
+        // before %s so the variable-length subject stays the final field.
         let mut args = vec![
             "log",
             "--no-walk",
             "--no-show-signature",
-            "--format=%H%x00%h%x00%ct%x00%s",
+            "--format=%H%x00%h%x00%ct%x00%T%x00%s",
         ];
         args.extend(commits);
 
@@ -123,17 +135,27 @@ impl Repository {
 
         let mut result = HashMap::with_capacity(commits.len());
         for line in stdout.lines() {
-            let mut parts = line.splitn(4, '\0');
-            let (Some(sha), Some(short_sha), Some(timestamp_str), Some(subject)) =
-                (parts.next(), parts.next(), parts.next(), parts.next())
-            else {
+            let mut parts = line.splitn(5, '\0');
+            let (Some(sha), Some(short_sha), Some(timestamp_str), Some(tree_sha), Some(subject)) = (
+                parts.next(),
+                parts.next(),
+                parts.next(),
+                parts.next(),
+                parts.next(),
+            ) else {
                 bail!(
-                    "Malformed git log output: expected '<sha>\\0<short>\\0<ts>\\0<subject>', got {line:?}"
+                    "Malformed git log output: expected '<sha>\\0<short>\\0<ts>\\0<tree>\\0<subject>', got {line:?}"
                 );
             };
             let timestamp: i64 = timestamp_str
                 .parse()
                 .with_context(|| format!("Failed to parse timestamp {timestamp_str:?}"))?;
+            // Prime the content-addressed commit→tree cache (get-or-insert; a
+            // concurrent resolver's entry wins, both are authoritative).
+            self.cache
+                .commit_tree
+                .entry(sha.to_string())
+                .or_insert_with(|| tree_sha.to_string());
             result.insert(
                 sha.to_string(),
                 (short_sha.to_owned(), timestamp, subject.to_owned()),
@@ -216,7 +238,22 @@ impl Repository {
     ///
     /// Inputs are commit SHAs. Skips the ambient ref→SHA conversion
     /// entirely; cache key is `(min(sha1, sha2), max(sha1, sha2))`.
+    ///
+    /// In-memory front over a persistent disk back
+    /// (`merge-base/{min}-{max}.json`): the `DashMap` dedups within one
+    /// process, the disk cache serves re-runs without re-forking. The
+    /// `wt list` orphan check (`AheadBehindTask`) calls this once per row
+    /// even when the ahead/behind counts are themselves cache-warm, so on a
+    /// repo with many branches the disk back turns that per-row
+    /// `git merge-base` fork into a file read. Content-addressed, never
+    /// stale. The `sha1 == sha2` short-circuit (a commit is its own
+    /// merge-base) skips both git and the cache for items sitting exactly at
+    /// the base tip — the common "freshly branched" case.
     pub fn merge_base_by_sha(&self, sha1: &str, sha2: &str) -> anyhow::Result<Option<String>> {
+        if sha1 == sha2 {
+            return Ok(Some(sha1.to_string()));
+        }
+
         // Normalize key order since merge-base is symmetric.
         let key = if sha1 <= sha2 {
             (sha1.to_string(), sha2.to_string())
@@ -227,6 +264,11 @@ impl Repository {
         match self.cache.merge_base.entry(key) {
             Entry::Occupied(e) => Ok(e.get().clone()),
             Entry::Vacant(e) => {
+                // Disk back: a prior run's result, served without forking git.
+                if let Some(cached) = super::sha_cache::merge_base(self, sha1, sha2) {
+                    return Ok(e.insert(cached).clone());
+                }
+
                 // Exit codes: 0 = found, 1 = no common ancestor, 128+ = invalid ref
                 let output = self.run_command_output(&["merge-base", sha1, sha2])?;
 
@@ -239,6 +281,7 @@ impl Repository {
                     bail!("git merge-base failed for {sha1} {sha2}: {}", stderr.trim());
                 };
 
+                super::sha_cache::put_merge_base(self, sha1, sha2, &result);
                 Ok(e.insert(result).clone())
             }
         }

--- a/src/git/repository/integration.rs
+++ b/src/git/repository/integration.rs
@@ -684,12 +684,17 @@ impl Repository {
     /// [`Self::would_merge_add_to_target`]; without the cache that is one
     /// identical `rev-parse` subprocess per row.
     ///
-    /// In-memory rather than the persistent `sha_cache`: the resolution is
-    /// ~1 ms, so cross-run persistence saves almost nothing, while the `Entry`
-    /// match holds the shard lock across check-and-insert so the first miss
-    /// computes once and every concurrent row reads it — no cold-start race.
-    /// The disk cache is reserved for results expensive enough that persisting
-    /// them across invocations outweighs a one-off recompute.
+    /// On the `wt list` path this cache is **primed in bulk** by
+    /// [`Self::commit_details_many`] (the pre-skeleton `git log` batch reads
+    /// `%T` for every item head + the default-branch tip), so the per-row
+    /// lookups here are memory hits and fire no subprocess at all. This method
+    /// remains the fallback for any SHA the batch didn't cover.
+    ///
+    /// In-memory rather than the persistent `sha_cache`: on the hot path the
+    /// batch above already resolves it fork-free, so disk persistence would
+    /// save only the rare off-batch miss. The `Entry` match holds the shard
+    /// lock across check-and-insert so the first miss computes once and every
+    /// concurrent row reads it — no cold-start race.
     fn commit_to_tree_sha(&self, commit_sha: &str) -> anyhow::Result<String> {
         use dashmap::mapref::entry::Entry;
         match self.cache.commit_tree.entry(commit_sha.to_string()) {

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -37,19 +37,27 @@
 //! die with the process. A third store — the persistent on-disk [`sha_cache`]
 //! (SHA-keyed JSON under `.git/wt/cache/`) — survives across invocations.
 //! Which store a git result belongs in turns on recompute cost and parallelism:
-//! - *Cheap, resolved many times per run* (commit→tree, merge-base) → in-memory
+//! - *Cheap per call, but primeable in bulk* (commit→tree) → in-memory
 //!   `RepoCache` `DashMap`, get-or-create. The `Entry` match holds the shard
 //!   lock across check-and-insert, so parallel `wt list` rows sharing a key
-//!   spawn one git process, not one each; recompute is ~1 ms, so cross-run
-//!   persistence isn't worth a file. Exemplars:
-//!   [`Repository::merge_base_by_sha`], [`Repository::commit_to_tree_sha`].
+//!   spawn one git process, not one each. On the `wt list` path the per-row
+//!   lookups never fork at all: the pre-skeleton commit-details `git log`
+//!   batch reads `%T` and primes this map in one round trip
+//!   ([`Repository::commit_details_many`]), so cross-run disk persistence
+//!   would save only the rare off-batch miss. Exemplar:
+//!   [`Repository::commit_to_tree_sha`].
 //! - *Expensive, worth persisting across invocations* (merge-tree, patch-id,
 //!   diff stats, ahead/behind) → the disk [`sha_cache`]; content-addressed by
 //!   SHA, so never stale.
 //! - *Both expensive and hot-in-parallel* → an in-memory `DashMap` front over
 //!   the disk back, so parallel tasks don't race through the file cache for the
 //!   same key (the in-memory layer pays the first miss once; the disk layer
-//!   persists it). Exemplar: the `diff_stats` field below.
+//!   persists it). Exemplars: the `diff_stats` field below, and
+//!   [`Repository::merge_base_by_sha`] — `wt list`'s orphan check forks
+//!   `merge-base` once per row even when the ahead/behind counts are already
+//!   cache-warm, so without the disk back every re-run re-pays N forks; per-row
+//!   recompute also runs 10–25 ms on macOS, not the ~1 ms a fast Linux box
+//!   sees.
 //!
 //! **Lifetime.** Neither in-memory layer is ever invalidated. `RepoCache` lives as
 //! long as the `Repository` it's attached to (typically the command).
@@ -242,7 +250,9 @@ pub(super) struct RepoCache {
     /// Merge-base cache: (sha1, sha2) -> merge_base_sha (None = no common ancestor).
     /// Keys are commit SHAs by contract — callers must resolve refs through
     /// a [`RefSnapshot`] before consulting. The key order is normalized
-    /// (`(min, max)`) since merge-base is symmetric.
+    /// (`(min, max)`) since merge-base is symmetric. This is the in-memory
+    /// front over the persistent `merge-base/` [`sha_cache`] back; see
+    /// [`Repository::merge_base_by_sha`].
     pub(super) merge_base: DashMap<(String, String), Option<String>>,
     /// Commit→tree cache: commit_sha -> tree_sha. Keys are commit SHAs by
     /// contract; a commit's tree is immutable, so the mapping is never stale
@@ -940,6 +950,76 @@ impl Repository {
         let raw = path.into();
         let path = canonicalize(&raw).unwrap_or(raw);
         WorkingTree { repo: self, path }
+    }
+
+    /// Prime the per-worktree path caches (`WORKTREE_ROOTS` and `GIT_DIRS`)
+    /// for every worktree in `worktrees`, from data already in hand.
+    ///
+    /// `git worktree list` already gives each worktree's top-level path, so
+    /// `root()` is just its canonical form, and each worktree's `.git` entry
+    /// gives its git dir without a fork. On the `wt list` path this elides the
+    /// per-worktree `git rev-parse --show-toplevel` / `--git-dir` subprocesses
+    /// (one each per linked worktree, both on the dirty-worktree
+    /// `WorkingTreeConflicts` / `GitOperation` critical chain) in favor of
+    /// cheap local fs reads — the same facts [`Self::prewarm`] caches for the
+    /// discovery worktree, generalized to all of them.
+    ///
+    /// Seeds via `or_insert`, so an entry the prewarm or a prior call already
+    /// resolved is left untouched. A worktree whose git dir can't be derived
+    /// cleanly (missing/odd `.git`, un-canonicalizable path) is left for the
+    /// `git rev-parse` fallback in [`WorkingTree::git_dir`] — seeding is an
+    /// optimization, never a correctness dependency. Prunable worktrees (gone
+    /// from disk) are skipped: nothing on disk to read, and their tasks don't
+    /// run.
+    pub fn prime_worktree_path_caches(&self, worktrees: &[WorktreeInfo]) {
+        for wt in worktrees {
+            if wt.is_prunable() {
+                continue;
+            }
+            // Key on the canonical path, matching `worktree_at` (and the
+            // membership invariant on `WORKTREE_ROOTS`). Skip when the path
+            // can't be canonicalized — same guard as `worktree_at`'s callers.
+            let Ok(key) = canonicalize(&wt.path) else {
+                continue;
+            };
+            // A worktree's top-level path is its own `root()`.
+            WORKTREE_ROOTS.entry(key.clone()).or_insert(key.clone());
+
+            if let Some(git_dir) = self.derive_worktree_git_dir(&key) {
+                GIT_DIRS.entry(key).or_insert(git_dir);
+            }
+        }
+    }
+
+    /// Resolve a worktree's git dir from its `.git` entry without forking
+    /// `git rev-parse --git-dir`. A `.git` directory *is* the git dir (the main
+    /// worktree, whose common dir we already hold); a `.git` file holds
+    /// `gitdir: <path>` pointing at `<common>/worktrees/<id>` (a linked
+    /// worktree). Returns the canonicalized git dir, or `None` when the entry
+    /// is missing, unreadable, or in a form not worth second-guessing — the
+    /// caller then leaves it to the subprocess. Mirrors the `--git-dir`
+    /// canonicalization in [`Self::prewarm`] (`prewarm_rev_parse`).
+    fn derive_worktree_git_dir(&self, worktree: &Path) -> Option<PathBuf> {
+        let dot_git = worktree.join(".git");
+        let file_type = std::fs::symlink_metadata(&dot_git).ok()?.file_type();
+        if file_type.is_dir() {
+            // Main worktree: git dir is the common dir (already canonicalized).
+            return Some(self.git_common_dir().to_path_buf());
+        }
+        if !file_type.is_file() {
+            return None;
+        }
+        // `.git` file: `gitdir: <path>` (git writes it absolute; resolve a
+        // relative form against the worktree, as `prewarm_rev_parse` does).
+        let content = std::fs::read_to_string(&dot_git).ok()?;
+        let gitdir = content.lines().find_map(|l| l.strip_prefix("gitdir: "))?;
+        let path = PathBuf::from(gitdir.trim());
+        let absolute = if path.is_relative() {
+            worktree.join(path)
+        } else {
+            path
+        };
+        canonicalize(&absolute).ok()
     }
 
     /// Get a branch handle for branch-specific operations.

--- a/src/git/repository/sha_cache.rs
+++ b/src/git/repository/sha_cache.rs
@@ -9,9 +9,9 @@
 //!
 //! Layout: `.git/wt/cache/{kind}/{key}.json` where `kind` is one of
 //! `merge-tree-conflicts`, `merge-add-probe`, `is-ancestor`,
-//! `has-added-changes`, `diff-stats`, or `ahead-behind`. Symmetric kinds
-//! sort the SHA pair so `(A, B)` and `(B, A)` hit the same entry;
-//! asymmetric kinds preserve ordering. See [`crate::cache`] for
+//! `has-added-changes`, `diff-stats`, `ahead-behind`, or `merge-base`.
+//! Symmetric kinds sort the SHA pair so `(A, B)` and `(B, A)` hit the same
+//! entry; asymmetric kinds preserve ordering. See [`crate::cache`] for
 //! read/write/clear mechanics, torn-write semantics, and the
 //! user-initiated clear error policy.
 
@@ -31,6 +31,7 @@ const KIND_IS_ANCESTOR: &str = "is-ancestor";
 const KIND_HAS_ADDED_CHANGES: &str = "has-added-changes";
 const KIND_DIFF_STATS: &str = "diff-stats";
 const KIND_AHEAD_BEHIND: &str = "ahead-behind";
+const KIND_MERGE_BASE: &str = "merge-base";
 
 /// All cache kind identifiers, used by [`clear_all`].
 const ALL_KINDS: &[&str] = &[
@@ -40,6 +41,7 @@ const ALL_KINDS: &[&str] = &[
     KIND_HAS_ADDED_CHANGES,
     KIND_DIFF_STATS,
     KIND_AHEAD_BEHIND,
+    KIND_MERGE_BASE,
 ];
 
 /// Build a symmetric filename from a SHA pair (order-independent).
@@ -233,6 +235,30 @@ where
         cache::write_json(&dir.join(asymmetric_key(base_sha, head_sha)), &value);
     }
     cache::sweep_lru(&dir, MAX_ENTRIES_PER_KIND);
+}
+
+// merge-base (symmetric)
+
+/// Look up a cached `merge_base_by_sha(sha1, sha2)` result.
+///
+/// The value is `Option<String>`: `Some(sha)` is the common ancestor,
+/// `None` is an orphan pair (no common ancestor). So the return type is
+/// `Option<Option<String>>`: the outer `None` is a cache miss, the inner
+/// `None` is a cached orphan. Symmetric — `(A, B)` and `(B, A)` hit the
+/// same entry, matching `merge-base(A, B) == merge-base(B, A)`.
+pub(super) fn merge_base(repo: &Repository, sha1: &str, sha2: &str) -> Option<Option<String>> {
+    cache::read(repo, KIND_MERGE_BASE, &symmetric_key(sha1, sha2))
+}
+
+/// Store a `merge_base_by_sha(sha1, sha2)` result.
+pub(super) fn put_merge_base(repo: &Repository, sha1: &str, sha2: &str, value: &Option<String>) {
+    cache::write_with_lru(
+        repo,
+        KIND_MERGE_BASE,
+        &symmetric_key(sha1, sha2),
+        value,
+        MAX_ENTRIES_PER_KIND,
+    );
 }
 
 // Maintenance
@@ -791,9 +817,10 @@ mod tests {
             },
         );
         put_ahead_behind(&repo, "a", "b", (1, 0));
+        put_merge_base(&repo, "a", "b", &Some("c".to_string()));
 
         let cleared = clear_all(&repo).unwrap();
-        assert_eq!(cleared, 6, "should clear one entry per kind");
+        assert_eq!(cleared, 7, "should clear one entry per kind");
 
         // All kinds should be empty
         assert_eq!(merge_conflicts(&repo, "a", "b"), None);
@@ -802,5 +829,68 @@ mod tests {
         assert_eq!(has_added_changes(&repo, "a", "b"), None);
         assert_eq!(diff_stats(&repo, "a", "b"), None);
         assert_eq!(ahead_behind(&repo, "a", "b"), None);
+        assert_eq!(merge_base(&repo, "a", "b"), None);
+    }
+
+    #[test]
+    fn test_merge_base_roundtrip() {
+        let test = TestRepo::with_initial_commit();
+        let repo = Repository::at(test.root_path()).unwrap();
+
+        assert_eq!(merge_base(&repo, "aaaa", "bbbb"), None);
+
+        // A common ancestor: outer Some, inner Some(sha).
+        put_merge_base(&repo, "aaaa", "bbbb", &Some("cccc".to_string()));
+        assert_eq!(
+            merge_base(&repo, "aaaa", "bbbb"),
+            Some(Some("cccc".to_string()))
+        );
+        // Symmetric: swapped args hit the same entry.
+        assert_eq!(
+            merge_base(&repo, "bbbb", "aaaa"),
+            Some(Some("cccc".to_string()))
+        );
+
+        // An orphan pair: outer Some (cached), inner None (no ancestor).
+        put_merge_base(&repo, "dddd", "eeee", &None);
+        assert_eq!(merge_base(&repo, "dddd", "eeee"), Some(None));
+    }
+
+    #[test]
+    fn test_merge_base_reads_cache() {
+        let test = TestRepo::with_initial_commit();
+
+        test.run_git(&["checkout", "-b", "feature"]);
+        fs::write(test.root_path().join("new.txt"), "content\n").unwrap();
+        test.run_git(&["add", "new.txt"]);
+        test.run_git(&["commit", "-m", "Feature"]);
+
+        let main_sha = test.git_output(&["rev-parse", "main"]);
+        let feature_sha = test.git_output(&["rev-parse", "feature"]);
+
+        let repo = Repository::at(test.root_path()).unwrap();
+
+        // Real computation: feature descends from main, so the merge base is main.
+        assert_eq!(
+            repo.merge_base_by_sha(&main_sha, &feature_sha).unwrap(),
+            Some(main_sha.clone())
+        );
+
+        // Tamper with the persisted entry; a fresh repo (cold in-memory front)
+        // reads the disk back.
+        let dir = cache::cache_dir(&repo, KIND_MERGE_BASE);
+        let entries: Vec<_> = fs::read_dir(&dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_str().is_some_and(|s| s.ends_with(".json")))
+            .collect();
+        assert_eq!(entries.len(), 1);
+        fs::write(entries[0].path(), "\"deadbeef\"").unwrap();
+
+        let repo2 = Repository::at(test.root_path()).unwrap();
+        assert_eq!(
+            repo2.merge_base_by_sha(&main_sha, &feature_sha).unwrap(),
+            Some("deadbeef".to_string())
+        );
     }
 }

--- a/src/git/repository/tests.rs
+++ b/src/git/repository/tests.rs
@@ -721,6 +721,77 @@ fn commit_details_many_empty_input_is_noop() {
 }
 
 #[test]
+fn commit_details_many_primes_commit_tree_cache() {
+    use crate::testing::TestRepo;
+
+    // The batch reads `%T` so the `wt list` per-row tree lookups
+    // (CommittedTreesMatch / WouldMergeAdd) hit memory instead of forking
+    // `git rev-parse <sha>^{tree}` each.
+    let test = TestRepo::new();
+    test.commit_with_message("first");
+    let sha = test.repo.run_command(&["rev-parse", "HEAD"]).unwrap();
+    let sha = sha.trim().to_string();
+    let tree = test.git_output(&["rev-parse", "HEAD^{tree}"]);
+
+    // Cold before the batch.
+    assert!(!test.repo.cache.commit_tree.contains_key(&sha));
+
+    test.repo.commit_details_many(&[sha.as_str()]).unwrap();
+
+    let cached = test
+        .repo
+        .cache
+        .commit_tree
+        .get(&sha)
+        .map(|e| e.value().clone());
+    assert_eq!(cached, Some(tree));
+}
+
+#[test]
+fn prime_worktree_path_caches_matches_subprocess() {
+    use crate::git::Repository;
+    use crate::testing::TestRepo;
+    use dunce::canonicalize;
+
+    let test = TestRepo::with_initial_commit();
+    // A linked worktree as a sibling of the main worktree.
+    let linked = test.root_path().parent().unwrap().join("linked-feature");
+    test.run_git(&["worktree", "add", "-b", "feature", linked.to_str().unwrap()]);
+
+    let repo = Repository::at(test.root_path()).unwrap();
+    let worktrees: Vec<_> = repo.list_worktrees().unwrap().to_vec();
+    assert!(worktrees.len() >= 2, "main + linked worktree");
+
+    repo.prime_worktree_path_caches(&worktrees);
+
+    for wt in &worktrees {
+        let key = canonicalize(&wt.path).unwrap();
+        // Priming actually populated both maps (no silent skip).
+        let primed_root = super::WORKTREE_ROOTS
+            .get(&key)
+            .map(|e| e.value().clone())
+            .expect("root primed");
+        let primed_git_dir = super::GIT_DIRS
+            .get(&key)
+            .map(|e| e.value().clone())
+            .expect("git_dir primed");
+
+        // Oracle: drop the primed entries, then let the production `root()` /
+        // `git_dir()` recompute via `git rev-parse`. The primed values must
+        // match what the subprocess path produces.
+        super::WORKTREE_ROOTS.remove(&key);
+        super::GIT_DIRS.remove(&key);
+        let wtree = repo.worktree_at(&wt.path);
+        assert_eq!(primed_root, wtree.root().unwrap(), "root for {key:?}");
+        assert_eq!(
+            primed_git_dir,
+            wtree.git_dir().unwrap(),
+            "git_dir for {key:?}"
+        );
+    }
+}
+
+#[test]
 fn commit_details_many_fails_loudly_on_unknown_sha() {
     // `git log --no-walk` refuses the whole batch on a single bad ref. The
     // error surfaces as an `Err`, which `collect()` turns into a user-facing
@@ -741,7 +812,7 @@ fn commit_details_many_fails_loudly_on_unknown_sha() {
 #[test]
 fn commit_details_many_preserves_multibyte_utf8_subject() {
     // Pin that multibyte UTF-8 round-trips through the NUL-delimited parser —
-    // `splitn(3, '\0')` works on byte positions, so char boundaries inside the
+    // `splitn(5, '\0')` works on byte positions, so char boundaries inside the
     // subject must be preserved intact.
     use crate::testing::TestRepo;
 

--- a/tests/helpers/wt-perf/src/lib.rs
+++ b/tests/helpers/wt-perf/src/lib.rs
@@ -515,6 +515,194 @@ pub fn add_history_spread_branches(repo_path: &Path, count: usize) {
     }
 }
 
+/// `git rev-parse HEAD` in `path`, trimmed.
+fn head_sha(path: &Path) -> String {
+    let out = git_command()
+        .args(["rev-parse", "HEAD"])
+        .current_dir(path)
+        .output()
+        .unwrap();
+    String::from_utf8_lossy(&out.stdout).trim().to_string()
+}
+
+/// Append a line to a tracked file (creating it if missing). Used to make
+/// working-tree edits in the mixed-state fixture.
+fn append_line(path: &Path, rel: &str, line: &str) {
+    let file = path.join(rel);
+    let mut content = std::fs::read_to_string(&file).unwrap_or_default();
+    content.push_str(line);
+    content.push('\n');
+    std::fs::write(&file, content).unwrap();
+}
+
+/// Create a repo with `worktrees` linked worktrees AND `branches` branchless
+/// branches, each in a deterministic rotation of states, for the warm-cache
+/// `wt list` re-run benchmark.
+///
+/// Unlike [`RepoConfig`] (every worktree/branch identical), this exercises the
+/// full spread of `wt list` gates and tasks — clean vs dirty working trees,
+/// merged vs ahead vs diverged branches — which is the realistic shape of "a
+/// huge number of worktrees & branches, all in various states". Returns the
+/// `TempDir`; the main worktree is at `temp.path().join("repo")`, linked
+/// worktrees are siblings (`repo.wt-NNNN`).
+///
+/// Worktree states cycle by index % 4:
+/// 0. clean, several commits ahead of base
+/// 1. unstaged modification (dirty working tree)
+/// 2. staged + unstaged + untracked (full dirty mix)
+/// 3. clean, sitting exactly at base
+///
+/// Branch states cycle by index % 4:
+/// 0. at an older checkpoint (ancestor of base — integration-positive)
+/// 1. ahead of base with its own commits (unmerged)
+/// 2. diverged: own commits from an older checkpoint while base advanced
+/// 3. identical to the base tip (trees match — squash-merge shape)
+pub fn create_mixed_repo(worktrees: usize, branches: usize) -> TempDir {
+    let temp = tempfile::tempdir().unwrap();
+    create_mixed_repo_at(worktrees, branches, &temp.path().join("repo"));
+    temp
+}
+
+/// [`create_mixed_repo`] at a caller-chosen path (used by `wt-perf setup
+/// mixed-W-B`). The main worktree is created at `repo`; linked worktrees are
+/// siblings.
+pub fn create_mixed_repo_at(worktrees: usize, branches: usize, repo: &Path) {
+    const FILES: usize = 50;
+    const BASE_COMMITS: usize = 120;
+
+    let repo = repo.to_path_buf();
+    std::fs::create_dir_all(&repo).unwrap();
+
+    run_git(&repo, &["init", "-b", "main"]);
+    run_git(&repo, &["config", "user.name", "Benchmark"]);
+    run_git(&repo, &["config", "user.email", "bench@test.com"]);
+    // Disable background auto-maintenance (see create_repo_at for why).
+    run_git(&repo, &["config", "gc.auto", "0"]);
+    run_git(&repo, &["config", "gc.autoPackLimit", "0"]);
+    run_git(&repo, &["config", "maintenance.auto", "false"]);
+
+    for i in 0..FILES {
+        let p = repo.join(format!("src/file_{i}.rs"));
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(
+            &p,
+            format!("// file {i}\npub fn f_{i}() -> i32 {{ {i} }}\n"),
+        )
+        .unwrap();
+    }
+    run_git(&repo, &["add", "."]);
+    run_git(&repo, &["commit", "-q", "-m", "Initial commit"]);
+
+    // Build base history, recording checkpoints for "behind"/"diverged" branches.
+    let mut checkpoints = vec![head_sha(&repo)];
+    for c in 1..BASE_COMMITS {
+        append_line(
+            &repo,
+            &format!("src/file_{}.rs", c % FILES),
+            &format!("pub fn f_{c}() {{}}"),
+        );
+        run_git(&repo, &["add", "."]);
+        run_git(&repo, &["commit", "-q", "-m", &format!("Commit {c}")]);
+        if c % 20 == 0 {
+            checkpoints.push(head_sha(&repo));
+        }
+    }
+    let base_tip = head_sha(&repo);
+
+    // Branches without worktrees, in varied states. States 1 and 2 check out
+    // in the main worktree and return to main; the loop always ends on main.
+    for i in 0..branches {
+        let name = format!("br-{i:04}");
+        match i % 4 {
+            0 => run_git(
+                &repo,
+                &["branch", &name, &checkpoints[i % checkpoints.len()]],
+            ),
+            1 => {
+                run_git(&repo, &["checkout", "-q", "-b", &name, &base_tip]);
+                for j in 0..=(i % 3) {
+                    std::fs::write(repo.join(format!("br_{i}_{j}.rs")), format!("// {i}/{j}\n"))
+                        .unwrap();
+                    run_git(&repo, &["add", "."]);
+                    run_git(
+                        &repo,
+                        &["commit", "-q", "-m", &format!("br {i} commit {j}")],
+                    );
+                }
+                run_git(&repo, &["checkout", "-q", "main"]);
+            }
+            2 => {
+                run_git(
+                    &repo,
+                    &[
+                        "checkout",
+                        "-q",
+                        "-b",
+                        &name,
+                        &checkpoints[i % checkpoints.len()],
+                    ],
+                );
+                std::fs::write(
+                    repo.join(format!("br_{i}_d.rs")),
+                    format!("// diverge {i}\n"),
+                )
+                .unwrap();
+                run_git(&repo, &["add", "."]);
+                run_git(&repo, &["commit", "-q", "-m", &format!("br {i} diverge")]);
+                run_git(&repo, &["checkout", "-q", "main"]);
+            }
+            _ => run_git(&repo, &["branch", &name, &base_tip]),
+        }
+    }
+
+    // Mature-repo shape: pack refs and write the commit-graph once, after every
+    // branch ref exists but before the worktrees (freshly added worktrees carry
+    // loose refs and uncommitted state — realistic, and keeps gc away from the
+    // dirty indexes below).
+    setup_fake_remote(&repo);
+    run_git(&repo, &["gc", "-q"]);
+
+    // Linked worktrees are siblings named `<repo-dir>.<branch>` (worktrunk
+    // convention), derived from the repo's own directory name so the path is
+    // correct whether the repo is the tempdir's `repo` or a custom `setup` path.
+    let parent = repo.parent().unwrap();
+    let repo_name = repo.file_name().unwrap().to_str().unwrap().to_string();
+    for j in 0..worktrees {
+        let branch = format!("wt-{j:04}");
+        let wt = parent.join(format!("{repo_name}.{branch}"));
+        run_git(
+            &repo,
+            &[
+                "worktree",
+                "add",
+                "-q",
+                "-b",
+                &branch,
+                wt.to_str().unwrap(),
+                &base_tip,
+            ],
+        );
+        match j % 4 {
+            0 => {
+                for k in 0..=(1 + j % 3) {
+                    std::fs::write(wt.join(format!("wt_{j}_{k}.txt")), format!("wt {j}/{k}\n"))
+                        .unwrap();
+                    run_git(&wt, &["add", "."]);
+                    run_git(&wt, &["commit", "-q", "-m", &format!("wt {j} commit {k}")]);
+                }
+            }
+            1 => append_line(&wt, "src/file_0.rs", &format!("// unstaged edit {j}")),
+            2 => {
+                append_line(&wt, "src/file_1.rs", &format!("// staged edit {j}"));
+                run_git(&wt, &["add", "src/file_1.rs"]);
+                append_line(&wt, "src/file_2.rs", &format!("// unstaged edit {j}"));
+                std::fs::write(wt.join(format!("untracked_{j}.txt")), "untracked\n").unwrap();
+            }
+            _ => {}
+        }
+    }
+}
+
 /// Canonicalize path without Windows `\\?\` prefix.
 pub fn canonicalize(path: &Path) -> std::io::Result<PathBuf> {
     dunce::canonicalize(path)

--- a/tests/helpers/wt-perf/src/main.rs
+++ b/tests/helpers/wt-perf/src/main.rs
@@ -9,7 +9,9 @@ use std::time::{Duration, Instant};
 
 use clap::{Parser, Subcommand};
 use worktrunk::trace::{TraceEntry, TraceEntryKind, TraceResult};
-use wt_perf::{canonicalize, create_repo_at, invalidate_caches_auto, parse_config};
+use wt_perf::{
+    canonicalize, create_mixed_repo_at, create_repo_at, invalidate_caches_auto, parse_config,
+};
 
 #[derive(Parser)]
 #[command(name = "wt-perf")]
@@ -23,7 +25,7 @@ struct Cli {
 enum Commands {
     /// Set up a benchmark repository
     Setup {
-        /// Config name: typical-N, branches-N, branches-N-M, divergent, picker-test
+        /// Config name: typical-N, branches-N, branches-N-M, divergent, mixed-W-B, picker-test
         config: String,
 
         /// Directory to create repo in (default: temp directory)
@@ -122,19 +124,31 @@ fn main() {
             path,
             persist,
         } => {
-            let repo_config = parse_config(&config).unwrap_or_else(|| {
-                eprintln!("Unknown config: {}", config);
-                eprintln!();
-                eprintln!("Available configs:");
-                eprintln!(
-                    "  typical-N       - Typical repo with N worktrees (500 commits, 100 files)"
-                );
-                eprintln!("  branches-N      - N branches with 1 commit each");
-                eprintln!("  branches-N-M    - N branches with M commits each");
-                eprintln!("  divergent       - 200 branches × 20 commits (GH #461 scenario)");
-                eprintln!("  picker-test     - Config for wt switch interactive picker testing");
-                std::process::exit(1);
-            });
+            // `mixed-W-B`: W worktrees + B branches in varied states (warm
+            // re-run benchmark fixture); handled separately since it doesn't
+            // map onto the flat `RepoConfig`.
+            let mixed = parse_mixed(&config);
+
+            let repo_config = if mixed.is_some() {
+                None
+            } else {
+                Some(parse_config(&config).unwrap_or_else(|| {
+                    eprintln!("Unknown config: {}", config);
+                    eprintln!();
+                    eprintln!("Available configs:");
+                    eprintln!(
+                        "  typical-N       - Typical repo with N worktrees (500 commits, 100 files)"
+                    );
+                    eprintln!("  branches-N      - N branches with 1 commit each");
+                    eprintln!("  branches-N-M    - N branches with M commits each");
+                    eprintln!("  divergent       - 200 branches × 20 commits (GH #461 scenario)");
+                    eprintln!("  mixed-W-B       - W worktrees + B branches in varied states");
+                    eprintln!(
+                        "  picker-test     - Config for wt switch interactive picker testing"
+                    );
+                    std::process::exit(1);
+                }))
+            };
 
             let base_path = if let Some(p) = path {
                 std::fs::create_dir_all(&p).unwrap();
@@ -149,14 +163,24 @@ fn main() {
             };
 
             eprintln!("Creating {} repo...", config);
-            create_repo_at(&repo_config, &base_path);
+            let (worktrees, branches) = match (mixed, &repo_config) {
+                (Some((w, b)), _) => {
+                    create_mixed_repo_at(w, b, &base_path);
+                    (w, b)
+                }
+                (None, Some(cfg)) => {
+                    create_repo_at(cfg, &base_path);
+                    (cfg.worktrees, cfg.branches)
+                }
+                (None, None) => unreachable!("repo_config is Some when mixed is None"),
+            };
 
             let mut parts = vec![format!("main @ {}", base_path.display())];
-            if repo_config.worktrees > 1 {
-                parts.push(format!("{} worktrees", repo_config.worktrees));
+            if worktrees > 1 {
+                parts.push(format!("{} worktrees", worktrees));
             }
-            if repo_config.branches > 0 {
-                parts.push(format!("{} branches", repo_config.branches));
+            if branches > 0 {
+                parts.push(format!("{} branches", branches));
             }
             eprintln!("Created: {}", parts.join(", "));
             eprintln!();
@@ -217,6 +241,13 @@ fn main() {
             wt_args,
         } => run_timeline(cold, repo, chrome, &wt_args),
     }
+}
+
+/// Parse a `mixed-W-B` config string into `(worktrees, branches)`.
+fn parse_mixed(config: &str) -> Option<(usize, usize)> {
+    let rest = config.strip_prefix("mixed-")?;
+    let (w, b) = rest.split_once('-')?;
+    Some((w.parse().ok()?, b.parse().ok()?))
 }
 
 /// Resolve the `wt` binary as a sibling of the current executable


### PR DESCRIPTION
## What

A warm re-run of `wt list` (where `.git/wt/cache/` is already populated) is throughput / critical-path bound on per-worktree and per-branch git subprocesses. Two of worktrunk's three cache layers — `Arc<RepoCache>` and the process-global path/merge-base/commit-tree `DashMap`s — live in process memory and don't survive across invocations, so every re-run re-forks work that's content-addressed or already in hand. The "~1 ms recompute, not worth a disk file" assumption behind keeping merge-base and commit→tree in memory is false at scale on macOS (10–25 ms per fork × dozens of rows).

This eliminates three classes of those forks. On a 24-worktree / 120-branch mixed-state fixture, subprocess work drops **3629 ms → 1013 ms**; the criterion `rerun_warm` benchmark goes **212 → 135 ms median** (−36%, p<0.05). What remains is the irreducible working-tree floor — per-worktree `git status`, and `add -A`/`diff`/`write-tree` for dirty worktrees — which depends on live working-tree state and genuinely can't be cached.

## The three changes

1. **`%T` primes the commit→tree cache** (`diff.rs`). The pre-skeleton `git log --no-walk` batch already resolves each commit for `%ct`; adding `%T` rides along for free and primes `commit_tree`, so the per-row `CommittedTreesMatch` / `WouldMergeAdd` tree lookups never fork `git rev-parse <sha>^{tree}`.
2. **Persist merge-base** (`sha_cache.rs`, `diff.rs`). New content-addressed `merge-base/` sha_cache kind (in-memory front over disk back) plus a `sha1 == sha2` short-circuit. The `AheadBehind` orphan check forked `git merge-base` per row even when ahead/behind counts were already cache-warm; now it's a file read on re-runs.
3. **Prime worktree root/git-dir** (`mod.rs`, `collect/mod.rs`). `git worktree list` already gives every worktree's path; seeding `WORKTREE_ROOTS`/`GIT_DIRS` from it (git-dir read from each `.git` entry, mirroring `prewarm_rev_parse`'s canonicalization) eliminates the per-worktree `git rev-parse --show-toplevel` / `--git-dir` forks. Runs post-skeleton — its values are consumed only by the worker pool, so it stays off the skeleton critical path and is skipped under `WORKTRUNK_SKELETON_ONLY` (measured: skeleton time unchanged at 24.4 ms).

All three are behavior-preserving: caches are content-addressed and never stale, and any value that can't be derived cleanly falls back to the original subprocess.

## Benchmark

Adds `cargo bench --bench list rerun_warm` (24 worktrees + 120 branches in varied states: clean / unstaged / staged+untracked worktrees; merged / ahead / diverged / identical branches), a reusable `wt_perf::create_mixed_repo` fixture, and a `wt-perf setup mixed-W-B` config. The existing list benches are warm-capable but each cover worktrees-only or branches-only in a single uniform state. A `TODO(bench-full-combined)` marks consolidating these into one cold+warm "full" scenario with per-feature trace attribution.

## Reviewer orientation

- Cache mechanics: `src/git/repository/sha_cache.rs` (new kind) and the `# Caching` docstring in `src/git/repository/mod.rs` (updated to document the in-memory-front-over-disk-back decision and correct the stale cost premise).
- The list-collect path: `src/commands/list/collect/mod.rs` module docstring (caching table + `%T` fork doc updated).
- Tests: cache priming, merge-base roundtrip (incl. orphan), and a prime-vs-subprocess equivalence test that pins the derived git-dir against the real `git rev-parse` across main + linked worktrees.

> _This was written by Claude Code on behalf of max_
