### PR TITLE
Release v0.64.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## 0.64.0
+
+### Improved
+
+- **`{{ git.branch.* }}` template namespace for custom columns**: `wt list` custom columns can now read a branch's own git config via `{{ git.branch.<key> }}` — both convention keys you set yourself (`branch.<name>.jira`) and the git-native `branch.<name>.description` — without re-storing the values through `wt config state vars set`. It complements `{{ vars.* }}`, which reads only worktrunk's own state namespace. ([#3319](https://github.com/max-sixty/worktrunk/pull/3319), thanks @cazador481 for the request)
+
+- **Faster warm-cache `wt list` re-runs**: A repeat `wt list` (with `.git/wt/cache/` already populated) is ~36% faster, by removing redundant per-row git subprocesses — priming the commit→tree cache from the `%ct` batch already issued, persisting merge-base results to a content-addressed on-disk cache, and seeding worktree roots and git-dirs from the single `git worktree list` instead of re-forking `git rev-parse` per worktree. ([#3334](https://github.com/max-sixty/worktrunk/pull/3334))
+
+### Fixed
+
+- **Refs that look like flags can't inject git options**: `wt`'s `git diff` previews and diffstats (picker diff previews, `show_diffstat`, push diffstat) now fence user-controlled refs behind `--end-of-options`, and branch removal (`git branch -D`) passes them after `--`, so a branch literally named like a flag (`-x`, `--foo`) reaches git as a positional ref instead of being misparsed as an option. ([#3317](https://github.com/max-sixty/worktrunk/pull/3317))
+
+- **Statusline renders untruncated when `COLUMNS=0`**: `wt list statusline` treated `COLUMNS=0` as a zero-width budget and dropped every segment, rendering an empty line. A zero or unparseable `COLUMNS` is now treated as no detectable width, so the line renders everything untruncated — as the statusline sizing already documented for a missing width. ([#3318](https://github.com/max-sixty/worktrunk/pull/3318))
+
+- **Watchdog "still waiting" line uses the hint symbol**: The transient `Waiting for the commit message (Ns)` line shown during a slow `wt step commit` LLM call now uses the hint prefix (`↳`) instead of the info symbol (`○`), matching the convention for fully-dim status lines. ([#3330](https://github.com/max-sixty/worktrunk/pull/3330))
+
 ## 0.63.0
 
 ### Improved

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@
 
 - **Refs that look like flags can't inject git options**: `wt`'s `git diff` previews and diffstats (picker diff previews, `show_diffstat`, push diffstat) now fence user-controlled refs behind `--end-of-options`, and branch removal (`git branch -D`) passes them after `--`, so a branch literally named like a flag (`-x`, `--foo`) reaches git as a positional ref instead of being misparsed as an option. ([#3317](https://github.com/max-sixty/worktrunk/pull/3317))
 
-- **Statusline renders untruncated when `COLUMNS=0`**: `wt list statusline` treated `COLUMNS=0` as a zero-width budget and dropped every segment, rendering an empty line. A zero or unparseable `COLUMNS` is now treated as no detectable width, so the line renders everything untruncated — as the statusline sizing already documented for a missing width. ([#3318](https://github.com/max-sixty/worktrunk/pull/3318))
+- **Statusline renders untruncated when `COLUMNS=0`**: `wt list statusline` treated `COLUMNS=0` as a zero-width budget and dropped every segment, rendering an empty line. A zero or unparsable `COLUMNS` is now treated as no detectable width, so the line renders everything untruncated — as the statusline sizing already documented for a missing width. ([#3318](https://github.com/max-sixty/worktrunk/pull/3318))
 
 - **Watchdog "still waiting" line uses the hint symbol**: The transient `Waiting for the commit message (Ns)` line shown during a slow `wt step commit` LLM call now uses the hint prefix (`↳`) instead of the info symbol (`○`), matching the convention for fully-dim status lines. ([#3330](https://github.com/max-sixty/worktrunk/pull/3330))
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5475,7 +5475,7 @@ dependencies = [
 
 [[package]]
 name = "worktrunk"
-version = "0.63.0"
+version = "0.64.0"
 dependencies = [
  "ansi-str",
  "ansi-to-html",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ filterset = "test(/readme_sync/)"
 
 [package]
 name = "worktrunk"
-version = "0.63.0"
+version = "0.64.0"
 edition = "2024"
 rust-version = "1.95"
 build = "build.rs"


### PR DESCRIPTION
Release v0.64.0. Folds the version bump (`Cargo.toml`, `Cargo.lock`) and the `CHANGELOG.md` section into one commit.

A small release on top of v0.63.0: a new per-branch git-config template namespace for `wt list` custom columns, a warm-cache `wt list` speedup, and a few correctness/safety fixes.

**Improved**: a `{{ git.branch.* }}` template namespace lets custom columns read a branch's own git config (`branch.<name>.jira`, the git-native `description`) without re-storing via `wt config state vars set` (thanks @cazador481 for the request); warm-cache `wt list` re-runs are ~36% faster after removing redundant per-row git forks (commit→tree priming, a persistent merge-base cache, and seeded worktree paths).

**Fixed**: refs that look like flags can no longer inject git options (`--end-of-options` / `--` fencing across diff previews, diffstats, and branch removal); `wt list statusline` renders untruncated when `COLUMNS=0` instead of collapsing to an empty line; the watchdog "still waiting" line uses the hint symbol (`↳`).

The release-process data-loss surface review (four independent finders over the full `v0.63.0..HEAD` diff) found no data-loss risk introduced. The one candidate — a new persistent merge-base cache that feeds the branch-deletion safety verdict — was adjudicated acceptable: the verdict's direct input (`has-added-changes`) was already a content-addressed, SHA-keyed persistent cache before this release, so the merge-base cache extends an accepted pattern rather than introducing a new risk class.

> _This was written by Claude Code on behalf of max_
