### PR TITLE
ci: watch nightly in Tend; issue on full-tests failure; release runs nightly

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -20,7 +20,10 @@ metadata:
    - Cross-platform: dispatch the `nightly` workflow on the cut-from tip and wait for it to go green. This is where a release gets its full linux/macos/windows validation: the PR path (`ci.yaml`) is moving to cargo-affected selection and will stop running the full `test` matrix, while `nightly` hosts `full-tests` (the full 3-OS suite) alongside feature-powerset, release-target, nix-flake, and minimal-versions. Benchmarks aren't part of `nightly` — they run in their own `benchmarks.yaml` and gate nothing.
      ```bash
      gh workflow run nightly.yaml --ref main
-     RUN=$(gh run list --workflow=nightly.yaml --event=workflow_dispatch --branch=main --limit 1 --json databaseId --jq '.[0].databaseId')
+     # Registration lags the dispatch, and a prior release may have left a
+     # stale completed workflow_dispatch run — filter to the in-flight one.
+     sleep 5
+     RUN=$(gh run list --workflow=nightly.yaml --event=workflow_dispatch --branch=main --limit 5 --json databaseId,status --jq 'map(select(.status != "completed")) | .[0].databaseId')
      ```
      Launch a ci-reporter to monitor `$RUN` to completion (avoid `gh run watch` — it can hang). Fix any failure before continuing.
 3. **Check current version**: Read `version` in `Cargo.toml`

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -15,7 +15,14 @@ metadata:
    git merge --ff-only origin/main
    ```
    `--ff-only` advances the branch when it's a strict ancestor of `origin/main` and **fails** (rather than creating a merge commit or discarding work) if it has diverged — reconcile manually before continuing. This is the release-branch equivalent of `wt up`, spelled out because the `up` alias rebases each branch onto its own upstream (`origin/release`), not `main`. Note the resulting commit SHA: this is the tip the changelog covers, and step 12 checks that nothing else reaches `main` before the tag.
-2. **Run tests**: `cargo run -- hook pre-merge --yes`
+2. **Run tests**: Two gates — the local suite and the full cross-platform suite.
+   - Local: `cargo run -- hook pre-merge --yes`.
+   - Cross-platform: dispatch the `nightly` workflow on the cut-from tip and wait for it to go green. This is where a release gets its full linux/macos/windows validation: the PR path (`ci.yaml`) is moving to cargo-affected selection and will stop running the full `test` matrix, while `nightly` hosts `full-tests` (the full 3-OS suite) alongside feature-powerset, release-target, nix-flake, and minimal-versions. Benchmarks aren't part of `nightly` — they run in their own `benchmarks.yaml` and gate nothing.
+     ```bash
+     gh workflow run nightly.yaml --ref main
+     RUN=$(gh run list --workflow=nightly.yaml --event=workflow_dispatch --branch=main --limit 1 --json databaseId --jq '.[0].databaseId')
+     ```
+     Launch a ci-reporter to monitor `$RUN` to completion (avoid `gh run watch` — it can hang). Fix any failure before continuing.
 3. **Check current version**: Read `version` in `Cargo.toml`
 4. **Review commits**: Check commits since last release to understand scope of changes. Audit the cumulative diff for the data-loss surface (see [Data-Loss Surface Review](#data-loss-surface-review)) before proceeding.
 5. **Check library API compatibility**: Run `cargo semver-checks check-release -p worktrunk` (install with `cargo install cargo-semver-checks --locked` if missing). If it reports breaking changes, the bump must be minor (pre-1.0) or major (post-1.0). See "Library API Compatibility" below.

--- a/.config/tend.yaml
+++ b/.config/tend.yaml
@@ -9,3 +9,9 @@ workflows:
     watched_workflows:
     - ci
     - publish-docs
+    # nightly hosts `full-tests` (the cargo-affected safety net), so a red
+    # nightly is actionable: Tend fixes it instead of leaving main's gaps
+    # uncaught. Tend watches at the workflow level, so this also signs Tend up
+    # for the other nightly jobs (minimal-versions, nix-flake, udeps) — an
+    # accepted trade for keeping the safety net green.
+    - nightly

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -384,6 +384,7 @@ jobs:
   create-issue-on-nightly-failure:
     needs:
       - feature-powerset
+      - full-tests
       - release-target
       - check-unused-dependencies
       - minimal-versions

--- a/.github/workflows/tend-ci-fix.yaml
+++ b/.github/workflows/tend-ci-fix.yaml
@@ -9,7 +9,7 @@
 name: tend-ci-fix
 on:
   workflow_run:
-    workflows: ["ci", "publish-docs"]
+    workflows: ["ci", "publish-docs", "nightly"]
     types: [completed]
     branches: ["main"]
 


### PR DESCRIPTION
Follow-up to #3332 (fast-checks split + nightly `full-tests`), landing the monitoring/wiring that makes `nightly` a reliable safety net for the cargo-affected rollout. The benchmarks-split half of the original follow-up was dropped — #3337 did it independently, and more completely.

## What changed

- **Tend watches `nightly`** (`.config/tend.yaml` + the generated `tend-ci-fix.yaml`). `nightly` hosts `full-tests` (the full 3-OS suite that catches what cargo-affected under-selects), so a red nightly is actionable — Tend now opens a fix PR instead of leaving it silent. #3339's 0.1.9 regen left the watched list at `[ci, publish-docs]`; this adds `nightly`. Tend watches at the workflow level, so it also covers the other nightly jobs (minimal-versions, nix-flake, udeps).
- **`create-issue-on-nightly-failure` now needs `full-tests`**, so a cron `full-tests` failure files a tracking issue (neither #3332 nor #3337 wired it in).
- **The `release` skill dispatches `nightly`** (benchmark-free) and waits on it — a release's full linux/macos/windows validation once the PR path moves to cargo-affected selection and stops running the full `test` matrix.

## Notes

- The generated `tend-ci-fix.yaml` line was hand-applied to match `.config/tend.yaml`; a `uvx tend@latest init` regen reproduces it.
- Trade-off: watching `nightly` at the workflow level also signs Tend up for the noisier nightly jobs (resolution drift, nix sandbox). Accepted to keep the safety net green.

## Testing

CI-config plus one skill; validated with `actionlint` and pre-commit. The Tend trigger and the release step only exercise on a real nightly failure / release run.

> _This was written by Claude Code on behalf of max_
