### PR TITLE
docs(skills): make /wt-switch-create worktree creation unconditional

### DIFF
--- a/skills/wt-switch-create/SKILL.md
+++ b/skills/wt-switch-create/SKILL.md
@@ -33,7 +33,9 @@ branch-shaped lead — all task).
 
 ## What to do
 
-Steps 1–3 come before any other work.
+Steps 1–3 run on every invocation, before any other work. The invocation is
+itself the explicit request to create the worktree; a research or read-only
+task gets one all the same.
 
 <!-- Maintainers: rationale.md (same directory) covers the harness rules and
 design choices behind this — read it before re-adding guards or routes. -->
@@ -99,6 +101,6 @@ entered by `path`, so removal is always `wt remove <branch>`.
 
 ## Scope
 
-This command authorizes creating/entering ONE worktree (in the named repo, if
-one was given) and doing the requested task. Commits, pushes, and merges still
-each require explicit user permission.
+The command's mandate is ONE worktree (in the named repo, if one was given)
+and the requested task inside it. Commits, pushes, and merges still each
+require explicit user permission.

--- a/skills/wt-switch-create/rationale.md
+++ b/skills/wt-switch-create/rationale.md
@@ -36,6 +36,17 @@ deliberately omitted — they re-minify every build.
 Two independent harness facts underlie this — re-root is repo-scoped, and `cd`
 persistence is working-directory-membership-scoped — detailed below.
 
+## Why creation is unconditional
+
+The recurring failure: handed a research or read-only task, the model decided
+it didn't need isolation and skipped creation. Two wordings fed that. Scope's
+"authorizes" read as permission, inviting a should-I test (user-level rules
+that gate worktree creation behind an explicit request answer it "no"); an
+ordering-only lead ("steps 1–3 come first") doesn't bind a model that decided
+the steps don't apply. So the lead makes the invocation the explicit request
+itself, and Scope states bounds rather than permission. Don't reintroduce
+either wording.
+
 ## wt CLI and git behavior (all live-tested)
 
 - `wt switch --create <branch>` exits 1 with `✗ Branch <branch> already


### PR DESCRIPTION
`/wt-switch-create` too often skipped creating the worktree, judging that a research or read-only task didn't need isolation. Two wordings invited that: the lead was only an ordering rule ("steps 1–3 come before any other work"), and Scope's "authorizes" read as permission, prompting a should-I test that user-level rules gating worktree creation behind explicit request answer with "no".

The lead now states that invoking the command is itself the explicit request (a research task gets a worktree all the same), Scope states the mandate's bounds without permission language, and rationale.md records the failure mode so the wording isn't softened back.

Prose-only; no code or generated docs touched.

> _This was written by Claude Code on behalf of max_
