### PR TITLE
fix(bench): restore worktree indexes after cache invalidation

### DIFF
--- a/benches/CLAUDE.md
+++ b/benches/CLAUDE.md
@@ -113,6 +113,20 @@ User state — `worktrunk.history`, `worktrunk.hints.*`, `worktrunk.state.<branc
 read-path performance and benches may depend on it (e.g., branch markers set during
 setup).
 
+**Deleting a worktree's index isn't a cold cache.** Git treats a missing index
+as empty, so `git status` reports every tracked file as a staged deletion — a
+*different repo state*, which flips any clean-worktree gate a benchmarked
+command exercises (e.g. `wt step prune`'s removability check would silently
+drop every worktree candidate). A benchmark exercising such a gate must pair
+`invalidate_caches_auto` with `wt_perf::restore_worktree_indexes`, which
+`git reset -q`s every worktree back to a clean `git status` while leaving the
+integration probes cold. It's a separate call, not folded into
+`invalidate_caches_auto`, because `git reset --mixed` discards
+staged-but-uncommitted index state that some fixtures plant on purpose (and
+that a real repo targeted by `wt-perf invalidate` / `timeline --cold` may hold
+as genuine work in progress) — pair it only with fixtures whose dirt is
+untracked files.
+
 **Which commands populate `.git/wt/cache/`:**
 
 | Command | Populates? | Notes |

--- a/tests/helpers/wt-perf/src/lib.rs
+++ b/tests/helpers/wt-perf/src/lib.rs
@@ -388,6 +388,35 @@ pub fn invalidate_caches_auto(repo_path: &Path) {
     }
 }
 
+/// Rebuild every worktree's index after [`invalidate_caches_auto`].
+///
+/// Deleting an index doesn't model a cold cache — git treats a missing index
+/// as empty, so `git status` reports every tracked file as a staged deletion.
+/// That is a *different repo state*, and it flips any clean-worktree gate:
+/// `wt step prune`'s removability check drops all worktree candidates against
+/// such a worktree. Benches that exercise those gates call this after
+/// invalidation; `git reset -q` rewrites the index from HEAD, leaving the
+/// integration probes cold but the working trees reading clean again.
+///
+/// This is deliberately NOT folded into `invalidate_caches_auto`: `git reset
+/// --mixed` discards staged-but-uncommitted index state, which the mixed
+/// fixture plants on purpose (worktree state 2) and which a real repo — the
+/// `wt-perf invalidate` / `timeline --cold` targets — may hold as the user's
+/// work in progress. Only pair it with fixtures whose dirt is untracked files.
+pub fn restore_worktree_indexes(repo_path: &Path) {
+    let output = git_command()
+        .args(["worktree", "list", "--porcelain"])
+        .current_dir(repo_path)
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "git worktree list failed");
+    for line in String::from_utf8_lossy(&output.stdout).lines() {
+        if let Some(path) = line.strip_prefix("worktree ") {
+            run_git(Path::new(path), &["reset", "-q"]);
+        }
+    }
+}
+
 /// Resolve git's common directory for `repo_path` from the filesystem.
 ///
 /// - Normal repo: `<repo>/.git` is a directory — use it directly.


### PR DESCRIPTION
## Summary

Deleting a worktree's `.git/index` isn't a cold cache: git treats a missing index as empty, so `git status` reports every tracked file as a staged deletion — a different repo state, not a cold cache. That flips any clean-worktree gate a benchmarked command exercises (e.g. `wt step prune`'s removability check would silently drop every worktree candidate against such a worktree; verified empirically on a `timeline --cold` prune run).

Adds `wt_perf::restore_worktree_indexes`, which `git reset -q`s every worktree back to a clean `git status` after `invalidate_caches_auto`, and documents the trap in `benches/CLAUDE.md`.

`restore_worktree_indexes` has no callers on this branch yet — an upcoming prune-benchmark branch is its first consumer.

## Test plan

- [x] `cargo build -p wt-perf` — clean, no warnings
- [x] `cargo clippy -p wt-perf --all-targets` — clean
- [x] `cargo run -- hook pre-merge --yes` — all pre-commit hooks, fmt, clippy, full nextest suite (4309 passed), doctests, and docs pass

> _This was written by Claude Code on behalf of Maximilian Roos_