### PR TITLE
fix(git): support custom SCP-style SSH users

### DIFF
--- a/src/git/url.rs
+++ b/src/git/url.rs
@@ -1,7 +1,7 @@
 //! Git remote URL parsing.
 //!
 //! Parses git remote URLs into structured components (host, owner, repo).
-//! Supports HTTPS, SSH, and git@ URL formats.
+//! Supports HTTPS, SSH, and SCP-style SSH URL formats.
 
 use schemars::JsonSchema;
 use serde::Serialize;
@@ -93,7 +93,7 @@ impl From<CiPlatform> for GitRepoProvider {
 /// - `https://<host>/<namespace>/<repo>.git`
 /// - `http://<host>/<namespace>/<repo>.git`
 /// - `git://<host>/<namespace>/<repo>.git`
-/// - `git@<host>:<namespace>/<repo>.git`
+/// - `<user>@<host>:<namespace>/<repo>.git`
 /// - `ssh://git@<host>/<namespace>/<repo>.git`
 /// - `ssh://git@<host>:<port>/<namespace>/<repo>.git`
 /// - `ssh://<host>/<namespace>/<repo>.git`
@@ -190,10 +190,15 @@ impl GitRemoteUrl {
             let host = host_with_port.split(':').next().unwrap_or(host_with_port);
             let (namespace, repo) = split_namespace_repo(path)?;
             (host, namespace, repo)
-        } else if let Some(rest) = url.strip_prefix("git@") {
-            // git@github.com:owner/repo.git
-            // git@gitlab.com:group/subgroup/repo.git
-            let (host, path) = rest.split_once(':')?;
+        } else if let Some((authority, path)) = url.split_once(':')
+            && !authority.contains('/')
+        {
+            // SCP-style SSH: user@github.com:owner/repo.git
+            // Split the authority before looking for `@` so `@` remains valid in the path.
+            let (user, host) = authority.rsplit_once('@')?;
+            if user.is_empty() || host.is_empty() {
+                return None;
+            }
             let (namespace, repo) = split_namespace_repo(path)?;
             (host, namespace, repo)
         } else {
@@ -481,7 +486,7 @@ mod tests {
     }
 
     #[test]
-    fn test_git_at_urls() {
+    fn test_scp_style_ssh_urls() {
         let url = GitRemoteUrl::parse("git@github.com:owner/repo.git").unwrap();
         assert_eq!(url.project_identifier(), "github.com/owner/repo");
 
@@ -496,6 +501,31 @@ mod tests {
         // Bitbucket
         let url = GitRemoteUrl::parse("git@bitbucket.org:owner/repo.git").unwrap();
         assert!(url.project_identifier().starts_with("bitbucket.org/"));
+
+        // GitHub organization-scoped SSH certificate user
+        let url = GitRemoteUrl::parse("org-14957082@github.com:openai/codex.git").unwrap();
+        assert_eq!(
+            url,
+            GitRemoteUrl {
+                host: "github.com".to_string(),
+                owner: "openai".to_string(),
+                repo: "codex".to_string(),
+            }
+        );
+        assert_eq!(url.project_identifier(), "github.com/openai/codex");
+        assert_eq!(
+            url,
+            GitRemoteUrl::parse("https://github.com/openai/codex.git").unwrap()
+        );
+
+        // The final `@` separates the SSH user from the host.
+        let url = GitRemoteUrl::parse("alice@alias@github.com:owner/repo.git").unwrap();
+        assert_eq!(url.host(), "github.com");
+
+        // `@` in the repository path must not be treated as the user delimiter.
+        let url = GitRemoteUrl::parse("deploy@github.com:org@company/repo.git").unwrap();
+        assert_eq!(url.host(), "github.com");
+        assert_eq!(url.owner(), "org@company");
     }
 
     #[test]
@@ -563,6 +593,10 @@ mod tests {
         assert!(GitRemoteUrl::parse("https://github.com/owner/").is_none());
         assert!(GitRemoteUrl::parse("git@github.com:").is_none());
         assert!(GitRemoteUrl::parse("git@github.com:owner/").is_none());
+        assert!(GitRemoteUrl::parse("@github.com:owner/repo.git").is_none());
+        assert!(GitRemoteUrl::parse("user@:owner/repo.git").is_none());
+        assert!(GitRemoteUrl::parse("github.com:owner/repo.git").is_none());
+        assert!(GitRemoteUrl::parse("path/to/user@host:owner/repo.git").is_none());
         assert!(GitRemoteUrl::parse("ftp://github.com/owner/repo.git").is_none());
     }
 
@@ -930,6 +964,7 @@ mod tests {
             "https://gitlab.com/group/subgroup/repo.git",
             "https://gitlab.com/group/subgroup/repo",
             "git@gitlab.com:group/subgroup/repo.git",
+            "deploy@gitlab.com:group/subgroup/repo.git",
             "git@gitlab.com:group/subgroup/repo",
             "ssh://git@gitlab.com/group/subgroup/repo.git",
             "ssh://gitlab.com/group/subgroup/repo.git",

--- a/tests/integration_tests/repository.rs
+++ b/tests/integration_tests/repository.rs
@@ -275,6 +275,25 @@ fn test_project_identifier_ssh_colon() {
 }
 
 #[test]
+fn test_project_identifier_scp_custom_user() {
+    let mut repo = TestRepo::with_initial_commit();
+    repo.setup_remote("main");
+    repo.git_command()
+        .args([
+            "remote",
+            "set-url",
+            "origin",
+            "org-14957082@github.com:openai/codex.git",
+        ])
+        .run()
+        .unwrap();
+
+    let repository = Repository::at(repo.root_path().to_path_buf()).unwrap();
+    let id = repository.project_identifier().unwrap();
+    assert_eq!(id, "github.com/openai/codex");
+}
+
+#[test]
 fn test_project_identifier_ssh_protocol() {
     let mut repo = TestRepo::with_initial_commit();
     repo.setup_remote("main");

--- a/tests/integration_tests/switch.rs
+++ b/tests/integration_tests/switch.rs
@@ -2841,9 +2841,9 @@ fn test_switch_pr_create_conflict(#[from(repo_with_remote)] repo: TestRepo) {
     });
 }
 
-/// Test same-repo PR checkout (base.repo == head.repo)
+/// Test same-repo PR checkout with a custom SCP-style SSH user.
 #[rstest]
-fn test_switch_pr_same_repo(#[from(repo_with_remote)] mut repo: TestRepo) {
+fn test_switch_pr_same_repo_custom_ssh_user(#[from(repo_with_remote)] mut repo: TestRepo) {
     // Create a feature branch and push it to the remote
     repo.add_worktree("feature-auth");
     repo.run_git(&["push", "origin", "feature-auth"]);
@@ -2860,23 +2860,15 @@ fn test_switch_pr_same_repo(#[from(repo_with_remote)] mut repo: TestRepo) {
     .trim()
     .to_string();
 
-    // Set origin URL to GitHub-style so find_remote_for_repo() can match owner/test-repo
-    repo.run_git(&[
-        "remote",
-        "set-url",
-        "origin",
-        "https://github.com/owner/test-repo.git",
-    ]);
+    // GitHub requires this URL form when an organization enforces SSH certificates.
+    let github_url = "org-14957082@github.com:owner/test-repo.git";
+    repo.run_git(&["remote", "set-url", "origin", github_url]);
 
     // Configure git to redirect github.com URLs to the local bare remote.
     // This is necessary because:
     // 1. origin must have a GitHub URL for find_remote_for_repo() to match owner/repo
     // 2. But we need git fetch to actually succeed using the local bare remote
-    repo.run_git(&[
-        "config",
-        &format!("url.{}.insteadOf", bare_url),
-        "https://github.com/owner/test-repo.git",
-    ]);
+    repo.run_git(&["config", &format!("url.{}.insteadOf", bare_url), github_url]);
 
     // gh api repos/{owner}/{repo}/pulls/{number} format
     let gh_response = r#"{


### PR DESCRIPTION
## Why

Worktrunk currently recognizes SCP-style SSH remotes only when the username is literally `git`. GitHub configurations can use account or organization aliases such as `org-12345678@github.com:organization/repo.git`. Worktrunk fails to parse that remote canonically, so `wt switch pr:30479` fetches the PR metadata but then exits with `No remote found for openai/codex`.

## What changed

- Recognize any non-empty username in SCP-style SSH remotes while preserving the canonical host, namespace, and repository.
- Continue rejecting malformed, userless, and local-path forms that only resemble SCP syntax.
- Cover canonical project identifiers and same-repository PR switching with custom SSH usernames.

## How to Test

1. Configure a repository remote such as `org-14957082@github.com:openai/codex.git`.
2. Run `wt switch pr:<number>` for a pull request in that repository.
3. Confirm Worktrunk matches the local remote and switches to the PR branch instead of reporting `No remote found`.
4. Verify malformed SCP-style URLs and local paths remain rejected.

Targeted tests:

- `cargo test --lib git::url::tests`
- `cargo test --test integration project_identifier_scp_custom_user`
- `cargo test --test integration switch_pr_same_repo_custom_ssh_user`
