### PR TITLE
refactor(hook): share command-label rendering with approvals surfaces

### DIFF
--- a/src/commands/hook_commands.rs
+++ b/src/commands/hook_commands.rs
@@ -27,6 +27,7 @@ use super::command_executor::{
 };
 use super::context::CommandEnv;
 use super::hooks::{HookAnnouncer, prepare_and_check, run_hooks_foreground};
+use super::project_config::command_label;
 use super::template_vars::TemplateVars;
 
 fn run_post_hook(
@@ -614,11 +615,7 @@ fn render_hook_commands(
     }
 
     for cmd in commands {
-        // Build label: "hook-type name:" or "hook-type:"
-        let label = match &cmd.name {
-            Some(name) => cformat!("{hook_type} <bold>{name}</>:"),
-            None => format!("{hook_type}:"),
-        };
+        let label = command_label(hook_type, cmd.name.as_deref());
 
         // Check approval status for project hooks
         let needs_approval = if let Some((approvals, Some(project_id))) = approval_context {

--- a/src/commands/project_config.rs
+++ b/src/commands/project_config.rs
@@ -48,11 +48,7 @@ impl ApprovableCommand {
     /// `phase name:` label shown before the command body, in the approval
     /// prompt and the approvals listing.
     pub fn label(&self) -> String {
-        let phase = &self.phase;
-        match &self.command.name {
-            Some(name) => cformat!("{phase} <bold>{name}</>:"),
-            None => format!("{phase}:"),
-        }
+        command_label(&self.phase, self.command.name.as_deref())
     }
 
     /// Gutter-formatted template. Shell commands get bash syntax
@@ -63,6 +59,16 @@ impl ApprovableCommand {
             Phase::CommitTemplateAppend => format_with_gutter(&self.command.template, None),
             _ => format_bash_with_gutter(&self.command.template),
         }
+    }
+}
+
+/// `phase name:` label shown before a command body. Free-standing rather
+/// than a method on [`ApprovableCommand`] so `wt hook show` can label user
+/// hooks, which are never approvable.
+pub fn command_label(phase: impl fmt::Display, name: Option<&str>) -> String {
+    match name {
+        Some(name) => cformat!("{phase} <bold>{name}</>:"),
+        None => format!("{phase}:"),
     }
 }
 


### PR DESCRIPTION
Follow-up to #3380: `wt hook show` still hand-built the `{phase} name:` command label that `ApprovableCommand::label()` renders for the approval prompt and `wt config approvals`. This extracts the format into a `command_label` free function in `project_config.rs` and calls it from both. It's free-standing rather than a method on `ApprovableCommand` because hook show also labels user hooks, which are never approvable.

Output is byte-identical — no snapshot changes.

> _This was written by Claude Code on behalf of max_
