### PR TITLE
ci: move lychee link check to the nightly workflow

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -108,12 +108,13 @@ Before opening a `fix/ci-*` PR, classify the failure:
 **Non-required ≠ transient.** A non-required job (e.g. `collect affected coverage`, `affected tests (linux, advisory)`) can fail from a real regression. The required/non-required distinction is about merge-blocking, not about how the failure is classified. If a deterministic build error (`error[E...]`, "binary not found", "ambiguous candidates", missing target) repeats across consecutive runs of the same shape, it's a real regression even when the job is advisory. Reserve "transient" for non-deterministic causes: `BrokenPipe`, `connection reset`, runner disk full, GitHub API timeouts, host-availability blips.
 
 **Lychee link-check timeouts are always transient** unless the same URL has
-failed on at least two separate runs within the last few days. `.config/lychee.toml`
+failed on at least two separate runs within the last few days. The check runs
+as the `link-check` job in the `nightly` workflow. `.config/lychee.toml`
 already sets `max_retries = 6` and lists known-unreliable hosts; one timeout
 is not enough evidence to extend that list. Signals you have a transient
 failure, not a broken link:
 
-- The previous CI run on the same or a nearby commit passed.
+- The previous run on the same or a nearby commit passed.
 - Only `[TIMEOUT]` is reported (not `404`/`403`/`410`).
 - The URL is reachable from a local `curl`.
 

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -21,7 +21,7 @@ sync = 'if [ "{{ target }}" = "main" ]; then git pull && git push; fi'
 # `--workspace` reconciles the lock against the manifests only; plain
 # `cargo update --locked` would also fail on dependencies merely behind latest.
 lockfile = "cargo update --workspace --locked"
-pre-commit = 'if [ -n "$MSYSTEM" ]; then SKIP=lychee-system pre-commit run --all-files; else pre-commit run --all-files; fi'
+pre-commit = "pre-commit run --all-files"
 insta = """RUSTFLAGS='-D warnings' NEXTEST_NO_INPUT_HANDLER=1 cargo insta test --test-runner nextest --dnd --check $([ "$(uname)" = 'Linux' ] && echo '--unreferenced reject') --features shell-integration-tests"""
 doctest = "RUSTDOCFLAGS='-Dwarnings' cargo test --doc"
 doc = "RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps --document-private-items"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -23,8 +23,6 @@ env:
   # with no benefit. Especially impactful on Windows where I/O is the bottleneck.
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: -C debuginfo=0
-  # Authenticate lychee requests to GitHub to avoid rate limiting
-  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
   lint:
@@ -40,12 +38,6 @@ jobs:
         # supply), gated to main so PRs restore but never write.
         cache-bin: "false"
         save-if: ${{ github.ref == 'refs/heads/main' }}
-
-    - name: Install lychee
-      uses: baptiste0928/cargo-install@v3
-      with:
-        crate: lychee
-        version: "=0.24.2"
 
     - name: 🔍 Pre-commit hooks
       uses: pre-commit/action@v3.0.1

--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -9,6 +9,7 @@ name: nightly
 #   - minimal-versions: cargo check against minimum-version dep resolution
 #   - nix-flake: nix flake check (packaging-environment bugs, motivated by #2624)
 #   - crate-build: build the crates.io archive with no `.git` (faithful #3123 repro)
+#   - link-check: lychee over tracked .md/.txt files (external-link volatility)
 #
 # Runs daily on cron, on demand via workflow_dispatch, on pushes to main that
 # touch dependency or toolchain files, and on PRs that either (a) touch the
@@ -352,6 +353,35 @@ jobs:
     - name: 🧪 Build crates.io archive without .git
       run: cargo test --test integration crate_io_archive_builds_and_versions_without_git -- --ignored
 
+  link-check:
+    # The pre-commit `lychee-system` hook (manual stage) over every tracked
+    # .md/.txt file. It lives here, not in PR CI: link health depends on the
+    # outside world (429s, bot-blocking, transient outages), so it was the
+    # flakiest PR check — and link rot isn't PR-correlated anyway; links
+    # break when external sites change, not when code does. A failure opens
+    # the nightly-failure issue instead of reddening an unrelated PR.
+    needs: gate
+    if: needs.gate.outputs.run == 'true'
+    runs-on: ubuntu-24.04
+    env:
+      # Authenticate lychee requests to GitHub to avoid rate limiting
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+    - name: 📂 Checkout code
+      uses: actions/checkout@v7
+
+    - name: Install lychee
+      uses: baptiste0928/cargo-install@v3
+      with:
+        crate: lychee
+        version: "=0.24.2"
+
+    - name: 🔗 Check links
+      # Through pre-commit so file selection (the `files` regex, symlink
+      # exclusion) has one definition; the manual stage keeps it out of the
+      # PR `lint` job and local `pre-commit run --all-files`.
+      run: pipx run pre-commit run lychee-system --all-files --hook-stage manual
+
   nix-flake:
     # Build and test under the nix sandbox so packaging-environment bugs
     # surface before a release / nixpkgs maintainer hits them. See #2624 for
@@ -390,6 +420,7 @@ jobs:
       - minimal-versions
       - nix-flake
       - crate-build
+      - link-check
     if: always() && contains(needs.*.result, 'failure') && github.repository_owner == 'max-sixty' && github.event_name == 'schedule'
     runs-on: ubuntu-24.04
     permissions:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,7 +33,12 @@ repos:
     hooks:
       # Check links using .config/lychee.toml exclusions
       # Uses lychee-system (requires `cargo install lychee`) to avoid /bin/bash dependency on Windows
+      #
+      # Manual stage only: link health depends on external sites (429s,
+      # bot-blocking, link rot), so it runs as the `link-check` job in the
+      # nightly workflow, not on every commit/PR.
       - id: lychee-system
+        stages: [manual]
         files: '\.(md|txt)$'
         args:
           - --config=.config/lychee.toml
@@ -84,6 +89,5 @@ repos:
 
 ci:
   # pre-commit.ci doesn't have Rust toolchain, so skip Rust-specific hooks.
-  # Network access also isn't supported, so skip lychee-system.
-  skip: [fmt, clippy, lychee-system, cargo-lock]
+  skip: [fmt, clippy, cargo-lock]
   autoupdate_commit_msg: "chore: pre-commit autoupdate"


### PR DESCRIPTION
Moves the lychee link check out of PR CI into the `nightly` workflow. Link health depends on external sites (429s, bot-blocking, link rot), which made `lint` the flakiest PR check, and breakage isn't correlated with the PR that trips it: the most recent main run's lint job went red on the docs.anthropic.com restructure (fixed in #3399) with no code change involved.

The hook stays defined once in `.pre-commit-config.yaml`, moved to the `manual` stage, so the PR `lint` job, local `pre-commit run --all-files`, and the `wt merge` gate all skip it (the wt.toml Windows conditional existed only to skip lychee and collapses). The new `link-check` nightly job runs that stage with the pinned lychee and is wired into `create-issue-on-nightly-failure`, so breakage lands in the nightly-failure issue for tend instead of blocking unrelated PRs. Running through pre-commit rather than `git ls-files | xargs lychee` keeps file selection at one definition: pre-commit's `types: [file]` filter excludes the 16 tracked `.md`/`.txt` symlinks, which would otherwise false-positive on relative links resolved against the symlink's directory.

The trade: a PR that introduces a genuinely wrong URL now merges green and is caught up to a day later, asynchronously.

Verified locally that the default stage no longer selects the hook and that `pre-commit run lychee-system --all-files --hook-stage manual` reproduces the CI lint run's selection exactly (same two flagged inputs). The nightly job itself first runs on the next cron or a `workflow_dispatch`.

> _This was written by Claude Code on behalf of max_
