### PR TITLE
fix(nix): provide lsof to the flake's test sandbox

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -12,8 +12,8 @@ name: nightly
 #   - link-check: lychee over tracked .md/.txt files (external-link volatility)
 #
 # Runs daily on cron, on demand via workflow_dispatch, on pushes to main that
-# touch dependency or toolchain files, and on PRs that either (a) touch the
-# same dependency/toolchain files or (b) carry the `nightly` label. The
+# touch dependency, toolchain, or nix packaging files, and on PRs that either
+# (a) touch the same files or (b) carry the `nightly` label. The
 # label is the iteration knob for fixes targeting nightly-only failures
 # (e.g. nix-flake's sandbox suite); without it, contributors had to wait for
 # the cron run or `gh workflow run` manually. The cron still catches drift
@@ -33,6 +33,9 @@ on:
       - '**/Cargo.toml'
       - 'Cargo.lock'
       - 'rust-toolchain.toml'
+      - 'flake.nix'
+      - 'flake.lock'
+      - 'nix/**'
       - '.github/workflows/nightly.yaml'
   pull_request:
     branches: [main]
@@ -56,8 +59,8 @@ jobs:
     # Decides whether to run on PR events. Non-PR events (cron,
     # workflow_dispatch, push) pass through unconditionally. PR events
     # run when either the `nightly` label is attached OR the diff touches
-    # one of the dependency/toolchain files. The decision is exposed via
-    # `outputs.run`; downstream jobs gate on it.
+    # one of the dependency/toolchain/nix files. The decision is exposed
+    # via `outputs.run`; downstream jobs gate on it.
     #
     # `dorny/paths-filter` works against the GitHub API for PR events, so
     # no checkout step is needed.
@@ -76,6 +79,9 @@ jobs:
               - '**/Cargo.toml'
               - 'Cargo.lock'
               - 'rust-toolchain.toml'
+              - 'flake.nix'
+              - 'flake.lock'
+              - 'nix/**'
               - '.github/workflows/nightly.yaml'
       - id: decide
         run: |

--- a/flake.nix
+++ b/flake.nix
@@ -158,12 +158,14 @@
               src = pkgs.lib.cleanSource ./.;
               # Tests shell out to a few host tools — `git` for the harness,
               # `python3` for argv-quoting and post-start fixtures, `ps`
-              # (procps) for the pgid invariant test. Without these on PATH
+              # (procps) for the pgid invariant test, `lsof` for the
+              # `--reap` process-discovery test. Without these on PATH
               # the sandbox surfaces them as `No such file or directory`.
               nativeBuildInputs = commonArgs.nativeBuildInputs ++ [
                 pkgs.git
                 pkgs.python3
                 pkgs.procps
+                pkgs.lsof
               ];
             }
           );

--- a/tests/integration_tests/remove.rs
+++ b/tests/integration_tests/remove.rs
@@ -90,7 +90,10 @@ fn test_remove_reap_kills_process(mut repo: TestRepo) {
         .iter()
         .any(|p| p.pid == pid)
     {
-        assert!(Instant::now() < deadline, "child {pid} never discovered");
+        assert!(
+            Instant::now() < deadline,
+            "child {pid} never discovered — is lsof installed and able to read process cwds?"
+        );
         std::thread::sleep(Duration::from_millis(50));
     }
 


### PR DESCRIPTION
The nix-flake job has failed on main since #3396: `test_remove_reap_kills_process` discovers its child via `lsof -d cwd`, but the flake's `worktrunk-tests` check didn't provide `lsof`, so `processes_under` fails to spawn it, returns an empty list forever, and the test's 5s discovery poll panics with `child <pid> never discovered`. Failing main run: https://github.com/max-sixty/worktrunk/actions/runs/29066326142.

Three changes:

- `flake.nix`: add `pkgs.lsof` to the test check's inputs, the same pattern as `git`/`python3`/`procps`. `ps` (procps) already works in the sandbox, so /proc-based process inspection is available there and the test should be genuinely exercised rather than excluded.
- `.github/workflows/nightly.yaml`: add `flake.nix`, `flake.lock`, and `nix/**` to the trigger paths (push and PR gate). A flake change couldn't previously trigger the nix-flake job that validates it; this PR relies on the fixed trigger for its own validation.
- `tests/integration_tests/remove.rs`: point the discovery-timeout panic message at lsof, so the next environment missing it doesn't need re-diagnosing.

Validation: nix isn't available locally, so the proof is this PR's own nightly run going green on the nix-flake job.

> _This was written by Claude Code on behalf of max_
