### PR TITLE
skills(running-tend): drop case-specific example from root-cause section

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -224,20 +224,6 @@ good guidance — a zero-code-risk change can still steer users toward a
 collision-prone or lossy config. If you do recommend a config change,
 surface its downsides in the PR body up front, not only when challenged.
 
-Example (PR #3390 / issue #3389, maintainer-flagged bad case): triage of the
-`⚑` `branch_worktree_mismatch` flag — which fires when an external agent CLI
-checks branch `claude/frosty-kilby-92c7d3` into a directory named
-`frosty-kilby-92c7d3` — shipped a docs PR recommending
-`worktree-path = "{{ branch | basename }}"`. But `basename` is lossy:
-`alice/foo` and `bob/foo` both collapse to `foo` and collide on one
-directory, whereas the default `{{ branch | sanitize }}`
-(`sanitize_branch_name` in `src/config/expansion.rs`, swaps `/`→`-`) keeps
-them distinct (`alice-foo` / `bob-foo`). The proportionate fix was a code change
-teaching the path-match check to tolerate a dropped namespace prefix — not
-asking every affected user to adopt a lossy template. The PR presented
-`basename` as *the* fix and surfaced the collision downside only after the
-maintainer pushed back.
-
 ### Don't fix tests by adding skip guards
 
 When a test fails because production code or test setup can't handle some


### PR DESCRIPTION
Follow-up to #3414: drops the example paragraph citing PR #3390 / issue #3389 from the "Weigh the root-cause fix" section. Skills state the recurrence pattern generically; per-incident references require institutional memory the reader lacks and age into noise. The rule paragraph stands alone; the case remains documented in #3414 and the #3390 discussion.

> _This was written by Claude Code on behalf of max_
