### PR TITLE
refactor(plugin): adopt Claude's canonical manifest layout, convention-only discovery

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,7 +49,7 @@ Design proposals live in `design/` and are review-only: open a PR to discuss, th
 
 ## Plugin Layout
 
-Per-tool layout and path resolution (Claude/Codex/Gemini), the Codex no-hooks re-enablement conditions, the accepted `wt-switch-create` tradeoff, and `test_plugin_layout_is_consolidated`: `plugins/worktrunk/CLAUDE.md`.
+Per-tool layout and path resolution (Claude/Codex/Gemini), the convention-only Claude manifest, the Codex inline-hooks rationale, the accepted `wt-switch-create` tradeoff, and `test_plugin_layout_is_consolidated`: `plugins/worktrunk/CLAUDE.md`.
 
 ## Data Safety
 

--- a/plugins/worktrunk/.claude-plugin/plugin.json
+++ b/plugins/worktrunk/.claude-plugin/plugin.json
@@ -3,10 +3,5 @@
   "description": "Worktrunk is a CLI for Git worktree management, designed for parallel AI agent workflows. This plugin provides configuration guidance (LLM commit messages, project hooks, worktree paths) and automatic activity tracking (🤖/💬 indicators in `wt list` showing active Claude sessions).",
   "author": {
     "name": "Worktrunk"
-  },
-  "hooks": "./hooks/hooks.json",
-  "skills": [
-    "./skills/worktrunk",
-    "./skills/wt-switch-create"
-  ]
+  }
 }

--- a/plugins/worktrunk/CLAUDE.md
+++ b/plugins/worktrunk/CLAUDE.md
@@ -16,14 +16,14 @@ worktrunk/                          ← repo root = marketplace root
 ├── hooks/hooks.json                ← Gemini activity hooks (call the wt.sh below)
 ├── skills -> (this dir)            ← Gemini reads ${extensionPath}/skills = repo-root skills/
 └── plugins/worktrunk/              ← plugin root (Claude + Codex resolve source here)
-    ├── plugin.json                 ← Claude manifest (NO .claude-plugin/ wrapper —
-    │                                  the wrapper is marketplace-root-only)
+    ├── .claude-plugin/plugin.json  ← Claude manifest (metadata only — NO `hooks`
+    │                                  or `skills` keys; components load by
+    │                                  convention, see below)
     ├── .codex-plugin/plugin.json   ← Codex manifest (Codex's required wrapper)
-    ├── hooks/hooks.json            ← Claude activity + WorktreeCreate/Remove hooks
-    │                                  (the conventional path Claude Code's loader
-    │                                  discovers — a Claude-scoped filename is NOT
-    │                                  honored by the string-path override, see #3417;
-    │                                  Codex is kept off it by its inline manifest, #3362)
+    ├── hooks/hooks.json            ← Claude activity + WorktreeCreate/Remove hooks,
+    │                                  discovered by convention at this exact path
+    │                                  (#3417; Codex is kept off it by its inline
+    │                                  manifest, #3362)
     ├── hooks/wt.sh                 ← canonical hook shim; Claude reaches it via
     │                                  $CLAUDE_PLUGIN_ROOT, Codex via $PLUGIN_ROOT,
     │                                  Gemini via
@@ -37,14 +37,22 @@ worktrunk/                          ← repo root = marketplace root
 
 Path resolution differs by tool, all verified end-to-end against the real CLIs:
 
-- **Claude**: `.claude-plugin/marketplace.json` `source: "./plugins/worktrunk"`.
-  Claude reads `plugins/worktrunk/plugin.json` (at the plugin root, *not* a
-  `.claude-plugin/` subdir). `skills` paths in `plugin.json` resolve from the
-  plugin root, so `./skills/worktrunk` follows the `skills` symlink to the
-  repo-root `skills/worktrunk`. Hooks are different: Claude's loader discovers
-  them by **convention** at `hooks/hooks.json` and does not honor the
-  string-path `hooks` override for plugin loads, so the file must sit at that
-  conventional path (#3417) even though `plugin.json` still names it.
+- **Claude** (claude-cli 2.1.207): `.claude-plugin/marketplace.json` `source:
+  "./plugins/worktrunk"`. Claude reads
+  `plugins/worktrunk/.claude-plugin/plugin.json` — the same wrapper convention
+  as the marketplace root, and the only manifest location `claude plugin
+  validate` accepts (a bare `plugin.json` at the plugin root loads through an
+  undocumented fallback but fails validation). Components load by
+  **convention**, and the manifest must not name them:
+  - Hooks are discovered at `hooks/hooks.json`. The loader does not honor the
+    string-path `hooks` manifest override for plugin loads, so a renamed file
+    silently loads nothing (#3417) and a `hooks` key pointing at the
+    conventional path is dead config that can only mask a mislocated file.
+  - Skills are auto-discovered by scanning `skills/` for `<dir>/SKILL.md`; a
+    `skills` manifest array only *adds* directories to that scan, so listing
+    the defaults is redundant. The installer dereferences the `skills` symlink
+    into a real directory in the install cache.
+
   `$CLAUDE_PLUGIN_ROOT` is the plugin root.
 - **Codex**: `.agents/plugins/marketplace.json` `source` object
   `{ "source": "local", "path": "./plugins/worktrunk" }`. Codex reads
@@ -55,10 +63,12 @@ Path resolution differs by tool, all verified end-to-end against the real CLIs:
   directly and `hooks/hooks.json` (repo root) calls the canonical shim at
   `${extensionPath}/plugins/worktrunk/hooks/wt.sh`. No symlink or copy.
 
-Each Claude skill directory must be listed in `plugin.json`'s `skills` array
-(Claude has no auto-discovery — `test_plugin_layout_is_consolidated` enforces
-that every repo-root skill is listed); Codex and Gemini pick up the whole
-`skills/` dir (accepted tradeoff — see Known Limitations below).
+All three tools pick up the whole `skills/` directory (Claude and Codex through
+the symlink, Gemini directly), so a new repo-root skill ships everywhere with
+no manifest change — provided its directory contains a `SKILL.md`
+(`test_plugin_layout_is_consolidated` enforces that; a directory without one is
+silently ignored). Claude-only skills reach the other tools too (accepted
+tradeoff — see Known Limitations below).
 
 ## Known Limitations
 
@@ -77,10 +87,9 @@ The 💬 transitions overlap deliberately: `Notification` covers the documented 
 
 ### Codex activity hooks (marker persists after session end)
 
-The Claude manifest carries `hooks: "./hooks/hooks.json"` (a path); the Codex manifest carries `hooks` as an **inline object**, `{ "hooks": { … } }`, embedding a Codex-tailored hooks file directly. The distinction is deliberate:
+Claude's hooks live in the standalone `hooks/hooks.json` its loader discovers by convention (see Directory Layout above); the Codex manifest carries `hooks` as an **inline object**, `{ "hooks": { … } }`, embedding a Codex-tailored hooks file directly. The inline form is deliberate:
 
-- **Why the Claude file sits at the conventional `hooks/hooks.json`.** Claude Code's loader discovers plugin hooks by convention at `hooks/hooks.json`; it does **not** honor the string-path `hooks` override in `plugin.json` for plugin loads. A Claude-scoped filename (`hooks/claude-hooks.json`) therefore loads *nothing* — `/hooks` shows no worktrunk handlers and the 🤖/💬 markers stop updating, silently ([#3417](https://github.com/max-sixty/worktrunk/issues/3417)). So the file must live at the conventional path.
-- **Why inline for Codex, not a path or an absent key.** Claude and Codex share one payload dir, and Codex *also* auto-discovers `hooks/hooks.json` at the plugin root by convention (`DEFAULT_HOOKS_CONFIG_FILE`, the `None` branch of `load_plugin_hooks`) — which once surfaced Worktrunk's *Claude* events in a Codex session ([#3362](https://github.com/max-sixty/worktrunk/issues/3362)). The Codex manifest carries its own hooks **inline**, taking Codex's `Some(Inline)` branch (`resolve_manifest_hooks` in `codex-rs/core-plugins/src/manifest.rs`), which **overrides** convention discovery. The inline object is both the functional definition of the Codex-native events and the thing that keeps Codex off the shared `hooks/hooks.json`, so the two toolchains coexist on one file: Claude discovers it, Codex ignores it. (An earlier revision Claude-scoped the filename as belt-and-suspenders against #3362, but that broke Claude's discovery — #3417 — and the inline override already made it redundant.)
+- **Why inline for Codex, not a path or an absent key.** Claude and Codex share one payload dir, and Codex *also* auto-discovers `hooks/hooks.json` at the plugin root by convention (`DEFAULT_HOOKS_CONFIG_FILE`, the `None` branch of `load_plugin_hooks`) — which once surfaced Worktrunk's *Claude* events in a Codex session ([#3362](https://github.com/max-sixty/worktrunk/issues/3362)). The Codex manifest carries its own hooks **inline**, taking Codex's `Some(Inline)` branch (`resolve_manifest_hooks` in `codex-rs/core-plugins/src/manifest.rs`), which **overrides** convention discovery. The inline object is both the functional definition of the Codex-native events and the thing that keeps Codex off the shared `hooks/hooks.json`, so the two toolchains coexist on one file: Claude discovers it, Codex ignores it. (Scoping via the filename instead — `hooks/claude-hooks.json` — breaks Claude's discovery, [#3417](https://github.com/max-sixty/worktrunk/issues/3417); the inline override makes it unnecessary.)
 - **Why `$PLUGIN_ROOT`, not `$CLAUDE_PLUGIN_ROOT`.** Codex exports both to hook commands (`PLUGIN_ROOT` native, `CLAUDE_PLUGIN_ROOT` as an OOTB-compat alias — `codex-rs/hooks/src/engine/discovery.rs`). The Codex file uses the native `$PLUGIN_ROOT` so nothing Claude-branded appears in a Codex session.
 
 The events (Codex's `HookEventsToml` vocabulary, verified against `codex-rs/config/src/hook_config.rs`):

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -3977,21 +3977,24 @@ fn test_codex_plugin_metadata_is_valid_json() {
 /// third loader-mandated repo-root pointer (`gemini-extension.json` +
 /// `hooks/hooks.json` — Gemini hard-probes `${extensionPath}/{hooks,skills}/`
 /// at the extension root with no path indirection). Verified end-to-end
-/// against the real CLIs: Claude (claude-cli 2.1.x) wants its manifest at the
-/// plugin root with NO `.claude-plugin/` wrapper (`source:
-/// "./plugins/worktrunk"` + `<subdir>/.claude-plugin/` fails "Plugin not
-/// found"); Gemini (gemini-cli 0.42) resolves the extension at the repo root,
-/// so `${extensionPath}/skills/` is the real single-sourced repo-root
-/// `skills/` and its hooks call the canonical
+/// against the real CLIs: Claude (claude-cli 2.1.207) reads the manifest at
+/// `<plugin-root>/.claude-plugin/plugin.json` — the only location `claude
+/// plugin validate` accepts — and discovers components by convention: hooks
+/// at `hooks/hooks.json`, skills by scanning `skills/*/SKILL.md` (the
+/// installer dereferences the `skills` symlink into a real directory in the
+/// install cache). A marketplace install of exactly this shape loads the
+/// skills and fires the hooks with no component keys in the manifest. Gemini
+/// (gemini-cli 0.42) resolves the extension at the repo root, so
+/// `${extensionPath}/skills/` is the real single-sourced repo-root `skills/`
+/// and its hooks call the canonical
 /// `${extensionPath}/plugins/worktrunk/hooks/wt.sh` — no symlink, no bundled
 /// copy, and `gemini extensions install owner/repo` works natively.
 ///
 /// Duplicated strings can't be `include!`d into JSON, so this test is the
 /// drift guard: the Claude marketplace/manifest descriptions stay
 /// byte-identical, every product description shares the canonical opening
-/// sentence, and every repo-root skill is listed in the Claude manifest
-/// (Claude has no skill auto-discovery — an unlisted skill is silently
-/// dropped).
+/// sentence, and the Claude manifest carries no component-path keys
+/// (conventions are the single loading mechanism).
 #[test]
 fn test_plugin_layout_is_consolidated() {
     let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
@@ -4007,9 +4010,26 @@ fn test_plugin_layout_is_consolidated() {
     let claude_mkt = json(".claude-plugin/marketplace.json");
     assert_eq!(claude_mkt["plugins"][0]["source"], "./plugins/worktrunk");
 
-    // Claude manifest at the plugin root (no wrapper); hooks relative to it.
-    let claude = json("plugins/worktrunk/plugin.json");
-    assert_eq!(claude["hooks"], "./hooks/hooks.json");
+    // Claude manifest in the plugin's own `.claude-plugin/` wrapper — the
+    // only manifest location `claude plugin validate` accepts (a bare
+    // plugin.json at the plugin root loads through an undocumented runtime
+    // fallback but fails validation).
+    let claude = json("plugins/worktrunk/.claude-plugin/plugin.json");
+    assert!(
+        !root.join("plugins/worktrunk/plugin.json").exists(),
+        "the Claude manifest lives at .claude-plugin/plugin.json; a root-level \
+         plugin.json rides an undocumented fallback and fails `claude plugin validate`"
+    );
+    // The manifest carries metadata only; hooks and skills load by convention.
+    // The override keys are worse than redundant: the string-path `hooks`
+    // override is not honored for plugin loads (#3417), so a `hooks` key can
+    // only mask a mislocated file, and a `skills` array re-adds directories
+    // the default `skills/` scan already picks up.
+    assert!(
+        claude.get("hooks").is_none() && claude.get("skills").is_none(),
+        "the Claude manifest must not carry `hooks`/`skills` keys — components \
+         load by convention (hooks/hooks.json; skills/*/SKILL.md)"
+    );
     assert!(
         root.join("plugins/worktrunk/hooks/hooks.json").exists()
             && root.join("plugins/worktrunk/hooks/wt.sh").exists(),
@@ -4042,7 +4062,8 @@ fn test_plugin_layout_is_consolidated() {
     // the Claude manifest — they must stay byte-identical.
     assert_eq!(
         claude_mkt["plugins"][0]["description"], claude["description"],
-        ".claude-plugin/marketplace.json and plugins/worktrunk/plugin.json descriptions drifted"
+        ".claude-plugin/marketplace.json and plugins/worktrunk/.claude-plugin/plugin.json \
+         descriptions drifted"
     );
 
     // Gemini extension: manifest + hooks are loader-mandated repo-root
@@ -4084,23 +4105,29 @@ fn test_plugin_layout_is_consolidated() {
         "no bundled Gemini wt.sh — hooks reference the canonical worktrunk shim"
     );
 
-    // Claude has no skill auto-discovery, so every repo-root skill dir MUST be
-    // listed explicitly in plugin.json — otherwise a new skill is silently
-    // invisible to Claude while Codex/Gemini (whole-dir) pick it up.
-    let listed: std::collections::BTreeSet<&str> = claude["skills"]
-        .as_array()
-        .expect("plugin.json `skills` must be an array")
-        .iter()
-        .map(|v| v.as_str().unwrap())
-        .collect();
+    // Claude auto-discovers skills by scanning skills/ for <dir>/SKILL.md, so
+    // the invariants are structural: the plugin's skills/ is the symlink that
+    // single-sources the repo-root skills/ (checked on unix only — a Windows
+    // checkout without core.symlinks materializes it as a plain file), and
+    // every repo-root skill dir carries a SKILL.md, since the scan silently
+    // ignores a directory without one.
+    if cfg!(unix) {
+        let skills_link = root.join("plugins/worktrunk/skills");
+        assert!(
+            skills_link.is_symlink()
+                && dunce::canonicalize(&skills_link).unwrap()
+                    == dunce::canonicalize(root.join("skills")).unwrap(),
+            "plugins/worktrunk/skills must be the symlink single-sourcing the \
+             repo-root skills/"
+        );
+    }
     for entry in fs::read_dir(root.join("skills")).unwrap() {
         let entry = entry.unwrap();
         if entry.file_type().unwrap().is_dir() {
-            let listed_form = format!("./skills/{}", entry.file_name().to_string_lossy());
             assert!(
-                listed.contains(listed_form.as_str()),
-                "repo-root skill {listed_form} is not in plugins/worktrunk/plugin.json \
-                 `skills` (Claude has no auto-discovery — add it or it is silently dropped)"
+                entry.path().join("SKILL.md").exists(),
+                "skills/{} has no SKILL.md — Claude's convention scan silently ignores it",
+                entry.file_name().to_string_lossy()
             );
         }
     }
@@ -4159,7 +4186,10 @@ fn test_plugin_layout_is_consolidated() {
         "Worktrunk is a CLI for Git worktree management, designed for parallel AI agent workflows.";
     let codex = json("plugins/worktrunk/.codex-plugin/plugin.json");
     for (label, val) in [
-        ("plugins/worktrunk/plugin.json", &claude["description"]),
+        (
+            "plugins/worktrunk/.claude-plugin/plugin.json",
+            &claude["description"],
+        ),
         (
             ".claude-plugin/marketplace.json",
             &claude_mkt["plugins"][0]["description"],


### PR DESCRIPTION
## What this does

Moves the Claude plugin manifest to the canonical `plugins/worktrunk/.claude-plugin/plugin.json` and strips it to metadata only, dropping the `hooks` and `skills` keys so that both component types load purely by Claude Code's convention discovery. Rewrites the layout docs and inverts `test_plugin_layout_is_consolidated` to pin the new invariants.

## Background

The plugin layout has been in flux: [#3382](https://github.com/max-sixty/worktrunk/pull/3382) Claude-scoped the hooks filename, which silently broke hook loading ([#3417](https://github.com/max-sixty/worktrunk/issues/3417)), and [#3418](https://github.com/max-sixty/worktrunk/pull/3418) reverted it. That revert restored working hooks but left two claims baked into the layout, the docs, and the test that this PR found to be stale.

## Research method

Everything below was verified empirically against claude-cli 2.1.207 (the current release), not from docs alone:

- **Scratch marketplace probe**: a throwaway marketplace mirroring worktrunk's exact shape (repo-root `.claude-plugin/marketplace.json`, plugin in a `./plugins/<name>` subdir source, `skills` as a symlink pointing outside the plugin dir, hooks at the conventional path) with two plugin variants — manifest in `.claude-plugin/plugin.json` vs. bare `plugin.json` at the plugin root — installed through the real `claude plugin marketplace add` + `claude plugin install` flow.
- **Component inventory**: `claude plugin details` and `claude plugin validate` on both variants.
- **Live sessions**: headless `claude -p` runs confirming skills appear in-session and hook commands actually execute (marker files, and reading the 🤖 activity marker from inside a live session).
- **Loader inspection**: the manifest resolution order read directly out of the claude-code binary's bundled loader code.

## Findings

1. **The "no `.claude-plugin/` wrapper" claim no longer holds.** The repo documented — and the test pinned — that Claude wants `plugin.json` bare at the plugin root, and that a `.claude-plugin/` wrapper in a subdir-source plugin fails with "Plugin not found". On 2.1.207 the wrapper form installs, loads skills, and fires hooks end-to-end. The loader tries `.claude-plugin/plugin.json` first with root `plugin.json` only as a runtime fallback, several marketplace-resolution paths read *only* the wrapper, and `claude plugin validate` rejects the root-level form outright ("No manifest found in directory. Expected .claude-plugin/marketplace.json or .claude-plugin/plugin.json").
2. **"Claude has no skill auto-discovery" is wrong.** Skills are auto-discovered by scanning `skills/*/SKILL.md`; a `skills` manifest array only *adds* directories to that scan (entries equal to the default dir are filtered). An unlisted skill behind the out-of-plugin symlink loaded fine — the installer dereferences the symlink into a real directory in the install cache. Dropping the array also makes the old test guard ("every skill must be listed or it's silently invisible") structurally unnecessary: a new repo-root skill now ships to Claude, Codex, and Gemini with no manifest change anywhere.
3. **The `hooks` manifest key was dead config.** #3417 established the string-path override isn't honored for plugin loads; convention discovery of `hooks/hooks.json` is the mechanism that works. A key pointing at the conventional path adds nothing and could mask a future mislocated file, so it's gone (one mechanism per guarantee).

## Changes

- `plugins/worktrunk/plugin.json` → `plugins/worktrunk/.claude-plugin/plugin.json`; content reduced to `name`/`description`/`author`.
- `plugins/worktrunk/CLAUDE.md`: layout diagram and Claude path-resolution bullet rewritten to the convention-only model; the refuted wrapper claim and the stale no-auto-discovery claim removed.
- Root `CLAUDE.md`: the Plugin Layout pointer updated (dropped the stale "Codex no-hooks re-enablement" phrase — Codex hooks shipped inline in #3364).
- `test_plugin_layout_is_consolidated`: now asserts the wrapper manifest exists, a root-level `plugin.json` does not, the manifest carries no `hooks`/`skills` keys, the plugin `skills` symlink resolves to the repo-root `skills/` (unix only — Windows checkouts without `core.symlinks` materialize it as a file), and every repo-root skill dir carries a `SKILL.md` (the scan silently ignores a dir without one).

Codex and Gemini are untouched: Codex reads only its `.codex-plugin/` wrapper, and its inline `hooks` object still overrides Codex's own convention discovery, so the #3362 collision stays closed independent of any of this.

## Verification

- `claude plugin validate plugins/worktrunk` passes (it failed on the old layout). Remaining warnings are deliberate: no `version` field (installs pin the git SHA as the version; a hand-maintained semver would go stale) and the plugin-root `CLAUDE.md` (developer docs, not plugin context).
- A live `claude --plugin-dir` session on this exact tree loads both skills and the `UserPromptSubmit` hook sets the 🤖 marker, observed from inside the session.
- The scratch-marketplace probe covered the same shape through the full marketplace install flow, including the symlinked skills dir.
- Full pre-merge gate: 4389 tests passed plus lints, doctests, and docs-sync.

## Risk

The one scenario this could regress is a Claude Code version old enough to read *only* the root-level manifest. That couldn't be tested directly; the mitigations are that the wrapper is the documented convention, the loader prefers it today, and Claude Code self-updates aggressively. The old layout's "verified end-to-end" claim most likely dates from an earlier 2.1.x behavior or a misdiagnosed failure.

> _This was written by Claude Code on behalf of max_
