### PR TITLE
refactor(perf): make wt-perf setup persist-only and trim the CLI/lib surface

### DIFF
--- a/benches/CLAUDE.md
+++ b/benches/CLAUDE.md
@@ -226,7 +226,7 @@ drain *plus* the removal itself: read it as "how long this removal stalled the
 run", not as pure removal work.
 
 ```bash
-cargo run -p wt-perf -- setup prune-4-8 --path /tmp/prune-repo --persist
+cargo run -p wt-perf -- setup prune-4-8 --path /tmp/prune-repo
 # A freshly built fixture is already probe-cold (empty sha_cache); don't use
 # `timeline --cold` here — it deletes worktree indexes, which flips prune's
 # clean-worktree gate and drops the worktree candidates from the run.
@@ -280,8 +280,9 @@ Use `wt-perf` to set up benchmark repos and generate Chrome Trace Format for vis
 ### Setting up benchmark repos
 
 ```bash
-# Set up a repo with 8 worktrees (persists at /tmp/wt-perf-typical-8)
-cargo run -p wt-perf -- setup typical-8 --persist
+# Set up a repo with 8 worktrees (persists at /tmp/wt-perf-typical-8; the
+# next `setup typical-8` run wipes and rebuilds it)
+cargo run -p wt-perf -- setup typical-8
 
 # Available configs:
 #   typical-N       - 500 commits, 100 files, N worktrees
@@ -313,9 +314,8 @@ Perfetto/chrome://tracing. `--cold` invalidates caches first.
 # Text timeline of one wt invocation
 cargo run -p wt-perf -- timeline -- list --progressive
 
-# Cold-cache run
-cargo run -p wt-perf -- timeline --cold --repo /tmp/wt-perf-typical-8 -- \
-  -C /tmp/wt-perf-typical-8 list --progressive
+# Cold-cache run (invalidates the traced repo — the `-C` arg, else cwd)
+cargo run -p wt-perf -- timeline --cold -- -C /tmp/wt-perf-typical-8 list --progressive
 
 # Chrome Trace Format JSON for Perfetto
 cargo run -p wt-perf -- timeline --chrome -- list --progressive > trace.json

--- a/benches/prune.rs
+++ b/benches/prune.rs
@@ -35,7 +35,7 @@
 //   cargo bench --bench prune --features real-repo-benches prune_real_repo
 //
 // For phase attribution (scan vs per-candidate removal), trace one invocation
-// instead: `wt-perf setup prune-4-8 --path /tmp/prune-repo --persist`, then
+// instead: `wt-perf setup prune-4-8 --path /tmp/prune-repo`, then
 // `wt-perf timeline -- -C /tmp/prune-repo step prune --dry-run --min-age 0s`
 // and read the `prune-gather` / `prune-scan` / `prune-check:*` /
 // `prune-remove:*` spans.

--- a/tests/helpers/wt-perf/src/lib.rs
+++ b/tests/helpers/wt-perf/src/lib.rs
@@ -112,7 +112,7 @@ impl RepoConfig {
 ///
 /// Most configs map onto the flat [`RepoConfig`] (every worktree/branch
 /// identical); the composite fixtures build varied states instead:
-/// `mixed-W-B` via [`create_mixed_repo_at`], `prune-M-U` via
+/// `mixed-W-B` via `create_mixed_repo_at`, `prune-M-U` via
 /// [`create_prune_repo_at`]. (`prune-real[-M-U]` is not a `SetupConfig`:
 /// it is cache-managed under `target/bench-repos/` and takes no path — see
 /// [`ensure_prune_real_repo`].)
@@ -277,7 +277,7 @@ fn init_bench_repo(repo_path: &Path) {
 /// Run a git plumbing command against a scratch `GIT_INDEX_FILE`, panicking on
 /// failure and returning trimmed stdout. Used to build commits without
 /// touching the repo's working tree or real index (see
-/// [`add_diverged_backdrop`]).
+/// `add_diverged_backdrop`).
 fn git_stdout(path: &Path, args: &[&str], index_file: &Path) -> String {
     run_capture(
         git_command()
@@ -603,7 +603,7 @@ fn bench_repos_dir() -> PathBuf {
 /// Get or clone the rust-lang/rust repository for real-world benchmarks.
 ///
 /// The repo is cached at `target/bench-repos/rust` and reused across runs.
-pub fn ensure_rust_repo() -> PathBuf {
+fn ensure_rust_repo() -> PathBuf {
     RUST_REPO
         .get_or_init(|| {
             let cache_dir = bench_repos_dir();
@@ -642,9 +642,9 @@ pub fn ensure_rust_repo() -> PathBuf {
         .clone()
 }
 
-/// Local-clone the cached rust repo ([`ensure_rust_repo`]) to `dest` and
+/// Local-clone the cached rust repo (`ensure_rust_repo`) to `dest` and
 /// configure a git user for commits.
-pub fn clone_rust_repo_at(dest: &Path) {
+fn clone_rust_repo_at(dest: &Path) {
     let rust_repo = ensure_rust_repo();
     let clone_output = git_command()
         .args([
@@ -680,7 +680,7 @@ pub fn clone_rust_repo(temp: &TempDir) -> PathBuf {
 /// (not count) drives cost: consumers fork branches at these points so
 /// merge-base walks and merge-tree three-ways span the whole history rather
 /// than a handful of tip-adjacent forks.
-pub fn history_spread_shas(repo_path: &Path, count: usize) -> Vec<String> {
+fn history_spread_shas(repo_path: &Path, count: usize) -> Vec<String> {
     let log_output = git_command()
         .args(["log", "--oneline", "-n", "5000", "--format=%H"])
         .current_dir(repo_path)
@@ -705,7 +705,7 @@ pub fn history_spread_shas(repo_path: &Path, count: usize) -> Vec<String> {
 
 /// Create branches pointing at different depths in the repo's commit history.
 ///
-/// Samples `count` commits via [`history_spread_shas`] and creates
+/// Samples `count` commits via `history_spread_shas` and creates
 /// `feature-NNN` branches pointing at them (behind-only — no own commits).
 pub fn add_history_spread_branches(repo_path: &Path, count: usize) {
     for (i, commit) in history_spread_shas(repo_path, count).iter().enumerate() {
@@ -718,7 +718,7 @@ pub fn add_history_spread_branches(repo_path: &Path, count: usize) {
 /// `branches` two-sided-diverged orphan branches (`feature-NNN`) to an
 /// existing repo.
 ///
-/// Each forks at a [`history_spread_shas`] point — so the default branch has
+/// Each forks at a `history_spread_shas` point — so the default branch has
 /// advanced past every fork — and carries its own commits on top. That is the
 /// shape of real long-lived feature work: `git merge-base` must walk back to
 /// the fork, and the integration probes (`merge-tree --write-tree`, diff)
@@ -732,7 +732,7 @@ pub fn add_history_spread_branches(repo_path: &Path, count: usize) {
 /// on large repos: an orphan branch is a few commits' worth of objects, while
 /// a linked worktree materializes a full working tree (~1 GiB on
 /// rust-lang/rust) and pays a checkout.
-pub fn add_diverged_backdrop(repo_path: &Path, worktrees: usize, branches: usize) {
+fn add_diverged_backdrop(repo_path: &Path, worktrees: usize, branches: usize) {
     let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
     let parent_dir = repo_path.parent().unwrap();
     let forks = history_spread_shas(repo_path, worktrees.max(branches).max(1));
@@ -870,7 +870,7 @@ pub fn create_mixed_repo(worktrees: usize, branches: usize) -> TempDir {
 /// [`create_mixed_repo`] at a caller-chosen path (used by `wt-perf setup
 /// mixed-W-B`). The main worktree is created at `repo`; linked worktrees are
 /// siblings.
-pub fn create_mixed_repo_at(worktrees: usize, branches: usize, repo: &Path) {
+fn create_mixed_repo_at(worktrees: usize, branches: usize, repo: &Path) {
     const FILES: usize = 50;
     // Deep enough that fork points spread across history give the
     // `%(ahead-behind)` walk real commits to traverse (GH #461 shape), while
@@ -1017,7 +1017,7 @@ pub fn create_mixed_repo_at(worktrees: usize, branches: usize, repo: &Path) {
 ///   squash commit, so it is integrated *by content* (the `merge-tree` probes),
 ///   not by ancestry — the post-PR-squash shape prune typically removes.
 /// - **Backdrop** (`unmerged` of each): two-sided-diverged linked worktrees
-///   and orphan branches ([`add_diverged_backdrop`] — forked at points spread
+///   and orphan branches (`add_diverged_backdrop` — forked at points spread
 ///   across history, with their own commits, while main advanced past them).
 ///   Scanned on every run, never removed — the steady state that dominates
 ///   scan cost, and the shape where merge-base walks and merge-tree
@@ -1136,12 +1136,12 @@ pub const PRUNE_REAL_UNMERGED: usize = 24;
 
 /// Create a rust-lang/rust-scale `wt step prune` workload at `base_path`.
 ///
-/// Local-clones the cached rust repo ([`ensure_rust_repo`] — first call clones
+/// Local-clones the cached rust repo (`ensure_rust_repo` — first call clones
 /// from the network, minutes) and adds the same two populations as
 /// [`create_prune_repo_at`]: `merged` squash-merged candidates of each kind
 /// ([`add_squash_merged`]) against a two-sided-diverged backdrop of `unmerged`
 /// worktrees and branches forked across the last 5000 commits
-/// ([`add_diverged_backdrop`]). This is the shape where prune's costs are
+/// (`add_diverged_backdrop`). This is the shape where prune's costs are
 /// real — merge-base walks over deep history, `merge-tree` three-ways over
 /// ~400 MiB trees, `git status` over ~60k files per worktree — and reproduces
 /// the "prune takes seconds" experience that small synthetic fixtures can't
@@ -1151,7 +1151,7 @@ pub const PRUNE_REAL_UNMERGED: usize = 24;
 /// per worktree, so the default populations build in minutes and take ~15 GiB.
 /// Prefer [`ensure_prune_real_repo`], which builds once into
 /// `target/bench-repos` and repairs consumed candidates on later runs.
-pub fn create_prune_real_repo_at(merged: usize, unmerged: usize, base_path: &Path) {
+fn create_prune_real_repo_at(merged: usize, unmerged: usize, base_path: &Path) {
     clone_rust_repo_at(base_path);
     add_diverged_backdrop(base_path, unmerged, unmerged);
     add_squash_merged(base_path, merged, 0);
@@ -1159,7 +1159,7 @@ pub fn create_prune_real_repo_at(merged: usize, unmerged: usize, base_path: &Pat
 
 /// How a cached prune fixture compares to its expected populations.
 #[derive(Debug, PartialEq, Eq)]
-pub enum PruneFixtureState {
+enum PruneFixtureState {
     /// Backdrop and candidates all present.
     Intact,
     /// Backdrop intact, candidates fully consumed — a live prune ran.
@@ -1170,13 +1170,13 @@ pub enum PruneFixtureState {
 }
 
 /// Classify a prune fixture ([`create_prune_repo_at`] /
-/// [`create_prune_real_repo_at`] layout) against its expected populations.
+/// `create_prune_real_repo_at` layout) against its expected populations.
 ///
 /// Counts are the fixture's invariants: `1 + unmerged + merged` worktrees,
 /// `2 * unmerged` `feature-*` branches (worktree + orphan), `2 * merged`
 /// `merged-*` branches. A live prune removes exactly the `merged-*` items,
 /// which is the [`PruneFixtureState::Consumed`] signature.
-pub fn prune_fixture_state(repo: &Path, merged: usize, unmerged: usize) -> PruneFixtureState {
+fn prune_fixture_state(repo: &Path, merged: usize, unmerged: usize) -> PruneFixtureState {
     if !run_git_ok(repo, &["rev-parse", "HEAD"]) {
         return PruneFixtureState::Broken;
     }
@@ -1226,9 +1226,9 @@ fn next_squash_round(repo: &Path) -> usize {
 /// Get or build the cached rust-scale prune fixture, returning the repo path.
 ///
 /// The fixture lives at `target/bench-repos/rust-prune-<merged>-<unmerged>/repo`
-/// (worktrees as siblings) so its minutes-long build ([`create_prune_real_repo_at`])
+/// (worktrees as siblings) so its minutes-long build (`create_prune_real_repo_at`)
 /// is paid once, not per bench run. On reuse it is validated by
-/// [`prune_fixture_state`]:
+/// `prune_fixture_state`:
 ///
 /// - `Intact` → returned as-is (dry runs don't mutate it).
 /// - `Consumed` — a live `wt step prune` removed the candidates — → repaired
@@ -1246,7 +1246,7 @@ fn next_squash_round(repo: &Path) -> usize {
 /// No cross-process locking: two concurrent callers (e.g. `cargo bench
 /// --bench prune` while `wt-perf setup prune-real` is mid-build) can classify
 /// each other's half-built tree as `Broken` and wipe it. Don't run two
-/// builders at once; the same limitation applies to [`ensure_rust_repo`].
+/// builders at once; the same limitation applies to `ensure_rust_repo`.
 pub fn ensure_prune_real_repo(merged: usize, unmerged: usize) -> PathBuf {
     let cache_dir = bench_repos_dir().join(format!("rust-prune-{merged}-{unmerged}"));
     let repo = cache_dir.join("repo");

--- a/tests/helpers/wt-perf/src/main.rs
+++ b/tests/helpers/wt-perf/src/main.rs
@@ -2,7 +2,7 @@
 //!
 //! Run `wt-perf --help` (and `wt-perf <subcommand> --help`) for usage.
 
-use std::io::{IsTerminal, Read, Write};
+use std::io::{IsTerminal, Read};
 use std::path::PathBuf;
 use std::process::{Command, Stdio};
 use std::time::{Duration, Instant};
@@ -31,10 +31,6 @@ enum Commands {
         /// Directory to create repo in (default: temp directory)
         #[arg(long)]
         path: Option<PathBuf>,
-
-        /// Keep the repo (don't wait for cleanup)
-        #[arg(long)]
-        persist: bool,
     },
 
     /// Invalidate git caches for cold benchmarks
@@ -76,23 +72,19 @@ enum Commands {
   # Text timeline of `wt list` in the current repo
   wt-perf timeline -- list
 
-  # Cold-cache run (invalidates ./ then runs)
+  # Cold-cache run (invalidates the traced repo, then runs)
   wt-perf timeline --cold -- list
 
   # Cold run against a specific repo
-  wt-perf timeline --cold --repo /tmp/wt-perf-typical-1 -- -C /tmp/wt-perf-typical-1 list
+  wt-perf timeline --cold -- -C /tmp/wt-perf-typical-1 list
 
   # Chrome Trace Format JSON for Perfetto
   wt-perf timeline --chrome -- list > trace.json
 "#)]
     Timeline {
-        /// Invalidate caches before running (cold measurement).
+        /// Invalidate the traced repo's caches before running (cold measurement).
         #[arg(long)]
         cold: bool,
-
-        /// Repo to invalidate (only used with --cold). Defaults to cwd.
-        #[arg(long, value_name = "PATH")]
-        repo: Option<PathBuf>,
 
         /// Output Chrome Trace Format JSON to stdout instead of a text timeline.
         #[arg(long)]
@@ -108,11 +100,7 @@ fn main() {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Setup {
-            config,
-            path,
-            persist,
-        } => {
+        Commands::Setup { config, path } => {
             // `prune-real[-M-U]`: cache-managed rust-scale fixture (built once
             // under target/bench-repos/, repaired after a live prune consumes
             // its candidates) — takes no --path and never offers cleanup.
@@ -213,20 +201,6 @@ fn main() {
                 example_args
             );
             eprintln!("  wt-perf invalidate {}", base_path.display());
-
-            if !persist {
-                eprintln!();
-                eprintln!("Press Enter to clean up (or Ctrl+C to keep)...");
-                std::io::stdout().flush().unwrap();
-                let mut input = String::new();
-                std::io::stdin().read_line(&mut input).unwrap();
-
-                eprintln!("Cleaning up...");
-                if let Err(e) = std::fs::remove_dir_all(&base_path) {
-                    eprintln!("Warning: Failed to clean up: {}", e);
-                    eprintln!("You may need to manually remove: {}", base_path.display());
-                }
-            }
         }
 
         Commands::Invalidate { repo } => {
@@ -251,10 +225,9 @@ fn main() {
 
         Commands::Timeline {
             cold,
-            repo,
             chrome,
             wt_args,
-        } => run_timeline(cold, repo, chrome, &wt_args),
+        } => run_timeline(cold, chrome, &wt_args),
     }
 }
 
@@ -285,15 +258,15 @@ fn resolve_wt_binary() -> PathBuf {
 /// the repo wt operated on (the humanized stderr/`trace.log` isn't parseable).
 /// We locate that repo the same way wt does — a `-C` in the args, else the
 /// cwd — and read the file back after the run.
-fn run_timeline(cold: bool, repo: Option<PathBuf>, chrome: bool, wt_args: &[String]) {
+fn run_timeline(cold: bool, chrome: bool, wt_args: &[String]) {
     let wt = resolve_wt_binary();
     // The trace lands in the repo wt operates on — resolved from `-C`/cwd the
     // same way wt resolves it, so we never read a different repo than wt wrote.
-    // `--repo` governs only `--cold` invalidation.
+    // `--cold` invalidates that same repo.
     let trace_dir = wt_target_dir(wt_args);
 
     if cold {
-        let path = canonicalize(repo.as_deref().unwrap_or(&trace_dir)).unwrap_or_else(|e| {
+        let path = canonicalize(&trace_dir).unwrap_or_else(|e| {
             eprintln!("Invalid --cold repo path: {e}");
             std::process::exit(1);
         });


### PR DESCRIPTION
Follow-up to #3403, applying the deferred `--persist` decision and two sibling subtractions found sweeping the perf tooling for the same shape (a vestigial option or dual path guarding nothing).

- **`wt-perf setup` is persist-only.** The `--persist` flag and the interactive "Press Enter to clean up (or Ctrl+C to keep)" path are gone — it was the one blocking, stdin-reading path in an otherwise scriptable tool, and it guarded little: default-path fixtures land in `/tmp/wt-perf-<config>`, which the next `setup <config>` run already wipes and rebuilds. `prune-real` never offered cleanup, so setup's exit behavior is now uniform.
- **`timeline --repo` deleted.** It only restated the traced repo: `run_timeline` resolves the repo from `-C`/cwd, `--repo` defaulted to exactly that, and the only documented use passed the identical path to both flags. `--cold` now invalidates the repo being traced — the only coherent target.
- **`wt_perf` lib surface tightened.** Seven helpers plus `PruneFixtureState` had no callers outside `lib.rs` and are now private (`ensure_rust_repo`, `clone_rust_repo_at`, `history_spread_shas`, `add_diverged_backdrop`, `create_mixed_repo_at`, `create_prune_real_repo_at`, `prune_fixture_state`); the public surface now matches what the benches and CLI actually use. Doc references to them are plain code spans rather than intra-doc links — rustdoc's `private-intra-doc-links` lint rejects public docs linking private items even under `--document-private-items`.

Checked and deliberately kept: `wt-perf trace` and `wt-perf invalidate` (distinct documented workflows), the `TraceResult`/`CacheReport` re-exports (public field types of `TraceEntry`/`Profile`), and the `create_repo`/`create_repo_at` two-layer fixture API (both layers used).

Gate green: 4387 tests, clippy/fmt/doctests/rustdoc (`-Dwarnings`) clean.

> _This was written by Claude Code on behalf of max_
