### PR TITLE
docs(plugins): record the deliberate absence of a manifest version field

### DIFF
--- a/plugins/worktrunk/CLAUDE.md
+++ b/plugins/worktrunk/CLAUDE.md
@@ -42,8 +42,11 @@ Path resolution differs by tool, all verified end-to-end against the real CLIs:
   `plugins/worktrunk/.claude-plugin/plugin.json` — the same wrapper convention
   as the marketplace root, and the only manifest location `claude plugin
   validate` accepts (a bare `plugin.json` at the plugin root loads through an
-  undocumented fallback but fails validation). Components load by
-  **convention**, and the manifest must not name them:
+  undocumented fallback but fails validation). The manifest deliberately
+  carries no `version` field: installs pin the marketplace git SHA, so a
+  semver here would be a second version to maintain with nothing consuming
+  it — `claude plugin validate`'s missing-`version` warning is accepted.
+  Components load by **convention**, and the manifest must not name them:
   - Hooks are discovered at `hooks/hooks.json`. The loader does not honor the
     string-path `hooks` manifest override for plugin loads, so a renamed file
     silently loads nothing (#3417) and a `hooks` key pointing at the


### PR DESCRIPTION
Follow-up to #3431: records in `plugins/worktrunk/CLAUDE.md` why the Claude manifest deliberately omits a `version` field — installs pin the marketplace git SHA, so a semver would be a second version to maintain with nothing consuming it — so a future cleanup pass doesn't "fix" the `claude plugin validate` warning by adding one.

> _This was written by Claude Code on behalf of max_
