### PR TITLE
fix(list): unify task-failure output vocabulary

### DIFF
--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -413,8 +413,12 @@ fn print_buffered_table(header: &str, rows: &[String], summary: &str) {
     for row in rows {
         println!("{row}");
     }
-    println!();
-    println!("{summary}");
+    // The summary narrates the table rather than being part of the answer
+    // (`--format=json` omits it), so it goes to stderr and piped stdout ends
+    // cleanly after the last row. The progressive path keeps it on stdout:
+    // there it's a repainted row of the table region.
+    eprintln!();
+    eprintln!("{summary}");
 }
 
 /// Options for controlling what data to collect.
@@ -656,12 +660,12 @@ fn format_stall_footer(
     first_name: &str,
 ) -> String {
     let dim = Style::new().dimmed();
-    let kind_str: &'static str = first_kind.into();
+    let kind_name = first_kind.display_name();
     let waiting_clause = if pending_count == 1 {
-        cformat!("waiting on <underline>{kind_str}</> for <underline>{first_name}</>")
+        cformat!("waiting on <underline>{kind_name}</> for <underline>{first_name}</>")
     } else {
         cformat!(
-            "waiting on {pending_count} tasks, including <underline>{kind_str}</> for <underline>{first_name}</>"
+            "waiting on {pending_count} tasks, including <underline>{kind_name}</> for <underline>{first_name}</>"
         )
     };
     cformat!(
@@ -718,8 +722,11 @@ fn format_drain_timeout_diag(
             .iter()
             .take(MAX_SHOWN)
             .map(|result| {
-                let missing_names: Vec<&str> =
-                    result.missing_kinds.iter().map(|k| k.into()).collect();
+                let missing_names: Vec<&str> = result
+                    .missing_kinds
+                    .iter()
+                    .map(|k| k.display_name())
+                    .collect();
                 cformat!("<bold>{}</>: {}", result.name, missing_names.join(", "))
             })
             .collect();
@@ -1983,14 +1990,15 @@ pub fn collect(
                 .iter()
                 .map(|error| {
                     let name = all_items[error.item_idx].branch_name();
-                    let kind_str: &'static str = error.kind.into();
                     // Take first line only - git errors can be multi-line with usage hints
                     let msg = error.message.lines().next().unwrap_or(&error.message);
-                    cformat!("<bold>{}</>: {} ({})", name, kind_str, msg)
+                    cformat!("<bold>{}</>: {} ({})", name, error.kind.display_name(), msg)
                 })
                 .collect();
+            let count = sorted_errors.len();
+            let plural = if count == 1 { "" } else { "s" };
             warning_parts.push(format!(
-                "Some git operations failed:\n{}",
+                "{count} task{plural} failed:\n{}",
                 format_with_gutter(&error_lines.join("\n"), None)
             ));
         }
@@ -2343,7 +2351,7 @@ mod tests {
             format_stall_footer("Showing 3 worktrees", 5, 12, 1, TaskKind::CiStatus, "feat");
         insta::assert_snapshot!(
             rendered.ansi_strip(),
-            @"○ Showing 3 worktrees (5/12 loaded, no recent progress; waiting on ci-status for feat)"
+            @"○ Showing 3 worktrees (5/12 loaded, no recent progress; waiting on CI status for feat)"
         );
     }
 
@@ -2353,7 +2361,7 @@ mod tests {
             format_stall_footer("Showing 3 worktrees", 5, 12, 3, TaskKind::CiStatus, "feat");
         insta::assert_snapshot!(
             rendered.ansi_strip(),
-            @"○ Showing 3 worktrees (5/12 loaded, no recent progress; waiting on 3 tasks, including ci-status for feat)"
+            @"○ Showing 3 worktrees (5/12 loaded, no recent progress; waiting on 3 tasks, including CI status for feat)"
         );
     }
 
@@ -2448,10 +2456,10 @@ mod tests {
         let rendered = format_drain_timeout_diag(3, &items);
         insta::assert_snapshot!(
             rendered.ansi_strip(),
-            @r"
+            @"
         Listing worktrees timed out after 120s (3 results received); blocked tasks:
-          feature-a: ci-status, branch-diff
-          feature-b: ahead-behind
+          feature-a: CI status, branch diff
+          feature-b: ahead/behind counts
         "
         );
     }
@@ -2470,13 +2478,13 @@ mod tests {
         let rendered = format_drain_timeout_diag(2, &items);
         insta::assert_snapshot!(
             rendered.ansi_strip(),
-            @r"
+            @"
         Listing worktrees timed out after 120s (2 results received); blocked tasks:
-          feature-0: ahead-behind
-          feature-1: ahead-behind
-          feature-2: ahead-behind
-          feature-3: ahead-behind
-          feature-4: ahead-behind
+          feature-0: ahead/behind counts
+          feature-1: ahead/behind counts
+          feature-2: ahead/behind counts
+          feature-3: ahead/behind counts
+          feature-4: ahead/behind counts
           … and 3 more
         "
         );

--- a/src/commands/list/collect/types.rs
+++ b/src/commands/list/collect/types.rs
@@ -271,6 +271,10 @@ mod tests {
         let names: Vec<&str> = TaskKind::iter().map(TaskKind::display_name).collect();
         assert!(names.iter().all(|name| !name.is_empty()));
         let unique: std::collections::HashSet<_> = names.iter().collect();
-        assert_eq!(unique.len(), names.len(), "duplicate display names: {names:?}");
+        assert_eq!(
+            unique.len(),
+            names.len(),
+            "duplicate display names: {names:?}"
+        );
     }
 }

--- a/src/commands/list/collect/types.rs
+++ b/src/commands/list/collect/types.rs
@@ -153,6 +153,30 @@ impl TaskKind {
             TaskKind::CiStatus | TaskKind::UrlStatus | TaskKind::SummaryGenerate
         )
     }
+
+    /// Human-readable task name for user-facing messages (failure warnings,
+    /// stall footers, timeout diagnostics). The strum kebab-case form
+    /// (`IntoStaticStr`) is developer vocabulary for tracing and `-vv`
+    /// diagnostics; this form names what the task computes for the table.
+    pub fn display_name(self) -> &'static str {
+        match self {
+            TaskKind::AheadBehind => "ahead/behind counts",
+            TaskKind::CommittedTreesMatch => "trees-match check",
+            TaskKind::HasFileChanges => "file-changes check",
+            TaskKind::WouldMergeAdd => "merge-simulation check",
+            TaskKind::IsAncestor => "ancestor check",
+            TaskKind::BranchDiff => "branch diff",
+            TaskKind::WorkingTreeDiff => "working-tree diff",
+            TaskKind::MergeTreeConflicts => "merge-conflict check",
+            TaskKind::WorkingTreeConflicts => "working-tree conflict check",
+            TaskKind::GitOperation => "operation-state check",
+            TaskKind::UserMarker => "user-marker lookup",
+            TaskKind::Upstream => "upstream status",
+            TaskKind::CiStatus => "CI status",
+            TaskKind::UrlStatus => "URL check",
+            TaskKind::SummaryGenerate => "summary generation",
+        }
+    }
 }
 
 /// Result of draining task results - indicates whether all results were received

--- a/src/commands/list/collect/types.rs
+++ b/src/commands/list/collect/types.rs
@@ -262,4 +262,15 @@ mod tests {
         let error = TaskError::new(0, TaskKind::AheadBehind, "timed out", ErrorCause::Timeout);
         assert!(error.is_timeout());
     }
+
+    /// Duplicate display names would make two different task failures
+    /// indistinguishable in the `wt list` failure warning.
+    #[test]
+    fn test_task_kind_display_names_unique_and_nonempty() {
+        use strum::IntoEnumIterator;
+        let names: Vec<&str> = TaskKind::iter().map(TaskKind::display_name).collect();
+        assert!(names.iter().all(|name| !name.is_empty()));
+        let unique: std::collections::HashSet<_> = names.iter().collect();
+        assert_eq!(unique.len(), names.len(), "duplicate display names: {names:?}");
+    }
 }

--- a/src/commands/list/mod.rs
+++ b/src/commands/list/mod.rs
@@ -331,17 +331,18 @@ impl SummaryMetrics {
     ) -> Vec<String> {
         let mut parts = Vec::new();
 
+        let plural = if self.worktrees == 1 { "" } else { "s" };
+        parts.push(format!("{} worktree{}", self.worktrees, plural));
+
         if include_branches {
-            parts.push(format!("{} worktrees", self.worktrees));
             if self.local_branches > 0 {
-                parts.push(format!("{} branches", self.local_branches));
+                let plural = if self.local_branches == 1 { "" } else { "es" };
+                parts.push(format!("{} branch{}", self.local_branches, plural));
             }
             if self.remote_branches > 0 {
-                parts.push(format!("{} remote branches", self.remote_branches));
+                let plural = if self.remote_branches == 1 { "" } else { "es" };
+                parts.push(format!("{} remote branch{}", self.remote_branches, plural));
             }
-        } else {
-            let plural = if self.worktrees == 1 { "" } else { "s" };
-            parts.push(format!("{} worktree{}", self.worktrees, plural));
         }
 
         if self.dirty_worktrees > 0 {
@@ -380,20 +381,24 @@ pub(crate) fn format_summary_message(
         .join(", ");
 
     if error_count > 0 {
-        let failure_msg = if error_count == timed_out_count {
-            // All failures are timeouts
-            let plural = if timed_out_count == 1 { "" } else { "s" };
-            format!("{timed_out_count} task{plural} timed out")
-        } else if timed_out_count > 0 {
-            // Mix of timeouts and other errors
-            let plural = if error_count == 1 { "" } else { "s" };
-            format!("{error_count} task{plural} failed ({timed_out_count} timed out)")
-        } else {
-            // No timeouts, just other errors
-            let plural = if error_count == 1 { "" } else { "s" };
-            format!("{error_count} task{plural} failed")
+        // "failed" and "timed out" are disjoint here, matching the warning
+        // that details the non-timeout failures after the table.
+        let failed_count = error_count - timed_out_count;
+        let failure_msg = match (failed_count, timed_out_count) {
+            (0, t) => {
+                let plural = if t == 1 { "" } else { "s" };
+                format!("{t} task{plural} timed out")
+            }
+            (f, 0) => {
+                let plural = if f == 1 { "" } else { "s" };
+                format!("{f} task{plural} failed")
+            }
+            (f, t) => {
+                let plural = if f == 1 { "" } else { "s" };
+                format!("{f} task{plural} failed, {t} timed out")
+            }
         };
-        format!("{INFO_SYMBOL} {dim}Showing {summary}. {failure_msg}{dim:#}")
+        format!("{INFO_SYMBOL} {dim}Showing {summary}; {failure_msg}{dim:#}")
     } else {
         format!("{INFO_SYMBOL} {dim}Showing {summary}{dim:#}")
     }
@@ -540,14 +545,14 @@ mod tests {
         // No errors
         assert_snapshot!(format_summary_message(&[], false, 0, 0, 0), @"[2m○[22m [2mShowing 0 worktrees[0m");
         // All timeouts
-        assert_snapshot!(format_summary_message(&[], false, 0, 3, 3), @"[2m○[22m [2mShowing 0 worktrees. 3 tasks timed out[0m");
+        assert_snapshot!(format_summary_message(&[], false, 0, 3, 3), @"[2m○[22m [2mShowing 0 worktrees; 3 tasks timed out[0m");
         // Mixed errors and timeouts
-        assert_snapshot!(format_summary_message(&[], false, 0, 5, 3), @"[2m○[22m [2mShowing 0 worktrees. 5 tasks failed (3 timed out)[0m");
+        assert_snapshot!(format_summary_message(&[], false, 0, 5, 3), @"[2m○[22m [2mShowing 0 worktrees; 2 tasks failed, 3 timed out[0m");
         // Only failures, no timeouts
-        assert_snapshot!(format_summary_message(&[], false, 0, 2, 0), @"[2m○[22m [2mShowing 0 worktrees. 2 tasks failed[0m");
+        assert_snapshot!(format_summary_message(&[], false, 0, 2, 0), @"[2m○[22m [2mShowing 0 worktrees; 2 tasks failed[0m");
         // Single error
-        assert_snapshot!(format_summary_message(&[], false, 0, 1, 0), @"[2m○[22m [2mShowing 0 worktrees. 1 task failed[0m");
+        assert_snapshot!(format_summary_message(&[], false, 0, 1, 0), @"[2m○[22m [2mShowing 0 worktrees; 1 task failed[0m");
         // Single timeout
-        assert_snapshot!(format_summary_message(&[], false, 0, 1, 1), @"[2m○[22m [2mShowing 0 worktrees. 1 task timed out[0m");
+        assert_snapshot!(format_summary_message(&[], false, 0, 1, 1), @"[2m○[22m [2mShowing 0 worktrees; 1 task timed out[0m");
     }
 }

--- a/src/commands/list/progressive_table.rs
+++ b/src/commands/list/progressive_table.rs
@@ -281,6 +281,13 @@ impl ProgressiveTable {
     /// When overflowing (skeleton showed a subset of rows), erases the skeleton
     /// and prints the complete table — the output scrolls naturally, avoiding
     /// the `MoveUp`-into-scrollback problem.
+    ///
+    /// The footer (summary) is written to stdout here even though the buffered
+    /// path (`print_buffered_table`) narrates it on stderr: progressive mode
+    /// repaints the footer as a row of the table region, and only runs when
+    /// stdout is a TTY (`RenderTarget::detect`), so this stdout never feeds a
+    /// pipe. A future non-TTY progressive mode must move the summary to stderr
+    /// with the buffered path.
     pub fn finalize(
         &mut self,
         final_rows: Vec<String>,

--- a/src/git/repository/working_tree.rs
+++ b/src/git/repository/working_tree.rs
@@ -937,7 +937,7 @@ mod tests {
         // A worktree whose `<gitdir>/index` file is absent must not error
         // when callers ask for a temp index — git itself treats a missing
         // index as empty, and the WorkingTreeConflictsTask used to surface
-        // this as a misleading `working-tree-conflicts (Failed to copy
+        // this as a misleading `working-tree conflict check (Failed to copy
         // index file)` footer.
         let test = TestRepo::with_initial_commit();
         std::fs::write(test.root_path().join("tracked.txt"), "hello\n").unwrap();

--- a/tests/integration_tests/bare_repository.rs
+++ b/tests/integration_tests/bare_repository.rs
@@ -1414,8 +1414,8 @@ fn test_clone_bare_repo_list_no_status_errors() {
         "Should not get 'must be run in a work tree' error.\nstderr: {stderr}"
     );
     assert!(
-        !stderr.contains("git operations failed"),
-        "Should not have git operation failures.\nstderr: {stderr}"
+        !stderr.contains("task failed") && !stderr.contains("tasks failed"),
+        "Should not have task failures.\nstderr: {stderr}"
     );
 }
 

--- a/tests/integration_tests/list.rs
+++ b/tests/integration_tests/list.rs
@@ -3620,8 +3620,8 @@ fn test_list_unborn_worktree_no_task_failures(repo: TestRepo) {
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        !stderr.contains("working-tree-diff") && !stderr.contains("working-tree-conflicts"),
-        "wt list should not surface working-tree-* task failures for unborn worktrees, got stderr:\n{stderr}"
+        !stderr.contains("working-tree diff") && !stderr.contains("working-tree conflict check"),
+        "wt list should not surface working-tree task failures for unborn worktrees, got stderr:\n{stderr}"
     );
     assert!(
         !stderr.contains("ambiguous argument 'HEAD'")
@@ -3861,8 +3861,8 @@ fn test_list_tolerates_missing_index(mut repo: TestRepo) {
         "missing index must not surface as a copy error.\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
     assert!(
-        !combined.contains("working-tree-conflicts ("),
-        "missing index must not produce a working-tree-conflicts task error.\nstdout:\n{stdout}\nstderr:\n{stderr}"
+        !combined.contains("working-tree conflict check ("),
+        "missing index must not produce a working-tree conflict task error.\nstdout:\n{stdout}\nstderr:\n{stderr}"
     );
     assert!(
         !feature_index.exists(),

--- a/tests/integration_tests/readme_sync.rs
+++ b/tests/integration_tests/readme_sync.rs
@@ -192,7 +192,7 @@ impl MarkerType {
 ///
 /// Handles:
 /// - YAML front matter removal
-/// - insta_cmd stdout/stderr section extraction (prefers stderr where user messages go)
+/// - insta_cmd stdout/stderr section extraction (both streams, in terminal order)
 /// - Malformed snapshots (returns raw content rather than erroring)
 fn parse_snapshot_raw(content: &str) -> String {
     // Remove YAML front matter
@@ -207,14 +207,18 @@ fn parse_snapshot_raw(content: &str) -> String {
         content.to_string()
     };
 
-    // Handle insta_cmd format with stdout/stderr sections
+    // Handle insta_cmd format with stdout/stderr sections. Show both streams
+    // in terminal order (stdout, then stderr) — a command like `wt list` puts
+    // the table on stdout and the summary/warnings on stderr, and the docs
+    // block should read like the terminal.
     if content.contains("----- stdout -----") {
-        let stderr = extract_section(&content, "----- stderr -----\n", "----- ");
-        if !stderr.is_empty() {
-            return stderr;
-        }
         let stdout = extract_section(&content, "----- stdout -----\n", "----- stderr -----");
-        return stdout; // May be empty if both sections are empty
+        let stderr = extract_section(&content, "----- stderr -----\n", "----- ");
+        return match (stdout.is_empty(), stderr.is_empty()) {
+            (false, false) => format!("{stdout}\n{stderr}"),
+            (true, _) => stderr, // both-empty also lands here, returning ""
+            (false, true) => stdout,
+        };
     }
 
     // Plain content (PTY-based tests without section markers)

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_commands_from_bare_directory.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_commands_from_bare_directory.snap
@@ -38,6 +38,6 @@ exit_code: 0
   [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
 ^ main        [2m^[22m                                             .     [2mb834638e[0m  [2m1d[0m    [2mInitial commit[0m
 
-[2m○[22m [2mShowing 1 worktree[0m
-
 ----- stderr -----
+
+○ Showing 1 worktree

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_identifies_primary_correctly.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_identifies_primary_correctly.snap
@@ -40,6 +40,6 @@ exit_code: 0
 + [2mfeature1[0m      [2m_[22m                                             [2m../feature1[0m  [2mb37a293c[0m  [2m1d[0m    [2mMain commit[0m
 + [2mfeature2[0m      [2m_[22m                                             [2m../feature2[0m  [2mb37a293c[0m  [2m1d[0m    [2mMain commit[0m
 
-[2m○[22m [2mShowing 3 worktrees[0m
-
 ----- stderr -----
+
+○ Showing 3 worktrees

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_list_shows_no_bare_entry.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_list_shows_no_bare_entry.snap
@@ -38,6 +38,6 @@ exit_code: 0
   [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
 @ main        [2m^[22m                                             .     [2mb834638e[0m  [2m1d[0m    [2mInitial commit[0m
 
-[2m○[22m [2mShowing 1 worktree[0m
-
 ----- stderr -----
+
+○ Showing 1 worktree

--- a/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_list_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__bare_repo_list_worktrees.snap
@@ -39,6 +39,6 @@ exit_code: 0
 @ main         [2m^[22m                                             .           [2m6c3da842[0m  [2m1d[0m    [2mInitial commit on main[0m
 + feature      [2m↑[22m                 [32m↑1[0m        [32m+1[0m   [31m-1[0m           ../feature  [2m72413a3b[0m  [2m1d[0m    [2mWork on feature[0m
 
-[2m○[22m [2mShowing 2 worktrees, 1 ahead[0m
-
 ----- stderr -----
+
+○ Showing 2 worktrees, 1 ahead

--- a/tests/snapshots/integration__integration_tests__bare_repository__nested_bare_repo_list_snapshot.snap
+++ b/tests/snapshots/integration__integration_tests__bare_repository__nested_bare_repo_list_snapshot.snap
@@ -39,6 +39,6 @@ exit_code: 0
 @ main         [2m^[22m                                             .           [2ma6c13b13[0m  [2m1d[0m    [2mInitial[0m
 + [2mfeature[0m      [2m_[22m                                             [2m../feature[0m  [2ma6c13b13[0m  [2m1d[0m    [2mInitial[0m
 
-[2m○[22m [2mShowing 2 worktrees[0m
-
 ----- stderr -----
+
+○ Showing 2 worktrees

--- a/tests/snapshots/integration__integration_tests__ci_status__azure_no_ci.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__azure_no_ci.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__azure_pipeline_failed.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__azure_pipeline_failed.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[31m#[0m      ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[31m#[0m      ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__azure_pipeline_passed.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__azure_pipeline_passed.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m#[0m      ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m#[0m      ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__azure_pipeline_retriable_error.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__azure_pipeline_retriable_error.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [33m⚠[0m      ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [33m⚠[0m      ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__azure_pipeline_running.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__azure_pipeline_running.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[34m#[0m      ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[34m#[0m      ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__azure_pr_conflicts.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__azure_pr_conflicts.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[33m#7[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[33m#7[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__azure_pr_list_retriable_error.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__azure_pr_list_retriable_error.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [33m⚠[0m      ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [33m⚠[0m      ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__azure_pr_queued.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__azure_pr_queued.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[34m#7[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[34m#7[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__azure_stale_pipeline.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__azure_stale_pipeline.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m#[0m      ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m#[0m      ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__filters_by_repo_owner.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__filters_by_repo_owner.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m#1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m#1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitea_commit_status.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitea_commit_status.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + feature        [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [31m#[0m      ../repo.feature    [2m9c1e078b[0m  [2m1d[0m    [2mfeat: gitea feature[0m
 
-[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitea_commit_status_retriable_error.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitea_commit_status_retriable_error.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + feature        [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [33m⚠[0m      ../repo.feature    [2m9c1e078b[0m  [2m1d[0m    [2mfeat: gitea feature[0m
 
-[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitea_fork_pr.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitea_fork_pr.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + feature        [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [32m#7[0m     ../repo.feature    [2m9a059eb4[0m  [2m1d[0m    [2mfeat: gitea fork feature[0m
 
-[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitea_no_ci.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitea_no_ci.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + feature        [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature    [2m9c1e078b[0m  [2m1d[0m    [2mfeat: gitea feature[0m
 
-[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitea_pr_conflicts.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitea_pr_conflicts.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + feature        [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [33m#7[0m     ../repo.feature    [2m9c1e078b[0m  [2m1d[0m    [2mfeat: gitea feature[0m
 
-[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitea_pr_failed.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitea_pr_failed.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + feature        [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [31m#7[0m     ../repo.feature    [2m9c1e078b[0m  [2m1d[0m    [2mfeat: gitea feature[0m
 
-[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitea_pr_passed.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitea_pr_passed.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + feature        [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [32m#7[0m     ../repo.feature    [2m9c1e078b[0m  [2m1d[0m    [2mfeat: gitea feature[0m
 
-[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitea_pr_running.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitea_pr_running.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + feature        [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [34m#7[0m     ../repo.feature    [2m9c1e078b[0m  [2m1d[0m    [2mfeat: gitea feature[0m
 
-[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitea_remote_branch_uses_branch_remote.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitea_remote_branch_uses_branch_remote.snap
@@ -8,6 +8,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -52,6 +53,6 @@ exit_code: 0
 + feature-c                [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 [2m| [0mfork/feature-remote     [2m/[22m[2m↑[22m                 [32m↑1[0m        [32m+1[0m                [32m#[0m                         [2m86db681a[0m  [2m1d[0m    [2mfeat: fork feature[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 remote branches, 4 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 1 remote branch, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitea_retriable_error.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitea_retriable_error.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [33m⚠[0m      ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + feature        [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [33m⚠[0m      ../repo.feature    [2m9c1e078b[0m  [2m1d[0m    [2mfeat: gitea feature[0m
 
-[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__github_pr_approved.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__github_pr_approved.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m#1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m#1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__github_pr_changes_requested.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__github_pr_changes_requested.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[35m#1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[35m#1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__github_pr_conflicts.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__github_pr_conflicts.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[33m#1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[33m#1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__github_pr_draft.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__github_pr_draft.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m#1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m#1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__github_pr_failed.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__github_pr_failed.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[31m#1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[31m#1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__github_pr_passed.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__github_pr_passed.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m#1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m#1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__github_pr_review_required.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__github_pr_review_required.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[36m#1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[36m#1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__github_pr_running.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__github_pr_running.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[34m#1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[34m#1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__github_workflow_run.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__github_workflow_run.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__github_workflow_running.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__github_workflow_running.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_ci_rate_limit.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_ci_rate_limit.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [33m⚠[0m      ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [33m⚠[0m      ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_empty_mr_list_no_project_id.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_empty_mr_list_no_project_id.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_filters_by_project_id.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_filters_by_project_id.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m!1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m!1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_conflicts.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_conflicts.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[33m!1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[33m!1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_failed.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_failed.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[31m!1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[31m!1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_passed.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_passed.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m!1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m!1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_pending.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_pending.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[34m!1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[34m!1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_running.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_running.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[34m!1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[34m!1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_view_failure.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_mr_view_failure.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[33m⚠[0m      ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[33m⚠[0m      ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_multiple_mrs_no_project_id.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_multiple_mrs_no_project_id.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_no_ci.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_no_ci.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[90m!1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[90m!1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_pipeline_success.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_pipeline_success.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m#[0m      ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m#[0m      ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_single_mr_no_project_id.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_single_mr_no_project_id.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m!1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m!1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitlab_stale_mr.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitlab_stale_mr.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m!1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + feature        [2m↑[22m[2m⇡[22m                [32m↑1[0m        [32m+1[0m        [32m⇡1[0m      [2m[32m!1[0m     ../repo.feature    [2mda7d235a[0m  [2m1d[0m    [2mLocal commit[0m
 
-[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_configured_platform_github.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_configured_platform_github.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,8 +52,8 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m#1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m#1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 1 with changes, 3 ahead[0m
-
 ----- stderr -----
 [33m▲[39m [33mProject config: [1m[ci][22m is deprecated in favor of [1m[forge][22m[39m
 [2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
+
+[2m○[22m [2mShowing 5 worktrees, 1 with changes, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_gitea_forge_platform.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_gitea_forge_platform.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 1 with changes, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 1 with changes, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_gitlab_remote.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_gitlab_remote.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__list_full_with_invalid_configured_platform.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__list_full_with_invalid_configured_platform.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -52,9 +53,9 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m#1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m#1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 1 with changes, 3 ahead[0m
-
 ----- stderr -----
 [33m▲[39m [33mProject config: [1m[ci][22m is deprecated in favor of [1m[forge][22m[39m
 [2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
 [2m[W][22m Invalid CI platform in config: 'invalid_platform'. Expected 'github', 'gitlab', 'gitea', or 'azure-devops'.
+
+[2m○[22m [2mShowing 5 worktrees, 1 with changes, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__mixed_check_types.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__mixed_check_types.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[34m#1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[34m#1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__no_ci_checks.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__no_ci_checks.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[90m#1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[90m#1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__stale_pr.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__stale_pr.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[32m#1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + feature        [2m↑[22m[2m⇡[22m                [32m↑1[0m        [32m+1[0m        [32m⇡1[0m      [2m[32m#1[0m     ../repo.feature    [2mda7d235a[0m  [2m1d[0m    [2mLocal commit[0m
 
-[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__status_context_failure.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__status_context_failure.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[31m#1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[31m#1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__status_context_pending.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__status_context_pending.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[34m#1[0m     ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [2m[34m#1[0m     ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__url_based_pushremote.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__url_based_pushremote.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_project_level_shows_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_project_level_shows_warning.snap
@@ -50,8 +50,8 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
 [33m▲[39m [33mUser config: [1m[projects."github.com/example/repo".commit-generation][22m is deprecated in favor of [1m[projects."github.com/example/repo".commit.generation][22m[39m
 [2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_section_shows_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_commit_generation_section_shows_warning.snap
@@ -50,8 +50,8 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
 [33m▲[39m [33mUser config: [1m[commit-generation][22m is deprecated in favor of [1m[commit.generation][22m[39m
 [2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_show_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_show_warning.snap
@@ -50,10 +50,10 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
 [33m▲[39m [33mUser config: template variable [1mrepo_root[22m is deprecated in favor of [1mrepo_path[22m[39m
 [33m▲[39m [33mUser config: template variable [1mworktree[22m is deprecated in favor of [1mworktree_path[22m[39m
 [33m▲[39m [33mUser config: template variable [1mmain_worktree[22m is deprecated in favor of [1mrepo[22m[39m
 [2m↳[22m [2mTo see details, run [4mwt config show[24m; to apply updates, run [4mwt config update[24m[22m
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_verbose_shows_content.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__deprecated_template_variables_verbose_shows_content.snap
@@ -51,8 +51,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
 [33m▲[39m [33mUser config: template variable [1mrepo_root[22m is deprecated in favor of [1mrepo_path[22m[39m
 [33m▲[39m [33mUser config: template variable [1mworktree[22m is deprecated in favor of [1mworktree_path[22m[39m
@@ -70,3 +68,5 @@ exit_code: 0
 [107m [0m [2m[0m[2m[34m../[0m[2m[32m{{[0m[2m[34m[0m[2m main_worktree [0m[2m[32m}}[0m[2m.[0m[2m[32m{{[0m[2m branch [0m[2m[32m}}[0m
 [2m○[22m [1mworktree-path[22m result
 [107m [0m [2m[0m[2m[34m../repo.feature-c[0m
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__config_show__explicit_config_path_not_found_shows_warning.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__explicit_config_path_not_found_shows_warning.snap
@@ -52,7 +52,7 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
 [33m▲[39m [33mConfig file not found: [1m/nonexistent/worktrunk/config.toml[22m[39m
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__commit_conflicts_with_full.snap
+++ b/tests/snapshots/integration__integration_tests__list__commit_conflicts_with_full.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                       ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + feature        [33m✗[39m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m   [31m-1[0m                  ../repo.feature    [2mdee7183a[0m  [2m1d[0m    [2mFeature changes shared.txt[0m
 
-[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__commit_conflicts_without_full.snap
+++ b/tests/snapshots/integration__integration_tests__list__commit_conflicts_without_full.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-c      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + feature        [33m✗[39m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m   [31m-1[0m           ../repo.feature    [2mdee7183a[0m  [2m1d[0m    [2mFeature changes shared.txt[0m
 
-[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_branch_only_with_status.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_branch_only_with_status.snap
@@ -52,6 +52,6 @@ exit_code: 0
 + feature-c        [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 [2m/ [0m[2mbranch-only[0m     [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 1 branch, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_branches_with_nonexistent_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_branches_with_nonexistent_default_branch.snap
@@ -51,8 +51,8 @@ exit_code: 0
 + feature-b                                                    ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c                                                    ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees[0m
-
 ----- stderr -----
 [33m▲[39m [33mConfigured default branch [1mnonexistent[22m does not exist locally[39m
 [2m↳[22m [2mTo reset, run [4mwt config state default-branch clear[24m[22m
+
+[2m○[22m [2mShowing 4 worktrees[0m

--- a/tests/snapshots/integration__integration_tests__list__list_detached_head.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_detached_head.snap
@@ -50,6 +50,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_detached_head_in_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_detached_head_in_worktree.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_empty_repo.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_empty_repo.snap
@@ -45,6 +45,6 @@ exit_code: 0
   [1mBranch[0m  [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m  [1mCommit[0m    [1mAge[0m   [1mMessage[0m
 @ main    [2m·[0m  [2m·[0m[2m^[22m             [2m·[0m                               .               [2m·[0m     [2m·[0m
 
-[2m○[22m [2mShowing 1 worktree[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 1 worktree[0m

--- a/tests/snapshots/integration__integration_tests__list__list_full_with_nonexistent_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_full_with_nonexistent_default_branch.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -50,8 +51,8 @@ exit_code: 0
 + feature-b                                                           ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c                                                           ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees[0m
-
 ----- stderr -----
 [33m▲[39m [33mConfigured default branch [1mnonexistent[22m does not exist locally[39m
 [2m↳[22m [2mTo reset, run [4mwt config state default-branch clear[24m[22m
+
+[2m○[22m [2mShowing 4 worktrees[0m

--- a/tests/snapshots/integration__integration_tests__list__list_handles_orphan_branch.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_handles_orphan_branch.snap
@@ -52,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 [2m/ [0massets        [2m/[22m[2m∅[22m                                                                [2m50209039[0m  [2m1d[0m    [2mAdd asset[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 1 branch, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_large_diffs_alignment.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_large_diffs_alignment.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + diverged          [36m![39m  [2m↑[22m 💬   [32m+40[0m  [31m-60[0m   [32m↑1[0m       [32m+60[0m                ../repo.diverged         [2m96d1fd92[0m  [2m1d[0m    [2mDiverged commit[0m
 + feature-changes   [36m![39m[36m?[39m [2m↑[22m 🤖   [32m+50[0m [31m-100[0m   [32m↑1[0m      [32m+100[0m                ../repo.feature-changes  [2mf5306ded[0m  [2m1d[0m    [2mAdd 100 lines[0m
 
-[2m○[22m [2mShowing 7 worktrees, 3 with changes, 5 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 3 with changes, 5 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_locked_no_reason.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_locked_no_reason.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-c             [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c         [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + [2mlocked-no-reason[0m     [33m⊞[39m[2m_[22m                                             [2m../repo.locked-no-reason[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_locked_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_locked_worktree.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-c           [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c       [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + [2mlocked-feature[0m     [33m⊞[39m[2m_[22m                                             [2m../repo.locked-feature[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_long_commit_message.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_long_commit_message.snap
@@ -50,6 +50,6 @@ exit_code: 0
 + feature-b      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_many_worktrees_with_varied_stats.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_many_worktrees_with_varied_stats.snap
@@ -54,6 +54,6 @@ exit_code: 0
 + [2mvery-long-branch-name-here[0m      [2m_[22m                                             [2m../repo.very-long-branch-name-here[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 + [2mwith-changes[0m                    [2m_[22m                                             [2m../repo.with-changes[0m                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 8 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 8 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_maximum_working_tree_symbols.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_maximum_working_tree_symbols.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + feature    [36m+[39m[36m![39m[36m?[39m [2m↑[22m       [32m+2[0m   [31m-3[0m   [32m↑1[0m        [32m+4[0m                ../repo.feature    [2mda422a12[0m  [2m1d[0m    [2mAdd files[0m
 
-[2m○[22m [2mShowing 5 worktrees, 1 with changes, 4 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 1 with changes, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_multiple_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_multiple_worktrees.snap
@@ -50,6 +50,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_nested_worktree_current_indicator.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_nested_worktree_current_indicator.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b     [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c     [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 1 with changes, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 1 with changes, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_no_progressive_flag.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_no_progressive_flag.snap
@@ -52,6 +52,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_ordering_rules.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_ordering_rules.snap
@@ -54,6 +54,6 @@ exit_code: 0
 + feature-middle       [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-middle   [2ma63f3739[0m  [2m22h[0m   [2mCommit at 02:00[0m
 + feature-oldest       [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-oldest   [2ma9b3e5b7[0m  [2m23h[0m   [2mCommit at 00:30[0m
 
-[2m○[22m [2mShowing 8 worktrees, 7 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 8 worktrees, 7 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_previous_worktree_gutter.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_previous_worktree_gutter.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_primary_on_different_branch.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_primary_on_different_branch.snap
@@ -50,6 +50,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_progressive_flag.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_progressive_flag.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_progressive_with_branches.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_progressive_with_branches.snap
@@ -54,6 +54,6 @@ exit_code: 0
 [2m/ [0m[2morphan-1[0m      [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 [2m/ [0m[2morphan-2[0m      [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 2 branches, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 2 branches, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_shows_warning_on_git_error.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_shows_warning_on_git_error.snap
@@ -51,19 +51,19 @@ exit_code: 0
 + feature-b      [2m↑[22m[2m·[0m                [32m↑1[0m        [32m+1[0m             [2m·[0m  ../repo.feature-b  [2mf62940fc[0m  [2m·[0m     [2m·[0m
 + feature-c      [2m↑[22m[2m·[0m                [32m↑1[0m        [32m+1[0m             [2m·[0m  ../repo.feature-c  [2m345c7c93[0m  [2m·[0m     [2m·[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead. 10 tasks failed[0m
-
 ----- stderr -----
 [33m▲[39m [33mFailed to batch-fetch commit details: fatal: bad object 0000000000000000000000000000000000000001[39m
-[33m▲[39m [33mSome git operations failed:
-[107m [0m [1mmain[22m: upstream (fatal: missing object 0000000000000000000000000000000000000001 for refs/heads/feature)
-[107m [0m [1mfeature[22m: ahead-behind (git merge-base failed for 05a4a45d0b981dad5c27db59dca482836d59f89e 0000000000000000000000000000000000000001: fatal: Not a valid commit name 0000000000000000000000000000000000000001)
-[107m [0m [1mfeature[22m: branch-diff (git merge-base failed for 05a4a45d0b981dad5c27db59dca482836d59f89e 0000000000000000000000000000000000000001: fatal: Not a valid commit name 0000000000000000000000000000000000000001)
-[107m [0m [1mfeature[22m: working-tree-diff (fatal: bad object HEAD)
-[107m [0m [1mfeature[22m: merge-tree-conflicts (fatal: bad object HEAD)
-[107m [0m [1mfeature[22m: working-tree-conflicts (fatal: bad object HEAD)
-[107m [0m [1mfeature[22m: upstream (fatal: missing object 0000000000000000000000000000000000000001 for refs/heads/feature)
-[107m [0m [1mfeature-a[22m: upstream (fatal: missing object 0000000000000000000000000000000000000001 for refs/heads/feature)
-[107m [0m [1mfeature-b[22m: upstream (fatal: missing object 0000000000000000000000000000000000000001 for refs/heads/feature)
-[107m [0m [1mfeature-c[22m: upstream (fatal: missing object 0000000000000000000000000000000000000001 for refs/heads/feature)[39m
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead; 10 tasks failed[0m
+[33m▲[39m [33m10 tasks failed:
+[107m [0m [1mmain[22m: upstream status (fatal: missing object 0000000000000000000000000000000000000001 for refs/heads/feature)
+[107m [0m [1mfeature[22m: ahead/behind counts (git merge-base failed for 05a4a45d0b981dad5c27db59dca482836d59f89e 0000000000000000000000000000000000000001: fatal: Not a valid commit name 0000000000000000000000000000000000000001)
+[107m [0m [1mfeature[22m: branch diff (git merge-base failed for 05a4a45d0b981dad5c27db59dca482836d59f89e 0000000000000000000000000000000000000001: fatal: Not a valid commit name 0000000000000000000000000000000000000001)
+[107m [0m [1mfeature[22m: working-tree diff (fatal: bad object HEAD)
+[107m [0m [1mfeature[22m: merge-conflict check (fatal: bad object HEAD)
+[107m [0m [1mfeature[22m: working-tree conflict check (fatal: bad object HEAD)
+[107m [0m [1mfeature[22m: upstream status (fatal: missing object 0000000000000000000000000000000000000001 for refs/heads/feature)
+[107m [0m [1mfeature-a[22m: upstream status (fatal: missing object 0000000000000000000000000000000000000001 for refs/heads/feature)
+[107m [0m [1mfeature-b[22m: upstream status (fatal: missing object 0000000000000000000000000000000000000001 for refs/heads/feature)
+[107m [0m [1mfeature-c[22m: upstream status (fatal: missing object 0000000000000000000000000000000000000001 for refs/heads/feature)[39m
 [2m↳[22m [2mTo create a diagnostic file, run with [4m-vv[24m[22m

--- a/tests/snapshots/integration__integration_tests__list__list_single_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_single_worktree.snap
@@ -50,6 +50,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_skips_operations_for_prunable_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_skips_operations_for_prunable_worktrees.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_status_column_padding_with_emoji.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_status_column_padding_with_emoji.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + pr-link           [2m↑[22m 🤖              [32m↑1[0m        [32m+1[0m                ../repo.pr-link       [2m152b5dea[0m  [2m1d[0m    [2mPR commit[0m
 + wli-sequence   [36m![39m[36m?[39m [2m↑[22m 🤖    [32m+1[0m [31m-112[0m   [32m↑1[0m      [32m+200[0m                ../repo.wli-sequence  [2m4353e28e[0m  [2m1d[0m    [2mInitial content[0m
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 6 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 6 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_task_dag_detached_head.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_task_dag_detached_head.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_task_dag_full_with_diffs.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_task_dag_full_with_diffs.snap
@@ -8,6 +8,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + feature-b      [2m↑[22m                 [32m↑2[0m        [32m+2[0m   [31m-1[0m                  ../repo.feature-b  [2m391b2a76[0m  [2m1d[0m    [2mTest commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 with changes, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 1 with changes, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_task_dag_many_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_task_dag_many_worktrees.snap
@@ -61,6 +61,6 @@ exit_code: 0
 + feature-b       [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b   [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c       [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c   [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 14 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 14 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_task_dag_multiple_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_task_dag_multiple_worktrees.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_task_dag_single_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_task_dag_single_worktree.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_task_dag_with_locked_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_task_dag_with_locked_worktree.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + [2mlocked[0m        [33m⊞[39m[2m_[22m                                             [2m../repo.locked[0m     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 + [2mnormal[0m         [2m_[22m                                             [2m../repo.normal[0m     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 6 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 6 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_task_dag_with_upstream.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_task_dag_with_upstream.snap
@@ -8,6 +8,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -53,6 +54,6 @@ exit_code: 0
 + ahead          [2m↑[22m[2m⇡[22m                [32m↑1[0m        [32m+1[0m        [32m⇡1[0m             ../repo.ahead      [2m76a1bef4[0m  [2m1d[0m    [2mAhead commit[0m
 + [2min-sync[0m        [2m_[22m[2m|[22m                                      [2m|[0m            [2m../repo.in-sync[0m    [2m01cab36c[0m  [2m1d[0m    [2mInitial commit on main[0m
 
-[2m○[22m [2mShowing 6 worktrees, 4 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 6 worktrees, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_unicode_commit_message.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_unicode_commit_message.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-c         [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                ../repo.feature-c     [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + [2mfeature-test[0m      [2m⊂[22m                     [2m[31m↓1[0m                      [2m../repo.feature-test[0m  [2m4b80044d[0m  [2m1d[0m    [2mAdd support for 日本語 and émoji 🎉[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_user_marker_with_special_characters.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_user_marker_with_special_characters.snap
@@ -52,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + [2mmulti[0m          [2m_[22m 👨‍💻                                          [2m../repo.multi[0m      [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 6 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 6 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_warns_when_commit_details_batch_fails.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_warns_when_commit_details_batch_fails.snap
@@ -51,15 +51,15 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m·[0m     [2m·[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m·[0m     [2m·[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead. 6 tasks failed[0m
-
 ----- stderr -----
 [33m▲[39m [33mFailed to batch-fetch commit details: fatal: bad object 0000000000000000000000000000000000000001[39m
-[33m▲[39m [33mSome git operations failed:
-[107m [0m [1m(detached)[22m: ahead-behind (git merge-base failed for 05a4a45d0b981dad5c27db59dca482836d59f89e 0000000000000000000000000000000000000001: fatal: Not a valid commit name 0000000000000000000000000000000000000001)
-[107m [0m [1m(detached)[22m: committed-trees-match (fatal: Needed a single revision)
-[107m [0m [1m(detached)[22m: branch-diff (git merge-base failed for 05a4a45d0b981dad5c27db59dca482836d59f89e 0000000000000000000000000000000000000001: fatal: Not a valid commit name 0000000000000000000000000000000000000001)
-[107m [0m [1m(detached)[22m: working-tree-diff (fatal: bad object HEAD)
-[107m [0m [1m(detached)[22m: merge-tree-conflicts (fatal: bad object HEAD)
-[107m [0m [1m(detached)[22m: working-tree-conflicts (fatal: bad object HEAD)[39m
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead; 6 tasks failed[0m
+[33m▲[39m [33m6 tasks failed:
+[107m [0m [1m(detached)[22m: ahead/behind counts (git merge-base failed for 05a4a45d0b981dad5c27db59dca482836d59f89e 0000000000000000000000000000000000000001: fatal: Not a valid commit name 0000000000000000000000000000000000000001)
+[107m [0m [1m(detached)[22m: trees-match check (fatal: Needed a single revision)
+[107m [0m [1m(detached)[22m: branch diff (git merge-base failed for 05a4a45d0b981dad5c27db59dca482836d59f89e 0000000000000000000000000000000000000001: fatal: Not a valid commit name 0000000000000000000000000000000000000001)
+[107m [0m [1m(detached)[22m: working-tree diff (fatal: bad object HEAD)
+[107m [0m [1m(detached)[22m: merge-conflict check (fatal: bad object HEAD)
+[107m [0m [1m(detached)[22m: working-tree conflict check (fatal: bad object HEAD)[39m
 [2m↳[22m [2mTo create a diagnostic file, run with [4m-vv[24m[22m

--- a/tests/snapshots/integration__integration_tests__list__list_warns_when_default_branch_missing_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_warns_when_default_branch_missing_worktree.snap
@@ -50,6 +50,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_with_branches_flag.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_branches_flag.snap
@@ -55,6 +55,6 @@ exit_code: 0
 [2m/ [0m[2mfeature-without-worktree[0m     [2m/[22m[2m_[22m                                                                            [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 [2m/ [0m[2mfix-bug[0m                      [2m/[22m[2m_[22m                                                                            [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 branches, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 branches, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_with_branches_flag_no_available.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_branches_flag_no_available.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_with_branches_flag_only_branches.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_branches_flag_only_branches.snap
@@ -54,6 +54,6 @@ exit_code: 0
 [2m/ [0m[2mbranch-beta[0m      [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 [2m/ [0m[2mbranch-gamma[0m     [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 branches, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 3 branches, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_with_c_flag.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_c_flag.snap
@@ -39,6 +39,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_with_nonexistent_default_branch.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_nonexistent_default_branch.snap
@@ -50,8 +50,8 @@ exit_code: 0
 + feature-b                                                    ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c                                                    ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees[0m
-
 ----- stderr -----
 [33m▲[39m [33mConfigured default branch [1mnonexistent[22m does not exist locally[39m
 [2m↳[22m [2mTo reset, run [4mwt config state default-branch clear[24m[22m
+
+[2m○[22m [2mShowing 4 worktrees[0m

--- a/tests/snapshots/integration__integration_tests__list__list_with_remotes_and_branches.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_remotes_and_branches.snap
@@ -56,6 +56,6 @@ exit_code: 0
 [2m| [0m[2morigin/remote-only-1[0m     [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 [2m| [0m[2morigin/remote-only-2[0m     [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 2 branches, 2 remote branches, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 2 branches, 2 remote branches, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_with_remotes_and_full.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_remotes_and_full.snap
@@ -8,6 +8,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -52,6 +53,6 @@ exit_code: 0
 + feature-c                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 [2m| [0m[2morigin/feature-remote[0m     [2m/[22m[2m_[22m                                                                       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 remote branches, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 1 remote branch, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_with_remotes_filters_tracked_branches.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_remotes_filters_tracked_branches.snap
@@ -52,6 +52,6 @@ exit_code: 0
 + feature-c               [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 [2m| [0m[2morigin/remote-only[0m     [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 remote branches, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 1 remote branch, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_with_remotes_filters_tracked_worktrees.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_remotes_filters_tracked_worktrees.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + [2mfeature-with-worktree[0m      [2m_[22m[2m|[22m                                      [2m|[0m     [2m../repo.feature-with-worktree[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 [2m| [0m[2morigin/remote-only[0m        [2m/[22m[2m_[22m                                                                            [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 5 worktrees, 1 remote branches, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 1 remote branch, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_with_remotes_flag.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_remotes_flag.snap
@@ -53,6 +53,6 @@ exit_code: 0
 [2m| [0m[2morigin/remote-feature-1[0m     [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 [2m| [0m[2morigin/remote-feature-2[0m     [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 2 remote branches, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 2 remote branches, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__list_with_user_marker.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_with_user_marker.snap
@@ -50,6 +50,6 @@ exit_code: 0
 + review-ui      [36m?[39m [2m↑[22m 💬              [32m↑1[0m        [32m+1[0m                ../repo.review-ui    [2ma585d6ed[0m  [2m1d[0m    [2mAdd dashboard component[0m
 + wip-docs       [36m?[39m [2m–[22m                                             ../repo.wip-docs     [2m33323bc1[0m  [2m1d[0m    [2mInitial commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 2 with changes, 2 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 2 with changes, 2 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__maximum_status_symbols.snap
+++ b/tests/snapshots/integration__integration_tests__list__maximum_status_symbols.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                       ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + feature    [36m+[39m[36m![39m[36m?[39m[33m⊞[39m[33m✗[39m[2m⇅[22m🤖    [32m+3[0m   [31m-2[0m   [32m↑2[0m  [2m[31m↓1[0m    [32m+3[0m   [31m-1[0m   [32m⇡1[0m  [2m[31m⇣1[0m         ../repo.feature    [2m342be366[0m  [2m1d[0m    [2mLocal commit[0m
 
-[2m○[22m [2mShowing 5 worktrees, 1 with changes, 4 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 1 with changes, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__maximum_status_with_git_operation.snap
+++ b/tests/snapshots/integration__integration_tests__list__maximum_status_with_git_operation.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                       ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + feature    [36m+[39m[36m![39m[36m?[39m[31m✘[39m[33m✗[39m 🤖    [32m+8[0m        [32m↑1[0m  [2m[31m↓1[0m    [32m+3[0m   [31m-2[0m                  ../repo.feature    [2m27eb0ee8[0m  [2m1d[0m    [2mMain conflicting changes[0m
 
-[2m○[22m [2mShowing 5 worktrees, 1 with changes, 4 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 1 with changes, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__quickstart_list.snap
+++ b/tests/snapshots/integration__integration_tests__list__quickstart_list.snap
@@ -48,6 +48,6 @@ exit_code: 0
 @ feature-auth  [36m+[39m   [2m↑[22m      [32m+27[0m   [31m-8[0m   [32m↑1[0m       [32m+31[0m                [2m4bc72dc9[0m  [2m2h[0m    [2mAdd authenticat…[0m
 ^ main              [2m^[22m[2m⇡[22m                                    [32m⇡1[0m      [2m0e631add[0m  [2m1d[0m    [2mInitial commit[0m
 
-[2m○[22m [2mShowing 2 worktrees, 1 with changes, 1 ahead, 1 column hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 2 worktrees, 1 with changes, 1 ahead, 1 column hidden[0m

--- a/tests/snapshots/integration__integration_tests__list__readme_example_list.snap
+++ b/tests/snapshots/integration__integration_tests__list__readme_example_list.snap
@@ -50,6 +50,6 @@ exit_code: 0
 + fix-auth         [2m↕[22m[2m|[22m                [32m↑2[0m  [2m[31m↓1[0m   [32m+25[0m  [31m-11[0m     [2m|[0m     [2mb772e68b[0m  [2m5h[0m    [2mAdd secure token…[0m
 + [2mfix-typos[0m        [2m_[22m[2m|[22m                                      [2m|[0m     [2m41ee0834[0m  [2m4d[0m    [2mMerge fix-auth:…[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 with changes, 2 ahead, 1 column hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 1 with changes, 2 ahead, 1 column hidden[0m

--- a/tests/snapshots/integration__integration_tests__list__readme_example_list_branches.snap
+++ b/tests/snapshots/integration__integration_tests__list__readme_example_list_branches.snap
@@ -8,6 +8,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "134"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -53,6 +54,6 @@ exit_code: 0
 [2m/ [0mexp             [2m/[22m[2m↕[22m                 [32m↑2[0m  [2m[31m↓1[0m  [32m+137[0m       Explore GraphQL schema and resolvers                                  [2m96379229[0m
 [2m/ [0mwip             [2m/[22m[2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m   [32m+33[0m       Start API documentation                                               [2mb40716dc[0m
 
-[2m○[22m [2mShowing 4 worktrees, 2 branches, 1 with changes, 4 ahead, 3 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 2 branches, 1 with changes, 4 ahead, 3 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__list__readme_example_list_full.snap
+++ b/tests/snapshots/integration__integration_tests__list__readme_example_list_full.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "134"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -50,6 +51,6 @@ exit_code: 0
 + fix-auth         [2m↕[22m[2m|[22m                [32m↑2[0m  [2m[31m↓1[0m   [32m+25[0m  [31m-11[0m  Harden auth with constant-time token validation           [2m|[0m     [32m#408[0m  [2mb772e68b[0m
 + [2mfix-typos[0m        [2m_[22m[2m|[22m                                                                                             [2m|[0m     [32m#410[0m  [2m41ee0834[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 with changes, 2 ahead, 3 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 1 with changes, 2 ahead, 3 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__list__readme_example_list_marker.snap
+++ b/tests/snapshots/integration__integration_tests__list__readme_example_list_marker.snap
@@ -50,6 +50,6 @@ exit_code: 0
 + review-ui      [36m?[39m [2m↑[22m 💬              [32m↑1[0m        [32m+1[0m                [2ma585d6ed[0m  [2m1d[0m    [2mAdd dashboard co…[0m
 + wip-docs       [36m?[39m [2m–[22m                                             [2m33323bc1[0m  [2m1d[0m    [2mInitial commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 2 with changes, 2 ahead, 1 column hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 2 with changes, 2 ahead, 1 column hidden[0m

--- a/tests/snapshots/integration__integration_tests__list__task_dag_ordering_stability.snap
+++ b/tests/snapshots/integration__integration_tests__list__task_dag_ordering_stability.snap
@@ -55,6 +55,6 @@ exit_code: 0
 + feature-middle       [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-middle   [2ma63f3739[0m  [2m22h[0m   [2mCommit at 02:00[0m
 + feature-oldest       [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-oldest   [2ma9b3e5b7[0m  [2m23h[0m   [2mCommit at 00:30[0m
 
-[2m○[22m [2mShowing 8 worktrees, 7 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 8 worktrees, 7 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__tips_dev_server_workflow.snap
+++ b/tests/snapshots/integration__integration_tests__list__tips_dev_server_workflow.snap
@@ -50,6 +50,6 @@ exit_code: 0
 + fix-auth         [2m↕[22m[2m|[22m                [32m↑2[0m  [2m[31m↓1[0m   [32m+25[0m  [31m-11[0m     [2m|[0m     [2mhttp://localhost:16460[0m  [2mb772e68b[0m
 + [2mfix-typos[0m        [2m_[22m[2m|[22m                                      [2m|[0m     [2mhttp://localhost:14301[0m  [2m41ee0834[0m
 
-[2m○[22m [2mShowing 4 worktrees, 2 with changes, 2 ahead, 3 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 2 with changes, 2 ahead, 3 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__list__with_upstream_tracking.snap
+++ b/tests/snapshots/integration__integration_tests__list__with_upstream_tracking.snap
@@ -8,6 +8,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -57,6 +58,6 @@ exit_code: 0
 + [2min-sync[0m            [2m_[22m[2m|[22m                                      [2m|[0m            [2m../repo.in-sync[0m        [2m01cab36c[0m  [2m1d[0m    [2mInitial commit on main[0m
 + [2mno-upstream[0m        [2m_[22m                                                    [2m../repo.no-upstream[0m    [2m01cab36c[0m  [2m1d[0m    [2mInitial commit on main[0m
 
-[2m○[22m [2mShowing 10 worktrees, 5 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 10 worktrees, 5 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__working_tree_conflicts_with_full.snap
+++ b/tests/snapshots/integration__integration_tests__list__working_tree_conflicts_with_full.snap
@@ -7,6 +7,7 @@ info:
     - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -51,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                       ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + feature     [36m![39m  [33m✗[39m       [32m+1[0m   [31m-1[0m       [2m[31m↓1[0m                             ../repo.feature    [2ma756a743[0m  [2m1d[0m    [2mInitial commit[0m
 
-[2m○[22m [2mShowing 5 worktrees, 1 with changes, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 1 with changes, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list__working_tree_conflicts_without_full.snap
+++ b/tests/snapshots/integration__integration_tests__list__working_tree_conflicts_without_full.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-c      [2m↕[22m                 [32m↑1[0m  [2m[31m↓2[0m    [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + feature     [36m![39m  [33m✗[39m       [32m+1[0m   [31m-1[0m       [2m[31m↓1[0m                      ../repo.feature    [2ma756a743[0m  [2m1d[0m    [2mInitial commit[0m
 
-[2m○[22m [2mShowing 5 worktrees, 1 with changes, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 1 with changes, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_column_alignment__status_column_alignment_with_header.snap
+++ b/tests/snapshots/integration__integration_tests__list_column_alignment__status_column_alignment_with_header.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + test        [36m![39m[36m?[39m [2m↑[22m       [32m+1[0m   [31m-1[0m   [32m↑1[0m        [32m+1[0m   [31m-1[0m           ../repo.test       [2m572ec619[0m  [2m1d[0m    [2mTest[0m
 
-[2m○[22m [2mShowing 5 worktrees, 1 with changes, 4 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 1 with changes, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_column_alignment__status_column_width_consistency.snap
+++ b/tests/snapshots/integration__integration_tests__list_column_alignment__status_column_width_consistency.snap
@@ -52,6 +52,6 @@ exit_code: 0
 + complex    [36m+[39m [36m?[39m [2m↑[22m       [32m+1[0m   [31m-1[0m   [32m↑1[0m        [32m+1[0m   [31m-1[0m           ../repo.complex    [2m0fdc439a[0m  [2m1d[0m    [2mComplex[0m
 + simple       [36m?[39m [2m↑[22m                 [32m↑1[0m        [32m+1[0m   [31m-1[0m           ../repo.simple     [2m42a9d012[0m  [2m1d[0m    [2mSimple[0m
 
-[2m○[22m [2mShowing 6 worktrees, 2 with changes, 5 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 6 worktrees, 2 with changes, 5 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_branches_enabled.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_branches_enabled.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 [2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 1 branch, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_branches_flag_overrides_file.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_branches_flag_overrides_file.snap
@@ -52,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 [2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 1 branch, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_cli_override_after_subcommand.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_cli_override_after_subcommand.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 [2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 1 branch, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_cli_override_beats_file.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_cli_override_beats_file.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 [2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 1 branch, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_cli_override_deprecated_key_silently_migrated.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_cli_override_deprecated_key_silently_migrated.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 [2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 1 branch, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_cli_override_malformed_warns_on_stderr.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_cli_override_malformed_warns_on_stderr.snap
@@ -53,8 +53,6 @@ exit_code: 0
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 [2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
-
 ----- stderr -----
 [33m▲[39m [33mIgnoring --config-set overrides: garbage[39m
 [107m [0m TOML parse error at line 1, column 8
@@ -62,3 +60,5 @@ exit_code: 0
 [107m [0m 1 | garbage
 [107m [0m   |        ^
 [107m [0m key with no value, expected `=`
+
+[2m○[22m [2mShowing 4 worktrees, 1 branch, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_columns_env_override_not_yet_supported.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_columns_env_override_not_yet_supported.snap
@@ -51,9 +51,9 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
 [33m▲[39m [33mIgnoring env var overrides: WORKTRUNK__LIST__COLUMNS=branch,age[39m
 [107m [0m invalid type: string "branch,age", expected a sequence
 [107m [0m in `list.columns`
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_env_deprecated_type_mismatch_drops_layer.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_env_deprecated_type_mismatch_drops_layer.snap
@@ -51,9 +51,9 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
 [33m▲[39m [33mIgnoring env var overrides: WORKTRUNK__COMMIT_GENERATION__COMMAND=42[39m
 [107m [0m invalid type: integer `42`, expected a string
 [107m [0m in `commit.generation.command`
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_bad_value_preserves_file_config.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_bad_value_preserves_file_config.snap
@@ -52,9 +52,9 @@ exit_code: 0
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 [2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
-
 ----- stderr -----
 [33m▲[39m [33mIgnoring env var overrides: WORKTRUNK__LIST__BRANCHES=not-a-bool[39m
 [107m [0m invalid type: string "not-a-bool", expected a boolean
 [107m [0m in `list.branches`
+
+[2m○[22m [2mShowing 4 worktrees, 1 branch, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_bad_value_warns_on_stderr.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_bad_value_warns_on_stderr.snap
@@ -51,9 +51,9 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
 [33m▲[39m [33mIgnoring env var overrides: WORKTRUNK__LIST__BRANCHES=not-a-bool[39m
 [107m [0m invalid type: string "not-a-bool", expected a boolean
 [107m [0m in `list.branches`
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_preserves_file_fields.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_preserves_file_fields.snap
@@ -52,6 +52,6 @@ exit_code: 0
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 [2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 1 branch, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_validation_failure.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_env_override_validation_failure.snap
@@ -51,7 +51,7 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
 [33m▲[39m [33mConfig validation warning: worktree-path cannot be empty[39m
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_full_and_branches.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_full_and_branches.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -50,6 +51,6 @@ exit_code: 0
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 [2m/ [0m[2mfeature[0m       [2m/[22m[2m_[22m                                                                       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 1 branch, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_full_enabled.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_full_enabled.snap
@@ -6,6 +6,7 @@ info:
     - list
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -49,6 +50,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                       ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_config_warns_on_stderr.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_config_warns_on_stderr.snap
@@ -50,8 +50,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
 [33m▲[39m [33mUser config @ [TEST_CONFIG] failed to parse, skipping[39m
 [107m [0m TOML parse error at line 2, column 12
@@ -59,3 +57,5 @@ exit_code: 0
 [107m [0m 2 | branches = "not-a-bool"
 [107m [0m   |            ^^^^^^^^^^^^
 [107m [0m invalid type: string "not-a-bool", expected a boolean
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_non_section_field_warns_on_stderr.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_non_section_field_warns_on_stderr.snap
@@ -50,8 +50,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
 [33m▲[39m [33mUser config @ [TEST_CONFIG] failed to parse, skipping[39m
 [107m [0m TOML parse error at line 1, column 33
@@ -59,3 +57,5 @@ exit_code: 0
 [107m [0m 1 | skip-shell-integration-prompt = "not-a-bool"
 [107m [0m   |                                 ^^^^^^^^^^^^
 [107m [0m invalid type: string "not-a-bool", expected a boolean
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_system_config_non_section_field.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_system_config_non_section_field.snap
@@ -50,8 +50,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 with changes, 3 ahead[0m
-
 ----- stderr -----
 [33m▲[39m [33mSystem config @ [TEST_SYSTEM_CONFIG_FILE] failed to parse, skipping[39m
 [107m [0m TOML parse error at line 1, column 33
@@ -59,3 +57,5 @@ exit_code: 0
 [107m [0m 1 | skip-shell-integration-prompt = "not-a-bool"
 [107m [0m   |                                 ^^^^^^^^^^^^
 [107m [0m invalid type: string "not-a-bool", expected a boolean
+
+[2m○[22m [2mShowing 4 worktrees, 1 with changes, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_system_config_warns_on_stderr.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_malformed_system_config_warns_on_stderr.snap
@@ -50,8 +50,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 with changes, 3 ahead[0m
-
 ----- stderr -----
 [33m▲[39m [33mSystem config @ [TEST_SYSTEM_CONFIG_FILE] failed to parse, skipping[39m
 [107m [0m TOML parse error at line 2, column 12
@@ -59,3 +57,5 @@ exit_code: 0
 [107m [0m 2 | branches = "not-a-bool"
 [107m [0m   |            ^^^^^^^^^^^^
 [107m [0m invalid type: string "not-a-bool", expected a boolean
+
+[2m○[22m [2mShowing 4 worktrees, 1 with changes, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_config_validation_error_warns_on_stderr.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_config_validation_error_warns_on_stderr.snap
@@ -50,7 +50,7 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
 [33m▲[39m [33mConfig validation warning: worktree-path cannot be empty[39m
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_custom_column_empty_everywhere_dropped.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_custom_column_empty_everywhere_dropped.snap
@@ -50,6 +50,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_custom_columns.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_custom_columns.snap
@@ -50,6 +50,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b             spirited-mink       [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c             secure-sicklebill   [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_no_config.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_no_config.snap
@@ -50,6 +50,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__list_config__list_project_url_column.snap
+++ b/tests/snapshots/integration__integration_tests__list_config__list_project_url_column.snap
@@ -50,6 +50,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mhttp://localhost:14072[0m  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2mhttp://localhost:14303[0m  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 with changes, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 1 with changes, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__security__commit_message_with_directive_not_executed.snap
+++ b/tests/snapshots/integration__integration_tests__security__commit_message_with_directive_not_executed.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-c      [2m↕[22m                 [32m↑1[0m  [2m[31m↓1[0m    [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + [2mfeature[0m        [2m_[22m                                             [2m../repo.feature[0m    [2m252b848b[0m  [2m1d[0m    [2mFix bug __WORKTRUNK_EXEC__echo PWNED > /tmp/hacked4[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__security__git_ignores_malformed_refs_with_ansi.snap
+++ b/tests/snapshots/integration__integration_tests__security__git_ignores_malformed_refs_with_ansi.snap
@@ -50,6 +50,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__security__literal_escape_like_branch_names_displayed_safely.snap
+++ b/tests/snapshots/integration__integration_tests__security__literal_escape_like_branch_names_displayed_safely.snap
@@ -52,6 +52,6 @@ exit_code: 0
 + feature-c                   [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 [2m/ [0m[2mfix-backslash-x1b-test[0m     [2m/[22m[2m_[22m                                                                [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 4 worktrees, 1 branches, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 1 branch, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__security__path_with_directive_not_executed.snap
+++ b/tests/snapshots/integration__integration_tests__security__path_with_directive_not_executed.snap
@@ -50,6 +50,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 4 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_empty_diffs.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_empty_diffs.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + [2mno-changes[0m           [2m_[22m                                             [2m../repo.no-changes[0m       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 + with-changes      [36m![39m  [2m–[22m       [32m+1[0m   [31m-1[0m                               ../repo.with-changes     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_extreme_diffs.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_extreme_diffs.snap
@@ -52,6 +52,6 @@ exit_code: 0
 + huge         [36m?[39m [2m–[22m                                             ../repo.huge       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 + tiny        [36m![39m  [2m–[22m       [32m+1[0m   [31m-1[0m                               ../repo.tiny       [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 6 worktrees, 2 with changes, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 6 worktrees, 2 with changes, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_varying_diffs.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__alignment_varying_diffs.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + feature-medium    [36m?[39m [2m–[22m                                             ../repo.feature-medium  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 + feature-small     [36m?[39m [2m–[22m                                             ../repo.feature-small   [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 7 worktrees, 3 with changes, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 3 with changes, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__long_branch_names.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__long_branch_names.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + [2mshort[0m                                 [2m_[22m                                             [2m../repo.short[0m                             [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 + [2mvery-long-feature-branch-name[0m         [2m_[22m                                             [2m../repo.very-long-feature-branch-name[0m     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 7 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__mixed_length_branch_names.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__mixed_length_branch_names.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + [2mmedium[0m                                                         [2m_[22m                                             [2m../repo.medium[0m                                                     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 + [2mx[0m                                                              [2m_[22m                                             [2m../repo.x[0m                                                          [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 7 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__short_branch_names.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__short_branch_names.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 7 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__unicode_branch_names.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__unicode_branch_names.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + [2mnaive[0m          [2m_[22m                                             [2m../repo.naive[0m      [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 + [2mresume[0m         [2m_[22m                                             [2m../repo.resume[0m     [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 7 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_100.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_100.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + [2mfix/database-connection-pool-exhaustion[0m      [2m_[22m                                             [2m16h[0m
 + [2mshort[0m                                        [2m_[22m                                             [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 3 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 3 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_120.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_120.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + [2mfix/database-connection-pool-exhaustion[0m      [2m_[22m                                             [2m05a4a45d[0m  [2m16h[0m   [2mInitial co…[0m
 + [2mshort[0m                                        [2m_[22m                                             [2m05a4a45d[0m  [2m16h[0m   [2mInitial co…[0m
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 1 column hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 1 column hidden[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_30.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_30.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + [2mfix/database-connection-poo[22m…[0m
 + [2mshort[0m
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 9 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 9 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_40.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_40.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + [2mfix/database-connection-pool-exhausti[22m…[0m
 + [2mshort[0m
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 9 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 9 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_50.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_50.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + [2mfix/database-connection-pool-exhaustion[0m  
 + [2mshort[0m                                    
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 8 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 8 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_60.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_60.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + [2mfix/database-connection-pool-exhaustion[0m      [2m_[22m     
 + [2mshort[0m                                        [2m_[22m     
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 7 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 7 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_80.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_long_80.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + [2mfix/database-connection-pool-exhaustion[0m      [2m_[22m                         
 + [2mshort[0m                                        [2m_[22m                         
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 5 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 5 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_100.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_100.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + feature-c                  [2m↑[22m                [2m16h[0m
 + [2mfix/login-timeout[0m          [2m_[22m                [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 6 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 6 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_120.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_120.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + feature-c                  [2m↑[22m                 [32m↑1[0m      [2m16h[0m
 + [2mfix/login-timeout[0m          [2m_[22m                         [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 5 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 5 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_160.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_160.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + feature-c                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2m16h[0m
 + [2mfix/login-timeout[0m          [2m_[22m                                             [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 3 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 3 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_60.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_60.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + feature-c              [2m16h[0m
 + [2mfix/login-timeout[0m      [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 8 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 8 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_80.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_picker_right_80.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + feature-c                  [2m↑[22m     [2m16h[0m
 + [2mfix/login-timeout[0m          [2m_[22m     [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 7 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 1 with changes, 3 ahead, 7 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_100.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_100.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + feature-c                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2m345c7c93[0m  [2m16h[0m
 + fix/login-timeout        [36m?[39m [2m–[22m                                             [2m05a4a45d[0m  [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 2 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 2 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_120.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_120.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + feature-c                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + fix/login-timeout        [36m?[39m [2m–[22m                                             [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 1 column hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 1 column hidden[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_30.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_30.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + feature-c              [2m16h[0m
 + fix/login-timeout      [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 8 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 8 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_40.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_40.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + feature-c                  [2m↑[22m     [2m16h[0m
 + fix/login-timeout        [36m?[39m [2m–[22m     [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 7 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 7 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_50.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_50.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + feature-c                  [2m↑[22m                [2m16h[0m
 + fix/login-timeout        [36m?[39m [2m–[22m                [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 6 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 6 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_60.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_60.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + feature-c                  [2m↑[22m                 [32m↑1[0m      [2m16h[0m
 + fix/login-timeout        [36m?[39m [2m–[22m                         [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 5 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 5 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_80.snap
+++ b/tests/snapshots/integration__integration_tests__spacing_edge_cases__width_survey_typical_80.snap
@@ -53,6 +53,6 @@ exit_code: 0
 + feature-c                  [2m↑[22m                 [32m↑1[0m        [32m+1[0m                [2m16h[0m
 + fix/login-timeout        [36m?[39m [2m–[22m                                             [2m16h[0m
 
-[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 3 columns hidden[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 7 worktrees, 2 with changes, 3 ahead, 3 columns hidden[0m

--- a/tests/snapshots/integration__integration_tests__step_promote__promote_shows_mismatch_in_list.snap
+++ b/tests/snapshots/integration__integration_tests__step_promote__promote_shows_mismatch_in_list.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m

--- a/tests/snapshots/integration__integration_tests__switch__list_with_relative_paths.snap
+++ b/tests/snapshots/integration__integration_tests__switch__list_with_relative_paths.snap
@@ -51,6 +51,6 @@ exit_code: 0
 + feature-c          [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c      [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
 + [2mrelative-test[0m      [2m_[22m                                             [2m../repo.relative-test[0m  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
-
 ----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m


### PR DESCRIPTION
Reviewing this real `wt list` output against the `writing-user-outputs` guidelines surfaced several inconsistencies:

```
○ Showing 15 worktrees, 6 branches, 2 with changes, 8 ahead, 2 columns hidden. 1 task failed
▲ Some git operations failed:
  plugins: working-tree-conflicts (fatal: Unable to create
  '/Users/…/.git/worktrees/worktrunk.plugins/index.lock': File exists.)
↳ To create a diagnostic file, run with -vv
```

The footer and the warning used different vocabulary for the same failure ("task" vs "git operations", the latter inaccurate since CI/URL/summary tasks aren't git operations), the warning said "Some" when the exact count was known, and the per-failure lines leaked internal kebab-case `TaskKind` discriminants (`working-tree-conflicts`) that appear nowhere in docs or help.

The same output now reads:

```
○ Showing 15 worktrees, 6 branches, 2 with changes, 8 ahead, 2 columns hidden; 1 task failed
▲ 1 task failed:
  plugins: working-tree conflict check (fatal: Unable to create '…/index.lock': File exists.)
↳ To create a diagnostic file, run with -vv
```

## Changes

- **One term, matching counts.** Footer and warning both say "N task(s) failed" ("task" is the documented term — the JSON docs already use it). The mixed form becomes disjoint (`2 tasks failed, 3 timed out` instead of `5 tasks failed (3 timed out)`), so the footer's "failed" count always equals the number of lines in the warning below it.
- **Human task names.** `TaskKind::display_name()` maps each task to user vocabulary (`working-tree conflict check`, `ahead/behind counts`, `CI status`, …) in the failure warning, the stall footer ("waiting on …"), and the drain-timeout diagnostic. The strum kebab-case form remains for tracing and `-vv` diagnostics.
- **Footer clause join.** Semicolon instead of a period splice, per house style; also fixes always-plural "1 worktrees"/"1 branches" in `--branches` mode.
- **Buffered summary to stderr.** The `○ Showing …` line narrates the table rather than being part of the answer (`--format=json` omits it), so in buffered mode it moves to stderr and piped stdout ends cleanly after the last row. The progressive path keeps it on stdout, where the summary is a repainted row of the table region. This is most of the 198-file snapshot churn (the line moves from the stdout section to the stderr section).
- **Docs generator reads both streams.** `parse_snapshot_raw` in readme_sync previously embedded stderr *or* stdout; it now concatenates both in terminal order. The generated docs are byte-identical before and after the stream move, which is the check that the console blocks still read like the terminal.

Two negative test assertions that guarded against surfacing these failures (`working-tree-conflicts` in `tests/integration_tests/list.rs`) were retargeted to the new display names so they don't pass vacuously.

## Testing

Pre-merge gate (all tests + lints) green; feature-gated clippy and the PTY progressive-list tests (`shell-integration-tests`) run separately and green, since the local gate skips them.

> _This was written by Claude Code on behalf of max_
