### PR TITLE
docs(list): drop dangling design-doc reference from resolve_json_schema

### DIFF
--- a/src/commands/list/mod.rs
+++ b/src/commands/list/mod.rs
@@ -215,8 +215,7 @@ pub(crate) fn print_json<T: serde::Serialize>(value: &T) -> anyhow::Result<()> {
 /// schema 1 is the deliberate manual edit), so the nag's hint offers that
 /// command exactly when running it would write the key — decided by the same
 /// detection update runs, so a missing, unreadable, or malformed user config
-/// falls back to naming the manual setting instead (migration plan in
-/// design/list-json-v2.md, reviewed in #3357).
+/// falls back to naming the manual setting instead.
 pub(crate) fn resolve_json_schema(repo: &Repository) -> u8 {
     use std::sync::Once;
 


### PR DESCRIPTION
The `resolve_json_schema` doc comment pointed at `design/list-json-v2.md`, which never landed on main (design proposals are review-only PRs), so the reference led readers to a file that doesn't exist in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> _This was written by Claude Code on behalf of max_