### PR TITLE
fix(list): show full git error text in task-failure warnings

### DIFF
--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -701,11 +701,10 @@ fn format_task_failure(name: &str, kind: TaskKind, message: &str) -> String {
             }
         }
         if line_count > TASK_FAILURE_MESSAGE_MAX_LINES {
+            let extra = line_count - TASK_FAILURE_MESSAGE_MAX_LINES;
+            let plural = if extra == 1 { "" } else { "s" };
             rendered.push('\n');
-            rendered.push_str(&format!(
-                "  … ({} more lines)",
-                line_count - TASK_FAILURE_MESSAGE_MAX_LINES
-            ));
+            rendered.push_str(&format!("  … ({extra} more line{plural})"));
         }
     } else if !message.is_empty() {
         let message = truncate_visible(message, TASK_FAILURE_MESSAGE_MAX_COLS);
@@ -2474,6 +2473,14 @@ remove the file manually to continue.";
             padded.lines().all(|line| line == line.trim_end()),
             "{padded:?}"
         );
+        // Exactly one line over the cap pluralizes the elision marker.
+        let thirteen = (0..13)
+            .map(|i| format!("line {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let capped = format_task_failure("plugins", TaskKind::CiStatus, &thirteen);
+        let capped = capped.ansi_strip();
+        assert!(capped.ends_with("… (1 more line)"), "{capped:?}");
         // One enormous line with no newlines is bounded too — the inline
         // form truncates rather than word-wrapping across dozens of rows.
         let monster = format_task_failure("plugins", TaskKind::CiStatus, &"x".repeat(2_000));

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -673,6 +673,44 @@ fn format_stall_footer(
     )
 }
 
+/// Cap on message lines shown per failed task. Real git errors fit well
+/// under this (the index.lock guidance is ~7 lines); the cap exists so a
+/// crashing task command (e.g. an LLM summary tool dumping a stack trace)
+/// can't flood the warning block. The `-vv` diagnostic hint that follows
+/// the warning is the route to full output.
+const TASK_FAILURE_MESSAGE_MAX_LINES: usize = 12;
+
+/// Render one entry of the task-failure warning: `branch: task-name`,
+/// with a single-line message inline in parens and a multi-line message
+/// indented underneath — git's recovery guidance (e.g. the index.lock
+/// "remove the file manually" paragraph) must survive display. The
+/// caller joins entries and wraps them in one gutter block.
+fn format_task_failure(name: &str, kind: TaskKind, message: &str) -> String {
+    let mut rendered = cformat!("<bold>{}</>: {}", name, kind.display_name());
+    let message = message.trim();
+    let line_count = message.lines().count();
+    if line_count > 1 {
+        for line in message.lines().take(TASK_FAILURE_MESSAGE_MAX_LINES) {
+            let line = line.trim_end();
+            rendered.push('\n');
+            if !line.is_empty() {
+                rendered.push_str("  ");
+                rendered.push_str(line);
+            }
+        }
+        if line_count > TASK_FAILURE_MESSAGE_MAX_LINES {
+            rendered.push('\n');
+            rendered.push_str(&format!(
+                "  … ({} more lines)",
+                line_count - TASK_FAILURE_MESSAGE_MAX_LINES
+            ));
+        }
+    } else if !message.is_empty() {
+        rendered.push_str(&format!(" ({message})"));
+    }
+    rendered
+}
+
 /// Emit the drain-timeout warning + hint when the default 120s
 /// `DRAIN_TIMEOUT` was hit. No-op for `Complete` outcomes or when an
 /// explicit `collect_deadline` was supplied — those are intentional
@@ -1990,9 +2028,7 @@ pub fn collect(
                 .iter()
                 .map(|error| {
                     let name = all_items[error.item_idx].branch_name();
-                    // Take first line only - git errors can be multi-line with usage hints
-                    let msg = error.message.lines().next().unwrap_or(&error.message);
-                    cformat!("<bold>{}</>: {} ({})", name, error.kind.display_name(), msg)
+                    format_task_failure(name, error.kind, &error.message)
                 })
                 .collect();
             let count = sorted_errors.len();
@@ -2336,6 +2372,7 @@ pub fn populate_item(
 mod tests {
     use super::*;
     use ansi_str::AnsiStr;
+    use insta::assert_snapshot;
 
     #[test]
     fn test_collect_pool_num_threads_honors_env() {
@@ -2349,7 +2386,7 @@ mod tests {
     fn test_format_stall_footer_single_pending() {
         let rendered =
             format_stall_footer("Showing 3 worktrees", 5, 12, 1, TaskKind::CiStatus, "feat");
-        insta::assert_snapshot!(
+        assert_snapshot!(
             rendered.ansi_strip(),
             @"○ Showing 3 worktrees (5/12 loaded, no recent progress; waiting on CI status for feat)"
         );
@@ -2359,9 +2396,80 @@ mod tests {
     fn test_format_stall_footer_many_pending() {
         let rendered =
             format_stall_footer("Showing 3 worktrees", 5, 12, 3, TaskKind::CiStatus, "feat");
-        insta::assert_snapshot!(
+        assert_snapshot!(
             rendered.ansi_strip(),
             @"○ Showing 3 worktrees (5/12 loaded, no recent progress; waiting on 3 tasks, including CI status for feat)"
+        );
+    }
+
+    /// The multi-line git failure the display must preserve: recovery
+    /// guidance follows a blank line.
+    const INDEX_LOCK_MESSAGE: &str = r"fatal: Unable to create '/repo/.git/index.lock': File exists.
+
+Another git process seems to be running in this repository, e.g.
+an editor opened by 'git commit'. Please make sure all processes
+are terminated then try again. If it still fails, a git process
+may have crashed in this repository earlier:
+remove the file manually to continue.";
+
+    /// Single-line git errors stay inline; multi-line ones keep every line
+    /// (git's recovery guidance) indented under the label, capped at
+    /// `TASK_FAILURE_MESSAGE_MAX_LINES`.
+    #[test]
+    fn test_format_task_failure() {
+        assert_snapshot!(
+            format_task_failure("plugins", TaskKind::WorkingTreeDiff, "fatal: bad object HEAD")
+                .ansi_strip(),
+            @"plugins: working-tree diff (fatal: bad object HEAD)"
+        );
+        assert_snapshot!(
+            format_task_failure("plugins", TaskKind::WorkingTreeConflicts, INDEX_LOCK_MESSAGE)
+                .ansi_strip(),
+            @r"
+        plugins: working-tree conflict check
+          fatal: Unable to create '/repo/.git/index.lock': File exists.
+
+          Another git process seems to be running in this repository, e.g.
+          an editor opened by 'git commit'. Please make sure all processes
+          are terminated then try again. If it still fails, a git process
+          may have crashed in this repository earlier:
+          remove the file manually to continue.
+        "
+        );
+        assert_snapshot!(
+            format_task_failure("plugins", TaskKind::CiStatus, "").ansi_strip(),
+            @"plugins: CI status"
+        );
+        // A crashing task command (e.g. an LLM summary tool's stack trace)
+        // is capped rather than flooding the warning block.
+        let trace = (0..30)
+            .map(|i| format!("at frame {i}"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        assert_snapshot!(
+            format_task_failure("plugins", TaskKind::SummaryGenerate, &trace).ansi_strip(),
+            @r"
+        plugins: summary generation
+          at frame 0
+          at frame 1
+          at frame 2
+          at frame 3
+          at frame 4
+          at frame 5
+          at frame 6
+          at frame 7
+          at frame 8
+          at frame 9
+          at frame 10
+          at frame 11
+          … (18 more lines)
+        "
+        );
+        // Whitespace-only interior lines render empty, not as trailing spaces.
+        let padded = format_task_failure("plugins", TaskKind::BranchDiff, "a\n   \nb");
+        assert!(
+            padded.lines().all(|line| line == line.trim_end()),
+            "{padded:?}"
         );
     }
 
@@ -2370,7 +2478,7 @@ mod tests {
     #[test]
     fn test_format_drain_timeout_diag_no_items() {
         let rendered = format_drain_timeout_diag(7, &[]);
-        insta::assert_snapshot!(
+        assert_snapshot!(
             rendered.ansi_strip(),
             @"Listing worktrees timed out after 120s (7 results received)"
         );
@@ -2454,7 +2562,7 @@ mod tests {
             },
         ];
         let rendered = format_drain_timeout_diag(3, &items);
-        insta::assert_snapshot!(
+        assert_snapshot!(
             rendered.ansi_strip(),
             @"
         Listing worktrees timed out after 120s (3 results received); blocked tasks:
@@ -2476,7 +2584,7 @@ mod tests {
             })
             .collect();
         let rendered = format_drain_timeout_diag(2, &items);
-        insta::assert_snapshot!(
+        assert_snapshot!(
             rendered.ansi_strip(),
             @"
         Listing worktrees timed out after 120s (2 results received); blocked tasks:

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -314,7 +314,7 @@ use once_cell::sync::OnceCell;
 use rayon::prelude::*;
 use worktrunk::git::{ErrorExt, LocalBranch, Repository, WorktreeInfo};
 use worktrunk::styling::{
-    INFO_SYMBOL, eprintln, format_with_gutter, hint_message, warning_message,
+    INFO_SYMBOL, eprintln, format_with_gutter, hint_message, truncate_visible, warning_message,
 };
 
 use crate::commands::is_worktree_at_expected_path;
@@ -673,12 +673,14 @@ fn format_stall_footer(
     )
 }
 
-/// Cap on message lines shown per failed task. Real git errors fit well
-/// under this (the index.lock guidance is ~7 lines); the cap exists so a
-/// crashing task command (e.g. an LLM summary tool dumping a stack trace)
-/// can't flood the warning block. The `-vv` diagnostic hint that follows
-/// the warning is the route to full output.
+/// Caps on the message shown per failed task: at most `MAX_LINES` lines,
+/// each at most `MAX_COLS` columns. Real git errors fit well under both
+/// (the index.lock guidance is ~7 short lines); the caps exist so a
+/// crashing task command (an LLM summary tool dumping a stack trace, or
+/// one enormous line of output) can't flood the warning block. The `-vv`
+/// diagnostic hint that follows the warning is the route to full output.
 const TASK_FAILURE_MESSAGE_MAX_LINES: usize = 12;
+const TASK_FAILURE_MESSAGE_MAX_COLS: usize = 500;
 
 /// Render one entry of the task-failure warning: `branch: task-name`,
 /// with a single-line message inline in parens and a multi-line message
@@ -691,11 +693,11 @@ fn format_task_failure(name: &str, kind: TaskKind, message: &str) -> String {
     let line_count = message.lines().count();
     if line_count > 1 {
         for line in message.lines().take(TASK_FAILURE_MESSAGE_MAX_LINES) {
-            let line = line.trim_end();
+            let line = truncate_visible(line.trim_end(), TASK_FAILURE_MESSAGE_MAX_COLS);
             rendered.push('\n');
             if !line.is_empty() {
                 rendered.push_str("  ");
-                rendered.push_str(line);
+                rendered.push_str(&line);
             }
         }
         if line_count > TASK_FAILURE_MESSAGE_MAX_LINES {
@@ -706,6 +708,7 @@ fn format_task_failure(name: &str, kind: TaskKind, message: &str) -> String {
             ));
         }
     } else if !message.is_empty() {
+        let message = truncate_visible(message, TASK_FAILURE_MESSAGE_MAX_COLS);
         rendered.push_str(&format!(" ({message})"));
     }
     rendered
@@ -2470,6 +2473,16 @@ remove the file manually to continue.";
         assert!(
             padded.lines().all(|line| line == line.trim_end()),
             "{padded:?}"
+        );
+        // One enormous line with no newlines is bounded too — the inline
+        // form truncates rather than word-wrapping across dozens of rows.
+        let monster = format_task_failure("plugins", TaskKind::CiStatus, &"x".repeat(2_000));
+        let monster = monster.ansi_strip();
+        assert!(monster.ends_with("…)"), "{monster:?}");
+        assert!(
+            monster.len() <= TASK_FAILURE_MESSAGE_MAX_COLS + "plugins: CI status ()…".len(),
+            "len={}",
+            monster.len()
         );
     }
 

--- a/src/styling/format.rs
+++ b/src/styling/format.rs
@@ -63,6 +63,19 @@ pub(super) fn wrap_text_at_width(text: &str, max_width: usize) -> Vec<String> {
         return vec![text.to_string()];
     }
 
+    // Preserve leading indentation (mirrors wrap_styled_text): wrap the
+    // content within the remaining width and re-prefix every line, so an
+    // indented line's continuations stay visually subordinate instead of
+    // rendering flush-left like a new entry.
+    let leading_spaces = text.chars().take_while(|c| *c == ' ').count();
+    if leading_spaces > 0 && max_width.saturating_sub(leading_spaces) >= 10 {
+        let indent = " ".repeat(leading_spaces);
+        return wrap_text_at_width(&text[leading_spaces..], max_width - leading_spaces)
+            .into_iter()
+            .map(|line| format!("{indent}{line}"))
+            .collect();
+    }
+
     let mut lines = Vec::new();
     let mut current_line = String::new();
     let mut current_width = 0;

--- a/src/styling/mod.rs
+++ b/src/styling/mod.rs
@@ -397,6 +397,19 @@ command = "npm install"
         ");
     }
 
+    /// An indented line that wraps keeps its indent on every continuation
+    /// line, so subordinate content (a task-failure message under its
+    /// label) stays visually subordinate instead of rendering flush-left.
+    #[test]
+    fn test_format_with_gutter_preserves_indent_on_wrap() {
+        let indented = "  fatal: Unable to create '/some/long/path/to/repository/.git/worktrees/name/index.lock': File exists.";
+        assert_snapshot!(format_with_gutter(indented, Some(50)), @"
+        [107m [0m   fatal: Unable to create
+        [107m [0m   '/some/long/path/to/repository/.git/worktrees/name/index.lock':
+        [107m [0m   File exists.
+        ");
+    }
+
     #[cfg(feature = "syntax-highlighting")]
     #[test]
     fn test_bash_gutter_formatting_ends_with_reset() {


### PR DESCRIPTION
Follow-up to #3435: the task-failure warning truncated each git error to its first line, which dropped git's own recovery guidance. The index.lock failure from the #3435 sample rendered as:

```
▲ 1 task failed:
  plugins: working-tree conflict check (fatal: Unable to create '…/index.lock': File exists.)
```

losing the paragraph that explains another git process may hold the lock and how to resolve it. Multi-line messages now render in full, indented under the label inside the existing gutter block — the same header-plus-gutter-body shape as `CommandError::render`:

```
▲ 1 task failed:
  plugins: working-tree conflict check
    fatal: Unable to create '…/.git/worktrees/worktrunk.plugins/index.lock': File exists.

    Another git process seems to be running in this repository, or the lock file may be stale
```

Single-line messages — the common case, and all existing snapshots — keep the compact inline-parens form and are byte-identical before and after; an empty message now renders as a bare label instead of `()`.

Two supporting changes from review:

- **Per-message caps** — at most 12 lines (`… (N more lines)`), each line at most 500 columns (`…` via `truncate_visible`): the first-line truncation was the only size bound, and the `commit.generation` failure path bails with the tool's full stderr/stdout — a crashing summary command could dump a stack trace (or one enormous line) per worktree. Real git guidance (~7 short lines for index.lock) fits well under both; the `-vv` hint that follows the warning is the route to full output.
- **`wrap_text_at_width` preserves leading indentation** on wrapped lines (mirroring `wrap_styled_text`): without this, a message line that exceeds the terminal width re-rendered flush-left, indistinguishable from the next failure's label. This benefits every `format_with_gutter` caller with indented content.

## Testing

Existing failure-warning snapshots are unchanged; a new unit snapshot test covers the inline, multi-line, and empty-message shapes. The original index.lock scenario (dirty worktree + pre-existing lock file) was reproduced end-to-end against the new binary.

> _This was written by Claude Code on behalf of max_
