### PR TITLE
fix(plugin): anchor WorktreeCreate at the project dir

### DIFF
--- a/plugins/worktrunk/hooks/hooks.json
+++ b/plugins/worktrunk/hooks/hooks.json
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'name=$(jq -er .name) || exit 1; bash \"$CLAUDE_PLUGIN_ROOT/hooks/wt.sh\" switch --create \"$name\" --no-cd --format=json | jq -er .path'"
+            "command": "bash -c 'name=$(jq -er .name) || exit 1; cd \"${CLAUDE_PROJECT_DIR:-.}\" || exit 1; bash \"$CLAUDE_PLUGIN_ROOT/hooks/wt.sh\" switch --create \"$name\" --base=@ --no-cd --format=json | jq -er .path'"
           }
         ]
       }

--- a/plugins/worktrunk/hooks/hooks.json
+++ b/plugins/worktrunk/hooks/hooks.json
@@ -69,7 +69,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'name=$(jq -er .name) || exit 1; cd \"${CLAUDE_PROJECT_DIR:-.}\" || exit 1; bash \"$CLAUDE_PLUGIN_ROOT/hooks/wt.sh\" switch --create \"$name\" --base=@ --no-cd --format=json | jq -er .path'"
+            "command": "bash -c 'name=$(jq -er .name) || exit 1; cd \"${CLAUDE_PROJECT_DIR:-.}\" || exit 1; bash \"$CLAUDE_PLUGIN_ROOT/hooks/wt.sh\" switch --create \"$name\" --no-cd --format=json | jq -er .path'"
           }
         ]
       }


### PR DESCRIPTION
**Anchor the `WorktreeCreate` hook at `CLAUDE_PROJECT_DIR`.** The hook command inherits the session shell's working directory. When the shell has `cd`'d outside the repository (e.g. into a reference-papers directory elsewhere on disk), `wt switch` dies with *not a git repository* and every isolated-agent spawn in the session fails — observed as a six-agent spawn failure mid-session. `cd "${CLAUDE_PROJECT_DIR:-.}"` pins the hook to the repository the session was launched in, falling back to the current behavior when the variable is unset.

_Originally this PR also added `--base=@` to base agent worktrees on the session's HEAD. That change was dropped at the maintainer's request (worktrunk-bot pushed the removal) so it can be evaluated separately — hardcoding `--base=@` would override the native `worktree.baseRef` setting for everyone, and the hook has no way to read that setting. This PR is now the `cd` anchor only._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
