### PR TITLE
fix: anchor relative WORKTRUNK_PROJECT_CONFIG_PATH to the worktree root

### DIFF
--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -630,7 +630,7 @@ Override the LLM command in CI to use a mock:
 | `WORKTRUNK_BIN` | Override binary path for shell wrappers; useful for testing dev builds |
 | `WORKTRUNK_CONFIG_PATH` | Override user config file location |
 | `WORKTRUNK_SYSTEM_CONFIG_PATH` | Override system config file location |
-| `WORKTRUNK_PROJECT_CONFIG_PATH` | Override project config file location (defaults to `.config/wt.toml`) |
+| `WORKTRUNK_PROJECT_CONFIG_PATH` | Override project config file location (defaults to `.config/wt.toml`); relative paths resolve from the worktree root |
 | `XDG_CONFIG_DIRS` | Colon-separated system config directories (default: `/etc/xdg`) |
 | `WORKTRUNK_DIRECTIVE_CD_FILE` | Internal: set by shell wrappers. wt writes a raw path; the wrapper `cd`s to it |
 | `WORKTRUNK_DIRECTIVE_EXEC_FILE` | Internal: set by shell wrappers. wt writes shell commands; the wrapper sources the file |

--- a/plugins/worktrunk/skills/worktrunk/reference/config.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/config.md
@@ -627,7 +627,7 @@ $ WORKTRUNK_COMMIT__GENERATION__COMMAND="echo 'test: automated commit'" wt merge
 | `WORKTRUNK_BIN` | Override binary path for shell wrappers; useful for testing dev builds |
 | `WORKTRUNK_CONFIG_PATH` | Override user config file location |
 | `WORKTRUNK_SYSTEM_CONFIG_PATH` | Override system config file location |
-| `WORKTRUNK_PROJECT_CONFIG_PATH` | Override project config file location (defaults to `.config/wt.toml`) |
+| `WORKTRUNK_PROJECT_CONFIG_PATH` | Override project config file location (defaults to `.config/wt.toml`); relative paths resolve from the worktree root |
 | `XDG_CONFIG_DIRS` | Colon-separated system config directories (default: `/etc/xdg`) |
 | `WORKTRUNK_DIRECTIVE_CD_FILE` | Internal: set by shell wrappers. wt writes a raw path; the wrapper `cd`s to it |
 | `WORKTRUNK_DIRECTIVE_EXEC_FILE` | Internal: set by shell wrappers. wt writes shell commands; the wrapper sources the file |

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -627,7 +627,7 @@ $ WORKTRUNK_COMMIT__GENERATION__COMMAND="echo 'test: automated commit'" wt merge
 | `WORKTRUNK_BIN` | Override binary path for shell wrappers; useful for testing dev builds |
 | `WORKTRUNK_CONFIG_PATH` | Override user config file location |
 | `WORKTRUNK_SYSTEM_CONFIG_PATH` | Override system config file location |
-| `WORKTRUNK_PROJECT_CONFIG_PATH` | Override project config file location (defaults to `.config/wt.toml`) |
+| `WORKTRUNK_PROJECT_CONFIG_PATH` | Override project config file location (defaults to `.config/wt.toml`); relative paths resolve from the worktree root |
 | `XDG_CONFIG_DIRS` | Colon-separated system config directories (default: `/etc/xdg`) |
 | `WORKTRUNK_DIRECTIVE_CD_FILE` | Internal: set by shell wrappers. wt writes a raw path; the wrapper `cd`s to it |
 | `WORKTRUNK_DIRECTIVE_EXEC_FILE` | Internal: set by shell wrappers. wt writes shell commands; the wrapper sources the file |

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2478,7 +2478,7 @@ $ WORKTRUNK_COMMIT__GENERATION__COMMAND="echo 'test: automated commit'" wt merge
 | `WORKTRUNK_BIN` | Override binary path for shell wrappers; useful for testing dev builds |
 | `WORKTRUNK_CONFIG_PATH` | Override user config file location |
 | `WORKTRUNK_SYSTEM_CONFIG_PATH` | Override system config file location |
-| `WORKTRUNK_PROJECT_CONFIG_PATH` | Override project config file location (defaults to `.config/wt.toml`) |
+| `WORKTRUNK_PROJECT_CONFIG_PATH` | Override project config file location (defaults to `.config/wt.toml`); relative paths resolve from the worktree root |
 | `XDG_CONFIG_DIRS` | Colon-separated system config directories (default: `/etc/xdg`) |
 | `WORKTRUNK_DIRECTIVE_CD_FILE` | Internal: set by shell wrappers. wt writes a raw path; the wrapper `cd`s to it |
 | `WORKTRUNK_DIRECTIVE_EXEC_FILE` | Internal: set by shell wrappers. wt writes shell commands; the wrapper sources the file |

--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -798,9 +798,9 @@ fn render_project_config(out: &mut String) -> anyhow::Result<()> {
             return Ok(());
         }
     };
-    let config_path = match repo.project_config_path() {
-        Ok(Some(path)) => path,
-        _ => {
+    let config_path = match repo.project_config_path()? {
+        Some(path) => path,
+        None => {
             writeln!(
                 out,
                 "{}",

--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -806,7 +806,7 @@ fn render_project_config(out: &mut String) -> anyhow::Result<()> {
                 "{}",
                 cformat!(
                     "<dim>{}</>",
-                    format_heading("PROJECT CONFIG", Some("Not in a git repository"))
+                    format_heading("PROJECT CONFIG", Some("No project config"))
                 )
             )?;
             return Ok(());

--- a/src/commands/config/update.rs
+++ b/src/commands/config/update.rs
@@ -183,9 +183,9 @@ fn check_project_config() -> anyhow::Result<Option<UpdateCandidate>> {
         Err(_) => return Ok(None),
     };
 
-    let config_path = match repo.project_config_path() {
-        Ok(Some(path)) => path,
-        _ => return Ok(None),
+    let config_path = match repo.project_config_path()? {
+        Some(path) => path,
+        None => return Ok(None),
     };
     if !config_path.exists() {
         return Ok(None);

--- a/src/git/repository/config.rs
+++ b/src/git/repository/config.rs
@@ -631,12 +631,13 @@ impl Repository {
     ///
     /// If `WORKTRUNK_PROJECT_CONFIG_PATH` is set, returns that path (used for
     /// test isolation so the spawned `wt` does not pick up this repo's
-    /// `.config/wt.toml`). A relative value resolves against the same worktree
-    /// root the default `.config/wt.toml` is anchored to — never the process
-    /// cwd, which would make the override silently depend on the invocation
-    /// directory — and errors when no worktree root exists to anchor it. A
-    /// missing file at the resulting path still resolves to `Ok(None)` via
-    /// `ProjectConfig::load`, matching the no-config case.
+    /// `.config/wt.toml`). An empty value means no project config. A relative
+    /// value resolves against the same worktree root the default
+    /// `.config/wt.toml` is anchored to — never the process cwd, which would
+    /// make the override silently depend on the invocation directory — and
+    /// errors when no worktree root exists to anchor it. A missing file at the
+    /// resulting path still resolves to `Ok(None)` via `ProjectConfig::load`,
+    /// matching the no-config case.
     ///
     /// Without the override: uses the current worktree when inside one (both
     /// normal and bare repos). For bare repos at the bare root (outside any
@@ -650,10 +651,33 @@ impl Repository {
     /// (`src/commands/hooks.rs`).
     pub fn project_config_path(&self) -> anyhow::Result<Option<PathBuf>> {
         let override_path = std::env::var_os("WORKTRUNK_PROJECT_CONFIG_PATH").map(PathBuf::from);
-        if let Some(path) = &override_path
-            && path.is_absolute()
-        {
-            return Ok(Some(path.clone()));
+        if let Some(path) = &override_path {
+            if path.as_os_str().is_empty() {
+                // An empty override means no project config, matching a
+                // missing file at the override path.
+                return Ok(None);
+            }
+            if path.is_absolute() {
+                return Ok(Some(path.clone()));
+            }
+            // Windows-only forms that are neither absolute nor purely
+            // relative — drive-relative (`C:cfg`) or rooted without a drive
+            // (`\cfg`, `/tmp/x`) — would resolve against the process drive or
+            // replace the anchor under `Path::join`; reject them rather than
+            // silently keep the cwd dependence this resolution exists to
+            // eliminate.
+            #[cfg(windows)]
+            if path.has_root()
+                || matches!(
+                    path.components().next(),
+                    Some(std::path::Component::Prefix(_))
+                )
+            {
+                anyhow::bail!(
+                    "WORKTRUNK_PROJECT_CONFIG_PATH ({}) is neither fully absolute nor relative; use an absolute path including the drive",
+                    path.display()
+                );
+            }
         }
 
         // Batched rev-parse: asks `--is-inside-work-tree` and also pre-warms
@@ -670,15 +694,16 @@ impl Repository {
             None => None,
         };
 
-        match (override_path, root) {
-            (Some(relative), Some(root)) => Ok(Some(root.join(relative))),
-            (Some(relative), None) => anyhow::bail!(
+        let Some(relative) = override_path else {
+            return Ok(root.map(|root| root.join(".config").join("wt.toml")));
+        };
+        let Some(root) = root else {
+            anyhow::bail!(
                 "WORKTRUNK_PROJECT_CONFIG_PATH is relative ({}) but there is no worktree root to resolve it against; use an absolute path",
                 relative.display()
-            ),
-            (None, Some(root)) => Ok(Some(root.join(".config").join("wt.toml"))),
-            (None, None) => Ok(None),
-        }
+            );
+        };
+        Ok(Some(root.join(relative)))
     }
 
     /// Load the project configuration (.config/wt.toml) if it exists.

--- a/src/git/repository/config.rs
+++ b/src/git/repository/config.rs
@@ -631,13 +631,17 @@ impl Repository {
     ///
     /// If `WORKTRUNK_PROJECT_CONFIG_PATH` is set, returns that path (used for
     /// test isolation so the spawned `wt` does not pick up this repo's
-    /// `.config/wt.toml`). A missing file at that path still resolves to
-    /// `Ok(None)` via `ProjectConfig::load`, matching the no-config case.
+    /// `.config/wt.toml`). A relative value resolves against the same worktree
+    /// root the default `.config/wt.toml` is anchored to — never the process
+    /// cwd, which would make the override silently depend on the invocation
+    /// directory — and errors when no worktree root exists to anchor it. A
+    /// missing file at the resulting path still resolves to `Ok(None)` via
+    /// `ProjectConfig::load`, matching the no-config case.
     ///
-    /// Otherwise: uses the current worktree when inside one (both normal and
-    /// bare repos). For bare repos at the bare root (outside any worktree),
-    /// falls back to the primary worktree. Returns `None` when no worktree can
-    /// be determined (bare repo with no linked worktrees).
+    /// Without the override: uses the current worktree when inside one (both
+    /// normal and bare repos). For bare repos at the bare root (outside any
+    /// worktree), falls back to the primary worktree. Returns `None` when no
+    /// worktree can be determined (bare repo with no linked worktrees).
     ///
     /// "The current worktree" is whatever this `Repository` was rooted at, so
     /// the answer to "which `.config/wt.toml` does a hook read" is decided by
@@ -645,8 +649,11 @@ impl Repository {
     /// is resolved against — is the spec in the `commands::hooks` module docs
     /// (`src/commands/hooks.rs`).
     pub fn project_config_path(&self) -> anyhow::Result<Option<PathBuf>> {
-        if let Ok(path) = std::env::var("WORKTRUNK_PROJECT_CONFIG_PATH") {
-            return Ok(Some(PathBuf::from(path)));
+        let override_path = std::env::var_os("WORKTRUNK_PROJECT_CONFIG_PATH").map(PathBuf::from);
+        if let Some(path) = &override_path
+            && path.is_absolute()
+        {
+            return Ok(Some(path.clone()));
         }
 
         // Batched rev-parse: asks `--is-inside-work-tree` and also pre-warms
@@ -654,21 +661,24 @@ impl Repository {
         // forks on the typical alias path.
         let info = self.current_worktree().prewarm_info().unwrap_or_default();
 
-        if let Some(root) = info.root {
-            // Inside a worktree — use it (normal repo or linked worktree in
-            // bare repo). `root` is `Some` iff the batch saw us inside a work
-            // tree, so no separate `is_inside` check.
-            return Ok(Some(root.join(".config").join("wt.toml")));
-        }
+        // Inside a worktree — use it (normal repo or linked worktree in bare
+        // repo; `root` is `Some` iff the batch saw us inside a work tree). At
+        // the bare root, fall back to the primary worktree.
+        let root = match info.root {
+            Some(root) => Some(root),
+            None if self.is_bare().unwrap_or(false) => self.primary_worktree()?,
+            None => None,
+        };
 
-        if self.is_bare().unwrap_or(false) {
-            // At bare repo root — use primary worktree
-            return Ok(self
-                .primary_worktree()?
-                .map(|p| p.join(".config").join("wt.toml")));
+        match (override_path, root) {
+            (Some(relative), Some(root)) => Ok(Some(root.join(relative))),
+            (Some(relative), None) => anyhow::bail!(
+                "WORKTRUNK_PROJECT_CONFIG_PATH is relative ({}) but there is no worktree root to resolve it against; use an absolute path",
+                relative.display()
+            ),
+            (None, Some(root)) => Ok(Some(root.join(".config").join("wt.toml"))),
+            (None, None) => Ok(None),
         }
-
-        Ok(None)
     }
 
     /// Load the project configuration (.config/wt.toml) if it exists.

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -5051,9 +5051,9 @@ fn test_project_config_path_env_var_override(repo: TestRepo, temp_home: TempDir)
 /// A relative `WORKTRUNK_PROJECT_CONFIG_PATH` resolves against the worktree
 /// root — the same anchor as the default `.config/wt.toml` — so the override
 /// behaves identically from any subdirectory instead of silently depending on
-/// the process cwd.
+/// the process cwd, and each worktree anchors to its own root.
 #[rstest]
-fn test_project_config_path_env_var_relative(repo: TestRepo, temp_home: TempDir) {
+fn test_project_config_path_env_var_relative(mut repo: TestRepo, temp_home: TempDir) {
     fs::write(
         repo.root_path().join("custom-wt.toml"),
         "pre-start = \"custom-hook\"\n",
@@ -5062,7 +5062,25 @@ fn test_project_config_path_env_var_relative(repo: TestRepo, temp_home: TempDir)
     let subdir = repo.root_path().join("sub");
     fs::create_dir_all(&subdir).unwrap();
 
-    for cwd in [repo.root_path(), subdir.as_path()] {
+    // A linked worktree carries its own config file at the same relative
+    // location; running there must load that file, not the main worktree's.
+    let linked = repo.add_worktree("linked-anchor");
+    fs::write(
+        linked.join("custom-wt.toml"),
+        "pre-start = \"linked-hook\"\n",
+    )
+    .unwrap();
+
+    let cases = [
+        (
+            repo.root_path().to_path_buf(),
+            repo.root_path().to_path_buf(),
+            "custom-hook",
+        ),
+        (subdir, repo.root_path().to_path_buf(), "custom-hook"),
+        (linked.clone(), linked, "linked-hook"),
+    ];
+    for (cwd, expected_root, expected_hook) in &cases {
         let mut cmd = repo.wt_command();
         set_xdg_config_path(&mut cmd, temp_home.path());
         set_temp_home_env(&mut cmd, temp_home.path());
@@ -5080,11 +5098,11 @@ fn test_project_config_path_env_var_relative(repo: TestRepo, temp_home: TempDir)
             serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).unwrap();
         assert_eq!(
             json["project"]["path"].as_str().unwrap(),
-            repo.root_path().join("custom-wt.toml").to_str().unwrap(),
+            expected_root.join("custom-wt.toml").to_str().unwrap(),
             "relative override should anchor to the worktree root from {cwd:?}"
         );
         assert_eq!(
-            json["project"]["config"]["pre-start"], "custom-hook",
+            json["project"]["config"]["pre-start"], *expected_hook,
             "relative override should load the root-anchored config from {cwd:?}, got: {}",
             json["project"]
         );
@@ -5115,7 +5133,9 @@ fn test_project_config_path_env_var_relative_no_worktree_errors() {
     );
 
     // Without the override, the same repo has no project config location at
-    // all; `wt config update` skips the project config rather than erroring.
+    // all; `wt config update` skips the project config rather than erroring,
+    // and `wt config show` reports the absence rather than claiming to be
+    // outside a git repository.
     let mut cmd = test.wt_command();
     cmd.args(["config", "update", "--yes"])
         .current_dir(test.bare_repo_path());
@@ -5124,6 +5144,21 @@ fn test_project_config_path_env_var_relative_no_worktree_errors() {
         output.status.success(),
         "config update should skip a missing project config location; stderr:\n{}",
         String::from_utf8_lossy(&output.stderr)
+    );
+
+    let mut cmd = test.wt_command();
+    cmd.args(["config", "show"])
+        .current_dir(test.bare_repo_path());
+    let output = cmd.output().unwrap();
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        output.status.success(),
+        "config show should succeed with no project config location; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        stdout.contains("No project config"),
+        "config show should report the missing project config location; stdout:\n{stdout}"
     );
 }
 

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -5113,6 +5113,18 @@ fn test_project_config_path_env_var_relative_no_worktree_errors() {
         stderr.contains("WORKTRUNK_PROJECT_CONFIG_PATH is relative"),
         "error should name the env var and the problem; stderr:\n{stderr}"
     );
+
+    // Without the override, the same repo has no project config location at
+    // all; `wt config update` skips the project config rather than erroring.
+    let mut cmd = test.wt_command();
+    cmd.args(["config", "update", "--yes"])
+        .current_dir(test.bare_repo_path());
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "config update should skip a missing project config location; stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 }
 
 /// On Windows, an override that is neither fully absolute nor relative — a

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -5022,6 +5022,30 @@ fn test_project_config_path_env_var_override(repo: TestRepo, temp_home: TempDir)
         "missing override path should resolve to no project config, got: {}",
         json["project"]["config"]
     );
+
+    // An empty override likewise means no project config — it must not fall
+    // back to the repo's own file or resolve to the worktree root directory.
+    let mut cmd = wt_command();
+    repo.configure_wt_cmd(&mut cmd);
+    set_xdg_config_path(&mut cmd, temp_home.path());
+    set_temp_home_env(&mut cmd, temp_home.path());
+    cmd.env("WORKTRUNK_PROJECT_CONFIG_PATH", "");
+    cmd.args(["config", "show", "--format=json"])
+        .current_dir(repo.root_path());
+
+    let output = cmd.output().unwrap();
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value =
+        serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).unwrap();
+    assert!(
+        json["project"]["config"].is_null(),
+        "empty override should resolve to no project config, got: {}",
+        json["project"]["config"]
+    );
 }
 
 /// A relative `WORKTRUNK_PROJECT_CONFIG_PATH` resolves against the worktree
@@ -5039,8 +5063,7 @@ fn test_project_config_path_env_var_relative(repo: TestRepo, temp_home: TempDir)
     fs::create_dir_all(&subdir).unwrap();
 
     for cwd in [repo.root_path(), subdir.as_path()] {
-        let mut cmd = wt_command();
-        repo.configure_wt_cmd(&mut cmd);
+        let mut cmd = repo.wt_command();
         set_xdg_config_path(&mut cmd, temp_home.path());
         set_temp_home_env(&mut cmd, temp_home.path());
         cmd.env("WORKTRUNK_PROJECT_CONFIG_PATH", "custom-wt.toml");
@@ -5075,8 +5098,7 @@ fn test_project_config_path_env_var_relative(repo: TestRepo, temp_home: TempDir)
 fn test_project_config_path_env_var_relative_no_worktree_errors() {
     let test = BareRepoTest::new();
 
-    let mut cmd = wt_command();
-    test.configure_wt_cmd(&mut cmd);
+    let mut cmd = test.wt_command();
     cmd.env("WORKTRUNK_PROJECT_CONFIG_PATH", "custom-wt.toml");
     cmd.args(["config", "show", "--format=json"])
         .current_dir(test.bare_repo_path());
@@ -5091,4 +5113,28 @@ fn test_project_config_path_env_var_relative_no_worktree_errors() {
         stderr.contains("WORKTRUNK_PROJECT_CONFIG_PATH is relative"),
         "error should name the env var and the problem; stderr:\n{stderr}"
     );
+}
+
+/// On Windows, an override that is neither fully absolute nor relative — a
+/// drive-relative (`C:cfg`) or rooted-but-driveless (`\cfg`) value — errors
+/// instead of silently resolving against the process drive or cwd.
+#[cfg(windows)]
+#[rstest]
+fn test_project_config_path_env_var_half_anchored_errors(repo: TestRepo) {
+    for value in [r"C:cfg\wt.toml", r"\cfg\wt.toml"] {
+        let mut cmd = repo.wt_command();
+        cmd.env("WORKTRUNK_PROJECT_CONFIG_PATH", value);
+        cmd.args(["config", "show", "--format=json"]);
+
+        let output = cmd.output().unwrap();
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert!(
+            !output.status.success(),
+            "override {value} should be rejected; stderr:\n{stderr}"
+        );
+        assert!(
+            stderr.contains("neither fully absolute nor relative"),
+            "error should explain the rejected form for {value}; stderr:\n{stderr}"
+        );
+    }
 }

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -1,5 +1,5 @@
 use crate::common::{
-    TestRepo, canonical_temp_home, repo, set_temp_home_env, set_xdg_config_path,
+    BareRepoTest, TestRepo, canonical_temp_home, repo, set_temp_home_env, set_xdg_config_path,
     setup_home_snapshot_settings, setup_snapshot_settings, setup_snapshot_settings_with_home,
     temp_home, wt_command,
 };
@@ -5021,5 +5021,74 @@ fn test_project_config_path_env_var_override(repo: TestRepo, temp_home: TempDir)
         json["project"]["config"].is_null(),
         "missing override path should resolve to no project config, got: {}",
         json["project"]["config"]
+    );
+}
+
+/// A relative `WORKTRUNK_PROJECT_CONFIG_PATH` resolves against the worktree
+/// root — the same anchor as the default `.config/wt.toml` — so the override
+/// behaves identically from any subdirectory instead of silently depending on
+/// the process cwd.
+#[rstest]
+fn test_project_config_path_env_var_relative(repo: TestRepo, temp_home: TempDir) {
+    fs::write(
+        repo.root_path().join("custom-wt.toml"),
+        "pre-start = \"custom-hook\"\n",
+    )
+    .unwrap();
+    let subdir = repo.root_path().join("sub");
+    fs::create_dir_all(&subdir).unwrap();
+
+    for cwd in [repo.root_path(), subdir.as_path()] {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        set_xdg_config_path(&mut cmd, temp_home.path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+        cmd.env("WORKTRUNK_PROJECT_CONFIG_PATH", "custom-wt.toml");
+        cmd.args(["config", "show", "--format=json"])
+            .current_dir(cwd);
+
+        let output = cmd.output().unwrap();
+        assert!(
+            output.status.success(),
+            "stderr: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        let json: serde_json::Value =
+            serde_json::from_str(&String::from_utf8_lossy(&output.stdout)).unwrap();
+        assert_eq!(
+            json["project"]["path"].as_str().unwrap(),
+            repo.root_path().join("custom-wt.toml").to_str().unwrap(),
+            "relative override should anchor to the worktree root from {cwd:?}"
+        );
+        assert_eq!(
+            json["project"]["config"]["pre-start"], "custom-hook",
+            "relative override should load the root-anchored config from {cwd:?}, got: {}",
+            json["project"]
+        );
+    }
+}
+
+/// A relative `WORKTRUNK_PROJECT_CONFIG_PATH` with no worktree root to anchor
+/// it (bare repo, no linked worktrees) errors instead of silently resolving
+/// against the process cwd.
+#[test]
+fn test_project_config_path_env_var_relative_no_worktree_errors() {
+    let test = BareRepoTest::new();
+
+    let mut cmd = wt_command();
+    test.configure_wt_cmd(&mut cmd);
+    cmd.env("WORKTRUNK_PROJECT_CONFIG_PATH", "custom-wt.toml");
+    cmd.args(["config", "show", "--format=json"])
+        .current_dir(test.bare_repo_path());
+
+    let output = cmd.output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "a relative override without a worktree root should fail; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("WORKTRUNK_PROJECT_CONFIG_PATH is relative"),
+        "error should name the env var and the problem; stderr:\n{stderr}"
     );
 }

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -600,21 +600,21 @@ Override the LLM command in CI to use a mock:
 
 [32mOther environment variables[0m
 
-             Variable                                                                   Purpose                                                      
- ───────────────────────────────── ───────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
- [2mWORKTRUNK_BIN[0m                     Override binary path for shell wrappers; useful for testing dev builds                                            
- [2mWORKTRUNK_CONFIG_PATH[0m             Override user config file location                                                                                
- [2mWORKTRUNK_SYSTEM_CONFIG_PATH[0m      Override system config file location                                                                              
- [2mWORKTRUNK_PROJECT_CONFIG_PATH[0m     Override project config file location (defaults to [2m.config/wt.toml[0m)                                               
- [2mXDG_CONFIG_DIRS[0m                   Colon-separated system config directories (default: [2m/etc/xdg[0m)                                                     
- [2mWORKTRUNK_DIRECTIVE_CD_FILE[0m       Internal: set by shell wrappers. wt writes a raw path; the wrapper [2mcd[0ms to it                                      
- [2mWORKTRUNK_DIRECTIVE_EXEC_FILE[0m     Internal: set by shell wrappers. wt writes shell commands; the wrapper sources the file                           
- [2mWORKTRUNK_SHELL[0m                   Internal: set by shell wrappers to indicate shell type (e.g., [2mpowershell[0m)                                         
- [2mWORKTRUNK_MAX_CONCURRENT_COMMANDS[0m Max parallel git commands (default: 32). Lower if hitting file descriptor limits.                                 
- [2mWORKTRUNK_VERBOSE[0m                 Verbosity level ([2m0[0m/[2m1[0m/[2m2[0m), like [2m-v[0m/[2m-vv[0m but applied everywhere — including shell completion, which no flag can reach 
- [2mRUST_LOG[0m                          Logging directive (e.g. [2mworktrunk=debug[0m); overrides the verbosity baseline for what reaches stderr                
- [2mNO_COLOR[0m                          Disable colored output (standard)                                                                                 
- [2mCLICOLOR_FORCE[0m                    Force colored output even when not a TTY                                                                          
+             Variable                                                                   Purpose                                                       
+ ───────────────────────────────── ────────────────────────────────────────────────────────────────────────────────────────────────────────────────── 
+ [2mWORKTRUNK_BIN[0m                     Override binary path for shell wrappers; useful for testing dev builds                                             
+ [2mWORKTRUNK_CONFIG_PATH[0m             Override user config file location                                                                                 
+ [2mWORKTRUNK_SYSTEM_CONFIG_PATH[0m      Override system config file location                                                                               
+ [2mWORKTRUNK_PROJECT_CONFIG_PATH[0m     Override project config file location (defaults to [2m.config/wt.toml[0m); relative paths resolve from the worktree root 
+ [2mXDG_CONFIG_DIRS[0m                   Colon-separated system config directories (default: [2m/etc/xdg[0m)                                                      
+ [2mWORKTRUNK_DIRECTIVE_CD_FILE[0m       Internal: set by shell wrappers. wt writes a raw path; the wrapper [2mcd[0ms to it                                       
+ [2mWORKTRUNK_DIRECTIVE_EXEC_FILE[0m     Internal: set by shell wrappers. wt writes shell commands; the wrapper sources the file                            
+ [2mWORKTRUNK_SHELL[0m                   Internal: set by shell wrappers to indicate shell type (e.g., [2mpowershell[0m)                                          
+ [2mWORKTRUNK_MAX_CONCURRENT_COMMANDS[0m Max parallel git commands (default: 32). Lower if hitting file descriptor limits.                                  
+ [2mWORKTRUNK_VERBOSE[0m                 Verbosity level ([2m0[0m/[2m1[0m/[2m2[0m), like [2m-v[0m/[2m-vv[0m but applied everywhere — including shell completion, which no flag can reach  
+ [2mRUST_LOG[0m                          Logging directive (e.g. [2mworktrunk=debug[0m); overrides the verbosity baseline for what reaches stderr                 
+ [2mNO_COLOR[0m                          Disable colored output (standard)                                                                                  
+ [2mCLICOLOR_FORCE[0m                    Force colored output even when not a TTY                                                                           
 
 [1m[32mInline config overrides (--config-set)[0m
 


### PR DESCRIPTION
`WORKTRUNK_PROJECT_CONFIG_PATH` was returned verbatim, so a relative value resolved against the process cwd while the default `.config/wt.toml` is anchored to the worktree root. Running `wt` from a subdirectory made a relative override silently no-op (or read an unintended file). This is the config-path footgun from #3454 (the RFC there is a separate discussion).

A relative override now resolves against the same worktree root as the default (current worktree, or the primary worktree at a bare root), so it behaves identically from any subdirectory. Values that can't be anchored fail loudly instead of guessing:

- relative with no worktree root to anchor to (bare repo with no linked worktrees) errors
- Windows forms that are neither fully absolute nor relative (drive-relative `C:cfg`, rooted-but-driveless `\cfg` or `/tmp/x`) error rather than resolving against the process drive or cwd

Absolute values are unchanged (returned verbatim, no git calls), which keeps the test-isolation use of the var working. An empty value still means no project config, as before. `wt config show` (human format) and `wt config update` previously folded a `project_config_path()` error into "not in a git repository" / a silent skip; they now propagate it, matching the JSON path.

Merging main brought in #3462's committed default-branch config fallback for bare repos whose primary worktree is parked off the default branch. That fallback now stands down when `WORKTRUNK_PROJECT_CONFIG_PATH` is set: an explicit override names the config source outright (a missing file there means no project config), and the override exists for test isolation, where reading the repo's own committed config is exactly the leak being prevented.

The human format of `wt config show` now reports "No project config" when no location exists (bare repo with no worktrees, empty override) instead of the inaccurate "Not in a git repository", which stays reserved for actually being outside a repo.

Compatibility: invoked from the worktree root, cwd and root coincide, so old and new resolution agree. From a subdirectory the old resolution found nothing, which is the bug being fixed, so no deprecation shim is included.

Thanks @indexzero for reporting in #3454.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> _This was written by Claude Code on behalf of max_
