### PR TITLE
fix(list): stop repeating the failure count in the list footer

### DIFF
--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -1987,8 +1987,6 @@ pub fn collect(
         item.refresh_status_symbols(primary_target);
     }
 
-    // Count errors for summary
-    let error_count = errors.len();
     let timed_out_count = errors.iter().filter(|e| e.is_timeout()).count();
 
     let table_render = render_table.then(|| TableRenderPlan {
@@ -2002,7 +2000,6 @@ pub fn collect(
             &all_items,
             show_branches || show_remotes,
             layout.hidden_column_count,
-            error_count,
             timed_out_count,
         ),
     });

--- a/src/commands/list/mod.rs
+++ b/src/commands/list/mod.rs
@@ -365,12 +365,17 @@ impl SummaryMetrics {
     }
 }
 
-/// Format a summary message for the given items (used by both collect/mod.rs and mod.rs)
+/// Format the summary line that closes the table.
+///
+/// The footer is the only home a timed-out task has: it leaves an empty cell
+/// and no message to print, so the count here is all that reports it. Tasks
+/// that failed instead get a named entry in the warning that follows the
+/// table, and that warning carries its own count — repeating it here would
+/// print the same number twice on adjacent lines.
 pub(crate) fn format_summary_message(
     items: &[ListItem],
     show_branches: bool,
     hidden_column_count: usize,
-    error_count: usize,
     timed_out_count: usize,
 ) -> String {
     let metrics = SummaryMetrics::from_items(items);
@@ -379,25 +384,11 @@ pub(crate) fn format_summary_message(
         .summary_parts(show_branches, hidden_column_count)
         .join(", ");
 
-    if error_count > 0 {
-        // "failed" and "timed out" are disjoint here, matching the warning
-        // that details the non-timeout failures after the table.
-        let failed_count = error_count - timed_out_count;
-        let failure_msg = match (failed_count, timed_out_count) {
-            (0, t) => {
-                let plural = if t == 1 { "" } else { "s" };
-                format!("{t} task{plural} timed out")
-            }
-            (f, 0) => {
-                let plural = if f == 1 { "" } else { "s" };
-                format!("{f} task{plural} failed")
-            }
-            (f, t) => {
-                let plural = if f == 1 { "" } else { "s" };
-                format!("{f} task{plural} failed, {t} timed out")
-            }
-        };
-        format!("{INFO_SYMBOL} {dim}Showing {summary}; {failure_msg}{dim:#}")
+    if timed_out_count > 0 {
+        let plural = if timed_out_count == 1 { "" } else { "s" };
+        format!(
+            "{INFO_SYMBOL} {dim}Showing {summary}; {timed_out_count} task{plural} timed out{dim:#}"
+        )
     } else {
         format!("{INFO_SYMBOL} {dim}Showing {summary}{dim:#}")
     }
@@ -538,20 +529,15 @@ mod tests {
     }
 
     #[test]
-    fn test_format_summary_message_error_variants() {
+    fn test_format_summary_message_timeout_variants() {
         use insta::assert_snapshot;
 
-        // No errors
-        assert_snapshot!(format_summary_message(&[], false, 0, 0, 0), @"[2m○[22m [2mShowing 0 worktrees[0m");
-        // All timeouts
-        assert_snapshot!(format_summary_message(&[], false, 0, 3, 3), @"[2m○[22m [2mShowing 0 worktrees; 3 tasks timed out[0m");
-        // Mixed errors and timeouts
-        assert_snapshot!(format_summary_message(&[], false, 0, 5, 3), @"[2m○[22m [2mShowing 0 worktrees; 2 tasks failed, 3 timed out[0m");
-        // Only failures, no timeouts
-        assert_snapshot!(format_summary_message(&[], false, 0, 2, 0), @"[2m○[22m [2mShowing 0 worktrees; 2 tasks failed[0m");
-        // Single error
-        assert_snapshot!(format_summary_message(&[], false, 0, 1, 0), @"[2m○[22m [2mShowing 0 worktrees; 1 task failed[0m");
+        // Nothing timed out. Failures alone leave the footer untouched — the
+        // warning after the table names them and carries their count.
+        assert_snapshot!(format_summary_message(&[], false, 0, 0), @"[2m○[22m [2mShowing 0 worktrees[0m");
         // Single timeout
-        assert_snapshot!(format_summary_message(&[], false, 0, 1, 1), @"[2m○[22m [2mShowing 0 worktrees; 1 task timed out[0m");
+        assert_snapshot!(format_summary_message(&[], false, 0, 1), @"[2m○[22m [2mShowing 0 worktrees; 1 task timed out[0m");
+        // Several timeouts
+        assert_snapshot!(format_summary_message(&[], false, 0, 3), @"[2m○[22m [2mShowing 0 worktrees; 3 tasks timed out[0m");
     }
 }

--- a/src/commands/list/model/status_symbols.rs
+++ b/src/commands/list/model/status_symbols.rs
@@ -186,9 +186,11 @@
 //!
 //! 1. Each position's last-known state is displayed: resolved positions show
 //!    their symbol; unresolved positions show `·`.
-//! 2. The diagnostic footer already lists which tasks did not finish per
-//!    item — this continues unchanged and gives the user the mapping from
-//!    "`·` in position X" back to "`TaskKind::Foo` timed out."
+//! 2. The `·` is the whole signal — budget truncation is deliberate, so it
+//!    goes unreported, and nothing maps a `·` in position X back to the
+//!    `TaskKind` that didn't finish. (A task whose own git command times out
+//!    is a separate path: it reaches the summary footer as one of "N tasks
+//!    timed out", a count that likewise doesn't name the task.)
 //! 3. JSON output omits fields that correspond to unresolved gates
 //!    (`working_tree`, `main_state`, `operation_state`, `upstream_divergence`,
 //!    etc.) so machine consumers can distinguish "loading / timeout" from

--- a/tests/snapshots/integration__integration_tests__list__list_shows_warning_on_git_error.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_shows_warning_on_git_error.snap
@@ -54,7 +54,7 @@ exit_code: 0
 ----- stderr -----
 [33m▲[39m [33mFailed to batch-fetch commit details: fatal: bad object 0000000000000000000000000000000000000001[39m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead; 10 tasks failed[0m
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
 [33m▲[39m [33m10 tasks failed:
 [107m [0m [1mmain[22m: upstream status (fatal: missing object 0000000000000000000000000000000000000001 for refs/heads/feature)
 [107m [0m [1mfeature[22m: ahead/behind counts (git merge-base failed for 05a4a45d0b981dad5c27db59dca482836d59f89e 0000000000000000000000000000000000000001: fatal: Not a valid commit name 0000000000000000000000000000000000000001)

--- a/tests/snapshots/integration__integration_tests__list__list_warns_when_commit_details_batch_fails.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_warns_when_commit_details_batch_fails.snap
@@ -54,7 +54,7 @@ exit_code: 0
 ----- stderr -----
 [33m▲[39m [33mFailed to batch-fetch commit details: fatal: bad object 0000000000000000000000000000000000000001[39m
 
-[2m○[22m [2mShowing 5 worktrees, 3 ahead; 6 tasks failed[0m
+[2m○[22m [2mShowing 5 worktrees, 3 ahead[0m
 [33m▲[39m [33m6 tasks failed:
 [107m [0m [1m(detached)[22m: ahead/behind counts (git merge-base failed for 05a4a45d0b981dad5c27db59dca482836d59f89e 0000000000000000000000000000000000000001: fatal: Not a valid commit name 0000000000000000000000000000000000000001)
 [107m [0m [1m(detached)[22m: trees-match check (fatal: Needed a single revision)


### PR DESCRIPTION
Follow-up to #3442. A failed task printed the same count twice on adjacent lines — the summary footer's `N tasks failed` clause and the `▲ N tasks failed:` warning header directly below it that names each failure:

```
○ Showing 5 worktrees, 3 ahead; 6 tasks failed
▲ 6 tasks failed:
  (detached): working-tree conflict check
    fatal: bad object HEAD
```

The footer clause was never a distinct signal: its count is exactly `non_timeout_errors.len()`, and that vector being non-empty is precisely the condition under which the warning renders. So the number was duplicated in 100% of cases.

Rather than suppress the duplicate when a warning happens to follow, this splits the two by what each reports. The footer counts what's *missing* from the table — timed-out tasks, which leave an empty cell and have no message to print, so a count is the only signal they can carry (and the warning deliberately filters them out). Failures are named in the warning with git's full error text. `format_summary_message` drops its `error_count` parameter entirely; the footer now reads:

```
○ Showing 5 worktrees, 3 ahead
▲ 6 tasks failed:
  ...
```

Also corrects a stale claim in the `status_symbols` module spec: it said the footer "lists which tasks did not finish per item," giving a mapping from a `·` cell back to the timed-out `TaskKind`. No such mapping ever existed — the footer only carried counts, and budget-based truncation produces no diagnostic at all by design.

One narrow behavior note: in progressive TTY mode the footer is stdout (a repainted table row) while the warning is stderr, so `wt list 2>/dev/null` on a TTY no longer shows a bare failure count. That case was already discarding the error detail, and discarding stderr discards narration by definition; the ordinary piped case (both on stderr) is unchanged.

## Testing

The `format_summary_message` unit test now covers the timeout-only footer variants; the two failure-warning integration snapshots are updated to show the deduplicated footer. Verified end-to-end against the `index.lock` scenario (dirty worktree + pre-existing lock file).

> _This was written by Claude Code on behalf of max_
