### PR TITLE
fix(plugin): anchor WorktreeRemove at the project dir

### DIFF
--- a/plugins/worktrunk/hooks/hooks.json
+++ b/plugins/worktrunk/hooks/hooks.json
@@ -79,7 +79,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'p=$(jq -er .worktree_path) || exit 1; bash \"$CLAUDE_PLUGIN_ROOT/hooks/wt.sh\" remove --foreground \"$p\"'"
+            "command": "bash -c 'p=$(jq -er .worktree_path) || exit 1; cd \"${CLAUDE_PROJECT_DIR:-.}\" || exit 1; bash \"$CLAUDE_PLUGIN_ROOT/hooks/wt.sh\" remove --foreground \"$p\"'"
           }
         ]
       }


### PR DESCRIPTION
Anchor the `WorktreeRemove` hook at `CLAUDE_PROJECT_DIR`, mirroring #3453 which did the same for `WorktreeCreate`.

The hook command inherits the working directory it is fired from. When that directory is not inside the repository — e.g. the agents-view session's worktree was already removed, or the hook is fired from a neutral cwd — `wt remove <path>` dies with *fatal: not a git repository* (repo discovery starts from cwd, not from the path argument). Claude Code (>= 2.1.211) surfaces this as `WorktreeRemove hook failed` and now keeps the session row, so the completed background session becomes undeletable from the `claude agents` view.

`cd "${CLAUDE_PROJECT_DIR:-.}"` pins the hook to the repository the session was launched in, falling back to current behavior when the variable is unset — identical to the WorktreeCreate anchor added in #3453.

### Reproduction

Current hook, run from a cwd outside the repo (worktree clean and pushed):

```
✗ Failed to remove worktree
  fatal: not a git repository (or any of the parent directories): .git
# exit 1 → "WorktreeRemove hook failed" → session undeletable
```

With the anchor (`CLAUDE_PROJECT_DIR` set to the repo), same cwd:

```
◎ Removing <branch> worktree...
✓ Removed <branch> worktree & branch
# exit 0
```

### Tests

No test change needed. `tests/integration_tests/config_show.rs` asserts (a) every hook command uses unbraced `$CLAUDE_PLUGIN_ROOT` — unchanged, since the added `${CLAUDE_PROJECT_DIR:-.}` sits inside the single-quoted `bash -c` body exactly like the existing WorktreeCreate anchor, and (b) WorktreeRemove passes no `-D`/`--force-delete` (#2939) — unchanged. This is a 1-line change, same shape as #3453.

### Out of scope

Firing `WorktreeRemove` for a worktree that no longer exists makes `wt remove` exit non-zero with `✗ No branch named <path>`; the cwd anchor does not affect that. Tracked separately in #3488.