### PR TITLE
Name the template owner in the -v variables block

### DIFF
--- a/docs/content/step.md
+++ b/docs/content/step.md
@@ -551,7 +551,7 @@ feature_auth_oauth2_a1b
 List the available template variables with `-v` (alongside the expansion, on stderr):
 
 {% terminal(cmd="wt step eval -v '__WT_OPEN__ branch __WT_CLOSE__'") %}
-○ Available template variables
+○ eval template variables:
   branch        = feature/auth-oauth2
   worktree_path = /home/user/projects/myapp-feature-auth-oauth2
 ○ eval source

--- a/plugins/worktrunk/skills/worktrunk/reference/step.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/step.md
@@ -568,7 +568,7 @@ List the available template variables with `-v` (alongside the expansion, on std
 
 ```bash
 $ wt step eval -v '{{ branch }}'
-○ Available template variables
+○ eval template variables:
   branch        = feature/auth-oauth2
   worktree_path = /home/user/projects/myapp-feature-auth-oauth2
 ○ eval source

--- a/skills/worktrunk/reference/step.md
+++ b/skills/worktrunk/reference/step.md
@@ -568,7 +568,7 @@ List the available template variables with `-v` (alongside the expansion, on std
 
 ```bash
 $ wt step eval -v '{{ branch }}'
-○ Available template variables
+○ eval template variables:
   branch        = feature/auth-oauth2
   worktree_path = /home/user/projects/myapp-feature-auth-oauth2
 ○ eval source

--- a/src/cli/step.rs
+++ b/src/cli/step.rs
@@ -439,7 +439,7 @@ List the available template variables with `-v` (alongside the expansion, on std
 
 ```console
 $ wt step eval -v '{{ branch }}'
-○ Available template variables
+○ eval template variables:
   branch        = feature/auth-oauth2
   worktree_path = /home/user/projects/myapp-feature-auth-oauth2
 ○ eval source

--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -618,7 +618,10 @@ fn run_alias(
 
     if verbosity() >= 1 {
         let vars = format_alias_variables(&context_map, Some(&referenced));
-        eprintln!("{}", info_message("template variables:"));
+        eprintln!(
+            "{}",
+            info_message(cformat!("<bold>{}</> template variables:", opts.name))
+        );
         eprintln!("{}", format_with_gutter(&vars, None));
     }
 

--- a/src/commands/command_executor.rs
+++ b/src/commands/command_executor.rs
@@ -628,7 +628,10 @@ fn announce_command(cmd: &PreparedCommand, kind: &PipelineKind, command_str: &st
     };
     if verbosity() >= 1 {
         let vars = format_hook_variables(*hook_type, &cmd.context);
-        eprintln!("{}", info_message("template variables:"));
+        eprintln!(
+            "{}",
+            info_message(cformat!("<bold>{hook_type}</> template variables:"))
+        );
         eprintln!("{}", format_with_gutter(&vars, None));
     }
     eprintln!("{}", progress_message(message));

--- a/src/commands/eval.rs
+++ b/src/commands/eval.rs
@@ -51,7 +51,10 @@ pub fn step_eval(template: &str, format: SwitchFormat) -> anyhow::Result<()> {
             })
             .collect::<Vec<_>>()
             .join("\n");
-        eprintln!("{}", info_message("Available template variables"));
+        eprintln!(
+            "{}",
+            info_message(cformat!("<bold>{EVAL_NAME}</> template variables:"))
+        );
         eprintln!("{}", format_with_gutter(&listing, None));
     }
 

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -465,7 +465,10 @@ fn print_background_variable_table(pipelines: &[PendingPipeline], hook_type: Hoo
             PreparedStep::Single(cmd) => cmd,
             PreparedStep::Concurrent(cmds) => &cmds[0],
         };
-        eprintln!("{}", info_message("template variables:"));
+        eprintln!(
+            "{}",
+            info_message(cformat!("<bold>{hook_type}</> template variables:"))
+        );
         eprintln!(
             "{}",
             format_with_gutter(&format_hook_variables(hook_type, &cmd.context), None)

--- a/tests/snapshots/integration__integration_tests__eval__eval_format_json_verbose.snap
+++ b/tests/snapshots/integration__integration_tests__eval__eval_format_json_verbose.snap
@@ -10,6 +10,7 @@ info:
     - "{{ branch | hash_port }}"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -38,6 +39,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -54,7 +56,7 @@ exit_code: 0
 }
 
 ----- stderr -----
-[2m○[22m Available template variables
+[2m○[22m [1meval[22m template variables:
 [107m [0m [1mbranch[22m                = main
 [107m [0m [1mcommit[22m                = 05a4a45d0b981dad5c27db59dca482836d59f89e
 [107m [0m [1mcwd[22m                   = _REPO_

--- a/tests/snapshots/integration__integration_tests__eval__eval_verbose.snap
+++ b/tests/snapshots/integration__integration_tests__eval__eval_verbose.snap
@@ -9,6 +9,7 @@ info:
     - "{{ branch | hash_port }}"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -37,6 +38,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -49,7 +51,7 @@ exit_code: 0
 12107
 
 ----- stderr -----
-[2m○[22m Available template variables
+[2m○[22m [1meval[22m template variables:
 [107m [0m [1mbranch[22m                = main
 [107m [0m [1mcommit[22m                = 05a4a45d0b981dad5c27db59dca482836d59f89e
 [107m [0m [1mcwd[22m                   = _REPO_

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_verbose_output.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_verbose_output.snap
@@ -9,6 +9,7 @@ info:
     - feature
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -37,6 +38,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -56,7 +58,7 @@ exit_code: 0
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
-[2m○[22m template variables:
+[2m○[22m [1mpost-start[22m template variables:
 [107m [0m branch                = feature
 [107m [0m worktree_path         = _REPO_.feature
 [107m [0m worktree_name         = repo.feature

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_verbose_template_expansion.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_verbose_template_expansion.snap
@@ -9,6 +9,7 @@ info:
     - verbose-hooks
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -37,6 +38,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -56,7 +58,7 @@ exit_code: 0
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setting up {{ branch | sanitize }} in {{ worktree_path }}'[0m
 [2m○[22m [1mproject:setup[22m result
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setting up verbose-hooks in _REPO_.verbose-hooks'[0m
-[2m○[22m template variables:
+[2m○[22m [1mpre-start[22m template variables:
 [107m [0m branch                = verbose-hooks
 [107m [0m worktree_path         = _REPO_.verbose-hooks
 [107m [0m worktree_name         = repo.verbose-hooks

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_verbose_args_shell_escaped.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_verbose_args_shell_escaped.snap
@@ -9,6 +9,7 @@ info:
     - bar baz
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -37,6 +38,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -49,7 +51,7 @@ exit_code: 0
 hello foo bar baz
 
 ----- stderr -----
-[2m○[22m template variables:
+[2m○[22m [1mgreet[22m template variables:
 [107m [0m branch                = feature
 [107m [0m worktree_path         = _REPO_.feature
 [107m [0m worktree_name         = repo.feature

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_verbose_variable_table.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_verbose_variable_table.snap
@@ -8,6 +8,7 @@ info:
     - world
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -36,6 +37,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -48,7 +50,7 @@ exit_code: 0
 hello world
 
 ----- stderr -----
-[2m○[22m template variables:
+[2m○[22m [1mgreet[22m template variables:
 [107m [0m branch                = feature
 [107m [0m worktree_path         = _REPO_.feature
 [107m [0m worktree_name         = repo.feature

--- a/tests/snapshots/integration__integration_tests__user_hooks__combined_post_remove_and_post_switch_verbose.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__combined_post_remove_and_post_switch_verbose.snap
@@ -38,6 +38,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -52,7 +53,7 @@ exit_code: 0
 [36m◎[39m [36mRemoving [1mfeature[22m worktree & branch in background (--force-delete)[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
-[2m○[22m template variables:
+[2m○[22m [1mpost-remove[22m template variables:
 [107m [0m branch                = feature
 [107m [0m worktree_path         = _REPO_.feature
 [107m [0m worktree_name         = repo.feature
@@ -71,7 +72,7 @@ exit_code: 0
 [107m [0m cwd                   = _REPO_
 [107m [0m hook_type             = post-remove
 [107m [0m hook_name             = cleanup
-[2m○[22m template variables:
+[2m○[22m [1mpost-switch[22m template variables:
 [107m [0m branch                = main
 [107m [0m worktree_path         = _REPO_
 [107m [0m worktree_name         = repo

--- a/tests/snapshots/integration__integration_tests__user_hooks__hook_verbose_background_dedup.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__hook_verbose_background_dedup.snap
@@ -9,6 +9,7 @@ info:
     - feature
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -37,6 +38,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -56,7 +58,7 @@ exit_code: 0
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
-[2m○[22m template variables:
+[2m○[22m [1mpost-start[22m template variables:
 [107m [0m branch                = feature
 [107m [0m worktree_path         = _REPO_.feature
 [107m [0m worktree_name         = repo.feature

--- a/tests/snapshots/integration__integration_tests__user_hooks__hook_verbose_variable_table.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__hook_verbose_variable_table.snap
@@ -37,6 +37,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -52,7 +53,7 @@ exit_code: 0
 [107m [0m [2m[0m[2m[34mtrue[0m
 [2m○[22m [1muser:noop[22m result
 [107m [0m [2m[0m[2m[34mtrue[0m
-[2m○[22m template variables:
+[2m○[22m [1mpre-switch[22m template variables:
 [107m [0m branch                = feature
 [107m [0m worktree_path         = _REPO_.feature
 [107m [0m worktree_name         = repo.feature


### PR DESCRIPTION
## The question

When `wt` shows a `template variables:` block under `-v`, does it say which template the variables belong to? Mostly no — and in one case it genuinely can't be worked out from the header.

## What was there

Four sites print a variables listing, and none named its owner in the header:

| Site | Header | How you'd tell what it's for |
|---|---|---|
| foreground hook (`command_executor.rs`) | `template variables:` | the `hook_type` row at the bottom of the table, or the `Running …` line below it |
| background hook (`hooks.rs`) | `template variables:` | same — but see below |
| alias (`alias.rs`) | `template variables:` | only the `Running alias greet` line below it |
| `wt step eval` (`eval.rs`) | `Available template variables` | unambiguous (one template, named on the command line) |

The adjacent blocks in the same `-v` lane already label themselves — `○ eval source`, `○ user:noop result` — so the variables table was the odd one out in its own family.

Background hooks turned that from inconvenient into ambiguous. `wt -v remove <branch>` prints one table per hook type back to back, then a *single* combined `Running post-remove: cleanup (user); post-switch: notify (user)` line — two identical headers over two ~20-row tables that differ only in their rows.

## The change

Prefix each header with the hook type, alias name, or `eval`.

```
- ○ template variables:                 ○ post-remove template variables:
- ○ template variables:                 ○ post-switch template variables:
```

`wt step eval -v` now reads as one labeled family:

```
○ eval template variables:
  branch = feature/auth-oauth2
○ eval source
  {{ branch }}
○ eval result
  feature/auth-oauth2
```

`eval`'s header was reworded from `Available template variables` for the same shape; it was never ambiguous, but it's the fourth member of the family and now matches the `source` / `result` headers directly beneath it.

Display-only — no logic changed. Snapshots and the generated `step.md` pages regenerated; `cargo run -- hook pre-merge --yes` green (4461 tests).

> _This was written by Claude Code on behalf of Maximilian Roos_

🤖 Generated with [Claude Code](https://claude.com/claude-code)