### PR TITLE
fix(testing): Isolate CLI logging environment

### DIFF
--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -546,12 +546,13 @@ pub fn configure_cli_command(cmd: &mut Command) {
     // by the env-strip above.
     isolate_subprocess_env(cmd, None);
     cmd.env("WORKTRUNK_TEST_EPOCH", TEST_EPOCH.to_string());
-    // RUST_LOG intentionally NOT set: the flag baseline and `RUST_LOG`
+    // Do not inherit the host's RUST_LOG: the flag baseline and `RUST_LOG`
     // merge via the env-wins-when-set contract enforced by
     // `tracing_subscriber::EnvFilter` (see `logging::init`), so a blanket
-    // `RUST_LOG=warn` default would cap `-vv` tests at Warn and starve
-    // `trace.log` of debug-level `[wt-trace]` records. Tests that need
-    // warn-level output should opt in per-invocation.
+    // host `RUST_LOG=warn` would cap `-vv` tests at Warn and starve `trace.log`
+    // of debug-level `[wt-trace]` records. Tests that need warn-level output
+    // can opt in after command construction.
+    cmd.env_remove("RUST_LOG");
     // Treat Claude as not installed by default (tests can override with "1")
     cmd.env("WORKTRUNK_TEST_CLAUDE_INSTALLED", "0");
     // Treat Codex as not installed by default (tests can override with "1")
@@ -3123,6 +3124,22 @@ mod tests {
         assert_eq!(
             removed.get("WORKTRUNK_APPROVALS_PATH"),
             Some(&Some(DEFAULT_ISOLATED_APPROVALS.to_string()))
+        );
+    }
+
+    #[test]
+    fn configure_cli_command_scrubs_host_rust_log() {
+        let mut cmd = Command::new("true");
+        configure_cli_command(&mut cmd);
+
+        let rust_log = cmd
+            .get_envs()
+            .find(|(key, _)| key.to_string_lossy() == "RUST_LOG")
+            .map(|(_, value)| value);
+
+        assert!(
+            matches!(rust_log, Some(None)),
+            "RUST_LOG should be explicitly removed from CLI test children"
         );
     }
 


### PR DESCRIPTION
## 🧢 Changes

- Remove inherited `RUST_LOG` from CLI integration-test children.
- Preserve explicit per-test logging overrides.
- Keep verbose trace assertions independent of the developer's shell.

## ☕️ Reasoning

The test harness should control the child CLI's logging baseline. A host
`RUST_LOG=warn` overrides `-vv`, suppresses debug trace records, and makes
otherwise-correct diagnostic tests fail.

This was a real-world agentic coding blocker: full verification inherited the
session environment and required an external `env -u RUST_LOG` workaround.

## 🧪 Reproduction

```sh
RUST_LOG=warn cargo test --test integration \
  test_diagnostic_trace_log_contains_git_commands -- --exact
```

Before this fix, the assertion failed because `trace.log` lacked the expected
Git command records:

```text
Trace log should contain git worktree list command
```

## ✅ Verification

- Focused harness test proves `RUST_LOG` is explicitly removed.
- The diagnostic regression passes with host `RUST_LOG=warn`.
- Combined publication-set pre-merge hook: 4,519 tests passed on macOS.

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>