### PR TITLE
fix(rebase): Preserve explicit remote targets

### DIFF
--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -329,7 +329,7 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
     let rebased = if rebase {
         // Auto-rebase onto target
         matches!(
-            super::step::handle_rebase(Some(&target_branch))?,
+            super::step::handle_rebase_onto_local_branch(&target_branch)?,
             super::step::RebaseResult::Rebased { .. }
         )
     } else {

--- a/src/commands/step/mod.rs
+++ b/src/commands/step/mod.rs
@@ -31,7 +31,7 @@ pub(crate) use copy_ignored::step_copy_ignored;
 pub(crate) use diff::step_diff;
 pub(crate) use promote::{PromoteResult, handle_promote};
 pub(crate) use prune::step_prune;
-pub(crate) use rebase::{RebaseResult, handle_rebase};
+pub(crate) use rebase::{RebaseResult, handle_rebase, handle_rebase_onto_local_branch};
 pub(crate) use relocate::step_relocate;
 pub(crate) use squash::{
     PreApprovedGuidance, SquashResult, handle_squash, step_dry_run_squash, step_show_squash_prompt,

--- a/src/commands/step/rebase.rs
+++ b/src/commands/step/rebase.rs
@@ -21,15 +21,37 @@ pub fn handle_rebase(target: Option<&str>) -> anyhow::Result<RebaseResult> {
 
     // Get and validate target ref (any commit-ish for rebase)
     let integration_target = repo.require_target_ref(target)?;
+    let git_target = match target {
+        Some("@") | Some("-") | Some("^") | None => integration_target.clone(),
+        Some(_) => {
+            let exact_target = repo.disambiguate_remote_ref(&integration_target)?;
+            repo.require_target_ref(Some(&exact_target))?
+        }
+    };
+    handle_rebase_target(&repo, integration_target, git_target)
+}
 
+/// Rebase onto an already-validated local branch, preserving its local identity.
+pub fn handle_rebase_onto_local_branch(target_branch: &str) -> anyhow::Result<RebaseResult> {
+    let repo = Repository::current()?;
+    let git_target = format!("refs/heads/{target_branch}");
+    repo.require_target_ref(Some(&git_target))?;
+    handle_rebase_target(&repo, target_branch.to_string(), git_target)
+}
+
+fn handle_rebase_target(
+    repo: &Repository,
+    integration_target: String,
+    git_target: String,
+) -> anyhow::Result<RebaseResult> {
     // Check if already up-to-date (linear extension of target, no merge commits)
-    if repo.is_rebased_onto(&integration_target)? {
+    if repo.is_rebased_onto(&git_target)? {
         return Ok(RebaseResult::UpToDate(integration_target));
     }
 
     // Check if this is a fast-forward or true rebase
     let merge_base = repo
-        .merge_base("HEAD", &integration_target)?
+        .merge_base("HEAD", &git_target)?
         .context("Cannot rebase: no common ancestor with target branch")?;
     let head_sha = repo.run_command(&["rev-parse", "HEAD"])?.trim().to_string();
     let is_fast_forward = merge_base == head_sha;
@@ -42,7 +64,7 @@ pub fn handle_rebase(target: Option<&str>) -> anyhow::Result<RebaseResult> {
         );
     }
 
-    let rebase_result = repo.run_command(&["rebase", "--end-of-options", &integration_target]);
+    let rebase_result = repo.run_command(&["rebase", "--end-of-options", &git_target]);
 
     // If rebase failed, check if it's due to conflicts
     if let Err(e) = rebase_result {

--- a/src/git/repository/config.rs
+++ b/src/git/repository/config.rs
@@ -506,6 +506,33 @@ impl Repository {
         Ok(reference)
     }
 
+    /// Fully qualify a remote-tracking shorthand when it exists or names a
+    /// configured remote.
+    ///
+    /// Git prefers `refs/heads/<name>` over `refs/remotes/<name>` for an
+    /// ambiguous short name. Explicit qualified inputs such as
+    /// `upstream/main` mean the remote-tracking ref when that ref exists;
+    /// callers keep the original string separately for user-facing output.
+    pub fn disambiguate_remote_ref(&self, reference: &str) -> anyhow::Result<String> {
+        if reference.starts_with("refs/") {
+            return Ok(reference.to_string());
+        }
+
+        let remote_ref = format!("refs/remotes/{reference}");
+        let configured_remote = if let Some((remote, _)) = reference.split_once('/') {
+            self.run_command(&["remote"])?
+                .lines()
+                .any(|configured| configured == remote)
+        } else {
+            false
+        };
+        if configured_remote || self.ref_exists(&remote_ref)? {
+            Ok(remote_ref)
+        } else {
+            Ok(reference.to_string())
+        }
+    }
+
     /// True when `branch` is checked out as an unborn HEAD (no commits yet)
     /// in some worktree — e.g. a freshly `git init`'d repo before its first
     /// commit. Such a branch has no `refs/heads/<branch>` ref, so the

--- a/tests/integration_tests/merge.rs
+++ b/tests/integration_tests/merge.rs
@@ -3265,6 +3265,170 @@ fn test_step_rebase_rebased_json(mut repo: TestRepo) {
     assert_eq!(parsed["target"], "main");
 }
 
+/// An explicit remote-tracking target must not collapse to a same-named local branch.
+#[rstest]
+fn test_step_rebase_preserves_explicit_remote_target(mut repo: TestRepo) {
+    let original_main = repo.head_sha();
+    repo.setup_custom_remote("upstream", "main");
+    let feature_wt =
+        repo.add_worktree_with_commit("feature", "feature.txt", "feature", "feat: feature");
+
+    fs::write(repo.root_path().join("upstream.txt"), "upstream").unwrap();
+    repo.run_git(&["add", "upstream.txt"]);
+    repo.run_git(&["commit", "-m", "upstream change"]);
+    let upstream_tip = repo.head_sha();
+    repo.run_git(&["push", "upstream", "main"]);
+    repo.run_git(&["reset", "--hard", &original_main]);
+    fs::write(repo.root_path().join("local-main.txt"), "local").unwrap();
+    repo.run_git(&["add", "local-main.txt"]);
+    repo.run_git(&["commit", "-m", "local main change"]);
+    let local_main = repo.head_sha();
+    repo.run_git(&["branch", "upstream/main", &local_main]);
+
+    let output = repo
+        .wt_command()
+        .args(["step", "rebase", "upstream/main", "--format=json"])
+        .current_dir(&feature_wt)
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "step rebase failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert_eq!(parsed["outcome"], "rebased");
+    assert_eq!(parsed["target"], "upstream/main");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Rebased onto")
+            && stderr.contains("upstream/main")
+            && !stderr.contains("refs/remotes/upstream/main"),
+        "text output should report the resolved user-facing target: {stderr}"
+    );
+
+    let parent = repo
+        .git_command()
+        .args(["rev-parse", "HEAD^"])
+        .current_dir(&feature_wt)
+        .run()
+        .unwrap();
+    assert_eq!(
+        String::from_utf8_lossy(&parent.stdout).trim(),
+        upstream_tip,
+        "feature should be replayed onto the exact remote-tracking tip"
+    );
+    assert_eq!(
+        repo.git_output(&["rev-parse", "main"]),
+        local_main,
+        "explicit remote rebase must not move local main"
+    );
+}
+
+/// A configured remote name must not fall back to a same-spelled local branch
+/// when the requested remote-tracking ref is missing.
+#[rstest]
+fn test_step_rebase_missing_explicit_remote_rejects_local_shadow(mut repo: TestRepo) {
+    repo.setup_custom_remote("upstream", "main");
+    let feature_wt =
+        repo.add_worktree_with_commit("feature", "feature.txt", "feature", "feat: feature");
+    let feature_head = repo.head_sha_in(&feature_wt);
+    let local_shadow = repo.git_output(&["rev-parse", "main"]);
+    repo.run_git(&["branch", "upstream/missing", &local_shadow]);
+
+    let output = repo
+        .wt_command()
+        .args(["step", "rebase", "upstream/missing"])
+        .current_dir(&feature_wt)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    assert_eq!(repo.head_sha_in(&feature_wt), feature_head);
+    assert_eq!(
+        repo.git_output(&["rev-parse", "upstream/missing"]),
+        local_shadow
+    );
+    let status = repo
+        .git_command()
+        .args(["status", "--porcelain"])
+        .current_dir(&feature_wt)
+        .run()
+        .unwrap();
+    assert!(
+        status.stdout.is_empty(),
+        "failed resolution must stay clean"
+    );
+}
+
+/// `wt merge` has already resolved its target as a local branch, even when
+/// that branch's name also resembles an existing remote-tracking ref.
+#[rstest]
+fn test_merge_rebase_preserves_slash_named_local_target(mut repo: TestRepo) {
+    let protected_main = repo.head_sha();
+    repo.setup_custom_remote("upstream", "main");
+    let remote_tip = repo.git_output(&["rev-parse", "refs/remotes/upstream/main"]);
+
+    fs::write(repo.root_path().join("target.txt"), "local target").unwrap();
+    repo.run_git(&["add", "target.txt"]);
+    repo.run_git(&["commit", "-m", "local target"]);
+    let local_target = repo.head_sha();
+    repo.run_git(&["branch", "upstream/main", &local_target]);
+    repo.run_git(&["reset", "--hard", &protected_main]);
+    let feature_wt =
+        repo.add_worktree_with_commit("feature", "feature.txt", "feature", "feat: feature");
+
+    let output = repo
+        .wt_command()
+        .args([
+            "merge",
+            "upstream/main",
+            "--no-squash",
+            "--no-remove",
+            "--no-hooks",
+        ])
+        .current_dir(&feature_wt)
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "merge failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert_eq!(
+        repo.git_output(&["show", "upstream/main:target.txt"]),
+        "local target"
+    );
+    assert_eq!(
+        repo.git_output(&["show", "upstream/main:feature.txt"]),
+        "feature"
+    );
+    assert_eq!(
+        repo.git_output(&["rev-parse", "refs/remotes/upstream/main"]),
+        remote_tip
+    );
+    assert_eq!(repo.git_output(&["rev-parse", "main"]), protected_main);
+}
+
+/// Worktrunk symbols still expand to their branch names for output and Git operations.
+#[rstest]
+fn test_step_rebase_caret_reports_resolved_default_branch(mut repo: TestRepo) {
+    let feature_wt = repo.add_worktree("feature");
+    let output = repo
+        .wt_command()
+        .args(["step", "rebase", "^", "--format=json"])
+        .current_dir(&feature_wt)
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+
+    let parsed: serde_json::Value = serde_json::from_slice(&output.stdout).expect("valid JSON");
+    assert_eq!(parsed["outcome"], "up_to_date");
+    assert_eq!(parsed["target"], "main");
+}
+
 /// `step commit --show-prompt --format=json` is rejected — show-prompt emits
 /// raw text that would corrupt JSON output.
 #[rstest]
@@ -3322,6 +3486,8 @@ fn test_merge_invalid_target(mut repo: TestRepo) {
 fn test_step_rebase_invalid_target(mut repo: TestRepo) {
     // Create a feature worktree
     let feature_wt = repo.add_worktree("feature");
+    let feature_head = repo.head_sha_in(&feature_wt);
+    let main_head = repo.git_output(&["rev-parse", "main"]);
 
     // Try to rebase onto nonexistent ref - should fail with clear error
     assert_cmd_snapshot!(make_snapshot_cmd(
@@ -3330,6 +3496,8 @@ fn test_step_rebase_invalid_target(mut repo: TestRepo) {
         &["rebase", "nonexistent-ref"],
         Some(&feature_wt)
     ));
+    assert_eq!(repo.head_sha_in(&feature_wt), feature_head);
+    assert_eq!(repo.git_output(&["rev-parse", "main"]), main_head);
 }
 
 #[rstest]

--- a/tests/integration_tests/repository.rs
+++ b/tests/integration_tests/repository.rs
@@ -681,6 +681,37 @@ fn test_primary_remote_errors_with_no_remotes() {
     );
 }
 
+#[test]
+fn test_disambiguate_remote_ref_preserves_other_commitishes() {
+    let mut repo = TestRepo::standard();
+    repo.setup_custom_remote("upstream", "main");
+    repo.run_git(&["tag", "v1.0"]);
+    let sha = repo.head_sha();
+
+    let r = Repository::at(repo.root_path().to_path_buf()).unwrap();
+    assert_eq!(
+        r.disambiguate_remote_ref("upstream/main").unwrap(),
+        "refs/remotes/upstream/main"
+    );
+    assert_eq!(r.disambiguate_remote_ref(&sha).unwrap(), sha);
+    assert_eq!(r.disambiguate_remote_ref("v1.0").unwrap(), "v1.0");
+    assert_eq!(
+        r.disambiguate_remote_ref("refs/tags/v1.0").unwrap(),
+        "refs/tags/v1.0"
+    );
+
+    repo.run_git(&["update-ref", "-d", "refs/remotes/upstream/main"]);
+    let r = Repository::at(repo.root_path().to_path_buf()).unwrap();
+    assert_eq!(
+        r.disambiguate_remote_ref("upstream/main").unwrap(),
+        "refs/remotes/upstream/main"
+    );
+    assert_eq!(
+        r.disambiguate_remote_ref("vendor/main").unwrap(),
+        "vendor/main"
+    );
+}
+
 /// `require_target_ref(None)` surfaces `StaleDefaultBranch` when the
 /// persisted default branch no longer resolves locally. Covers the
 /// `target.is_none()` arm added alongside `require_target_branch` for


### PR DESCRIPTION
# fix(rebase): Preserve explicit remote targets

## 🧢 Changes

- Keep explicit remote-tracking refs exact when a same-spelled local branch
  exists.
- Preserve deliberately local slash-named merge targets.
- Reject a missing configured remote ref instead of falling back locally.

## ☕️ Reasoning

Git's short-name resolution prefers `refs/heads/<name>`, so an explicit
`upstream/main` could silently resolve to a local branch named
`upstream/main`. The command succeeded while rebasing onto the wrong base.

This was a real-world agentic coding blocker: Worktrees intended to refresh
from canonical `upstream/main` stayed on protected local history and falsely
appeared current.

## 🧪 Reproduction

With both `refs/remotes/upstream/main` and a local `upstream/main`:

```sh
wt step rebase upstream/main
git reflog -1 --format=%gs
```

Before this fix, the command succeeded but the reflog showed:

```text
rebase (start): checkout main
```

## ✅ Verification

- Focused remote-ref disambiguation and `wt step rebase` tests pass.
- Missing remote refs fail without moving or dirtying the source worktree.
- Local slash-named merge-target coverage passes.
- Combined publication-set pre-merge hook: 4,519 tests passed on macOS.

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>
