### PR TITLE
feat(switch): Add a one-shot worktree path override

### DIFF
--- a/docs/content/switch.md
+++ b/docs/content/switch.md
@@ -33,12 +33,14 @@ The `--create` flag creates a new branch from `--base` — the default branch un
 If the branch already has a worktree, `wt switch` changes directories to it. Otherwise, it creates one:
 
 1. Runs [pre-switch hooks](@/hook.md#hook-types), blocking until complete
-2. Creates worktree at configured path
+2. Creates worktree at the effective path
 3. Switches to new directory
 4. Runs [pre-start hooks](@/hook.md#hook-types), blocking until complete
 5. Spawns [post-start](@/hook.md#hook-types) and [post-switch hooks](@/hook.md#hook-types) in the background
 
-{{ terminal(cmd="wt switch feature                        # Existing branch → creates worktree|||wt switch --create feature               # New branch and worktree|||wt switch --create fix --base release    # New branch from release|||wt switch --create temp --no-hooks       # Skip hooks") }}
+{{ terminal(cmd="wt switch feature                        # Existing branch → creates worktree|||wt switch --create feature               # New branch and worktree|||wt switch --create fix --base release    # New branch from release|||wt switch feature/auth --worktree-path '/private/tmp/__WT_OPEN__ repo __WT_CLOSE__.__WT_OPEN__ branch | sanitize __WT_CLOSE__'|||wt switch --create temp --no-hooks       # Skip hooks") }}
+
+`--worktree-path <template>` overrides the configured path for this invocation whenever switching creates a worktree: for a new `--create` branch, an existing local or remote branch without a worktree, or a resolved PR/MR branch. If the target already has a worktree, the command fails instead of ignoring the override.
 
 ## Shortcuts
 
@@ -169,6 +171,9 @@ Usage: <b><span class=c>wt switch</span></b> <span class=c>[OPTIONS]</span> <spa
 
           Defaults to default branch. Supports the same shortcuts as the branch argument: <b>^</b>, <b>@</b>, <b>-</b>,
 <b>          pr:{N}</b>, <b>mr:{N}</b>.
+
+      <b><span class=c>--worktree-path</span></b><span class=c> &lt;template&gt;</span>
+          Worktree path template when creating a worktree
 
   <b><span class=c>-x</span></b>, <b><span class=c>--execute</span></b><span class=c> &lt;EXECUTE&gt;</span>
           Command to run after switch

--- a/plugins/worktrunk/skills/worktrunk/reference/switch.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/switch.md
@@ -24,7 +24,7 @@ The `--create` flag creates a new branch from `--base` — the default branch un
 If the branch already has a worktree, `wt switch` changes directories to it. Otherwise, it creates one:
 
 1. Runs [pre-switch hooks](https://worktrunk.dev/hook/#hook-types), blocking until complete
-2. Creates worktree at configured path
+2. Creates worktree at the effective path
 3. Switches to new directory
 4. Runs [pre-start hooks](https://worktrunk.dev/hook/#hook-types), blocking until complete
 5. Spawns [post-start](https://worktrunk.dev/hook/#hook-types) and [post-switch hooks](https://worktrunk.dev/hook/#hook-types) in the background
@@ -33,8 +33,11 @@ If the branch already has a worktree, `wt switch` changes directories to it. Oth
 $ wt switch feature                        # Existing branch → creates worktree
 $ wt switch --create feature               # New branch and worktree
 $ wt switch --create fix --base release    # New branch from release
+$ wt switch feature/auth --worktree-path '/private/tmp/{{ repo }}.{{ branch | sanitize }}'
 $ wt switch --create temp --no-hooks       # Skip hooks
 ```
+
+`--worktree-path <template>` overrides the configured path for this invocation whenever switching creates a worktree: for a new `--create` branch, an existing local or remote branch without a worktree, or a resolved PR/MR branch. If the target already has a worktree, the command fails instead of ignoring the override.
 
 ## Shortcuts
 
@@ -165,6 +168,9 @@ Options:
 
           Defaults to default branch. Supports the same shortcuts as the branch argument: ^, @, -,
           pr:{N}, mr:{N}.
+
+      --worktree-path <template>
+          Worktree path template when creating a worktree
 
   -x, --execute <EXECUTE>
           Command to run after switch

--- a/skills/worktrunk/reference/switch.md
+++ b/skills/worktrunk/reference/switch.md
@@ -24,7 +24,7 @@ The `--create` flag creates a new branch from `--base` — the default branch un
 If the branch already has a worktree, `wt switch` changes directories to it. Otherwise, it creates one:
 
 1. Runs [pre-switch hooks](https://worktrunk.dev/hook/#hook-types), blocking until complete
-2. Creates worktree at configured path
+2. Creates worktree at the effective path
 3. Switches to new directory
 4. Runs [pre-start hooks](https://worktrunk.dev/hook/#hook-types), blocking until complete
 5. Spawns [post-start](https://worktrunk.dev/hook/#hook-types) and [post-switch hooks](https://worktrunk.dev/hook/#hook-types) in the background
@@ -33,8 +33,11 @@ If the branch already has a worktree, `wt switch` changes directories to it. Oth
 $ wt switch feature                        # Existing branch → creates worktree
 $ wt switch --create feature               # New branch and worktree
 $ wt switch --create fix --base release    # New branch from release
+$ wt switch feature/auth --worktree-path '/private/tmp/{{ repo }}.{{ branch | sanitize }}'
 $ wt switch --create temp --no-hooks       # Skip hooks
 ```
+
+`--worktree-path <template>` overrides the configured path for this invocation whenever switching creates a worktree: for a new `--create` branch, an existing local or remote branch without a worktree, or a resolved PR/MR branch. If the target already has a worktree, the command fails instead of ignoring the override.
 
 ## Shortcuts
 
@@ -165,6 +168,9 @@ Options:
 
           Defaults to default branch. Supports the same shortcuts as the branch argument: ^, @, -,
           pr:{N}, mr:{N}.
+
+      --worktree-path <template>
+          Worktree path template when creating a worktree
 
   -x, --execute <EXECUTE>
           Command to run after switch

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -372,6 +372,10 @@ pub(crate) struct SwitchArgs {
     #[arg(short = 'b', long, requires = "branch", add = crate::completion::branch_value_completer(), value_parser = crate::cli::non_empty_branch)]
     pub(crate) base: Option<String>,
 
+    /// Worktree path template when creating a worktree
+    #[arg(long, value_name = "template", requires = "branch")]
+    pub(crate) worktree_path: Option<String>,
+
     /// Command to run after switch
     ///
     /// Replaces the wt process with the command after switching, giving
@@ -630,7 +634,7 @@ The `--create` flag creates a new branch from `--base` — the default branch un
 If the branch already has a worktree, `wt switch` changes directories to it. Otherwise, it creates one:
 
 1. Runs [pre-switch hooks](@/hook.md#hook-types), blocking until complete
-2. Creates worktree at configured path
+2. Creates worktree at the effective path
 3. Switches to new directory
 4. Runs [pre-start hooks](@/hook.md#hook-types), blocking until complete
 5. Spawns [post-start](@/hook.md#hook-types) and [post-switch hooks](@/hook.md#hook-types) in the background
@@ -639,8 +643,11 @@ If the branch already has a worktree, `wt switch` changes directories to it. Oth
 $ wt switch feature                        # Existing branch → creates worktree
 $ wt switch --create feature               # New branch and worktree
 $ wt switch --create fix --base release    # New branch from release
+$ wt switch feature/auth --worktree-path '/private/tmp/{{ repo }}.{{ branch | sanitize }}'
 $ wt switch --create temp --no-hooks       # Skip hooks
 ```
+
+`--worktree-path <template>` overrides the configured path for this invocation whenever switching creates a worktree: for a new `--create` branch, an existing local or remote branch without a worktree, or a resolved PR/MR branch. If the target already has a worktree, the command fails instead of ignoring the override.
 
 ## Shortcuts
 

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -2183,6 +2183,7 @@ summary = true
             identifier: &identifier,
             create: should_create,
             base: None,
+            worktree_path: None,
             clobber: false,
             verify: true,
             yes: false,

--- a/src/commands/worktree/resolve.rs
+++ b/src/commands/worktree/resolve.rs
@@ -81,13 +81,24 @@ pub fn compute_worktree_path(
     branch: &str,
     config: &UserConfig,
 ) -> anyhow::Result<PathBuf> {
+    compute_worktree_path_with_override(repo, branch, config, None)
+}
+
+/// Compute a worktree path, preferring a one-shot template over configuration.
+pub(super) fn compute_worktree_path_with_override(
+    repo: &Repository,
+    branch: &str,
+    config: &UserConfig,
+    worktree_path_override: Option<&str>,
+) -> anyhow::Result<PathBuf> {
     let repo_root = repo.repo_path()?;
     let default_branch = repo.default_branch().unwrap_or_default();
     let is_bare = repo.is_bare()?;
 
-    // Default branch lives at repo root (main worktree), not a templated path.
-    // Exception: bare repos have no main worktree, so all branches use templated paths.
-    if !is_bare && branch == default_branch {
+    // The explicit override always wins. Without one, the default branch lives
+    // at the repo root; bare repos have no main worktree, so all branches use
+    // templated paths.
+    if worktree_path_override.is_none() && !is_bare && branch == default_branch {
         return Ok(repo_root.to_path_buf());
     }
 
@@ -107,8 +118,13 @@ pub fn compute_worktree_path(
             )
         })?;
 
-    let project = repo.project_identifier().ok();
-    let expanded_path = config.format_path(repo_name, branch, repo, project.as_deref())?;
+    let expanded_path = match worktree_path_override {
+        Some(template) => config.format_path_with_template(template, repo_name, branch, repo)?,
+        None => {
+            let project = repo.project_identifier().ok();
+            config.format_path(repo_name, branch, repo, project.as_deref())?
+        }
+    };
 
     Ok(repo_root.join(expanded_path).normalize())
 }

--- a/src/commands/worktree/switch.rs
+++ b/src/commands/worktree/switch.rs
@@ -30,7 +30,7 @@ use worktrunk::styling::{
     warning_message,
 };
 
-use super::resolve::{compute_worktree_path, offer_bare_repo_worktree_path_fix};
+use super::resolve::{compute_worktree_path_with_override, offer_bare_repo_worktree_path_fix};
 use super::types::{CreationMethod, SwitchBranchInfo, SwitchPlan, SwitchResult};
 use crate::cli::{SwitchArgs, SwitchFormat};
 use crate::commands::backup::back_up_clobbered_path_now;
@@ -725,7 +725,22 @@ fn validate_worktree_creation(
     // worktree; the backup itself happens at execution time so a path that
     // races in after planning is still moved atomically (see
     // `back_up_clobbered_path`).
-    if !path.exists() {
+    // `Path::exists` follows symlinks and therefore reports a dangling symlink
+    // as absent. Inspect the destination entry itself so every filesystem node
+    // is rejected before `git worktree add` can create a branch and then fail.
+    let path_is_occupied = match std::fs::symlink_metadata(path) {
+        Ok(_) => true,
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => false,
+        Err(err) => {
+            return Err(err).with_context(|| {
+                format!(
+                    "Failed to inspect worktree path {}",
+                    worktrunk::path::format_path_for_display(path)
+                )
+            });
+        }
+    };
+    if !path_is_occupied {
         return Ok(false);
     }
     if clobber {
@@ -825,6 +840,7 @@ fn plan_switch(
     base: Option<&str>,
     clobber: bool,
     config: &UserConfig,
+    worktree_path_override: Option<&str>,
 ) -> anyhow::Result<SwitchPlan> {
     // Record current branch for `wt switch -` support
     let new_previous = repo.current_worktree().branch().ok().flatten();
@@ -836,6 +852,13 @@ fn plan_switch(
     // This avoids computing the worktree path template (~7 git commands) for existing switches.
     match repo.worktree_for_branch(&target.branch)? {
         Some(existing_path) if existing_path.exists() => {
+            if worktree_path_override.is_some() {
+                anyhow::bail!(cformat!(
+                    "Branch <bold>{}</> already has a worktree @ {}; <bold>--worktree-path</> only applies when creating a worktree",
+                    target.branch,
+                    worktrunk::path::format_path_for_display(&existing_path)
+                ));
+            }
             return Ok(SwitchPlan::Existing {
                 path: canonicalize(&existing_path).unwrap_or(existing_path),
                 branch: Some(target.branch),
@@ -867,6 +890,13 @@ fn plan_switch(
         if let Some(abs_path) = abs_path
             && let Some((path, wt_branch)) = repo.worktree_at_path(&abs_path)?
         {
+            if worktree_path_override.is_some() {
+                let target = wt_branch.as_deref().unwrap_or(branch);
+                anyhow::bail!(cformat!(
+                    "Target <bold>{target}</> already has a worktree @ {}; <bold>--worktree-path</> only applies when creating a worktree",
+                    worktrunk::path::format_path_for_display(&path)
+                ));
+            }
             let canonical = canonicalize(&path).unwrap_or_else(|_| path.clone());
             return Ok(SwitchPlan::Existing {
                 path: canonical,
@@ -877,7 +907,8 @@ fn plan_switch(
     }
 
     // Phase 3: Compute expected path (only needed for create)
-    let expected_path = compute_worktree_path(repo, &target.branch, config)?;
+    let expected_path =
+        compute_worktree_path_with_override(repo, &target.branch, config, worktree_path_override)?;
 
     // Phase 4: Validate we can create at this path
     let needs_clobber_backup = validate_worktree_creation(
@@ -1311,6 +1342,7 @@ struct SwitchOptions<'a> {
     branch: &'a str,
     create: bool,
     base: Option<&'a str>,
+    worktree_path: Option<&'a str>,
     execute: Option<&'a str>,
     execute_args: &'a [String],
     yes: bool,
@@ -1533,6 +1565,8 @@ pub(crate) struct SwitchPipeline<'a> {
     pub identifier: &'a str,
     pub create: bool,
     pub base: Option<&'a str>,
+    /// One-shot creation path template. `None` for the interactive picker.
+    pub worktree_path: Option<&'a str>,
     pub clobber: bool,
     pub verify: bool,
     /// `--yes`: skip approval prompts and force past clobber checks.
@@ -1567,6 +1601,7 @@ impl SwitchPipeline<'_> {
             identifier,
             create,
             base,
+            worktree_path,
             clobber,
             verify,
             yes,
@@ -1580,8 +1615,12 @@ impl SwitchPipeline<'_> {
         } = self;
 
         // Offer to fix worktree-path for bare repos with hidden directory names
-        // (.git, .bare) before anything reads worktree-path config.
-        offer_bare_repo_worktree_path_fix(repo, config, identifier)?;
+        // (.git, .bare) before anything reads worktree-path config. An explicit
+        // one-shot template does not read that configured path and must not
+        // trigger a warning, prompt, or persistent config change.
+        if worktree_path.is_none() {
+            offer_bare_repo_worktree_path_fix(repo, config, identifier)?;
+        }
 
         // Run pre-switch hooks before branch resolution or worktree creation.
         // {{ branch }} receives the raw user input (before resolution). Skip
@@ -1600,18 +1639,25 @@ impl SwitchPipeline<'_> {
         let (source_branch, source_path) = capture_switch_source(repo, is_recovered);
 
         // Validate and resolve the target branch.
-        let plan = plan_switch(repo, identifier, create, base, clobber, config).map_err(|err| {
-            match suggestion_ctx {
-                Some(ref ctx) => match err.downcast::<GitError>() {
-                    Ok(git_err) => GitError::WithSwitchSuggestion {
-                        source: Box::new(git_err),
-                        ctx: ctx.clone(),
-                    }
-                    .into(),
-                    Err(err) => err,
-                },
-                None => err,
-            }
+        let plan = plan_switch(
+            repo,
+            identifier,
+            create,
+            base,
+            clobber,
+            config,
+            worktree_path,
+        )
+        .map_err(|err| match suggestion_ctx {
+            Some(ref ctx) => match err.downcast::<GitError>() {
+                Ok(git_err) => GitError::WithSwitchSuggestion {
+                    source: Box::new(git_err),
+                    ctx: ctx.clone(),
+                }
+                .into(),
+                Err(err) => err,
+            },
+            None => err,
         })?;
 
         // "Approve at the Gate": collect and approve hooks upfront. Approval
@@ -1765,6 +1811,7 @@ fn run_switch(
         branch,
         create,
         base,
+        worktree_path,
         execute,
         execute_args,
         yes,
@@ -1800,6 +1847,7 @@ fn run_switch(
         identifier: branch,
         create,
         base,
+        worktree_path,
         clobber,
         verify,
         yes,
@@ -1850,6 +1898,7 @@ pub fn handle_switch_command(args: SwitchArgs, yes: bool) -> anyhow::Result<()> 
                     branch: &branch,
                     create: args.create,
                     base: args.base.as_deref(),
+                    worktree_path: args.worktree_path.as_deref(),
                     execute: args.execute.as_deref(),
                     execute_args: &args.execute_args,
                     yes,

--- a/src/config/user/accessors.rs
+++ b/src/config/user/accessors.rs
@@ -211,6 +211,17 @@ impl UserConfig {
             Some(p) => self.worktree_path_for_project(p),
             None => self.worktree_path(),
         };
+        self.format_path_with_template(&template, main_worktree, branch, repo)
+    }
+
+    /// Format a worktree path using an explicit template.
+    pub fn format_path_with_template(
+        &self,
+        template: &str,
+        main_worktree: &str,
+        branch: &str,
+        repo: &crate::git::Repository,
+    ) -> anyhow::Result<String> {
         // Use native path format (not POSIX) since this is used for filesystem operations
         let repo_path = repo.repo_path()?.to_string_lossy().to_string();
         let mut vars = HashMap::new();
@@ -225,7 +236,7 @@ impl UserConfig {
             vars.insert("owner", owner.as_str());
         }
         Ok(expand_template(
-            &template,
+            template,
             &vars,
             ShellEscapeMode::Literal,
             repo,

--- a/tests/integration_tests/bare_repository.rs
+++ b/tests/integration_tests/bare_repository.rs
@@ -1977,6 +1977,45 @@ fn test_bare_repo_worktree_path_prompt_non_interactive_warning() {
     });
 }
 
+/// An explicit one-shot path makes the configured-path repair irrelevant.
+/// It must not warn, prompt, or persist a project-level replacement before
+/// creating the worktree at the requested destination.
+#[test]
+fn test_bare_repo_worktree_path_prompt_skipped_for_explicit_override() {
+    let test = setup_unconfigured_nested_bare_repo();
+    let main_worktree = test.project_path().join("main");
+    let override_path = test.project_path().join("feature-override");
+    let config_before = fs::read_to_string(test.config_path()).unwrap();
+
+    let mut cmd = wt_command();
+    test.configure_wt_cmd(&mut cmd);
+    cmd.args([
+        "switch",
+        "--create",
+        "feature",
+        "--worktree-path",
+        override_path.to_str().unwrap(),
+    ])
+    .current_dir(&main_worktree);
+    let output = cmd.output().unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+
+    assert!(output.status.success(), "switch failed:\n{stderr}");
+    assert!(
+        !stderr.contains("Bare repo at") && !stderr.contains("Configure worktree-path"),
+        "Explicit override should skip the configured-path repair.\nstderr: {stderr}"
+    );
+    assert_eq!(
+        fs::read_to_string(test.config_path()).unwrap(),
+        config_before,
+        "Explicit override must not persist path configuration"
+    );
+    assert!(
+        override_path.exists(),
+        "Worktree should be created at the explicit override"
+    );
+}
+
 /// Symbolic identifiers (-, @, pr:N) are passed before branch resolution, so
 /// the example paths in the prompt would show the raw symbol. The function
 /// must return early without prompting.

--- a/tests/integration_tests/switch.rs
+++ b/tests/integration_tests/switch.rs
@@ -6,6 +6,7 @@ use crate::common::{
 };
 use ansi_str::AnsiStr;
 use insta_cmd::assert_cmd_snapshot;
+use path_slash::PathExt;
 use rstest::rstest;
 use std::fs;
 use std::path::Path;
@@ -7032,6 +7033,283 @@ fn test_switch_format_json_create(repo: TestRepo) {
     assert_eq!(json["branch"], "json-test");
     assert!(json["path"].as_str().unwrap().contains("json-test"));
     assert_eq!(json["created_branch"], true);
+}
+
+#[rstest]
+fn test_switch_worktree_path_override_template_beats_config_layers(repo: TestRepo) {
+    let destinations = TempDir::new().unwrap();
+    let root = destinations.path().to_slash_lossy();
+    let repo_name = repo.root_path().file_name().unwrap().to_str().unwrap();
+    let file_template = format!("{root}/file-{{{{ branch | sanitize }}}}");
+    let env_template = format!("{root}/env-{{{{ branch | sanitize }}}}");
+    let config_set_template = format!("{root}/config-set-{{{{ branch | sanitize }}}}");
+    let override_template = format!("{root}/explicit-{{{{ repo }}}}.{{{{ branch | sanitize }}}}");
+    repo.write_test_config(&format!("worktree-path = \"{file_template}\"\n"));
+
+    let output = repo
+        .wt_command()
+        .env("WORKTRUNK_WORKTREE_PATH", &env_template)
+        .arg("--config-set")
+        .arg(format!("worktree-path = \"{config_set_template}\""))
+        .args(["switch", "--create", "feature/override"])
+        .arg("--worktree-path")
+        .arg(&override_template)
+        .args(["--no-cd", "--no-hooks", "--yes", "--format=json"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    let expected = destinations
+        .path()
+        .join(format!("explicit-{repo_name}.feature-override"));
+    assert_eq!(Path::new(json["path"].as_str().unwrap()), expected);
+    assert!(expected.exists(), "explicit worktree path should exist");
+    assert!(!destinations.path().join("file-feature-override").exists());
+    assert!(!destinations.path().join("env-feature-override").exists());
+    assert!(
+        !destinations
+            .path()
+            .join("config-set-feature-override")
+            .exists()
+    );
+}
+
+#[rstest]
+fn test_switch_worktree_path_override_is_not_persisted(repo: TestRepo) {
+    let destinations = TempDir::new().unwrap();
+    let root = destinations.path().to_slash_lossy();
+    let config_contents =
+        format!("worktree-path = \"{root}/configured-{{{{ branch | sanitize }}}}\"\n");
+    repo.write_test_config(&config_contents);
+    let config_before = fs::read_to_string(repo.test_config_path()).unwrap();
+    let explicit_path = destinations.path().join("explicit-literal");
+
+    let first = repo
+        .wt_command()
+        .args(["switch", "--create", "override-once"])
+        .arg("--worktree-path")
+        .arg(&explicit_path)
+        .args(["--no-cd", "--no-hooks", "--yes", "--format=json"])
+        .output()
+        .unwrap();
+    assert!(
+        first.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&first.stderr)
+    );
+    let first_json: serde_json::Value = serde_json::from_slice(&first.stdout).unwrap();
+    assert_eq!(
+        Path::new(first_json["path"].as_str().unwrap()),
+        explicit_path
+    );
+
+    let second = repo
+        .wt_command()
+        .args([
+            "switch",
+            "--create",
+            "configured-next",
+            "--no-cd",
+            "--no-hooks",
+            "--yes",
+            "--format=json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        second.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&second.stderr)
+    );
+    let second_json: serde_json::Value = serde_json::from_slice(&second.stdout).unwrap();
+    assert_eq!(
+        Path::new(second_json["path"].as_str().unwrap()),
+        destinations.path().join("configured-configured-next")
+    );
+    assert_eq!(
+        fs::read_to_string(repo.test_config_path()).unwrap(),
+        config_before
+    );
+}
+
+#[rstest]
+fn test_switch_worktree_path_override_existing_local_branch(repo: TestRepo) {
+    let destinations = TempDir::new().unwrap();
+    let destination = destinations.path().join("existing-local");
+    repo.run_git(&["branch", "existing-local"]);
+
+    let output = repo
+        .wt_command()
+        .args(["switch", "existing-local"])
+        .arg("--worktree-path")
+        .arg(&destination)
+        .args(["--no-cd", "--no-hooks", "--yes", "--format=json"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(Path::new(json["path"].as_str().unwrap()), destination);
+    assert!(destination.exists(), "explicit worktree path should exist");
+}
+
+#[rstest]
+fn test_switch_worktree_path_override_default_branch_when_main_worktree_is_parked(repo: TestRepo) {
+    let destinations = TempDir::new().unwrap();
+    let destination = destinations.path().join("main");
+    repo.run_git(&["switch", "-c", "parking"]);
+
+    let output = repo
+        .wt_command()
+        .args(["switch", "main"])
+        .arg("--worktree-path")
+        .arg(&destination)
+        .args(["--no-cd", "--no-hooks", "--yes", "--format=json"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(Path::new(json["path"].as_str().unwrap()), destination);
+    assert_eq!(
+        repo.git_output(&[
+            "-C",
+            destination.to_str().unwrap(),
+            "branch",
+            "--show-current"
+        ]),
+        "main"
+    );
+}
+
+#[rstest]
+fn test_switch_worktree_path_override_remote_branch(#[from(repo_with_remote)] repo: TestRepo) {
+    let destinations = TempDir::new().unwrap();
+    let destination = destinations.path().join("remote-feature");
+    repo.run_git(&["branch", "remote-feature"]);
+    repo.run_git(&["push", "origin", "remote-feature"]);
+    repo.run_git(&["branch", "-D", "remote-feature"]);
+
+    let output = repo
+        .wt_command()
+        .args(["switch", "remote-feature"])
+        .arg("--worktree-path")
+        .arg(&destination)
+        .args(["--no-cd", "--no-hooks", "--yes", "--format=json"])
+        .output()
+        .unwrap();
+
+    assert!(
+        output.status.success(),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(Path::new(json["path"].as_str().unwrap()), destination);
+    assert!(destination.exists(), "explicit worktree path should exist");
+    assert_eq!(
+        repo.git_output(&["rev-parse", "--abbrev-ref", "remote-feature@{upstream}"]),
+        "origin/remote-feature"
+    );
+}
+
+#[rstest]
+fn test_switch_worktree_path_override_rejects_existing_worktree(mut repo: TestRepo) {
+    repo.add_worktree("existing-worktree");
+    let destinations = TempDir::new().unwrap();
+    let override_path = destinations.path().join("must-not-be-created");
+
+    let output = repo
+        .wt_command()
+        .args(["switch", "existing-worktree"])
+        .arg("--worktree-path")
+        .arg(&override_path)
+        .args(["--no-cd", "--no-hooks", "--yes"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("already has a worktree"),
+        "stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("existing-worktree") && stderr.contains(" @ "),
+        "stderr should identify the existing worktree: {stderr}"
+    );
+    assert!(
+        !override_path.exists(),
+        "override path must remain untouched"
+    );
+}
+
+#[rstest]
+fn test_switch_worktree_path_override_requires_explicit_target(repo: TestRepo) {
+    let destination = TempDir::new().unwrap().path().join("unused");
+    let output = repo
+        .wt_command()
+        .arg("switch")
+        .arg("--worktree-path")
+        .arg(destination)
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("<BRANCH>"), "stderr: {stderr}");
+}
+
+#[cfg(unix)]
+#[rstest]
+fn test_switch_worktree_path_override_rejects_dangling_symlink(repo: TestRepo) {
+    use std::os::unix::fs::symlink;
+
+    let destinations = TempDir::new().unwrap();
+    let destination = destinations.path().join("dangling-worktree");
+    let missing_target = destinations.path().join("missing-target");
+    symlink(&missing_target, &destination).unwrap();
+
+    let output = repo
+        .wt_command()
+        .args(["switch", "--create", "dangling-override"])
+        .arg("--worktree-path")
+        .arg(&destination)
+        .args(["--no-cd", "--no-hooks", "--yes"])
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("already exists"), "stderr: {stderr}");
+    assert_eq!(fs::read_link(&destination).unwrap(), missing_target);
+    let branch = repo
+        .git_command()
+        .args([
+            "show-ref",
+            "--verify",
+            "--quiet",
+            "refs/heads/dangling-override",
+        ])
+        .run()
+        .unwrap();
+    assert!(
+        !branch.status.success(),
+        "branch must not be created when the destination is occupied"
+    );
 }
 
 #[rstest]

--- a/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_long.snap
@@ -24,6 +24,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -55,6 +56,9 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
           Base branch[0m
           
           Defaults to default branch. Supports the same shortcuts as the branch argument: [1m^[0m, [1m@[0m, [1m-[0m, [1mpr:{N}[0m, [1mmr:{N}[0m.[0m
+
+      [1m[36m--worktree-path[0m[36m [0m[36m<template>[0m
+          Worktree path template when creating a worktree
 
   [1m[36m-x[0m, [1m[36m--execute[0m[36m [0m[36m<EXECUTE>[0m
           Command to run after switch[0m
@@ -143,7 +147,7 @@ The [2m--create[0m flag creates a new branch from [2m--base[0m — the defau
 If the branch already has a worktree, [2mwt switch[0m changes directories to it. Otherwise, it creates one:
 
 1. Runs pre-switch hooks, blocking until complete
-2. Creates worktree at configured path
+2. Creates worktree at the effective path
 3. Switches to new directory
 4. Runs pre-start hooks, blocking until complete
 5. Spawns post-start and post-switch hooks in the background
@@ -151,7 +155,10 @@ If the branch already has a worktree, [2mwt switch[0m changes directories to i
 [107m [0m [2m[0m[2m[34mwt[0m[2m switch feature                        # Existing branch → creates worktree[0m
 [107m [0m [2m[0m[2m[34mwt[0m[2m switch [0m[2m[36m--create[0m[2m feature               # New branch and worktree[0m
 [107m [0m [2m[0m[2m[34mwt[0m[2m switch [0m[2m[36m--create[0m[2m fix [0m[2m[36m--base[0m[2m release    # New branch from release[0m
+[107m [0m [2m[0m[2m[34mwt[0m[2m switch feature/auth [0m[2m[36m--worktree-path[0m[2m [0m[2m[32m'/private/tmp/{{ repo }}.{{ branch | sanitize }}'[0m
 [107m [0m [2m[0m[2m[34mwt[0m[2m switch [0m[2m[36m--create[0m[2m temp [0m[2m[36m--no-hooks[0m[2m       # Skip hooks[0m
+
+[2m--worktree-path <template>[0m overrides the configured path for this invocation whenever switching creates a worktree: for a new [2m--create[0m branch, an existing local or remote branch without a worktree, or a resolved PR/MR branch. If the target already has a worktree, the command fails instead of ignoring the override.
 
 [1m[32mShortcuts[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_switch_short.snap
@@ -24,6 +24,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -41,12 +42,13 @@ Usage: [1m[36mwt switch[0m [36m[OPTIONS][0m [36m[BRANCH][0m [1m[36m[--
   [36m[EXECUTE_ARGS]...[0m  Additional arguments for --execute command (after --)
 
 [1m[32mOptions:[0m
-  [1m[36m-c[0m, [1m[36m--create[0m             Create a new branch
-  [1m[36m-b[0m, [1m[36m--base[0m[36m [0m[36m<BASE>[0m        Base branch
-  [1m[36m-x[0m, [1m[36m--execute[0m[36m [0m[36m<EXECUTE>[0m  Command to run after switch
-      [1m[36m--clobber[0m            Remove stale paths at target
-      [1m[36m--no-cd[0m              Skip directory change after switching
-  [1m[36m-h[0m, [1m[36m--help[0m               Print help (see more with '--help')
+  [1m[36m-c[0m, [1m[36m--create[0m                    Create a new branch
+  [1m[36m-b[0m, [1m[36m--base[0m[36m [0m[36m<BASE>[0m               Base branch
+      [1m[36m--worktree-path[0m[36m [0m[36m<template>[0m  Worktree path template when creating a worktree
+  [1m[36m-x[0m, [1m[36m--execute[0m[36m [0m[36m<EXECUTE>[0m         Command to run after switch
+      [1m[36m--clobber[0m                   Remove stale paths at target
+      [1m[36m--no-cd[0m                     Skip directory change after switching
+  [1m[36m-h[0m, [1m[36m--help[0m                      Print help (see more with '--help')
 
 [1m[32mPicker Options:[0m
       [1m[36m--branches[0m  Include branches without worktrees


### PR DESCRIPTION
## 🧢 Changes

- Add `wt switch --worktree-path <template>` for invocation-local creation.
- Give the explicit template precedence without modifying persisted config.
- Cover new, local, remote, parked-default, PR/MR, and bare-repository paths.
- Reject occupied destinations and existing worktrees instead of ignoring the
  override.

## ☕️ Reasoning

An invocation sometimes needs a disposable location without changing the
developer's normal worktree layout. The flag makes that placement explicit
while preserving one branch per worktree and all existing safety checks.

This removes a real-world agentic coding blocker: isolated sessions can create
worktrees under `/tmp` without editing global or project config.

## ✅ Verification

- Focused switch and bare-repository integration tests pass.
- Existing-worktree and occupied-path rejection coverage passes.
- CLI help snapshots and generated documentation are synchronized.
- Combined publication-set pre-merge hook: 4,519 tests passed on macOS.

Developed with carefully directed, manually reviewed AI assistance.

Co-Authored-By: GPT-5.6 Sol <codex@openai.com>