### PR TITLE
style: sentence-case the verbose "Template variables:" label

### DIFF
--- a/docs/content/hook.md
+++ b/docs/content/hook.md
@@ -175,7 +175,7 @@ Undefined variables error — use conditionals or defaults for optional behavior
 sync = "{% if upstream %}git fetch && git rebase {{ upstream }}{% endif %}"
 ```
 
-Run any hook-firing command with `-v` to see the resolved variables for the actual invocation — each hook prints a `template variables:` block showing every in-scope variable and its value (`(unset)` for conditional vars that didn't populate, like `target_worktree_path` during `wt switch -`). Aliases do the same under `-v`: `wt -v <alias>` prints the alias's in-scope variables before the pipeline runs.
+Run any hook-firing command with `-v` to see the resolved variables for the actual invocation — each hook prints a `Template variables:` block showing every in-scope variable and its value (`(unset)` for conditional vars that didn't populate, like `target_worktree_path` during `wt switch -`). Aliases do the same under `-v`: `wt -v <alias>` prints the alias's in-scope variables before the pipeline runs.
 
 Variables use dot access and the `default` filter for missing keys. JSON object/array values are parsed automatically, so `{{ vars.config.port }}` works when the value is `{"port": 3000}`:
 

--- a/plugins/worktrunk/skills/worktrunk/reference/hook.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/hook.md
@@ -166,7 +166,7 @@ Undefined variables error — use conditionals or defaults for optional behavior
 sync = "{% if upstream %}git fetch && git rebase {{ upstream }}{% endif %}"
 ```
 
-Run any hook-firing command with `-v` to see the resolved variables for the actual invocation — each hook prints a `template variables:` block showing every in-scope variable and its value (`(unset)` for conditional vars that didn't populate, like `target_worktree_path` during `wt switch -`). Aliases do the same under `-v`: `wt -v <alias>` prints the alias's in-scope variables before the pipeline runs.
+Run any hook-firing command with `-v` to see the resolved variables for the actual invocation — each hook prints a `Template variables:` block showing every in-scope variable and its value (`(unset)` for conditional vars that didn't populate, like `target_worktree_path` during `wt switch -`). Aliases do the same under `-v`: `wt -v <alias>` prints the alias's in-scope variables before the pipeline runs.
 
 Variables use dot access and the `default` filter for missing keys. JSON object/array values are parsed automatically, so `{{ vars.config.port }}` works when the value is `{"port": 3000}`:
 

--- a/skills/worktrunk/reference/hook.md
+++ b/skills/worktrunk/reference/hook.md
@@ -166,7 +166,7 @@ Undefined variables error — use conditionals or defaults for optional behavior
 sync = "{% if upstream %}git fetch && git rebase {{ upstream }}{% endif %}"
 ```
 
-Run any hook-firing command with `-v` to see the resolved variables for the actual invocation — each hook prints a `template variables:` block showing every in-scope variable and its value (`(unset)` for conditional vars that didn't populate, like `target_worktree_path` during `wt switch -`). Aliases do the same under `-v`: `wt -v <alias>` prints the alias's in-scope variables before the pipeline runs.
+Run any hook-firing command with `-v` to see the resolved variables for the actual invocation — each hook prints a `Template variables:` block showing every in-scope variable and its value (`(unset)` for conditional vars that didn't populate, like `target_worktree_path` during `wt switch -`). Aliases do the same under `-v`: `wt -v <alias>` prints the alias's in-scope variables before the pipeline runs.
 
 Variables use dot access and the `default` filter for missing keys. JSON object/array values are parsed automatically, so `{{ vars.config.port }}` works when the value is `{"port": 3000}`:
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1669,7 +1669,7 @@ Undefined variables error — use conditionals or defaults for optional behavior
 sync = "{% if upstream %}git fetch && git rebase {{ upstream }}{% endif %}"
 ```
 
-Run any hook-firing command with `-v` to see the resolved variables for the actual invocation — each hook prints a `template variables:` block showing every in-scope variable and its value (`(unset)` for conditional vars that didn't populate, like `target_worktree_path` during `wt switch -`). Aliases do the same under `-v`: `wt -v <alias>` prints the alias's in-scope variables before the pipeline runs.
+Run any hook-firing command with `-v` to see the resolved variables for the actual invocation — each hook prints a `Template variables:` block showing every in-scope variable and its value (`(unset)` for conditional vars that didn't populate, like `target_worktree_path` during `wt switch -`). Aliases do the same under `-v`: `wt -v <alias>` prints the alias's in-scope variables before the pipeline runs.
 
 Variables use dot access and the `default` filter for missing keys. JSON object/array values are parsed automatically, so `{{ vars.config.port }}` works when the value is `{"port": 3000}`:
 

--- a/src/commands/alias.rs
+++ b/src/commands/alias.rs
@@ -618,7 +618,7 @@ fn run_alias(
 
     if verbosity() >= 1 {
         let vars = format_alias_variables(&context_map, Some(&referenced));
-        eprintln!("{}", info_message("template variables:"));
+        eprintln!("{}", info_message("Template variables:"));
         eprintln!("{}", format_with_gutter(&vars, None));
     }
 

--- a/src/commands/command_executor.rs
+++ b/src/commands/command_executor.rs
@@ -228,7 +228,7 @@ impl<'a> CommandContext<'a> {
 /// `referenced_vars_for_config` set (extended via `alias_context_filter`)
 /// so unused git lookups (`var_commit` rev-parse, `var_default_branch` cold
 /// detection, `branch().upstream()`) are skipped, and the verbose
-/// `template variables:` table only lists vars the body actually references.
+/// `Template variables:` table only lists vars the body actually references.
 /// Hooks pass `None` so every standard var stays available — the child
 /// receives the full context as JSON on stdin and may consume keys that
 /// don't appear in the inline `{{ }}` template (e.g. via `jq`).
@@ -628,7 +628,7 @@ fn announce_command(cmd: &PreparedCommand, kind: &PipelineKind, command_str: &st
     };
     if verbosity() >= 1 {
         let vars = format_hook_variables(*hook_type, &cmd.context);
-        eprintln!("{}", info_message("template variables:"));
+        eprintln!("{}", info_message("Template variables:"));
         eprintln!("{}", format_with_gutter(&vars, None));
     }
     eprintln!("{}", progress_message(message));

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -448,7 +448,7 @@ pub(crate) fn into_source_groups(flat: Vec<SourcedStep>) -> Vec<Vec<SourcedStep>
     groups
 }
 
-/// Emit a `template variables:` block for one hook type, using the first
+/// Emit a `Template variables:` block for one hook type, using the first
 /// matching pipeline's first step context.
 ///
 /// Background hooks don't flow through `announce_command` (which prints the
@@ -465,7 +465,7 @@ fn print_background_variable_table(pipelines: &[PendingPipeline], hook_type: Hoo
             PreparedStep::Single(cmd) => cmd,
             PreparedStep::Concurrent(cmds) => &cmds[0],
         };
-        eprintln!("{}", info_message("template variables:"));
+        eprintln!("{}", info_message("Template variables:"));
         eprintln!(
             "{}",
             format_with_gutter(&format_hook_variables(hook_type, &cmd.context), None)

--- a/tests/integration_tests/user_hooks.rs
+++ b/tests/integration_tests/user_hooks.rs
@@ -1232,7 +1232,7 @@ notify = "echo switched"
 
 /// Verbose variant of [`test_combined_post_remove_and_post_switch_hooks`].
 ///
-/// Under `-v`, the announcer prints a `template variables:` table for each
+/// Under `-v`, the announcer prints a `Template variables:` table for each
 /// registered hook type, iterating over pipelines and skipping those whose
 /// hook type doesn't match — that filter branch needs at least two hook
 /// types in one batch to fire. Removing the current worktree's branch is

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_verbose_output.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_verbose_output.snap
@@ -9,6 +9,7 @@ info:
     - feature
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -37,6 +38,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -56,7 +58,7 @@ exit_code: 0
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
-[2m○[22m template variables:
+[2m○[22m Template variables:
 [107m [0m branch                = feature
 [107m [0m worktree_path         = _REPO_.feature
 [107m [0m worktree_name         = repo.feature

--- a/tests/snapshots/integration__integration_tests__post_start_commands__post_start_verbose_template_expansion.snap
+++ b/tests/snapshots/integration__integration_tests__post_start_commands__post_start_verbose_template_expansion.snap
@@ -9,6 +9,7 @@ info:
     - verbose-hooks
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -37,6 +38,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -56,7 +58,7 @@ exit_code: 0
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setting up {{ branch | sanitize }} in {{ worktree_path }}'[0m
 [2m○[22m [1mproject:setup[22m result
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Setting up verbose-hooks in _REPO_.verbose-hooks'[0m
-[2m○[22m template variables:
+[2m○[22m Template variables:
 [107m [0m branch                = verbose-hooks
 [107m [0m worktree_path         = _REPO_.verbose-hooks
 [107m [0m worktree_name         = repo.verbose-hooks

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_verbose_args_shell_escaped.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_verbose_args_shell_escaped.snap
@@ -9,6 +9,7 @@ info:
     - bar baz
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -37,6 +38,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -49,7 +51,7 @@ exit_code: 0
 hello foo bar baz
 
 ----- stderr -----
-[2m○[22m template variables:
+[2m○[22m Template variables:
 [107m [0m branch                = feature
 [107m [0m worktree_path         = _REPO_.feature
 [107m [0m worktree_name         = repo.feature

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_verbose_variable_table.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_verbose_variable_table.snap
@@ -8,6 +8,7 @@ info:
     - world
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -36,6 +37,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -48,7 +50,7 @@ exit_code: 0
 hello world
 
 ----- stderr -----
-[2m○[22m template variables:
+[2m○[22m Template variables:
 [107m [0m branch                = feature
 [107m [0m worktree_path         = _REPO_.feature
 [107m [0m worktree_name         = repo.feature

--- a/tests/snapshots/integration__integration_tests__user_hooks__combined_post_remove_and_post_switch_verbose.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__combined_post_remove_and_post_switch_verbose.snap
@@ -38,6 +38,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -52,7 +53,7 @@ exit_code: 0
 [36m◎[39m [36mRemoving [1mfeature[22m worktree & branch in background (--force-delete)[39m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
-[2m○[22m template variables:
+[2m○[22m Template variables:
 [107m [0m branch                = feature
 [107m [0m worktree_path         = _REPO_.feature
 [107m [0m worktree_name         = repo.feature
@@ -71,7 +72,7 @@ exit_code: 0
 [107m [0m cwd                   = _REPO_
 [107m [0m hook_type             = post-remove
 [107m [0m hook_name             = cleanup
-[2m○[22m template variables:
+[2m○[22m Template variables:
 [107m [0m branch                = main
 [107m [0m worktree_path         = _REPO_
 [107m [0m worktree_name         = repo

--- a/tests/snapshots/integration__integration_tests__user_hooks__hook_verbose_background_dedup.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__hook_verbose_background_dedup.snap
@@ -9,6 +9,7 @@ info:
     - feature
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -37,6 +38,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -56,7 +58,7 @@ exit_code: 0
 [2m↳[22m [2mTo customize worktree locations, run [4mwt config create[24m[22m
 [33m▲[39m [33mCannot change directory — shell integration not installed[39m
 [2m↳[22m [2mTo enable automatic cd, run [4mwt config shell install[24m[22m
-[2m○[22m template variables:
+[2m○[22m Template variables:
 [107m [0m branch                = feature
 [107m [0m worktree_path         = _REPO_.feature
 [107m [0m worktree_name         = repo.feature

--- a/tests/snapshots/integration__integration_tests__user_hooks__hook_verbose_variable_table.snap
+++ b/tests/snapshots/integration__integration_tests__user_hooks__hook_verbose_variable_table.snap
@@ -37,6 +37,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -52,7 +53,7 @@ exit_code: 0
 [107m [0m [2m[0m[2m[34mtrue[0m
 [2m○[22m [1muser:noop[22m result
 [107m [0m [2m[0m[2m[34mtrue[0m
-[2m○[22m template variables:
+[2m○[22m Template variables:
 [107m [0m branch                = feature
 [107m [0m worktree_path         = _REPO_.feature
 [107m [0m worktree_name         = repo.feature


### PR DESCRIPTION
The three call sites that print the `-v` template-variable table used a lowercase `template variables:` — the only user-facing message in the codebase that broke the sentence-case convention for a reason other than a literal identifier keeping its real case (`gh`, `pre-merge`, a branch or repo name). Sibling messages for the same concept were already capitalized: `wt step eval` prints "Available template variables" and template expansion prints "Available variables:".

Capitalizes the three emitters (`alias.rs`, `hooks.rs`, `command_executor.rs`), the doc comments and `wt hook` help text that name the block, the generated `hook.md` mirrors, and the seven affected snapshots.

> _This was written by Claude Code on behalf of max_
