### PR TITLE
refactor(eval): render -v variables through the shared formatter

### DIFF
--- a/src/commands/eval.rs
+++ b/src/commands/eval.rs
@@ -6,7 +6,7 @@
 use std::collections::HashMap;
 
 use color_print::cformat;
-use worktrunk::config::{UserConfig, expand_template};
+use worktrunk::config::{UserConfig, expand_template, format_base_variables};
 use worktrunk::git::Repository;
 use worktrunk::shell_exec::ShellEscapeMode;
 use worktrunk::styling::{eprintln, format_with_gutter, info_message, println, verbosity};
@@ -40,22 +40,14 @@ pub fn step_eval(template: &str, format: SwitchFormat) -> anyhow::Result<()> {
     let context_map = build_hook_context(&ctx, &[], None)?;
 
     if verbosity() >= 1 {
-        let width = context_map.keys().map(String::len).max().unwrap_or(0);
-        let mut keys: Vec<&str> = context_map.keys().map(String::as_str).collect();
-        keys.sort();
-        let listing = keys
-            .iter()
-            .map(|key| {
-                let pad = " ".repeat(width - key.len());
-                cformat!("<bold>{key}</>{pad} = {}", context_map[*key])
-            })
-            .collect::<Vec<_>>()
-            .join("\n");
         eprintln!(
             "{}",
             info_message(cformat!("<bold>{EVAL_NAME}</> template variables:"))
         );
-        eprintln!("{}", format_with_gutter(&listing, None));
+        eprintln!(
+            "{}",
+            format_with_gutter(&format_base_variables(&context_map), None)
+        );
     }
 
     let vars: HashMap<&str, &str> = context_map

--- a/src/config/expansion.rs
+++ b/src/config/expansion.rs
@@ -287,6 +287,17 @@ pub fn format_alias_variables(
     format_variables_table(&vars, &display_ctx, referenced)
 }
 
+/// Format the resolved template variables for a bare template expansion
+/// (`wt step eval`), whose scope is exactly [`base_vars`] — no hook operation
+/// or infrastructure vars, no alias `args`.
+///
+/// Same curated ordering and `(unset)` treatment as [`format_hook_variables`],
+/// so the four `-v` variable listings (hook foreground, hook background, alias,
+/// eval) render one family.
+pub fn format_base_variables(ctx: &HashMap<String, String>) -> String {
+    format_variables_table(&base_vars(), ctx, None)
+}
+
 /// Extend `referenced` with the implicit context-map keys an alias dispatch
 /// needs:
 ///

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -162,10 +162,10 @@ pub use deprecation::{DeprecationKind, Deprecations};
 pub use expansion::{
     ACTIVE_VARS, ALIAS_ARGS_KEY, DEPRECATED_TEMPLATE_VARS, EXEC_BASE_VARS, REPO_VARS,
     TemplateExpandError, ValidationScope, alias_context_filter, base_vars, expand_template,
-    format_alias_variables, format_hook_variables, redact_credentials, referenced_vars_for_config,
-    sanitize_branch_name, sanitize_db, short_hash, template_environment, template_references_var,
-    validate_list_column_template, validate_template, validate_template_syntax, vars_available_in,
-    vars_map_to_value,
+    format_alias_variables, format_base_variables, format_hook_variables, redact_credentials,
+    referenced_vars_for_config, sanitize_branch_name, sanitize_db, short_hash,
+    template_environment, template_references_var, validate_list_column_template,
+    validate_template, validate_template_syntax, vars_available_in, vars_map_to_value,
 };
 pub use hooks::HooksConfig;
 pub use project::{

--- a/tests/snapshots/integration__integration_tests__eval__eval_format_json_verbose.snap
+++ b/tests/snapshots/integration__integration_tests__eval__eval_format_json_verbose.snap
@@ -57,23 +57,20 @@ exit_code: 0
 
 ----- stderr -----
 [2m○[22m [1meval[22m template variables:
-[107m [0m [1mbranch[22m                = main
-[107m [0m [1mcommit[22m                = 05a4a45d0b981dad5c27db59dca482836d59f89e
-[107m [0m [1mcwd[22m                   = _REPO_
-[107m [0m [1mdefault_branch[22m        = main
-[107m [0m [1mmain_worktree[22m         = repo
-[107m [0m [1mmain_worktree_path[22m    = _REPO_
-[107m [0m [1mprimary_worktree_path[22m = _REPO_
-[107m [0m [1mremote[22m                = origin
-[107m [0m [1mremote_url[22m            = ../origin.git
-[107m [0m [1mrepo[22m                  = repo
-[107m [0m [1mrepo_path[22m             = _REPO_
-[107m [0m [1mrepo_root[22m             = _REPO_
-[107m [0m [1mshort_commit[22m          = 05a4a45
-[107m [0m [1mupstream[22m              = origin/main
-[107m [0m [1mworktree[22m              = _REPO_
-[107m [0m [1mworktree_name[22m         = repo
-[107m [0m [1mworktree_path[22m         = _REPO_
+[107m [0m branch                = main
+[107m [0m worktree_path         = _REPO_
+[107m [0m worktree_name         = repo
+[107m [0m commit                = 05a4a45d0b981dad5c27db59dca482836d59f89e
+[107m [0m short_commit          = 05a4a45
+[107m [0m upstream              = origin/main
+[107m [0m repo                  = repo
+[107m [0m repo_path             = _REPO_
+[107m [0m owner                 = (unset)
+[107m [0m primary_worktree_path = _REPO_
+[107m [0m default_branch        = main
+[107m [0m remote                = origin
+[107m [0m remote_url            = ../origin.git
+[107m [0m cwd                   = _REPO_
 [2m○[22m [1meval[22m source
 [107m [0m [2m[0m[2m[32m{{[0m[2m[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34mhash_port[0m[2m [0m[2m[32m}}[0m
 [2m○[22m [1meval[22m result

--- a/tests/snapshots/integration__integration_tests__eval__eval_verbose.snap
+++ b/tests/snapshots/integration__integration_tests__eval__eval_verbose.snap
@@ -52,23 +52,20 @@ exit_code: 0
 
 ----- stderr -----
 [2m○[22m [1meval[22m template variables:
-[107m [0m [1mbranch[22m                = main
-[107m [0m [1mcommit[22m                = 05a4a45d0b981dad5c27db59dca482836d59f89e
-[107m [0m [1mcwd[22m                   = _REPO_
-[107m [0m [1mdefault_branch[22m        = main
-[107m [0m [1mmain_worktree[22m         = repo
-[107m [0m [1mmain_worktree_path[22m    = _REPO_
-[107m [0m [1mprimary_worktree_path[22m = _REPO_
-[107m [0m [1mremote[22m                = origin
-[107m [0m [1mremote_url[22m            = ../origin.git
-[107m [0m [1mrepo[22m                  = repo
-[107m [0m [1mrepo_path[22m             = _REPO_
-[107m [0m [1mrepo_root[22m             = _REPO_
-[107m [0m [1mshort_commit[22m          = 05a4a45
-[107m [0m [1mupstream[22m              = origin/main
-[107m [0m [1mworktree[22m              = _REPO_
-[107m [0m [1mworktree_name[22m         = repo
-[107m [0m [1mworktree_path[22m         = _REPO_
+[107m [0m branch                = main
+[107m [0m worktree_path         = _REPO_
+[107m [0m worktree_name         = repo
+[107m [0m commit                = 05a4a45d0b981dad5c27db59dca482836d59f89e
+[107m [0m short_commit          = 05a4a45
+[107m [0m upstream              = origin/main
+[107m [0m repo                  = repo
+[107m [0m repo_path             = _REPO_
+[107m [0m owner                 = (unset)
+[107m [0m primary_worktree_path = _REPO_
+[107m [0m default_branch        = main
+[107m [0m remote                = origin
+[107m [0m remote_url            = ../origin.git
+[107m [0m cwd                   = _REPO_
 [2m○[22m [1meval[22m source
 [107m [0m [2m[0m[2m[32m{{[0m[2m[0m[2m branch [0m[2m[36m|[0m[2m [0m[2m[34mhash_port[0m[2m [0m[2m[32m}}[0m
 [2m○[22m [1meval[22m result


### PR DESCRIPTION
`wt step eval -v` was the last of the four `-v` template-variable listings to hand-roll its own formatting. The hook (foreground + background) and alias sites all render through `format_hook_variables` / `format_alias_variables`; eval instead sorted keys alphabetically, padded, and joined them by hand. #3495 labelled all four block *headers* with their owner, which made eval's differently-formatted *body* stand out.

This adds a sibling `format_base_variables` for the bare `base_vars` scope (no hook operation/infrastructure vars, no alias `args`) and routes eval through it, so all four listings are one family.

Consequences for the eval listing, now matching the other three:

- curated help-table order instead of alphabetical
- deprecated aliases (`main_worktree`, `repo_root`, `worktree`, `main_worktree_path`) dropped, as the other sites already omit them
- absent optional vars show `(unset)` (e.g. `owner` with no PR context)
- variable names render plain, not bold

Behavior-only change to the `-v` diagnostic lane; the `eval_verbose` / `eval_format_json_verbose` snapshots capture the new output.

> _This was written by Claude Code on behalf of max_
