### PR TITLE
refactor(wt-perf): cache fixtures in the platform cache dir, not /tmp or target/

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -59,7 +59,10 @@ jobs:
     - name: 💰 Rust repo cache
       uses: actions/cache@v6
       with:
-        path: target/bench-repos
+        # wt-perf caches real-repo fixtures under the platform cache dir
+        # (~/.cache/wt-perf on the Linux runner), not target/, so they survive
+        # `cargo clean` and are shared across checkouts.
+        path: ~/.cache/wt-perf/bench-repos
         key: bench-repos-rust-${{ runner.os }}
 
     - name: 📊 Run benchmarks

--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -29,6 +29,10 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: -C debuginfo=0
+  # Pin wt-perf's fixture cache to an explicit path so the `actions/cache` step
+  # below and wt-perf itself can't drift (wt-perf would otherwise compute the
+  # root from the XDG cache dir, which honors $XDG_CACHE_HOME).
+  WT_PERF_CACHE_DIR: ${{ github.workspace }}/.wt-perf-cache
 
 jobs:
   benchmarks:
@@ -59,10 +63,10 @@ jobs:
     - name: 💰 Rust repo cache
       uses: actions/cache@v6
       with:
-        # wt-perf caches real-repo fixtures under the platform cache dir
-        # (~/.cache/wt-perf on the Linux runner), not target/, so they survive
-        # `cargo clean` and are shared across checkouts.
-        path: ~/.cache/wt-perf/bench-repos
+        # wt-perf caches real-repo fixtures under WT_PERF_CACHE_DIR (set above),
+        # not target/, so they survive `cargo clean`. Referencing the same var
+        # here keeps the cached path and the path wt-perf writes in lockstep.
+        path: ${{ env.WT_PERF_CACHE_DIR }}/bench-repos
         key: bench-repos-rust-${{ runner.os }}
 
     - name: 📊 Run benchmarks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4597,8 +4597,8 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "criterion",
- "dirs",
  "dunce",
+ "etcetera",
  "serde_json",
  "tempfile",
  "worktrunk",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4597,6 +4597,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "criterion",
+ "dirs",
  "dunce",
  "serde_json",
  "tempfile",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,8 +102,8 @@ syntax-highlighting = ["dep:tree-sitter", "dep:tree-sitter-bash", "dep:tree-sitt
 # Includes: shell wrapper tests, PTY-based approval prompts, TUI select, progressive rendering
 shell-integration-tests = []
 # Enable benchmarks whose fixture is too large for hosted CI: the rust-scale
-# prune fixture (~15 GiB of rust-lang/rust worktrees, cached in
-# target/bench-repos/). The daily benchmarks workflow runs plain `cargo bench`
+# prune fixture (~15 GiB of rust-lang/rust worktrees, cached in the wt-perf
+# cache dir). The daily benchmarks workflow runs plain `cargo bench`
 # and must never build it; opt in locally with
 # `cargo bench --bench prune --features real-repo-benches`.
 real-repo-benches = []

--- a/benches/CLAUDE.md
+++ b/benches/CLAUDE.md
@@ -281,12 +281,11 @@ count.
 
 ## Output Locations
 
-Fixture repos live under the wt-perf cache dir — `~/.cache/wt-perf/` on Linux,
-`~/Library/Caches/wt-perf/` on macOS, or `$WT_PERF_CACHE_DIR` if set. This is
+Fixture repos live under the wt-perf cache dir — `~/.cache/wt-perf/` (the XDG
+cache dir on Linux and macOS alike), or `$WT_PERF_CACHE_DIR` if set. This is
 per-user and shared across worktrees/checkouts, so an expensive fixture is built
 once per machine and survives `cargo clean` (a `target/`-rooted cache is
-per-worktree and clean-wiped). `wt-perf setup` prints the exact path. Paths below
-show the Linux location.
+per-worktree and clean-wiped). `wt-perf setup` prints the exact path.
 
 - Results: `target/criterion/`
 - Cached rust repo: `~/.cache/wt-perf/bench-repos/rust/`

--- a/benches/CLAUDE.md
+++ b/benches/CLAUDE.md
@@ -34,7 +34,7 @@ cargo bench --bench picker_preview warm          # warm only
 
 ## Rust Repo Caching
 
-Real repo benchmarks clone rust-lang/rust on first run (~2-5 minutes). The clone is cached in `target/bench-repos/` and reused. Corrupted caches are auto-recovered.
+Real repo benchmarks clone rust-lang/rust on first run (~2-5 minutes). The clone is cached in `~/.cache/wt-perf/bench-repos/` and reused. Corrupted caches are auto-recovered.
 
 ## Faster Iteration
 
@@ -183,7 +183,7 @@ diverged branches as backdrop, 200 commits, 100 files; `prune_real_repo` runs
 warm and probe-cold dry-runs on the `prune-real` fixture — a rust-lang/rust clone with 12
 squash-merged candidate pairs + 24 diverged worktrees and 24 diverged
 branches, i.e. 36 linked worktrees, cached and self-repairing in
-`target/bench-repos/rust-prune-12-24/`. That group is opt-in —
+`~/.cache/wt-perf/bench-repos/rust-prune-12-24/`. That group is opt-in —
 `cargo bench --bench prune --features real-repo-benches prune_real_repo` —
 because its ~15 GiB fixture must never build on a hosted CI runner):
 
@@ -251,7 +251,7 @@ cargo run -p wt-perf -- timeline -- -C /tmp/prune-repo step prune --min-age 0s
 **Live prune at real scale is a one-shot timeline, not a criterion group** —
 each live run consumes the candidates, and re-creating them on rust costs
 minutes per iteration. The `prune-real[-M-U]` fixture is built for this
-workflow: it lives in `target/bench-repos/` (no `--path`), and after a live
+workflow: it lives in `~/.cache/wt-perf/bench-repos/` (no `--path`), and after a live
 prune the next `wt-perf setup prune-real` or `prune_real_repo` bench run
 detects the consumed candidates and re-creates just them (~1 min) instead of
 rebuilding the ~15 GiB fixture. Don't run two builders concurrently (a bench
@@ -262,7 +262,7 @@ invalidated for measures a degraded scan:
 
 ```bash
 cargo run -p wt-perf -- setup prune-real     # build or validate/repair the cache
-cargo run -p wt-perf -- timeline -- -C target/bench-repos/rust-prune-12-24/repo step prune --min-age 0s
+cargo run -p wt-perf -- timeline -- -C ~/.cache/wt-perf/bench-repos/rust-prune-12-24/repo step prune --min-age 0s
 cargo run -p wt-perf -- setup prune-real     # repair the consumed candidates
 ```
 
@@ -281,9 +281,16 @@ count.
 
 ## Output Locations
 
+Fixture repos live under the wt-perf cache dir — `~/.cache/wt-perf/` on Linux,
+`~/Library/Caches/wt-perf/` on macOS, or `$WT_PERF_CACHE_DIR` if set. This is
+per-user and shared across worktrees/checkouts, so an expensive fixture is built
+once per machine and survives `cargo clean` (a `target/`-rooted cache is
+per-worktree and clean-wiped). `wt-perf setup` prints the exact path. Paths below
+show the Linux location.
+
 - Results: `target/criterion/`
-- Cached rust repo: `target/bench-repos/rust/`
-- Cached rust prune fixture: `target/bench-repos/rust-prune-<M>-<U>/` (repo +
+- Cached rust repo: `~/.cache/wt-perf/bench-repos/rust/`
+- Cached rust prune fixture: `~/.cache/wt-perf/bench-repos/rust-prune-<M>-<U>/` (repo +
   sibling worktrees + `round` counter for candidate re-creation)
 - HTML reports: `target/criterion/*/report/index.html`
 
@@ -294,7 +301,7 @@ Use `wt-perf` to set up benchmark repos and generate Chrome Trace Format for vis
 ### Setting up benchmark repos
 
 ```bash
-# Set up a repo with 8 worktrees (persists at /tmp/wt-perf-typical-8; the
+# Set up a repo with 8 worktrees (persists at ~/.cache/wt-perf/typical-8; the
 # next `setup typical-8` run wipes and rebuilds it)
 cargo run -p wt-perf -- setup typical-8
 
@@ -309,12 +316,12 @@ cargo run -p wt-perf -- setup typical-8
 #                     benches/prune.rs)
 #   prune-real[-M-U] - rust-lang/rust clone + M squash-merged candidate pairs
 #                     + U diverged worktrees/branches (default 12-24), cached
-#                     and self-repairing in target/bench-repos/ (no --path);
+#                     and self-repairing in ~/.cache/wt-perf/bench-repos/ (no --path);
 #                     first run clones from the network
 #   picker-test     - Config for wt switch interactive picker testing
 
 # Invalidate caches for cold run
-cargo run -p wt-perf -- invalidate /tmp/wt-perf-typical-8
+cargo run -p wt-perf -- invalidate ~/.cache/wt-perf/typical-8
 ```
 
 ### Generating traces
@@ -329,7 +336,7 @@ Perfetto/chrome://tracing. `--cold` invalidates caches first.
 cargo run -p wt-perf -- timeline -- list --progressive
 
 # Cold-cache run (invalidates the traced repo — the `-C` arg, else cwd)
-cargo run -p wt-perf -- timeline --cold -- -C /tmp/wt-perf-typical-8 list --progressive
+cargo run -p wt-perf -- timeline --cold -- -C ~/.cache/wt-perf/typical-8 list --progressive
 
 # Chrome Trace Format JSON for Perfetto
 cargo run -p wt-perf -- timeline --chrome -- list --progressive > trace.json
@@ -389,8 +396,8 @@ Three questions drive `wt list` performance work:
 
 ```bash
 # Trace on rust-lang/rust (must run benchmark first to clone)
-cargo run --release -q -- -vv -C target/bench-repos/rust list --progressive --branches
-cargo run -p wt-perf -- trace target/bench-repos/rust/.git/wt/logs/trace.jsonl > rust-trace.json
+cargo run --release -q -- -vv -C ~/.cache/wt-perf/bench-repos/rust list --progressive --branches
+cargo run -p wt-perf -- trace ~/.cache/wt-perf/bench-repos/rust/.git/wt/logs/trace.jsonl > rust-trace.json
 ```
 
 ## Key Performance Insights

--- a/benches/prune.rs
+++ b/benches/prune.rs
@@ -175,7 +175,7 @@ fn bench_prune_e2e(c: &mut Criterion) {
 /// --write-tree` ~130 ms, `git status` over ~60k files — vs the synthetic
 /// fixture where probes bottom out at subprocess spawn. First run clones
 /// rust-lang/rust from the network (minutes), then builds ~36 worktrees at
-/// ~3 s each; both are cached in `target/bench-repos/` across runs.
+/// ~3 s each; both are cached in the wt-perf cache dir across runs.
 ///
 /// Dry-runs only, in two flavors: warm (steady-state re-scan) and probe-cold
 /// (`.git/wt/cache/` cleared per iteration — the "first prune after fetching

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -10,7 +10,7 @@ When debugging TUI commands like `wt switch` (interactive picker), use the `tmux
 cargo run -p wt-perf -- setup picker-test
 ```
 
-This creates a reproducible test repo under the wt-perf cache dir and prints its exact path — `~/.cache/wt-perf/picker-test/` on Linux, `~/Library/Caches/wt-perf/picker-test/` on macOS. `WT_PERF_CACHE_DIR` overrides the root. The Linux path is used in the examples below.
+This creates a reproducible test repo at `~/.cache/wt-perf/picker-test/` (XDG cache dir on Linux and macOS; `WT_PERF_CACHE_DIR` overrides the root). `wt-perf setup` also prints the exact path.
 
 ### 2. Test Interactively
 

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -10,7 +10,7 @@ When debugging TUI commands like `wt switch` (interactive picker), use the `tmux
 cargo run -p wt-perf -- setup picker-test
 ```
 
-This creates a reproducible test repo at `/tmp/wt-perf-picker-test/`.
+This creates a reproducible test repo under the wt-perf cache dir and prints its exact path — `~/.cache/wt-perf/picker-test/` on Linux, `~/Library/Caches/wt-perf/picker-test/` on macOS. `WT_PERF_CACHE_DIR` overrides the root. The Linux path is used in the examples below.
 
 ### 2. Test Interactively
 
@@ -21,7 +21,7 @@ Load the `tmux-cli` skill, then use the `tmux-cli` tool. Install if needed: `uv 
 ```bash
 # Launch shell in test repo
 pane=$(tmux-cli launch "zsh")
-tmux-cli send "cd /tmp/wt-perf-picker-test" --pane=$pane
+tmux-cli send "cd ~/.cache/wt-perf/picker-test" --pane=$pane
 tmux-cli wait_idle --pane=$pane
 
 # Run with debug logging
@@ -43,7 +43,7 @@ MCP terminals use pseudo-TTY, not real terminals. If tests pass in MCP but users
 ```typescript
 // Create terminal and navigate to test repo
 mcp__node-terminal__terminal_create({ sessionId: "test" })
-mcp__node-terminal__terminal_write({ sessionId: "test", input: "cd /tmp/wt-perf-picker-test" })
+mcp__node-terminal__terminal_write({ sessionId: "test", input: "cd ~/.cache/wt-perf/picker-test" })
 mcp__node-terminal__terminal_send_key({ sessionId: "test", key: "enter" })
 
 // Run with debug logging

--- a/tests/helpers/wt-perf/Cargo.toml
+++ b/tests/helpers/wt-perf/Cargo.toml
@@ -15,6 +15,8 @@ description = "Performance testing and tracing tools for worktrunk"
 # For repo setup
 tempfile = "3.27"
 dunce = "1"
+# Resolve the platform cache directory for reusable fixtures
+dirs = "6.0"
 
 # For CLI
 clap = { version = "4.6", features = ["derive"] }

--- a/tests/helpers/wt-perf/Cargo.toml
+++ b/tests/helpers/wt-perf/Cargo.toml
@@ -15,8 +15,9 @@ description = "Performance testing and tracing tools for worktrunk"
 # For repo setup
 tempfile = "3.27"
 dunce = "1"
-# Resolve the platform cache directory for reusable fixtures
-dirs = "6.0"
+# Resolve the cache directory for reusable fixtures (XDG on macOS too,
+# matching worktrunk's own base-dir strategy in src/config/user/path.rs)
+etcetera = "0.11"
 
 # For CLI
 clap = { version = "4.6", features = ["derive"] }

--- a/tests/helpers/wt-perf/src/lib.rs
+++ b/tests/helpers/wt-perf/src/lib.rs
@@ -114,7 +114,7 @@ impl RepoConfig {
 /// identical); the composite fixtures build varied states instead:
 /// `mixed-W-B` via `create_mixed_repo_at`, `prune-M-U` via
 /// [`create_prune_repo_at`]. (`prune-real[-M-U]` is not a `SetupConfig`:
-/// it is cache-managed under `target/bench-repos/` and takes no path — see
+/// it is cache-managed under `<cache>/bench-repos/` and takes no path — see
 /// [`ensure_prune_real_repo`].)
 pub enum SetupConfig {
     Flat(RepoConfig),
@@ -620,21 +620,33 @@ fn resolve_git_common_dir(repo_path: &Path) -> Option<PathBuf> {
     pointed.parent()?.parent().map(Path::to_path_buf)
 }
 
-/// The shared cache for real-repo fixtures: `<workspace>/target/bench-repos`,
-/// anchored to the workspace root at compile time so every entry point —
-/// benches (cwd = workspace root) and the `wt-perf` CLI (cwd = anywhere) —
-/// resolves the same cache.
+/// Root of wt-perf's on-disk cache: `$WT_PERF_CACHE_DIR` if set, else the
+/// per-user platform cache directory (`~/.cache/wt-perf` on Linux,
+/// `~/Library/Caches/wt-perf` on macOS).
+///
+/// Both entry points — benches (cwd = workspace root) and the `wt-perf` CLI
+/// (cwd = anywhere) — resolve the same machine-global path, so an expensive
+/// fixture is built once per machine rather than once per git worktree. A
+/// `target/`-rooted cache would be per-worktree (worktrees don't share
+/// `target/`) and wiped by `cargo clean`; the platform cache dir is neither.
+pub fn wt_perf_cache_dir() -> PathBuf {
+    if let Some(dir) = std::env::var_os("WT_PERF_CACHE_DIR") {
+        return PathBuf::from(dir);
+    }
+    dirs::cache_dir()
+        .expect("no platform cache directory; set WT_PERF_CACHE_DIR")
+        .join("wt-perf")
+}
+
+/// The shared cache for real, cloned upstream fixtures (rust-lang/rust and the
+/// prune fixtures derived from it): `<cache>/bench-repos`.
 fn bench_repos_dir() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .ancestors()
-        .nth(3)
-        .unwrap()
-        .join("target/bench-repos")
+    wt_perf_cache_dir().join("bench-repos")
 }
 
 /// Get or clone the rust-lang/rust repository for real-world benchmarks.
 ///
-/// The repo is cached at `target/bench-repos/rust` and reused across runs.
+/// The repo is cached at `<cache>/bench-repos/rust` and reused across runs.
 fn ensure_rust_repo() -> PathBuf {
     RUST_REPO
         .get_or_init(|| {
@@ -1182,7 +1194,7 @@ pub const PRUNE_REAL_UNMERGED: usize = 24;
 /// Each linked worktree materializes a full working tree: ~400 MiB and ~3 s
 /// per worktree, so the default populations build in minutes and take ~15 GiB.
 /// Prefer [`ensure_prune_real_repo`], which builds once into
-/// `target/bench-repos` and repairs consumed candidates on later runs.
+/// `<cache>/bench-repos` and repairs consumed candidates on later runs.
 fn create_prune_real_repo_at(merged: usize, unmerged: usize, base_path: &Path) {
     clone_rust_repo_at(base_path);
     add_diverged_backdrop(base_path, unmerged, unmerged);
@@ -1257,7 +1269,7 @@ fn next_squash_round(repo: &Path) -> usize {
 
 /// Get or build the cached rust-scale prune fixture, returning the repo path.
 ///
-/// The fixture lives at `target/bench-repos/rust-prune-<merged>-<unmerged>/repo`
+/// The fixture lives at `<cache>/bench-repos/rust-prune-<merged>-<unmerged>/repo`
 /// (worktrees as siblings) so its minutes-long build (`create_prune_real_repo_at`)
 /// is paid once, not per bench run. On reuse it is validated by
 /// `prune_fixture_state`:

--- a/tests/helpers/wt-perf/src/lib.rs
+++ b/tests/helpers/wt-perf/src/lib.rs
@@ -27,6 +27,7 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
+use etcetera::base_strategy::{BaseStrategy, choose_base_strategy};
 use tempfile::TempDir;
 use worktrunk::testing::{NULL_DEVICE, configure_git_cmd};
 
@@ -621,20 +622,23 @@ fn resolve_git_common_dir(repo_path: &Path) -> Option<PathBuf> {
 }
 
 /// Root of wt-perf's on-disk cache: `$WT_PERF_CACHE_DIR` if set, else the
-/// per-user platform cache directory (`~/.cache/wt-perf` on Linux,
-/// `~/Library/Caches/wt-perf` on macOS).
+/// per-user cache directory `<cache>/wt-perf` (`~/.cache/wt-perf`, or
+/// `$XDG_CACHE_HOME/wt-perf`). `etcetera::choose_base_strategy` follows the
+/// XDG convention on macOS too, matching worktrunk's own base-dir strategy
+/// (`src/config/user/path.rs`), so the path is identical on Linux and macOS.
 ///
 /// Both entry points — benches (cwd = workspace root) and the `wt-perf` CLI
 /// (cwd = anywhere) — resolve the same machine-global path, so an expensive
 /// fixture is built once per machine rather than once per git worktree. A
 /// `target/`-rooted cache would be per-worktree (worktrees don't share
-/// `target/`) and wiped by `cargo clean`; the platform cache dir is neither.
+/// `target/`) and wiped by `cargo clean`; the cache dir is neither.
 pub fn wt_perf_cache_dir() -> PathBuf {
     if let Some(dir) = std::env::var_os("WT_PERF_CACHE_DIR") {
         return PathBuf::from(dir);
     }
-    dirs::cache_dir()
-        .expect("no platform cache directory; set WT_PERF_CACHE_DIR")
+    choose_base_strategy()
+        .expect("no home directory; set WT_PERF_CACHE_DIR")
+        .cache_dir()
         .join("wt-perf")
 }
 

--- a/tests/helpers/wt-perf/src/lib.rs
+++ b/tests/helpers/wt-perf/src/lib.rs
@@ -24,10 +24,10 @@
 //!
 //! See `wt-perf --help` for CLI usage.
 
+use etcetera::base_strategy::{BaseStrategy, choose_base_strategy};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
-use etcetera::base_strategy::{BaseStrategy, choose_base_strategy};
 use tempfile::TempDir;
 use worktrunk::testing::{NULL_DEVICE, configure_git_cmd};
 

--- a/tests/helpers/wt-perf/src/lib.rs
+++ b/tests/helpers/wt-perf/src/lib.rs
@@ -633,7 +633,10 @@ fn resolve_git_common_dir(repo_path: &Path) -> Option<PathBuf> {
 /// `target/`-rooted cache would be per-worktree (worktrees don't share
 /// `target/`) and wiped by `cargo clean`; the cache dir is neither.
 pub fn wt_perf_cache_dir() -> PathBuf {
-    if let Some(dir) = std::env::var_os("WT_PERF_CACHE_DIR") {
+    // Treat an empty value as unset: `WT_PERF_CACHE_DIR=` would otherwise yield
+    // an empty root, so `setup <config>` would remove_dir_all a *relative*
+    // `<config>` in the cwd instead of a dir under the cache.
+    if let Some(dir) = std::env::var_os("WT_PERF_CACHE_DIR").filter(|d| !d.is_empty()) {
         return PathBuf::from(dir);
     }
     choose_base_strategy()

--- a/tests/helpers/wt-perf/src/main.rs
+++ b/tests/helpers/wt-perf/src/main.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use clap::{Parser, Subcommand};
 use wt_perf::{
     PRUNE_REAL_MERGED, PRUNE_REAL_UNMERGED, canonicalize, ensure_prune_real_repo,
-    invalidate_caches_auto, parse_config, parse_pair,
+    invalidate_caches_auto, parse_config, parse_pair, wt_perf_cache_dir,
 };
 
 #[derive(Parser)]
@@ -28,7 +28,7 @@ enum Commands {
         /// Config name: typical-N, branches-N, branches-N-M, divergent, mixed-W-B, prune-M-U, prune-real[-M-U], picker-test
         config: String,
 
-        /// Directory to create repo in (default: temp directory)
+        /// Directory to create repo in (default: wt-perf cache directory)
         #[arg(long)]
         path: Option<PathBuf>,
     },
@@ -75,8 +75,8 @@ enum Commands {
   # Cold-cache run (invalidates the traced repo, then runs)
   wt-perf timeline --cold -- list
 
-  # Cold run against a specific repo
-  wt-perf timeline --cold -- -C /tmp/wt-perf-typical-1 list
+  # Cold run against a specific repo (setup prints the exact path)
+  wt-perf timeline --cold -- -C ~/.cache/wt-perf/typical-1 list
 
   # Chrome Trace Format JSON for Perfetto
   wt-perf timeline --chrome -- list > trace.json
@@ -102,7 +102,7 @@ fn main() {
     match cli.command {
         Commands::Setup { config, path } => {
             // `prune-real[-M-U]`: cache-managed rust-scale fixture (built once
-            // under target/bench-repos/, repaired after a live prune consumes
+            // under the wt-perf cache dir, repaired after a live prune consumes
             // its candidates) — takes no --path and never offers cleanup.
             // Tested before parse_config so its `prune-` arm never sees it.
             let prune_real = if config == "prune-real" {
@@ -113,7 +113,8 @@ fn main() {
             if let Some((merged, unmerged)) = prune_real {
                 if path.is_some() {
                     eprintln!(
-                        "prune-real fixtures are cache-managed under target/bench-repos/; --path is not supported"
+                        "prune-real fixtures are cache-managed under {}; --path is not supported",
+                        wt_perf_cache_dir().join("bench-repos").display()
                     );
                     std::process::exit(1);
                 }
@@ -155,7 +156,7 @@ fn main() {
                     "  prune-M-U       - M squash-merged candidates + U unmerged worktrees/branches (wt step prune workload)"
                 );
                 eprintln!(
-                    "  prune-real[-M-U] - rust-lang/rust clone + M squash-merged candidates + U unmerged worktrees/branches, cached in target/bench-repos (default {PRUNE_REAL_MERGED}-{PRUNE_REAL_UNMERGED}; first run clones from network)"
+                    "  prune-real[-M-U] - rust-lang/rust clone + M squash-merged candidates + U unmerged worktrees/branches, cached in the wt-perf cache dir (default {PRUNE_REAL_MERGED}-{PRUNE_REAL_UNMERGED}; first run clones from network)"
                 );
                 eprintln!("  picker-test     - Config for wt switch interactive picker testing");
                 std::process::exit(1);
@@ -165,12 +166,12 @@ fn main() {
                 std::fs::create_dir_all(&p).unwrap();
                 canonicalize(&p).unwrap()
             } else {
-                let temp = std::env::temp_dir().join(format!("wt-perf-{}", config));
-                if temp.exists() {
-                    std::fs::remove_dir_all(&temp).unwrap();
+                let dir = wt_perf_cache_dir().join(&config);
+                if dir.exists() {
+                    std::fs::remove_dir_all(&dir).unwrap();
                 }
-                std::fs::create_dir_all(&temp).unwrap();
-                canonicalize(&temp).unwrap()
+                std::fs::create_dir_all(&dir).unwrap();
+                canonicalize(&dir).unwrap()
             };
 
             eprintln!("Creating {} repo...", config);


### PR DESCRIPTION
## What

Move `wt-perf`'s benchmark/debug fixture repos out of `std::env::temp_dir()` and `target/bench-repos/` into the per-user cache dir, resolved by a new `wt_perf_cache_dir()`:

- `$WT_PERF_CACHE_DIR` if set, else `<cache>/wt-perf` via `etcetera::choose_base_strategy().cache_dir()` — `~/.cache/wt-perf` (or `$XDG_CACHE_HOME/wt-perf`) on Linux **and** macOS. This matches worktrunk's own base-dir convention (`src/config/user/path.rs` resolves user config through the same XDG-on-macOS strategy).
- `setup <config>` fixtures → `<cache>/<config>` (was `temp_dir()/wt-perf-<config>`). `--path` still overrides.
- Real cloned fixtures (`prune-real`, the rust-lang/rust clone) → `<cache>/bench-repos/` (was `target/bench-repos/`).
- In-process throwaway fixtures (`create_repo`) are unchanged — they keep using `tempfile::TempDir`.

## Why

Both old homes were wrong for a *reused* fixture (these are given stable names, persist between runs, and are referenced from docs and `-C <path>` — that's a cache, not a temp file):

- **A fixed name in a shared `/tmp` (Linux)** collides across users: `/tmp` is sticky (`1777`), so a second user's `setup` hits `remove_dir_all().unwrap()` on a dir they don't own → `EPERM` → panic. It's also a predictable-path/TOCTOU hazard, and `systemd-tmpfiles` reaps `/tmp` per-file at 10 days by `max(atime,mtime,ctime)` — on a `noatime` mount an actively-*read* fixture still loses cold `.git/objects/pack/*.pack` mid-use → silent git corruption.
- **On macOS**, `temp_dir()` is already `/var/folders/.../T` (per-user, `0700`), so the docs' `/tmp/wt-perf-*` paths were simply wrong there.
- **`target/`** is per-worktree (git worktrees don't share it) and wiped by `cargo clean`, so the ~15 GiB rust clone was re-cloned per worktree — worst for the most expensive fixture, in a worktree-heavy workflow.

The cache dir is per-user (no collision, no TOCTOU), stable and discoverable (docs/`-C` references still work), shared across worktrees (clone once per machine), and survives `cargo clean` — matching sccache, cargo, rustup, Go, Bazel, and Hugging Face, which all place large reusable caches there rather than in `/tmp`.

## Migration notes

- First bench/setup run after this rebuilds the cache under the new location (the old `target/bench-repos/` is no longer read). Existing fixtures can be dropped with `rm -rf target/bench-repos`.
- `.github/workflows/benchmarks.yaml` sets `WT_PERF_CACHE_DIR` and caches `$WT_PERF_CACHE_DIR/bench-repos`, so the cached path and the path wt-perf writes stay pinned together (no drift if a runner sets `$XDG_CACHE_HOME`); key unchanged.
- Docs (`benches/CLAUDE.md`, `src/commands/CLAUDE.md`) updated to the new paths, noting that `wt-perf setup` prints the exact path.

## Testing

- `cargo build --workspace --all-targets`, `cargo clippy --workspace --all-targets --features shell-integration-tests -- -D warnings` — clean.
- `cargo test -p wt-perf` — passes.
- Smoke-tested default resolution (`~/.cache/wt-perf/…` on macOS), `$WT_PERF_CACHE_DIR` override, and the `prune-real --path` rejection (now names the resolved cache path).

> _This was written by Claude Code on behalf of Maximilian_
