### PR TITLE
fix: use @ before path in -vv startup pointer message

### DIFF
--- a/src/logging.rs
+++ b/src/logging.rs
@@ -721,7 +721,7 @@ fn announce_trace_destination() {
     let dir_display = worktrunk::path::format_path_for_display(dir);
     eprintln!(
         "{}",
-        info_message(format!("Verbose logging to {dir_display}/"))
+        info_message(format!("Verbose logging @ {dir_display}/"))
     );
 }
 

--- a/tests/integration_tests/diagnostic.rs
+++ b/tests/integration_tests/diagnostic.rs
@@ -315,7 +315,7 @@ fn test_diagnostic_trace_log_contains_git_commands(mut repo: TestRepo) {
 /// The `-vv` end block names what the run captured and saved
 /// (`diagnostic.md`, the single human-facing doc). It doesn't re-list the
 /// raw companion logs (`trace.jsonl`, `subprocess.log`) — the start-of-run
-/// pointer (`Verbose logging to <dir>/`) already names the log directory,
+/// pointer (`Verbose logging @ <dir>/`) already names the log directory,
 /// and the report body points at the companions directly.
 #[rstest]
 fn test_diagnostic_saved_message_with_vv(mut repo: TestRepo) {
@@ -649,7 +649,7 @@ fn test_vv_debug_pipeline_silent_on_stderr(repo: TestRepo) {
     // Stderr at -vv opens with a one-line pointer to the log directory (the
     // per-file rundown is deferred to the end-of-run diagnostic announcement).
     assert!(
-        stderr.contains("Verbose logging to") && stderr.contains("wt/logs"),
+        stderr.contains("Verbose logging @") && stderr.contains("wt/logs"),
         "stderr should point at the log directory at startup: {stderr}"
     );
 }
@@ -890,7 +890,7 @@ fn test_vv_pointer_handles_split_init(repo: TestRepo) {
     let stderr = String::from_utf8_lossy(&output.stderr);
 
     assert!(
-        stderr.contains("Verbose logging to") && stderr.contains("wt/logs"),
+        stderr.contains("Verbose logging @") && stderr.contains("wt/logs"),
         "startup pointer should still name the log directory when subprocess.log can't open: {stderr}"
     );
     assert!(
@@ -965,7 +965,7 @@ fn test_vv_outside_repo_no_crash() {
     // announce_trace_destination took its early-return path.
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        !stderr.contains("Verbose logging to"),
+        !stderr.contains("Verbose logging @"),
         "no startup pointer when trace.log can't open: {stderr}"
     );
 }


### PR DESCRIPTION
The \`-vv\` startup pointer (\`announce_trace_destination\` in \`src/logging.rs\`) printed "Verbose logging to \<dir\>/", using "to" before the path. The codebase convention (see the \`writing-user-outputs\` skill) is \`@\` before paths in user-facing output — #3521 already applied this to the \`-vv\` end-of-run block but left this start-of-run pointer as the one remaining inconsistency.

Changes "Verbose logging to \<dir\>/" to "Verbose logging @ \<dir\>/" and updates the matching test assertions/doc comment in \`tests/integration_tests/diagnostic.rs\`. The historical wording quoted in \`CHANGELOG.md\` is left as-is since it documents a past release.

> _This was written by Claude Code on behalf of max_