### PR TITLE
refactor(wt-perf): place fixtures under target/wt-perf, not the cache dir

### DIFF
--- a/.github/workflows/benchmarks.yaml
+++ b/.github/workflows/benchmarks.yaml
@@ -29,10 +29,6 @@ env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
   RUSTFLAGS: -C debuginfo=0
-  # Pin wt-perf's fixture cache to an explicit path so the `actions/cache` step
-  # below and wt-perf itself can't drift (wt-perf would otherwise compute the
-  # root from the XDG cache dir, which honors $XDG_CACHE_HOME).
-  WT_PERF_CACHE_DIR: ${{ github.workspace }}/.wt-perf-cache
 
 jobs:
   benchmarks:
@@ -63,10 +59,10 @@ jobs:
     - name: 💰 Rust repo cache
       uses: actions/cache@v6
       with:
-        # wt-perf caches real-repo fixtures under WT_PERF_CACHE_DIR (set above),
-        # not target/, so they survive `cargo clean`. Referencing the same var
-        # here keeps the cached path and the path wt-perf writes in lockstep.
-        path: ${{ env.WT_PERF_CACHE_DIR }}/bench-repos
+        # wt-perf builds real-repo fixtures under target/wt-perf/bench-repos at
+        # the workspace root. `cargo clean` would wipe them, so this cache
+        # restores the ~15 GiB rust clone across runs.
+        path: target/wt-perf/bench-repos
         key: bench-repos-rust-${{ runner.os }}
 
     - name: 📊 Run benchmarks

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4598,7 +4598,6 @@ dependencies = [
  "clap",
  "criterion",
  "dunce",
- "etcetera",
  "serde_json",
  "tempfile",
  "worktrunk",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -102,8 +102,8 @@ syntax-highlighting = ["dep:tree-sitter", "dep:tree-sitter-bash", "dep:tree-sitt
 # Includes: shell wrapper tests, PTY-based approval prompts, TUI select, progressive rendering
 shell-integration-tests = []
 # Enable benchmarks whose fixture is too large for hosted CI: the rust-scale
-# prune fixture (~15 GiB of rust-lang/rust worktrees, cached in the wt-perf
-# cache dir). The daily benchmarks workflow runs plain `cargo bench`
+# prune fixture (~15 GiB of rust-lang/rust worktrees, cached under
+# target/wt-perf/bench-repos). The daily benchmarks workflow runs plain `cargo bench`
 # and must never build it; opt in locally with
 # `cargo bench --bench prune --features real-repo-benches`.
 real-repo-benches = []

--- a/benches/CLAUDE.md
+++ b/benches/CLAUDE.md
@@ -34,7 +34,7 @@ cargo bench --bench picker_preview warm          # warm only
 
 ## Rust Repo Caching
 
-Real repo benchmarks clone rust-lang/rust on first run (~2-5 minutes). The clone is cached in `~/.cache/wt-perf/bench-repos/` and reused. Corrupted caches are auto-recovered.
+Real repo benchmarks clone rust-lang/rust on first run (~2-5 minutes). The clone is cached in `target/wt-perf/bench-repos/` and reused. Corrupted caches are auto-recovered.
 
 ## Faster Iteration
 
@@ -183,7 +183,7 @@ diverged branches as backdrop, 200 commits, 100 files; `prune_real_repo` runs
 warm and probe-cold dry-runs on the `prune-real` fixture — a rust-lang/rust clone with 12
 squash-merged candidate pairs + 24 diverged worktrees and 24 diverged
 branches, i.e. 36 linked worktrees, cached and self-repairing in
-`~/.cache/wt-perf/bench-repos/rust-prune-12-24/`. That group is opt-in —
+`target/wt-perf/bench-repos/rust-prune-12-24/`. That group is opt-in —
 `cargo bench --bench prune --features real-repo-benches prune_real_repo` —
 because its ~15 GiB fixture must never build on a hosted CI runner):
 
@@ -251,7 +251,7 @@ cargo run -p wt-perf -- timeline -- -C /tmp/prune-repo step prune --min-age 0s
 **Live prune at real scale is a one-shot timeline, not a criterion group** —
 each live run consumes the candidates, and re-creating them on rust costs
 minutes per iteration. The `prune-real[-M-U]` fixture is built for this
-workflow: it lives in `~/.cache/wt-perf/bench-repos/` (no `--path`), and after a live
+workflow: it lives in `target/wt-perf/bench-repos/` (no `--path`), and after a live
 prune the next `wt-perf setup prune-real` or `prune_real_repo` bench run
 detects the consumed candidates and re-creates just them (~1 min) instead of
 rebuilding the ~15 GiB fixture. Don't run two builders concurrently (a bench
@@ -262,7 +262,7 @@ invalidated for measures a degraded scan:
 
 ```bash
 cargo run -p wt-perf -- setup prune-real     # build or validate/repair the cache
-cargo run -p wt-perf -- timeline -- -C ~/.cache/wt-perf/bench-repos/rust-prune-12-24/repo step prune --min-age 0s
+cargo run -p wt-perf -- timeline -- -C target/wt-perf/bench-repos/rust-prune-12-24/repo step prune --min-age 0s
 cargo run -p wt-perf -- setup prune-real     # repair the consumed candidates
 ```
 
@@ -281,15 +281,15 @@ count.
 
 ## Output Locations
 
-Fixture repos live under the wt-perf cache dir — `~/.cache/wt-perf/` (the XDG
-cache dir on Linux and macOS alike), or `$WT_PERF_CACHE_DIR` if set. This is
-per-user and shared across worktrees/checkouts, so an expensive fixture is built
-once per machine and survives `cargo clean` (a `target/`-rooted cache is
-per-worktree and clean-wiped). `wt-perf setup` prints the exact path.
+Fixture repos live under `target/wt-perf/` at the workspace root. That is
+per-worktree (git worktrees don't share `target/`) and reaped by `cargo clean`,
+so an expensive fixture — the ~15 GiB rust clone under `bench-repos/` — is
+rebuilt per worktree and after every `cargo clean`. `wt-perf setup` prints the
+exact path.
 
 - Results: `target/criterion/`
-- Cached rust repo: `~/.cache/wt-perf/bench-repos/rust/`
-- Cached rust prune fixture: `~/.cache/wt-perf/bench-repos/rust-prune-<M>-<U>/` (repo +
+- Cached rust repo: `target/wt-perf/bench-repos/rust/`
+- Cached rust prune fixture: `target/wt-perf/bench-repos/rust-prune-<M>-<U>/` (repo +
   sibling worktrees + `round` counter for candidate re-creation)
 - HTML reports: `target/criterion/*/report/index.html`
 
@@ -300,7 +300,7 @@ Use `wt-perf` to set up benchmark repos and generate Chrome Trace Format for vis
 ### Setting up benchmark repos
 
 ```bash
-# Set up a repo with 8 worktrees (persists at ~/.cache/wt-perf/typical-8; the
+# Set up a repo with 8 worktrees (persists at target/wt-perf/typical-8; the
 # next `setup typical-8` run wipes and rebuilds it)
 cargo run -p wt-perf -- setup typical-8
 
@@ -315,12 +315,12 @@ cargo run -p wt-perf -- setup typical-8
 #                     benches/prune.rs)
 #   prune-real[-M-U] - rust-lang/rust clone + M squash-merged candidate pairs
 #                     + U diverged worktrees/branches (default 12-24), cached
-#                     and self-repairing in ~/.cache/wt-perf/bench-repos/ (no --path);
+#                     and self-repairing in target/wt-perf/bench-repos/ (no --path);
 #                     first run clones from the network
 #   picker-test     - Config for wt switch interactive picker testing
 
 # Invalidate caches for cold run
-cargo run -p wt-perf -- invalidate ~/.cache/wt-perf/typical-8
+cargo run -p wt-perf -- invalidate target/wt-perf/typical-8
 ```
 
 ### Generating traces
@@ -335,7 +335,7 @@ Perfetto/chrome://tracing. `--cold` invalidates caches first.
 cargo run -p wt-perf -- timeline -- list --progressive
 
 # Cold-cache run (invalidates the traced repo — the `-C` arg, else cwd)
-cargo run -p wt-perf -- timeline --cold -- -C ~/.cache/wt-perf/typical-8 list --progressive
+cargo run -p wt-perf -- timeline --cold -- -C target/wt-perf/typical-8 list --progressive
 
 # Chrome Trace Format JSON for Perfetto
 cargo run -p wt-perf -- timeline --chrome -- list --progressive > trace.json
@@ -395,8 +395,8 @@ Three questions drive `wt list` performance work:
 
 ```bash
 # Trace on rust-lang/rust (must run benchmark first to clone)
-cargo run --release -q -- -vv -C ~/.cache/wt-perf/bench-repos/rust list --progressive --branches
-cargo run -p wt-perf -- trace ~/.cache/wt-perf/bench-repos/rust/.git/wt/logs/trace.jsonl > rust-trace.json
+cargo run --release -q -- -vv -C target/wt-perf/bench-repos/rust list --progressive --branches
+cargo run -p wt-perf -- trace target/wt-perf/bench-repos/rust/.git/wt/logs/trace.jsonl > rust-trace.json
 ```
 
 ## Key Performance Insights

--- a/benches/prune.rs
+++ b/benches/prune.rs
@@ -175,7 +175,7 @@ fn bench_prune_e2e(c: &mut Criterion) {
 /// --write-tree` ~130 ms, `git status` over ~60k files — vs the synthetic
 /// fixture where probes bottom out at subprocess spawn. First run clones
 /// rust-lang/rust from the network (minutes), then builds ~36 worktrees at
-/// ~3 s each; both are cached in the wt-perf cache dir across runs.
+/// ~3 s each; both are cached under target/wt-perf/bench-repos across runs.
 ///
 /// Dry-runs only, in two flavors: warm (steady-state re-scan) and probe-cold
 /// (`.git/wt/cache/` cleared per iteration — the "first prune after fetching

--- a/src/commands/CLAUDE.md
+++ b/src/commands/CLAUDE.md
@@ -10,7 +10,7 @@ When debugging TUI commands like `wt switch` (interactive picker), use the `tmux
 cargo run -p wt-perf -- setup picker-test
 ```
 
-This creates a reproducible test repo at `~/.cache/wt-perf/picker-test/` (XDG cache dir on Linux and macOS; `WT_PERF_CACHE_DIR` overrides the root). `wt-perf setup` also prints the exact path.
+This creates a reproducible test repo at `target/wt-perf/picker-test/` (under the workspace root, reaped by `cargo clean`). `wt-perf setup` also prints the exact path.
 
 ### 2. Test Interactively
 
@@ -21,7 +21,7 @@ Load the `tmux-cli` skill, then use the `tmux-cli` tool. Install if needed: `uv 
 ```bash
 # Launch shell in test repo
 pane=$(tmux-cli launch "zsh")
-tmux-cli send "cd ~/.cache/wt-perf/picker-test" --pane=$pane
+tmux-cli send "cd target/wt-perf/picker-test" --pane=$pane
 tmux-cli wait_idle --pane=$pane
 
 # Run with debug logging
@@ -43,7 +43,7 @@ MCP terminals use pseudo-TTY, not real terminals. If tests pass in MCP but users
 ```typescript
 // Create terminal and navigate to test repo
 mcp__node-terminal__terminal_create({ sessionId: "test" })
-mcp__node-terminal__terminal_write({ sessionId: "test", input: "cd ~/.cache/wt-perf/picker-test" })
+mcp__node-terminal__terminal_write({ sessionId: "test", input: "cd target/wt-perf/picker-test" })
 mcp__node-terminal__terminal_send_key({ sessionId: "test", key: "enter" })
 
 // Run with debug logging

--- a/tests/helpers/wt-perf/Cargo.toml
+++ b/tests/helpers/wt-perf/Cargo.toml
@@ -15,9 +15,6 @@ description = "Performance testing and tracing tools for worktrunk"
 # For repo setup
 tempfile = "3.27"
 dunce = "1"
-# Resolve the cache directory for reusable fixtures (XDG on macOS too,
-# matching worktrunk's own base-dir strategy in src/config/user/path.rs)
-etcetera = "0.11"
 
 # For CLI
 clap = { version = "4.6", features = ["derive"] }

--- a/tests/helpers/wt-perf/src/lib.rs
+++ b/tests/helpers/wt-perf/src/lib.rs
@@ -24,7 +24,6 @@
 //!
 //! See `wt-perf --help` for CLI usage.
 
-use etcetera::base_strategy::{BaseStrategy, choose_base_strategy};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
@@ -115,7 +114,7 @@ impl RepoConfig {
 /// identical); the composite fixtures build varied states instead:
 /// `mixed-W-B` via `create_mixed_repo_at`, `prune-M-U` via
 /// [`create_prune_repo_at`]. (`prune-real[-M-U]` is not a `SetupConfig`:
-/// it is cache-managed under `<cache>/bench-repos/` and takes no path — see
+/// it is managed under `target/wt-perf/bench-repos/` and takes no path — see
 /// [`ensure_prune_real_repo`].)
 pub enum SetupConfig {
     Flat(RepoConfig),
@@ -621,39 +620,36 @@ fn resolve_git_common_dir(repo_path: &Path) -> Option<PathBuf> {
     pointed.parent()?.parent().map(Path::to_path_buf)
 }
 
-/// Root of wt-perf's on-disk cache: `$WT_PERF_CACHE_DIR` if set, else the
-/// per-user cache directory `<cache>/wt-perf` (`~/.cache/wt-perf`, or
-/// `$XDG_CACHE_HOME/wt-perf`). `etcetera::choose_base_strategy` follows the
-/// XDG convention on macOS too, matching worktrunk's own base-dir strategy
-/// (`src/config/user/path.rs`), so the path is identical on Linux and macOS.
+/// Root of wt-perf's on-disk fixtures: `<workspace>/target/wt-perf`.
 ///
-/// Both entry points — benches (cwd = workspace root) and the `wt-perf` CLI
-/// (cwd = anywhere) — resolve the same machine-global path, so an expensive
-/// fixture is built once per machine rather than once per git worktree. A
-/// `target/`-rooted cache would be per-worktree (worktrees don't share
-/// `target/`) and wiped by `cargo clean`; the cache dir is neither.
-pub fn wt_perf_cache_dir() -> PathBuf {
-    // Treat an empty value as unset: `WT_PERF_CACHE_DIR=` would otherwise yield
-    // an empty root, so `setup <config>` would remove_dir_all a *relative*
-    // `<config>` in the cwd instead of a dir under the cache.
-    if let Some(dir) = std::env::var_os("WT_PERF_CACHE_DIR").filter(|d| !d.is_empty()) {
-        return PathBuf::from(dir);
-    }
-    choose_base_strategy()
-        .expect("no home directory; set WT_PERF_CACHE_DIR")
-        .cache_dir()
-        .join("wt-perf")
+/// Resolved from this crate's compile-time manifest dir (`tests/helpers/wt-perf`,
+/// three levels below the workspace root), so both entry points — benches
+/// (in-process) and the `wt-perf` CLI — land on the same path regardless of the
+/// caller's cwd or build profile.
+///
+/// Living under `target/` means `cargo clean` reaps every fixture and each git
+/// worktree keeps its own copy (worktrees don't share `target/`). That is cheap
+/// for the synthetic `setup` fixtures — rebuilt in seconds — but a deliberate
+/// cost for the ~15 GiB rust clone under `bench-repos/`, which then re-clones
+/// per worktree and after every `cargo clean`. There is no env override;
+/// relocate by hand (a symlink at `target/wt-perf`) if that cost bites.
+pub fn wt_perf_fixture_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(3)
+        .expect("wt-perf crate sits three levels below the workspace root")
+        .join("target/wt-perf")
 }
 
-/// The shared cache for real, cloned upstream fixtures (rust-lang/rust and the
-/// prune fixtures derived from it): `<cache>/bench-repos`.
+/// The shared store for real, cloned upstream fixtures (rust-lang/rust and the
+/// prune fixtures derived from it): `<workspace>/target/wt-perf/bench-repos`.
 fn bench_repos_dir() -> PathBuf {
-    wt_perf_cache_dir().join("bench-repos")
+    wt_perf_fixture_dir().join("bench-repos")
 }
 
 /// Get or clone the rust-lang/rust repository for real-world benchmarks.
 ///
-/// The repo is cached at `<cache>/bench-repos/rust` and reused across runs.
+/// The repo is cached at `target/wt-perf/bench-repos/rust` and reused across runs.
 fn ensure_rust_repo() -> PathBuf {
     RUST_REPO
         .get_or_init(|| {
@@ -1201,7 +1197,7 @@ pub const PRUNE_REAL_UNMERGED: usize = 24;
 /// Each linked worktree materializes a full working tree: ~400 MiB and ~3 s
 /// per worktree, so the default populations build in minutes and take ~15 GiB.
 /// Prefer [`ensure_prune_real_repo`], which builds once into
-/// `<cache>/bench-repos` and repairs consumed candidates on later runs.
+/// `target/wt-perf/bench-repos` and repairs consumed candidates on later runs.
 fn create_prune_real_repo_at(merged: usize, unmerged: usize, base_path: &Path) {
     clone_rust_repo_at(base_path);
     add_diverged_backdrop(base_path, unmerged, unmerged);
@@ -1276,7 +1272,7 @@ fn next_squash_round(repo: &Path) -> usize {
 
 /// Get or build the cached rust-scale prune fixture, returning the repo path.
 ///
-/// The fixture lives at `<cache>/bench-repos/rust-prune-<merged>-<unmerged>/repo`
+/// The fixture lives at `target/wt-perf/bench-repos/rust-prune-<merged>-<unmerged>/repo`
 /// (worktrees as siblings) so its minutes-long build (`create_prune_real_repo_at`)
 /// is paid once, not per bench run. On reuse it is validated by
 /// `prune_fixture_state`:

--- a/tests/helpers/wt-perf/src/lib.rs
+++ b/tests/helpers/wt-perf/src/lib.rs
@@ -620,25 +620,61 @@ fn resolve_git_common_dir(repo_path: &Path) -> Option<PathBuf> {
     pointed.parent()?.parent().map(Path::to_path_buf)
 }
 
-/// Root of wt-perf's on-disk fixtures: `<workspace>/target/wt-perf`.
+/// Root of wt-perf's on-disk fixtures: `<cargo-target-dir>/wt-perf`.
 ///
-/// Resolved from this crate's compile-time manifest dir (`tests/helpers/wt-perf`,
-/// three levels below the workspace root), so both entry points — benches
-/// (in-process) and the `wt-perf` CLI — land on the same path regardless of the
-/// caller's cwd or build profile.
+/// The target dir is `cargo_target_dir`, derived from the running executable, so
+/// it tracks wherever cargo actually built — the default `<workspace>/target`, a
+/// `CARGO_TARGET_DIR` / `build.target-dir` override, or cargo-llvm-cov's
+/// relocated dir — keeping fixtures co-located with build output and reaped by
+/// `cargo clean`.
 ///
 /// Living under `target/` means `cargo clean` reaps every fixture and each git
 /// worktree keeps its own copy (worktrees don't share `target/`). That is cheap
 /// for the synthetic `setup` fixtures — rebuilt in seconds — but a deliberate
 /// cost for the ~15 GiB rust clone under `bench-repos/`, which then re-clones
-/// per worktree and after every `cargo clean`. There is no env override;
-/// relocate by hand (a symlink at `target/wt-perf`) if that cost bites.
+/// per worktree and after every `cargo clean`. Relocate it with cargo's own
+/// `CARGO_TARGET_DIR` if that cost bites.
 pub fn wt_perf_fixture_dir() -> PathBuf {
-    Path::new(env!("CARGO_MANIFEST_DIR"))
-        .ancestors()
-        .nth(3)
-        .expect("wt-perf crate sits three levels below the workspace root")
-        .join("target/wt-perf")
+    cargo_target_dir().join("wt-perf")
+}
+
+/// The cargo target directory containing the current executable.
+///
+/// Both entry points live inside it — the `wt-perf` CLI at
+/// `<target>/debug/wt-perf`, the in-process benches at
+/// `<target>/release/deps/<bench>` — so the closest ancestor named `debug` or
+/// `release` (the profile dir) has the target dir as its parent. Reading the
+/// running binary's path rather than `CARGO_TARGET_DIR` alone also honors a
+/// config-file `build.target-dir` and cargo-llvm-cov's `--target-dir`: the
+/// binary is physically inside whichever dir cargo used. Falls back to
+/// `<workspace>/target` (from the compile-time manifest dir) if the executable
+/// isn't under a recognizable profile dir.
+fn cargo_target_dir() -> PathBuf {
+    std::env::current_exe()
+        .ok()
+        .and_then(|exe| target_dir_from_exe(&exe))
+        .unwrap_or_else(|| {
+            Path::new(env!("CARGO_MANIFEST_DIR"))
+                .ancestors()
+                .nth(3)
+                .expect("wt-perf crate sits three levels below the workspace root")
+                .join("target")
+        })
+}
+
+/// The target dir containing `exe`: the closest ancestor named `debug` or
+/// `release` (the cargo profile dir) has the target dir as its parent. `None`
+/// if `exe` isn't under such a dir.
+fn target_dir_from_exe(exe: &Path) -> Option<PathBuf> {
+    exe.ancestors()
+        .find(|p| {
+            matches!(
+                p.file_name().and_then(|n| n.to_str()),
+                Some("debug" | "release")
+            )
+        })?
+        .parent()
+        .map(Path::to_path_buf)
 }
 
 /// The shared store for real, cloned upstream fixtures (rust-lang/rust and the
@@ -1395,6 +1431,42 @@ pub fn parse_config(s: &str) -> Option<SetupConfig> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `target_dir_from_exe` finds the cargo target dir as the parent of the
+    /// closest `debug`/`release` profile dir, so fixtures track wherever cargo
+    /// actually built: a relocated `CARGO_TARGET_DIR`, a bench binary under
+    /// `release/deps/`, or cargo-llvm-cov's nested target. A binary outside any
+    /// target dir yields `None`, so the caller uses the workspace fallback.
+    #[test]
+    fn target_dir_from_exe_finds_cargo_target() {
+        let cases = [
+            // CLI binary at <target>/debug/wt-perf
+            ("/w/target/debug/wt-perf", Some("/w/target")),
+            // Relocated via CARGO_TARGET_DIR / build.target-dir
+            ("/tmp/tgt/debug/wt-perf", Some("/tmp/tgt")),
+            // Bench binary at <target>/release/deps/<bench>
+            ("/w/target/release/deps/list-abc123", Some("/w/target")),
+            // cargo-llvm-cov's nested target dir
+            (
+                "/w/target/llvm-cov-target/debug/deps/x-1",
+                Some("/w/target/llvm-cov-target"),
+            ),
+            // Closest profile dir wins even if an ancestor is literally "release"
+            (
+                "/home/release/proj/target/debug/wt-perf",
+                Some("/home/release/proj/target"),
+            ),
+            // Installed outside any target dir → None (caller uses the fallback)
+            ("/usr/local/bin/wt-perf", None),
+        ];
+        for (exe, expected) in cases {
+            assert_eq!(
+                target_dir_from_exe(Path::new(exe)),
+                expected.map(PathBuf::from),
+                "{exe}"
+            );
+        }
+    }
 
     /// Regression: `create_repo_at` ends with `git gc`, which packs every loose
     /// ref into `.git/packed-refs` and prunes the loose copies. A prior version

--- a/tests/helpers/wt-perf/src/main.rs
+++ b/tests/helpers/wt-perf/src/main.rs
@@ -10,7 +10,7 @@ use std::time::{Duration, Instant};
 use clap::{Parser, Subcommand};
 use wt_perf::{
     PRUNE_REAL_MERGED, PRUNE_REAL_UNMERGED, canonicalize, ensure_prune_real_repo,
-    invalidate_caches_auto, parse_config, parse_pair, wt_perf_cache_dir,
+    invalidate_caches_auto, parse_config, parse_pair, wt_perf_fixture_dir,
 };
 
 #[derive(Parser)]
@@ -28,7 +28,7 @@ enum Commands {
         /// Config name: typical-N, branches-N, branches-N-M, divergent, mixed-W-B, prune-M-U, prune-real[-M-U], picker-test
         config: String,
 
-        /// Directory to create repo in (default: wt-perf cache directory)
+        /// Directory to create repo in (default: target/wt-perf)
         #[arg(long)]
         path: Option<PathBuf>,
     },
@@ -76,7 +76,7 @@ enum Commands {
   wt-perf timeline --cold -- list
 
   # Cold run against a specific repo (setup prints the exact path)
-  wt-perf timeline --cold -- -C ~/.cache/wt-perf/typical-1 list
+  wt-perf timeline --cold -- -C target/wt-perf/typical-1 list
 
   # Chrome Trace Format JSON for Perfetto
   wt-perf timeline --chrome -- list > trace.json
@@ -102,7 +102,7 @@ fn main() {
     match cli.command {
         Commands::Setup { config, path } => {
             // `prune-real[-M-U]`: cache-managed rust-scale fixture (built once
-            // under the wt-perf cache dir, repaired after a live prune consumes
+            // under target/wt-perf/bench-repos, repaired after a live prune consumes
             // its candidates) — takes no --path and never offers cleanup.
             // Tested before parse_config so its `prune-` arm never sees it.
             let prune_real = if config == "prune-real" {
@@ -113,8 +113,8 @@ fn main() {
             if let Some((merged, unmerged)) = prune_real {
                 if path.is_some() {
                     eprintln!(
-                        "prune-real fixtures are cache-managed under {}; --path is not supported",
-                        wt_perf_cache_dir().join("bench-repos").display()
+                        "prune-real fixtures are managed under {}; --path is not supported",
+                        wt_perf_fixture_dir().join("bench-repos").display()
                     );
                     std::process::exit(1);
                 }
@@ -156,7 +156,7 @@ fn main() {
                     "  prune-M-U       - M squash-merged candidates + U unmerged worktrees/branches (wt step prune workload)"
                 );
                 eprintln!(
-                    "  prune-real[-M-U] - rust-lang/rust clone + M squash-merged candidates + U unmerged worktrees/branches, cached in the wt-perf cache dir (default {PRUNE_REAL_MERGED}-{PRUNE_REAL_UNMERGED}; first run clones from network)"
+                    "  prune-real[-M-U] - rust-lang/rust clone + M squash-merged candidates + U unmerged worktrees/branches, cached under target/wt-perf/bench-repos (default {PRUNE_REAL_MERGED}-{PRUNE_REAL_UNMERGED}; first run clones from network)"
                 );
                 eprintln!("  picker-test     - Config for wt switch interactive picker testing");
                 std::process::exit(1);
@@ -166,7 +166,7 @@ fn main() {
                 std::fs::create_dir_all(&p).unwrap();
                 canonicalize(&p).unwrap()
             } else {
-                let dir = wt_perf_cache_dir().join(&config);
+                let dir = wt_perf_fixture_dir().join(&config);
                 if dir.exists() {
                     std::fs::remove_dir_all(&dir).unwrap();
                 }


### PR DESCRIPTION
## What

Move every `wt-perf` on-disk fixture out of the per-user cache dir and under the cargo target dir at `<target>/wt-perf/`, resolved by a renamed `wt_perf_fixture_dir()`:

- `setup <config>` fixtures → `<target>/wt-perf/<config>` (was `~/.cache/wt-perf/<config>`).
- The rust-lang/rust clone and `prune-real` fixtures → `<target>/wt-perf/bench-repos/` (was `~/.cache/wt-perf/bench-repos/`).
- `wt_perf_cache_dir()` → `wt_perf_fixture_dir()`. The target dir is derived from the **running executable's own path** (it lives inside whichever dir cargo built into — `<target>/debug/wt-perf`, `<target>/release/deps/<bench>`), so it honors `CARGO_TARGET_DIR`, a config-file `build.target-dir`, and cargo-llvm-cov's `target/llvm-cov-target/` — none of which a bare `CARGO_TARGET_DIR` env read covers. Falls back to `<workspace>/target` if the binary isn't under a recognizable profile dir. The `etcetera` dependency is dropped.
- The `WT_PERF_CACHE_DIR` env override (and the empty-value guard it required) is removed; the benchmarks workflow now caches the deterministic `target/wt-perf/bench-repos` path directly.
- In-process throwaway fixtures (`create_repo`) are unchanged — they keep using `tempfile::TempDir`.

This reverses the location decision from #3542, which had moved these into `~/.cache/wt-perf`.

## Why

`target/` is the conventional home for build/test-generated artifacts — gitignored, reaped by `cargo clean`, and already where criterion writes (`target/criterion`). Keeping every wt-perf fixture there gives one predictable location under the repo that `cargo clean` fully resets. Deriving the target dir from the running binary (rather than assuming `<workspace>/target`) keeps that property intact even when the target dir is relocated.

## Tradeoff (accepted)

`target/` is **not** shared across git worktrees (worktrees don't share it) and is wiped by `cargo clean`. So the ~15 GiB `prune-real` rust clone re-clones per worktree and after every `cargo clean` — the cost #3542 avoided by using the cache dir. This is deliberate and documented on `wt_perf_fixture_dir`; it's cheap for the synthetic `setup` fixtures, which rebuild in seconds.

## Testing

- `cargo build -p wt-perf --all-targets`, `cargo test -p wt-perf` — clean.
- New unit test `target_dir_from_exe_finds_cargo_target` covers the resolution logic (relocated `CARGO_TARGET_DIR`, bench binary under `release/deps/`, cargo-llvm-cov's nested target, closest-profile-wins, and the outside-any-target fallback).
- `pre-commit run --all-files` (fmt, clippy, yaml, typos, cargo-lock, custom hooks) — clean.
- Smoke-tested end-to-end: `setup branches-2` lands at `<worktree>/target/wt-perf/branches-2` and writes nothing to `~/.cache/`; a copy of the binary run from a fake `<dir>/debug/wt-perf` correctly resolves fixtures to `<dir>/wt-perf/`, proving a relocated target dir is honored.

> _This was written by Claude Code on behalf of Maximilian_
