### PR TITLE
refactor(perf): canonicalize wt-perf prune-fixture layering + completion config

### DIFF
--- a/benches/CLAUDE.md
+++ b/benches/CLAUDE.md
@@ -32,6 +32,32 @@ cargo bench --bench picker_preview               # all variants
 cargo bench --bench picker_preview warm          # warm only
 ```
 
+## Fixtures and Benches
+
+**Bench groups are named for what they measure; fixtures for the repo shape they
+build.** The two never match by convention because the relationship is
+many-to-one — one fixture feeds several bench groups that measure different
+things (`RepoConfig::typical` alone backs five). Don't read a bench group and its
+fixture as duplicates of each other: `full` is a benchmark, `mixed` is the repo
+it runs on.
+
+| Fixture (generator) | `wt-perf setup` handle | Bench group(s) |
+|---|---|---|
+| `RepoConfig::typical(N)` | `typical-N` | `skeleton`, `worktree_scaling` (list.rs); `first_output` (time_to_first_output.rs); `picker_preview`; `remove_e2e` |
+| `RepoConfig::branches(N, M)` | `branches-N[-M]` | `completion_switch` (completion.rs) |
+| `RepoConfig::many_divergent_branches()` | `divergent` | `divergent_branches` (list.rs) |
+| `create_mixed_repo(W, B)` | `mixed-W-B` | `full` (list.rs) |
+| `create_prune_repo_at(M, U)` | `prune-M-U` | `prune_e2e` (prune.rs) |
+| `ensure_prune_real_repo(M, U)` | `prune-real[-M-U]` | `prune_real_repo` (prune.rs) |
+| rust-lang/rust clone (`clone_rust_repo`) | — | `real_repo`, `real_repo_many_branches` (list.rs) |
+| `lean_worktrees` (local to alias.rs) | — | `dispatch` (alias.rs) |
+| `RepoConfig::picker_test()` | `picker-test` | — (interactive picker debugging only) |
+
+Renaming a bench group is not free: `.github/scripts/criterion-to-jsonl.py`
+keys each time-series row by the criterion output path (`<group>/<id>`), and the
+daily `benchmarks` workflow appends those to a gist. A rename orphans that
+series.
+
 ## Rust Repo Caching
 
 Real repo benchmarks clone rust-lang/rust on first run (~2-5 minutes). The clone is cached in `target/bench-repos/` and reused. Corrupted caches are auto-recovered.

--- a/benches/completion.rs
+++ b/benches/completion.rs
@@ -23,15 +23,7 @@ fn bench_completion_switch(c: &mut Criterion) {
 
     // Without worktrees: all branches are candidates
     group.bench_function("branches_only", |b| {
-        let config = RepoConfig {
-            commits_on_main: 1,
-            files: 1,
-            branches: 50,
-            commits_per_branch: 0,
-            worktrees: 0,
-            worktree_commits_ahead: 0,
-            worktree_uncommitted_files: 0,
-        };
+        let config = RepoConfig::branches(50, 0);
         let temp = create_repo(&config);
         let repo = temp.path().join("repo");
         b.iter(|| run_completion(binary, &repo, &["wt", "switch", ""]));
@@ -40,13 +32,8 @@ fn bench_completion_switch(c: &mut Criterion) {
     // With worktrees: filters out branches that already have worktrees
     group.bench_function("with_worktrees", |b| {
         let config = RepoConfig {
-            commits_on_main: 1,
-            files: 1,
-            branches: 50,
-            commits_per_branch: 0,
             worktrees: 10,
-            worktree_commits_ahead: 0,
-            worktree_uncommitted_files: 0,
+            ..RepoConfig::branches(50, 0)
         };
         let temp = create_repo(&config);
         let repo = temp.path().join("repo");

--- a/tests/helpers/wt-perf/src/lib.rs
+++ b/tests/helpers/wt-perf/src/lib.rs
@@ -1068,8 +1068,7 @@ pub fn create_prune_repo_at(merged: usize, unmerged: usize, base_path: &Path) {
         worktree_uncommitted_files: 0,
     };
     create_repo_at(&config, base_path);
-    add_diverged_backdrop(base_path, unmerged, unmerged);
-    add_squash_merged(base_path, merged, 0);
+    add_prune_populations(base_path, merged, unmerged);
     // The squash commits advanced main past the fake remote ref written by
     // `create_repo_at`; refresh so origin/main tracks the final tip.
     setup_fake_remote(base_path);
@@ -1158,6 +1157,20 @@ pub fn add_squash_merged(repo_path: &Path, count: usize, round: usize) {
     }
 }
 
+/// Add the two populations that turn a repo into a `wt step prune` workload:
+/// `unmerged` two-sided-diverged worktrees and branches (`add_diverged_backdrop`
+/// — the backdrop prune scans every run but never removes) and `merged`
+/// squash-merged candidate pairs (`add_squash_merged` — what prune removes).
+///
+/// The base repo is the only thing the synthetic ([`create_prune_repo_at`]) and
+/// rust-scale (`create_prune_real_repo_at`) prune fixtures differ in; both layer
+/// these identical populations on top, so keeping the layering in one place
+/// stops the two fixtures from drifting.
+fn add_prune_populations(base_path: &Path, merged: usize, unmerged: usize) {
+    add_diverged_backdrop(base_path, unmerged, unmerged);
+    add_squash_merged(base_path, merged, 0);
+}
+
 /// Default populations for the rust-scale prune fixture (`prune-real`):
 /// 12 squash-merged candidates of each kind + 24 unmerged worktrees and
 /// branches → 36 linked worktrees, and a live prune that removes 24
@@ -1185,8 +1198,7 @@ pub const PRUNE_REAL_UNMERGED: usize = 24;
 /// `target/bench-repos` and repairs consumed candidates on later runs.
 fn create_prune_real_repo_at(merged: usize, unmerged: usize, base_path: &Path) {
     clone_rust_repo_at(base_path);
-    add_diverged_backdrop(base_path, unmerged, unmerged);
-    add_squash_merged(base_path, merged, 0);
+    add_prune_populations(base_path, merged, unmerged);
 }
 
 /// How a cached prune fixture compares to its expected populations.


### PR DESCRIPTION
## What

Three behavior-preserving canonicalizations of the `wt-perf` benchmark fixtures, from a design pass on "why does prune need its own generator, and can the fixtures consolidate?"

1. **Share the prune-population layer.** `create_prune_repo_at` (synthetic) and `create_prune_real_repo_at` (rust-scale) both layered the same two populations onto their base repo — `add_diverged_backdrop` (the scanned-but-never-removed backdrop) + `add_squash_merged` (the removable candidates). Extracted into `add_prune_populations`, so the base repo (synthetic `create_repo_at` vs. rust clone) is now the *only* thing the two fixtures differ in, spelled out once instead of twice.

2. **Canonicalize `completion.rs` onto `RepoConfig::branches`.** Its two inline `RepoConfig` literals were exactly `RepoConfig::branches(50, 0)` (one with `worktrees` overridden), so they now use the canonical preset via struct-update instead of respelling all seven fields.

3. **Document the fixture → bench mapping.** `benches/CLAUDE.md` listed the `wt-perf setup` handles in one section and the bench groups in another with nothing connecting them, so a bench and its fixture (`full` and `mixed`) read as overlapping names for the same thing. Added a mapping table and the rule behind it.

## Why this is the whole safe consolidation

The design question was whether prune could drop its bespoke generator for a "standard one with different params" — ideally one diverse repo serving prune *and* the other benches. The answer is that prune's generator is **already** a thin composition (`create_repo_at` + two additive layers), and it can't fold into the shared `mixed`/`full` fixture without breaking three prune-specific invariants: a known/cleanly-separated candidate count (the destructive `live` path re-creates exactly the consumed candidates), untracked-only dirt (the `git reset --mixed` index-heal depends on it — `mixed`'s staged-dirt states violate it), and a provably-unintegrated backdrop. And benchmark fixtures optimize for *attribution*, not realism: the uniform single-axis fixtures (`worktree_scaling`, etc.) exist precisely because the diverse `full` fixture can't localize a regression, so diversifying them would lose that.

On the `full`/`mixed` naming specifically: they can't be canonicalized to one name, because fixtures and benches are **many-to-one** — `RepoConfig::typical` alone backs five bench groups (`skeleton`, `worktree_scaling`, `first_output`, `picker_preview`, `remove_e2e`), two of which sit in the same file measuring different things. `full`/`mixed` only looks 1:1 by coincidence. Renaming also isn't free: `.github/scripts/criterion-to-jsonl.py` keys each time-series row by the criterion output path (`<group>/<id>`) for the daily gist append, so a rename orphans that series. Documented rather than renamed.

## Proposed follow-up (not in this PR)

The one remaining real duplication is two *implementations* of "two-sided-diverged population forked across history depth": `add_diverged_backdrop` (plumbing-based, scales to rust) vs. the diverged branch states inside `create_mixed_repo` (checkout-based, synthetic-only). They can't naively merge — the checkout path would make `prune-real` take minutes per branch — but a shared plumbing primitive could back both. That rewrites a carefully-tuned fixture feeding the `full` bench with **no shape-assertion test to catch drift**, so I'd land a fixture-shape test first (count refs by state + assert integration status). Happy to do it if wanted.

## Verification

fmt `--check` clean; `clippy -p wt-perf --all-targets` and `clippy --bench completion` clean; `pre-commit` clean on the doc; `cargo test -p wt-perf` passes (incl. the prune-fixture tests `squash_merged_fixture_is_content_integrated` / `prune_fixture_state_classifies_lifecycle`, which exercise `create_prune_repo_at` → `add_prune_populations`); all benches build. Table contents verified against the code by grep.

> _This was written by Claude Code on behalf of Maximilian Roos_

🤖 Generated with [Claude Code](https://claude.com/claude-code)