### PR TITLE
fix(merge): measure squash/rebase against the target's upstream, not a stale local ref

### DIFF
--- a/docs/content/merge.md
+++ b/docs/content/merge.md
@@ -77,7 +77,7 @@ Preserve the exact clean commit graph and tip:
 
 Use `--no-commit` to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless `--no-rebase` is passed. Combining both flags preserves the exact source graph and requires the target to be its ancestor. Useful after preparing commits manually with `wt step commit`. Requires a clean working tree.
 
-`wt merge` targets the *local* default-branch ref and never fetches. When that ref has fallen behind its upstream — e.g. a primary checkout's `main` left behind `origin/main` — the merge is refused rather than folding already-upstream commits into it. Updating the local branch from its upstream lifts the refusal.
+`wt merge` targets the *local* default-branch ref and never fetches. When that ref lags its upstream — e.g. a primary checkout's `main` left behind `origin/main` — a branch based on the newer upstream tip is measured, squashed, and rebased against the upstream (so already-upstream commits are never folded into the squash), and the final fast-forward carries the local ref through the already-fetched upstream commits by their real SHAs. `wt step squash` and `wt step rebase` measure the same way. A local target that has *diverged* from its upstream — its own commits and behind — cannot fast-forward, so the merge is refused until the target is reconciled.
 
 ## Local CI
 

--- a/docs/content/merge.md
+++ b/docs/content/merge.md
@@ -77,6 +77,8 @@ Preserve the exact clean commit graph and tip:
 
 Use `--no-commit` to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless `--no-rebase` is passed. Combining both flags preserves the exact source graph and requires the target to be its ancestor. Useful after preparing commits manually with `wt step commit`. Requires a clean working tree.
 
+`wt merge` targets the *local* default-branch ref and never fetches. When that ref has fallen behind its upstream — e.g. a primary checkout's `main` left behind `origin/main` — the merge is refused rather than folding already-upstream commits into it. Updating the local branch from its upstream lifts the refusal.
+
 ## Local CI
 
 For personal projects, pre-merge hooks open up the possibility of a workflow with much faster iteration — an order of magnitude more small changes instead of fewer large ones.

--- a/plugins/worktrunk/skills/worktrunk/reference/merge.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/merge.md
@@ -74,6 +74,8 @@ $ wt merge --no-commit --no-rebase
 
 Use `--no-commit` to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless `--no-rebase` is passed. Combining both flags preserves the exact source graph and requires the target to be its ancestor. Useful after preparing commits manually with `wt step commit`. Requires a clean working tree.
 
+`wt merge` targets the *local* default-branch ref and never fetches. When that ref has fallen behind its upstream — e.g. a primary checkout's `main` left behind `origin/main` — the merge is refused rather than folding already-upstream commits into it. Updating the local branch from its upstream lifts the refusal.
+
 ## Local CI
 
 For personal projects, pre-merge hooks open up the possibility of a workflow with much faster iteration — an order of magnitude more small changes instead of fewer large ones.

--- a/plugins/worktrunk/skills/worktrunk/reference/merge.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/merge.md
@@ -74,7 +74,7 @@ $ wt merge --no-commit --no-rebase
 
 Use `--no-commit` to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless `--no-rebase` is passed. Combining both flags preserves the exact source graph and requires the target to be its ancestor. Useful after preparing commits manually with `wt step commit`. Requires a clean working tree.
 
-`wt merge` targets the *local* default-branch ref and never fetches. When that ref has fallen behind its upstream — e.g. a primary checkout's `main` left behind `origin/main` — the merge is refused rather than folding already-upstream commits into it. Updating the local branch from its upstream lifts the refusal.
+`wt merge` targets the *local* default-branch ref and never fetches. When that ref lags its upstream — e.g. a primary checkout's `main` left behind `origin/main` — a branch based on the newer upstream tip is measured, squashed, and rebased against the upstream (so already-upstream commits are never folded into the squash), and the final fast-forward carries the local ref through the already-fetched upstream commits by their real SHAs. `wt step squash` and `wt step rebase` measure the same way. A local target that has *diverged* from its upstream — its own commits and behind — cannot fast-forward, so the merge is refused until the target is reconciled.
 
 ## Local CI
 

--- a/skills/worktrunk/reference/merge.md
+++ b/skills/worktrunk/reference/merge.md
@@ -74,6 +74,8 @@ $ wt merge --no-commit --no-rebase
 
 Use `--no-commit` to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless `--no-rebase` is passed. Combining both flags preserves the exact source graph and requires the target to be its ancestor. Useful after preparing commits manually with `wt step commit`. Requires a clean working tree.
 
+`wt merge` targets the *local* default-branch ref and never fetches. When that ref has fallen behind its upstream — e.g. a primary checkout's `main` left behind `origin/main` — the merge is refused rather than folding already-upstream commits into it. Updating the local branch from its upstream lifts the refusal.
+
 ## Local CI
 
 For personal projects, pre-merge hooks open up the possibility of a workflow with much faster iteration — an order of magnitude more small changes instead of fewer large ones.

--- a/skills/worktrunk/reference/merge.md
+++ b/skills/worktrunk/reference/merge.md
@@ -74,7 +74,7 @@ $ wt merge --no-commit --no-rebase
 
 Use `--no-commit` to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless `--no-rebase` is passed. Combining both flags preserves the exact source graph and requires the target to be its ancestor. Useful after preparing commits manually with `wt step commit`. Requires a clean working tree.
 
-`wt merge` targets the *local* default-branch ref and never fetches. When that ref has fallen behind its upstream — e.g. a primary checkout's `main` left behind `origin/main` — the merge is refused rather than folding already-upstream commits into it. Updating the local branch from its upstream lifts the refusal.
+`wt merge` targets the *local* default-branch ref and never fetches. When that ref lags its upstream — e.g. a primary checkout's `main` left behind `origin/main` — a branch based on the newer upstream tip is measured, squashed, and rebased against the upstream (so already-upstream commits are never folded into the squash), and the final fast-forward carries the local ref through the already-fetched upstream commits by their real SHAs. `wt step squash` and `wt step rebase` measure the same way. A local target that has *diverged* from its upstream — its own commits and behind — cannot fast-forward, so the merge is refused until the target is reconciled.
 
 ## Local CI
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1408,7 +1408,7 @@ $ wt merge --no-commit --no-rebase
 
 Use `--no-commit` to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless `--no-rebase` is passed. Combining both flags preserves the exact source graph and requires the target to be its ancestor. Useful after preparing commits manually with `wt step commit`. Requires a clean working tree.
 
-`wt merge` targets the *local* default-branch ref and never fetches. When that ref has fallen behind its upstream — e.g. a primary checkout's `main` left behind `origin/main` — the merge is refused rather than folding already-upstream commits into it. Updating the local branch from its upstream lifts the refusal.
+`wt merge` targets the *local* default-branch ref and never fetches. When that ref lags its upstream — e.g. a primary checkout's `main` left behind `origin/main` — a branch based on the newer upstream tip is measured, squashed, and rebased against the upstream (so already-upstream commits are never folded into the squash), and the final fast-forward carries the local ref through the already-fetched upstream commits by their real SHAs. `wt step squash` and `wt step rebase` measure the same way. A local target that has *diverged* from its upstream — its own commits and behind — cannot fast-forward, so the merge is refused until the target is reconciled.
 
 ## Local CI
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1408,6 +1408,8 @@ $ wt merge --no-commit --no-rebase
 
 Use `--no-commit` to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless `--no-rebase` is passed. Combining both flags preserves the exact source graph and requires the target to be its ancestor. Useful after preparing commits manually with `wt step commit`. Requires a clean working tree.
 
+`wt merge` targets the *local* default-branch ref and never fetches. When that ref has fallen behind its upstream — e.g. a primary checkout's `main` left behind `origin/main` — the merge is refused rather than folding already-upstream commits into it. Updating the local branch from its upstream lifts the refusal.
+
 ## Local CI
 
 For personal projects, pre-merge hooks open up the possibility of a workflow with much faster iteration — an order of magnitude more small changes instead of fewer large ones.

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -1,6 +1,7 @@
 use std::path::Path;
 
 use anyhow::Context;
+use color_print::cformat;
 use worktrunk::HookType;
 use worktrunk::config::{MergeConfig, UserConfig};
 use worktrunk::git::Repository;
@@ -205,17 +206,48 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
     // Get and validate target branch (must be a branch since we're updating it)
     let target_branch = repo.require_target_branch(target)?;
 
-    // Data-safety guard (#3519): refuse to squash/rebase against a local target
-    // ref that has fallen behind its upstream. Doing so would fold commits
-    // already published on the upstream into a new commit on the local ref,
-    // corrupting it (and, if later pushed, duplicating upstream content under
-    // new SHAs). Local-only check — no fetch, consistent with local-first merge.
-    if let Some(upstream) = repo.merge_target_behind_upstream(&target_branch)? {
-        return Err(worktrunk::git::GitError::MergeTargetBehindUpstream {
-            target_branch: target_branch.clone(),
-            upstream,
+    // #3519: when the branch is based past the local target into the target's
+    // upstream, the rewrite steps measure against the upstream (see
+    // `span_upstream`) and the final fast-forward carries the local target
+    // through the upstream commits by their real SHAs. That fast-forward exists
+    // only while the local target is strictly behind its upstream; a target
+    // that has *diverged* — its own commits AND behind — can never fast-forward
+    // to this branch, so refuse up front with the real reason rather than
+    // failing late in the push step. Local-only check — no fetch.
+    if let Some(upstream) = repo.span_upstream(&target_branch)? {
+        let target_sha = repo
+            .run_command(&[
+                "rev-parse",
+                "--verify",
+                "--end-of-options",
+                &format!("refs/heads/{target_branch}"),
+            ])?
+            .trim()
+            .to_string();
+        let upstream_sha = repo
+            .run_command(&["rev-parse", "--verify", "--end-of-options", &upstream])?
+            .trim()
+            .to_string();
+        if repo.is_ancestor_by_sha(&target_sha, &upstream_sha)? {
+            let carried = repo.count_commits(&target_branch, &upstream)?;
+            let (commit_text, pronoun) = if carried == 1 {
+                ("commit", "it")
+            } else {
+                ("commits", "them")
+            };
+            eprintln!(
+                "{}",
+                info_message(cformat!(
+                    "Local <bold>{target_branch}</> is {carried} {commit_text} behind <bold>{upstream}</>; the merge fast-forwards through {pronoun}"
+                ))
+            );
+        } else {
+            return Err(worktrunk::git::GitError::MergeTargetDivergedFromUpstream {
+                target_branch: target_branch.clone(),
+                upstream,
+            }
+            .into());
         }
-        .into());
     }
 
     // Worktree for target is optional: if present we use it for safety checks and as destination.

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -204,6 +204,20 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
 
     // Get and validate target branch (must be a branch since we're updating it)
     let target_branch = repo.require_target_branch(target)?;
+
+    // Data-safety guard (#3519): refuse to squash/rebase against a local target
+    // ref that has fallen behind its upstream. Doing so would fold commits
+    // already published on the upstream into a new commit on the local ref,
+    // corrupting it (and, if later pushed, duplicating upstream content under
+    // new SHAs). Local-only check — no fetch, consistent with local-first merge.
+    if let Some(upstream) = repo.merge_target_behind_upstream(&target_branch)? {
+        return Err(worktrunk::git::GitError::MergeTargetBehindUpstream {
+            target_branch: target_branch.clone(),
+            upstream,
+        }
+        .into());
+    }
+
     // Worktree for target is optional: if present we use it for safety checks and as destination.
     let target_worktree_path = repo.worktree_for_branch(&target_branch)?;
     // Where `post-merge` / `post-remove` / `post-switch` run: the target

--- a/src/commands/step/rebase.rs
+++ b/src/commands/step/rebase.rs
@@ -21,6 +21,13 @@ pub fn handle_rebase(target: Option<&str>) -> anyhow::Result<RebaseResult> {
 
     // Get and validate target ref (any commit-ish for rebase)
     let integration_target = repo.require_target_ref(target)?;
+    // #3519: when the branch's history extends past the local target into the
+    // target's upstream, rebase onto the upstream instead — replaying the span
+    // onto the stale local ref would duplicate commits the upstream already
+    // contains under new SHAs.
+    let integration_target = repo
+        .span_upstream(&integration_target)?
+        .unwrap_or(integration_target);
 
     // Check if already up-to-date (linear extension of target, no merge commits)
     if repo.is_rebased_onto(&integration_target)? {

--- a/src/commands/step/squash.rs
+++ b/src/commands/step/squash.rs
@@ -139,6 +139,12 @@ pub fn handle_squash(
 
     // Get and validate target ref (any commit-ish for merge-base calculation)
     let integration_target = repo.require_target_ref(target)?;
+    // #3519: when the branch's history extends past the local target into the
+    // target's upstream, measure the squash against the upstream — so commits
+    // already published there are never folded into the squash commit.
+    let span_target = repo
+        .span_upstream(&integration_target)?
+        .unwrap_or_else(|| integration_target.clone());
     let template_vars = TemplateVars::new().with_target(&integration_target);
 
     // Auto-stage changes before running pre-commit hooks so both beta and merge paths behave identically
@@ -169,7 +175,7 @@ pub fn handle_squash(
 
     // Get merge base with target branch (required for squash)
     let merge_base = repo
-        .merge_base("HEAD", &integration_target)?
+        .merge_base("HEAD", &span_target)?
         .context("Cannot squash: no common ancestor with target branch")?;
 
     // Count commits since merge base
@@ -182,7 +188,7 @@ pub fn handle_squash(
     // Handle different scenarios
     if commit_count == 0 && !has_staged {
         // No commits and no staged changes - nothing to squash
-        return Ok(SquashResult::NoCommitsAhead(integration_target));
+        return Ok(SquashResult::NoCommitsAhead(span_target));
     }
 
     if commit_count == 1 && !has_staged {
@@ -251,7 +257,7 @@ pub fn handle_squash(
 
     // Create safety backup before potentially destructive reset if there are working tree changes
     if has_staged {
-        let backup_message = format!("{} → {} (squash)", current_branch, integration_target);
+        let backup_message = format!("{} → {} (squash)", current_branch, span_target);
         let sha = wt.create_safety_backup(&backup_message)?;
         eprintln!("{}", hint_message(format!("Backup created @ {sha}")));
     }
@@ -275,7 +281,7 @@ pub fn handle_squash(
         .unwrap_or("repo");
 
     let commit_message = crate::llm::generate_squash_message(
-        &integration_target,
+        &span_target,
         &merge_base,
         &commit_details,
         &current_branch,
@@ -363,12 +369,16 @@ fn preview_squash(target: Option<&str>, dry_run: bool, yes: bool) -> anyhow::Res
     let commit_config = config.commit_generation(project_id.as_deref());
 
     let integration_target = repo.require_target_ref(target)?;
+    // #3519: preview against the same upstream-aware span the real squash uses.
+    let span_target = repo
+        .span_upstream(&integration_target)?
+        .unwrap_or(integration_target);
 
     let wt = repo.current_worktree();
     let current_branch = wt.branch()?.unwrap_or_else(|| "HEAD".to_string());
 
     let merge_base = repo
-        .merge_base("HEAD", &integration_target)?
+        .merge_base("HEAD", &span_target)?
         .context("Cannot generate squash message: no common ancestor with target branch")?;
 
     let range = format!("{}..HEAD", merge_base);
@@ -385,7 +395,7 @@ fn preview_squash(target: Option<&str>, dry_run: bool, yes: bool) -> anyhow::Res
     let project_append = resolve_template_for_preview(&ctx, &commit_config, dry_run)?;
 
     let prompt = crate::llm::build_squash_prompt(
-        &integration_target,
+        &span_target,
         &merge_base,
         &commit_details,
         &current_branch,
@@ -398,7 +408,7 @@ fn preview_squash(target: Option<&str>, dry_run: bool, yes: bool) -> anyhow::Res
         return Ok(());
     }
     let message = crate::llm::generate_squash_message(
-        &integration_target,
+        &span_target,
         &merge_base,
         &commit_details,
         &current_branch,

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -512,15 +512,13 @@ pub enum GitError {
         target_branch: String,
         error: String,
     },
-    /// `wt merge` would squash/rebase against a *local* target ref that has
-    /// fallen behind its upstream, folding commits already published on the
-    /// upstream into a new commit on that local ref — corrupting it (#3519).
-    /// Detected locally, with no fetch (worktrunk is local-first): the target
-    /// branch has an upstream that resolves locally and
-    /// `merge-base(HEAD, upstream)` is not an ancestor of the local target, so
-    /// the merge span reaches commits the upstream already contains. Refused
-    /// rather than silently mutating a stale ref, per the Data Safety posture.
-    MergeTargetBehindUpstream {
+    /// `wt merge` requires the local target ref to fast-forward to the merge
+    /// result. When the target has both fallen behind its upstream and grown
+    /// its own commits — diverged — while the branch is based past it on the
+    /// upstream side, no fast-forward exists in any mode: the target's own
+    /// commits first need reconciling with the upstream (#3519). Detected
+    /// locally, with no fetch, before any rewrite or approval prompt.
+    MergeTargetDivergedFromUpstream {
         target_branch: String,
         upstream: String,
     },
@@ -738,11 +736,11 @@ impl GitError {
                 cformat!("Can't push to local <bold>{target_branch}</> branch")
             }
 
-            GitError::MergeTargetBehindUpstream {
+            GitError::MergeTargetDivergedFromUpstream {
                 target_branch,
                 upstream,
             } => cformat!(
-                "Local <bold>{target_branch}</> is behind <bold>{upstream}</> — merging would fold already-upstream commits into <bold>{target_branch}</>"
+                "Local <bold>{target_branch}</> has diverged from <bold>{upstream}</> — can't fast-forward to a branch based on <bold>{upstream}</>"
             ),
 
             GitError::NotInteractive => {
@@ -1210,7 +1208,7 @@ impl GitError {
                 write!(f, "{}", format_error_block(error_message(&title), error))
             }
 
-            GitError::MergeTargetBehindUpstream {
+            GitError::MergeTargetDivergedFromUpstream {
                 target_branch,
                 upstream,
             } => {
@@ -1220,7 +1218,7 @@ impl GitError {
                     "{}\n{}",
                     error_message(&title),
                     hint_message(cformat!(
-                        "Update <underline>{target_branch}</> from <underline>{upstream}</> before merging, or specify a different target"
+                        "Reconcile <underline>{target_branch}</> with <underline>{upstream}</> (rebase or merge its local commits), or specify a different target"
                     ))
                 )
             }

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -512,6 +512,18 @@ pub enum GitError {
         target_branch: String,
         error: String,
     },
+    /// `wt merge` would squash/rebase against a *local* target ref that has
+    /// fallen behind its upstream, folding commits already published on the
+    /// upstream into a new commit on that local ref — corrupting it (#3519).
+    /// Detected locally, with no fetch (worktrunk is local-first): the target
+    /// branch has an upstream that resolves locally and
+    /// `merge-base(HEAD, upstream)` is not an ancestor of the local target, so
+    /// the merge span reaches commits the upstream already contains. Refused
+    /// rather than silently mutating a stale ref, per the Data Safety posture.
+    MergeTargetBehindUpstream {
+        target_branch: String,
+        upstream: String,
+    },
 
     // Validation/other errors
     NotInteractive,
@@ -725,6 +737,13 @@ impl GitError {
             GitError::PushFailed { target_branch, .. } => {
                 cformat!("Can't push to local <bold>{target_branch}</> branch")
             }
+
+            GitError::MergeTargetBehindUpstream {
+                target_branch,
+                upstream,
+            } => cformat!(
+                "Local <bold>{target_branch}</> is behind <bold>{upstream}</> — merging would fold already-upstream commits into <bold>{target_branch}</>"
+            ),
 
             GitError::NotInteractive => {
                 "Cannot prompt for approval in non-interactive environment".to_string()
@@ -1189,6 +1208,21 @@ impl GitError {
             GitError::PushFailed { error, .. } => {
                 let title = self.title();
                 write!(f, "{}", format_error_block(error_message(&title), error))
+            }
+
+            GitError::MergeTargetBehindUpstream {
+                target_branch,
+                upstream,
+            } => {
+                let title = self.title();
+                write!(
+                    f,
+                    "{}\n{}",
+                    error_message(&title),
+                    hint_message(cformat!(
+                        "Update <underline>{target_branch}</> from <underline>{upstream}</> before merging, or specify a different target"
+                    ))
+                )
             }
 
             GitError::NotInteractive => {

--- a/src/git/repository/integration.rs
+++ b/src/git/repository/integration.rs
@@ -727,30 +727,32 @@ impl Repository {
         self.rev_parse_commit(r)
     }
 
-    /// Whether merging `HEAD` into the local `target_branch` ref would fold in
-    /// commits already reachable from the target's upstream — the #3519
-    /// stale-local-default-branch hazard.
+    /// The target's upstream, when the current branch's history extends past
+    /// the local `target_branch` ref into it — the #3519 stale-local-target
+    /// topology.
     ///
-    /// `wt merge` squashes/rebases the span `merge-base(target, HEAD)..HEAD`
-    /// and fast-forwards the *local* `target` ref to the result. When that
-    /// local ref is behind its upstream (e.g. the primary checkout's `main` is
-    /// behind `origin/main`) and `HEAD` descends from the newer upstream tip,
-    /// the span sweeps in commits already published upstream, folding them into
-    /// a new commit and leaving the local ref diverged from its upstream.
+    /// The rewrite steps (`wt step squash`, `wt step rebase`, and `wt merge`
+    /// through them) measure "the branch's own commits" as
+    /// `merge-base(target, HEAD)..HEAD`. When the local target ref lags its
+    /// upstream (e.g. the primary checkout's `main` left behind `origin/main`)
+    /// and the branch was built on the newer upstream tip, that span sweeps in
+    /// commits the upstream already contains — folding (squash) or replaying
+    /// (rebase) them would duplicate published history under new SHAs. Callers
+    /// measure against the returned upstream instead, which keeps the span to
+    /// the branch's own commits; `wt merge`'s final fast-forward then carries
+    /// the local target through the upstream commits by their real SHAs.
     ///
-    /// Detected locally, with no fetch (worktrunk is local-first): fires when
-    /// the target branch has a configured upstream and `merge-base(HEAD,
-    /// upstream)` is not an ancestor of the local `target` ref — i.e. the merge
-    /// span reaches commits the upstream already contains. Quiet on a
-    /// legitimately-diverged local target (where the span is only the feature's
-    /// own commits, so the fork point is still an ancestor of the local target)
-    /// and on an orphan feature with no shared history (nothing upstream to
-    /// re-fold). Returns the upstream's short name (e.g. `origin/main`) for the
-    /// caller's error; `None` when there's no upstream or the span is clean.
-    pub fn merge_target_behind_upstream(
-        &self,
-        target_branch: &str,
-    ) -> anyhow::Result<Option<String>> {
+    /// Detected locally, with no fetch (worktrunk is local-first): returns
+    /// `Some(upstream)` (short name, e.g. `origin/main`) when the target branch
+    /// has a configured upstream and `merge-base(HEAD, upstream)` is not an
+    /// ancestor of the local `target` ref — i.e. the local-target span would
+    /// reach commits the upstream already has. `None` — measure against the
+    /// local target as usual — for a legitimately-diverged local target whose
+    /// span holds only the branch's own commits (the fork point is still an
+    /// ancestor of the local target), an orphan branch with no shared history,
+    /// a non-branch target (an explicit `origin/main` has no upstream of its
+    /// own), or a target with no upstream at all.
+    pub fn span_upstream(&self, target_branch: &str) -> anyhow::Result<Option<String>> {
         // `upstream()` already excludes a `[gone]` upstream, so a `Some` value
         // is a live remote-tracking ref that `merge_base` resolves locally — no
         // fetch, and no separate existence check.

--- a/src/git/repository/integration.rs
+++ b/src/git/repository/integration.rs
@@ -727,6 +727,45 @@ impl Repository {
         self.rev_parse_commit(r)
     }
 
+    /// Whether merging `HEAD` into the local `target_branch` ref would fold in
+    /// commits already reachable from the target's upstream — the #3519
+    /// stale-local-default-branch hazard.
+    ///
+    /// `wt merge` squashes/rebases the span `merge-base(target, HEAD)..HEAD`
+    /// and fast-forwards the *local* `target` ref to the result. When that
+    /// local ref is behind its upstream (e.g. the primary checkout's `main` is
+    /// behind `origin/main`) and `HEAD` descends from the newer upstream tip,
+    /// the span sweeps in commits already published upstream, folding them into
+    /// a new commit and leaving the local ref diverged from its upstream.
+    ///
+    /// Detected locally, with no fetch (worktrunk is local-first): fires when
+    /// the target branch has a configured upstream and `merge-base(HEAD,
+    /// upstream)` is not an ancestor of the local `target` ref — i.e. the merge
+    /// span reaches commits the upstream already contains. Quiet on a
+    /// legitimately-diverged local target (where the span is only the feature's
+    /// own commits, so the fork point is still an ancestor of the local target)
+    /// and on an orphan feature with no shared history (nothing upstream to
+    /// re-fold). Returns the upstream's short name (e.g. `origin/main`) for the
+    /// caller's error; `None` when there's no upstream or the span is clean.
+    pub fn merge_target_behind_upstream(
+        &self,
+        target_branch: &str,
+    ) -> anyhow::Result<Option<String>> {
+        // `upstream()` already excludes a `[gone]` upstream, so a `Some` value
+        // is a live remote-tracking ref that `merge_base` resolves locally — no
+        // fetch, and no separate existence check.
+        let Some(upstream) = self.branch(target_branch).upstream()? else {
+            return Ok(None);
+        };
+        let target_sha = self.resolve_to_commit_sha(target_branch)?;
+        match self.merge_base("HEAD", &upstream)? {
+            Some(fork_point) if !self.is_ancestor_by_sha(&fork_point, &target_sha)? => {
+                Ok(Some(upstream))
+            }
+            _ => Ok(None),
+        }
+    }
+
     /// Check if a branch is integrated into a target.
     ///
     /// Combines [`compute_integration_lazy()`] and [`check_integration()`], and

--- a/tests/integration_tests/merge.rs
+++ b/tests/integration_tests/merge.rs
@@ -4400,6 +4400,109 @@ fn test_merge_removes_branch_when_local_main_diverged_from_upstream(
     );
 }
 
+/// Data-safety regression (#3519): `wt merge` must refuse to squash/rebase
+/// against a *local* target ref that has fallen behind its upstream. Otherwise
+/// the merge span `merge-base(local-main, HEAD)..HEAD` sweeps in commits already
+/// on `origin/main` and folds them into a new squash commit on the local ref —
+/// corrupting the primary checkout's `main` and, if later pushed, duplicating
+/// upstream content under new SHAs.
+///
+/// Contrast with `test_merge_removes_branch_when_local_main_diverged_from_upstream`:
+/// there the feature forks from the *shared base*, so the span is only the
+/// feature's own commit and the merge legitimately succeeds. Here the feature
+/// forks from the newer `origin/main` tip, so the span reaches already-upstream
+/// commits and the merge must fail rather than mutate the stale ref.
+#[rstest]
+fn test_merge_refuses_stale_local_default_behind_upstream(
+    #[from(repo_with_remote)] repo: TestRepo,
+) {
+    let remote_path = repo.remote_path().unwrap().to_path_buf();
+
+    // Advance origin/main by two commits (stand-ins for already-merged PRs)
+    // from a second clone, without touching the primary's local main.
+    let github_sim = repo.home_path().join("github-sim");
+    repo.run_git_in(
+        repo.home_path(),
+        &["clone", remote_path.to_str().unwrap(), "github-sim"],
+    );
+    for (file, msg) in [
+        ("upstream-1.txt", "Upstream PR 1 (already merged)"),
+        ("upstream-2.txt", "Upstream PR 2 (already merged)"),
+    ] {
+        fs::write(github_sim.join(file), "upstream").unwrap();
+        repo.run_git_in(&github_sim, &["add", file]);
+        repo.run_git_in(&github_sim, &["commit", "-m", msg]);
+    }
+    repo.run_git_in(&github_sim, &["push", "origin", "main"]);
+
+    // Primary fetches origin (so origin/main is known locally) but leaves its
+    // local main stale — behind origin/main by the two upstream commits.
+    repo.run_git(&["fetch", "origin"]);
+    let stale_main = repo.git_output(&["rev-parse", "main"]);
+    assert!(
+        !repo
+            .git_command()
+            .args(["merge-base", "--is-ancestor", "origin/main", "main"])
+            .run()
+            .unwrap()
+            .status
+            .success(),
+        "setup: local main should be behind origin/main"
+    );
+
+    // Create a feature worktree off the *newer* origin/main tip (mirrors
+    // `wt switch --create feature --base origin/main`) with one real commit.
+    let feature_wt = repo.root_path().parent().unwrap().join("repo.feature");
+    repo.run_git(&[
+        "worktree",
+        "add",
+        "-b",
+        "feature",
+        feature_wt.to_str().unwrap(),
+        "origin/main",
+    ]);
+    fs::write(feature_wt.join("feature.txt"), "feature").unwrap();
+    repo.run_git_in(&feature_wt, &["add", "feature.txt"]);
+    repo.run_git_in(
+        &feature_wt,
+        &["commit", "-m", "the one real feature commit"],
+    );
+
+    // Merge must fail rather than fold the two upstream commits into main.
+    let output = repo
+        .wt_command()
+        .args(["merge", "main", "--yes", "--no-hooks"])
+        .current_dir(&feature_wt)
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !output.status.success(),
+        "merge must refuse a stale local default branch\nstderr:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("is behind"),
+        "error should explain the stale local target\nstderr:\n{stderr}",
+    );
+
+    // The local main ref must be untouched — not fast-forwarded, not squashed.
+    assert_eq!(
+        repo.git_output(&["rev-parse", "main"]),
+        stale_main,
+        "local main must not be mutated by a refused merge",
+    );
+    // The feature branch must survive a refused merge (no removal).
+    assert!(
+        repo.git_command()
+            .args(["rev-parse", "--verify", "--quiet", "refs/heads/feature"])
+            .run()
+            .unwrap()
+            .status
+            .success(),
+        "feature branch must survive a refused merge",
+    );
+}
+
 /// Approval-boundary TOCTOU regression: a `post-merge` command that enters the
 /// invoking worktree's `.config/wt.toml` only via the rebase — after the gate
 /// froze the plan — must not run.

--- a/tests/integration_tests/merge.rs
+++ b/tests/integration_tests/merge.rs
@@ -4400,26 +4400,11 @@ fn test_merge_removes_branch_when_local_main_diverged_from_upstream(
     );
 }
 
-/// Data-safety regression (#3519): `wt merge` must refuse to squash/rebase
-/// against a *local* target ref that has fallen behind its upstream. Otherwise
-/// the merge span `merge-base(local-main, HEAD)..HEAD` sweeps in commits already
-/// on `origin/main` and folds them into a new squash commit on the local ref —
-/// corrupting the primary checkout's `main` and, if later pushed, duplicating
-/// upstream content under new SHAs.
-///
-/// Contrast with `test_merge_removes_branch_when_local_main_diverged_from_upstream`:
-/// there the feature forks from the *shared base*, so the span is only the
-/// feature's own commit and the merge legitimately succeeds. Here the feature
-/// forks from the newer `origin/main` tip, so the span reaches already-upstream
-/// commits and the merge must fail rather than mutate the stale ref.
-#[rstest]
-fn test_merge_refuses_stale_local_default_behind_upstream(
-    #[from(repo_with_remote)] repo: TestRepo,
-) {
+/// Set up the #3519 stale-local-default topology: origin/main advanced by two
+/// commits (stand-ins for already-merged PRs) that the primary has fetched but
+/// not fast-forwarded into its local main.
+fn setup_stale_local_main(repo: &TestRepo) {
     let remote_path = repo.remote_path().unwrap().to_path_buf();
-
-    // Advance origin/main by two commits (stand-ins for already-merged PRs)
-    // from a second clone, without touching the primary's local main.
     let github_sim = repo.home_path().join("github-sim");
     repo.run_git_in(
         repo.home_path(),
@@ -4435,10 +4420,9 @@ fn test_merge_refuses_stale_local_default_behind_upstream(
     }
     repo.run_git_in(&github_sim, &["push", "origin", "main"]);
 
-    // Primary fetches origin (so origin/main is known locally) but leaves its
-    // local main stale — behind origin/main by the two upstream commits.
+    // Fetch so origin/main is known locally, but leave local main stale —
+    // behind origin/main by the two upstream commits.
     repo.run_git(&["fetch", "origin"]);
-    let stale_main = repo.git_output(&["rev-parse", "main"]);
     assert!(
         !repo
             .git_command()
@@ -4449,9 +4433,15 @@ fn test_merge_refuses_stale_local_default_behind_upstream(
             .success(),
         "setup: local main should be behind origin/main"
     );
+}
 
-    // Create a feature worktree off the *newer* origin/main tip (mirrors
-    // `wt switch --create feature --base origin/main`) with one real commit.
+/// Add a `feature` worktree branched from `base`, with commits for the given
+/// (file, message) pairs.
+fn add_feature_worktree(
+    repo: &TestRepo,
+    base: &str,
+    commits: &[(&str, &str)],
+) -> std::path::PathBuf {
     let feature_wt = repo.root_path().parent().unwrap().join("repo.feature");
     repo.run_git(&[
         "worktree",
@@ -4459,16 +4449,211 @@ fn test_merge_refuses_stale_local_default_behind_upstream(
         "-b",
         "feature",
         feature_wt.to_str().unwrap(),
-        "origin/main",
+        base,
     ]);
-    fs::write(feature_wt.join("feature.txt"), "feature").unwrap();
-    repo.run_git_in(&feature_wt, &["add", "feature.txt"]);
-    repo.run_git_in(
-        &feature_wt,
-        &["commit", "-m", "the one real feature commit"],
+    for (file, msg) in commits {
+        fs::write(feature_wt.join(file), "feature").unwrap();
+        repo.run_git_in(&feature_wt, &["add", file]);
+        repo.run_git_in(&feature_wt, &["commit", "-m", msg]);
+    }
+    feature_wt
+}
+
+/// #3519: `wt merge` from a branch based on origin/main, with the primary's
+/// local main left behind it, measures the squash against the *upstream* — so
+/// only the branch's own commits fold — and the final fast-forward carries
+/// local main through the upstream commits by their real SHAs.
+///
+/// Contrast with `test_merge_removes_branch_when_local_main_diverged_from_upstream`:
+/// there the feature forks from the *shared base*, so the span is only the
+/// feature's own commit and the merge proceeds against the local ref unchanged.
+#[rstest]
+fn test_merge_carries_stale_local_main_through_upstream(#[from(repo_with_remote)] repo: TestRepo) {
+    setup_stale_local_main(&repo);
+    let upstream_tip = repo.git_output(&["rev-parse", "origin/main"]);
+    // Two feature commits so the squash step actually rewrites (one commit
+    // takes the AlreadySingleCommit early-out).
+    let feature_wt = add_feature_worktree(
+        &repo,
+        "origin/main",
+        &[
+            ("feature-1.txt", "feature commit one"),
+            ("feature-2.txt", "feature commit two"),
+        ],
     );
 
-    // Merge must fail rather than fold the two upstream commits into main.
+    let output = repo
+        .wt_command()
+        .args(["merge", "main", "--yes", "--no-hooks", "--no-remove"])
+        .current_dir(&feature_wt)
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "merge must carry a stale local main through its upstream\nstderr:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("2 commits behind"),
+        "merge should announce the carry\nstderr:\n{stderr}",
+    );
+
+    // The squash folded only the branch's own commits: the merged tip sits
+    // directly on the origin/main tip and its message names no upstream PR.
+    assert_eq!(
+        repo.git_output(&["rev-parse", "main^"]),
+        upstream_tip,
+        "squash commit must sit on the origin/main tip",
+    );
+    let tip_message = repo.git_output(&["log", "-1", "--format=%B", "main"]);
+    assert!(
+        tip_message.contains("feature commit one") && !tip_message.contains("Upstream PR"),
+        "squash must fold only the branch's own commits\nmessage:\n{tip_message}",
+    );
+    // The upstream commits arrived by their real SHAs — main descends from
+    // origin/main instead of duplicating its content.
+    assert!(
+        repo.git_command()
+            .args(["merge-base", "--is-ancestor", "origin/main", "main"])
+            .run()
+            .unwrap()
+            .status
+            .success(),
+        "origin/main must be an ancestor of the merged main",
+    );
+}
+
+/// #3519 (standalone step): `wt step squash` measures against the target's
+/// upstream when the local target ref is stale, folding only the branch's own
+/// commits — and never touches the target ref at all.
+#[rstest]
+fn test_step_squash_measures_against_upstream_when_local_main_stale(
+    #[from(repo_with_remote)] repo: TestRepo,
+) {
+    setup_stale_local_main(&repo);
+    let stale_main = repo.git_output(&["rev-parse", "main"]);
+    let upstream_tip = repo.git_output(&["rev-parse", "origin/main"]);
+    let feature_wt = add_feature_worktree(
+        &repo,
+        "origin/main",
+        &[
+            ("feature-1.txt", "feature commit one"),
+            ("feature-2.txt", "feature commit two"),
+        ],
+    );
+
+    let output = repo
+        .wt_command()
+        .args(["step", "squash", "main", "--yes", "--no-hooks"])
+        .current_dir(&feature_wt)
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "step squash must succeed against the upstream span\nstderr:\n{stderr}",
+    );
+
+    // Only the branch's own commits folded: the squash sits on the origin/main
+    // tip, and no upstream commit was swept into it.
+    assert_eq!(
+        repo.git_output(&["rev-parse", "feature^"]),
+        upstream_tip,
+        "squash commit must sit on the origin/main tip",
+    );
+    let tip_message = repo.git_output(&["log", "-1", "--format=%B", "feature"]);
+    assert!(
+        tip_message.contains("feature commit two") && !tip_message.contains("Upstream PR"),
+        "squash must fold only the branch's own commits\nmessage:\n{tip_message}",
+    );
+    // A standalone squash rewrites the branch only — the target ref is not its
+    // business.
+    assert_eq!(
+        repo.git_output(&["rev-parse", "main"]),
+        stale_main,
+        "step squash must never move the target ref",
+    );
+}
+
+/// #3519 (standalone step): `wt step rebase` with a stale local target rebases
+/// onto the target's *upstream*, replaying only the branch's own commits.
+/// Rebasing onto the stale local ref would replay the upstream commits too,
+/// duplicating them under new SHAs.
+#[rstest]
+fn test_step_rebase_targets_upstream_when_local_main_stale(
+    #[from(repo_with_remote)] repo: TestRepo,
+) {
+    setup_stale_local_main(&repo);
+    let stale_main = repo.git_output(&["rev-parse", "main"]);
+    // A branch forked from the *old* local main tip that then merged
+    // origin/main — non-linear history whose local-main span contains the
+    // upstream commits, so the rebase step actually rewrites.
+    let feature_wt = add_feature_worktree(
+        &repo,
+        "main",
+        &[("feature.txt", "the one real feature commit")],
+    );
+    repo.run_git_in(&feature_wt, &["merge", "--no-edit", "origin/main"]);
+
+    let output = repo
+        .wt_command()
+        .args(["step", "rebase", "main"])
+        .current_dir(&feature_wt)
+        .output()
+        .unwrap();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        output.status.success(),
+        "step rebase must succeed onto the upstream\nstderr:\n{stderr}",
+    );
+    assert!(
+        stderr.contains("origin/main"),
+        "rebase should name the upstream it targeted\nstderr:\n{stderr}",
+    );
+
+    // The upstream commits stay by their real SHAs (origin/main is an
+    // ancestor), the merge commit is linearized away, and the local target ref
+    // is untouched.
+    assert!(
+        repo.git_command()
+            .args(["merge-base", "--is-ancestor", "origin/main", "feature"])
+            .run()
+            .unwrap()
+            .status
+            .success(),
+        "origin/main must be an ancestor of the rebased branch",
+    );
+    assert_eq!(
+        repo.git_output(&["rev-list", "--merges", "--count", "feature"]),
+        "0",
+        "rebase must linearize the branch",
+    );
+    assert_eq!(
+        repo.git_output(&["rev-parse", "main"]),
+        stale_main,
+        "step rebase must never move the target ref",
+    );
+}
+
+/// #3519: a local target that has *diverged* from its upstream — its own
+/// commits and behind — can never fast-forward to a branch based on the
+/// upstream. The merge refuses up front, mutating nothing.
+#[rstest]
+fn test_merge_refuses_diverged_target_when_branch_based_on_upstream(
+    #[from(repo_with_remote)] repo: TestRepo,
+) {
+    setup_stale_local_main(&repo);
+    // Give local main its own commit so it diverges from origin/main.
+    fs::write(repo.root_path().join("local-only.txt"), "local").unwrap();
+    repo.run_git(&["add", "local-only.txt"]);
+    repo.run_git(&["commit", "-m", "local-only commit on main"]);
+    let diverged_main = repo.git_output(&["rev-parse", "main"]);
+    let feature_wt = add_feature_worktree(
+        &repo,
+        "origin/main",
+        &[("feature.txt", "the one real feature commit")],
+    );
+
     let output = repo
         .wt_command()
         .args(["merge", "main", "--yes", "--no-hooks"])
@@ -4478,20 +4663,17 @@ fn test_merge_refuses_stale_local_default_behind_upstream(
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
         !output.status.success(),
-        "merge must refuse a stale local default branch\nstderr:\n{stderr}",
+        "merge must refuse a diverged local target\nstderr:\n{stderr}",
     );
     assert!(
-        stderr.contains("is behind"),
-        "error should explain the stale local target\nstderr:\n{stderr}",
+        stderr.contains("has diverged"),
+        "error should explain the divergence\nstderr:\n{stderr}",
     );
-
-    // The local main ref must be untouched — not fast-forwarded, not squashed.
     assert_eq!(
         repo.git_output(&["rev-parse", "main"]),
-        stale_main,
+        diverged_main,
         "local main must not be mutated by a refused merge",
     );
-    // The feature branch must survive a refused merge (no removal).
     assert!(
         repo.git_command()
             .args(["rev-parse", "--verify", "--quiet", "refs/heads/feature"])

--- a/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
@@ -174,7 +174,7 @@ $ wt merge --no-commit --no-rebase
 
 Use `--no-commit` to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless `--no-rebase` is passed. Combining both flags preserves the exact source graph and requires the target to be its ancestor. Useful after preparing commits manually with `wt step commit`. Requires a clean working tree.
 
-`wt merge` targets the *local* default-branch ref and never fetches. When that ref has fallen behind its upstream — e.g. a primary checkout's `main` left behind `origin/main` — the merge is refused rather than folding already-upstream commits into it. Updating the local branch from its upstream lifts the refusal.
+`wt merge` targets the *local* default-branch ref and never fetches. When that ref lags its upstream — e.g. a primary checkout's `main` left behind `origin/main` — a branch based on the newer upstream tip is measured, squashed, and rebased against the upstream (so already-upstream commits are never folded into the squash), and the final fast-forward carries the local ref through the already-fetched upstream commits by their real SHAs. `wt step squash` and `wt step rebase` measure the same way. A local target that has *diverged* from its upstream — its own commits and behind — cannot fast-forward, so the merge is refused until the target is reconciled.
 
 ## Local CI
 

--- a/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_md_merge.snap
@@ -24,6 +24,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -172,6 +173,8 @@ $ wt merge --no-commit --no-rebase
 8. **Post-remove + post-merge hooks** — Run in background after cleanup.
 
 Use `--no-commit` to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless `--no-rebase` is passed. Combining both flags preserves the exact source graph and requires the target to be its ancestor. Useful after preparing commits manually with `wt step commit`. Requires a clean working tree.
+
+`wt merge` targets the *local* default-branch ref and never fetches. When that ref has fallen behind its upstream — e.g. a primary checkout's `main` left behind `origin/main` — the merge is refused rather than folding already-upstream commits into it. Updating the local branch from its upstream lifts the refusal.
 
 ## Local CI
 

--- a/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
@@ -158,7 +158,8 @@ Preserve the exact clean commit graph and tip:
 
 Use [2m--no-commit[0m to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless [2m--no-rebase[0m is passed. Combining both flags preserves the exact source graph and requires the target to be its ancestor. Useful after preparing commits manually with [2mwt step commit[0m. Requires a clean working tree.
 
-[2mwt merge[0m targets the *local* default-branch ref and never fetches. When that ref has fallen behind its upstream — e.g. a primary checkout's [2mmain[0m left behind [2morigin/main[0m — the merge is refused rather than folding already-upstream commits into it. Updating the local branch from its upstream lifts the refusal.
+[2mwt merge[0m targets the *local* default-branch ref and never fetches. When that ref lags its upstream — e.g. a primary checkout's [2mmain[0m left behind [2morigin/main[0m — a branch based on the newer upstream tip is measured, squashed, and rebased against the upstream (so already-upstream commits are never folded into the squash), and the final fast-forward carries the local ref through the already-fetched upstream commits by their real SHAs. [2mwt step squash[0m and [2mwt step rebase[0m measure the same way. A local 
+target that has *diverged* from its upstream — its own commits and behind — cannot fast-forward, so the merge is refused until the target is reconciled.
 
 [1m[32mLocal CI[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_merge_long.snap
@@ -24,6 +24,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -156,6 +157,8 @@ Preserve the exact clean commit graph and tip:
 8. [1mPost-remove + post-merge hooks[0m — Run in background after cleanup.
 
 Use [2m--no-commit[0m to skip committing uncommitted changes and squashing; rebase still runs by default and can rewrite commits unless [2m--no-rebase[0m is passed. Combining both flags preserves the exact source graph and requires the target to be its ancestor. Useful after preparing commits manually with [2mwt step commit[0m. Requires a clean working tree.
+
+[2mwt merge[0m targets the *local* default-branch ref and never fetches. When that ref has fallen behind its upstream — e.g. a primary checkout's [2mmain[0m left behind [2morigin/main[0m — the merge is refused rather than folding already-upstream commits into it. Updating the local branch from its upstream lifts the refusal.
 
 [1m[32mLocal CI[0m
 


### PR DESCRIPTION
Fixes #3519.

## The bug

`wt merge` resolves its target to the **local** default-branch ref and squashes/rebases the span `merge-base(local-target, HEAD)..HEAD`. When the primary checkout's local `main` is behind `origin/main` **and** the branch descends from the newer `origin/main` tip (e.g. created with `--base origin/main`), that merge-base falls back at the stale local tip, so the span sweeps in every commit already on `origin/main`. The squash folds them into a single commit and the local fast-forward lands it — corrupting the primary checkout's `main` and, if that ref is later pushed, duplicating already-upstream content under new SHAs. Reproduced deterministically before fixing: a 1-commit feature off `origin/main`, with local `main` two commits behind, squashed "3 commits" into a new SHA on local `main` — matching the report.

The same mis-measured span reaches every rewrite entry point: a standalone `wt step squash` folds the upstream commits into the *branch* (the reporter's 1-commit PR becoming 13), and `wt step rebase` replays them onto the stale ref when it fires.

## The fix: measure against the upstream; let the merge carry

One local-only predicate (no fetch — worktrunk is local-first), `Repository::span_upstream`: the target's upstream, returned exactly when the branch's history extends past the local target ref into it — i.e. `merge-base(HEAD, upstream)` is not an ancestor of the local target. The rewrite pipeline responds by *measuring* there instead of guessing from the stale ref:

- **`wt step squash`** (and the squash inside `wt merge`) computes its span, commit count, message, and `reset --soft` base against the upstream — only the branch's own commits fold, and the target ref is never touched. The `--dry-run`/`--show-prompt` previews use the same base.
- **`wt step rebase`** (and the rebase inside `wt merge`) rebases *onto* the upstream, so a non-linear branch replays only its own commits instead of duplicating upstream ones onto the stale ref. In the plain stale topology it no-ops, as before.
- **`wt merge`** announces the situation up front, then completes: the fast-forward carries local `main` through the already-fetched upstream commits by their real SHAs to the result — the same graph a fresh local `main` would have produced:

  ```
  ○ Local main is 2 commits behind origin/main; the merge fast-forwards through them
  ◎ Squashing 2 commits into a single commit (2 files, +2)...
  ✓ Squashed @ 3f2a91c
  ✓ Merged to main (3 commits, 3 files, +3)
  ```

The one refusal left is forced by topology rather than chosen by policy: a target that has **diverged** from its upstream (its own commits *and* behind, with the branch based past it) can never fast-forward in any mode — reconciling the target's own commits is the user's call, so the merge stops before any rewrite or approval prompt:

```
✗ Local main has diverged from origin/main — can't fast-forward to a branch based on origin/main
↳ Reconcile main with origin/main (rebase or merge its local commits), or specify a different target
```

This is the reporter's suggested direction ("use `origin/<default>` as the merge/rebase target"), minus the network: the already-fetched remote-tracking ref is the measurement base, and `wt merge` still never touches the wire. It also extends the rule the rest of worktrunk already applies — `IntegrationTargets` / the preview panes' comparison base treat the upstream as the truth when the local default lags it; the merge pipeline was the one mutating surface that didn't.

Quiet on everything that must keep working: a legitimately-diverged local target with the branch forked from the shared base (the supported offline workflow — existing regression test unchanged), targets with no upstream, orphan branches, and explicit non-branch targets like `wt step squash origin/main`.

## Tests

- `test_merge_carries_stale_local_main_through_upstream` — the #3519 topology end-to-end: merge succeeds, the carry is announced, the squash folds only the branch's own commits and sits directly on the `origin/main` tip, and `origin/main` is an ancestor of the merged `main` (real SHAs, no duplication).
- `test_step_squash_measures_against_upstream_when_local_main_stale` — the standalone squash folds only the branch's own commits and never moves the target ref (this scenario previously corrupted `main` through a squash-then-merge sequence).
- `test_step_rebase_targets_upstream_when_local_main_stale` — a branch that merged `origin/main` in rebases onto the upstream: linearized, real upstream SHAs retained, target ref untouched.
- `test_merge_refuses_diverged_target_when_branch_based_on_upstream` — the forced refusal: nothing mutated, branch survives.
- `test_merge_removes_branch_when_local_main_diverged_from_upstream` (legitimate divergence, branch from shared base) still passes — no regression.

Docs: the merge help page (primary source in `src/cli/mod.rs`) describes the upstream-aware measurement, the carry, and the diverged refusal; generated mirrors and help snapshots regenerated.

> _This was written by Claude Code on behalf of Maximilian_
