### PR TITLE
feat(statusline): make the CI and URL segments clickable in Claude Code

### DIFF
--- a/docs/content/claude-code.md
+++ b/docs/content/claude-code.md
@@ -109,6 +109,8 @@ Claude Code agents can run in isolated worktrees (`isolation: "worktree"`). By d
 
 <code>~/w/myproject.feature-auth  !🤖  @<span style='color:#0a0'>+42</span> <span style='color:#a00'>-8</span>  <span style='color:#0a0'>↑3</span>  <span style='color:#0a0'>⇡1</span>  <span style='color:#0a0'>#3035</span>  Opus  🌔 65%  <span style='color:#a70'>1.4×(10am–3pm)</span></code>
 
+The CI reference (`#3035`) links to its pull request, and a configured [dev server URL](@/list.md) collapses to a clickable `:3000` instead of rendering in full. Both are OSC 8 hyperlinks: underlined and clickable in terminals that support them, plain text everywhere else.
+
 When Claude Code provides context window usage via stdin JSON, a moon phase gauge appears (🌕→🌑 as context fills). A `<n>×(<window>)` segment appears when Claude's 5-hour or weekly rate limit is on track to be hit before reset — `1.4×(10am–3pm)` reads as 1.4× the pace that would exactly fill that window. Its colour deepens with severity — dim, then dim-yellow, then yellow — as more of the window would be spent locked out at the cap, so a fast pace that would only tip over near the reset stays dim. Above 90% used it shows usage instead of pace — `93%(10am–3pm)` — near the cap, how much is left matters more than how fast it's going.
 
 <figure class="demo">

--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -323,7 +323,7 @@ The original bare-array format, and the default while unset:
 | `url` | string | Dev server URL from project config; absent when not configured |
 | `url_active` | boolean | Whether the URL's port is listening; absent when not configured |
 | `summary` | string | LLM-generated branch summary; `--full` only, then absent when not configured or no summary |
-| `statusline` | string | Pre-formatted status with ANSI colors, plus OSC 8 hyperlinks on the PR and URL cells |
+| `statusline` | string | Pre-formatted status with colors and links |
 | `symbols` | string | Raw status symbols without colors (e.g., `"!?↓"`) |
 | `vars` | object | Per-branch variables from [`wt config state vars`](@/config.md#wt-config-state-vars) (absent when empty) |
 | `columns` | object | Rendered [custom column](#custom-columns) values keyed by header; empty cells omitted (absent when none configured) |

--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -283,7 +283,7 @@ Item fields:
 | `dev_server` | `{url, listening}` from the project's `list.url` template |
 | `summary` | LLM branch summary (requires `[list] summary = true`) |
 | `vars` | Per-branch variables from [`wt config state vars`](@/config.md#wt-config-state-vars) |
-| `display` | Rendered strings: `state` (schema 1's `main_state` vocabulary), `symbols`, `statusline` (with ANSI colors), `columns` (custom-column cells keyed by header) |
+| `display` | Rendered strings: `state` (schema 1's `main_state` vocabulary), `symbols`, `statusline` (with ANSI colors and OSC 8 hyperlinks), `columns` (custom-column cells keyed by header) |
 
 Schema 1 names map directly: `commit` → `head`, `working_tree` →
 `worktree.changes`, `main` + `main_state` → `default_branch` +
@@ -323,7 +323,7 @@ The original bare-array format, and the default while unset:
 | `url` | string | Dev server URL from project config; absent when not configured |
 | `url_active` | boolean | Whether the URL's port is listening; absent when not configured |
 | `summary` | string | LLM-generated branch summary; `--full` only, then absent when not configured or no summary |
-| `statusline` | string | Pre-formatted status with ANSI colors |
+| `statusline` | string | Pre-formatted status with ANSI colors, plus OSC 8 hyperlinks on the PR and URL cells |
 | `symbols` | string | Raw status symbols without colors (e.g., `"!?↓"`) |
 | `vars` | object | Per-branch variables from [`wt config state vars`](@/config.md#wt-config-state-vars) (absent when empty) |
 | `columns` | object | Rendered [custom column](#custom-columns) values keyed by header; empty cells omitted (absent when none configured) |

--- a/plugins/worktrunk/skills/worktrunk/reference/claude-code.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/claude-code.md
@@ -111,6 +111,8 @@ Claude Code agents can run in isolated worktrees (`isolation: "worktree"`). By d
 
 <code>~/w/myproject.feature-auth  !🤖  @<span style='color:#0a0'>+42</span> <span style='color:#a00'>-8</span>  <span style='color:#0a0'>↑3</span>  <span style='color:#0a0'>⇡1</span>  <span style='color:#0a0'>#3035</span>  Opus  🌔 65%  <span style='color:#a70'>1.4×(10am–3pm)</span></code>
 
+The CI reference (`#3035`) links to its pull request, and a configured [dev server URL](https://worktrunk.dev/list/) collapses to a clickable `:3000` instead of rendering in full. Both are OSC 8 hyperlinks: underlined and clickable in terminals that support them, plain text everywhere else.
+
 When Claude Code provides context window usage via stdin JSON, a moon phase gauge appears (🌕→🌑 as context fills). A `<n>×(<window>)` segment appears when Claude's 5-hour or weekly rate limit is on track to be hit before reset — `1.4×(10am–3pm)` reads as 1.4× the pace that would exactly fill that window. Its colour deepens with severity — dim, then dim-yellow, then yellow — as more of the window would be spent locked out at the cap, so a fast pace that would only tip over near the reset stays dim. Above 90% used it shows usage instead of pace — `93%(10am–3pm)` — near the cap, how much is left matters more than how fast it's going.
 
 Add to `~/.claude/settings.json`:

--- a/plugins/worktrunk/skills/worktrunk/reference/list.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/list.md
@@ -268,7 +268,7 @@ Item fields:
 | `dev_server` | `{url, listening}` from the project's `list.url` template |
 | `summary` | LLM branch summary (requires `[list] summary = true`) |
 | `vars` | Per-branch variables from [`wt config state vars`](https://worktrunk.dev/config/#wt-config-state-vars) |
-| `display` | Rendered strings: `state` (schema 1's `main_state` vocabulary), `symbols`, `statusline` (with ANSI colors), `columns` (custom-column cells keyed by header) |
+| `display` | Rendered strings: `state` (schema 1's `main_state` vocabulary), `symbols`, `statusline` (with ANSI colors and OSC 8 hyperlinks), `columns` (custom-column cells keyed by header) |
 
 Schema 1 names map directly: `commit` → `head`, `working_tree` →
 `worktree.changes`, `main` + `main_state` → `default_branch` +
@@ -344,7 +344,7 @@ $ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 | `url` | string | Dev server URL from project config; absent when not configured |
 | `url_active` | boolean | Whether the URL's port is listening; absent when not configured |
 | `summary` | string | LLM-generated branch summary; `--full` only, then absent when not configured or no summary |
-| `statusline` | string | Pre-formatted status with ANSI colors |
+| `statusline` | string | Pre-formatted status with ANSI colors, plus OSC 8 hyperlinks on the PR and URL cells |
 | `symbols` | string | Raw status symbols without colors (e.g., `"!?↓"`) |
 | `vars` | object | Per-branch variables from [`wt config state vars`](https://worktrunk.dev/config/#wt-config-state-vars) (absent when empty) |
 | `columns` | object | Rendered [custom column](#custom-columns) values keyed by header; empty cells omitted (absent when none configured) |

--- a/plugins/worktrunk/skills/worktrunk/reference/list.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/list.md
@@ -344,7 +344,7 @@ $ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 | `url` | string | Dev server URL from project config; absent when not configured |
 | `url_active` | boolean | Whether the URL's port is listening; absent when not configured |
 | `summary` | string | LLM-generated branch summary; `--full` only, then absent when not configured or no summary |
-| `statusline` | string | Pre-formatted status with ANSI colors, plus OSC 8 hyperlinks on the PR and URL cells |
+| `statusline` | string | Pre-formatted status with colors and links |
 | `symbols` | string | Raw status symbols without colors (e.g., `"!?↓"`) |
 | `vars` | object | Per-branch variables from [`wt config state vars`](https://worktrunk.dev/config/#wt-config-state-vars) (absent when empty) |
 | `columns` | object | Rendered [custom column](#custom-columns) values keyed by header; empty cells omitted (absent when none configured) |

--- a/skills/worktrunk/reference/claude-code.md
+++ b/skills/worktrunk/reference/claude-code.md
@@ -111,6 +111,8 @@ Claude Code agents can run in isolated worktrees (`isolation: "worktree"`). By d
 
 <code>~/w/myproject.feature-auth  !🤖  @<span style='color:#0a0'>+42</span> <span style='color:#a00'>-8</span>  <span style='color:#0a0'>↑3</span>  <span style='color:#0a0'>⇡1</span>  <span style='color:#0a0'>#3035</span>  Opus  🌔 65%  <span style='color:#a70'>1.4×(10am–3pm)</span></code>
 
+The CI reference (`#3035`) links to its pull request, and a configured [dev server URL](https://worktrunk.dev/list/) collapses to a clickable `:3000` instead of rendering in full. Both are OSC 8 hyperlinks: underlined and clickable in terminals that support them, plain text everywhere else.
+
 When Claude Code provides context window usage via stdin JSON, a moon phase gauge appears (🌕→🌑 as context fills). A `<n>×(<window>)` segment appears when Claude's 5-hour or weekly rate limit is on track to be hit before reset — `1.4×(10am–3pm)` reads as 1.4× the pace that would exactly fill that window. Its colour deepens with severity — dim, then dim-yellow, then yellow — as more of the window would be spent locked out at the cap, so a fast pace that would only tip over near the reset stays dim. Above 90% used it shows usage instead of pace — `93%(10am–3pm)` — near the cap, how much is left matters more than how fast it's going.
 
 Add to `~/.claude/settings.json`:

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -268,7 +268,7 @@ Item fields:
 | `dev_server` | `{url, listening}` from the project's `list.url` template |
 | `summary` | LLM branch summary (requires `[list] summary = true`) |
 | `vars` | Per-branch variables from [`wt config state vars`](https://worktrunk.dev/config/#wt-config-state-vars) |
-| `display` | Rendered strings: `state` (schema 1's `main_state` vocabulary), `symbols`, `statusline` (with ANSI colors), `columns` (custom-column cells keyed by header) |
+| `display` | Rendered strings: `state` (schema 1's `main_state` vocabulary), `symbols`, `statusline` (with ANSI colors and OSC 8 hyperlinks), `columns` (custom-column cells keyed by header) |
 
 Schema 1 names map directly: `commit` → `head`, `working_tree` →
 `worktree.changes`, `main` + `main_state` → `default_branch` +
@@ -344,7 +344,7 @@ $ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 | `url` | string | Dev server URL from project config; absent when not configured |
 | `url_active` | boolean | Whether the URL's port is listening; absent when not configured |
 | `summary` | string | LLM-generated branch summary; `--full` only, then absent when not configured or no summary |
-| `statusline` | string | Pre-formatted status with ANSI colors |
+| `statusline` | string | Pre-formatted status with ANSI colors, plus OSC 8 hyperlinks on the PR and URL cells |
 | `symbols` | string | Raw status symbols without colors (e.g., `"!?↓"`) |
 | `vars` | object | Per-branch variables from [`wt config state vars`](https://worktrunk.dev/config/#wt-config-state-vars) (absent when empty) |
 | `columns` | object | Rendered [custom column](#custom-columns) values keyed by header; empty cells omitted (absent when none configured) |

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -344,7 +344,7 @@ $ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 | `url` | string | Dev server URL from project config; absent when not configured |
 | `url_active` | boolean | Whether the URL's port is listening; absent when not configured |
 | `summary` | string | LLM-generated branch summary; `--full` only, then absent when not configured or no summary |
-| `statusline` | string | Pre-formatted status with ANSI colors, plus OSC 8 hyperlinks on the PR and URL cells |
+| `statusline` | string | Pre-formatted status with colors and links |
 | `symbols` | string | Raw status symbols without colors (e.g., `"!?↓"`) |
 | `vars` | object | Per-branch variables from [`wt config state vars`](https://worktrunk.dev/config/#wt-config-state-vars) (absent when empty) |
 | `columns` | object | Rendered [custom column](#custom-columns) values keyed by header; empty cells omitted (absent when none configured) |

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1024,7 +1024,7 @@ Item fields:
 | `dev_server` | `{url, listening}` from the project's `list.url` template |
 | `summary` | LLM branch summary (requires `[list] summary = true`) |
 | `vars` | Per-branch variables from [`wt config state vars`](@/config.md#wt-config-state-vars) |
-| `display` | Rendered strings: `state` (schema 1's `main_state` vocabulary), `symbols`, `statusline` (with ANSI colors), `columns` (custom-column cells keyed by header) |
+| `display` | Rendered strings: `state` (schema 1's `main_state` vocabulary), `symbols`, `statusline` (with ANSI colors and OSC 8 hyperlinks), `columns` (custom-column cells keyed by header) |
 
 Schema 1 names map directly: `commit` → `head`, `working_tree` →
 `worktree.changes`, `main` + `main_state` → `default_branch` +
@@ -1100,7 +1100,7 @@ $ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 | `url` | string | Dev server URL from project config; absent when not configured |
 | `url_active` | boolean | Whether the URL's port is listening; absent when not configured |
 | `summary` | string | LLM-generated branch summary; `--full` only, then absent when not configured or no summary |
-| `statusline` | string | Pre-formatted status with ANSI colors |
+| `statusline` | string | Pre-formatted status with ANSI colors, plus OSC 8 hyperlinks on the PR and URL cells |
 | `symbols` | string | Raw status symbols without colors (e.g., `"!?↓"`) |
 | `vars` | object | Per-branch variables from [`wt config state vars`](@/config.md#wt-config-state-vars) (absent when empty) |
 | `columns` | object | Rendered [custom column](#custom-columns) values keyed by header; empty cells omitted (absent when none configured) |

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1100,7 +1100,7 @@ $ wt list --format=json --full | jq '.[] | select(.ci.stale) | .branch'
 | `url` | string | Dev server URL from project config; absent when not configured |
 | `url_active` | boolean | Whether the URL's port is listening; absent when not configured |
 | `summary` | string | LLM-generated branch summary; `--full` only, then absent when not configured or no summary |
-| `statusline` | string | Pre-formatted status with ANSI colors, plus OSC 8 hyperlinks on the PR and URL cells |
+| `statusline` | string | Pre-formatted status with colors and links |
 | `symbols` | string | Raw status symbols without colors (e.g., `"!?↓"`) |
 | `vars` | object | Per-branch variables from [`wt config state vars`](@/config.md#wt-config-state-vars) (absent when empty) |
 | `columns` | object | Rendered [custom column](#custom-columns) values keyed by header; empty cells omitted (absent when none configured) |

--- a/src/commands/list/ci_status/mod.rs
+++ b/src/commands/list/ci_status/mod.rs
@@ -529,7 +529,7 @@ impl PrStatus {
     /// `#3035` would be indistinguishable from a conflicted PR.
     ///
     /// When `include_link` is false, the cell is colored but not clickable
-    /// (for environments without OSC 8 hyperlinks, e.g. Claude Code).
+    /// (for renderers that strip OSC 8, e.g. the skim-based picker).
     pub fn format_cell(&self, max_width: usize, include_link: bool) -> String {
         match self.number {
             Some(r) if !matches!(self.ci_status, CiStatus::Error) && r.width() <= max_width => {

--- a/src/commands/list/ci_status/mod.rs
+++ b/src/commands/list/ci_status/mod.rs
@@ -528,8 +528,9 @@ impl PrStatus {
     /// known: Error and Conflicts share the warning color, so a yellow
     /// `#3035` would be indistinguishable from a conflicted PR.
     ///
-    /// When `include_link` is false, the cell is colored but not clickable
-    /// (for renderers that strip OSC 8, e.g. the skim-based picker).
+    /// When `include_link` is false, the cell is colored but not clickable —
+    /// for the `wt list` table on a terminal without OSC 8, and for the picker,
+    /// which strips the sequences.
     pub fn format_cell(&self, max_width: usize, include_link: bool) -> String {
         match self.number {
             Some(r) if !matches!(self.ci_status, CiStatus::Error) && r.width() <= max_width => {

--- a/src/commands/list/layout.rs
+++ b/src/commands/list/layout.rs
@@ -599,10 +599,6 @@ struct PendingColumn<'a> {
     format: ColumnFormat,
 }
 
-/// Estimate URL column width using heuristics.
-///
-/// When hyperlinks are supported, URLs display as `:PORT` (6 chars for 5-digit ports).
-/// Otherwise, estimates full URL width from template structure.
 /// Format the dev-server URL, optionally as an OSC 8 hyperlink.
 ///
 /// A linked cell shows just the port (e.g. `:3000`) — the URL rides inside the
@@ -627,6 +623,10 @@ pub(crate) fn format_url_cell(url: &str, include_link: bool) -> String {
     url.to_string()
 }
 
+/// Estimate URL column width using heuristics.
+///
+/// When hyperlinks are supported, URLs display as `:PORT` (6 chars for 5-digit ports).
+/// Otherwise, estimates full URL width from template structure.
 fn estimate_url_width(url_template: Option<&str>, hyperlinks_supported: bool) -> usize {
     let Some(template) = url_template else {
         return 0;

--- a/src/commands/list/layout.rs
+++ b/src/commands/list/layout.rs
@@ -603,6 +603,30 @@ struct PendingColumn<'a> {
 ///
 /// When hyperlinks are supported, URLs display as `:PORT` (6 chars for 5-digit ports).
 /// Otherwise, estimates full URL width from template structure.
+/// Format the dev-server URL, optionally as an OSC 8 hyperlink.
+///
+/// A linked cell shows just the port (e.g. `:3000`) — the URL rides inside the
+/// escape sequence, so the cell costs the port's width rather than the whole
+/// URL's. Without links, or when the URL carries no parseable port, there is
+/// nowhere to hide the URL, so it renders in full and stays copyable.
+///
+/// Callers pass the decision rather than probing the terminal here: the
+/// statusline's stdout is a pipe to its editor, so `supports_hyperlinks` reports
+/// false there even though the consumer renders OSC 8.
+///
+/// [`estimate_url_width`] budgets the column against this, so the two have to
+/// agree on when a cell collapses to `:port` — hence the adjacency.
+pub(crate) fn format_url_cell(url: &str, include_link: bool) -> String {
+    if include_link && let Some(port) = parse_port_from_url(url) {
+        return format!(
+            "{}:{port}{}",
+            osc8::Hyperlink::new(url),
+            osc8::Hyperlink::END
+        );
+    }
+    url.to_string()
+}
+
 fn estimate_url_width(url_template: Option<&str>, hyperlinks_supported: bool) -> usize {
     let Some(template) = url_template else {
         return 0;

--- a/src/commands/list/model/item.rs
+++ b/src/commands/list/model/item.rs
@@ -469,26 +469,15 @@ impl ListItem {
     /// Format: `branch  status  @working  commits  ^branch_diff  upstream  ci`
     /// Uses 2-space separators between non-empty parts.
     pub fn format_statusline(&self) -> String {
-        self.format_statusline_with_options(true)
-    }
-
-    /// Format this item as a single-line statusline string with link control.
-    ///
-    /// When `include_links` is false, CI indicators are colored but not clickable.
-    /// Used for environments that don't support OSC 8 hyperlinks (e.g., Claude Code).
-    pub fn format_statusline_with_options(&self, include_links: bool) -> String {
         use super::statusline_segment::StatuslineSegment;
-        StatuslineSegment::join(&self.format_statusline_segments(include_links))
+        StatuslineSegment::join(&self.format_statusline_segments())
     }
 
     /// Format this item as prioritized segments for smart truncation.
     ///
     /// Returns segments with priorities matching `wt list` column priorities.
     /// Use [`super::statusline_segment::StatuslineSegment::fit_to_width`] to truncate intelligently.
-    pub fn format_statusline_segments(
-        &self,
-        include_links: bool,
-    ) -> Vec<super::statusline_segment::StatuslineSegment> {
+    pub fn format_statusline_segments(&self) -> Vec<super::statusline_segment::StatuslineSegment> {
         use super::statusline_segment::StatuslineSegment;
 
         let mut segments = Vec::new();
@@ -557,7 +546,7 @@ impl ListItem {
         // bare `#` otherwise (no width cap in the statusline)
         if let Some(Some(ref pr_status)) = self.pr_status {
             segments.push(StatuslineSegment::from_column(
-                pr_status.format_cell(usize::MAX, include_links),
+                pr_status.format_cell(usize::MAX, true),
                 ColumnKind::CiStatus,
             ));
         }
@@ -887,6 +876,44 @@ mod tests {
     fn test_list_item_head() {
         let item = ListItem::new_branch("abc123def".to_string(), "feature".to_string());
         assert_eq!(item.head(), "abc123def");
+    }
+
+    /// The statusline links its CI segment to the PR, and the hidden URL costs
+    /// no visible width — segment priorities budget by rendered columns, so a
+    /// URL counted as width would truncate the line early.
+    #[test]
+    fn test_statusline_ci_segment_links_without_width_cost() {
+        use crate::commands::list::ci_status::{CiSource, CiStatus, PrRef};
+
+        let mut item = ListItem::new_branch("abc123".to_string(), "feature".to_string());
+        item.pr_status = Some(Some(PrStatus {
+            ci_status: CiStatus::Passed,
+            source: CiSource::PullRequest,
+            is_stale: false,
+            is_priming: false,
+            url: Some("https://github.com/owner/repo/pull/123".to_string()),
+            number: Some(PrRef::pr(123)),
+            review_state: None,
+            title: None,
+            body: None,
+            author: None,
+            comment_count: None,
+            updated_at: None,
+        }));
+
+        let ci = item
+            .format_statusline_segments()
+            .into_iter()
+            .find(|s| s.kind == Some(ColumnKind::CiStatus))
+            .expect("CI segment present when a PR is known");
+
+        assert!(
+            ci.content
+                .contains("\x1b]8;;https://github.com/owner/repo/pull/123"),
+            "CI segment should carry an OSC 8 link, got {:?}",
+            ci.content
+        );
+        assert_eq!(ci.width(), "#123".len());
     }
 
     #[test]

--- a/src/commands/list/model/item.rs
+++ b/src/commands/list/model/item.rs
@@ -12,6 +12,7 @@ use super::stats::{AheadBehind, BranchDiffTotals, CommitDetails, UpstreamStatus}
 use super::status_symbols::{StatusSymbols, WorkingTreeStatus};
 use crate::commands::list::ci_status::PrStatus;
 use crate::commands::list::columns::ColumnKind;
+use crate::commands::list::layout::format_url_cell;
 
 /// Compute the `WorktreeState` from `WorktreeData` metadata alone.
 ///
@@ -518,7 +519,7 @@ impl ListItem {
             ));
         }
 
-        // 5. Branch diff vs main (priority 5)
+        // 5. Branch diff vs main (priority 6)
         if let Some(branch_diff) = self.branch_diff()
             && !branch_diff.diff.is_empty()
             && let Some(formatted) = ColumnKind::BranchDiff
@@ -530,7 +531,7 @@ impl ListItem {
             ));
         }
 
-        // 6. Upstream status (priority 7)
+        // 6. Upstream status (priority 8)
         if let Some(ref upstream) = self.upstream
             && let Some(active) = upstream.active()
             && let Some(formatted) =
@@ -542,7 +543,7 @@ impl ListItem {
             ));
         }
 
-        // 7. CI status (priority 9) — PR/MR reference when one exists,
+        // 7. CI status (priority 5) — PR/MR reference when one exists,
         // bare `#` otherwise (no width cap in the statusline)
         if let Some(Some(ref pr_status)) = self.pr_status {
             segments.push(StatuslineSegment::from_column(
@@ -551,10 +552,10 @@ impl ListItem {
             ));
         }
 
-        // 8. URL (priority 8) — the port as a link to the dev server, as in `wt list`
+        // 8. URL (priority 9) — the port as a link to the dev server, as in `wt list`
         if let Some(ref url) = self.url {
             segments.push(StatuslineSegment::from_column(
-                crate::commands::list::render::format_url_cell(url, true),
+                format_url_cell(url, true),
                 ColumnKind::Url,
             ));
         }

--- a/src/commands/list/model/item.rs
+++ b/src/commands/list/model/item.rs
@@ -551,9 +551,12 @@ impl ListItem {
             ));
         }
 
-        // 8. URL (priority 8)
+        // 8. URL (priority 8) — the port as a link to the dev server, as in `wt list`
         if let Some(ref url) = self.url {
-            segments.push(StatuslineSegment::from_column(url.clone(), ColumnKind::Url));
+            segments.push(StatuslineSegment::from_column(
+                crate::commands::list::render::format_url_cell(url, true),
+                ColumnKind::Url,
+            ));
         }
 
         segments

--- a/src/commands/list/render.rs
+++ b/src/commands/list/render.rs
@@ -2,7 +2,7 @@ use crate::display::{format_relative_time_short, shorten_path, truncate_to_width
 use anstyle::{Effects, Style};
 use std::path::Path;
 use unicode_width::UnicodeWidthStr;
-use worktrunk::styling::{Stream, StyledLine, hyperlink_stdout, supports_hyperlinks};
+use worktrunk::styling::{Stream, StyledLine, supports_hyperlinks};
 
 use super::collect::parse_port_from_url;
 use super::columns::{ColumnKind, DiffVariant};
@@ -568,7 +568,7 @@ impl ColumnLayout {
                     return StyledLine::new();
                 };
                 let mut cell = StyledLine::new();
-                let formatted = format_url_cell(url);
+                let formatted = format_url_cell(url, supports_hyperlinks(Stream::Stdout));
                 if item.url_active == Some(true) {
                     cell.push_raw(formatted);
                 } else {
@@ -632,18 +632,24 @@ impl ColumnLayout {
     }
 }
 
-/// Format URL cell with optional hyperlink.
+/// Format the dev-server URL, optionally as an OSC 8 hyperlink.
 ///
-/// When the terminal supports OSC 8 hyperlinks, shows just the port (e.g., `:3000`)
-/// as a clickable link. Otherwise, shows the full URL.
-fn format_url_cell(url: &str) -> String {
-    if supports_hyperlinks(Stream::Stdout) {
-        // Extract port from URL for compact display
-        if let Some(port) = parse_port_from_url(url) {
-            return hyperlink_stdout(url, &format!(":{port}"));
-        }
+/// A linked cell shows just the port (e.g. `:3000`) — the URL rides inside the
+/// escape sequence, so the cell costs the port's width rather than the whole
+/// URL's. Without links there is nowhere to hide the URL, so it renders in
+/// full and stays copyable.
+///
+/// Callers pass the decision rather than probing the terminal here: the
+/// statusline's stdout is a pipe to its editor, so `supports_hyperlinks` reports
+/// false there even though the consumer renders OSC 8.
+pub(crate) fn format_url_cell(url: &str, include_link: bool) -> String {
+    if include_link && let Some(port) = parse_port_from_url(url) {
+        return format!(
+            "{}:{port}{}",
+            osc8::Hyperlink::new(url),
+            osc8::Hyperlink::END
+        );
     }
-    // Fallback: show full URL
     url.to_string()
 }
 

--- a/src/commands/list/render.rs
+++ b/src/commands/list/render.rs
@@ -4,9 +4,8 @@ use std::path::Path;
 use unicode_width::UnicodeWidthStr;
 use worktrunk::styling::{Stream, StyledLine, supports_hyperlinks};
 
-use super::collect::parse_port_from_url;
 use super::columns::{ColumnKind, DiffVariant};
-use super::layout::{ColumnFormat, ColumnLayout, DiffColumnConfig, LayoutConfig};
+use super::layout::{ColumnFormat, ColumnLayout, DiffColumnConfig, LayoutConfig, format_url_cell};
 use super::model::{ItemKind, ListItem, PositionMask};
 
 /// Placeholder glyph for unresolved Status positions — both "still loading" and
@@ -630,27 +629,6 @@ impl ColumnLayout {
             }
         }
     }
-}
-
-/// Format the dev-server URL, optionally as an OSC 8 hyperlink.
-///
-/// A linked cell shows just the port (e.g. `:3000`) — the URL rides inside the
-/// escape sequence, so the cell costs the port's width rather than the whole
-/// URL's. Without links there is nowhere to hide the URL, so it renders in
-/// full and stays copyable.
-///
-/// Callers pass the decision rather than probing the terminal here: the
-/// statusline's stdout is a pipe to its editor, so `supports_hyperlinks` reports
-/// false there even though the consumer renders OSC 8.
-pub(crate) fn format_url_cell(url: &str, include_link: bool) -> String {
-    if include_link && let Some(port) = parse_port_from_url(url) {
-        return format!(
-            "{}:{port}{}",
-            osc8::Hyperlink::new(url),
-            osc8::Hyperlink::END
-        );
-    }
-    url.to_string()
 }
 
 #[cfg(test)]

--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -1207,6 +1207,52 @@ mod tests {
         );
     }
 
+    /// Width fitting must never cut inside the CI segment's OSC 8 sequence:
+    /// `truncate_visible` closes with `\e[0m`, which resets color but leaves a
+    /// hyperlink open, so a split link would make the rest of the terminal
+    /// line clickable. Priority ordering is what prevents it — CI is the
+    /// lowest-priority segment, so it is dropped whole long before the
+    /// highest-priority survivor is character-truncated.
+    #[test]
+    fn test_statusline_fitting_never_splits_the_ci_hyperlink() {
+        use super::super::list::columns::ColumnKind;
+
+        let ci = StatuslineSegment::from_column(
+            format!(
+                "{}#3550{}",
+                osc8::Hyperlink::new("https://github.com/max-sixty/worktrunk/pull/3550"),
+                osc8::Hyperlink::END
+            ),
+            ColumnKind::CiStatus,
+        );
+        let segments = vec![
+            StatuslineSegment::from_column(
+                "statusline-osc8-hyperlinks".to_string(),
+                ColumnKind::Branch,
+            ),
+            ci,
+        ];
+
+        let (mut kept, mut dropped) = (0, 0);
+        for max_width in 1usize..=80 {
+            let fitted =
+                StatuslineSegment::fit_to_width(segments.clone(), max_width.saturating_sub(1));
+            let joined = StatuslineSegment::join(&fitted);
+            let out = truncate_visible(&format!("{} {joined}", anstyle::Reset), max_width);
+
+            // Opener and closer both begin `\e]8;;`, so an intact link
+            // contributes exactly two — an odd count means one was severed.
+            match out.matches("\u{1b}]8;;").count() {
+                2 => kept += 1,
+                0 => dropped += 1,
+                n => panic!("severed hyperlink at width {max_width} ({n} markers): {out:?}"),
+            }
+        }
+
+        // The sweep is only meaningful if it spans both regimes.
+        assert!(kept > 0 && dropped > 0, "kept={kept} dropped={dropped}");
+    }
+
     #[test]
     fn test_statusline_truncation() {
         use color_print::cformat;

--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -770,11 +770,11 @@ pub fn run(format: StatuslineFormat) -> Result<()> {
         None
     };
 
-    // Git status segments (skip links in claude-code mode - OSC 8 not supported)
+    // Git status segments
     if let Ok(repo) = Repository::current()
         && repo.worktree_at(&cwd).git_dir().is_ok()
     {
-        let git_segments = git_status_segments(&repo, &cwd, !claude_code)?;
+        let git_segments = git_status_segments(&repo, &cwd)?;
 
         // In claude-code mode, skip branch segment if directory matches worktrunk template
         let git_segments = if let Some(ref dir) = dir_str {
@@ -990,12 +990,8 @@ fn filter_redundant_branch(segments: Vec<StatuslineSegment>, dir: &str) -> Vec<S
 
 /// Get git status as prioritized segments for the current worktree.
 ///
-/// When `include_links` is true, CI status includes clickable OSC 8 hyperlinks.
-fn git_status_segments(
-    repo: &Repository,
-    cwd: &Path,
-    include_links: bool,
-) -> Result<Vec<StatuslineSegment>> {
+/// CI status renders as a clickable OSC 8 hyperlink to the PR/pipeline URL.
+fn git_status_segments(repo: &Repository, cwd: &Path) -> Result<Vec<StatuslineSegment>> {
     use super::list::columns::ColumnKind;
 
     // Get current worktree info
@@ -1065,7 +1061,7 @@ fn git_status_segments(
     list::populate_item(repo, &mut item, options)?;
 
     // Get prioritized segments
-    let segments = item.format_statusline_segments(include_links);
+    let segments = item.format_statusline_segments();
 
     if segments.is_empty() {
         // Fallback: just show branch name

--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -990,7 +990,7 @@ fn filter_redundant_branch(segments: Vec<StatuslineSegment>, dir: &str) -> Vec<S
 
 /// Get git status as prioritized segments for the current worktree.
 ///
-/// CI status renders as a clickable OSC 8 hyperlink to the PR/pipeline URL.
+/// CI status and the dev-server URL render as clickable OSC 8 hyperlinks.
 fn git_status_segments(repo: &Repository, cwd: &Path) -> Result<Vec<StatuslineSegment>> {
     use super::list::columns::ColumnKind;
 
@@ -1207,15 +1207,24 @@ mod tests {
         );
     }
 
-    /// Width fitting must never cut inside the CI segment's OSC 8 sequence:
-    /// `truncate_visible` closes with `\e[0m`, which resets color but leaves a
-    /// hyperlink open, so a split link would make the rest of the terminal
-    /// line clickable. Priority ordering is what prevents it — CI is the
-    /// lowest-priority segment, so it is dropped whole long before the
-    /// highest-priority survivor is character-truncated.
+    /// Width fitting must never cut inside a linked segment's OSC 8 sequence.
+    /// `truncate_visible` ends its cut with `\e[0m`, which resets colour but
+    /// leaves a hyperlink *open*, so a severed link would make the rest of the
+    /// terminal line clickable.
+    ///
+    /// What rules it out is that the two cuts can't meet. `fit_to_width` drops
+    /// whole segments, worst priority first, and stops at one; character
+    /// truncation only ever reaches that lone survivor, which is always a
+    /// best-priority segment — Directory (0), Branch or Model (1). Every
+    /// link-bearing segment is strictly worse — CI (5), URL (9) — so each is
+    /// dropped entire long before the survivor is cut into.
+    ///
+    /// The sweep covers both, and they leave at different pressures: URL is
+    /// the worst priority in the table, so it goes before CI.
     #[test]
-    fn test_statusline_fitting_never_splits_the_ci_hyperlink() {
+    fn test_statusline_fitting_never_splits_a_hyperlink() {
         use super::super::list::columns::ColumnKind;
+        use super::super::list::layout::format_url_cell;
 
         let ci = StatuslineSegment::from_column(
             format!(
@@ -1225,33 +1234,56 @@ mod tests {
             ),
             ColumnKind::CiStatus,
         );
+        let url = StatuslineSegment::from_column(
+            format_url_cell("http://127.0.0.1:17913", true),
+            ColumnKind::Url,
+        );
         let segments = vec![
             StatuslineSegment::from_column(
                 "statusline-osc8-hyperlinks".to_string(),
                 ColumnKind::Branch,
             ),
             ci,
+            url,
         ];
 
-        let (mut kept, mut dropped) = (0, 0);
-        for max_width in 1usize..=80 {
+        // Count of intact links seen at each width, so the sweep can prove it
+        // exercised every drop stage rather than only the roomy ones.
+        let mut seen_link_counts = std::collections::BTreeSet::new();
+        for max_width in 1usize..=90 {
             let fitted =
                 StatuslineSegment::fit_to_width(segments.clone(), max_width.saturating_sub(1));
             let joined = StatuslineSegment::join(&fitted);
             let out = truncate_visible(&format!("{} {joined}", anstyle::Reset), max_width);
 
-            // Opener and closer both begin `\e]8;;`, so the segment is either
-            // present whole (two markers) or dropped whole (none). Anything
-            // else is a link the cut landed inside.
-            match out.matches("\u{1b}]8;;").count() {
-                2 => kept += 1,
-                0 => dropped += 1,
-                n => panic!("severed hyperlink at width {max_width} ({n} markers): {out:?}"),
+            // Opener and closer both begin `\e]8;;`, so every surviving link
+            // contributes exactly two markers. An odd total is a link the cut
+            // landed inside.
+            let markers = out.matches("\u{1b}]8;;").count();
+            assert_eq!(
+                markers % 2,
+                0,
+                "severed hyperlink at width {max_width} ({markers} markers): {out:?}"
+            );
+            seen_link_counts.insert(markers / 2);
+
+            // When only one link is left it must be CI's: the URL is the
+            // worst priority in the table, so it is the first to go.
+            if markers / 2 == 1 {
+                assert!(
+                    out.contains("/pull/3550") && !out.contains("127.0.0.1"),
+                    "URL should drop before CI, got {out:?}"
+                );
             }
         }
 
-        // The sweep is only meaningful if it spans both regimes.
-        assert!(kept > 0 && dropped > 0, "kept={kept} dropped={dropped}");
+        // Both links, then one, then none — if fitting stopped dropping them
+        // the sweep would silently cover only one regime.
+        assert_eq!(
+            seen_link_counts,
+            [0, 1, 2].into_iter().collect(),
+            "sweep should span every drop stage"
+        );
     }
 
     #[test]

--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -1240,8 +1240,9 @@ mod tests {
             let joined = StatuslineSegment::join(&fitted);
             let out = truncate_visible(&format!("{} {joined}", anstyle::Reset), max_width);
 
-            // Opener and closer both begin `\e]8;;`, so an intact link
-            // contributes exactly two — an odd count means one was severed.
+            // Opener and closer both begin `\e]8;;`, so the segment is either
+            // present whole (two markers) or dropped whole (none). Anything
+            // else is a link the cut landed inside.
             match out.matches("\u{1b}]8;;").count() {
                 2 => kept += 1,
                 0 => dropped += 1,

--- a/src/styling/hyperlink.rs
+++ b/src/styling/hyperlink.rs
@@ -5,15 +5,6 @@ use osc8::Hyperlink;
 // Re-export for direct use
 pub use supports_hyperlinks::{Stream, on as supports_hyperlinks};
 
-/// Format text as a clickable hyperlink for stdout, or return plain text if unsupported.
-pub fn hyperlink_stdout(url: &str, text: &str) -> String {
-    if supports_hyperlinks(Stream::Stdout) {
-        format!("{}{}{}", Hyperlink::new(url), text, Hyperlink::END)
-    } else {
-        text.to_string()
-    }
-}
-
 /// Strip OSC 8 hyperlinks while preserving other ANSI sequences (colors).
 ///
 /// OSC 8 terminal hyperlinks are great for terminal output (clickable links!), but can cause
@@ -63,12 +54,6 @@ pub fn strip_osc8_hyperlinks(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn test_hyperlink_returns_text_when_not_tty() {
-        let result = hyperlink_stdout("https://example.com", "link");
-        assert!(result == "link" || result.contains("https://example.com"));
-    }
 
     #[test]
     fn test_strip_osc8_hyperlinks_removes_hyperlink() {

--- a/src/styling/mod.rs
+++ b/src/styling/mod.rs
@@ -36,7 +36,7 @@ pub use format::{
     wrap_styled_text,
 };
 pub use highlighting::format_toml;
-pub use hyperlink::{Stream, hyperlink_stdout, strip_osc8_hyperlinks, supports_hyperlinks};
+pub use hyperlink::{Stream, strip_osc8_hyperlinks, supports_hyperlinks};
 pub use line::{StyledLine, StyledString, truncate_visible};
 pub use suggest::{suggest_command, suggest_command_in_dir};
 

--- a/tests/integration_tests/statusline.rs
+++ b/tests/integration_tests/statusline.rs
@@ -402,7 +402,7 @@ url = "http://{{ branch }}.localhost:3000"
 
     let output = run_statusline(&repo, &[], None);
     // Shows `?` because writing project config creates uncommitted file
-    assert_snapshot!(output, @"[0m main  [36m?[0m[2m^[22m[2m|[22m  @[32m+2[0m  http://main.localhost:3000");
+    assert_snapshot!(output, @r"[0m main  [36m?[0m[2m^[22m[2m|[22m  @[32m+2[0m  ]8;;http://main.localhost:3000\:3000]8;;\");
 }
 
 #[rstest]
@@ -423,7 +423,7 @@ url = "http://{{ branch }}.localhost:3000"
 
     // Run statusline from feature worktree
     let output = run_statusline_from_dir(&repo, &[], None, &feature_path);
-    assert_snapshot!(output, @"[0m feature  [2m_[22m  http://feature.localhost:3000");
+    assert_snapshot!(output, @r"[0m feature  [2m_[22m  ]8;;http://feature.localhost:3000\:3000]8;;\");
 }
 
 // --- JSON Format Tests ---

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -408,7 +408,7 @@ The original bare-array format, and the default while unset:
  [2murl[0m                string      Dev server URL from project config; absent when not configured                                   
  [2murl_active[0m         boolean     Whether the URL's port is listening; absent when not configured                                  
  [2msummary[0m            string      LLM-generated branch summary; [2m--full[0m only, then absent when not configured or no summary         
- [2mstatusline[0m         string      Pre-formatted status with ANSI colors, plus OSC 8 hyperlinks on the PR and URL cells             
+ [2mstatusline[0m         string      Pre-formatted status with colors and links                                                       
  [2msymbols[0m            string      Raw status symbols without colors (e.g., [2m"!?↓"[0m)                                                  
  [2mvars[0m               object      Per-branch variables from [2mwt config state vars[0m (absent when empty)                               
  [2mcolumns[0m            object      Rendered custom column values keyed by header; empty cells omitted (absent when none configured) 

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -24,6 +24,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -335,7 +336,7 @@ Item fields:
  [2mdev_server[0m     [2m{url, listening}[0m from the project's [2mlist.url[0m template                                                                                                                                                                                                                                                            
  [2msummary[0m        LLM branch summary (requires [2m[list] summary = true[0m)                                                                                                                                                                                                                                                              
  [2mvars[0m           Per-branch variables from [2mwt config state vars[0m                                                                                                                                                                                                                                                                   
- [2mdisplay[0m        Rendered strings: [2mstate[0m (schema 1's [2mmain_state[0m vocabulary), [2msymbols[0m, [2mstatusline[0m (with ANSI colors), [2mcolumns[0m (custom-column cells keyed by header)                                                                                                                                                                
+ [2mdisplay[0m        Rendered strings: [2mstate[0m (schema 1's [2mmain_state[0m vocabulary), [2msymbols[0m, [2mstatusline[0m (with ANSI colors and OSC 8 hyperlinks), [2mcolumns[0m (custom-column cells keyed by header)                                                                                                                                           
 
 Schema 1 names map directly: [2mcommit[0m → [2mhead[0m, [2mworking_tree[0m →
 [2mworktree.changes[0m, [2mmain[0m + [2mmain_state[0m → [2mdefault_branch[0m +
@@ -407,7 +408,7 @@ The original bare-array format, and the default while unset:
  [2murl[0m                string      Dev server URL from project config; absent when not configured                                   
  [2murl_active[0m         boolean     Whether the URL's port is listening; absent when not configured                                  
  [2msummary[0m            string      LLM-generated branch summary; [2m--full[0m only, then absent when not configured or no summary         
- [2mstatusline[0m         string      Pre-formatted status with ANSI colors                                                            
+ [2mstatusline[0m         string      Pre-formatted status with ANSI colors, plus OSC 8 hyperlinks on the PR and URL cells             
  [2msymbols[0m            string      Raw status symbols without colors (e.g., [2m"!?↓"[0m)                                                  
  [2mvars[0m               object      Per-branch variables from [2mwt config state vars[0m (absent when empty)                               
  [2mcolumns[0m            object      Rendered custom column values keyed by header; empty cells omitted (absent when none configured) 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -24,6 +24,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -420,8 +421,8 @@ Item fields:
  [2msummary[0m LLM branch summary (requires [2m[list] summary = true[0m)                    
  [2mvars[0m    Per-branch variables from [2mwt config state vars[0m                         
  [2mdisplay[0m Rendered strings: [2mstate[0m (schema 1's [2mmain_state[0m vocabulary), [2msymbols[0m,   
-         [2mstatusline[0m (with ANSI colors), [2mcolumns[0m (custom-column cells keyed by   
-         header)                                                                
+         [2mstatusline[0m (with ANSI colors and OSC 8 hyperlinks), [2mcolumns[0m            
+         (custom-column cells keyed by header)                                  
 
 Schema 1 names map directly: [2mcommit[0m → [2mhead[0m, [2mworking_tree[0m →
 [2mworktree.changes[0m, [2mmain[0m + [2mmain_state[0m → [2mdefault_branch[0m +
@@ -476,46 +477,46 @@ The original bare-array format, and the default while unset:
 
 [1mFields:[0m
 
-      Field         Type                        Description                     
- ─────────────── ─────────── ────────────────────────────────────────────────── 
- [2mbranch[0m          string/null Branch name (null for detached HEAD)               
- [2mpath[0m            string      Worktree path (absent for branches without         
-                             worktrees)                                         
- [2mkind[0m            string      [2m"worktree"[0m or [2m"branch"[0m                             
- [2mcommit[0m          object      Commit info (see below)                            
- [2mworking_tree[0m    object      Working tree state (see below)                     
- [2mmain_state[0m      string      Relation to the default branch (see below)         
- [2mintegration_rea[0m string      Why branch is integrated (see below)               
- [2mson[0m                                                                            
- [2moperation_state[0m string      [2m"conflicts"[0m, [2m"rebase"[0m, or [2m"merge"[0m (see Worktree);  
-                             absent when clean                                  
- [2mmain[0m            object      Relationship to the default branch (see below);    
-                             absent when is_main                                
- [2mremote[0m          object      Tracking branch info (see below); absent when no   
-                             tracking                                           
- [2mworktree[0m        object      Worktree metadata (see below)                      
- [2mis_main[0m         boolean     Is the main worktree                               
- [2mis_current[0m      boolean     Is the current worktree                            
- [2mis_previous[0m     boolean     Previous worktree from wt switch                   
- [2mci[0m              object      CI status (see below); [2m--full[0m only, then absent    
-                             when no PR/MR or branch workflow                   
- [2mrepo_url[0m        string      Repository web URL derived from the primary        
-                             remote; absent when the remote URL cannot be       
-                             parsed                                             
- [2mrepo[0m            object      Structured repository metadata (see below);        
-                             includes [2mremote[0m                                    
- [2murl[0m             string      Dev server URL from project config; absent when    
-                             not configured                                     
- [2murl_active[0m      boolean     Whether the URL's port is listening; absent when   
-                             not configured                                     
- [2msummary[0m         string      LLM-generated branch summary; [2m--full[0m only, then    
-                             absent when not configured or no summary           
- [2mstatusline[0m      string      Pre-formatted status with ANSI colors              
- [2msymbols[0m         string      Raw status symbols without colors (e.g., [2m"!?↓"[0m)    
- [2mvars[0m            object      Per-branch variables from [2mwt config state vars[0m     
-                             (absent when empty)                                
- [2mcolumns[0m         object      Rendered custom column values keyed by header;     
-                             empty cells omitted (absent when none configured)  
+     Field        Type                         Description                      
+ ───────────── ─────────── ──────────────────────────────────────────────────── 
+ [2mbranch[0m        string/null Branch name (null for detached HEAD)                 
+ [2mpath[0m          string      Worktree path (absent for branches without           
+                           worktrees)                                           
+ [2mkind[0m          string      [2m"worktree"[0m or [2m"branch"[0m                               
+ [2mcommit[0m        object      Commit info (see below)                              
+ [2mworking_tree[0m  object      Working tree state (see below)                       
+ [2mmain_state[0m    string      Relation to the default branch (see below)           
+ [2mintegration_r[0m string      Why branch is integrated (see below)                 
+ [2meason[0m                                                                          
+ [2moperation_sta[0m string      [2m"conflicts"[0m, [2m"rebase"[0m, or [2m"merge"[0m (see Worktree);    
+ [2mte[0m                        absent when clean                                    
+ [2mmain[0m          object      Relationship to the default branch (see below);      
+                           absent when is_main                                  
+ [2mremote[0m        object      Tracking branch info (see below); absent when no     
+                           tracking                                             
+ [2mworktree[0m      object      Worktree metadata (see below)                        
+ [2mis_main[0m       boolean     Is the main worktree                                 
+ [2mis_current[0m    boolean     Is the current worktree                              
+ [2mis_previous[0m   boolean     Previous worktree from wt switch                     
+ [2mci[0m            object      CI status (see below); [2m--full[0m only, then absent when 
+                           no PR/MR or branch workflow                          
+ [2mrepo_url[0m      string      Repository web URL derived from the primary remote;  
+                           absent when the remote URL cannot be parsed          
+ [2mrepo[0m          object      Structured repository metadata (see below); includes 
+                           [2mremote[0m                                               
+ [2murl[0m           string      Dev server URL from project config; absent when not  
+                           configured                                           
+ [2murl_active[0m    boolean     Whether the URL's port is listening; absent when not 
+                           configured                                           
+ [2msummary[0m       string      LLM-generated branch summary; [2m--full[0m only, then      
+                           absent when not configured or no summary             
+ [2mstatusline[0m    string      Pre-formatted status with ANSI colors, plus OSC 8    
+                           hyperlinks on the PR and URL cells                   
+ [2msymbols[0m       string      Raw status symbols without colors (e.g., [2m"!?↓"[0m)      
+ [2mvars[0m          object      Per-branch variables from [2mwt config state vars[0m       
+                           (absent when empty)                                  
+ [2mcolumns[0m       object      Rendered custom column values keyed by header; empty 
+                           cells omitted (absent when none configured)          
 
 [32mCommit object[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -477,46 +477,46 @@ The original bare-array format, and the default while unset:
 
 [1mFields:[0m
 
-     Field        Type                         Description                      
- ───────────── ─────────── ──────────────────────────────────────────────────── 
- [2mbranch[0m        string/null Branch name (null for detached HEAD)                 
- [2mpath[0m          string      Worktree path (absent for branches without           
-                           worktrees)                                           
- [2mkind[0m          string      [2m"worktree"[0m or [2m"branch"[0m                               
- [2mcommit[0m        object      Commit info (see below)                              
- [2mworking_tree[0m  object      Working tree state (see below)                       
- [2mmain_state[0m    string      Relation to the default branch (see below)           
- [2mintegration_r[0m string      Why branch is integrated (see below)                 
- [2meason[0m                                                                          
- [2moperation_sta[0m string      [2m"conflicts"[0m, [2m"rebase"[0m, or [2m"merge"[0m (see Worktree);    
- [2mte[0m                        absent when clean                                    
- [2mmain[0m          object      Relationship to the default branch (see below);      
-                           absent when is_main                                  
- [2mremote[0m        object      Tracking branch info (see below); absent when no     
-                           tracking                                             
- [2mworktree[0m      object      Worktree metadata (see below)                        
- [2mis_main[0m       boolean     Is the main worktree                                 
- [2mis_current[0m    boolean     Is the current worktree                              
- [2mis_previous[0m   boolean     Previous worktree from wt switch                     
- [2mci[0m            object      CI status (see below); [2m--full[0m only, then absent when 
-                           no PR/MR or branch workflow                          
- [2mrepo_url[0m      string      Repository web URL derived from the primary remote;  
-                           absent when the remote URL cannot be parsed          
- [2mrepo[0m          object      Structured repository metadata (see below); includes 
-                           [2mremote[0m                                               
- [2murl[0m           string      Dev server URL from project config; absent when not  
-                           configured                                           
- [2murl_active[0m    boolean     Whether the URL's port is listening; absent when not 
-                           configured                                           
- [2msummary[0m       string      LLM-generated branch summary; [2m--full[0m only, then      
-                           absent when not configured or no summary             
- [2mstatusline[0m    string      Pre-formatted status with ANSI colors, plus OSC 8    
-                           hyperlinks on the PR and URL cells                   
- [2msymbols[0m       string      Raw status symbols without colors (e.g., [2m"!?↓"[0m)      
- [2mvars[0m          object      Per-branch variables from [2mwt config state vars[0m       
-                           (absent when empty)                                  
- [2mcolumns[0m       object      Rendered custom column values keyed by header; empty 
-                           cells omitted (absent when none configured)          
+      Field         Type                        Description                     
+ ─────────────── ─────────── ────────────────────────────────────────────────── 
+ [2mbranch[0m          string/null Branch name (null for detached HEAD)               
+ [2mpath[0m            string      Worktree path (absent for branches without         
+                             worktrees)                                         
+ [2mkind[0m            string      [2m"worktree"[0m or [2m"branch"[0m                             
+ [2mcommit[0m          object      Commit info (see below)                            
+ [2mworking_tree[0m    object      Working tree state (see below)                     
+ [2mmain_state[0m      string      Relation to the default branch (see below)         
+ [2mintegration_rea[0m string      Why branch is integrated (see below)               
+ [2mson[0m                                                                            
+ [2moperation_state[0m string      [2m"conflicts"[0m, [2m"rebase"[0m, or [2m"merge"[0m (see Worktree);  
+                             absent when clean                                  
+ [2mmain[0m            object      Relationship to the default branch (see below);    
+                             absent when is_main                                
+ [2mremote[0m          object      Tracking branch info (see below); absent when no   
+                             tracking                                           
+ [2mworktree[0m        object      Worktree metadata (see below)                      
+ [2mis_main[0m         boolean     Is the main worktree                               
+ [2mis_current[0m      boolean     Is the current worktree                            
+ [2mis_previous[0m     boolean     Previous worktree from wt switch                   
+ [2mci[0m              object      CI status (see below); [2m--full[0m only, then absent    
+                             when no PR/MR or branch workflow                   
+ [2mrepo_url[0m        string      Repository web URL derived from the primary        
+                             remote; absent when the remote URL cannot be       
+                             parsed                                             
+ [2mrepo[0m            object      Structured repository metadata (see below);        
+                             includes [2mremote[0m                                    
+ [2murl[0m             string      Dev server URL from project config; absent when    
+                             not configured                                     
+ [2murl_active[0m      boolean     Whether the URL's port is listening; absent when   
+                             not configured                                     
+ [2msummary[0m         string      LLM-generated branch summary; [2m--full[0m only, then    
+                             absent when not configured or no summary           
+ [2mstatusline[0m      string      Pre-formatted status with colors and links         
+ [2msymbols[0m         string      Raw status symbols without colors (e.g., [2m"!?↓"[0m)    
+ [2mvars[0m            object      Per-branch variables from [2mwt config state vars[0m     
+                             (absent when empty)                                
+ [2mcolumns[0m         object      Rendered custom column values keyed by header;     
+                             empty cells omitted (absent when none configured)  
 
 [32mCommit object[0m
 


### PR DESCRIPTION
The statusline suppressed OSC 8 hyperlinks in Claude Code mode, so its CI segment was colored but not clickable and its dev-server URL printed in full. Claude Code renders OSC 8, so both segments now link the way they already do in `wt list`.

```
 ~/w/worktrunk.statusline-osc8-hyperlinks  ↕|🤖  ↑2 ↓1  ^+93 -24  #3550  :17913  Opus 4.8
                                                                   └link┘  └link┘
```

## Why it was off

The gate dated from 2026-01-02, inside Claude Code's OSC 8 regression window — links worked through 2.0.76, broke around 2.1.3, and got a partial IDE-terminal-only fix in 2.1.42 ([anthropics/claude-code#26356](https://github.com/anthropics/claude-code/issues/26356)). The premise was correct when written and has since expired; that issue was auto-closed for inactivity rather than on a fix, so the tracker understates current support.

## Verification

PTY-captured the raw byte stream from Claude Code 2.1.218, with `TERM_PROGRAM`/`VSCODE_*` stripped so it exercises the standalone-terminal path that was reported broken. Claude Code doesn't strip or blindly pass through — it parses OSC 8 into its frame model, assigns a hyperlink id, and re-emits canonically (normalizing an ST terminator to BEL):

```
PRE ESC]8;id=1l7bqdh;https://example.com/ST-PROBE BEL STLINKTEXT ESC]8;; BEL  MID …
```

It holds in both the normal and alt-screen (`CLAUDE_CODE_NO_FLICKER=1`) render paths, with `FORCE_HYPERLINK` unset. Driving the real `wt` binary through Claude Code end to end yields both links live:

```
LINK: https://github.com/max-sixty/worktrunk/pull/3550
LINK: http://127.0.0.1:17913
```

Degradation is graceful: a terminal or multiplexer that drops OSC 8 shows the same text, just not clickable (tmux only gained OSC 8 in 3.4; zellij and Alacritty support it).

## Shape of the change

With links unconditional for the statusline, the plumbed `include_links` flag had one value, so it collapses into the segment builder. `format_url_cell` likewise takes the link decision from its caller rather than probing the terminal, matching `PrStatus::format_cell` — the statusline's stdout is a pipe, so `supports_hyperlinks` reports false there even though the consumer renders OSC 8. That left `hyperlink_stdout` with no callers, so it goes.

`format_cell` keeps its `include_link` parameter: `wt list` passes the terminal probe, and the picker passes `false` because a `--prs` row never reaches the strip path.

`format_url_cell` moved next to `estimate_url_width`, which budgets the column against it — the two have to agree on when a cell collapses to `:port` and were in separate files.

The URL segment also gets shorter: the URL rides inside the escape sequence, so `http://127.0.0.1:17913` becomes `:17913`, returning 16 columns on a line that budgets by width.

## Safety of the truncation interaction

`truncate_visible` ends its cut with `\e[0m`, which resets colour but leaves an OSC 8 link *open* — a severed link would make the rest of the terminal line clickable, and `ansi_cut` really will sever one if reached.

It can't be reached, because the two cuts never meet: `fit_to_width` drops whole segments worst-priority-first and stops at one, so character truncation only ever lands on a best-priority survivor — Directory (0), Branch or Model (1) — none of which carry escapes beyond SGR. Every link-bearing segment is strictly worse (CI 5, URL 9), so each is dropped entire first.

Reviewing the branch turned up that the numbered comments in `format_statusline_segments` had drifted from `COLUMN_SPECS` — CI was labelled 9 (it is 5) and the URL 8 (it is 9), with branch-diff and upstream also off — and the first version of the test had taken those stale numbers as its specification. The comments are corrected and the test now rests on the invariant above, which doesn't depend on where CI sits. It sweeps widths 1–90 over both links, asserts it spans every drop stage, and pins that the URL goes before CI.

A second test pins that the hidden URL costs no visible width (`ansi_strip` drops OSC 8 for both terminators), so priority budgeting isn't inflated.

## Docs

The Claude Code statusline page now says the segments are clickable — it's the feature's own page and said nothing about it. The `wt list --help` JSON field description gains the links but stays short: an earlier, longer wording shrank the help table's Field column and wrapped two dozen unrelated rows.

## One judgement call worth flagging

`format_statusline_segments` also feeds plain `wt list statusline` (shell prompts) and the JSON `statusline` field. The CI link was already unconditional on both before this change; what's new is that the URL cell renders as a linked `:3000` rather than the full URL, so a consumer that strips OSC 8 sees only `:3000`. The structured `url` / `dev_server.url` field still carries the full URL, and `:3000` still answers "which port", so this reads as the right trade — but it is the one place the collapse to a constant reaches a renderer that isn't Claude Code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> _This was written by Claude Code on behalf of max_
