### PR TITLE
feat(release): sign Windows binaries via SignPath

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -167,9 +167,9 @@ jobs:
         uses: signpath/github-action-submit-signing-request@v2
         with:
           api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
-          organization-id: '9424a34f-9491-47e1-a8a2-e0ff32b2a099'
-          project-slug: 'Worktrunk'
-          signing-policy-slug: 'Test_signing'
+          organization-id: '56bf7020-7661-4b4e-ad77-b627278eaefd'
+          project-slug: 'worktrunk'
+          signing-policy-slug: 'test-signing'
           github-artifact-id: '${{ steps.upload-unsigned-windows-artifact.outputs.artifact-id }}'
           wait-for-completion: true
           output-artifact-directory: 'target/distrib'

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -150,6 +150,35 @@ jobs:
           # Actually do builds and make zips and whatnot
           dist build ${{ needs.plan.outputs.tag-flag }} --print=linkage --output-format=json ${{ matrix.dist_args }} > dist-manifest.json
           echo "dist ran successfully"
+      # SignPath is on a self-signed test certificate while the project's OSS
+      # application is under review, so signing failures are expected and must
+      # not block crates.io/homebrew/winget/AUR publishing.
+      - name: Upload unsigned Windows artifact
+        if: contains(matrix.targets, 'x86_64-pc-windows-msvc')
+        id: upload-unsigned-windows-artifact
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: unsigned-windows-zip
+          path: target/distrib/worktrunk-x86_64-pc-windows-msvc.zip
+      - name: Submit SignPath signing request
+        if: contains(matrix.targets, 'x86_64-pc-windows-msvc') && steps.upload-unsigned-windows-artifact.outcome == 'success'
+        continue-on-error: true
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: '${{ secrets.SIGNPATH_API_TOKEN }}'
+          organization-id: '9424a34f-9491-47e1-a8a2-e0ff32b2a099'
+          project-slug: 'Worktrunk'
+          signing-policy-slug: 'Test_signing'
+          github-artifact-id: '${{ steps.upload-unsigned-windows-artifact.outputs.artifact-id }}'
+          wait-for-completion: true
+          output-artifact-directory: 'target/distrib'
+      - name: Recompute checksum for signed Windows artifact
+        if: contains(matrix.targets, 'x86_64-pc-windows-msvc')
+        shell: bash
+        run: |
+          cd target/distrib
+          sha256sum worktrunk-x86_64-pc-windows-msvc.zip > worktrunk-x86_64-pc-windows-msvc.zip.sha256
       - id: cargo-dist
         name: Post-build
         # We force bash here just because github makes it really hard to get values up


### PR DESCRIPTION
## Summary
- Signs the Windows release zip (`wt.exe` + `git-wt.exe`) via [SignPath](https://signpath.io)'s free OSS code-signing program, using the `test-signing` policy (self-signed test certificate) while the project's Foundation-program application is under review.
- Non-blocking (`continue-on-error`) so a signing hiccup can't take down crates.io/homebrew/winget/AUR publishing.
- Recomputes the `.sha256` checksum after signing, since the signed zip's bytes differ from the unsigned one.
- Uses a dedicated low-privilege `CI builds` SignPath identity (submitter-only), not an admin account.

## Test plan
- [x] `actionlint` clean (only pre-existing shellcheck style warnings elsewhere in the file)
- [x] Artifact configuration (zip containing `wt.exe` + `git-wt.exe`) validated against SignPath's own XML parser and against the real file layout inside a downloaded `v0.68.0` Windows release zip
- [ ] First real Windows build after merge will be the first live signing round-trip through GitHub Actions — watch that release's CI run

> _This was written by Claude Code on behalf of Max_