### PR TITLE
fix(release): preserve signed Windows zip filename, match checksum format

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -173,12 +173,18 @@ jobs:
           github-artifact-id: '${{ steps.upload-unsigned-windows-artifact.outputs.artifact-id }}'
           wait-for-completion: true
           output-artifact-directory: 'target/distrib'
+          # Without this, the action extracts the zip's contents as loose
+          # files instead of saving back the signed zip under its original
+          # name, silently breaking the checksum step and the release upload.
+          skip-decompress: true
       - name: Recompute checksum for signed Windows artifact
         if: contains(matrix.targets, 'x86_64-pc-windows-msvc')
         shell: bash
         run: |
           cd target/distrib
-          sha256sum worktrunk-x86_64-pc-windows-msvc.zip > worktrunk-x86_64-pc-windows-msvc.zip.sha256
+          # -b matches cargo-dist's own checksum format (`<hash> *<filename>`);
+          # sha256sum's default text mode omits the asterisk.
+          sha256sum -b worktrunk-x86_64-pc-windows-msvc.zip > worktrunk-x86_64-pc-windows-msvc.zip.sha256
       - id: cargo-dist
         name: Post-build
         # We force bash here just because github makes it really hard to get values up


### PR DESCRIPTION
## Summary
- The SignPath action's `skip-decompress` defaults to `false`, so it would have extracted the returned zip's contents as loose files into `target/distrib/` instead of saving back a signed `worktrunk-x86_64-pc-windows-msvc.zip`. The checksum step would have silently hashed the still-unsigned zip, and the release would have shipped unsigned Windows binaries with no CI failure to flag it.
- `sha256sum` without `-b` omits the `*` binary-mode marker; cargo-dist's own checksums use `<hash> *<filename>` (confirmed against a real release asset). Added `-b` to match.

Confirmed via `gh run view` on #3553's own CI run that `build-local-artifacts` is skipped on PRs in this repo, so this code path has never actually executed — this is the first real fix before it runs for real on a tagged release.

## Test plan
- [x] `actionlint .github/workflows/release.yaml` — no new warnings (same pre-existing shellcheck style notes as before)
- [x] Verified `skip-decompress` behavior against the action's own `action.yml` input spec
- [x] Verified checksum format against a real downloaded release asset (`v0.68.0`)

> _This was written by Claude Code on behalf of Max_