### PR TITLE
fix(switch): trim redundant Repository rebuilds on the accept path

### DIFF
--- a/src/commands/hook_plan.rs
+++ b/src/commands/hook_plan.rs
@@ -308,6 +308,14 @@ impl ApprovedHookPlan {
         }
     }
 
+    /// True when the plan has no entries for any hook type or anchor — the
+    /// common case (no project hooks configured). Lets a caller skip building
+    /// a render context before finding out `lookup` would return `&[]`
+    /// anyway.
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
     /// The frozen selection for `(hook_type, anchor)`, by exact match.
     ///
     /// Every covered gate anchors at the identical path its executor passes:

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -2162,9 +2162,16 @@ summary = true
         let query = out.query.trim().to_string();
         let identifier = resolve_identifier(&action, query, selected_name)?;
 
-        // Load config — reuse the recovered repo if we recovered earlier.
+        // Rebuild fresh rather than reuse `repo` (whose `OnceCell` worktree/
+        // branch caches were primed at picker startup and never invalidated,
+        // same discipline `spawn`'s `rebuild_repo` doc explains): an in-picker
+        // alt-x/alt-r during this session can have removed or added
+        // worktrees/branches since. `Repository::current()` re-discovers from
+        // cwd, which fails after a deleted-CWD recovery, so the recovered arm
+        // rebuilds via `Repository::at` on the already-recovered discovery
+        // path instead of reusing the stale startup snapshot.
         let repo = if is_recovered {
-            repo.clone()
+            Repository::at(repo.discovery_path()).context("Failed to switch worktree")?
         } else {
             Repository::current().context("Failed to switch worktree")?
         };

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -2162,19 +2162,7 @@ summary = true
         let query = out.query.trim().to_string();
         let identifier = resolve_identifier(&action, query, selected_name)?;
 
-        // Rebuild fresh rather than reuse `repo` (whose `OnceCell` worktree/
-        // branch caches were primed at picker startup and never invalidated,
-        // same discipline `spawn`'s `rebuild_repo` doc explains): an in-picker
-        // alt-x/alt-r during this session can have removed or added
-        // worktrees/branches since. `Repository::current()` re-discovers from
-        // cwd, which fails after a deleted-CWD recovery, so the recovered arm
-        // rebuilds via `Repository::at` on the already-recovered discovery
-        // path instead of reusing the stale startup snapshot.
-        let repo = if is_recovered {
-            Repository::at(repo.discovery_path()).context("Failed to switch worktree")?
-        } else {
-            Repository::current().context("Failed to switch worktree")?
-        };
+        let repo = switch_pipeline_repo(&repo, is_recovered)?;
         // Clone user config out — `SwitchPipeline` takes `&mut UserConfig` (the
         // bare-repo path-fix offer and the shell-integration offer record onto
         // it). Project config is loaded on demand inside the pipeline.
@@ -2494,13 +2482,33 @@ fn resolve_identifier(
     }
 }
 
+/// Select the `Repository` the accept path's `SwitchPipeline` runs against.
+///
+/// Extracted from the picker's accept handler for testability.
+///
+/// Rebuilds fresh rather than reuse `repo` (whose `OnceCell` worktree/branch
+/// caches were primed at picker startup and never invalidated, same
+/// discipline `spawn`'s `rebuild_repo` doc explains): an in-picker alt-x/alt-r
+/// during this session can have removed or added worktrees/branches since.
+/// `Repository::current()` re-discovers from cwd, which fails after a
+/// deleted-CWD recovery, so the recovered arm rebuilds via `Repository::at`
+/// on the already-recovered discovery path instead of reusing the stale
+/// startup snapshot.
+fn switch_pipeline_repo(repo: &Repository, is_recovered: bool) -> anyhow::Result<Repository> {
+    if is_recovered {
+        Repository::at(repo.discovery_path()).context("Failed to switch worktree")
+    } else {
+        Repository::current().context("Failed to switch worktree")
+    }
+}
+
 #[cfg(test)]
 pub mod tests {
     use super::items::{LocalCheckout, LocalContent, PickerRow, worktree_output_token};
     use super::{
         AltXRemover, PickerAction, PickerRemovalTarget, RemovalEffect, drain_stashed_warnings,
         install_preview_tab_keybindings, install_shortcut_keybindings, picker_item_identifier,
-        resolve_identifier, resolve_shortcut_branch, resolve_shortcut_url,
+        resolve_identifier, resolve_shortcut_branch, resolve_shortcut_url, switch_pipeline_repo,
     };
     use crate::commands::list::model::{BranchScope, ItemKind, ListItem, WorktreeData};
     use crate::commands::worktree::RemoveResult;
@@ -2664,6 +2672,47 @@ pub mod tests {
         // Create with empty query is an error
         let result = resolve_identifier(&PickerAction::Create, String::new(), None);
         assert!(result.unwrap_err().to_string().contains("no branch name"));
+    }
+
+    /// `is_recovered=true` must rebuild rather than reuse `repo`: a worktree
+    /// added after `repo`'s `OnceCell` list is primed must be visible through
+    /// the returned `Repository`, and not through the stale one — proving the
+    /// fix actually observes post-mutation state instead of just "not
+    /// panicking".
+    #[test]
+    fn test_switch_pipeline_repo_recovered_rebuilds_fresh() {
+        let test = worktrunk::testing::TestRepo::with_initial_commit();
+        let stale_repo = worktrunk::git::Repository::at(test.path()).unwrap();
+        // Prime the worktree-list cache before the mutation, same as the
+        // picker priming its startup repo.
+        assert!(stale_repo.worktree_for_branch("feature").unwrap().is_none());
+
+        stale_repo
+            .run_command(&[
+                "worktree",
+                "add",
+                "-b",
+                "feature",
+                test.path()
+                    .parent()
+                    .unwrap()
+                    .join("feature")
+                    .to_str()
+                    .unwrap(),
+            ])
+            .unwrap();
+
+        let fresh_repo = switch_pipeline_repo(&stale_repo, true).unwrap();
+        assert!(
+            fresh_repo.worktree_for_branch("feature").unwrap().is_some(),
+            "recovered arm must rebuild fresh so a worktree added after the \
+             startup snapshot was primed is visible"
+        );
+        assert!(
+            stale_repo.worktree_for_branch("feature").unwrap().is_none(),
+            "the startup repo's own cache stays stale, confirming the fix \
+             rebuilds rather than mutates in place"
+        );
     }
 
     /// `from_signal` rejects tokens that carry no usable target: a blank or

--- a/src/commands/worktree/switch.rs
+++ b/src/commands/worktree/switch.rs
@@ -1481,6 +1481,14 @@ fn spawn_switch_background_hooks(
     hooks_display_path: Option<&Path>,
     hook_plan: &ApprovedHookPlan,
 ) -> anyhow::Result<()> {
+    // The common case (no project hooks configured): nothing to render or
+    // announce, so skip building the destination-rooted `Repository` — it
+    // would only be discarded by `HookAnnouncer::flush`'s own no-op-when-empty
+    // check below.
+    if hook_plan.is_empty() {
+        return Ok(());
+    }
+
     // Background hooks run in the new/destination worktree. `hook_repo` roots
     // the *render* context there; the command set is the frozen `hook_plan`
     // (selected at the gate from the invoking worktree's config), so no


### PR DESCRIPTION
## Summary

Follow-up to #3544's `wt switch` review, from investigating why the accept path re-forks `git config --list -z` and rebuilds `Repository` more than necessary.

- Skip the destination-rooted `Repository::at()` in `spawn_switch_background_hooks` when the approved hook plan is empty (the common no-project-hooks case) — `HookAnnouncer::flush()` is already a no-op there, so this changes no behavior, only cost.
- Fix the picker's `is_recovered` accept-path arm, which reused the startup-time `Repository` unconditionally. An in-picker alt-x/alt-r during a recovered session can mutate the worktree/branch inventory, and that arm never rebuilt to see it — the non-recovered arm already gets this via a fresh `Repository::current()`. Rebuild via `Repository::at` (mirrors the picker's own `rebuild_repo` idiom) instead of `Repository::current()`, which fails after a deleted-CWD recovery.
- Replace a misleading comment ("reuse the recovered repo") with the actual freshness rationale.

A fourth change — sharing the bulk config cache across same-process `Repository` instances by `git_common_dir` — was implemented and then reverted: the pre-merge gate's `test_primary_remote_honours_checkout_default_remote` caught a real staleness bug (a config mutation between two `Repository::at()` calls, e.g. from a switch hook, would go unobserved by a cache hit with no invalidation path). Measured idle-repo cost of the remaining duplicated config forks is small (~5-10ms each), and the risk of a bespoke process-wide cache with no write-invalidation wasn't worth it.

## Test plan

- [x] `cargo run -- hook pre-merge --yes` (full test + lint suite): 4483 tests passed
- [x] `cargo clippy --all-targets --features shell-integration-tests -- -D warnings`: clean
- [x] Targeted tests: `git::repository::`, `picker::`, `worktree::switch::`, `hook_plan::`

> _This was written by Claude Code on behalf of Maximilian Roos_