### PR TITLE
docs: TODO deferred merge-stats split and squash-preview coverage

### DIFF
--- a/src/commands/step/squash.rs
+++ b/src/commands/step/squash.rs
@@ -370,6 +370,10 @@ fn preview_squash(target: Option<&str>, dry_run: bool, yes: bool) -> anyhow::Res
 
     let integration_target = repo.require_target_ref(target)?;
     // #3519: preview against the same upstream-aware span the real squash uses.
+    // TODO(#3519 follow-up): unlike `handle_squash`, this path (--dry-run /
+    // --show-prompt) has no test asserting it measures against the stale
+    // target's upstream — a snapshot test pinning the preview output in that
+    // topology would close the one unasserted consumer of `span_upstream`.
     let span_target = repo
         .span_upstream(&integration_target)?
         .unwrap_or(integration_target);

--- a/src/commands/worktree/push.rs
+++ b/src/commands/worktree/push.rs
@@ -124,6 +124,13 @@ impl MergeContext {
         let stash_guard =
             repo.prepare_target_worktree(target_worktree_path.as_ref(), &target_branch)?;
 
+        // TODO(#3519 follow-up): when `target_branch` was behind its upstream
+        // (see `Repository::span_upstream`), this count mixes the carried
+        // fast-forwarded upstream commits in with the branch's own squash
+        // commit, so the success line ("Merged to main (N commits, ...)")
+        // overstates what the branch itself contributed. Splitting them needs
+        // a carried-count threaded through `MergeContext`; deferred as
+        // cosmetic.
         let commit_count = repo.count_commits(&target_branch, "HEAD")?;
 
         let stats_summary = if commit_count > 0 {


### PR DESCRIPTION
## Summary

Follow-ups from #3549 (the stale-local-ref fix, fixing #3519), recorded as inline TODOs rather than a separate tracking issue:

- **`src/commands/worktree/push.rs`**: `MergeContext::prepare`'s `commit_count` mixes carried fast-forwarded upstream commits with the branch's own squash commit when the target was behind its upstream, so the merge success line ("Merged to main (N commits, ...)") overstates the branch's own contribution. Splitting it needs a carried-count threaded through `MergeContext` — deferred as cosmetic.
- **`src/commands/step/squash.rs`**: `preview_squash` (backing `--dry-run`/`--show-prompt`) shares the upstream-measured base with `handle_squash`, but only the mutating path has a test asserting it (`test_step_squash_measures_against_upstream_when_local_main_stale`). A snapshot test pinning the preview output in the same stale topology would close this gap.

No behavior changes — comments only.

## Test plan

- [x] `cargo check`
- [x] `cargo clippy --all-targets`
- [x] `cargo fmt --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> _This was written by Claude Code on behalf of Maximilian Roos_