### PR TITLE
ci: publish to crates.io via trusted publishing

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -25,9 +25,12 @@ Only the repo owner (`@max-sixty`, admin) can merge to `main`.
 
 ## Environment protection
 
-`CARGO_REGISTRY_TOKEN` and `AUR_SSH_PRIVATE_KEY` are in a protected GitHub
-Environment (`release`) requiring deployment approval from `@max-sixty`,
-restricted to `v*` tags.
+`AUR_SSH_PRIVATE_KEY` is in a protected GitHub Environment (`release`) requiring
+deployment approval from `@max-sixty`, restricted to `v*` tags.
+
+crates.io publishing holds no stored token — it uses Trusted Publishing.
+crates.io mints a short-lived one only for an OIDC claim from `release.yaml`
+running in that same `release` environment.
 
 ## Build environment
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -330,18 +330,29 @@ jobs:
 
           gh release create "${{ needs.plan.outputs.tag }}" --target "$RELEASE_COMMIT" $PRERELEASE_FLAG --title "$ANNOUNCEMENT_TITLE" --notes-file "$RUNNER_TEMP/notes.txt" artifacts/*
 
+  # Auth is via crates.io Trusted Publishing (GitHub Actions OIDC): the job mints
+  # a short-lived, auto-revoked token per run instead of a long-lived API token.
+  # This requires a Trusted Publisher to be configured for the crate on
+  # crates.io, scoped to this repo, the `release.yaml` workflow, and the
+  # `release` environment.
   publish-cargo:
     needs:
       - plan
       - host
     runs-on: ubuntu-24.04
     environment: release
+    permissions:
+      contents: read
+      id-token: write
     if: ${{ needs.plan.outputs.publishing == 'true' }}
     steps:
       - uses: actions/checkout@v7
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
       - name: Publish to crates.io
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo publish --package worktrunk
 
   publish-winget:


### PR DESCRIPTION
## What

`publish-cargo` now mints its crates.io credential per run through
`rust-lang/crates-io-auth-action` (GitHub Actions OIDC) instead of reading
the `CARGO_REGISTRY_TOKEN` environment secret. The job gains
`id-token: write` for the OIDC exchange and `contents: read` for checkout,
narrowing it from the workflow-level `contents: write`.

The token lives for about 30 minutes and the action's post step revokes it,
so no long-lived publish credential exists anywhere.

## Why

The stored token expires on a schedule, and each expiry is a silent trap:
nothing breaks until the next release tag, which is exactly when you don't
want to discover it.

## Prerequisite, already in place

A Trusted Publisher is configured for `worktrunk` on crates.io — repository `max-sixty/worktrunk`, workflow `release.yaml`, environment `release`. It had to land before this merge, since otherwise `publish-cargo` would fail at the auth step on the next release tag.

`CARGO_REGISTRY_TOKEN` can be deleted from the `release` environment once a release has gone out this way. `AUR_SSH_PRIVATE_KEY` stays.

> _This was written by Claude Code on behalf of max_
