### PR TITLE
docs(list): render `wt list statusline`'s help on the docs site

### DIFF
--- a/docs/content/claude-code.md
+++ b/docs/content/claude-code.md
@@ -105,13 +105,13 @@ Claude Code agents can run in isolated worktrees (`isolation: "worktree"`). By d
 
 ## Statusline (Claude Code only)
 
-`wt list statusline --format=claude-code` outputs a single-line status for the Claude Code statusline. When the CI status cache is stale, this fetches from the network — typically 1–2 seconds — making it suitable for async statuslines but too slow for synchronous shell prompts. If a faster version would be helpful, please [open an issue](https://github.com/max-sixty/worktrunk/issues).
+`wt list statusline --format=claude-code` outputs a single-line status for the Claude Code statusline. Claude Code runs it in the background, which is what makes the occasional 1–2 second CI fetch invisible.
 
 <code>~/w/myproject.feature-auth  !🤖  @<span style='color:#0a0'>+42</span> <span style='color:#a00'>-8</span>  <span style='color:#0a0'>↑3</span>  <span style='color:#0a0'>⇡1</span>  <span style='color:#0a0'>#3035</span>  Opus  🌔 65%  <span style='color:#a70'>1.4×(10am–3pm)</span></code>
 
-The CI reference (`#3035`) links to its pull request, and a configured [dev server URL](@/list.md) shows as its port — `:3000`, dim until something answers on it. Both links are OSC 8, which Claude Code re-emits to the terminal rather than drawing itself: underlined and clickable where the terminal supports them, the same text unclickable where it doesn't.
+Worktree state comes from the same cells [`wt list`](@/list.md) renders. Claude Code's stdin JSON adds the model, the `🌔 65%` context gauge, and the rate-limit pace notice, where `1.4×(10am–3pm)` reads as 1.4× the pace that would exactly fill that window, coloured by how much of it would be spent locked out at the cap. [`wt list statusline`](@/list.md#wt-list-statusline) documents every segment and the JSON fields behind them.
 
-When Claude Code provides context window usage via stdin JSON, a moon phase gauge appears (🌕→🌑 as context fills). A `<n>×(<window>)` segment appears when Claude's 5-hour or weekly rate limit is on track to be hit before reset — `1.4×(10am–3pm)` reads as 1.4× the pace that would exactly fill that window. Its colour deepens with severity — dim, then dim-yellow, then yellow — as more of the window would be spent locked out at the cap, so a fast pace that would only tip over near the reset stays dim. Above 90% used it shows usage instead of pace — `93%(10am–3pm)` — near the cap, how much is left matters more than how fast it's going.
+The CI reference and the dev server URL are OSC 8 links, which Claude Code re-emits to the terminal rather than drawing itself: underlined and clickable where the terminal supports them, the same text unclickable where it doesn't.
 
 <figure class="demo">
 <picture>

--- a/docs/content/claude-code.md
+++ b/docs/content/claude-code.md
@@ -111,7 +111,7 @@ Claude Code agents can run in isolated worktrees (`isolation: "worktree"`). By d
 
 Worktree state comes from the same cells [`wt list`](@/list.md) renders. Claude Code's stdin JSON adds the model, the `🌔 65%` context gauge, and the rate-limit pace notice, where `1.4×(10am–3pm)` reads as 1.4× the pace that would exactly fill that window, coloured by how much of it would be spent locked out at the cap. [`wt list statusline`](@/list.md#wt-list-statusline) documents every segment and the JSON fields behind them.
 
-The CI reference and the dev server URL are OSC 8 links, which Claude Code re-emits to the terminal rather than drawing itself: underlined and clickable where the terminal supports them, the same text unclickable where it doesn't.
+The CI reference and the dev server URL are clickable links where the terminal supports them, plain text where it doesn't.
 
 <figure class="demo">
 <picture>

--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -441,7 +441,7 @@ Usage: <b><span class=c>wt list</span></b> <span class=c>[OPTIONS]</span>
        <b><span class=c>wt list</span></b> <span class=c>&lt;COMMAND&gt;</span>
 
 <b><span class=g>Commands:</span></b>
-  <b><span class=c>statusline</span></b>  Single-line status for shell prompts
+  <b><span class=c>statusline</span></b>  Single-line status for the current worktree
 
 <b><span class=g>Options:</span></b>
       <b><span class=c>--format</span></b><span class=c> &lt;FORMAT&gt;</span>
@@ -465,6 +465,78 @@ Usage: <b><span class=c>wt list</span></b> <span class=c>[OPTIONS]</span>
           Displays local data (branches, paths, status) first, then updates with remote data (CI,
           upstream) as it arrives. Use --no-progressive to force buffered rendering. Auto-enabled
           for TTY.
+
+  <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
+          Print help (see a summary with &#39;-h&#39;)
+
+<b><span class=g>Global Options:</span></b>
+  <b><span class=c>-C</span></b><span class=c> &lt;path&gt;</span>
+          Working directory for this command
+
+      <b><span class=c>--config</span></b><span class=c> &lt;path&gt;</span>
+          User config file path
+
+      <b><span class=c>--config-set</span></b><span class=c> &lt;toml&gt;</span>
+          Override config with inline TOML, e.g. --config-set list.full=true (repeatable)
+
+  <b><span class=c>-v</span></b>, <b><span class=c>--verbose</span></b><span class=c>...</span>
+          Verbose output (-v: info logs + hook/alias template variables on stderr; -vv: also debug
+          logs and raw subprocess output written to .git/wt/logs/). Set WORKTRUNK_VERBOSE=0|1|2 to
+          apply the same level everywhere — including shell completion, which no flag can reach
+
+  <b><span class=c>-y</span></b>, <b><span class=c>--yes</span></b>
+          Skip approval prompts
+{% end %}
+
+# Subcommands
+
+## wt list statusline
+
+Single-line status for the current worktree.
+
+The line carries the same cells as the worktree's row in `wt list`. A stale CI status cache makes it reach the network for a second or two, so it fits a statusline the host renders in the background — Claude Code's, a `tmux` status bar — better than a prompt the shell blocks on. Want it fast enough for a synchronous prompt? [Open an issue](https://github.com/max-sixty/worktrunk/issues).
+
+### Output formats
+
+- `table` (default): `branch  status  HEAD±  main↕  main…±  Remote⇅  CI  URL`
+- `json`: A one-entry array in the `wt list --format=json` schema
+- `claude-code`: the `table` cells, preceded by `dir` and followed by `model  context  pace`
+
+A cell with nothing to show is left out rather than blanked, so most lines are shorter than that; `claude-code` also drops `branch` where `dir` already ends in `.<branch>`. A line that still overruns the terminal drops whole cells, least important first, starting with the dev server URL.
+
+The CI reference links to its PR/MR, and a dev server URL carrying a port shows as `:3000` linking to the URL in full, dim until something answers on that port. Both links are OSC 8, which a terminal that doesn't support them discards, leaving the same text unclickable.
+
+### Claude Code mode
+
+`--format=claude-code` reads JSON context from stdin (`.workspace.current_dir` is required; the rest are optional):
+
+- `.workspace.current_dir` — working directory
+- `.model.display_name` — model name
+- `.context_window.used_percentage` — context usage (0–100), rendered as `🌔 65%`, the moon waning 🌕→🌑 as context fills
+- `.rate_limits.{five_hour,seven_day}.used_percentage` — rate-limit window usage (0–100)
+- `.rate_limits.{five_hour,seven_day}.resets_at` — window reset time (Unix epoch seconds)
+
+The pace segment appears only when usage is likely to hit a rate limit before its window resets, and shows the higher-risk window: `2.9×(Tue–Tue 5pm)` reads as 2.9× the pace that would exactly fill that window. Above 90% used it shows usage instead of pace — `93%(Tue–Tue 5pm)` — near the cap, how much is left matters more than how fast it's going. "Likely" is a Bayesian forecast; early-window bursts don't trigger it. Its colour deepens with severity — dim, then dim-yellow, then yellow — as the forecast lockout (how much of the window would be spent capped) grows, so a fast pace that would only tip over near the reset stays dim rather than alarming. With `-vv`, each window's inputs and projection are logged to `.git/wt/logs/trace.log`.
+
+[Claude Code statusline setup](@/claude-code.md#statusline-claude-code-only) has the `~/.claude/settings.json` entry that feeds this mode.
+
+### Command reference
+
+{% terminal() %}
+wt list statusline - Single-line status for the current worktree
+
+Usage: <b><span class=c>wt list statusline</span></b> <span class=c>[OPTIONS]</span>
+
+<b><span class=g>Options:</span></b>
+      <b><span class=c>--format</span></b><span class=c> &lt;FORMAT&gt;</span>
+          Output format
+
+          Possible values:
+          - <b><span class=c>table</span></b>
+          - <b><span class=c>json</span></b>
+          - <b><span class=c>claude-code</span></b>: Claude Code statusline mode (reads context from stdin)
+
+          [default: table]
 
   <b><span class=c>-h</span></b>, <b><span class=c>--help</span></b>
           Print help (see a summary with &#39;-h&#39;)

--- a/plugins/worktrunk/skills/worktrunk/reference/claude-code.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/claude-code.md
@@ -113,7 +113,7 @@ Claude Code agents can run in isolated worktrees (`isolation: "worktree"`). By d
 
 Worktree state comes from the same cells [`wt list`](https://worktrunk.dev/list/) renders. Claude Code's stdin JSON adds the model, the `🌔 65%` context gauge, and the rate-limit pace notice, where `1.4×(10am–3pm)` reads as 1.4× the pace that would exactly fill that window, coloured by how much of it would be spent locked out at the cap. [`wt list statusline`](https://worktrunk.dev/list/#wt-list-statusline) documents every segment and the JSON fields behind them.
 
-The CI reference and the dev server URL are OSC 8 links, which Claude Code re-emits to the terminal rather than drawing itself: underlined and clickable where the terminal supports them, the same text unclickable where it doesn't.
+The CI reference and the dev server URL are clickable links where the terminal supports them, plain text where it doesn't.
 
 Add to `~/.claude/settings.json`:
 

--- a/plugins/worktrunk/skills/worktrunk/reference/claude-code.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/claude-code.md
@@ -107,13 +107,13 @@ Claude Code agents can run in isolated worktrees (`isolation: "worktree"`). By d
 
 ## Statusline (Claude Code only)
 
-`wt list statusline --format=claude-code` outputs a single-line status for the Claude Code statusline. When the CI status cache is stale, this fetches from the network — typically 1–2 seconds — making it suitable for async statuslines but too slow for synchronous shell prompts. If a faster version would be helpful, please [open an issue](https://github.com/max-sixty/worktrunk/issues).
+`wt list statusline --format=claude-code` outputs a single-line status for the Claude Code statusline. Claude Code runs it in the background, which is what makes the occasional 1–2 second CI fetch invisible.
 
 <code>~/w/myproject.feature-auth  !🤖  @<span style='color:#0a0'>+42</span> <span style='color:#a00'>-8</span>  <span style='color:#0a0'>↑3</span>  <span style='color:#0a0'>⇡1</span>  <span style='color:#0a0'>#3035</span>  Opus  🌔 65%  <span style='color:#a70'>1.4×(10am–3pm)</span></code>
 
-The CI reference (`#3035`) links to its pull request, and a configured [dev server URL](https://worktrunk.dev/list/) shows as its port — `:3000`, dim until something answers on it. Both links are OSC 8, which Claude Code re-emits to the terminal rather than drawing itself: underlined and clickable where the terminal supports them, the same text unclickable where it doesn't.
+Worktree state comes from the same cells [`wt list`](https://worktrunk.dev/list/) renders. Claude Code's stdin JSON adds the model, the `🌔 65%` context gauge, and the rate-limit pace notice, where `1.4×(10am–3pm)` reads as 1.4× the pace that would exactly fill that window, coloured by how much of it would be spent locked out at the cap. [`wt list statusline`](https://worktrunk.dev/list/#wt-list-statusline) documents every segment and the JSON fields behind them.
 
-When Claude Code provides context window usage via stdin JSON, a moon phase gauge appears (🌕→🌑 as context fills). A `<n>×(<window>)` segment appears when Claude's 5-hour or weekly rate limit is on track to be hit before reset — `1.4×(10am–3pm)` reads as 1.4× the pace that would exactly fill that window. Its colour deepens with severity — dim, then dim-yellow, then yellow — as more of the window would be spent locked out at the cap, so a fast pace that would only tip over near the reset stays dim. Above 90% used it shows usage instead of pace — `93%(10am–3pm)` — near the cap, how much is left matters more than how fast it's going.
+The CI reference and the dev server URL are OSC 8 links, which Claude Code re-emits to the terminal rather than drawing itself: underlined and clickable where the terminal supports them, the same text unclickable where it doesn't.
 
 Add to `~/.claude/settings.json`:
 

--- a/plugins/worktrunk/skills/worktrunk/reference/list.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/list.md
@@ -458,7 +458,7 @@ Usage: wt list [OPTIONS]
        wt list <COMMAND>
 
 Commands:
-  statusline  Single-line status for shell prompts
+  statusline  Single-line status for the current worktree
 
 Options:
       --format <FORMAT>
@@ -482,6 +482,78 @@ Options:
           Displays local data (branches, paths, status) first, then updates with remote data (CI,
           upstream) as it arrives. Use --no-progressive to force buffered rendering. Auto-enabled
           for TTY.
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+Global Options:
+  -C <path>
+          Working directory for this command
+
+      --config <path>
+          User config file path
+
+      --config-set <toml>
+          Override config with inline TOML, e.g. --config-set list.full=true (repeatable)
+
+  -v, --verbose...
+          Verbose output (-v: info logs + hook/alias template variables on stderr; -vv: also debug
+          logs and raw subprocess output written to .git/wt/logs/). Set WORKTRUNK_VERBOSE=0|1|2 to
+          apply the same level everywhere — including shell completion, which no flag can reach
+
+  -y, --yes
+          Skip approval prompts
+```
+
+# Subcommands
+
+## wt list statusline
+
+Single-line status for the current worktree.
+
+The line carries the same cells as the worktree's row in `wt list`. A stale CI status cache makes it reach the network for a second or two, so it fits a statusline the host renders in the background — Claude Code's, a `tmux` status bar — better than a prompt the shell blocks on. Want it fast enough for a synchronous prompt? Open an issue at https://github.com/max-sixty/worktrunk.
+
+### Output formats
+
+- `table` (default): `branch  status  HEAD±  main↕  main…±  Remote⇅  CI  URL`
+- `json`: A one-entry array in the `wt list --format=json` schema
+- `claude-code`: the `table` cells, preceded by `dir` and followed by `model  context  pace`
+
+A cell with nothing to show is left out rather than blanked, so most lines are shorter than that; `claude-code` also drops `branch` where `dir` already ends in `.<branch>`. A line that still overruns the terminal drops whole cells, least important first, starting with the dev server URL.
+
+The CI reference links to its PR/MR, and a dev server URL carrying a port shows as `:3000` linking to the URL in full, dim until something answers on that port. Both links are OSC 8, which a terminal that doesn't support them discards, leaving the same text unclickable.
+
+### Claude Code mode
+
+`--format=claude-code` reads JSON context from stdin (`.workspace.current_dir` is required; the rest are optional):
+
+- `.workspace.current_dir` — working directory
+- `.model.display_name` — model name
+- `.context_window.used_percentage` — context usage (0–100), rendered as `🌔 65%`, the moon waning 🌕→🌑 as context fills
+- `.rate_limits.{five_hour,seven_day}.used_percentage` — rate-limit window usage (0–100)
+- `.rate_limits.{five_hour,seven_day}.resets_at` — window reset time (Unix epoch seconds)
+
+The pace segment appears only when usage is likely to hit a rate limit before its window resets, and shows the higher-risk window: `2.9×(Tue–Tue 5pm)` reads as 2.9× the pace that would exactly fill that window. Above 90% used it shows usage instead of pace — `93%(Tue–Tue 5pm)` — near the cap, how much is left matters more than how fast it's going. "Likely" is a Bayesian forecast; early-window bursts don't trigger it. Its colour deepens with severity — dim, then dim-yellow, then yellow — as the forecast lockout (how much of the window would be spent capped) grows, so a fast pace that would only tip over near the reset stays dim rather than alarming. With `-vv`, each window's inputs and projection are logged to `.git/wt/logs/trace.log`.
+
+[Claude Code statusline setup](https://worktrunk.dev/claude-code/#statusline-claude-code-only) has the `~/.claude/settings.json` entry that feeds this mode.
+
+### Command reference
+
+```
+wt list statusline - Single-line status for the current worktree
+
+Usage: wt list statusline [OPTIONS]
+
+Options:
+      --format <FORMAT>
+          Output format
+
+          Possible values:
+          - table
+          - json
+          - claude-code: Claude Code statusline mode (reads context from stdin)
+
+          [default: table]
 
   -h, --help
           Print help (see a summary with '-h')

--- a/skills/worktrunk/reference/claude-code.md
+++ b/skills/worktrunk/reference/claude-code.md
@@ -113,7 +113,7 @@ Claude Code agents can run in isolated worktrees (`isolation: "worktree"`). By d
 
 Worktree state comes from the same cells [`wt list`](https://worktrunk.dev/list/) renders. Claude Code's stdin JSON adds the model, the `🌔 65%` context gauge, and the rate-limit pace notice, where `1.4×(10am–3pm)` reads as 1.4× the pace that would exactly fill that window, coloured by how much of it would be spent locked out at the cap. [`wt list statusline`](https://worktrunk.dev/list/#wt-list-statusline) documents every segment and the JSON fields behind them.
 
-The CI reference and the dev server URL are OSC 8 links, which Claude Code re-emits to the terminal rather than drawing itself: underlined and clickable where the terminal supports them, the same text unclickable where it doesn't.
+The CI reference and the dev server URL are clickable links where the terminal supports them, plain text where it doesn't.
 
 Add to `~/.claude/settings.json`:
 

--- a/skills/worktrunk/reference/claude-code.md
+++ b/skills/worktrunk/reference/claude-code.md
@@ -107,13 +107,13 @@ Claude Code agents can run in isolated worktrees (`isolation: "worktree"`). By d
 
 ## Statusline (Claude Code only)
 
-`wt list statusline --format=claude-code` outputs a single-line status for the Claude Code statusline. When the CI status cache is stale, this fetches from the network — typically 1–2 seconds — making it suitable for async statuslines but too slow for synchronous shell prompts. If a faster version would be helpful, please [open an issue](https://github.com/max-sixty/worktrunk/issues).
+`wt list statusline --format=claude-code` outputs a single-line status for the Claude Code statusline. Claude Code runs it in the background, which is what makes the occasional 1–2 second CI fetch invisible.
 
 <code>~/w/myproject.feature-auth  !🤖  @<span style='color:#0a0'>+42</span> <span style='color:#a00'>-8</span>  <span style='color:#0a0'>↑3</span>  <span style='color:#0a0'>⇡1</span>  <span style='color:#0a0'>#3035</span>  Opus  🌔 65%  <span style='color:#a70'>1.4×(10am–3pm)</span></code>
 
-The CI reference (`#3035`) links to its pull request, and a configured [dev server URL](https://worktrunk.dev/list/) shows as its port — `:3000`, dim until something answers on it. Both links are OSC 8, which Claude Code re-emits to the terminal rather than drawing itself: underlined and clickable where the terminal supports them, the same text unclickable where it doesn't.
+Worktree state comes from the same cells [`wt list`](https://worktrunk.dev/list/) renders. Claude Code's stdin JSON adds the model, the `🌔 65%` context gauge, and the rate-limit pace notice, where `1.4×(10am–3pm)` reads as 1.4× the pace that would exactly fill that window, coloured by how much of it would be spent locked out at the cap. [`wt list statusline`](https://worktrunk.dev/list/#wt-list-statusline) documents every segment and the JSON fields behind them.
 
-When Claude Code provides context window usage via stdin JSON, a moon phase gauge appears (🌕→🌑 as context fills). A `<n>×(<window>)` segment appears when Claude's 5-hour or weekly rate limit is on track to be hit before reset — `1.4×(10am–3pm)` reads as 1.4× the pace that would exactly fill that window. Its colour deepens with severity — dim, then dim-yellow, then yellow — as more of the window would be spent locked out at the cap, so a fast pace that would only tip over near the reset stays dim. Above 90% used it shows usage instead of pace — `93%(10am–3pm)` — near the cap, how much is left matters more than how fast it's going.
+The CI reference and the dev server URL are OSC 8 links, which Claude Code re-emits to the terminal rather than drawing itself: underlined and clickable where the terminal supports them, the same text unclickable where it doesn't.
 
 Add to `~/.claude/settings.json`:
 

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -458,7 +458,7 @@ Usage: wt list [OPTIONS]
        wt list <COMMAND>
 
 Commands:
-  statusline  Single-line status for shell prompts
+  statusline  Single-line status for the current worktree
 
 Options:
       --format <FORMAT>
@@ -482,6 +482,78 @@ Options:
           Displays local data (branches, paths, status) first, then updates with remote data (CI,
           upstream) as it arrives. Use --no-progressive to force buffered rendering. Auto-enabled
           for TTY.
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+Global Options:
+  -C <path>
+          Working directory for this command
+
+      --config <path>
+          User config file path
+
+      --config-set <toml>
+          Override config with inline TOML, e.g. --config-set list.full=true (repeatable)
+
+  -v, --verbose...
+          Verbose output (-v: info logs + hook/alias template variables on stderr; -vv: also debug
+          logs and raw subprocess output written to .git/wt/logs/). Set WORKTRUNK_VERBOSE=0|1|2 to
+          apply the same level everywhere — including shell completion, which no flag can reach
+
+  -y, --yes
+          Skip approval prompts
+```
+
+# Subcommands
+
+## wt list statusline
+
+Single-line status for the current worktree.
+
+The line carries the same cells as the worktree's row in `wt list`. A stale CI status cache makes it reach the network for a second or two, so it fits a statusline the host renders in the background — Claude Code's, a `tmux` status bar — better than a prompt the shell blocks on. Want it fast enough for a synchronous prompt? Open an issue at https://github.com/max-sixty/worktrunk.
+
+### Output formats
+
+- `table` (default): `branch  status  HEAD±  main↕  main…±  Remote⇅  CI  URL`
+- `json`: A one-entry array in the `wt list --format=json` schema
+- `claude-code`: the `table` cells, preceded by `dir` and followed by `model  context  pace`
+
+A cell with nothing to show is left out rather than blanked, so most lines are shorter than that; `claude-code` also drops `branch` where `dir` already ends in `.<branch>`. A line that still overruns the terminal drops whole cells, least important first, starting with the dev server URL.
+
+The CI reference links to its PR/MR, and a dev server URL carrying a port shows as `:3000` linking to the URL in full, dim until something answers on that port. Both links are OSC 8, which a terminal that doesn't support them discards, leaving the same text unclickable.
+
+### Claude Code mode
+
+`--format=claude-code` reads JSON context from stdin (`.workspace.current_dir` is required; the rest are optional):
+
+- `.workspace.current_dir` — working directory
+- `.model.display_name` — model name
+- `.context_window.used_percentage` — context usage (0–100), rendered as `🌔 65%`, the moon waning 🌕→🌑 as context fills
+- `.rate_limits.{five_hour,seven_day}.used_percentage` — rate-limit window usage (0–100)
+- `.rate_limits.{five_hour,seven_day}.resets_at` — window reset time (Unix epoch seconds)
+
+The pace segment appears only when usage is likely to hit a rate limit before its window resets, and shows the higher-risk window: `2.9×(Tue–Tue 5pm)` reads as 2.9× the pace that would exactly fill that window. Above 90% used it shows usage instead of pace — `93%(Tue–Tue 5pm)` — near the cap, how much is left matters more than how fast it's going. "Likely" is a Bayesian forecast; early-window bursts don't trigger it. Its colour deepens with severity — dim, then dim-yellow, then yellow — as the forecast lockout (how much of the window would be spent capped) grows, so a fast pace that would only tip over near the reset stays dim rather than alarming. With `-vv`, each window's inputs and projection are logged to `.git/wt/logs/trace.log`.
+
+[Claude Code statusline setup](https://worktrunk.dev/claude-code/#statusline-claude-code-only) has the `~/.claude/settings.json` entry that feeds this mode.
+
+### Command reference
+
+```
+wt list statusline - Single-line status for the current worktree
+
+Usage: wt list statusline [OPTIONS]
+
+Options:
+      --format <FORMAT>
+          Output format
+
+          Possible values:
+          - table
+          - json
+          - claude-code: Claude Code statusline mode (reads context from stdin)
+
+          [default: table]
 
   -h, --help
           Print help (see a summary with '-h')

--- a/src/cli/list.rs
+++ b/src/cli/list.rs
@@ -5,14 +5,19 @@ use super::StatuslineFormat;
 /// Subcommands for `wt list`
 #[derive(Subcommand)]
 pub enum ListSubcommand {
-    /// Single-line status for shell prompts
-    #[command(after_long_help = r#"## Output formats
+    /// Single-line status for the current worktree
+    #[command(
+        after_long_help = r#"The line carries the same cells as the worktree's row in `wt list`. A stale CI status cache makes it reach the network for a second or two, so it fits a statusline the host renders in the background — Claude Code's, a `tmux` status bar — better than a prompt the shell blocks on. Want it fast enough for a synchronous prompt? Open an issue at https://github.com/max-sixty/worktrunk.
 
-- `table` (default): `branch  status  ±working  commits  upstream  ci  url`
-- `json`: Same structure as `wt list --format=json` but for the current worktree only
-- `claude-code`: `dir  branch  status  ±working  commits  upstream  ci  url  model  context  pace`
+## Output formats
 
-The CI reference links to its PR/MR, and a dev server URL carrying a port shows as `:3000` linking to the URL in full, dim until something answers on that port — the same cells `wt list` renders. Both links are OSC 8, which a terminal that doesn't support them discards, leaving the same text unclickable.
+- `table` (default): `branch  status  HEAD±  main↕  main…±  Remote⇅  CI  URL`
+- `json`: A one-entry array in the `wt list --format=json` schema
+- `claude-code`: the `table` cells, preceded by `dir` and followed by `model  context  pace`
+
+A cell with nothing to show is left out rather than blanked, so most lines are shorter than that; `claude-code` also drops `branch` where `dir` already ends in `.<branch>`. A line that still overruns the terminal drops whole cells, least important first, starting with the dev server URL.
+
+The CI reference links to its PR/MR, and a dev server URL carrying a port shows as `:3000` linking to the URL in full, dim until something answers on that port. Both links are OSC 8, which a terminal that doesn't support them discards, leaving the same text unclickable.
 
 ## Claude Code mode
 
@@ -20,12 +25,15 @@ The CI reference links to its PR/MR, and a dev server URL carrying a port shows 
 
 - `.workspace.current_dir` — working directory
 - `.model.display_name` — model name
-- `.context_window.used_percentage` — context usage (0–100)
+- `.context_window.used_percentage` — context usage (0–100), rendered as `🌔 65%`, the moon waning 🌕→🌑 as context fills
 - `.rate_limits.{five_hour,seven_day}.used_percentage` — rate-limit window usage (0–100)
 - `.rate_limits.{five_hour,seven_day}.resets_at` — window reset time (Unix epoch seconds)
 
 The pace segment appears only when usage is likely to hit a rate limit before its window resets, and shows the higher-risk window: `2.9×(Tue–Tue 5pm)` reads as 2.9× the pace that would exactly fill that window. Above 90% used it shows usage instead of pace — `93%(Tue–Tue 5pm)` — near the cap, how much is left matters more than how fast it's going. "Likely" is a Bayesian forecast; early-window bursts don't trigger it. Its colour deepens with severity — dim, then dim-yellow, then yellow — as the forecast lockout (how much of the window would be spent capped) grows, so a fast pace that would only tip over near the reset stays dim rather than alarming. With `-vv`, each window's inputs and projection are logged to `.git/wt/logs/trace.log`.
-"#)]
+
+[Claude Code statusline setup](@/claude-code.md#statusline-claude-code-only) has the `~/.claude/settings.json` entry that feeds this mode.
+"#
+    )]
     Statusline {
         /// Output format
         #[arg(long, value_enum, default_value = "table")]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1208,7 +1208,7 @@ Missing a field that would be generally useful? Open an issue at https://github.
 ## See also
 
 - [`wt switch`](@/switch.md) — Switch worktrees or open interactive picker
-"#
+<!-- subdoc: statusline -->"#
     )]
     // TODO: `args_conflicts_with_subcommands` causes confusing errors for unknown
     // subcommands ("cannot be used with --branches") instead of "unknown subcommand".

--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -1,7 +1,8 @@
-//! Statusline output for shell prompts and editors.
+//! Statusline output for hosts that render in the background (Claude Code's
+//! statusline, a `tmux` status bar).
 //!
 //! Outputs a single-line status for the current worktree:
-//! `branch  status  ±working  commits  upstream  [ci]  [url]`
+//! `branch  status  HEAD±  main↕  main…±  Remote⇅  CI  URL`
 //!
 //! This command reuses the data collection infrastructure from `wt list`,
 //! avoiding duplication of git operations.

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -39,7 +39,7 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
        [1m[36mwt list[0m [36m<COMMAND>[0m
 
 [1m[32mCommands:[0m
-  [1m[36mstatusline[0m  Single-line status for shell prompts
+  [1m[36mstatusline[0m  Single-line status for the current worktree
 
 [1m[32mOptions:[0m
       [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -39,7 +39,7 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
        [1m[36mwt list[0m [36m<COMMAND>[0m
 
 [1m[32mCommands:[0m
-  [1m[36mstatusline[0m  Single-line status for shell prompts
+  [1m[36mstatusline[0m  Single-line status for the current worktree
 
 [1m[32mOptions:[0m
       [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m

--- a/tests/snapshots/integration__integration_tests__help__help_list_short.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_short.snap
@@ -24,6 +24,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -38,7 +39,7 @@ Usage: [1m[36mwt list[0m [36m[OPTIONS][0m
        [1m[36mwt list[0m [36m<COMMAND>[0m
 
 [1m[32mCommands:[0m
-  [1m[36mstatusline[0m  Single-line status for shell prompts
+  [1m[36mstatusline[0m  Single-line status for the current worktree
 
 [1m[32mOptions:[0m
       [1m[36m--format[0m[36m [0m[36m<FORMAT>[0m  Output format [default: table] [possible values: table, json]


### PR DESCRIPTION
`wt list statusline`'s `after_long_help` documents the three output formats, the Claude Code stdin JSON contract, and the pace segment, but `wt list`'s help had no `<!-- subdoc: statusline -->` placeholder, so none of it reached `docs/content/list.md` or the skill reference. It was terminal-only.

Adding the placeholder pulls it in as a `wt list statusline` section under `# Subcommands`, matching how `wt step` and `wt config` expose theirs.

## What reading it on the web surfaced

The help text needed edits once it rendered as a page rather than a block below an Options list. A context-blind agent was given the two rendered pages and asked to answer setup questions from them alone; three of its snags were real.

**The format lists were stale and used private names.** They read `branch status ±working commits upstream ci url`, while the Columns table higher up the same page calls those `HEAD±`, `main↕`, `Remote⇅`. They also omitted `main…±`, which `format_statusline_segments` has emitted since that column became a default. The lists now use the column names and include it, and `claude-code` is stated as a delta on `table` rather than repeating it.

**The formats read as a fixed layout.** The example line on the Claude Code page has nine segments against an eleven-name format string, with no explanation. Three rules were in the code and in no doc: empty cells are omitted, `claude-code` drops `branch` when `dir` already ends in `.<branch>` (`filter_redundant_branch`), and an overlong line drops whole cells worst-priority-first (`fit_to_width`). All three are now stated.

**The latency caveat lived only on the Claude Code page.** A reader of the command's own docs had no way to learn it reaches the network. It moves to the reference. That exposed a contradiction with the definition, "Single-line status for shell prompts", against a caveat saying it is too slow for a synchronous prompt — so the definition becomes "Single-line status for the current worktree". This is the one user-visible string change here; it lands in `wt list --help` and the three help snapshots.

## Deduplication with the Claude Code page

The pace paragraph and the OSC 8 paragraph were near-verbatim on both pages, and would have rendered twice on the site. `claude-code.md` keeps what is Claude Code-side (install, demo, the example line, and a plain note that the links degrade to unclickable text where the terminal lacks support) and links to the reference for the rest.

## Follow-ups folded in

The module docstring at `src/commands/statusline.rs:4` carried `±working  commits  upstream`, the last occurrence in the tree of the labels this branch retired, and opened "Statusline output for shell prompts" — the framing the definition dropped. Both now match the help text.

## Not done

An audit of every `after_long_help` in `src/cli/` found 46 that never reach a docs page. Most are editorial calls rather than oversights: `wt config create` alone would embed ~450 lines of example TOML into a page that already covers that ground by hand. The one that looks like a plain oversight is `wt step rebase` / `wt step push`, the only two of twelve step operations without a marker, and the only two the `## Operations` list leaves unlinked. Covering them needs their openers rewritten first, since both currently restate their definition. Left for a follow-up.

Verified with `wt hook pre-merge --yes` (4499 tests) and a `zola build`, which checks internal anchors.

> _This was written by Claude Code on behalf of Maximilian Roos_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

