### PR TITLE
docs(claude-code): link the statusline segment details instead of restating them

### DIFF
--- a/docs/content/claude-code.md
+++ b/docs/content/claude-code.md
@@ -109,9 +109,7 @@ Claude Code agents can run in isolated worktrees (`isolation: "worktree"`). By d
 
 <code>~/w/myproject.feature-auth  !🤖  @<span style='color:#0a0'>+42</span> <span style='color:#a00'>-8</span>  <span style='color:#0a0'>↑3</span>  <span style='color:#0a0'>⇡1</span>  <span style='color:#0a0'>#3035</span>  Opus  🌔 65%  <span style='color:#a70'>1.4×(10am–3pm)</span></code>
 
-Worktree state comes from the same cells [`wt list`](@/list.md) renders. Claude Code's stdin JSON adds the model, the `🌔 65%` context gauge, and the rate-limit pace notice, where `1.4×(10am–3pm)` reads as 1.4× the pace that would exactly fill that window, coloured by how much of it would be spent locked out at the cap. [`wt list statusline`](@/list.md#wt-list-statusline) documents every segment and the JSON fields behind them.
-
-The CI reference and the dev server URL are clickable links where the terminal supports them, plain text where it doesn't.
+Worktree state comes from the same cells [`wt list`](@/list.md) renders; Claude Code's stdin JSON adds the model, the `🌔 65%` context gauge, and the rate-limit pace notice. [`wt list statusline`](@/list.md#wt-list-statusline) documents every segment, how the links behave, and the JSON fields behind them.
 
 <figure class="demo">
 <picture>

--- a/plugins/worktrunk/skills/worktrunk/reference/claude-code.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/claude-code.md
@@ -111,9 +111,7 @@ Claude Code agents can run in isolated worktrees (`isolation: "worktree"`). By d
 
 <code>~/w/myproject.feature-auth  !🤖  @<span style='color:#0a0'>+42</span> <span style='color:#a00'>-8</span>  <span style='color:#0a0'>↑3</span>  <span style='color:#0a0'>⇡1</span>  <span style='color:#0a0'>#3035</span>  Opus  🌔 65%  <span style='color:#a70'>1.4×(10am–3pm)</span></code>
 
-Worktree state comes from the same cells [`wt list`](https://worktrunk.dev/list/) renders. Claude Code's stdin JSON adds the model, the `🌔 65%` context gauge, and the rate-limit pace notice, where `1.4×(10am–3pm)` reads as 1.4× the pace that would exactly fill that window, coloured by how much of it would be spent locked out at the cap. [`wt list statusline`](https://worktrunk.dev/list/#wt-list-statusline) documents every segment and the JSON fields behind them.
-
-The CI reference and the dev server URL are clickable links where the terminal supports them, plain text where it doesn't.
+Worktree state comes from the same cells [`wt list`](https://worktrunk.dev/list/) renders; Claude Code's stdin JSON adds the model, the `🌔 65%` context gauge, and the rate-limit pace notice. [`wt list statusline`](https://worktrunk.dev/list/#wt-list-statusline) documents every segment, how the links behave, and the JSON fields behind them.
 
 Add to `~/.claude/settings.json`:
 

--- a/skills/worktrunk/reference/claude-code.md
+++ b/skills/worktrunk/reference/claude-code.md
@@ -111,9 +111,7 @@ Claude Code agents can run in isolated worktrees (`isolation: "worktree"`). By d
 
 <code>~/w/myproject.feature-auth  !🤖  @<span style='color:#0a0'>+42</span> <span style='color:#a00'>-8</span>  <span style='color:#0a0'>↑3</span>  <span style='color:#0a0'>⇡1</span>  <span style='color:#0a0'>#3035</span>  Opus  🌔 65%  <span style='color:#a70'>1.4×(10am–3pm)</span></code>
 
-Worktree state comes from the same cells [`wt list`](https://worktrunk.dev/list/) renders. Claude Code's stdin JSON adds the model, the `🌔 65%` context gauge, and the rate-limit pace notice, where `1.4×(10am–3pm)` reads as 1.4× the pace that would exactly fill that window, coloured by how much of it would be spent locked out at the cap. [`wt list statusline`](https://worktrunk.dev/list/#wt-list-statusline) documents every segment and the JSON fields behind them.
-
-The CI reference and the dev server URL are clickable links where the terminal supports them, plain text where it doesn't.
+Worktree state comes from the same cells [`wt list`](https://worktrunk.dev/list/) renders; Claude Code's stdin JSON adds the model, the `🌔 65%` context gauge, and the rate-limit pace notice. [`wt list statusline`](https://worktrunk.dev/list/#wt-list-statusline) documents every segment, how the links behave, and the JSON fields behind them.
 
 Add to `~/.claude/settings.json`:
 


### PR DESCRIPTION
The `## Statusline` section of `claude-code.md` paraphrased three facts that the `wt list statusline` reference already owns:

| Fact | `claude-code.md` said | `src/cli/list.rs` says |
|---|---|---|
| Pace maths | "1.4× the pace that would exactly fill that window, coloured by how much of it would be spent locked out at the cap" | "2.9× the pace that would exactly fill that window… colour deepens with severity as the forecast lockout grows" |
| Link degradation | "clickable links where the terminal supports them, plain text where it doesn't" | "Both links are OSC 8, which a terminal that doesn't support them discards" |
| CI fetch latency | "runs it in the background… 1–2 second CI fetch invisible" | "reach the network for a second or two, so it fits a statusline the host renders in the background" |

#3568 removed the near-verbatim copies from this section but left these paraphrases behind, which is arguably the worse state: two wordings of one fact drift apart independently, and a reader can't tell whether they're the same claim or two different ones.

## What stays

The cut isn't to zero. The page shows an example line, so it needs enough gloss for a reader to parse the line in front of them — a bare pointer would make the section a stub. It keeps one sentence naming what the stdin JSON contributes, with "how the links behave" folded into the pointer that was already there.

The latency clause also stays, though it is the third duplicated fact. Without it the opening paragraph only restates the command name, and it is the one "why" that justifies the `settings.json` block below it.

## Side effect

This leaves the `OSC 8` wording in `src/cli/list.rs` as the single home for the link behaviour. A precise term earns its place in an exhaustive `--help` reference and grated on an end-user integration page — so the jargon was really a symptom of the fact living in two places.

Docs-only. Mirrors regenerated by `test_docs_are_in_sync`; `zola build` clean (14 pages, anchors resolve).

> _This was written by Claude Code on behalf of Maximilian Roos_

🤖 Generated with [Claude Code](https://claude.com/claude-code)