### PR TITLE
perf(fsmonitor): resolve all daemons in one lsof spawn

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -22,6 +22,10 @@ ba = "ba"  # Part of commit hashes like e28e0ba
 ede = "ede"  # Part of commit hashes like ede2fd3
 # ANSI escape codes in snapshots make is_main/is_current/is_previous look like "mis"
 mis = "mis"
+# `lsof -F pn` field spec (PID + name) in the fsmonitor sweep; typos maps the
+# lowercase token `pn` to "on", which silently breaks the field request (`on`
+# is offset+name, dropping the `p<pid>` record opener the parser splits on).
+pn = "pn"
 # Intentional typos in tests for "did you mean?" suggestions
 deplyo = "deplyo"
 comit = "comit"

--- a/plugins/worktrunk/skills/worktrunk/reference/troubleshooting.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/troubleshooting.md
@@ -117,7 +117,7 @@ done
 
 Sockets listed as bare `fsmonitor--daemon.ipc` (no resolved path) belong to deleted worktrees. Any `wt remove` cleans these up: it terminates the removed worktree's own daemon and sweeps daemons whose worktree no longer exists, including ones orphaned by `git worktree remove` or `rm -rf` (mechanism details: [What can Worktrunk delete?](https://worktrunk.dev/faq/#what-can-worktrunk-delete)).
 
-The residual case both paths deliberately leave is a wedged daemon on a *live* worktree that is never removed: `git status` in that worktree blocks on the unresponsive IPC, but the daemon still serves a real worktree, so reaping it implicitly is out of scope. Terminate it manually: kill the daemon whose socket path matches the worktree, or `pkill -9 -f 'git fsmonitor--daemon'` and let the next `wt list` respawn the live ones. Disabling fsmonitor globally (`git config --global core.fsmonitor false`) avoids the class of problem entirely at the cost of some `git status` speed on large repos.
+The residual case both paths deliberately leave is a wedged daemon on a *live* worktree that is never removed: `git status` in that worktree blocks on the unresponsive IPC, but the daemon still serves a real worktree, so reaping it implicitly is out of scope. Terminate it manually: kill the daemon whose socket path matches the worktree, or `pkill -9 -f 'git fsmonitor--daemon'` and let the next `wt list` respawn the live ones.
 
 ## PowerShell on Windows
 

--- a/skills/worktrunk/reference/troubleshooting.md
+++ b/skills/worktrunk/reference/troubleshooting.md
@@ -117,7 +117,7 @@ done
 
 Sockets listed as bare `fsmonitor--daemon.ipc` (no resolved path) belong to deleted worktrees. Any `wt remove` cleans these up: it terminates the removed worktree's own daemon and sweeps daemons whose worktree no longer exists, including ones orphaned by `git worktree remove` or `rm -rf` (mechanism details: [What can Worktrunk delete?](https://worktrunk.dev/faq/#what-can-worktrunk-delete)).
 
-The residual case both paths deliberately leave is a wedged daemon on a *live* worktree that is never removed: `git status` in that worktree blocks on the unresponsive IPC, but the daemon still serves a real worktree, so reaping it implicitly is out of scope. Terminate it manually: kill the daemon whose socket path matches the worktree, or `pkill -9 -f 'git fsmonitor--daemon'` and let the next `wt list` respawn the live ones. Disabling fsmonitor globally (`git config --global core.fsmonitor false`) avoids the class of problem entirely at the cost of some `git status` speed on large repos.
+The residual case both paths deliberately leave is a wedged daemon on a *live* worktree that is never removed: `git status` in that worktree blocks on the unresponsive IPC, but the daemon still serves a real worktree, so reaping it implicitly is out of scope. Terminate it manually: kill the daemon whose socket path matches the worktree, or `pkill -9 -f 'git fsmonitor--daemon'` and let the next `wt list` respawn the live ones.
 
 ## PowerShell on Windows
 

--- a/src/git/fsmonitor.rs
+++ b/src/git/fsmonitor.rs
@@ -299,10 +299,22 @@ impl ProcessSignaller for NixSignaller {
 /// Enumerate running `git fsmonitor--daemon` processes and resolve each one's
 /// IPC socket via `lsof`.
 ///
-/// `pgrep -f 'git fsmonitor--daemon'` lists candidate PIDs; `lsof` resolves
-/// each PID's Unix socket. Both run through [`crate::shell_exec::Cmd`] with a
-/// short timeout. Any failure (tool missing, non-zero exit, unparsable
-/// output) is treated as "no daemons" — the sweep is best-effort.
+/// `pgrep -f 'git fsmonitor--daemon'` lists candidate PIDs; a single `lsof`
+/// call resolves all of their Unix sockets at once. Both run through
+/// [`crate::shell_exec::Cmd`] with a short timeout. Any failure (tool missing,
+/// unparsable output) is treated as "no daemons" — the sweep is best-effort.
+///
+/// # Why one batched `lsof`
+///
+/// `lsof -p` accepts a comma-separated PID list and emits `-F` records grouped
+/// under a `p<pid>` line per process, so N daemons cost one process spawn
+/// instead of N. This matters because the candidate set is MACHINE-wide, not
+/// repo-scoped: a machine with many worktrees accumulates a daemon per repo
+/// ever touched (100+ is routine), and every `wt remove` paid one spawn each.
+/// The cost was superlinear in practice, not merely linear — a fork storm
+/// makes macOS `syspolicyd`/`XProtect` assess each new image under contention,
+/// which inflates per-spawn cost for every other spawn on the box, sweeps
+/// included. Idle, a spawn is ~2 ms; under a storm of them, ~50 ms.
 #[cfg(unix)]
 fn enumerate_daemons() -> Vec<DaemonProcess> {
     use crate::shell_exec::Cmd;
@@ -325,31 +337,77 @@ fn enumerate_daemons() -> Vec<DaemonProcess> {
         .lines()
         .filter_map(|l| l.trim().parse::<u32>().ok())
         .collect();
-    // The per-PID `lsof` resolution below is the expensive part of the whole
-    // sweep (~50ms each on macOS), and it scales with the MACHINE-wide daemon
-    // count, not this repo — surface the count so a slow sweep is explainable
-    // from the trace.
+    if pids.is_empty() {
+        return Vec::new();
+    }
+    // The candidate count scales with the MACHINE-wide daemon population, not
+    // this repo — surface it so a slow sweep is explainable from the trace.
     tracing::debug!(
         count = pids.len(),
-        "fsmonitor sweep: resolving sockets for {} daemon(s) via lsof",
+        "fsmonitor sweep: resolving sockets for {} daemon(s) via one lsof",
         pids.len()
     );
 
-    pids.into_iter()
-        .filter_map(|pid| {
-            let out = Cmd::new("lsof")
-                .args(["-a", "-p", &pid.to_string(), "-U", "-F", "n"])
-                .timeout(timeout)
-                .run()
-                .ok()?;
-            // lsof exits non-zero when a PID vanished mid-scan; skip it
-            // (a gone process is not an orphan we need to reap).
-            if !out.status.success() {
-                return None;
+    let pid_list = pids
+        .iter()
+        .map(u32::to_string)
+        .collect::<Vec<_>>()
+        .join(",");
+    let Ok(out) = Cmd::new("lsof")
+        .args(["-a", "-p", &pid_list, "-U", "-F", "pn"])
+        .timeout(timeout)
+        .run()
+    else {
+        return Vec::new();
+    };
+    // Deliberately NOT gated on exit status. `lsof` exits non-zero when ANY
+    // requested PID has vanished mid-scan, while still printing full records
+    // for every PID that survived. Treating that as failure would drop the
+    // whole sweep whenever one daemon happened to exit — the common case on a
+    // busy machine. Vanished PIDs simply emit no record and are never
+    // classified, which is the same outcome the per-PID path produced.
+    daemons_from_batched_lsof(&String::from_utf8_lossy(&out.stdout))
+}
+
+/// Split batched `lsof -F pn` output into per-PID records and classify each
+/// via [`daemon_from_lsof_stdout`].
+///
+/// `lsof -F` streams field-prefixed lines; a `p<pid>` line opens a process
+/// record and every line up to the next `p` line belongs to it. Splitting on
+/// that boundary hands each PID exactly the output the per-PID `lsof` call
+/// used to produce, so classification — and with it the whole data-safety
+/// contract in the module docs — is unchanged.
+///
+/// A PID that produced no record (it exited between `pgrep` and `lsof`) is
+/// absent from the result rather than classified as an orphan. That direction
+/// matters: inventing a socket-less entry for a missing PID would make it look
+/// like orphan class 1 and get an unrelated, possibly recycled PID signalled.
+#[cfg(unix)]
+fn daemons_from_batched_lsof(stdout: &str) -> Vec<DaemonProcess> {
+    let mut daemons = Vec::new();
+    let mut open: Option<(u32, String)> = None;
+
+    for line in stdout.lines() {
+        if let Some(pid_field) = line.strip_prefix('p') {
+            if let Some((pid, record)) = open.take() {
+                daemons.extend(daemon_from_lsof_stdout(pid, &record));
             }
-            daemon_from_lsof_stdout(pid, &String::from_utf8_lossy(&out.stdout))
-        })
-        .collect()
+            // An unparsable `p` line leaves no record open, so its lines are
+            // discarded rather than misattributed to the previous PID.
+            open = pid_field
+                .trim()
+                .parse::<u32>()
+                .ok()
+                .map(|pid| (pid, String::new()));
+        } else if let Some((_, record)) = open.as_mut() {
+            record.push_str(line);
+            record.push('\n');
+        }
+    }
+    if let Some((pid, record)) = open {
+        daemons.extend(daemon_from_lsof_stdout(pid, &record));
+    }
+    daemons
 }
 
 /// Classify the lsof output for one PID into an [`Option<DaemonProcess>`].
@@ -484,6 +542,68 @@ mod tests {
     fn no_fsmonitor_socket_yields_none() {
         let lsof = "p999\nf3\nn->0xdead\nf4\nn->0xbeef\n";
         assert_eq!(parse_lsof_socket_path(lsof), None);
+    }
+
+    /// Verbatim `lsof -a -p <pids> -U -F pn` output shape (macOS 26, lsof
+    /// 4.99.5): each process opens with `p<pid>`, then `f`/`n` pairs. Covers
+    /// all three classifications in one batch — a resolved socket, a bare
+    /// name (orphan class 1), and a `pgrep` false positive holding no
+    /// fsmonitor socket at all.
+    #[cfg(unix)]
+    #[test]
+    fn batched_lsof_splits_records_per_pid() {
+        let batched = concat!(
+            "p2337\n",
+            "f15\n",
+            "n->0xf3491abb08452a68\n",
+            "f18\n",
+            "n/Users/me/repo/.git/fsmonitor--daemon.ipc\n",
+            "p2497\n",
+            "f24\n",
+            "nfsmonitor--daemon.ipc\n",
+            "p3068\n",
+            "f3\n",
+            "n->0xdeadbeef\n",
+        );
+        let daemons = daemons_from_batched_lsof(batched);
+        assert_eq!(
+            daemons,
+            vec![
+                DaemonProcess {
+                    pid: 2337,
+                    socket: Some(PathBuf::from("/Users/me/repo/.git/fsmonitor--daemon.ipc")),
+                },
+                // Bare name → unresolvable socket, orphan class 1.
+                DaemonProcess {
+                    pid: 2497,
+                    socket: None,
+                },
+                // pid 3068 holds no fsmonitor socket → not a daemon, dropped
+                // rather than misclassified as class 1.
+            ],
+            "each p-record must classify exactly as the per-PID call did"
+        );
+    }
+
+    /// A PID that exits between `pgrep` and `lsof` emits no record at all.
+    /// It must be absent from the result — never synthesized as a
+    /// socket-less entry, which would read as orphan class 1 and signal a
+    /// PID that no longer belongs to the daemon we enumerated.
+    #[cfg(unix)]
+    #[test]
+    fn batched_lsof_omits_pids_that_produced_no_record() {
+        let batched = "p2337\nf18\nn/Users/me/repo/.git/fsmonitor--daemon.ipc\n";
+        let daemons = daemons_from_batched_lsof(batched);
+        assert_eq!(daemons.len(), 1);
+        assert_eq!(daemons[0].pid, 2337);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn batched_lsof_handles_empty_output() {
+        // Every requested PID vanished: lsof exits non-zero with no stdout.
+        // The sweep must find nothing rather than panic or invent orphans.
+        assert!(daemons_from_batched_lsof("").is_empty());
     }
 
     #[cfg(unix)]

--- a/src/git/fsmonitor.rs
+++ b/src/git/fsmonitor.rs
@@ -354,7 +354,7 @@ fn enumerate_daemons() -> Vec<DaemonProcess> {
         .collect::<Vec<_>>()
         .join(",");
     let Ok(out) = Cmd::new("lsof")
-        .args(["-a", "-p", &pid_list, "-U", "-F", "pn"])
+        .args(["-a", "-p", &pid_list, "-U", "-F", "on"])
         .timeout(timeout)
         .run()
     else {
@@ -369,7 +369,7 @@ fn enumerate_daemons() -> Vec<DaemonProcess> {
     daemons_from_batched_lsof(&String::from_utf8_lossy(&out.stdout))
 }
 
-/// Split batched `lsof -F pn` output into per-PID records and classify each
+/// Split batched `lsof -F on` output into per-PID records and classify each
 /// via [`daemon_from_lsof_stdout`].
 ///
 /// `lsof -F` streams field-prefixed lines; a `p<pid>` line opens a process
@@ -544,7 +544,7 @@ mod tests {
         assert_eq!(parse_lsof_socket_path(lsof), None);
     }
 
-    /// Verbatim `lsof -a -p <pids> -U -F pn` output shape (macOS 26, lsof
+    /// Verbatim `lsof -a -p <pids> -U -F on` output shape (macOS 26, lsof
     /// 4.99.5): each process opens with `p<pid>`, then `f`/`n` pairs. Covers
     /// all three classifications in one batch — a resolved socket, a bare
     /// name (orphan class 1), and a `pgrep` false positive holding no

--- a/src/git/fsmonitor.rs
+++ b/src/git/fsmonitor.rs
@@ -354,7 +354,7 @@ fn enumerate_daemons() -> Vec<DaemonProcess> {
         .collect::<Vec<_>>()
         .join(",");
     let Ok(out) = Cmd::new("lsof")
-        .args(["-a", "-p", &pid_list, "-U", "-F", "on"])
+        .args(["-a", "-p", &pid_list, "-U", "-F", "pn"])
         .timeout(timeout)
         .run()
     else {
@@ -369,7 +369,7 @@ fn enumerate_daemons() -> Vec<DaemonProcess> {
     daemons_from_batched_lsof(&String::from_utf8_lossy(&out.stdout))
 }
 
-/// Split batched `lsof -F on` output into per-PID records and classify each
+/// Split batched `lsof -F pn` output into per-PID records and classify each
 /// via [`daemon_from_lsof_stdout`].
 ///
 /// `lsof -F` streams field-prefixed lines; a `p<pid>` line opens a process
@@ -544,7 +544,7 @@ mod tests {
         assert_eq!(parse_lsof_socket_path(lsof), None);
     }
 
-    /// Verbatim `lsof -a -p <pids> -U -F on` output shape (macOS 26, lsof
+    /// Verbatim `lsof -a -p <pids> -U -F pn` output shape (macOS 26, lsof
     /// 4.99.5): each process opens with `p<pid>`, then `f`/`n` pairs. Covers
     /// all three classifications in one batch — a resolved socket, a bare
     /// name (orphan class 1), and a `pgrep` false positive holding no

--- a/src/testing/mock_commands.rs
+++ b/src/testing/mock_commands.rs
@@ -216,6 +216,24 @@ impl MockConfig {
     }
 }
 
+/// Every invocation of mock command `name`, in call order, one entry per
+/// spawn with the arguments space-joined.
+///
+/// Lets a test assert on the *number of spawns*, not just the response —
+/// the property under test wherever a command is batched (one `lsof` for N
+/// PIDs) rather than called in a loop. Returns empty when the command was
+/// never invoked, so a "was not called" assertion reads naturally.
+///
+/// `log_dir` is the directory passed to the command as `MOCK_CALL_LOG_DIR`.
+/// It must be OUTSIDE the repo under test: mocks spawned by hooks would
+/// otherwise dirty the working tree mid-run and change the behavior being
+/// measured.
+pub fn mock_calls(log_dir: &Path, name: &str) -> Vec<String> {
+    fs::read_to_string(log_dir.join(format!("{}.calls", name)))
+        .map(|s| s.lines().map(str::to_string).collect())
+        .unwrap_or_default()
+}
+
 /// Create mock binary in bin_dir with the given name.
 /// Uses symlinks on Unix (instant, works across filesystems).
 /// Uses hard links on Windows (symlinks require admin privileges).

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -1126,6 +1126,29 @@ impl TestRepo {
         check_git_status(&output, &args.join(" "));
     }
 
+    /// Create many branches at `HEAD` in a single `git update-ref --stdin`
+    /// spawn, panicking on failure.
+    ///
+    /// A fixture that needs N branches to cross a threshold cares about the
+    /// ref count, not about how the refs got there. Looping `git branch`
+    /// turns that into N process spawns, and integration tests run at full
+    /// core parallelism — so a fixture loop is multiplied by every other test
+    /// running beside it. One spawn keeps the fixture's cost proportional to
+    /// what it is actually setting up.
+    pub fn create_branches(&self, names: &[String]) {
+        let stdin: String = names
+            .iter()
+            .map(|n| format!("create refs/heads/{n} HEAD\n"))
+            .collect();
+        let output = self
+            .git_command()
+            .args(["update-ref", "--stdin"])
+            .stdin_bytes(stdin)
+            .run()
+            .unwrap();
+        check_git_status(&output, "update-ref --stdin");
+    }
+
     /// Run a git command in a specific directory, panicking on failure.
     ///
     /// Thin wrapper around `git_command()` that runs in `dir` and checks status.

--- a/tests/helpers/mock-stub/src/main.rs
+++ b/tests/helpers/mock-stub/src/main.rs
@@ -76,10 +76,39 @@ fn config_dir() -> PathBuf {
     PathBuf::from(env::var_os("MOCK_CONFIG_DIR").expect("mock: MOCK_CONFIG_DIR not set"))
 }
 
+/// Append this invocation's argv to `<MOCK_CALL_LOG_DIR>/<command>.calls` so
+/// a test can assert *how many times* and *with what arguments* a command was
+/// spawned, not just what it returned. Needed wherever the spawn count is the
+/// behavior under test — e.g. the fsmonitor sweep resolving every daemon in
+/// one batched `lsof` rather than one call per PID.
+///
+/// Opt-in, and deliberately NOT written next to the JSON config. Tests
+/// routinely place `MOCK_CONFIG_DIR` inside the repo under test
+/// (`<repo>/.bin`), so logging there would create an untracked file mid-run
+/// and change what the command being tested observes — a hook-spawned mock
+/// dirties the working tree, and `wt merge` then stashes. Observability must
+/// not perturb the system under test, so the log goes wherever the test says
+/// and nowhere by default.
+///
+/// One line per invocation, arguments space-joined. Best-effort: a log-write
+/// failure must not change what the mock returns, or a test would fail on the
+/// logging rather than on its actual assertion.
+fn log_invocation(cmd_name: &str, args: &[String]) {
+    let Some(dir) = env::var_os("MOCK_CALL_LOG_DIR") else {
+        return;
+    };
+    let path = PathBuf::from(dir).join(format!("{}.calls", cmd_name));
+    if let Ok(mut f) = fs::OpenOptions::new().create(true).append(true).open(path) {
+        let _ = writeln!(f, "{}", args.join(" "));
+    }
+}
+
 fn main() {
     let cmd_name = command_name();
     let config_dir = config_dir();
     let config_path = config_dir.join(format!("{}.json", cmd_name));
+
+    log_invocation(&cmd_name, &env::args().skip(1).collect::<Vec<_>>());
 
     let content = fs::read_to_string(&config_path).unwrap_or_else(|e| {
         eprintln!("mock: failed to read {}: {}", config_path.display(), e);

--- a/tests/integration_tests/completion.rs
+++ b/tests/integration_tests/completion.rs
@@ -1710,18 +1710,22 @@ fn test_complete_switch_excludes_remote_branches_when_over_threshold(mut repo: T
     repo.commit("initial");
     repo.setup_remote("main");
 
-    // Create 50 local branches
-    for i in 0..50 {
-        repo.run_git(&["branch", &format!("local/branch-{i}")]);
-    }
+    // Only the ref COUNT matters here, so the whole fixture is built in five
+    // git spawns rather than one per branch (was ~230, and every one of them
+    // competes with the rest of the suite running at full core parallelism).
+    let local: Vec<String> = (0..50).map(|i| format!("local/branch-{i}")).collect();
+    let remote: Vec<String> = (0..60).map(|i| format!("remote/branch-{i}")).collect();
+    repo.create_branches(&local);
+    repo.create_branches(&remote);
 
-    // Create 60 remote-only branches (push then delete locally)
-    for i in 0..60 {
-        let name = format!("remote/branch-{i}");
-        repo.run_git(&["branch", &name]);
-        repo.run_git(&["push", "origin", &name]);
-        repo.run_git(&["branch", "-D", &name]);
-    }
+    // Push all 60 in one call, then delete all 60 locally in one call, so
+    // they survive only as remote-tracking refs.
+    let mut push = vec!["push", "origin"];
+    push.extend(remote.iter().map(String::as_str));
+    repo.run_git(&push);
+    let mut delete = vec!["branch", "-D"];
+    delete.extend(remote.iter().map(String::as_str));
+    repo.run_git(&delete);
     repo.run_git(&["fetch", "origin"]);
 
     // Total branches: 1 (main worktree) + 50 local + 60 remote = 111 > 100

--- a/tests/integration_tests/remove.rs
+++ b/tests/integration_tests/remove.rs
@@ -3247,6 +3247,72 @@ fn test_remove_resolves_all_fsmonitor_daemons_in_one_lsof(mut repo: TestRepo) {
     );
 }
 
+/// When `pgrep` succeeds but yields no parseable PID, the sweep returns before
+/// spawning `lsof` at all.
+///
+/// `pgrep` exits 0 with output that isn't a PID (the `parse::<u32>` filter
+/// drops every line), so the candidate set is empty. `enumerate_daemons` must
+/// take its empty-set early return — never build a `lsof -p` call with an
+/// empty PID list, which would resolve every open Unix socket on the machine.
+/// Asserted by `lsof` being spawned zero times and the per-daemon "resolving
+/// sockets" trace line (emitted only past the guard) being absent.
+#[rstest]
+#[cfg(unix)]
+fn test_remove_sweep_skips_lsof_when_no_daemon_pids(mut repo: TestRepo) {
+    use crate::common::mock_commands::{MockConfig, MockResponse, mock_calls};
+
+    let bin_dir = repo.root_path().join(".bin");
+    std::fs::create_dir_all(&bin_dir).unwrap();
+    // Exit 0 (a match) but a non-numeric line, so parsing drops it to empty.
+    MockConfig::new("pgrep")
+        .command("_default", MockResponse::output("not-a-pid\n"))
+        .write(&bin_dir);
+    // Present so a stray call would be logged and caught; it must never run.
+    MockConfig::new("lsof")
+        .command("_default", MockResponse::output(""))
+        .write(&bin_dir);
+
+    let mut paths: Vec<std::path::PathBuf> = std::env::var_os("PATH")
+        .map(|p| std::env::split_paths(&p).collect())
+        .unwrap_or_default();
+    paths.insert(0, bin_dir.clone());
+    let new_path = std::env::join_paths(&paths).unwrap();
+
+    let call_log = tempfile::tempdir().unwrap();
+
+    repo.add_worktree("feature-fsmon");
+    let output = repo
+        .wt_command()
+        .args(["remove", "feature-fsmon", "-vv"])
+        .env("PATH", &new_path)
+        .env("MOCK_CONFIG_DIR", &bin_dir)
+        .env("MOCK_CALL_LOG_DIR", call_log.path())
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "wt remove should succeed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    assert!(
+        mock_calls(call_log.path(), "lsof").is_empty(),
+        "an empty PID set must skip the lsof spawn entirely"
+    );
+
+    let trace_log =
+        crate::common::resolve_git_common_dir(repo.root_path()).join("wt/logs/trace.log");
+    let trace = std::fs::read_to_string(&trace_log).unwrap();
+    assert!(
+        trace.contains("◷ enumerate-fsmonitor-daemons"),
+        "sweep span should still appear even when it finds no PIDs. trace.log: {trace}"
+    );
+    assert!(
+        !trace.contains("resolving sockets for"),
+        "the per-daemon resolution line must not appear when there are no PIDs. trace.log: {trace}"
+    );
+}
+
 /// Tests that foreground removal shows remaining directory entries when
 /// `git worktree remove` fails because a directory can't be deleted.
 ///

--- a/tests/integration_tests/remove.rs
+++ b/tests/integration_tests/remove.rs
@@ -3155,25 +3155,42 @@ fn test_remove_sweeps_stale_trash_entries(mut repo: TestRepo) {
     );
 }
 
-/// `wt remove -vv` traces the end-of-command fsmonitor sweep: the
-/// `enumerate-fsmonitor-daemons` span appears and the machine-wide daemon
-/// count is surfaced, so a slow sweep (per-PID `lsof` resolution) is
-/// explainable from the trace. `pgrep` is mocked to report one bogus PID —
-/// CI runners have no real fsmonitor daemons, so the count line is otherwise
-/// unreachable — and `lsof` is mocked to fail its per-PID resolution, which
-/// the best-effort sweep treats as "no daemons".
+/// `wt remove -vv` resolves every fsmonitor daemon in ONE `lsof` spawn and
+/// traces the sweep.
+///
+/// The spawn count is the load-bearing assertion. The candidate set is
+/// machine-wide, so a machine that has accumulated a daemon per repo ever
+/// touched (100+ is routine) once paid one `lsof` spawn each on every
+/// `wt remove`. That fork storm makes macOS assess each new image under
+/// contention, inflating per-spawn cost for everything else on the box — so
+/// regressing to a per-PID loop is not a linear slowdown, and a duration
+/// assertion would not catch it on an idle CI runner. Counting spawns does.
+///
+/// `pgrep` is mocked to report three bogus PIDs (CI runners have no real
+/// daemons) and `lsof` to return batched `-F pn` output covering all three.
 #[rstest]
 #[cfg(unix)]
-fn test_remove_vv_traces_fsmonitor_sweep(mut repo: TestRepo) {
-    use crate::common::mock_commands::{MockConfig, MockResponse};
+fn test_remove_resolves_all_fsmonitor_daemons_in_one_lsof(mut repo: TestRepo) {
+    use crate::common::mock_commands::{MockConfig, MockResponse, mock_calls};
 
     let bin_dir = repo.root_path().join(".bin");
     std::fs::create_dir_all(&bin_dir).unwrap();
     MockConfig::new("pgrep")
-        .command("_default", MockResponse::output("999999999\n"))
+        .command("_default", MockResponse::output("777001\n777002\n777003\n"))
         .write(&bin_dir);
+    // Batched `lsof -F pn` shape: a `p<pid>` line opens each process record.
+    // All three sockets resolve under a git-dir that is not this repo's, so
+    // the sweep classifies them as "not ours" and signals nothing — the test
+    // asserts call shape, and must never depend on killing a real PID.
     MockConfig::new("lsof")
-        .command("_default", MockResponse::exit(1))
+        .command(
+            "_default",
+            MockResponse::output(concat!(
+                "p777001\nf18\nn/elsewhere/a/.git/fsmonitor--daemon.ipc\n",
+                "p777002\nf18\nn/elsewhere/b/.git/fsmonitor--daemon.ipc\n",
+                "p777003\nf18\nn/elsewhere/c/.git/fsmonitor--daemon.ipc\n",
+            )),
+        )
         .write(&bin_dir);
 
     let mut paths: Vec<std::path::PathBuf> = std::env::var_os("PATH")
@@ -3182,18 +3199,36 @@ fn test_remove_vv_traces_fsmonitor_sweep(mut repo: TestRepo) {
     paths.insert(0, bin_dir.clone());
     let new_path = std::env::join_paths(&paths).unwrap();
 
+    // Outside the repo: a call log written under `bin_dir` (which lives at
+    // `<repo>/.bin`) would leave an untracked file in the working tree the
+    // command under test is inspecting.
+    let call_log = tempfile::tempdir().unwrap();
+
     repo.add_worktree("feature-fsmon");
     let output = repo
         .wt_command()
         .args(["remove", "feature-fsmon", "-vv"])
         .env("PATH", &new_path)
         .env("MOCK_CONFIG_DIR", &bin_dir)
+        .env("MOCK_CALL_LOG_DIR", call_log.path())
         .output()
         .unwrap();
     assert!(
         output.status.success(),
         "wt remove should succeed: {}",
         String::from_utf8_lossy(&output.stderr)
+    );
+
+    let calls = mock_calls(call_log.path(), "lsof");
+    assert_eq!(
+        calls.len(),
+        1,
+        "3 daemons must cost exactly one lsof spawn, not one per PID. calls: {calls:#?}"
+    );
+    assert!(
+        calls[0].contains("777001,777002,777003"),
+        "the single lsof call must pass every PID as one comma-separated list. call: {}",
+        calls[0]
     );
 
     // -vv streams primary output to stderr but writes trace records to the
@@ -3207,7 +3242,7 @@ fn test_remove_vv_traces_fsmonitor_sweep(mut repo: TestRepo) {
         "sweep span should appear in the -vv trace. trace.log: {trace}"
     );
     assert!(
-        trace.contains("resolving sockets for 1 daemon(s) via lsof"),
+        trace.contains("resolving sockets for 3 daemon(s) via one lsof"),
         "sweep should surface the daemon count. trace.log: {trace}"
     );
 }

--- a/tests/integration_tests/remove.rs
+++ b/tests/integration_tests/remove.rs
@@ -3167,7 +3167,7 @@ fn test_remove_sweeps_stale_trash_entries(mut repo: TestRepo) {
 /// assertion would not catch it on an idle CI runner. Counting spawns does.
 ///
 /// `pgrep` is mocked to report three bogus PIDs (CI runners have no real
-/// daemons) and `lsof` to return batched `-F on` output covering all three.
+/// daemons) and `lsof` to return batched `-F pn` output covering all three.
 #[rstest]
 #[cfg(unix)]
 fn test_remove_resolves_all_fsmonitor_daemons_in_one_lsof(mut repo: TestRepo) {
@@ -3178,7 +3178,7 @@ fn test_remove_resolves_all_fsmonitor_daemons_in_one_lsof(mut repo: TestRepo) {
     MockConfig::new("pgrep")
         .command("_default", MockResponse::output("777001\n777002\n777003\n"))
         .write(&bin_dir);
-    // Batched `lsof -F on` shape: a `p<pid>` line opens each process record.
+    // Batched `lsof -F pn` shape: a `p<pid>` line opens each process record.
     // All three sockets resolve under a git-dir that is not this repo's, so
     // the sweep classifies them as "not ours" and signals nothing — the test
     // asserts call shape, and must never depend on killing a real PID.

--- a/tests/integration_tests/remove.rs
+++ b/tests/integration_tests/remove.rs
@@ -3167,7 +3167,7 @@ fn test_remove_sweeps_stale_trash_entries(mut repo: TestRepo) {
 /// assertion would not catch it on an idle CI runner. Counting spawns does.
 ///
 /// `pgrep` is mocked to report three bogus PIDs (CI runners have no real
-/// daemons) and `lsof` to return batched `-F pn` output covering all three.
+/// daemons) and `lsof` to return batched `-F on` output covering all three.
 #[rstest]
 #[cfg(unix)]
 fn test_remove_resolves_all_fsmonitor_daemons_in_one_lsof(mut repo: TestRepo) {
@@ -3178,7 +3178,7 @@ fn test_remove_resolves_all_fsmonitor_daemons_in_one_lsof(mut repo: TestRepo) {
     MockConfig::new("pgrep")
         .command("_default", MockResponse::output("777001\n777002\n777003\n"))
         .write(&bin_dir);
-    // Batched `lsof -F pn` shape: a `p<pid>` line opens each process record.
+    // Batched `lsof -F on` shape: a `p<pid>` line opens each process record.
     // All three sockets resolve under a git-dir that is not this repo's, so
     // the sweep classifies them as "not ours" and signals nothing — the test
     // asserts call shape, and must never depend on killing a real PID.

--- a/tests/integration_tests/statusline.rs
+++ b/tests/integration_tests/statusline.rs
@@ -138,9 +138,7 @@ fn test_statusline_commits_ahead(mut repo: TestRepo) {
 
 #[rstest]
 fn test_statusline_does_not_run_repo_wide_ahead_behind_scan(repo: TestRepo) {
-    for i in 0..12 {
-        repo.run_git(&["branch", &format!("unused-{i}")]);
-    }
+    repo.create_branches(&(0..12).map(|i| format!("unused-{i}")).collect::<Vec<_>>());
 
     let output = repo
         .wt_command()

--- a/tests/integration_tests/switch_picker.rs
+++ b/tests/integration_tests/switch_picker.rs
@@ -1054,10 +1054,11 @@ fn test_switch_picker_scrollbar_on_overflow(mut repo: TestRepo) {
 
     // Far more branches than the ~24 item rows the 30-row terminal can show, so
     // the list is guaranteed to overflow and skim paints the scrollbar.
-    for i in 0..50 {
-        let name = format!("scroll-{i:02}");
-        repo.run_git(&["branch", name.as_str()]);
-    }
+    repo.create_branches(
+        &(0..50)
+            .map(|i| format!("scroll-{i:02}"))
+            .collect::<Vec<_>>(),
+    );
 
     let env_vars = repo.test_env_vars();
     let result = exec_in_pty_capture_before_abort(


### PR DESCRIPTION
## Why

`wt remove`'s end-of-command fsmonitor sweep forked one `lsof` per *machine-wide* `git fsmonitor--daemon` — and with `core.fsmonitor` enabled globally, a machine accumulates one daemon per repo ever touched (100+ is routine). So every `wt remove` paid ~100 process spawns. The cost is superlinear under load, not linear: a fork storm makes macOS Gatekeeper/XProtect assess each new image under contention, inflating per-spawn cost for everything else on the box, sweeps included. The `~50ms each` figure in the old docstring was measured *under that load* and read as a fixed per-call cost — so the sweep looked merely slow rather than self-amplifying. Two concurrent test suites driving hundreds of `wt remove` calls pinned all 18 cores (load average 142) with nothing hot in `htop`.

This was diagnosed and measured before (#2814 added the sweep; #3401 wrote the cost into the docstring and explicitly changed no behavior) but never fixed.

## The fix

Resolve every daemon in a single `lsof -a -p <pid1,pid2,…> -U -F pn` call and split its output on the `p<pid>` record boundary, handing each PID exactly the output the per-PID call produced — so classification and the whole data-safety contract in the module docs are unchanged. Verified end-to-end against a live 108-daemon machine with a PATH shim counting invocations: **108 spawns → 1**.

Two details the batched path must preserve, each covered by a new test:

- **Don't gate on `lsof`'s exit status.** It exits non-zero when *any* requested PID vanished mid-scan, while still printing full records for every survivor. Gating would drop the whole sweep whenever one daemon happened to exit — the common case on a busy machine.
- **A PID with no record is dropped**, never synthesized as a socket-less entry. A socket-less entry reads as orphan class 1 and gets SIGTERM/SIGKILL — on a possibly-recycled PID.

## Also here

- **Test consolidation.** Three integration fixtures built their branch set by spawning git per loop iteration. A new `TestRepo::create_branches` creates them in one `git update-ref --stdin`. The over-threshold completion test drops **10.5s → 1.4s** (~230 git spawns → 5); `switch_picker` and `statusline` branch loops get the same treatment. `mock-stub` gains an opt-in `MOCK_CALL_LOG_DIR` call log so a test can assert *spawn count*, not just response — deliberately outside the repo under test, since a log written inside the tree would dirty it mid-`wt merge`.
- **Docs.** Dropped the "disable `core.fsmonitor` globally" workaround from the troubleshooting docs (canonical `skills/`, mirror regenerated). It stays enabled by choice, and the daemons were never the actual fseventsd CPU driver.

- **CI hardening.** pre-commit.ci's `typos` hook maps the token `pn`→`on` and had auto-rewritten `lsof -F pn` to the broken `lsof -F on` (offset+name — no `p<pid>` records, so the parser reaps nothing). Pinned `pn` in `.typos.toml` next to the existing `PN`-from-`PNGs` entry that documents the same mapping, and added a test covering the empty-PID-set early return (flagged by `codecov/patch`).

## Testing

New unit tests cover `daemons_from_batched_lsof` against real captured `lsof -F pn` output, a vanished-PID gap, and empty output; the rewritten integration test asserts exactly one `lsof` spawn with a comma-joined PID list. Full integration suite green (1960 passed), clippy and fmt clean.

> _This was written by Claude Code on behalf of max_
