### PR TITLE
fix(switch): classify forge-CLI failures by structure, not tool prose

### DIFF
--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -228,7 +228,14 @@ pub(super) fn is_plugin_installed() -> bool {
         .is_some()
 }
 
-/// Check if the statusline is configured in Claude Code settings
+/// Whether Claude Code's statusline runs worktrunk's.
+///
+/// The question is which subcommand the configured command invokes, so it's
+/// asked of the adjacent tokens `list statusline` — the binary answers the
+/// same whether it's `wt`, `git-wt`, or an absolute path. Matching on the
+/// binary alone accepted any command that merely spelled `wt ` somewhere
+/// (`newt status`), which reported a foreign statusline as worktrunk's and
+/// left `install-statusline` refusing to install.
 pub(super) fn is_statusline_configured() -> bool {
     let Some(config_dir) = claude_config_dir() else {
         return false;
@@ -246,7 +253,10 @@ pub(super) fn is_statusline_configured() -> bool {
     json.get("statusLine")
         .and_then(|s| s.get("command"))
         .and_then(|c| c.as_str())
-        .is_some_and(|cmd| cmd.contains("wt "))
+        .is_some_and(|cmd| {
+            let tokens: Vec<&str> = cmd.split_whitespace().collect();
+            tokens.windows(2).any(|pair| pair == ["list", "statusline"])
+        })
 }
 
 /// Get the git version string (e.g., "2.47.1")

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -1146,12 +1146,13 @@ impl GitError {
                     )?;
                 }
                 // Fragile by necessity: matches git's English, which is
-                // localized and could be reworded. `remaining_entries` is not a
-                // substitute — a permission-denied failure also leaves entries
-                // behind, and this hint is only right for ENOTEMPTY. The
-                // structured form (`io::ErrorKind::DirectoryNotEmpty`) is lost
-                // upstream, where the cause is flattened to a rendered string
-                // before it reaches this type. A miss costs one hint.
+                // localized and could be reworded. The text is `git worktree
+                // remove`'s own stderr — the failure never passes through a
+                // Rust `io::Error`, and git offers no porcelain or exit code
+                // that separates ENOTEMPTY from the rest. `remaining_entries`
+                // is not a substitute either: a permission-denied failure also
+                // leaves entries behind, and this hint is only right for
+                // ENOTEMPTY. A miss costs one hint.
                 if error.contains("not empty") {
                     write!(
                         f,

--- a/src/git/remote_ref/azure.rs
+++ b/src/git/remote_ref/azure.rs
@@ -10,6 +10,7 @@ use super::{CliApiRequest, PlatformData, RemoteRefInfo, RemoteRefProvider, cli_a
 use crate::git::canonical_url_path_segment;
 use crate::git::url::GitRemoteUrl;
 use crate::git::{RefType, Repository};
+use crate::shell_exec::Cmd;
 
 /// Azure DevOps Pull Request provider.
 #[derive(Debug, Clone, Copy)]
@@ -204,6 +205,31 @@ fn parse_web_url(web_url: Option<&str>) -> Option<(String, String)> {
     }
 }
 
+/// One entry of `az extension list --output json`.
+#[derive(Debug, Deserialize)]
+struct AzExtension {
+    name: String,
+}
+
+/// Whether the `azure-devops` extension is installed.
+///
+/// `az extension list --output json` answers with a name/version array, so no
+/// prose is involved. An `az` that can't answer — spawn failure, non-zero
+/// exit, output that won't parse — leaves the question open, and an open
+/// question counts as installed: the caller then falls through to `az`'s own
+/// error rather than blaming an extension we never confirmed was missing.
+fn azure_devops_extension_installed(repo_root: &std::path::Path) -> bool {
+    Cmd::new("az")
+        .args(["extension", "list", "--output", "json"])
+        .current_dir(repo_root)
+        .env("AZURE_CORE_NO_COLOR", "true")
+        .run()
+        .ok()
+        .filter(|output| output.status.success())
+        .and_then(|output| serde_json::from_slice::<Vec<AzExtension>>(&output.stdout).ok())
+        .is_none_or(|extensions| extensions.iter().any(|e| e.name == "azure-devops"))
+}
+
 fn fetch_pr_info(pr_number: u32, repo: &Repository) -> anyhow::Result<RemoteRefInfo> {
     let repo_root = repo.repo_path()?;
     let pr_id = pr_number.to_string();
@@ -236,12 +262,21 @@ fn fetch_pr_info(pr_number: u32, repo: &Repository) -> anyhow::Result<RemoteRefI
     })?;
 
     if !output.status.success() {
-        // `az` reports failures only as prose on stderr — no exit-code or JSON
-        // error channel to branch on. Rather than guess at the cause from
-        // English substrings, surface what `az` said: its own text names the
-        // remedy ("Please run 'az login' …", the missing-extension prompt) more
-        // reliably than a paraphrase keyed on a word that can occur anywhere in
-        // an org, project, or repo name.
+        // The whole `az repos` command group ships in the azure-devops
+        // extension, so "is the extension installed?" is a precondition of this
+        // call rather than one guess among many — and `az extension list`
+        // answers it in JSON. Asking it here, on the failure path only, keeps
+        // the install command out of the happy path's cost.
+        if !azure_devops_extension_installed(repo_root) {
+            bail!(
+                "Azure DevOps CLI extension not installed; run az extension add --name azure-devops"
+            );
+        }
+        // Everything else `az` reports is prose on stderr — no exit code, no
+        // JSON error channel. Rather than guess at the cause from English
+        // substrings, surface what `az` said: its own text names the remedy
+        // ("Please run 'az login' …") more reliably than a paraphrase keyed on
+        // a word that can occur anywhere in an org, project, or repo name.
         return Err(cli_api_error(
             RefType::Pr,
             format!("az repos pr show failed for PR #{}", pr_number),

--- a/src/git/remote_ref/gitea.rs
+++ b/src/git/remote_ref/gitea.rs
@@ -55,7 +55,8 @@ struct TeaApiPrResponse {
     html_url: String,
 }
 
-/// Error response from Gitea API.
+/// Gitea's `APIError` body, which the API returns in place of the resource
+/// whenever the request fails.
 #[derive(Debug, Deserialize)]
 struct TeaApiErrorResponse {
     #[serde(default)]
@@ -117,25 +118,11 @@ fn fetch_pr_info(pr_number: u32, repo: &Repository) -> anyhow::Result<RemoteRefI
         run_context: "Failed to run tea api",
     })?;
 
+    // `tea api` never reads the HTTP status — it copies the response body to
+    // stdout and exits 0 — so a non-zero exit means `tea` itself failed (no
+    // login configured, unresolvable endpoint, transport error), and its own
+    // stderr names which.
     if !output.status.success() {
-        if let Ok(error_response) = serde_json::from_slice::<TeaApiErrorResponse>(&output.stdout) {
-            let message_lower = error_response.message.to_ascii_lowercase();
-            if message_lower.contains("404") || message_lower.contains("not found") {
-                bail!(
-                    "Gitea PR #{} not found on {}/{}",
-                    pr_number,
-                    parsed.owner(),
-                    parsed.repo()
-                );
-            }
-            if message_lower.contains("401") || message_lower.contains("unauthorized") {
-                bail!("Gitea CLI not authenticated; run tea login add");
-            }
-            if message_lower.contains("403") || message_lower.contains("forbidden") {
-                bail!("Gitea API access forbidden for PR #{}", pr_number);
-            }
-        }
-
         return Err(cli_api_error(
             RefType::Pr,
             format!("tea api failed for PR #{}", pr_number),
@@ -143,13 +130,32 @@ fn fetch_pr_info(pr_number: u32, repo: &Repository) -> anyhow::Result<RemoteRefI
         ));
     }
 
-    let response: TeaApiPrResponse = serde_json::from_slice(&output.stdout).with_context(|| {
-        format!(
-            "Failed to parse Gitea API response for PR #{}. \
-             This may indicate a Gitea API change.",
-            pr_number
-        )
-    })?;
+    // A 404, 401, or 403 therefore arrives here, as a successful spawn
+    // carrying Gitea's `APIError` body instead of the PR. The response shape
+    // is what separates them, and it's the only thing that can: the status
+    // code never reaches us, and Gitea's message doesn't spell it either.
+    let response: TeaApiPrResponse = match serde_json::from_slice(&output.stdout) {
+        Ok(response) => response,
+        Err(parse_error) => {
+            let api_error = serde_json::from_slice::<TeaApiErrorResponse>(&output.stdout)
+                .ok()
+                .filter(|e| !e.message.trim().is_empty());
+            if let Some(api_error) = api_error {
+                bail!(
+                    "Gitea API error for PR #{} on {}/{}: {}",
+                    pr_number,
+                    parsed.owner(),
+                    parsed.repo(),
+                    api_error.message.trim()
+                );
+            }
+            return Err(anyhow::Error::from(parse_error).context(format!(
+                "Failed to parse Gitea API response for PR #{}. \
+                 This may indicate a Gitea API change.",
+                pr_number
+            )));
+        }
+    };
 
     // Check head.repo before extract_source_branch so deleted-source PRs hit
     // the specific "source repository was deleted" message instead of falling

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -4455,6 +4455,38 @@ fn test_plugins_claude_install_statusline_already_configured(repo: TestRepo, tem
     });
 }
 
+/// A foreign statusline that happens to spell `wt ` is still foreign, so
+/// install proceeds instead of reporting the statusline as already configured.
+#[rstest]
+fn test_plugins_claude_install_statusline_foreign_command(repo: TestRepo, temp_home: TempDir) {
+    let claude_dir = temp_home.path().join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(
+        claude_dir.join("settings.json"),
+        r#"{"statusLine":{"type":"command","command":"newt status --short"}}"#,
+    )
+    .unwrap();
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        cmd.args(["config", "plugins", "claude", "install-statusline", "--yes"])
+            .current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(cmd);
+
+        let settings_path = temp_home.path().join(".claude/settings.json");
+        let content = fs::read_to_string(&settings_path).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(
+            parsed["statusLine"]["command"],
+            "wt list statusline --format=claude-code"
+        );
+    });
+}
+
 #[rstest]
 fn test_plugins_claude_install_statusline_preserves_existing(repo: TestRepo, temp_home: TempDir) {
     // Write existing settings with other keys

--- a/tests/integration_tests/switch.rs
+++ b/tests/integration_tests/switch.rs
@@ -4917,6 +4917,11 @@ fn test_switch_pr_gitea_fork(#[from(repo_with_remote)] repo: TestRepo) {
     });
 }
 
+/// A missing PR reaches the user as Gitea's own message.
+///
+/// `tea api` exits 0 for every HTTP response, so the 404 arrives as a
+/// successful spawn whose stdout carries Gitea's `APIError` body rather than
+/// the PR — the shape, not the exit code, is what says the request failed.
 #[rstest]
 fn test_switch_pr_gitea_not_found(#[from(repo_with_remote)] repo: TestRepo) {
     repo.run_git(&[
@@ -4935,7 +4940,9 @@ fn test_switch_pr_gitea_not_found(#[from(repo_with_remote)] repo: TestRepo) {
         .version("tea version development (mock)")
         .command(
             "api",
-            MockResponse::output(r#"{"message":"404 Not found"}"#).with_exit_code(1),
+            MockResponse::output(
+                r#"{"errors":null,"message":"pull request does not exist [index: 9999]","url":"https://gitea.example.com/api/swagger"}"#,
+            ),
         )
         .command("_default", MockResponse::exit(1))
         .write(&mock_bin);
@@ -5272,10 +5279,10 @@ fn test_switch_pr_gitea_invalid_json(#[from(repo_with_remote)] repo: TestRepo) {
     });
 }
 
-/// Gitea API returns a 5xx-style generic error (non-404/401/403) — exercises
-/// the generic `cli_api_error` fallback in `gitea::fetch_pr_info`.
+/// `tea` itself failing — never reaching the API — is the one case that
+/// exits non-zero, and it surfaces `tea`'s own stderr via `cli_api_error`.
 #[rstest]
-fn test_switch_pr_gitea_server_error(#[from(repo_with_remote)] repo: TestRepo) {
+fn test_switch_pr_gitea_request_failed(#[from(repo_with_remote)] repo: TestRepo) {
     repo.run_git(&[
         "remote",
         "set-url",
@@ -5291,9 +5298,10 @@ fn test_switch_pr_gitea_server_error(#[from(repo_with_remote)] repo: TestRepo) {
         .version("tea version development (mock)")
         .command(
             "api",
-            MockResponse::output(r#"{"message":"500 Internal Server Error"}"#)
-                .with_stderr("tea: server error\n")
-                .with_exit_code(1),
+            MockResponse::stderr(
+                "Error: request failed: Get \"https://gitea.example.com/api/v1/repos/owner/test-repo/pulls/101\": dial tcp: connection refused\n",
+            )
+            .with_exit_code(1),
         )
         .command("_default", MockResponse::exit(1))
         .write(&mock_bin);
@@ -5302,7 +5310,7 @@ fn test_switch_pr_gitea_server_error(#[from(repo_with_remote)] repo: TestRepo) {
     settings.bind(|| {
         let mut cmd = make_snapshot_cmd(&repo, "switch", &["pr:101"], None);
         configure_mock_cli_env(&mut cmd, &mock_bin);
-        assert_cmd_snapshot!("switch_pr_gitea_server_error", cmd);
+        assert_cmd_snapshot!("switch_pr_gitea_request_failed", cmd);
     });
 }
 
@@ -5384,8 +5392,8 @@ fn test_switch_pr_gitea_deleted_fork(#[from(repo_with_remote)] repo: TestRepo) {
     });
 }
 
-/// Gitea CLI returning 401/Unauthorized hits the dedicated bail message
-/// (covers the auth-error branch in `gitea::fetch_pr_info`).
+/// An unauthenticated request reaches the user as Gitea's own message, which
+/// names the remedy a paraphrase would have restated.
 #[rstest]
 fn test_switch_pr_gitea_unauthorized(#[from(repo_with_remote)] repo: TestRepo) {
     repo.run_git(&[
@@ -5403,7 +5411,9 @@ fn test_switch_pr_gitea_unauthorized(#[from(repo_with_remote)] repo: TestRepo) {
         .version("tea version development (mock)")
         .command(
             "api",
-            MockResponse::output(r#"{"message":"401 Unauthorized"}"#).with_exit_code(1),
+            MockResponse::output(
+                r#"{"errors":null,"message":"token is required","url":"https://gitea.example.com/api/swagger"}"#,
+            ),
         )
         .command("_default", MockResponse::exit(1))
         .write(&mock_bin);
@@ -5416,8 +5426,9 @@ fn test_switch_pr_gitea_unauthorized(#[from(repo_with_remote)] repo: TestRepo) {
     });
 }
 
-/// Gitea CLI returning 403/Forbidden hits the dedicated bail message
-/// (covers the forbidden branch in `gitea::fetch_pr_info`).
+/// A PR the token can see but not read reaches the user as Gitea's own
+/// message — the same path as the 404 and 401, which is the point: `tea`
+/// hands over one body shape for every failed request.
 #[rstest]
 fn test_switch_pr_gitea_forbidden(#[from(repo_with_remote)] repo: TestRepo) {
     repo.run_git(&[
@@ -5435,7 +5446,9 @@ fn test_switch_pr_gitea_forbidden(#[from(repo_with_remote)] repo: TestRepo) {
         .version("tea version development (mock)")
         .command(
             "api",
-            MockResponse::output(r#"{"message":"403 Forbidden"}"#).with_exit_code(1),
+            MockResponse::output(
+                r#"{"errors":null,"message":"user does not have permission to read this repository","url":"https://gitea.example.com/api/swagger"}"#,
+            ),
         )
         .command("_default", MockResponse::exit(1))
         .write(&mock_bin);
@@ -5457,6 +5470,13 @@ fn test_switch_pr_gitea_forbidden(#[from(repo_with_remote)] repo: TestRepo) {
 // matches and the ambiguous fallback is skipped — the runtime calls only the
 // mock `az`, not real `gh`.
 // ============================================================================
+
+/// `az extension list --output json` with the azure-devops extension present.
+///
+/// Every `az repos pr show` failure asks this, so an az failure that is *not*
+/// a missing extension has to answer it — otherwise the test proves nothing
+/// about which of the two errors the user sees.
+const AZ_EXTENSION_INSTALLED: &str = r#"[{"name": "azure-devops", "version": "1.0.0"}]"#;
 
 /// Helper to set up mock `az` for Azure DevOps PR tests with a custom
 /// `az repos pr show` response.
@@ -5800,10 +5820,10 @@ fn test_switch_pr_azure_fork(#[from(repo_with_remote)] repo: TestRepo) {
 
 /// A missing PR reaches the user as the `TF401174` line `az` printed.
 ///
-/// `azure::fetch_pr_info` classifies nothing: `az` has no error channel but
-/// prose on stderr, so worktrunk reports that prose rather than guessing a
-/// cause from it. The three azure error tests each pin the tool's own words
-/// surviving to the terminal.
+/// Once the extension question is settled, `azure::fetch_pr_info` classifies
+/// nothing: `az` has no error channel but prose on stderr, so worktrunk
+/// reports that prose rather than guessing a cause from it. Each azure error
+/// test below pins the tool's own words surviving to the terminal.
 #[rstest]
 fn test_switch_pr_azure_not_found(#[from(repo_with_remote)] repo: TestRepo) {
     repo.run_git(&[
@@ -5825,6 +5845,10 @@ fn test_switch_pr_azure_not_found(#[from(repo_with_remote)] repo: TestRepo) {
                 "TF401174: The requested pull request was not found, or it does not exist.\n",
             )
             .with_exit_code(1),
+        )
+        .command(
+            "extension list",
+            MockResponse::output(AZ_EXTENSION_INSTALLED),
         )
         .command("_default", MockResponse::exit(1))
         .write(&mock_bin);
@@ -5922,8 +5946,12 @@ fn test_switch_pr_azure_invalid_json(#[from(repo_with_remote)] repo: TestRepo) {
     });
 }
 
-/// `az repos pr show` failing with a generic (non-auth, non-not-found) error
-/// exercises the `cli_api_error` fallback in `azure::fetch_pr_info`.
+/// An `az` that can't answer the extension question still reports its own
+/// error, not a missing extension.
+///
+/// Here `az extension list` fails alongside the generic `az repos pr show`
+/// failure, so the check comes back unanswered — and an unanswered check must
+/// not turn into an accusation the user would act on.
 #[rstest]
 fn test_switch_pr_azure_server_error(#[from(repo_with_remote)] repo: TestRepo) {
     repo.run_git(&[
@@ -5943,6 +5971,7 @@ fn test_switch_pr_azure_server_error(#[from(repo_with_remote)] repo: TestRepo) {
             "repos pr show",
             MockResponse::stderr("az: TF400898: An internal error occurred.\n").with_exit_code(1),
         )
+        .command("extension list", MockResponse::exit(1))
         .command("_default", MockResponse::exit(1))
         .write(&mock_bin);
 
@@ -5975,6 +6004,10 @@ fn test_switch_pr_azure_auth_error(#[from(repo_with_remote)] repo: TestRepo) {
             "repos pr show",
             MockResponse::stderr("Please run 'az login' to setup account.\n").with_exit_code(1),
         )
+        .command(
+            "extension list",
+            MockResponse::output(AZ_EXTENSION_INSTALLED),
+        )
         .command("_default", MockResponse::exit(1))
         .write(&mock_bin);
 
@@ -5986,13 +6019,12 @@ fn test_switch_pr_azure_auth_error(#[from(repo_with_remote)] repo: TestRepo) {
     });
 }
 
-/// A missing `azure-devops` extension reaches the user as `az`'s own line.
+/// A missing `azure-devops` extension reaches the user as the install command,
+/// which `az` names the need for but never spells out.
 ///
-/// This is the case that cost something: worktrunk used to append the exact
-/// `az extension add --name azure-devops` command, which `az` doesn't print.
-/// Detecting it needs prose matching — no code, no exit status distinguishes
-/// it — and the extension is named in the text `az` does print, so the
-/// remaining gap is the install verb rather than the package.
+/// The whole `repos` command group lives in that extension, so `az extension
+/// list` decides this from JSON — `az`'s "is misspelled or not recognized"
+/// prose is never consulted, and never reaches the user.
 #[rstest]
 fn test_switch_pr_azure_extension_not_installed(#[from(repo_with_remote)] repo: TestRepo) {
     repo.run_git(&[
@@ -6016,6 +6048,7 @@ fn test_switch_pr_azure_extension_not_installed(#[from(repo_with_remote)] repo: 
             )
             .with_exit_code(2),
         )
+        .command("extension list", MockResponse::output("[]"))
         .command("_default", MockResponse::exit(1))
         .write(&mock_bin);
 

--- a/tests/snapshots/integration__integration_tests__config_show__plugins_claude_install_statusline_foreign_command.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__plugins_claude_install_statusline_foreign_command.snap
@@ -1,10 +1,13 @@
 ---
-source: tests/integration_tests/switch.rs
+source: tests/integration_tests/config_show.rs
 info:
   program: wt
   args:
-    - switch
-    - "pr:101"
+    - config
+    - plugins
+    - claude
+    - install-statusline
+    - "--yes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
@@ -43,10 +46,9 @@ info:
     WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
-success: false
-exit_code: 1
+success: true
+exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[36m◎[39m [36mFetching PR #101...[39m
-[31m✗[39m [31mAzure DevOps CLI extension not installed; run az extension add --name azure-devops[39m
+[32m✓[39m [32mStatusline configured[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_forbidden.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_forbidden.snap
@@ -7,6 +7,7 @@ info:
     - "pr:101"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -35,6 +36,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -47,4 +49,4 @@ exit_code: 1
 
 ----- stderr -----
 [36m◎[39m [36mFetching PR #101...[39m
-[31m✗[39m [31mGitea API access forbidden for PR #101[39m
+[31m✗[39m [31mGitea API error for PR #101 on owner/test-repo: user does not have permission to read this repository[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_not_found.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_not_found.snap
@@ -7,6 +7,7 @@ info:
     - "pr:9999"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -35,6 +36,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -47,4 +49,4 @@ exit_code: 1
 
 ----- stderr -----
 [36m◎[39m [36mFetching PR #9999...[39m
-[31m✗[39m [31mGitea PR #9999 not found on owner/test-repo[39m
+[31m✗[39m [31mGitea API error for PR #9999 on owner/test-repo: pull request does not exist [index: 9999][39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_request_failed.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_request_failed.snap
@@ -7,6 +7,7 @@ info:
     - "pr:101"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -35,6 +36,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -48,4 +50,4 @@ exit_code: 1
 ----- stderr -----
 [36m◎[39m [36mFetching PR #101...[39m
 [31m✗[39m [31mtea api failed for PR #101[39m
-[107m [0m tea: server error
+[107m [0m Error: request failed: Get "https://gitea.example.com/api/v1/repos/owner/test-repo/pulls/101": dial tcp: connection refused

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_unauthorized.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_unauthorized.snap
@@ -7,6 +7,7 @@ info:
     - "pr:101"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
@@ -35,6 +36,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -47,4 +49,4 @@ exit_code: 1
 
 ----- stderr -----
 [36m◎[39m [36mFetching PR #101...[39m
-[31m✗[39m [31mGitea CLI not authenticated; run tea login add[39m
+[31m✗[39m [31mGitea API error for PR #101 on owner/test-repo: token is required[39m


### PR DESCRIPTION
Follow-ups from #3589's audit of brittle string matching, plus one live bug the audit turned up.

## Gitea: the error path was unreachable

From tea's own `cmd/api.go`: `runApi` never inspects `resp.StatusCode` — it copies the response body to stdout and returns nil. So `tea api` **exits 0 for 404, 401, and 403**, which put the whole 404/401/403 classification behind an `if !output.status.success()` that those responses never reach. A missing PR surfaced as `Failed to parse Gitea API response for PR #N. This may indicate a Gitea API change.` The fabricated `{"message":"403 Forbidden"}` fixtures hid this by mocking an exit code tea does not produce.

The response *shape* now discriminates — the PR object, or Gitea's `APIError` body whose message is surfaced verbatim. A non-zero exit means `tea` itself failed (no login configured, transport error) and keeps the existing `cli_api_error` path, which shows tea's own stderr.

## Azure: the install command, from JSON

#3589 dropped the appended `az extension add --name azure-devops` because detecting the case needed prose matching. `az extension list --output json` answers it structurally instead, and the whole `az repos` command group ships in that extension — so it's a precondition of the call, not one guess among many. The check runs only after a failure, so the happy path pays nothing, and an `az` that can't answer counts as installed: an unanswered check never becomes an accusation the user would act on.

## Statusline detection

`is_statusline_configured` matched the substring `"wt "`, which `newt status` also satisfies. That is not only a wrong diagnostic line — `install-statusline` early-returns on it, so a foreign statusline made install refuse. It now asks for the adjacent token pair `list statusline`, which is the actual question and stays agnostic to `wt` / `git-wt` / an absolute path.

## Worktree removal: comment only

The remaining `error.contains("not empty")` stays. There is no structured form to recover: the text is `git worktree remove`'s own stderr, so the failure never passes through a Rust `io::Error`, and `remaining_entries` can't substitute because permission-denied also leaves entries behind. The comment claiming an `io::ErrorKind` was lost upstream is corrected.

## Testing

Every changed path is covered by an integration test with realistic mocks: the four Gitea tests now mock exit 0 with `APIError` bodies (`gitea_server_error` became `gitea_request_failed`, since a 5xx no longer exits non-zero), the Azure tests mock `az extension list` on both sides — present, and failing so the check comes back unanswered — and a new `install_statusline_foreign_command` test asserts a foreign statusline gets replaced rather than mistaken for worktrunk's.

> _This was written by Claude Code on behalf of max_
