### PR TITLE
test: stop the suite reaching the network

### DIFF
--- a/src/git/repository/tests.rs
+++ b/src/git/repository/tests.rs
@@ -978,16 +978,7 @@ fn build_worktree_config_bare_layout() -> (tempfile::TempDir, std::path::PathBuf
         "[init]\n\tdefaultBranch = main\n[user]\n\tname = test\n\temail = test@test\n",
     )
     .unwrap();
-    let git = || {
-        Cmd::new("git")
-            .env("GIT_CONFIG_GLOBAL", &gitconfig)
-            .env("GIT_CONFIG_SYSTEM", "/dev/null")
-            .env("GIT_TERMINAL_PROMPT", "0")
-            .env("LC_ALL", "C")
-            .env("LANG", "C")
-            .env("GIT_AUTHOR_DATE", "2025-01-01T00:00:00Z")
-            .env("GIT_COMMITTER_DATE", "2025-01-01T00:00:00Z")
-    };
+    let git = || crate::testing::configure_git_env(Cmd::new("git"), &gitconfig);
 
     let path_str = |p: &std::path::Path| p.to_str().unwrap().to_owned();
 

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -291,6 +291,33 @@ pub const STATIC_TEST_ENV_VARS: &[(&str, &str)] = &[
 // - PTY tests (especially skim-based picker tests) need a TERM with valid terminfo
 // - macOS CI doesn't have alacritty terminfo, causing skim to fail
 
+/// Value for `GIT_ALLOW_PROTOCOL` on every git process a test spawns: local
+/// paths and `file://` only, so the suite cannot reach the wire.
+///
+/// Tests point remotes at real hosts (`https://github.com/test-owner/…`) to
+/// drive forge detection, and `Repository::default_branch()` is allowed to
+/// fall through to `git ls-remote` when neither the worktrunk cache nor
+/// `origin/HEAD` resolves. So a test that never meant to do network work
+/// makes an unbounded connect to whatever host the URL names. Nothing in that
+/// path has a timeout: an unanswered SYN costs ~127 s per address on Linux
+/// (`tcp_syn_retries=6`) and a host with several A/AAAA records is tried in
+/// turn, which is how a 2-second test reaches nextest's 180 s limit.
+///
+/// Denying the transport turns that into an immediate `transport 'https' not
+/// allowed`; detection then falls back to local inference, leaving output
+/// unchanged. The adjacent `GIT_TERMINAL_PROMPT=0` doesn't subsume this: it
+/// only suppresses the credential prompt the host's 401 triggers, so the
+/// request has already gone out by the time it applies.
+const GIT_ALLOWED_PROTOCOLS: &str = "file";
+
+/// Restore git's default protocol set on a command built by
+/// [`configure_git_cmd`], for a caller whose job is to fetch a fixture from
+/// upstream — the real-repo benchmark clone. Grep for this to enumerate
+/// everything that may reach the wire; tests are not among them.
+pub fn allow_network_transports(cmd: &mut Command) {
+    cmd.env_remove("GIT_ALLOW_PROTOCOL");
+}
+
 /// Null device path, platform-appropriate.
 /// Use this for GIT_CONFIG_SYSTEM to disable system config in tests.
 #[cfg(windows)]
@@ -590,6 +617,7 @@ pub fn configure_cli_command(cmd: &mut Command) {
 /// - Deterministic commit timestamps
 /// - Consistent locale settings
 /// - No terminal prompts
+/// - No network transports (`GIT_ALLOWED_PROTOCOLS`)
 ///
 /// # Arguments
 /// * `cmd` - The git Command to configure
@@ -608,6 +636,7 @@ pub fn configure_git_cmd(cmd: &mut Command, git_config_path: &Path) {
     cmd.env("LANG", "C");
     cmd.env("WORKTRUNK_TEST_EPOCH", TEST_EPOCH.to_string());
     cmd.env("GIT_TERMINAL_PROMPT", "0");
+    cmd.env("GIT_ALLOW_PROTOCOL", GIT_ALLOWED_PROTOCOLS);
 }
 
 /// Configure a `Cmd`-based git command with isolated environment for testing.
@@ -627,6 +656,7 @@ pub fn configure_git_env(cmd: Cmd, git_config_path: &Path) -> Cmd {
         .env("LANG", "C")
         .env("WORKTRUNK_TEST_EPOCH", TEST_EPOCH.to_string())
         .env("GIT_TERMINAL_PROMPT", "0")
+        .env("GIT_ALLOW_PROTOCOL", GIT_ALLOWED_PROTOCOLS)
 }
 
 /// Shared interface for test repository fixtures.
@@ -1063,6 +1093,10 @@ impl TestRepo {
             ),
             // Prevent git from prompting for credentials when running under a TTY
             ("GIT_TERMINAL_PROMPT".to_string(), "0".to_string()),
+            (
+                "GIT_ALLOW_PROTOCOL".to_string(),
+                GIT_ALLOWED_PROTOCOLS.to_string(),
+            ),
             // Use test-specific home directory for isolation
             ("HOME".to_string(), self.home_path().display().to_string()),
             (
@@ -3056,6 +3090,46 @@ fn is_leap_year(year: i64) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A harness-built `git` reaches local paths and nothing else, so no test
+    /// can make an unbounded connect to whatever host a fixture URL names
+    /// (see [`GIT_ALLOWED_PROTOCOLS`]).
+    #[test]
+    fn test_harness_git_allows_local_paths_only() {
+        let repo = TestRepo::with_initial_commit();
+        let ls_remote = |url: &str| {
+            repo.git_command()
+                .args(["ls-remote", "--symref", url, "HEAD"])
+                .run()
+                .unwrap()
+        };
+
+        let local = ls_remote(&path_slash::PathExt::to_slash_lossy(repo.root_path()));
+        assert!(
+            local.status.success(),
+            "local-path remote must still resolve: {}",
+            String::from_utf8_lossy(&local.stderr)
+        );
+
+        let remote = ls_remote("https://github.com/test-owner/test-repo.git");
+        let stderr = String::from_utf8_lossy(&remote.stderr);
+        assert!(
+            stderr.contains("transport 'https' not allowed"),
+            "https transport must be refused, got: {stderr}"
+        );
+
+        // The opt-out has to clear the var, not narrow it: a value that still
+        // named a protocol list would silently keep the fixture clone offline,
+        // and the daily benchmark run is the only thing that would notice.
+        let mut opted_out = Command::new("git");
+        configure_git_cmd(&mut opted_out, Path::new(NULL_DEVICE));
+        allow_network_transports(&mut opted_out);
+        assert!(
+            opted_out
+                .get_envs()
+                .any(|(k, v)| k == "GIT_ALLOW_PROTOCOL" && v.is_none())
+        );
+    }
 
     #[test]
     fn test_unix_to_iso8601() {

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -243,6 +243,34 @@ pub const TEST_EPOCH: u64 = 1735776000;
 /// Generous to avoid flakiness under CI load; exponential backoff means fast tests when things work.
 const BG_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 
+/// Value for `GIT_ALLOW_PROTOCOL` on every git process a test spawns, whether
+/// directly or as a child of `wt`: local paths and `file://` only, so the
+/// suite cannot reach the wire.
+///
+/// Tests point remotes at real hosts (`https://github.com/test-owner/…`) to
+/// drive forge detection, and `Repository::default_branch()` is allowed to
+/// fall through to `git ls-remote` when neither the worktrunk cache nor
+/// `origin/HEAD` resolves. So a test that never meant to do network work
+/// makes an unbounded connect to whatever host the URL names. Nothing in that
+/// path has a timeout: an unanswered SYN costs ~127 s per address on Linux
+/// (`tcp_syn_retries=6`) and a host with several A/AAAA records is tried in
+/// turn, which is how a 2-second test reaches nextest's 180 s limit.
+///
+/// Denying the transport turns that into an immediate `transport 'https' not
+/// allowed`; detection then falls back to local inference, leaving output
+/// unchanged. The adjacent `GIT_TERMINAL_PROMPT=0` doesn't subsume this: it
+/// only suppresses the credential prompt the host's 401 triggers, so the
+/// request has already gone out by the time it applies.
+const GIT_ALLOWED_PROTOCOLS: &str = "file";
+
+/// Restore git's default protocol set on a command built by
+/// [`configure_git_cmd`], for a caller whose job is to fetch a fixture from
+/// upstream — the real-repo benchmark clone. Grep for this to enumerate
+/// everything that may reach the wire; tests are not among them.
+pub fn allow_network_transports(cmd: &mut Command) {
+    cmd.env_remove("GIT_ALLOW_PROTOCOL");
+}
+
 /// Static environment variables shared by all test isolation helpers.
 ///
 /// These are used by both `configure_cli_command()` (for Command-based tests)
@@ -253,6 +281,10 @@ const BG_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
 /// are NOT included here because they depend on the TestRepo instance.
 pub const STATIC_TEST_ENV_VARS: &[(&str, &str)] = &[
     ("CLICOLOR_FORCE", "1"),
+    // Deny network git transports (see GIT_ALLOWED_PROTOCOLS). Host-independent,
+    // so it belongs here rather than in each builder's path-dependent block —
+    // which is what reaches the hand-rolled PTY env builders too.
+    ("GIT_ALLOW_PROTOCOL", GIT_ALLOWED_PROTOCOLS),
     // Terminal width for PTY tests. configure_cli_command() overrides to 500 for longer paths.
     ("COLUMNS", "150"),
     // Deterministic locale settings
@@ -290,33 +322,6 @@ pub const STATIC_TEST_ENV_VARS: &[(&str, &str)] = &[
 // - configure_cli_command() sets TERM=alacritty for hyperlink detection testing
 // - PTY tests (especially skim-based picker tests) need a TERM with valid terminfo
 // - macOS CI doesn't have alacritty terminfo, causing skim to fail
-
-/// Value for `GIT_ALLOW_PROTOCOL` on every git process a test spawns: local
-/// paths and `file://` only, so the suite cannot reach the wire.
-///
-/// Tests point remotes at real hosts (`https://github.com/test-owner/…`) to
-/// drive forge detection, and `Repository::default_branch()` is allowed to
-/// fall through to `git ls-remote` when neither the worktrunk cache nor
-/// `origin/HEAD` resolves. So a test that never meant to do network work
-/// makes an unbounded connect to whatever host the URL names. Nothing in that
-/// path has a timeout: an unanswered SYN costs ~127 s per address on Linux
-/// (`tcp_syn_retries=6`) and a host with several A/AAAA records is tried in
-/// turn, which is how a 2-second test reaches nextest's 180 s limit.
-///
-/// Denying the transport turns that into an immediate `transport 'https' not
-/// allowed`; detection then falls back to local inference, leaving output
-/// unchanged. The adjacent `GIT_TERMINAL_PROMPT=0` doesn't subsume this: it
-/// only suppresses the credential prompt the host's 401 triggers, so the
-/// request has already gone out by the time it applies.
-const GIT_ALLOWED_PROTOCOLS: &str = "file";
-
-/// Restore git's default protocol set on a command built by
-/// [`configure_git_cmd`], for a caller whose job is to fetch a fixture from
-/// upstream — the real-repo benchmark clone. Grep for this to enumerate
-/// everything that may reach the wire; tests are not among them.
-pub fn allow_network_transports(cmd: &mut Command) {
-    cmd.env_remove("GIT_ALLOW_PROTOCOL");
-}
 
 /// Null device path, platform-appropriate.
 /// Use this for GIT_CONFIG_SYSTEM to disable system config in tests.
@@ -1093,10 +1098,6 @@ impl TestRepo {
             ),
             // Prevent git from prompting for credentials when running under a TTY
             ("GIT_TERMINAL_PROMPT".to_string(), "0".to_string()),
-            (
-                "GIT_ALLOW_PROTOCOL".to_string(),
-                GIT_ALLOWED_PROTOCOLS.to_string(),
-            ),
             // Use test-specific home directory for isolation
             ("HOME".to_string(), self.home_path().display().to_string()),
             (
@@ -3105,10 +3106,10 @@ mod tests {
         };
 
         let local = ls_remote(&path_slash::PathExt::to_slash_lossy(repo.root_path()));
+        let local_stderr = String::from_utf8_lossy(&local.stderr);
         assert!(
             local.status.success(),
-            "local-path remote must still resolve: {}",
-            String::from_utf8_lossy(&local.stderr)
+            "local-path remote must still resolve: {local_stderr}"
         );
 
         let remote = ls_remote("https://github.com/test-owner/test-repo.git");

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -47,6 +47,7 @@ be isolated from the host environment to prevent:
 - **Directive leakage**: Test commands writing to the user's shell directive file
 - **Config pollution**: Tests reading/writing the user's real config
 - **Git interference**: Host GIT_* environment variables affecting test behavior
+- **Network access**: a fixture's `https://` remote URL becoming a real connect, with no timeout bounding it (`GIT_ALLOWED_PROTOCOLS` in `src/testing/mod.rs`)
 
 ### With a TestRepo fixture (most tests)
 

--- a/tests/helpers/wt-perf/src/lib.rs
+++ b/tests/helpers/wt-perf/src/lib.rs
@@ -28,7 +28,7 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::OnceLock;
 use tempfile::TempDir;
-use worktrunk::testing::{NULL_DEVICE, configure_git_cmd};
+use worktrunk::testing::{NULL_DEVICE, allow_network_transports, configure_git_cmd};
 
 /// Lazy-initialized rust repo path.
 static RUST_REPO: OnceLock<PathBuf> = OnceLock::new();
@@ -156,7 +156,8 @@ pub fn parse_pair(config: &str, prefix: &str) -> Option<(usize, usize)> {
 /// redirected to `NULL_DEVICE`. Thin call-site wrapper around
 /// [`configure_git_cmd`] — every git invocation in this crate goes
 /// through here. Doesn't set `current_dir`; callers do that explicitly
-/// when they have a target.
+/// when they have a target. Network transports are denied; the upstream
+/// fixture clone re-permits them via [`allow_network_transports`].
 fn git_command() -> Command {
     let mut cmd = Command::new("git");
     configure_git_cmd(&mut cmd, Path::new(NULL_DEVICE));
@@ -709,7 +710,9 @@ fn ensure_rust_repo() -> PathBuf {
             std::fs::create_dir_all(&cache_dir).unwrap();
             eprintln!("Cloning rust-lang/rust (this will take several minutes)...");
 
-            let clone_output = git_command()
+            let mut clone = git_command();
+            allow_network_transports(&mut clone);
+            let clone_output = clone
                 .args([
                     "clone",
                     "https://github.com/rust-lang/rust.git",

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_self_hosted_tea_authed.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_self_hosted_tea_authed.snap
@@ -7,8 +7,10 @@ info:
     - "pr:101"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
     GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
@@ -35,6 +37,7 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -51,4 +54,4 @@ exit_code: 1
 [107m [0m by @alice · open · feature-auth · [90mhttps://forge.selfhosted.test/owner/test-repo/pulls/101[39m
 [36m◎[39m [36mFetching [1mfeature-auth[22m from origin...[39m
 [31m✗[39m [31mFailed to fetch branch [1mfeature-auth[22m from origin[39m
-[107m [0m fatal: unable to access 'https://forge.selfhosted.test/owner/test-repo.git/': Could not resolve host: forge.selfhosted.test
+[107m [0m fatal: transport 'https' not allowed


### PR DESCRIPTION
`ci_status::test_list_full_with_configured_platform_github` hit nextest's 180s timeout in an advisory CI job while the same 2586-test run passed everything else. Its unloaded runtime is 2.2s, and a `-vv` trace of the same fixture shows exactly one non-local subprocess: `git ls-remote --symref origin HEAD` against `https://bitbucket.org/test-owner/test-repo.git`, the URL the test sets on itself. `Repository::default_branch()` falls through to the wire when neither the worktrunk cache nor `origin/HEAD` resolves, which is sanctioned behavior, but nothing bounds it, so the test blocks for as long as the connect takes. Reproduced by pointing that remote at an unroutable address: 11s on macOS, and on Linux an unanswered SYN costs ~127s per address (`tcp_syn_retries=6`), with `bitbucket.org` publishing six.

It isn't one test. Setting `GIT_TRACE` across the harness shows a single full-suite run spawning 180 `git-remote-https` processes: 63 to github.com, 42 to gitlab.com, 27 to dev.azure.com, 3 to bitbucket.org, and the rest to names that don't resolve. Every one is unbounded, on three OSes, on every PR.

So the fix goes in the harness rather than in the one test. `GIT_ALLOW_PROTOCOL=file` joins `STATIC_TEST_ENV_VARS`, which covers every `wt` subprocess and every PTY env builder including the hand-rolled ones, and the two git-only builders set it as well for direct `git_command()` spawns that don't consult that table. Local paths and `file://` keep working; anything else fails in milliseconds with `transport 'https' not allowed`, and default-branch detection falls back to local inference, so output is unchanged. `GIT_TERMINAL_PROMPT` was never enough on its own: it only suppresses the credential prompt that the host's 401 triggers, by which point the request has already gone out.

The rust-lang/rust benchmark fixture clone is the one git call that *should* reach upstream. It opts back in through `allow_network_transports`, which lives next to the constant so the deny and the opt-out can't drift apart.

`switch_pr_self_hosted_tea_authed` recorded the resolver's `Could not resolve host` in its snapshot, which is the same defect class (asserted output depending on DNS). It now records the transport refusal.

Also folded in: `build_worktree_config_bare_layout` in `src/git/repository/tests.rs` carried a nine-line hand-rolled copy of `configure_git_env`, so it now calls it.

Not addressed here: nothing bounds that `ls-remote` for real users either, so an unreachable remote blocks `wt list --full` and `wt switch` for minutes on the first call per repo. That needs a decision about whether a timed-out detection should write the `worktrunk.default-branch` cache.

> _This was written by Claude Code on behalf of max_
