### PR TITLE
fix(ci-status): classify tea failures by shape; report azure-devops extension

### DIFF
--- a/src/commands/config/show.rs
+++ b/src/commands/config/show.rs
@@ -12,6 +12,7 @@ use color_print::cformat;
 use worktrunk::config::{
     ProjectConfig, UserConfig, default_system_config_path, require_config_path, system_config_path,
 };
+use worktrunk::git::remote_ref::azure::azure_devops_extension_installed;
 use worktrunk::git::{CiPlatform, ErrorExt, Repository};
 use worktrunk::path::format_path_for_display;
 use worktrunk::shell::{FileDetectionResult, Shell, scan_for_detection_details};
@@ -570,6 +571,18 @@ fn render_diagnostics(out: &mut String) -> anyhow::Result<()> {
                 ci_tools.az_installed,
                 ci_tools.az_authenticated,
             )?;
+            // The whole `az repos` command group ships in the azure-devops
+            // extension, so an `az` without it reports no CI status however
+            // well it's authenticated — and only the user can install it.
+            if ci_tools.az_installed && !azure_devops_extension_installed(repo.repo_path()?) {
+                writeln!(
+                    out,
+                    "{}",
+                    warning_message(cformat!(
+                        "<bold>azure-devops</> extension not installed; run <bold>az extension add --name azure-devops</>"
+                    ))
+                )?;
+            }
         }
         None => {
             writeln!(

--- a/src/commands/list/ci_status/gitea.rs
+++ b/src/commands/list/ci_status/gitea.rs
@@ -9,7 +9,7 @@ use worktrunk::git::{Repository, parse_owner_repo};
 
 use super::{
     CiBranchName, CiSource, CiStatus, MAX_PRS_TO_FETCH, PrRef, PrStatus, branch_owner_repo,
-    is_retriable_error, non_interactive_cmd, output_error_text, parse_json, retriable_pr_error,
+    is_retriable_error, non_interactive_cmd, output_error_text, parse_json,
 };
 
 /// Run `tea api <path>` from the worktree root.
@@ -26,6 +26,27 @@ fn tea_api(repo: &Repository, path: &str) -> Option<Output> {
         .ok()
 }
 
+/// The error text of a `tea api` call, or `None` when the response carries the
+/// resource.
+///
+/// Neither failure shape is an exit code. `tea api` never reads the HTTP status
+/// — it copies the response body to stdout and exits 0 — so a non-zero exit
+/// means `tea` itself failed (transport error, no login configured) and its
+/// stderr names which, while every HTTP error arrives as a successful spawn
+/// carrying Gitea's `APIError` body in place of the resource. Branching on the
+/// exit code alone would let that body through as data: every field of
+/// [`GiteaCombinedStatus`] defaults, so a 500 would deserialize as "no
+/// statuses" and paint a blank CI cell.
+fn tea_api_error(output: &Output) -> Option<String> {
+    if !output.status.success() {
+        return Some(output_error_text(output));
+    }
+    serde_json::from_slice::<GiteaApiError>(&output.stdout)
+        .ok()
+        .map(|error| error.message)
+        .filter(|message| !message.trim().is_empty())
+}
+
 /// Fetch the combined CI status for a commit SHA.
 ///
 /// Returns `Some(CiStatus::Error)` for retriable failures (rate limit, network),
@@ -38,11 +59,10 @@ fn fetch_combined_status(
 ) -> Option<CiStatus> {
     let path = format!("repos/{owner}/{repo_name}/commits/{sha}/status");
     let output = tea_api(repo, &path)?;
-    if !output.status.success() {
+    if let Some(error) = tea_api_error(&output) {
         // The PR-status warning from `retriable_pr_error` is the wrong shape
-        // here (this returns just CiStatus); reuse `output_error_text` so
-        // both stdout and stderr are sniffed.
-        return is_retriable_error(&output_error_text(&output)).then_some(CiStatus::Error);
+        // here (this returns just CiStatus).
+        return is_retriable_error(&error).then_some(CiStatus::Error);
     }
     let combined: GiteaCombinedStatus = parse_json(&output.stdout, "tea api commit status", sha)?;
     if combined.total_count == 0 {
@@ -73,8 +93,8 @@ pub(super) fn detect_gitea_pr(
     let path =
         format!("repos/{query_owner}/{query_repo}/pulls?state=open&limit={MAX_PRS_TO_FETCH}");
     let output = tea_api(repo, &path)?;
-    if !output.status.success() {
-        return retriable_pr_error(&output);
+    if let Some(error) = tea_api_error(&output) {
+        return is_retriable_error(&error).then(PrStatus::error);
     }
 
     let prs: Vec<GiteaPr> = parse_json(&output.stdout, "tea api pulls", &branch.full_name)?;
@@ -173,6 +193,15 @@ fn parse_gitea_status_state(state: &str) -> Option<CiStatus> {
     }
 }
 
+/// Gitea's `APIError` body, which the API returns in place of the resource
+/// whenever a request fails. `message` carries no `#[serde(default)]` so the
+/// shape only matches a real error body — the success shapes here (a PR array,
+/// a combined status) have no `message` field.
+#[derive(Debug, Deserialize)]
+struct GiteaApiError {
+    message: String,
+}
+
 /// Combined commit status from `GET /repos/{owner}/{repo}/commits/{ref}/status`.
 #[derive(Debug, Deserialize)]
 struct GiteaCombinedStatus {
@@ -256,6 +285,33 @@ mod tests {
         assert_eq!(pr(Some(0)).comment_count(), None);
         assert_eq!(pr(None).comment_count(), None);
         assert_eq!(pr(Some(2)).comment_count(), Some(2));
+    }
+
+    /// `tea_api_error` reads the response shape, since the exit code carries
+    /// nothing: a PR array and a combined status are data, an `APIError` body
+    /// is the failure. Gitea blanks the message of a 500 for a non-admin token,
+    /// which leaves nothing to sniff — that falls through to the data path,
+    /// where the parse decides.
+    #[test]
+    fn test_tea_api_error_reads_the_response_shape() {
+        // `ExitStatus::default()` is success on every platform, so these all
+        // exercise the exit-0 path — the one the exit code can't classify.
+        let response = |stdout: &str| Output {
+            status: Default::default(),
+            stdout: stdout.as_bytes().to_vec(),
+            stderr: Vec::new(),
+        };
+
+        assert_eq!(tea_api_error(&response("[]")), None);
+        assert_eq!(
+            tea_api_error(&response(r#"{"state":"success","total_count":2}"#)),
+            None
+        );
+        assert_eq!(
+            tea_api_error(&response(r#"{"message":"token does not have scope"}"#)),
+            Some("token does not have scope".to_string())
+        );
+        assert_eq!(tea_api_error(&response(r#"{"message":"  "}"#)), None);
     }
 
     #[test]

--- a/src/commands/list/ci_status/mod.rs
+++ b/src/commands/list/ci_status/mod.rs
@@ -1061,7 +1061,8 @@ mod tests {
         let status = retriable_pr_error(&out).expect("retriable should yield Some");
         assert_eq!(status.ci_status, CiStatus::Error);
 
-        // Retriable from stdout (the `tea` shape).
+        // Retriable from stdout — a tool that copies the server's error body
+        // through rather than writing its own message to stderr.
         let out = fake_output("", r#"{"message":"rate limit exceeded"}"#);
         assert!(retriable_pr_error(&out).is_some());
 

--- a/src/git/remote_ref/azure.rs
+++ b/src/git/remote_ref/azure.rs
@@ -216,9 +216,13 @@ struct AzExtension {
 /// `az extension list --output json` answers with a name/version array, so no
 /// prose is involved. An `az` that can't answer — spawn failure, non-zero
 /// exit, output that won't parse — leaves the question open, and an open
-/// question counts as installed: the caller then falls through to `az`'s own
-/// error rather than blaming an extension we never confirmed was missing.
-fn azure_devops_extension_installed(repo_root: &std::path::Path) -> bool {
+/// question counts as installed: callers then say nothing about the extension
+/// rather than blaming one we never confirmed was missing.
+///
+/// Two callers, both on a path where the answer is actionable: `fetch_pr_info`
+/// when `az repos pr show` has already failed, and `wt config show --full`,
+/// which reports a missing extension as the persistent condition it is.
+pub fn azure_devops_extension_installed(repo_root: &std::path::Path) -> bool {
     Cmd::new("az")
         .args(["extension", "list", "--output", "json"])
         .current_dir(repo_root)
@@ -268,9 +272,7 @@ fn fetch_pr_info(pr_number: u32, repo: &Repository) -> anyhow::Result<RemoteRefI
         // answers it in JSON. Asking it here, on the failure path only, keeps
         // the install command out of the happy path's cost.
         if !azure_devops_extension_installed(repo_root) {
-            bail!(
-                "Azure DevOps CLI extension not installed; run az extension add --name azure-devops"
-            );
+            bail!("azure-devops extension not installed; run az extension add --name azure-devops");
         }
         // Everything else `az` reports is prose on stderr — no exit code, no
         // JSON error channel. Rather than guess at the cause from English

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -1797,6 +1797,27 @@ impl TestRepo {
             .write(mock_bin);
     }
 
+    /// Add a mock `az` (installed and authenticated) whose `az extension list`
+    /// reports `extensions_json` to the existing mock bin.
+    ///
+    /// Call this after `setup_mock_ci_tools_unauthenticated()` to make
+    /// `wt config show --full` against an Azure DevOps remote deterministic —
+    /// the Azure diagnostics rows depend on `az`'s state and on whether the
+    /// `azure-devops` extension is among the installed ones.
+    pub fn setup_mock_az_with_extensions(&mut self, extensions_json: &str) {
+        let mock_bin = self
+            .mock_bin_path
+            .as_ref()
+            .expect("call setup_mock_ci_tools_unauthenticated() first");
+        std::fs::write(mock_bin.join("az_extensions.json"), extensions_json).unwrap();
+        MockConfig::new("az")
+            .version("azure-cli 2.60.0 (mock)")
+            .command("account show", MockResponse::exit(0))
+            .command("extension list", MockResponse::file("az_extensions.json"))
+            .command("_default", MockResponse::exit(1))
+            .write(mock_bin);
+    }
+
     /// Setup mock `claude` CLI as installed
     ///
     /// Call this after setup_mock_ci_tools_unauthenticated() to simulate

--- a/tests/integration_tests/ci_status.rs
+++ b/tests/integration_tests/ci_status.rs
@@ -1347,6 +1347,16 @@ fn run_gitea_ci_status_test(
     });
 }
 
+/// Gitea's `APIError` body, which the API returns in place of the resource
+/// whenever a request fails — and which `tea api` copies to stdout with exit 0,
+/// since it never reads the HTTP status. The message is a 500's wrapped
+/// internal error (Gitea passes it through for an admin token), so
+/// `is_retriable_error` recognizes the cause.
+const GITEA_API_ERROR_BODY: &str = r#"{
+    "message": "pq: dial tcp 10.0.0.5:5432: connect: connection refused",
+    "url": "https://gitea.example.com/api/swagger"
+}"#;
+
 /// Build a one-PR `tea api .../pulls` response for the `feature` branch.
 fn gitea_feature_pr_json(head_sha: &str, mergeable: bool) -> String {
     format!(
@@ -1426,14 +1436,47 @@ fn test_list_full_with_gitea_no_ci(mut repo: TestRepo) {
     );
 }
 
-/// A retriable error from `tea api .../pulls` surfaces as an error indicator
+/// A Gitea 500 whose `APIError` body names a retriable cause surfaces as an
+/// error indicator rather than NoCI. `tea api` exits 0 here — it copies the
+/// response body through without reading the HTTP status — so the body's shape
+/// is what separates this from a PR list.
+#[rstest]
+fn test_list_full_with_gitea_pr_error_body(mut repo: TestRepo) {
+    let head_sha = setup_gitea_repo_with_feature(&mut repo);
+    run_gitea_ci_status_test(
+        &mut repo,
+        "gitea_pr_error_body",
+        &head_sha,
+        GITEA_API_ERROR_BODY,
+        r#"{"state":"","total_count":0}"#,
+    );
+}
+
+/// The same `APIError` body from the commit-status lookup (when no PR exists
+/// for the branch). Without shape discrimination this one is the quieter bug:
+/// every field of `GiteaCombinedStatus` defaults, so the error body would
+/// deserialize as "no statuses" and paint a blank cell.
+#[rstest]
+fn test_list_full_with_gitea_commit_status_error_body(mut repo: TestRepo) {
+    let head_sha = setup_gitea_repo_with_feature(&mut repo);
+    run_gitea_ci_status_test(
+        &mut repo,
+        "gitea_commit_status_error_body",
+        &head_sha,
+        "[]",
+        GITEA_API_ERROR_BODY,
+    );
+}
+
+/// `tea` itself failing on `tea api .../pulls` surfaces as an error indicator
 /// rather than NoCI (exercises the `is_retriable_error` branch in
-/// `detect_gitea_pr`).
+/// `detect_gitea_pr`). A transport failure is the case that does exit non-zero,
+/// and `tea` names it on stderr.
 #[rstest]
 fn test_list_full_with_gitea_retriable_error(mut repo: TestRepo) {
     setup_gitea_repo_with_feature(&mut repo);
     repo.setup_mock_tea_with_detection_error(
-        "Error: GET .../api/v1/repos/owner/test-repo/pulls: 429 Too Many Requests",
+        r#"Error: Get "https://gitea.example.com/api/v1/repos/owner/test-repo/pulls": dial tcp 10.0.0.5:443: connect: connection refused"#,
     );
 
     let settings = setup_snapshot_settings(&repo);
@@ -1452,7 +1495,7 @@ fn test_list_full_with_gitea_commit_status_retriable_error(mut repo: TestRepo) {
     let head_sha = setup_gitea_repo_with_feature(&mut repo);
     repo.setup_mock_tea_commit_status_error(
         &head_sha,
-        "Error: GET .../api/v1/repos/owner/test-repo/commits/.../status: 429 Too Many Requests",
+        r#"Error: Get "https://gitea.example.com/api/v1/repos/owner/test-repo/commits/HEAD/status": dial tcp 10.0.0.5:443: connect: connection refused"#,
     );
 
     let settings = setup_snapshot_settings(&repo);

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -1560,6 +1560,58 @@ fn test_config_show_full_gitea_remote(mut repo: TestRepo, temp_home: TempDir) {
     });
 }
 
+/// `wt config show --full` against an Azure DevOps remote reports the `az` CLI
+/// row plus the `azure-devops` extension, which the whole `az repos` command
+/// group ships in: without it CI status stays blank however well `az` is
+/// authenticated, and only the user can install it.
+#[rstest]
+#[case::missing("[]", "config_show_full_azure_extension_missing")]
+#[case::installed(
+    r#"[{"name": "azure-devops", "version": "1.0.0"}]"#,
+    "config_show_full_azure_extension_installed"
+)]
+fn test_config_show_full_azure_remote(
+    mut repo: TestRepo,
+    temp_home: TempDir,
+    #[case] extensions_json: &str,
+    #[case] snapshot_name: &str,
+) {
+    repo.setup_mock_ci_tools_unauthenticated();
+    repo.setup_mock_az_with_extensions(extensions_json);
+
+    // The fixture already has an `origin`; point it at an Azure DevOps host.
+    repo.run_git(&[
+        "remote",
+        "set-url",
+        "origin",
+        "https://dev.azure.com/myorg/myproject/_git/test-repo",
+    ]);
+
+    let global_config_dir = temp_home.path().join(".config").join("worktrunk");
+    fs::create_dir_all(&global_config_dir).unwrap();
+    fs::write(
+        global_config_dir.join("config.toml"),
+        "worktree-path = \"../{{ repo }}.{{ branch }}\"",
+    )
+    .unwrap();
+
+    let settings = setup_snapshot_settings_with_home(&repo, &temp_home);
+    settings.bind(|| {
+        let mut cmd = wt_command();
+        repo.configure_wt_cmd(&mut cmd);
+        repo.configure_mock_commands(&mut cmd);
+        cmd.env("WORKTRUNK_TEST_LATEST_VERSION", env!("CARGO_PKG_VERSION"));
+        cmd.arg("config")
+            .arg("show")
+            .arg("--full")
+            .current_dir(repo.root_path());
+        set_temp_home_env(&mut cmd, temp_home.path());
+        set_xdg_config_path(&mut cmd, temp_home.path());
+
+        assert_cmd_snapshot!(snapshot_name, cmd);
+    });
+}
+
 #[rstest]
 fn test_config_show_github_remote(mut repo: TestRepo, temp_home: TempDir) {
     // Setup mock gh/glab for deterministic BINARIES output

--- a/tests/snapshots/integration__integration_tests__ci_status__gitea_commit_status_error_body.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitea_commit_status_error_body.snap
@@ -1,10 +1,10 @@
 ---
-source: tests/integration_tests/switch.rs
+source: tests/integration_tests/ci_status.rs
 info:
   program: wt
   args:
-    - switch
-    - "pr:101"
+    - list
+    - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
@@ -43,10 +43,16 @@ info:
     WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
-success: false
-exit_code: 1
+success: true
+exit_code: 0
 ----- stdout -----
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCI[0m     [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m            .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ feature        [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [33m⚠[0m      ../repo.feature    [2m9c1e078b[0m  [2m1d[0m    [2mfeat: gitea feature[0m
 
 ----- stderr -----
-[36m◎[39m [36mFetching PR #101...[39m
-[31m✗[39m [31mazure-devops extension not installed; run az extension add --name azure-devops[39m
+
+[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitea_pr_error_body.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitea_pr_error_body.snap
@@ -1,10 +1,10 @@
 ---
-source: tests/integration_tests/switch.rs
+source: tests/integration_tests/ci_status.rs
 info:
   program: wt
   args:
-    - switch
-    - "pr:101"
+    - list
+    - "--full"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
@@ -43,10 +43,16 @@ info:
     WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
-success: false
-exit_code: 1
+success: true
+exit_code: 0
 ----- stdout -----
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCI[0m     [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     [33m⚠[0m      .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [33m⚠[0m      ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [33m⚠[0m      ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [33m⚠[0m      ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ feature        [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [33m⚠[0m      ../repo.feature    [2m9c1e078b[0m  [2m1d[0m    [2mfeat: gitea feature[0m
 
 ----- stderr -----
-[36m◎[39m [36mFetching PR #101...[39m
-[31m✗[39m [31mazure-devops extension not installed; run az extension add --name azure-devops[39m
+
+[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_azure_extension_installed.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_azure_extension_installed.snap
@@ -1,0 +1,89 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - show
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_LATEST_VERSION: "[VERSION]"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
+[33m▲[39m [33mUser config: [1m[list] json-schema[22m is unset; a future release switches the JSON default to schema 2[39m
+[2m↳[22m [2mTo apply: [4mwt config update[24m[22m
+[2m○[22m Proposed diff:
+[107m [0m [1mdiff --git a/config.toml/current b/config.toml/migrated[m
+[107m [0m [1mindex a10f823..894e11f 100644[m
+[107m [0m [1m--- a/config.toml/current[m
+[107m [0m [1m+++ b/config.toml/migrated[m
+[107m [0m [36m@@ -1 +1,4 @@[m
+[107m [0m [31m-worktree-path = "../{{ repo }}.{{ branch }}"[m
+[107m [0m \ No newline at end of file[m
+[107m [0m [32m+[m[32mworktree-path = "../{{ repo }}.{{ branch }}"[m
+[107m [0m [32m+[m
+[107m [0m [32m+[m[32m[list][m
+[107m [0m [32m+[m[32mjson-schema = 2[m
+
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"[0m
+[2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
+
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
+[2m○[22m Identifier: [1mdev.azure.com/myorg/myproject/_git/test-repo[22m
+[2m↳[22m [2mNot found[22m
+
+[36mSHELL INTEGRATION[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
+
+[36mDIAGNOSTICS[39m
+[32m✓[39m [32m[1maz[22m installed & authenticated[39m
+[2m○[22m Up to date ([1m[VERSION][22m)
+[2m↳[22m [2mCommit generation not configured[22m
+
+[36mOTHER[39m
+[2m○[22m wt: [1m[VERSION][22m
+[2m○[22m git: [1m[VERSION][22m
+[2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----

--- a/tests/snapshots/integration__integration_tests__config_show__config_show_full_azure_extension_missing.snap
+++ b/tests/snapshots/integration__integration_tests__config_show__config_show_full_azure_extension_missing.snap
@@ -1,0 +1,90 @@
+---
+source: tests/integration_tests/config_show.rs
+info:
+  program: wt
+  args:
+    - config
+    - show
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
+    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_LATEST_VERSION: "[VERSION]"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+[36mUSER CONFIG[39m @ ~/.config/worktrunk/config.toml
+[33m▲[39m [33mUser config: [1m[list] json-schema[22m is unset; a future release switches the JSON default to schema 2[39m
+[2m↳[22m [2mTo apply: [4mwt config update[24m[22m
+[2m○[22m Proposed diff:
+[107m [0m [1mdiff --git a/config.toml/current b/config.toml/migrated[m
+[107m [0m [1mindex a10f823..894e11f 100644[m
+[107m [0m [1m--- a/config.toml/current[m
+[107m [0m [1m+++ b/config.toml/migrated[m
+[107m [0m [36m@@ -1 +1,4 @@[m
+[107m [0m [31m-worktree-path = "../{{ repo }}.{{ branch }}"[m
+[107m [0m \ No newline at end of file[m
+[107m [0m [32m+[m[32mworktree-path = "../{{ repo }}.{{ branch }}"[m
+[107m [0m [32m+[m
+[107m [0m [32m+[m[32m[list][m
+[107m [0m [32m+[m[32mjson-schema = 2[m
+
+[107m [0m [2mworktree-path = [0m[2m[32m"../{{ repo }}.{{ branch }}"[0m
+[2m↳[22m [2mOptional system config not found @ [2m/etc/xdg/worktrunk/config.toml[22m[22m
+
+[36mPROJECT CONFIG[39m @ _REPO_/.config/wt.toml
+[2m○[22m Identifier: [1mdev.azure.com/myorg/myproject/_git/test-repo[22m
+[2m↳[22m [2mNot found[22m
+
+[36mSHELL INTEGRATION[39m
+[33m▲[39m [33mShell integration not configured[39m
+[2m↳[22m [2mTo configure, run [4mwt config shell install[24m[22m
+[107m [0m Invoked as: [1m[PROJECT_ROOT]/target/[BUILD_MODE]/wt[22m
+
+[36mDIAGNOSTICS[39m
+[32m✓[39m [32m[1maz[22m installed & authenticated[39m
+[33m▲[39m [33m[1mazure-devops[22m extension not installed; run [1maz extension add --name azure-devops[22m[39m
+[2m○[22m Up to date ([1m[VERSION][22m)
+[2m↳[22m [2mCommit generation not configured[22m
+
+[36mOTHER[39m
+[2m○[22m wt: [1m[VERSION][22m
+[2m○[22m git: [1m[VERSION][22m
+[2m○[22m Hyperlinks: [1minactive[22m
+
+----- stderr -----


### PR DESCRIPTION
Two follow-ups from #3595, both in code that talks to a forge CLI.

## Gitea CI status had the same exit-0 blind spot as the switch path

`tea api` never reads the HTTP status — it copies the response body to stdout and exits 0 — so the `!output.status.success()` gate in `src/commands/list/ci_status/gitea.rs` never fired for a 4xx/5xx. #3595 fixed this for `wt switch pr:<n>`; the CI-status backend is the second instance of the same bug.

The commit-status path was the quieter one: every field of `GiteaCombinedStatus` carries `#[serde(default)]`, so Gitea's `APIError` body deserialized as `{state: "", total_count: 0}` — an error indistinguishable from "this commit has no statuses". The PR-list path was noisier but less harmful: the error body failed to parse and logged `Failed to parse tea api pulls JSON`, blaming an API change for what was an API error.

`tea_api_error` now reads the response shape — the `APIError` body, whose message feeds the existing retriable sniff — and a non-zero exit keeps meaning what it always meant, `tea` itself failing (transport error, no login). A proxy's HTML error page stays unclassified, as before: sniffing arbitrary bodies is the string-heuristic pile this removes.

## `wt config show --full` reports the azure-devops extension

The whole `az repos` command group ships in that extension, so without it CI status stays blank however well `az` is authenticated — a persistent, user-fixable condition, which is what this surface is for. `azure_devops_extension_installed` (added in #3595) answers it in JSON:

```console
✓ az installed & authenticated
▲ azure-devops extension not installed; run az extension add --name azure-devops
```

An `az` that can't answer counts as installed, so an unanswered check never becomes an accusation. The `wt switch pr:<n>` bail now uses the same sentence — one wording for one condition, which is the one-line change to `switch_pr_azure_extension_not_installed.snap`.

## Testing

The two new Gitea tests were checked against the unfixed source: reverting `gitea.rs` alone fails both, so they pin the fix rather than describe it. The two pre-existing retriable tests kept their exit-1 shape but lost their fabricated payload — `exit 1` alongside `429 Too Many Requests` is the combination `tea` can't produce — and now carry a real transport error, which is the case that does exit non-zero. `config show --full` gets a case per extension state.

> _This was written by Claude Code on behalf of max_
