### PR TITLE
refactor(commit): give the staging gate one name and one StageMode mapping

### DIFF
--- a/src/commands/commit.rs
+++ b/src/commands/commit.rs
@@ -64,7 +64,6 @@ pub struct CommitOptions<'a> {
     pub target_branch: Option<&'a str>,
     pub hooks: HookGate,
     pub stage_mode: StageMode,
-    pub warn_about_untracked: bool,
     pub show_no_squash_note: bool,
     /// Whether `commit()` runs its own guidance approval gate or trusts a
     /// value supplied by the caller (`wt merge` resolves the guidance via
@@ -73,14 +72,12 @@ pub struct CommitOptions<'a> {
 }
 
 impl<'a> CommitOptions<'a> {
-    /// Convenience constructor for the common case where untracked files should trigger a warning.
     pub fn new(ctx: &'a CommandContext<'a>) -> Self {
         Self {
             ctx,
             target_branch: None,
             hooks: HookGate::Run,
             stage_mode: StageMode::All,
-            warn_about_untracked: true,
             show_no_squash_note: false,
             guidance: super::step::PreApprovedGuidance::RunOwnGate,
         }
@@ -259,7 +256,7 @@ impl CommitOptions<'_> {
             )?;
         }
 
-        if self.warn_about_untracked && self.stage_mode == StageMode::All {
+        if self.stage_mode == StageMode::All {
             let status = wt
                 .run_command(&["status", "--porcelain", "-z"])
                 .context("Failed to get status")?;
@@ -269,7 +266,7 @@ impl CommitOptions<'_> {
         // Stage changes based on mode. Re-gated inside `stage`: the refusal
         // above ran before the pre-commit hooks, and a hook is free to leave
         // unmerged paths behind.
-        wt.stage(self.stage_mode, "commit")?;
+        wt.stage(self.stage_mode)?;
 
         let effective_config = self.ctx.commit_generation();
         // Skip the approval gate when the LLM isn't configured — the fallback

--- a/src/commands/merge.rs
+++ b/src/commands/merge.rs
@@ -347,7 +347,6 @@ pub fn handle_merge(opts: MergeOptions<'_>) -> anyhow::Result<()> {
             options.target_branch = Some(&target_branch);
             options.hooks = commit_hooks;
             options.stage_mode = stage_mode;
-            options.warn_about_untracked = stage_mode == super::commit::StageMode::All;
             options.show_no_squash_note = true;
             options.guidance = guidance.clone();
 

--- a/src/commands/relocate.rs
+++ b/src/commands/relocate.rs
@@ -305,7 +305,7 @@ pub fn validate_candidates(
                 // Stage all changes. `stage` refuses an unmerged index first —
                 // `git add -A` over an unresolved conflict would otherwise
                 // commit the `<<<<<<<` markers.
-                worktree.stage(StageMode::All, "relocate")?;
+                worktree.stage(StageMode::All)?;
                 // Commit using shared pipeline
                 let project_id = repo.project_identifier().ok();
                 let commit_config = config.commit_generation(project_id.as_deref());

--- a/src/commands/step/commit.rs
+++ b/src/commands/step/commit.rs
@@ -62,8 +62,6 @@ pub fn step_commit(
     options.hooks = hooks;
     options.stage_mode = stage_mode;
     options.show_no_squash_note = false;
-    // Only warn about untracked if we're staging all
-    options.warn_about_untracked = stage_mode == StageMode::All;
 
     let mut announcer = HookAnnouncer::new(ctx.repo, false);
     let outcome = options.commit(&mut announcer)?;
@@ -86,12 +84,9 @@ fn preview_commit(stage: Option<StageMode>, dry_run: bool, yes: bool) -> anyhow:
     // run would send. --show-prompt skips this — it's the cheap "what's already staged"
     // path. StageMode::None has nothing to stage, so we use the existing index as-is.
     let temp_index = if dry_run {
-        let add_args: Option<&[&str]> = match stage.unwrap_or(env.resolved().commit.stage()) {
-            StageMode::All => Some(&["add", "-A"]),
-            StageMode::Tracked => Some(&["add", "-u"]),
-            StageMode::None => None,
-        };
-        add_args
+        stage
+            .unwrap_or(env.resolved().commit.stage())
+            .add_args()
             .map(|args| stage_to_temp_index(&env.repo, args))
             .transpose()?
     } else {

--- a/src/commands/step/squash.rs
+++ b/src/commands/step/squash.rs
@@ -88,9 +88,9 @@ pub fn handle_squash(
     // `git switch`, the one command that throws the operation away.
     repo.ensure_no_operation_in_progress("squash")?;
     // Squash auto-stages, and `git add -A` would resolve an unmerged path to
-    // whatever is on disk — conflict markers included. Refuse ahead of the
-    // hooks and the LLM call, neither of which is worth running for a squash
-    // that cannot happen. `wt.stage` re-checks with nothing in between.
+    // whatever is on disk — conflict markers included. `wt.stage` gates that
+    // directly; refusing here too keeps the approval prompt below from asking
+    // about hooks for a squash that cannot happen.
     let wt = repo.worktree_at(&env.worktree_path);
     wt.ensure_no_unmerged_paths("squash")?;
     // Squash requires being on a branch (can't squash in detached HEAD)
@@ -162,7 +162,7 @@ pub fn handle_squash(
     if stage_mode == StageMode::All {
         repo.warn_if_auto_staging_untracked()?;
     }
-    wt.stage(stage_mode, "squash")?;
+    wt.stage(stage_mode)?;
 
     // Run pre-commit hooks (user first, then project).
     if hooks.run() {

--- a/src/config/user/sections.rs
+++ b/src/config/user/sections.rs
@@ -29,6 +29,23 @@ pub enum StageMode {
     None,
 }
 
+impl StageMode {
+    /// The `git` invocation this mode stages with, or `None` when it stages nothing.
+    ///
+    /// One home for the mapping, so a new variant can't be handled at one call
+    /// site and forgotten at the other: staging the real index
+    /// ([`WorkingTree::stage`](crate::git::WorkingTree::stage)) and mirroring the
+    /// mode into a throwaway index for `wt step commit --dry-run` both read it
+    /// from here.
+    pub fn add_args(self) -> Option<&'static [&'static str]> {
+        match self {
+            StageMode::All => Some(&["add", "-A"]),
+            StageMode::Tracked => Some(&["add", "-u"]),
+            StageMode::None => None,
+        }
+    }
+}
+
 /// Configuration for commit message generation
 ///
 /// The command is a shell string executed via `sh -c`. Environment variables

--- a/src/git/repository/working_tree.rs
+++ b/src/git/repository/working_tree.rs
@@ -520,8 +520,10 @@ impl<'a> WorkingTree<'a> {
     /// with it. Asking before staging is what keeps the markers out of a
     /// commit.
     ///
-    /// `action` names the command the user typed, so each entry point gates in
-    /// its own name rather than in the name of a step it delegates to.
+    /// `action` names the command the user typed. An entry point knows only
+    /// that, and often not yet whether it will commit at all —
+    /// `wt merge --no-commit` resolves its flags after this gate — so it
+    /// refuses in the name of the operation it was asked for.
     ///
     /// Every one of those gates refuses *early* — ahead of hooks, approval
     /// prompts, and the LLM call, none of which is worth running for a commit
@@ -560,27 +562,21 @@ impl<'a> WorkingTree<'a> {
     /// commands — and those hooks are arbitrary project code, free to leave
     /// unmerged paths behind after that gate has passed.
     ///
+    /// The refusal names the commit rather than taking an `action` from the
+    /// caller, because the commit is the only thing this gate guards — staging
+    /// on the user's behalf happens for no other reason. So
+    /// `wt merge --no-squash` reports `Cannot commit` even though the user
+    /// typed `merge`: that is the step actually blocked, and by then the flags
+    /// have resolved and the commit is certain.
+    ///
     /// [`StageMode::None`] stages nothing but is still gated: the caller is
     /// about to commit whatever the index already holds.
     ///
     /// [`StageMode::None`]: crate::config::StageMode::None
-    pub fn stage(&self, mode: crate::config::StageMode, action: &str) -> anyhow::Result<()> {
-        use crate::config::StageMode;
-
-        self.ensure_no_unmerged_paths(action)?;
-        match mode {
-            // Stage everything: tracked modifications + untracked files
-            StageMode::All => {
-                self.run_command(&["add", "-A"])
-                    .context("Failed to stage changes")?;
-            }
-            // Stage tracked modifications only (no untracked files)
-            StageMode::Tracked => {
-                self.run_command(&["add", "-u"])
-                    .context("Failed to stage tracked changes")?;
-            }
-            // Commit only what is already in the index
-            StageMode::None => {}
+    pub fn stage(&self, mode: crate::config::StageMode) -> anyhow::Result<()> {
+        self.ensure_no_unmerged_paths("commit")?;
+        if let Some(args) = mode.add_args() {
+            self.run_command(args).context("Failed to stage changes")?;
         }
         Ok(())
     }


### PR DESCRIPTION
Three simplifications to the staging gate #3588 introduced, all deletions.

## `stage` names the commit instead of taking a caller's name

`WorkingTree::stage` took an `action` string purely so its refusal could name the command the user typed. But staging on the user's behalf happens for exactly one reason — a commit is about to run — so the string was a constant wearing a parameter's clothes. It now names the commit, and three call-site strings go with it.

The entry gates keep their `action`, and the reason is worth stating because it's what stopped me deleting the parameter outright. An entry point often doesn't yet know it will commit at all:

```rust
current_wt.ensure_no_unmerged_paths("merge")?;   // src/commands/merge.rs:179
...
let ResolvedMergeFlags { commit, .. } = flags.resolve(&resolved.merge);   // :187
```

`wt merge --no-commit` resolves its flags *after* that gate, and requires a clean tree — which an unmerged path is not. So a conflicted `--no-commit` run hits the entry gate, and `Cannot commit` would be actively wrong for a command explicitly told not to commit. The two gates know different things, and now say different things for that reason.

This also settles the seam #3588 documented as a tradeoff: `wt merge --no-squash` reporting `Cannot commit` isn't a wrong label to be fixed later, it's the funnel correctly naming the only step it guards, at a point where the flags have resolved and the commit is certain.

## `CommitOptions::warn_about_untracked` was dead

It defaulted to `true`, and both assignments set it to `stage_mode == StageMode::All` immediately after assigning `stage_mode`:

```rust
options.stage_mode = stage_mode;
options.warn_about_untracked = stage_mode == super::commit::StageMode::All;
```

while the consumer already ANDs with the same condition:

```rust
if self.warn_about_untracked && self.stage_mode == StageMode::All {
```

No caller could make it `false` while the mode was `All`, so the field never decided anything.

## One home for the `StageMode` → `git add` mapping

The mapping existed as two matches: one in `stage`, one in `preview_commit` for the `--dry-run` temp index. Adding a variant meant finding both, and missing the preview would silently produce a `--dry-run` that disagreed with the real run. `StageMode::add_args` now owns it. `stage`'s two per-arm `.context()` strings collapse into one, which costs nothing the args don't already say.

## Also

`src/commands/step/squash.rs` justified its entry gate as refusing "ahead of the hooks and the LLM call" — but `wt.stage` is ahead of both too, so that reason no longer distinguished it. The gate is still worth keeping; what it uniquely precedes is the pre-commit approval prompt, so the comment says that now.

## Verification

No user-visible message changes, and the tests confirm it rather than assert it: the pre-merge gate reports **no snapshots to review**. Every refusal a test pins comes from an entry gate, which kept its name, and the one funnel-driven snapshot (`step_commit_refuses_hook_created_conflict`) already read `Cannot commit`.

`cargo run -- hook pre-merge --yes` green (4562/4562, clippy, fmt, doctests, doc sync). Also `cargo nextest run --features shell-integration-tests` (4562/4562) and `cargo clippy --all-targets --features shell-integration-tests`, which the gate doesn't compile — the blind spot that matters for removing a struct field. `RUSTDOCFLAGS=-Dwarnings cargo doc` clean for the new intra-doc link.

> _This was written by Claude Code on behalf of Maximilian_
