### PR TITLE
refactor(error): give the unmerged-index phrase one home

### DIFF
--- a/src/commands/relocate.rs
+++ b/src/commands/relocate.rs
@@ -26,7 +26,7 @@ use std::path::{Path, PathBuf};
 use anyhow::Context;
 use color_print::cformat;
 use worktrunk::config::UserConfig;
-use worktrunk::git::{ErrorExt, Repository, WorktreeInfo};
+use worktrunk::git::{ErrorExt, Repository, WorktreeInfo, format_unresolved_conflicts};
 use worktrunk::path::{format_path_for_display, paths_match};
 use worktrunk::styling::{
     eprintln, format_with_gutter, hint_message, info_message, println, progress_message,
@@ -283,12 +283,11 @@ pub fn validate_candidates(
                 // is the policy choice of skip over abort, not the guard.
                 let unmerged = worktree.unmerged_paths()?;
                 if !unmerged.is_empty() {
-                    let count = unmerged.len();
-                    let paths = if count == 1 { "path" } else { "paths" };
                     eprintln!(
                         "{}",
                         warning_message(cformat!(
-                            "Skipping <bold>{branch}</> ({count} {paths} with unresolved conflicts)"
+                            "Skipping <bold>{branch}</> ({})",
+                            format_unresolved_conflicts(unmerged.len())
                         ))
                     );
                     eprintln!("{}", format_with_gutter(&unmerged.join("\n"), None));

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -640,6 +640,15 @@ pub enum GitError {
 
 impl std::error::Error for GitError {}
 
+/// `"1 path with unresolved conflicts"` — the shared tail of every message
+/// about an unmerged index. [`GitError::UnmergedPaths`] refuses outright;
+/// `wt step relocate` warns and skips instead, because a conflict blocks only
+/// one of the many worktrees it walks. The phrase is shared, not the error type.
+pub fn format_unresolved_conflicts(count: usize) -> String {
+    let paths = if count == 1 { "path" } else { "paths" };
+    format!("{count} {paths} with unresolved conflicts")
+}
+
 impl GitError {
     /// Styled title for this variant (first line, with inline `<bold>`
     /// highlights on entity names like branch and path).
@@ -662,9 +671,10 @@ impl GitError {
             }
 
             GitError::UnmergedPaths { action, files } => {
-                let count = files.len();
-                let paths = if count == 1 { "path" } else { "paths" };
-                cformat!("Cannot {action}: {count} {paths} with unresolved conflicts")
+                format!(
+                    "Cannot {action}: {}",
+                    format_unresolved_conflicts(files.len())
+                )
             }
 
             GitError::UncommittedChanges { action, branch, .. } => match (action, branch) {

--- a/src/git/mod.rs
+++ b/src/git/mod.rs
@@ -66,6 +66,8 @@ pub use error::{
     WorktrunkError,
     // Wrap a HookCommandFailed-bearing error with a --no-hooks hint
     add_hook_skip_hint,
+    // Shared phrasing for an unmerged index ("1 path with unresolved conflicts")
+    format_unresolved_conflicts,
     // Render a single error via Diagnostic if it implements one
     try_render_diagnostic,
 };


### PR DESCRIPTION
`{count} {paths} with unresolved conflicts` was built twice, pluralization and all — once in `GitError::UnmergedPaths` (`src/git/error.rs`), once in the warning `wt step relocate` prints when it skips a worktree it can't commit (`src/commands/relocate.rs`).

The two can't share an error type: relocate warns and carries on, since an unresolved conflict blocks one worktree out of the many it walks, while `UnmergedPaths` refuses outright. So only the phrase moves, into `format_unresolved_conflicts`.

Output is unchanged — the four snapshots covering both sites are untouched and pass.

> _This was written by Claude Code on behalf of Maximilian_