### PR TITLE
docs(faq): scope the worktree-lock advice to removal

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -177,7 +177,7 @@ Worktrunk can delete **worktrees** and **branches**. Both have safeguards.
 
 `wt remove` mirrors `git worktree remove`: it refuses to remove worktrees with uncommitted changes (staged, modified, or untracked files). The `--force` flag removes the worktree anyway, discarding all of those changes.
 
-For worktrees containing precious ignored data (databases, caches, large assets), use `git worktree lock`:
+To protect a worktree from removal entirely (say it holds a local database), lock it:
 
 {{ terminal(cmd="git worktree lock ../myproject.feature --reason __WT_QUOT__Contains local database__WT_QUOT__") }}
 

--- a/plugins/worktrunk/skills/worktrunk/reference/faq.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/faq.md
@@ -170,7 +170,7 @@ Worktrunk can delete **worktrees** and **branches**. Both have safeguards.
 
 `wt remove` mirrors `git worktree remove`: it refuses to remove worktrees with uncommitted changes (staged, modified, or untracked files). The `--force` flag removes the worktree anyway, discarding all of those changes.
 
-For worktrees containing precious ignored data (databases, caches, large assets), use `git worktree lock`:
+To protect a worktree from removal entirely (say it holds a local database), lock it:
 
 ```bash
 git worktree lock ../myproject.feature --reason "Contains local database"

--- a/skills/worktrunk/reference/faq.md
+++ b/skills/worktrunk/reference/faq.md
@@ -170,7 +170,7 @@ Worktrunk can delete **worktrees** and **branches**. Both have safeguards.
 
 `wt remove` mirrors `git worktree remove`: it refuses to remove worktrees with uncommitted changes (staged, modified, or untracked files). The `--force` flag removes the worktree anyway, discarding all of those changes.
 
-For worktrees containing precious ignored data (databases, caches, large assets), use `git worktree lock`:
+To protect a worktree from removal entirely (say it holds a local database), lock it:
 
 ```bash
 git worktree lock ../myproject.feature --reason "Contains local database"


### PR DESCRIPTION
The FAQ recommended `git worktree lock` "for worktrees containing precious ignored data (databases, caches, large assets)". The lock does not do that — it blocks removal and nothing else. Someone who locked a worktree to keep a local database safe has protection against `wt remove --force`, and none at all against the thing that actually rewrites files there.

An ignored file in a locked worktree is still replaced when commits arriving via `wt merge` or `wt step push` track a file at the same path. Reproduced against this FAQ's own example: a locked worktree holding `db.sqlite` had it overwritten by the branch's tracked file, exit 0, no warning.

That behavior is git's, not worktrunk's. A plain `git merge` in that worktree does the same, and draws the line in the same place — it refuses when the colliding file is untracked, and overwrites when it's ignored:

```
ignored locally   → Fast-forward, db.sqlite | 1 +      (content: TRACKED-FROM-BRANCH)
untracked locally → error: The following untracked working tree files
                    would be overwritten by merge  (content: REAL-LOCAL-DATABASE)
```

So the fix is one sentence: the opener now says what the lock buys (removal protection) instead of implying it guards ignored data. Nothing in the paragraph below it changes — `wt remove --force` and `git worktree remove --force` do both still refuse on a locked worktree, checked against a scratch repo while editing.

> _This was written by Claude Code on behalf of Maximilian Roos_

🤖 Generated with [Claude Code](https://claude.com/claude-code)
