### PR TITLE
docs(push): record that destination-worktree safety matches git

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,6 +60,8 @@ Never risk data loss without explicit user consent. A failed command that preser
 - **Time-of-check vs time-of-use** — be conservative when there's a gap between the safety check and the operation. `wt merge` verifies clean before rebasing, but files could appear before cleanup — don't force-remove during cleanup.
 - **Replace files, never truncate them** — `fs::write` truncates before it writes, so a crash mid-write leaves the file empty. Every write to a file worktrunk can't put back (rc files, shell wrappers, `config.toml`, `approvals.toml`, another tool's `settings.json`) goes through `utils::write_atomically`, which renames a sibling temp file over the target; the spec on that function covers symlinks, mode, and what a rename costs. Regenerable content (the cache, the `-vv` diagnostic report) keeps the plain write.
 
+These stop where git's own protections stop: `wt merge` and `wt step push` overwrite an ignored file in the destination worktree whose path the incoming commits track, exactly as a `git merge` run there would. Matching git is deliberate — the spec in `src/commands/worktree/push.rs` says why.
+
 Full inventory: FAQ [What files does Worktrunk create?](docs/content/faq.md#what-files-does-worktrunk-create) and [What can Worktrunk delete?](docs/content/faq.md#what-can-worktrunk-delete). Review new code that changes this surface against those sections.
 
 ## Command Execution Principles

--- a/src/commands/repository_ext.rs
+++ b/src/commands/repository_ext.rs
@@ -62,6 +62,11 @@ pub trait RepositoryCliExt {
     /// The caller has already established that `target_worktree` exists on disk
     /// (`MergeContext::prepare` refuses a registered-but-missing worktree), so
     /// the status read here is free to fail if the directory is gone.
+    ///
+    /// Ignored files are deliberately out of scope — they're absent from the
+    /// `git status --porcelain` read this works from, and matching git there is
+    /// the decision, not an oversight. The module spec in
+    /// `commands/worktree/push.rs` says why.
     fn prepare_target_worktree(
         &self,
         target_worktree: Option<&PathBuf>,

--- a/src/commands/worktree/push.rs
+++ b/src/commands/worktree/push.rs
@@ -11,10 +11,14 @@
 //! a dirty tree is autostashed and restored. Ignored files fall outside that
 //! report, so a push overwrites one whose path the incoming commits track.
 //!
-//! That is git's own line, not an oversight — a `git merge` run in that
-//! worktree refuses the untracked collision and overwrites the ignored one.
-//! Matching git is the decision; don't add an ignored-file probe to make `wt`
-//! stricter than the tool it wraps.
+//! That is git's own line, not an oversight, and it holds at the mechanisms
+//! actually used: the fast-forward hands the checkout to
+//! `receive.denyCurrentBranch=updateInstead`, `--no-ff` syncs with
+//! `read-tree -m -u`, and both run git's unpack-trees checks, which refuse to
+//! clobber an untracked file and silently overwrite an ignored one — the same
+//! split a `git merge` there would produce. Matching git is the decision;
+//! don't add an ignored-file probe to make `wt` stricter than the tool it
+//! wraps.
 
 use std::path::PathBuf;
 

--- a/src/commands/worktree/push.rs
+++ b/src/commands/worktree/push.rs
@@ -3,6 +3,18 @@
 //! Push changes to target branch with safety checks. Both fast-forward push and
 //! `--no-ff` merge share common scaffolding (target resolution, fast-forward check,
 //! stash guard, progress/success output) extracted into [`MergeContext`].
+//!
+//! # Destination-worktree safety follows git
+//!
+//! The checks cover what `git status --porcelain` reports: a modified or
+//! untracked file at a path the push range changes is refused, and the rest of
+//! a dirty tree is autostashed and restored. Ignored files fall outside that
+//! report, so a push overwrites one whose path the incoming commits track.
+//!
+//! That is git's own line, not an oversight — a `git merge` run in that
+//! worktree refuses the untracked collision and overwrites the ignored one.
+//! Matching git is the decision; don't add an ignored-file probe to make `wt`
+//! stricter than the tool it wraps.
 
 use std::path::PathBuf;
 


### PR DESCRIPTION
Comment-only. It records a decision rather than changing one: `wt merge` and `wt step push` overwrite an ignored file in the destination worktree whose path the incoming commits track, and that is intended.

`prepare_target_worktree` works from `git status --porcelain`, which omits ignored files. So the existing protection covers modified-tracked and untracked collisions (refused as `ConflictingChanges`) and autostashes the rest of a dirty tree, while an ignored file at a colliding path is neither refused nor stashed.

git draws the line in the same place. A plain `git merge` run in that worktree, against a scratch repo:

```
ignored locally   → Fast-forward, db.sqlite | 1 +      (content: TRACKED-FROM-BRANCH)
untracked locally → error: The following untracked working tree files
                    would be overwritten by merge  (content: REAL-LOCAL-DATABASE)
```

So a probe that refused here would make `wt` stricter than the tool it wraps, over data git treats as expendable. Three places say so now, each where someone would otherwise reach the opposite conclusion:

- **`src/commands/worktree/push.rs`** — the module spec, at the point where such a probe would be added. It names the mechanisms rather than arguing by analogy: the fast-forward hands the checkout to `receive.denyCurrentBranch=updateInstead`, `--no-ff` syncs with `read-tree -m -u`, and both run git's unpack-trees checks. Confirmed against a scratch repo — `read-tree -m -u` silently overwrites an ignored file at a colliding path and refuses an untracked one (`exit 128`, file intact), the same split `git merge` produces.
- **`src/commands/repository_ext.rs`** — `prepare_target_worktree`, which owns the status read, pointing at that spec from the implementation site. (A `[`crate::…`]` intra-doc link was the first attempt; `push` is a private module, so `RUSTDOCFLAGS=-D warnings` rejected it. Plain path instead.)
- **`CLAUDE.md`** — Data Safety, bounding "prefer failure over silent loss" at git's edge. Read unqualified, that rule is what invites the stricter check.

Follows #3601, which fixed the user-facing half: the FAQ had recommended `git worktree lock` for "precious ignored data", which the lock does not protect — it blocks removal only.

## Verification

`RUSTDOCFLAGS="-D warnings" cargo doc`, `cargo clippy --all-targets -- -D warnings`, and pre-commit all clean.

The local gate flagged `test_readme_example_hooks_pre_merge`, which is the known load flake — an extra `Waiting for the commit generation command (4s)` spinner line under full-suite CPU contention. It passes in isolation with no retries. The diff contains no executable lines at all (every changed line is `///`, `//!`, or markdown), so it cannot be causal.

> _This was written by Claude Code on behalf of Maximilian Roos_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

