### PR TITLE
test(pty): suppress the TTY spinners in PTY captures

### DIFF
--- a/src/progress.rs
+++ b/src/progress.rs
@@ -70,6 +70,20 @@ mod imp {
     /// finishes.
     const WATCHDOG_ESCALATE_DELAY: Duration = Duration::from_secs(10);
 
+    /// Whether either spinner renders at all — the shared half of both `start`
+    /// gates, checked alongside the TTY (and, for [`Watchdog`], verbosity).
+    ///
+    /// A terminal *erases* an in-place redraw, so a frame never survives into
+    /// what the user is left with. A PTY test capturing the raw byte stream
+    /// keeps every frame instead, and whether any were drawn at all depends on
+    /// whether load pushed the operation past a startup delay above — with the
+    /// elapsed seconds baked into the bytes. So the test PTY environments set
+    /// `WORKTRUNK_TEST_SPINNERS=0` and capture only the output that persists.
+    /// Counters are unaffected: this gates the render, not the accounting.
+    fn spinners_enabled() -> bool {
+        !matches!(std::env::var("WORKTRUNK_TEST_SPINNERS").as_deref(), Ok("0"))
+    }
+
     /// Shared state between the spinner and its ticker thread. `rendered` flips
     /// true once the ticker has actually drawn a line, so `Drop` clears the line
     /// only when there's something to clear — a sub-startup-delay operation that
@@ -103,14 +117,15 @@ mod imp {
     }
 
     impl Progress {
-        /// Start a progress reporter, enabling the spinner iff stderr is a TTY.
+        /// Start a progress reporter, enabling the spinner iff stderr is a TTY
+        /// and `spinners_enabled`.
         ///
         /// `verb` is the present-participle label shown to the user (e.g.
         /// `"Copying"`, `"Removing"`). Spawns a background ticker thread when a
         /// TTY is detected. When stderr is not a TTY, returns a disabled
         /// reporter that still counts but renders nothing.
         pub fn start(verb: &'static str) -> Self {
-            Self::start_with(verb, std::io::stderr().is_terminal())
+            Self::start_with(verb, std::io::stderr().is_terminal() && spinners_enabled())
         }
 
         /// Dispatch helper that picks the enabled or disabled branch from an
@@ -326,11 +341,13 @@ mod imp {
         /// command runs past the escalation delay, so a slow or stuck command
         /// is debuggable.
         ///
-        /// Enabled only when stderr is a TTY and verbosity is 0 — under
-        /// `-v`/`-vv` the structured diagnostics take over, and a non-TTY (piped)
-        /// context renders nothing.
+        /// Enabled only when stderr is a TTY, verbosity is 0, and
+        /// `spinners_enabled` — under `-v`/`-vv` the structured diagnostics
+        /// take over, and a non-TTY (piped) context renders nothing.
         pub fn start(waiting_for: &str, command: Option<&str>) -> Self {
-            let enabled = std::io::stderr().is_terminal() && crate::styling::verbosity() == 0;
+            let enabled = std::io::stderr().is_terminal()
+                && crate::styling::verbosity() == 0
+                && spinners_enabled();
             Self::start_with(waiting_for, command, enabled)
         }
 

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -1104,6 +1104,13 @@ impl TestRepo {
                 "XDG_CONFIG_HOME".to_string(),
                 self.home_path().join(".config").display().to_string(),
             ),
+            // Suppress the in-place TTY spinners (`Progress`, `Watchdog`). A
+            // PTY capture keeps every redraw frame the terminal would have
+            // erased, so an operation that load pushes past a startup delay
+            // adds frames — with their elapsed seconds — to the snapshot. Only
+            // the PTY path needs this: `configure_cli_command()` pipes stdout
+            // and stderr, so the TTY half of the gate is already false there.
+            ("WORKTRUNK_TEST_SPINNERS".to_string(), "0".to_string()),
             ("WORKTRUNK_TEST_EPOCH".to_string(), TEST_EPOCH.to_string()),
             (
                 "WORKTRUNK_CONFIG_PATH".to_string(),

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -250,6 +250,12 @@ Two traps:
 - **Give each half its own wait.** Sleeping once and then asserting both "X happened" and "Y didn't" makes the presence half flaky. Poll for X, then hold the window for Y.
 - **Structural absence needs no window at all.** When the event is gated on a condition the test never sets up, it can't fire regardless of timing. Drop the sleep: poll the positive precondition and the absence holds by construction. A watchdog whose escalation is gated on `command.is_some()` can't escalate with no command, so the test polls for the first render and asserts `!escalated` with no window.
 
+### Time-thresholded output: suppress it at the source
+
+Output that appears only once an operation runs past a threshold is a function of machine load, not of behavior: the `Progress` and `Watchdog` spinners (`src/progress.rs`), `Cmd::delayed_stream`'s progress line, the picker's placeholder reveal. A PTY test captures the raw byte stream, so it keeps every in-place redraw frame a terminal would have erased, elapsed-second counter and all — frames that show up when the whole suite runs together and not when the test runs alone.
+
+Each threshold has an env override the PTY env builders pin (`WORKTRUNK_TEST_SPINNERS=0`, `WORKTRUNK_TEST_DELAYED_STREAM_MS=-1`, `WORKTRUNK_PLACEHOLDER_REVEAL_MS=0`), so the output is present or absent by construction rather than by timing; a new builder or a new threshold needs the same. Filtering the frames out of the capture afterwards is the weaker fix: the filter has to model cursor movement, and a block that redraws with a cursor-up spans lines a line-scoped filter can't follow.
+
 ## No Retries
 
 Tests run once. Worktrunk configures no nextest `retries` and writes no retry loops: a test that passes only on a second attempt is a bug report, and retrying it discards the report while leaving the bug. A green suite has to mean the code is green, not that the run's flakes stayed under a retry budget. Fix the flake at its root:

--- a/tests/integration_tests/bare_repository.rs
+++ b/tests/integration_tests/bare_repository.rs
@@ -1532,6 +1532,10 @@ impl NestedBareRepoTest {
                 "XDG_CONFIG_HOME".to_string(),
                 home.join(".config").display().to_string(),
             ),
+            // Suppress the in-place TTY spinners; a PTY capture keeps every
+            // redraw frame a terminal would have erased. Mirrors
+            // `TestRepo::test_env_vars`, which explains why.
+            ("WORKTRUNK_TEST_SPINNERS".to_string(), "0".to_string()),
             ("WORKTRUNK_TEST_EPOCH".to_string(), TEST_EPOCH.to_string()),
             (
                 "WORKTRUNK_CONFIG_PATH".to_string(),

--- a/tests/integration_tests/shell_wrapper.rs
+++ b/tests/integration_tests/shell_wrapper.rs
@@ -794,6 +794,10 @@ const STANDARD_TEST_ENV: &[(&str, &str)] = &[
     // Suppress delayed-stream progress output so git worktree add doesn't
     // produce extra lines when the system is under load (>400ms threshold).
     ("WORKTRUNK_TEST_DELAYED_STREAM_MS", "-1"),
+    // Same, for the in-place TTY spinners: a PTY capture keeps every redraw
+    // frame a terminal would have erased, so a command that load pushes past a
+    // startup delay adds frames — with their elapsed seconds — to the snapshot.
+    ("WORKTRUNK_TEST_SPINNERS", "0"),
 ];
 
 /// Build standard test env vars with config and approvals paths


### PR DESCRIPTION
`test_readme_example_hooks_pre_merge` flakes when the whole suite runs together. The mock `commit.generation` command gets starved past the watchdog's 4s threshold, and the PTY capture records the redraw frames a terminal would have erased:

```
↳ Waiting for the commit generation command (4s)
```

The elapsed seconds vary run to run, so accepting the snapshot just moves the flake.

## The fix

Both spinners in `src/progress.rs` now check `WORKTRUNK_TEST_SPINNERS` alongside the existing TTY (and, for `Watchdog`, verbosity) gate, and the PTY env builders set it to `0`. This is the shape the repo already uses for `WORKTRUNK_TEST_DELAYED_STREAM_MS=-1`, whose comment names the same failure mode: "slow CI triggers progress messages that don't appear on faster systems". Only the render is gated, so the counters behind the summary lines the snapshots do assert are untouched.

Gating both spinner types rather than the one call site closes the latent exposure elsewhere: `Progress` renders after 300ms in any PTY test that copies or removes files, and `Watchdog` also wraps `wt switch` and the version check.

## Why not filter the frames out of the capture

A line-scoped filter in `add_pty_filters` would be a one-liner, but it only covers the single-row block. Past 10s the watchdog escalates to two rows and redraws with a cursor-up, which spans a newline the filter cannot follow, and the revealed command line carries a tempdir path. Closing that would mean modeling cursor arithmetic in a regex that silently deletes bytes from captured output.

## Evidence

Reproduced first, by making the mock command slow directly rather than waiting for ambient CPU starvation to do it. The resulting diff is byte-identical to the reported flake, including the `(4s)` / `(5s)` counters:

- `sleep 6` in the mock, before the fix: FAIL, same diff as reported
- `sleep 6`, after the fix: pass
- `sleep 12` (past the 10s escalation tier, where a filter would not have helped): pass
- negative control, `sleep 6` with only `WORKTRUNK_TEST_SPINNERS` flipped from `0` to `1`: FAIL again, so the knob is what engages

Full gate green: 4601 tests, no pending snapshots.

> _This was written by Claude Code on behalf of Maximilian_
