### PR TITLE
fix(hooks): make the warm build and the gate agree on their flags

### DIFF
--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -12,11 +12,8 @@ docs = "wt step tether -C docs -- zola serve -p {{ branch | hash_port }}"
 clippy = "pre-commit run clippy --all-files || true"
 # Warms the cache the pre-merge `insta` gate reuses, so RUSTFLAGS and the
 # feature set must match that line: cargo fingerprints both, and a mismatch in
-# either leaves the gate rebuilding artifacts it can't reuse. Target selection
-# isn't a fingerprint input, so `--all-targets` rides along free and keeps the
-# benches compiling. `--all-features` doesn't: it adds the `git-wt` binary,
-# whose unit tests are a byte-identical duplicate of `wt`'s.
-build = "RUSTFLAGS='-D warnings' cargo test --no-run --locked --all-targets --features shell-integration-tests"
+# either leaves the gate rebuilding artifacts it can't reuse.
+build = "RUSTFLAGS='-D warnings' cargo test --no-run --locked --all-targets --all-features"
 install = "cargo install --path ."
 sync = 'if [ "{{ target }}" = "main" ]; then git pull && git push; fi'
 
@@ -28,7 +25,7 @@ sync = 'if [ "{{ target }}" = "main" ]; then git pull && git push; fi'
 # `cargo update --locked` would also fail on dependencies merely behind latest.
 lockfile = "cargo update --workspace --locked"
 pre-commit = "pre-commit run --all-files"
-insta = """RUSTFLAGS='-D warnings' cargo insta test --test-runner nextest --dnd --check $([ "$(uname)" = 'Linux' ] && echo '--unreferenced reject') --features shell-integration-tests"""
+insta = """RUSTFLAGS='-D warnings' cargo insta test --test-runner nextest --dnd --check $([ "$(uname)" = 'Linux' ] && echo '--unreferenced reject') --all-features"""
 doctest = "RUSTDOCFLAGS='-Dwarnings' cargo test --doc"
 doc = "RUSTDOCFLAGS='-Dwarnings' cargo doc --no-deps --document-private-items"
 

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -10,12 +10,13 @@ docs = "wt step tether -C docs -- zola serve -p {{ branch | hash_port }}"
 
 [post-merge]
 clippy = "pre-commit run clippy --all-files || true"
-# Warms the cache the pre-merge `insta` gate reuses, so the flags must match
-# that line: cargo fingerprints RUSTFLAGS alongside the feature set, and a
-# mismatch in either leaves the gate rebuilding from scratch. The clippy step
-# above type-checks benches and the `git-wt` binary under `--all-targets
-# --all-features`, so this step builds only what the gate runs.
-build = "RUSTFLAGS='-D warnings' cargo test --no-run --locked --features shell-integration-tests"
+# Warms the cache the pre-merge `insta` gate reuses, so RUSTFLAGS and the
+# feature set must match that line: cargo fingerprints both, and a mismatch in
+# either leaves the gate rebuilding artifacts it can't reuse. Target selection
+# isn't a fingerprint input, so `--all-targets` rides along free and keeps the
+# benches compiling. `--all-features` doesn't: it adds the `git-wt` binary,
+# whose unit tests are a byte-identical duplicate of `wt`'s.
+build = "RUSTFLAGS='-D warnings' cargo test --no-run --locked --all-targets --features shell-integration-tests"
 install = "cargo install --path ."
 sync = 'if [ "{{ target }}" = "main" ]; then git pull && git push; fi'
 

--- a/.config/wt.toml
+++ b/.config/wt.toml
@@ -10,7 +10,12 @@ docs = "wt step tether -C docs -- zola serve -p {{ branch | hash_port }}"
 
 [post-merge]
 clippy = "pre-commit run clippy --all-files || true"
-build = "cargo test --no-run --all-targets --locked --all-features"
+# Warms the cache the pre-merge `insta` gate reuses, so the flags must match
+# that line: cargo fingerprints RUSTFLAGS alongside the feature set, and a
+# mismatch in either leaves the gate rebuilding from scratch. The clippy step
+# above type-checks benches and the `git-wt` binary under `--all-targets
+# --all-features`, so this step builds only what the gate runs.
+build = "RUSTFLAGS='-D warnings' cargo test --no-run --locked --features shell-integration-tests"
 install = "cargo install --path ."
 sync = 'if [ "{{ target }}" = "main" ]; then git pull && git push; fi'
 


### PR DESCRIPTION
The `post-merge` `build` step exists to warm the cache the `pre-merge` `insta` gate reuses. Its flags never matched that gate's, so it warmed nothing.

```diff
-build = "cargo test --no-run --all-targets --locked --all-features"
+build = "RUSTFLAGS='-D warnings' cargo test --no-run --locked --all-targets --all-features"

-insta = """… --features shell-integration-tests"""
+insta = """… --all-features"""
```

Cargo fingerprints RUSTFLAGS alongside the feature set, so the two lines produced disjoint artifacts:

| Build | `integration` hash |
|---|---|
| `post-merge build`: `--all-features`, no RUSTFLAGS | `f4f93b9e202ea20b` |
| the gate: `RUSTFLAGS='-D warnings' --features shell-integration-tests` | `742b05e128bc5d53` |

Measured: the gate used to recompile worktrunk from scratch (28.6s) right after the warm build had finished building the same crate. With matched flags it compiles nothing (0.16s).

They can agree at either feature set. `--all-features` is the one that's obvious to oversee, and it keeps every target building, so both lines use it.

The test set is unchanged at 4607 either way: the extra features gate a bench (`real-repo-benches`, which nextest never runs) and the `git-wt` binary, whose unit tests are `test = false` because `git_wt.rs` is `include!("main.rs")` and they'd be byte-identical duplicates of `wt`'s.

## Verification

`wt hook post-merge --yes build` produces the gate's exact artifact hashes, after which `cargo nextest list --all-features` compiles nothing. `cargo nextest list` reports 4607 tests under both feature sets. `pre-commit run --files .config/wt.toml` passes.

## Context

This came out of asking why `cargo test --no-run --all-targets --locked --all-features` reports 17 test binaries, given we follow [matklad's guidance](https://matklad.github.io/2021/02/27/delete-cargo-integration-tests.html) that each `tests/*.rs` file relinks the library. We do follow it: one `integration` binary plus one documented exception (`cancel_background`, which latches process-wide state). The 17 was the widest build in the repo, not the test build.

> _This was written by Claude Code on behalf of Maximilian Roos_

🤖 Generated with [Claude Code](https://claude.com/claude-code)