### PR TITLE
docs(alias): correct the vars.* claim in alias dry-run

### DIFF
--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -417,7 +417,7 @@ $ wt config alias show deploy
 
     /// Preview an alias invocation with template expansion
     #[command(
-        after_long_help = r#"Runs the same parser used at invocation time, applies template expansion (including `{{ args }}` and any `--KEY=VALUE` assignments), and prints the resulting command without executing it. Templates referencing `vars.*` are shown unexpanded — those values resolve from git config at execution time, after earlier steps have had a chance to set them.
+        after_long_help = r#"Runs the same parser used at invocation time, applies template expansion (including `{{ args }}` and any `--KEY=VALUE` assignments), and prints the resulting command without executing it. Each `{{ vars.<key> }}` renders as itself while everything around it expands — those values resolve from git config at execution time, after earlier steps have had a chance to set them.
 
 Arguments after `--` are forwarded verbatim as if typed after `wt <name>`.
 

--- a/src/commands/config/alias.rs
+++ b/src/commands/config/alias.rs
@@ -139,10 +139,9 @@ fn warn_if_shadowed(name: &str) {
 /// and print the rendered command(s) without executing.
 ///
 /// Rendering goes through [`render_template_preview`], which mirrors
-/// execution-time semantics: templates referencing `vars.*` are shown raw
-/// (after syntax validation) because those values resolve from git config
-/// when the step runs, potentially written by earlier pipeline steps. Other
-/// templates expand against the current context.
+/// execution-time semantics for everything but `{{ vars.<key> }}`: each of
+/// those renders as itself, because the value resolves from git config when
+/// the step runs, potentially written by an earlier pipeline step.
 pub fn handle_alias_dry_run(name: String, args: Vec<String>) -> anyhow::Result<()> {
     let repo = Repository::current()?;
     let user_config = repo.user_config();


### PR DESCRIPTION
#3638 changed the preview renderer so a template expands everything around a `{{ vars.<key> }}` reference and leaves only that reference literal. `wt config alias dry-run` shares that renderer, but its `--help` text and the `handle_alias_dry_run` docstring still described the previous all-or-nothing behavior, where a single `vars.` token left the whole template raw.

This corrects both. The docstring's mention of a separate syntax-validation step goes with them: expansion reports syntax errors itself, so there is no longer a distinct validation pass to describe.

No behavior change. The `dry-run` long help isn't rendered into any generated doc or snapshot, so no mirrors move with it.

> _This was written by Claude Code on behalf of max_
