### PR TITLE
fix(picker): stop underlining links the picker can't carry

### DIFF
--- a/.claude/skills/writing-user-outputs/SKILL.md
+++ b/.claude/skills/writing-user-outputs/SKILL.md
@@ -756,9 +756,12 @@ format!("{style}{}{style:#}", hyperlink(url, text))
 format!("{}{text}{}", osc8::Hyperlink::new(url), osc8::Hyperlink::END)
 ```
 
-Text that isn't a link stays plain. On a terminal without OSC 8 support `wt
-list` prints the dev-server URL in full, unadorned, because there's nothing
-there to click.
+Text that isn't a link stays plain, and whether a run of text is a link belongs
+to the render rather than to the cell emitting it: `LayoutConfig::link_style`
+answers it once for a whole row, so a CI reference and a dev-server port can't
+disagree. Two destinations carry no links, and so no underline: a terminal
+without OSC 8 support, where `wt list` prints the dev-server URL in full, and
+the picker, whose rows pass through skim.
 
 ## Design Principles
 

--- a/src/commands/list/ci_status/mod.rs
+++ b/src/commands/list/ci_status/mod.rs
@@ -14,6 +14,7 @@ mod platform;
 
 use std::process::Output;
 
+use super::layout::LinkStyle;
 use anstyle::{AnsiColor, Color, Style};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize, de::DeserializeOwned};
@@ -498,15 +499,15 @@ impl PrStatus {
         }
     }
 
-    /// Wrap `text` in this status's style, optionally as an OSC 8 hyperlink
-    /// to the PR/pipeline URL.
+    /// Wrap `text` in this status's style, as an OSC 8 hyperlink to the
+    /// PR/pipeline URL when the render carries links.
     ///
     /// The status color goes outside the link, which supplies its own
     /// underline and closes it without disturbing that color.
-    fn styled(&self, text: &str, include_link: bool) -> String {
+    fn styled(&self, text: &str, link: LinkStyle) -> String {
         let style = self.style();
-        let body = match (include_link, &self.url) {
-            (true, Some(url)) => worktrunk::styling::hyperlink(url, text),
+        let body = match (link, &self.url) {
+            (LinkStyle::Linked, Some(url)) => worktrunk::styling::hyperlink(url, text),
             _ => text.to_string(),
         };
         format!("{style}{body}{style:#}")
@@ -523,15 +524,15 @@ impl PrStatus {
     /// known: Error and Conflicts share the warning color, so a yellow
     /// `#3035` would be indistinguishable from a conflicted PR.
     ///
-    /// When `include_link` is false, the cell is colored but not clickable —
-    /// for the `wt list` table on a terminal without OSC 8, and for the picker,
-    /// which strips the sequences.
-    pub fn format_cell(&self, max_width: usize, include_link: bool) -> String {
+    /// Under any style but [`LinkStyle::Linked`] the cell is colored but not
+    /// clickable, and carries no underline to suggest otherwise — the `wt list`
+    /// table on a terminal without OSC 8, and every picker row.
+    pub fn format_cell(&self, max_width: usize, link: LinkStyle) -> String {
         match self.number {
             Some(r) if !matches!(self.ci_status, CiStatus::Error) && r.width() <= max_width => {
-                self.styled(&r.to_string(), include_link)
+                self.styled(&r.to_string(), link)
             }
-            _ => self.styled(self.indicator(), include_link),
+            _ => self.styled(self.indicator(), link),
         }
     }
 
@@ -828,19 +829,25 @@ mod tests {
             updated_at: None,
         };
 
-        // Number fits → PR reference, hyperlinked when supported
-        assert_snapshot!(pr.format_cell(4, false), @"[32m#123[0m");
-        assert_snapshot!(pr.format_cell(4, true), @r"[32m[4m]8;;https://github.com/owner/repo/pull/123\#123]8;;\[24m[0m");
+        // Number fits → PR reference, underlined and linked only where the
+        // render carries links. A reference has no URL to fall back on, so
+        // `Expanded` reads the same as `Unlinked`.
+        assert_eq!(
+            pr.format_cell(4, LinkStyle::Expanded),
+            pr.format_cell(4, LinkStyle::Unlinked)
+        );
+        assert_snapshot!(pr.format_cell(4, LinkStyle::Unlinked), @"[32m#123[0m");
+        assert_snapshot!(pr.format_cell(4, LinkStyle::Linked), @r"[32m[4m]8;;https://github.com/owner/repo/pull/123\#123]8;;\[24m[0m");
         // Number wider than the column → bare # indicator, still hyperlinked
-        assert_snapshot!(pr.format_cell(3, false), @"[32m#[0m");
-        assert_snapshot!(pr.format_cell(3, true), @r"[32m[4m]8;;https://github.com/owner/repo/pull/123\#]8;;\[24m[0m");
+        assert_snapshot!(pr.format_cell(3, LinkStyle::Unlinked), @"[32m#[0m");
+        assert_snapshot!(pr.format_cell(3, LinkStyle::Linked), @r"[32m[4m]8;;https://github.com/owner/repo/pull/123\#]8;;\[24m[0m");
 
         // No number (branch workflow or pre-number cache entry) → bare # indicator
         let branch = PrStatus {
             number: None,
             ..pr.clone()
         };
-        assert_snapshot!(branch.format_cell(10, false), @"[32m#[0m");
+        assert_snapshot!(branch.format_cell(10, LinkStyle::Unlinked), @"[32m#[0m");
 
         // Error renders ⚠ even when the number fits: Error and Conflicts
         // share yellow, so a yellow "#123" would read as a conflicted PR
@@ -848,14 +855,14 @@ mod tests {
             ci_status: CiStatus::Error,
             ..pr.clone()
         };
-        assert_snapshot!(error.format_cell(usize::MAX, false), @"[33m⚠[0m");
+        assert_snapshot!(error.format_cell(usize::MAX, LinkStyle::Unlinked), @"[33m⚠[0m");
 
         // GitLab sigil
         let mr = PrStatus {
             number: Some(PrRef::mr(7)),
             ..pr
         };
-        assert_snapshot!(mr.format_cell(usize::MAX, false), @"[32m!7[0m");
+        assert_snapshot!(mr.format_cell(usize::MAX, LinkStyle::Unlinked), @"[32m!7[0m");
     }
 
     #[test]
@@ -929,7 +936,7 @@ mod tests {
         let dim = "\u{1b}[2m";
 
         // Fresh verdict: green, not dimmed.
-        let fresh = passed(false, false).format_cell(3, false);
+        let fresh = passed(false, false).format_cell(3, LinkStyle::Unlinked);
         assert!(
             fresh.contains(green) && !fresh.contains(dim),
             "fresh: green, no dim: {fresh:?}"
@@ -937,7 +944,7 @@ mod tests {
 
         // SHA-mismatch stale keeps its verdict color, dimmed — `wt list` flags a
         // failing/passing pushed commit even when local HEAD has moved on.
-        let stale = passed(true, false).format_cell(3, false);
+        let stale = passed(true, false).format_cell(3, LinkStyle::Unlinked);
         assert!(
             stale.contains(green) && stale.contains(dim),
             "stale: green + dim: {stale:?}"
@@ -945,7 +952,7 @@ mod tests {
 
         // Cache-prime placeholder: dimmed and neutral — the number shows, but no
         // green/red is asserted until the live fetch lands.
-        let priming = passed(false, true).format_cell(3, false);
+        let priming = passed(false, true).format_cell(3, LinkStyle::Unlinked);
         assert!(
             priming.contains(dim) && !priming.contains(green),
             "priming: dim, neutral: {priming:?}"

--- a/src/commands/list/collect/mod.rs
+++ b/src/commands/list/collect/mod.rs
@@ -1338,13 +1338,20 @@ pub fn collect(
 
     // Calculate layout from items (worktrees, local branches, and remote branches).
     // The picker passes an explicit width because the list only gets part of the
-    // terminal — the rest belongs to the preview pane.
+    // terminal — the rest belongs to the preview pane — and takes its rows
+    // link-free because skim mangles OSC 8 (see `Destination`).
+    let width = list_width
+        .or_else(crate::display::terminal_width)
+        .unwrap_or(usize::MAX);
+    let destination = if progressive_handler.is_some() {
+        super::layout::Destination::picker(width)
+    } else {
+        super::layout::Destination::terminal(width)
+    };
     let layout = super::layout::calculate_layout_with_width(
         &all_items,
         &tasks,
-        list_width
-            .or_else(crate::display::terminal_width)
-            .unwrap_or(usize::MAX),
+        destination,
         &main_worktree.path,
         url_template.as_deref(),
         max_pr_number,
@@ -2634,7 +2641,7 @@ remove the file manually to continue.";
     /// any task results.
     #[test]
     fn test_render_reveal_picks_renderer_per_row() {
-        use super::super::layout::calculate_layout_with_width;
+        use super::super::layout::{Destination, LinkStyle, calculate_layout_with_width};
         use super::super::model::ListItem;
         use std::path::Path;
 
@@ -2646,7 +2653,10 @@ remove the file manually to continue.";
         let layout = calculate_layout_with_width(
             &items,
             &tasks,
-            80,
+            Destination {
+                width: 80,
+                link_style: LinkStyle::Expanded,
+            },
             Path::new("/tmp"),
             None,
             None,

--- a/src/commands/list/layout.rs
+++ b/src/commands/list/layout.rs
@@ -531,6 +531,9 @@ pub struct LayoutConfig {
     pub max_summary_len: usize,
     pub hidden_column_count: usize,
     pub status_position_mask: super::model::PositionMask,
+    /// How every cell in this layout presents a reference with a URL behind it.
+    /// Set once for the whole render — see [`LinkStyle`].
+    pub link_style: LinkStyle,
 }
 
 /// `Send + Sync` snapshot of the column geometry: `(kind, start, width)` per
@@ -538,9 +541,23 @@ pub struct LayoutConfig {
 /// threads, so renderers running outside `collect` — the picker's `--prs`
 /// thread — take this snapshot to place their cells on the same grid as the
 /// worktree rows.
-#[derive(Clone, Debug, Default)]
+#[derive(Clone, Debug)]
 pub struct ColumnGrid {
     pub columns: Vec<GridColumn>,
+    /// The layout's [`LinkStyle`], so a row rendered off-thread presents its
+    /// references exactly as the worktree rows beside it do.
+    pub link_style: LinkStyle,
+}
+
+impl Default for ColumnGrid {
+    /// An empty grid places no cells, so it emits nothing either way;
+    /// [`LinkStyle::Expanded`] is the inert choice.
+    fn default() -> Self {
+        Self {
+            columns: Vec::new(),
+            link_style: LinkStyle::Expanded,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -568,6 +585,7 @@ impl LayoutConfig {
                     width: col.width,
                 })
                 .collect(),
+            link_style: self.link_style,
         }
     }
 }
@@ -601,41 +619,110 @@ struct PendingColumn<'a> {
     format: ColumnFormat,
 }
 
-/// Format the dev-server URL, optionally as an OSC 8 hyperlink.
+/// How one render presents a reference that has a URL behind it — a PR number
+/// (`#3604`) or a dev-server port (`:11486`).
 ///
-/// A linked cell shows just the port (e.g. `:3000`) — the URL rides inside the
-/// escape sequence, so the cell costs the port's width rather than the whole
-/// URL's. Without links, or when the URL carries no parseable port, there is
-/// nowhere to hide the URL, so it renders in full and stays copyable.
-///
-/// `wt list` passes the terminal probe, because there the answer changes what
-/// the reader gets: [`estimate_url_width`] reserves a column wide enough for the
-/// full URL, so an unlinked cell can print it (the two have to agree on when a
-/// cell collapses to `:port`, hence the adjacency). The statusline passes
-/// `true`. It has no column to reserve — it fits a fixed-width line by dropping
-/// its worst-priority segment, and the URL is the worst — so an unlinked cell
-/// would grow past the budget and be dropped entirely, trading a port for
-/// nothing. A terminal that doesn't implement OSC 8 discards the escape and
-/// renders the same `:3000`, so emitting it unconditionally costs that reader
-/// nothing.
-pub(crate) fn format_url_cell(url: &str, include_link: bool) -> String {
-    if include_link && let Some(port) = parse_port_from_url(url) {
-        return worktrunk::styling::hyperlink(url, &format!(":{port}"));
+/// A reference is short because the URL rides inside the OSC 8 escape, and two
+/// facts decide whether it can: whether the terminal draws OSC 8, and whether
+/// the destination delivers the escape there intact. One value answers both for
+/// a whole render, so a row's cells cannot disagree — a cell that underlines a
+/// reference whose escape something downstream strips leaves an underline with
+/// nothing to click.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum LinkStyle {
+    /// An underlined OSC 8 link. A dev-server URL shows as `:3000` with the URL
+    /// itself inside the escape.
+    Linked,
+    /// The same short text, with neither escape nor underline: the picker feeds
+    /// its rows through skim, whose pipeline mangles OSC 8 into garbage like
+    /// `^[8;;…`. Nothing on those rows is clickable, so nothing is underlined.
+    /// The column is sized for the short form either way, so a dev-server URL
+    /// still collapses to `:3000`.
+    Unlinked,
+    /// The terminal doesn't draw OSC 8, so there is no escape to hide a URL in
+    /// and a dev-server URL prints in full, staying copyable. A PR reference
+    /// reads the same as under [`Unlinked`](Self::Unlinked) — it has nothing to
+    /// expand.
+    Expanded,
+}
+
+impl LinkStyle {
+    /// Resolve the style from the one thing a caller knows that the terminal
+    /// probe doesn't: whether its output reaches the terminal intact.
+    fn for_destination(carries_escapes: bool) -> Self {
+        match (supports_hyperlinks(Stream::Stdout), carries_escapes) {
+            (true, true) => Self::Linked,
+            (true, false) => Self::Unlinked,
+            (false, _) => Self::Expanded,
+        }
     }
-    url.to_string()
+}
+
+/// Where a rendered row is going: how many columns it may occupy, and whether
+/// an OSC 8 escape survives the trip.
+///
+/// The two travel together because one fact decides both. `wt list` writes to
+/// the terminal, so it gets the full width and its escapes arrive intact. The
+/// picker hands its rows to skim, which grants the list only part of the
+/// terminal — the rest is the preview pane — and mangles OSC 8 on the way.
+#[derive(Clone, Copy, Debug)]
+pub struct Destination {
+    pub width: usize,
+    pub link_style: LinkStyle,
+}
+
+impl Destination {
+    /// Rows written straight to the terminal — the `wt list` table.
+    pub fn terminal(width: usize) -> Self {
+        Self {
+            width,
+            link_style: LinkStyle::for_destination(true),
+        }
+    }
+
+    /// Rows handed to skim — the interactive picker.
+    pub fn picker(width: usize) -> Self {
+        Self {
+            width,
+            link_style: LinkStyle::for_destination(false),
+        }
+    }
+}
+
+/// Format the dev-server URL for a cell.
+///
+/// A collapsed cell shows just the port (e.g. `:3000`), costing the port's
+/// width rather than the whole URL's. Only [`LinkStyle::Expanded`] has nowhere
+/// to put the URL, so it renders in full and stays copyable — and
+/// [`estimate_url_width`] reserves a column wide enough for that, which is why
+/// the two sit together and read the same style.
+///
+/// The statusline passes [`LinkStyle::Linked`] whatever the terminal reports.
+/// It has no column to reserve — it fits a fixed-width line by dropping its
+/// worst-priority segment, and the URL is the worst — so an expanded cell would
+/// grow past the budget and be dropped entirely, trading a port for nothing. A
+/// terminal that doesn't implement OSC 8 discards the escape and renders the
+/// same `:3000`, so emitting it unconditionally costs that reader nothing.
+pub(crate) fn format_url_cell(url: &str, link: LinkStyle) -> String {
+    match (link, parse_port_from_url(url)) {
+        (LinkStyle::Linked, Some(port)) => worktrunk::styling::hyperlink(url, &format!(":{port}")),
+        (LinkStyle::Unlinked, Some(port)) => format!(":{port}"),
+        _ => url.to_string(),
+    }
 }
 
 /// Estimate URL column width using heuristics.
 ///
-/// When hyperlinks are supported, URLs display as `:PORT` (6 chars for 5-digit ports).
-/// Otherwise, estimates full URL width from template structure.
-fn estimate_url_width(url_template: Option<&str>, hyperlinks_supported: bool) -> usize {
+/// A cell that collapses to its port displays as `:PORT` (6 chars for 5-digit
+/// ports); an [`Expanded`](LinkStyle::Expanded) one needs the full URL width,
+/// estimated from the template structure.
+fn estimate_url_width(url_template: Option<&str>, link: LinkStyle) -> usize {
     let Some(template) = url_template else {
         return 0;
     };
 
-    // When hyperlinks are supported, URLs with ports display as ":XXXXX" (6 chars)
-    if hyperlinks_supported {
+    // A collapsed cell shows ":XXXXX" (6 chars) whenever the template has a port
+    if link != LinkStyle::Expanded {
         // Check for port patterns: template variables or static ports
         if template.contains("hash_port")
             || template.contains(":{{")
@@ -783,10 +870,14 @@ fn allocate_columns_with_priority(
     tasks: &HashSet<TaskKind>,
     max_path_width: usize,
     commit_width: usize,
-    terminal_width: usize,
+    destination: Destination,
     main_worktree_path: PathBuf,
     columns: ColumnSelection,
 ) -> LayoutConfig {
+    let Destination {
+        width: terminal_width,
+        link_style,
+    } = destination;
     let ColumnSelection {
         custom: custom_columns,
         selected,
@@ -1049,6 +1140,7 @@ fn allocate_columns_with_priority(
         max_summary_len,
         hidden_column_count,
         status_position_mask: metadata.status_position_mask,
+        link_style,
     }
 }
 
@@ -1079,12 +1171,13 @@ fn allocate_columns_with_priority(
 pub fn calculate_layout_with_width(
     items: &[super::model::ListItem],
     tasks: &HashSet<TaskKind>,
-    terminal_width: usize,
+    destination: Destination,
     main_worktree_path: &Path,
     url_template: Option<&str>,
     max_pr_number: Option<u64>,
     columns: ColumnSelection,
 ) -> LayoutConfig {
+    let link_style = destination.link_style;
     let custom_columns = columns.custom;
     // Calculate actual widths for things we know
     // Include branch names from both worktrees and standalone branches
@@ -1113,7 +1206,7 @@ pub fn calculate_layout_with_width(
         .any(|data| data.branch_worktree_mismatch || data.duplicate_branch);
 
     // Estimate URL width from template (heuristic, no expansion needed)
-    let url_width = estimate_url_width(url_template, supports_hyperlinks(Stream::Stdout));
+    let url_width = estimate_url_width(url_template, link_style);
 
     // Custom column widths are measured, not estimated: values were expanded
     // before layout. A column empty on every row stays 0 and is excluded.
@@ -1152,7 +1245,7 @@ pub fn calculate_layout_with_width(
         tasks,
         max_path_width,
         commit_width,
-        terminal_width,
+        destination,
         main_worktree_path.to_path_buf(),
         columns,
     )
@@ -1563,7 +1656,10 @@ mod tests {
         let layout = calculate_layout_with_width(
             &items,
             &tasks,
-            terminal_width().expect("COLUMNS=80 is set in .cargo/config.toml"),
+            Destination {
+                width: terminal_width().expect("COLUMNS=80 is set in .cargo/config.toml"),
+                link_style: LinkStyle::Expanded,
+            },
             &main_worktree_path,
             None,
             None,
@@ -1680,7 +1776,10 @@ mod tests {
         let layout = calculate_layout_with_width(
             &items,
             &tasks,
-            terminal_width().expect("COLUMNS=80 is set in .cargo/config.toml"),
+            Destination {
+                width: terminal_width().expect("COLUMNS=80 is set in .cargo/config.toml"),
+                link_style: LinkStyle::Expanded,
+            },
             &main_worktree_path,
             None,
             None,
@@ -1705,8 +1804,8 @@ mod tests {
 
     #[test]
     fn test_estimate_url_width_no_template() {
-        assert_eq!(estimate_url_width(None, false), 0);
-        assert_eq!(estimate_url_width(None, true), 0);
+        assert_eq!(estimate_url_width(None, LinkStyle::Expanded), 0);
+        assert_eq!(estimate_url_width(None, LinkStyle::Linked), 0);
     }
 
     #[test]
@@ -1715,10 +1814,10 @@ mod tests {
 
         // Without hyperlinks: full URL width from template expansion
         // Replaces {{ branch | hash_port }} with "12345" → "http://localhost:12345" = 22
-        assert_eq!(estimate_url_width(Some(template), false), 22);
+        assert_eq!(estimate_url_width(Some(template), LinkStyle::Expanded), 22);
 
         // With hyperlinks: compact port display ":12345" = 6
-        assert_eq!(estimate_url_width(Some(template), true), 6);
+        assert_eq!(estimate_url_width(Some(template), LinkStyle::Linked), 6);
     }
 
     #[test]
@@ -1728,10 +1827,10 @@ mod tests {
 
         // Without hyperlinks: full URL width from template expansion
         // Replaces {{ branch }} with "feature-xx" → "http://localhost/feature-xx" = 27
-        assert_eq!(estimate_url_width(Some(template), false), 27);
+        assert_eq!(estimate_url_width(Some(template), LinkStyle::Expanded), 27);
 
         // With hyperlinks: no port pattern, so still uses template estimation
-        assert_eq!(estimate_url_width(Some(template), true), 27);
+        assert_eq!(estimate_url_width(Some(template), LinkStyle::Linked), 27);
     }
 
     #[test]
@@ -1739,10 +1838,10 @@ mod tests {
         let template = "http://localhost:3000";
 
         // Without hyperlinks: template length = 21
-        assert_eq!(estimate_url_width(Some(template), false), 21);
+        assert_eq!(estimate_url_width(Some(template), LinkStyle::Expanded), 21);
 
         // With hyperlinks: has static port, compact display ":3000" = 6
-        assert_eq!(estimate_url_width(Some(template), true), 6);
+        assert_eq!(estimate_url_width(Some(template), LinkStyle::Linked), 6);
     }
 
     #[test]
@@ -1750,10 +1849,13 @@ mod tests {
         let template = "http://localhost:{{ port }}";
 
         // Without hyperlinks: template length (no branch/hash_port replacement)
-        assert_eq!(estimate_url_width(Some(template), false), template.len());
+        assert_eq!(
+            estimate_url_width(Some(template), LinkStyle::Expanded),
+            template.len()
+        );
 
         // With hyperlinks: has ":{{" pattern, compact display = 6
-        assert_eq!(estimate_url_width(Some(template), true), 6);
+        assert_eq!(estimate_url_width(Some(template), LinkStyle::Linked), 6);
     }
 
     // --- Flexible column (Summary/Message) allocation tests ---
@@ -1810,7 +1912,10 @@ mod tests {
         calculate_layout_with_width(
             &items,
             tasks,
-            width,
+            Destination {
+                width,
+                link_style: LinkStyle::Expanded,
+            },
             Path::new("/test"),
             None,
             None,
@@ -1853,7 +1958,10 @@ mod tests {
         let layout = calculate_layout_with_width(
             &items,
             &full_run_tasks(),
-            300,
+            Destination {
+                width: 300,
+                link_style: LinkStyle::Expanded,
+            },
             Path::new("/test"),
             None,
             None,
@@ -1912,7 +2020,10 @@ mod tests {
         let layout = calculate_layout_with_width(
             &items,
             &full_run_tasks(),
-            300,
+            Destination {
+                width: 300,
+                link_style: LinkStyle::Expanded,
+            },
             Path::new("/test"),
             None,
             None,
@@ -1955,7 +2066,10 @@ mod tests {
         let layout = calculate_layout_with_width(
             &items,
             &full_run_tasks(),
-            300,
+            Destination {
+                width: 300,
+                link_style: LinkStyle::Expanded,
+            },
             Path::new("/test"),
             None,
             None,
@@ -1985,7 +2099,10 @@ mod tests {
         let unplanned = calculate_layout_with_width(
             &items,
             &non_full_run_tasks(),
-            200,
+            Destination {
+                width: 200,
+                link_style: LinkStyle::Expanded,
+            },
             Path::new("/test"),
             None,
             None,
@@ -2005,7 +2122,10 @@ mod tests {
         let planned = calculate_layout_with_width(
             &items,
             &full_run_tasks(),
-            200,
+            Destination {
+                width: 200,
+                link_style: LinkStyle::Expanded,
+            },
             Path::new("/test"),
             None,
             None,
@@ -2030,7 +2150,10 @@ mod tests {
         let layout = calculate_layout_with_width(
             &items,
             &full_run_tasks(),
-            24,
+            Destination {
+                width: 24,
+                link_style: LinkStyle::Expanded,
+            },
             Path::new("/test"),
             None,
             None,
@@ -2303,7 +2426,10 @@ mod tests {
         let layout_wide = calculate_layout_with_width(
             &items,
             &tasks,
-            300,
+            Destination {
+                width: 300,
+                link_style: LinkStyle::Expanded,
+            },
             main_path,
             None,
             None,
@@ -2327,7 +2453,10 @@ mod tests {
         let layout_170 = calculate_layout_with_width(
             &items,
             &tasks,
-            170,
+            Destination {
+                width: 170,
+                link_style: LinkStyle::Expanded,
+            },
             main_path,
             None,
             None,
@@ -2480,7 +2609,10 @@ mod tests {
         let layout = calculate_layout_with_width(
             &items,
             &tasks,
-            170,
+            Destination {
+                width: 170,
+                link_style: LinkStyle::Expanded,
+            },
             main_path,
             None,
             None,
@@ -2518,7 +2650,10 @@ mod tests {
         let layout = calculate_layout_with_width(
             &items,
             &tasks,
-            30,
+            Destination {
+                width: 30,
+                link_style: LinkStyle::Expanded,
+            },
             main_path,
             None,
             None,
@@ -2542,7 +2677,10 @@ mod tests {
         let layout = calculate_layout_with_width(
             &items,
             &tasks,
-            80,
+            Destination {
+                width: 80,
+                link_style: LinkStyle::Expanded,
+            },
             main_path,
             None,
             None,
@@ -2606,7 +2744,10 @@ mod tests {
         let layout = calculate_layout_with_width(
             &items,
             &non_full_run_tasks(),
-            300,
+            Destination {
+                width: 300,
+                link_style: LinkStyle::Expanded,
+            },
             Path::new("/test"),
             None,
             None,
@@ -2648,7 +2789,10 @@ mod tests {
         let layout = calculate_layout_with_width(
             &items,
             &tasks,
-            300,
+            Destination {
+                width: 300,
+                link_style: LinkStyle::Expanded,
+            },
             Path::new("/test"),
             None,
             None,
@@ -2674,7 +2818,10 @@ mod tests {
         let narrow = calculate_layout_with_width(
             &items,
             &non_full_run_tasks(),
-            30,
+            Destination {
+                width: 30,
+                link_style: LinkStyle::Expanded,
+            },
             Path::new("/test"),
             None,
             None,

--- a/src/commands/list/model/item.rs
+++ b/src/commands/list/model/item.rs
@@ -15,7 +15,7 @@ use super::stats::{AheadBehind, BranchDiffTotals, CommitDetails, UpstreamStatus}
 use super::status_symbols::{StatusSymbols, WorkingTreeStatus};
 use crate::commands::list::ci_status::PrStatus;
 use crate::commands::list::columns::ColumnKind;
-use crate::commands::list::layout::format_url_cell;
+use crate::commands::list::layout::{LinkStyle, format_url_cell};
 
 /// Compute the `WorktreeState` from `WorktreeData` metadata alone.
 ///
@@ -568,7 +568,7 @@ impl ListItem {
         // bare `#` otherwise (no width cap in the statusline)
         if let Some(Some(ref pr_status)) = self.pr_status {
             segments.push(StatuslineSegment::from_column(
-                pr_status.format_cell(usize::MAX, true),
+                pr_status.format_cell(usize::MAX, LinkStyle::Linked),
                 ColumnKind::CiStatus,
             ));
         }
@@ -576,7 +576,7 @@ impl ListItem {
         // 8. URL (priority 9) — the dev server, as in `wt list`: the port as a
         // link, dimmed unless the health check found something listening on it.
         if let Some(ref url) = self.url {
-            let cell = format_url_cell(url, true);
+            let cell = format_url_cell(url, LinkStyle::Linked);
             segments.push(StatuslineSegment::from_column(
                 if self.url_active == Some(true) {
                     cell
@@ -973,7 +973,7 @@ mod tests {
                 .content
         };
 
-        let plain = format_url_cell("http://127.0.0.1:17913", true);
+        let plain = format_url_cell("http://127.0.0.1:17913", LinkStyle::Linked);
         let dim = cformat!("<dim>{plain}</>");
         assert_eq!(url_cell(Some(false)), dim, "a dead port should dim");
         assert_eq!(url_cell(None), dim, "an unfinished health check should dim");

--- a/src/commands/list/render.rs
+++ b/src/commands/list/render.rs
@@ -1,12 +1,13 @@
 use crate::display::{format_relative_time_short, shorten_path, truncate_to_width};
 use anstyle::{Effects, Style};
-use std::path::Path;
 use unicode_width::UnicodeWidthStr;
-use worktrunk::styling::{Stream, StyledLine, supports_hyperlinks};
+use worktrunk::styling::StyledLine;
 
 use super::columns::{ColumnKind, DiffVariant};
-use super::layout::{ColumnFormat, ColumnLayout, DiffColumnConfig, LayoutConfig, format_url_cell};
-use super::model::{ItemKind, ListItem, PositionMask};
+use super::layout::{
+    ColumnFormat, ColumnLayout, DiffColumnConfig, LayoutConfig, LinkStyle, format_url_cell,
+};
+use super::model::{ItemKind, ListItem};
 
 /// Placeholder glyph for unresolved Status positions — both "still loading" and
 /// "drain deadline fired, won't arrive."
@@ -277,16 +278,7 @@ impl LayoutConfig {
     /// to [`PLACEHOLDER`] on the reveal tick. Non-progressive callers pass
     /// [`PLACEHOLDER`] directly.
     pub fn render_list_item_line(&self, item: &ListItem, placeholder: &str) -> StyledLine {
-        self.render_line(|column| {
-            column.render_cell(
-                item,
-                &self.status_position_mask,
-                &self.main_worktree_path,
-                self.max_message_len,
-                self.max_summary_len,
-                placeholder,
-            )
-        })
+        self.render_line(|column| column.render_cell(item, self, placeholder))
     }
 
     /// Render a skeleton row showing known data (branch, path) with placeholders for other columns.
@@ -358,10 +350,7 @@ impl LayoutConfig {
                     return match &item.pr_status {
                         Some(Some(pr_status)) => {
                             let mut ci = StyledLine::new();
-                            ci.push_raw(
-                                pr_status
-                                    .format_cell(col.width, supports_hyperlinks(Stream::Stdout)),
-                            );
+                            ci.push_raw(pr_status.format_cell(col.width, self.link_style));
                             ci
                         }
                         _ => StyledLine::new(),
@@ -377,14 +366,7 @@ impl LayoutConfig {
                 // skeleton paint) `item.commit` is `None`, and `render_cell`
                 // returns the same placeholder the `_` arm below would.
                 ColumnKind::Time | ColumnKind::Message => {
-                    return col.render_cell(
-                        item,
-                        &self.status_position_mask,
-                        &self.main_worktree_path,
-                        self.max_message_len,
-                        self.max_summary_len,
-                        spinner,
-                    );
+                    return col.render_cell(item, self, spinner);
                 }
                 _ => {
                     // Show spinner for data columns (placeholder_cell handles alignment)
@@ -431,15 +413,18 @@ impl ColumnLayout {
         config.render_segment(positive, negative)
     }
 
-    fn render_cell(
-        &self,
-        item: &ListItem,
-        status_mask: &PositionMask,
-        main_worktree_path: &Path,
-        max_message_len: usize,
-        max_summary_len: usize,
-        placeholder: &str,
-    ) -> StyledLine {
+    /// Render this column's cell for `item`.
+    ///
+    /// Reads the render-wide facts — the Status mask, the path rows shorten
+    /// against, the text budgets, the [`LinkStyle`] — off the `layout` this
+    /// column belongs to, so every cell in a row answers them the same way.
+    fn render_cell(&self, item: &ListItem, layout: &LayoutConfig, placeholder: &str) -> StyledLine {
+        let status_mask = &layout.status_position_mask;
+        let main_worktree_path = &layout.main_worktree_path;
+        let max_message_len = layout.max_message_len;
+        let max_summary_len = layout.max_summary_len;
+        let link: LinkStyle = layout.link_style;
+
         // Compute derived values inline (avoids separate context struct)
         let worktree_data = item.worktree_data();
         let text_style = item.should_dim().then(|| Style::new().dimmed());
@@ -560,14 +545,13 @@ impl ColumnLayout {
             }
             ColumnKind::Url => {
                 // URL column: shows dev server URL from project config template
-                // - When hyperlinks supported: show ":port" as clickable link
-                // - When hyperlinks not supported: show full URL
-                // - dim if not available/active, normal if active
+                // as ":port" or in full (see `format_url_cell`), dim if not
+                // available/active, normal if active
                 let Some(url) = &item.url else {
                     return StyledLine::new();
                 };
                 let mut cell = StyledLine::new();
-                let formatted = format_url_cell(url, supports_hyperlinks(Stream::Stdout));
+                let formatted = format_url_cell(url, link);
                 if item.url_active == Some(true) {
                     cell.push_raw(formatted);
                 } else {
@@ -582,9 +566,7 @@ impl ColumnLayout {
                     Some(None) => StyledLine::new(), // No CI for this branch
                     Some(Some(pr_status)) => {
                         let mut cell = StyledLine::new();
-                        cell.push_raw(
-                            pr_status.format_cell(self.width, supports_hyperlinks(Stream::Stdout)),
-                        );
+                        cell.push_raw(pr_status.format_cell(self.width, link));
                         cell
                     }
                 }
@@ -633,9 +615,11 @@ impl ColumnLayout {
 
 #[cfg(test)]
 mod tests {
+    use super::super::model::PositionMask;
     use super::*;
     use crate::commands::list::layout::DiffDisplayConfig;
     use ansi_str::AnsiStr;
+    use std::path::PathBuf;
     use worktrunk::styling::{ADDITION, DELETION};
 
     fn format_diff_like_column(
@@ -644,6 +628,19 @@ mod tests {
         config: DiffColumnConfig,
     ) -> StyledLine {
         config.render_segment(positive, negative)
+    }
+
+    /// A one-column layout carrying the render-wide facts `render_cell` reads.
+    fn cell_layout(column: ColumnLayout) -> LayoutConfig {
+        LayoutConfig {
+            columns: vec![column],
+            main_worktree_path: PathBuf::from("/tmp"),
+            max_message_len: 50,
+            max_summary_len: 40,
+            hidden_column_count: 0,
+            status_position_mask: PositionMask::FULL,
+            link_style: LinkStyle::Expanded,
+        }
     }
 
     #[test]
@@ -1316,11 +1313,92 @@ mod tests {
         insta::assert_snapshot!(arrow_behind_dim.render(), @"    [31m↓1C[0m");
     }
 
+    /// A row's link markup is a property of the render, not of the cell that
+    /// happens to emit it: the CI reference and the dev-server port either both
+    /// carry an underlined OSC 8 link or neither does. The picker renders
+    /// `Unlinked` because skim mangles the escape, and an underline there would
+    /// mark text with nothing behind it.
+    #[test]
+    fn test_link_markup_is_uniform_across_a_row() {
+        use super::super::ci_status::{CiSource, CiStatus, PrRef, PrStatus};
+        use super::super::layout::{ColumnLayout, LayoutConfig};
+        use super::super::model::ListItem;
+
+        let columns = || {
+            [(ColumnKind::CiStatus, "CI", 5), (ColumnKind::Url, "URL", 6)]
+                .into_iter()
+                .enumerate()
+                .map(|(i, (kind, header, width))| ColumnLayout {
+                    kind,
+                    header: std::borrow::Cow::Borrowed(header),
+                    start: i * 8,
+                    width,
+                    format: ColumnFormat::Text,
+                })
+                .collect()
+        };
+        let layout = |link_style| LayoutConfig {
+            columns: columns(),
+            main_worktree_path: PathBuf::from("/tmp"),
+            max_message_len: 0,
+            max_summary_len: 10,
+            hidden_column_count: 0,
+            status_position_mask: PositionMask::FULL,
+            link_style,
+        };
+
+        let mut item = ListItem::new_branch("abc123".into(), "feat".into());
+        item.url = Some("http://127.0.0.1:17913".into());
+        item.url_active = Some(true);
+        item.pr_status = Some(Some(PrStatus {
+            ci_status: CiStatus::Passed,
+            source: CiSource::PullRequest,
+            is_stale: false,
+            is_priming: false,
+            url: Some("https://github.com/owner/repo/pull/123".into()),
+            number: Some(PrRef::pr(123)),
+            review_state: None,
+            title: None,
+            body: None,
+            author: None,
+            comment_count: None,
+            updated_at: None,
+        }));
+
+        let linked = layout(LinkStyle::Linked)
+            .render_list_item_line(&item, PLACEHOLDER)
+            .render();
+        for (url, text) in [
+            ("https://github.com/owner/repo/pull/123", "#123"),
+            ("http://127.0.0.1:17913", ":17913"),
+        ] {
+            assert!(
+                linked.contains(&worktrunk::styling::hyperlink(url, text)),
+                "{text} should be an underlined link in {linked:?}"
+            );
+        }
+
+        let unlinked = layout(LinkStyle::Unlinked)
+            .render_list_item_line(&item, PLACEHOLDER)
+            .render();
+        assert!(
+            unlinked.contains("#123") && unlinked.contains(":17913"),
+            "both references keep their short text in {unlinked:?}"
+        );
+        assert!(
+            !unlinked.contains("\u{1b}]8;"),
+            "an unlinked row carries no OSC 8 escape: {unlinked:?}"
+        );
+        assert!(
+            !unlinked.contains("\u{1b}[4m"),
+            "and no underline, which would mark text with nothing behind it: {unlinked:?}"
+        );
+    }
+
     #[test]
     fn test_loading_uses_middle_dot() {
         use super::super::layout::{ColumnLayout, LayoutConfig};
-        use super::super::model::{ListItem, PositionMask};
-        use std::path::PathBuf;
+        use super::super::model::ListItem;
 
         let layout = LayoutConfig {
             columns: vec![ColumnLayout {
@@ -1335,6 +1413,7 @@ mod tests {
             max_summary_len: 10,
             hidden_column_count: 0,
             status_position_mask: PositionMask::FULL,
+            link_style: LinkStyle::Expanded,
         };
 
         let item = ListItem::new_branch("abc123".into(), "feat".into());
@@ -1347,8 +1426,7 @@ mod tests {
     #[test]
     fn test_summary_column_rendering() {
         use super::super::layout::ColumnLayout;
-        use super::super::model::{ListItem, PositionMask};
-        use std::path::PathBuf;
+        use super::super::model::ListItem;
 
         let summary_col = ColumnLayout {
             kind: ColumnKind::Summary,
@@ -1358,23 +1436,20 @@ mod tests {
             format: ColumnFormat::Text,
         };
 
-        let mask = PositionMask::FULL;
-        let main_path = PathBuf::from("/tmp");
-
         // Case 1: summary = None (not loaded yet → placeholder)
         let mut item = ListItem::new_branch("abc123".into(), "feat".into());
         item.summary = None;
-        let cell = summary_col.render_cell(&item, &mask, &main_path, 50, 40, PLACEHOLDER);
+        let cell = summary_col.render_cell(&item, &cell_layout(summary_col.clone()), PLACEHOLDER);
         insta::assert_snapshot!(cell.render(), @"[2m·[0m");
 
         // Case 2: summary = Some(None) (loaded, no summary → blank)
         item.summary = Some(None);
-        let cell = summary_col.render_cell(&item, &mask, &main_path, 50, 40, PLACEHOLDER);
+        let cell = summary_col.render_cell(&item, &cell_layout(summary_col.clone()), PLACEHOLDER);
         assert!(cell.render().is_empty());
 
         // Case 3: summary = Some(Some(text)) (has summary)
         item.summary = Some(Some("Add user authentication".into()));
-        let cell = summary_col.render_cell(&item, &mask, &main_path, 50, 40, PLACEHOLDER);
+        let cell = summary_col.render_cell(&item, &cell_layout(summary_col.clone()), PLACEHOLDER);
         insta::assert_snapshot!(cell.render(), @"Add user authentication");
     }
 
@@ -1412,6 +1487,7 @@ mod tests {
             max_summary_len: 10,
             hidden_column_count: 0,
             status_position_mask: PositionMask::FULL,
+            link_style: LinkStyle::Expanded,
         };
 
         // commit = None (first skeleton paint, before the batch) → placeholders.
@@ -1447,8 +1523,7 @@ mod tests {
     #[test]
     fn test_working_diff_placeholder_when_not_loaded() {
         use super::super::layout::ColumnLayout;
-        use super::super::model::{ItemKind, ListItem, PositionMask};
-        use std::path::PathBuf;
+        use super::super::model::{ItemKind, ListItem};
         use worktrunk::styling::{ADDITION, DELETION};
 
         let col = ColumnLayout {
@@ -1468,30 +1543,26 @@ mod tests {
             }),
         };
 
-        let mask = PositionMask::FULL;
-        let main_path = PathBuf::from("/tmp");
-
         // Branch item (no worktree data) → blank, not placeholder
         let branch_item = ListItem::new_branch("abc123".into(), "feat".into());
-        let cell = col.render_cell(&branch_item, &mask, &main_path, 50, 40, PLACEHOLDER);
+        let cell = col.render_cell(&branch_item, &cell_layout(col.clone()), PLACEHOLDER);
         assert!(cell.render().is_empty(), "branch item should be blank");
 
         // Worktree item with working_tree_diff: None → placeholder
         let mut wt_item = ListItem::new_branch("abc123".into(), "feat".into());
         wt_item.kind = ItemKind::Worktree(Box::default());
-        let cell = col.render_cell(&wt_item, &mask, &main_path, 50, 40, PLACEHOLDER);
+        let cell = col.render_cell(&wt_item, &cell_layout(col.clone()), PLACEHOLDER);
         insta::assert_snapshot!(cell.render(), @"        [2m·[0m");
 
         // Stale placeholder
-        let cell = col.render_cell(&wt_item, &mask, &main_path, 50, 40, "·");
+        let cell = col.render_cell(&wt_item, &cell_layout(col.clone()), "·");
         insta::assert_snapshot!(cell.render(), @"        [2m·[0m");
     }
 
     #[test]
     fn test_upstream_placeholder_when_not_loaded() {
         use super::super::layout::ColumnLayout;
-        use super::super::model::{ListItem, PositionMask, UpstreamStatus};
-        use std::path::PathBuf;
+        use super::super::model::{ListItem, UpstreamStatus};
         use worktrunk::styling::{ADDITION, DELETION};
 
         let col = ColumnLayout {
@@ -1511,19 +1582,16 @@ mod tests {
             }),
         };
 
-        let mask = PositionMask::FULL;
-        let main_path = PathBuf::from("/tmp");
-
         // upstream: None (not loaded) → placeholder
         let item = ListItem::new_branch("abc123".into(), "feat".into());
         assert!(item.upstream.is_none());
-        let cell = col.render_cell(&item, &mask, &main_path, 50, 40, PLACEHOLDER);
+        let cell = col.render_cell(&item, &cell_layout(col.clone()), PLACEHOLDER);
         insta::assert_snapshot!(cell.render(), @"      [2m·[0m");
 
         // upstream: Some(default) (loaded, no active upstream) → blank
         let mut item = ListItem::new_branch("abc123".into(), "feat".into());
         item.upstream = Some(UpstreamStatus::default());
-        let cell = col.render_cell(&item, &mask, &main_path, 50, 40, PLACEHOLDER);
+        let cell = col.render_cell(&item, &cell_layout(col.clone()), PLACEHOLDER);
         assert!(
             cell.render().is_empty(),
             "no active upstream should be blank"

--- a/src/commands/picker/mod.rs
+++ b/src/commands/picker/mod.rs
@@ -122,9 +122,7 @@ use worktrunk::HookType;
 use worktrunk::config::Approvals;
 use worktrunk::git::{ErrorExt, Repository, current_or_recover};
 use worktrunk::path::format_path_for_display;
-use worktrunk::styling::{
-    eprintln, error_message, hint_message, info_message, strip_osc8_hyperlinks, warning_message,
-};
+use worktrunk::styling::{eprintln, error_message, hint_message, info_message, warning_message};
 
 use super::hook_plan::{ApprovedHookPlan, HookPlanBuilder};
 use super::hooks::HookAnnouncer;
@@ -832,8 +830,7 @@ struct MorphRevert {
 /// kind — `refresh_status_symbols` only fills empty slots, so the worktree's must
 /// be cleared first. The [`LocalContent`] is read off the demoted item, so its
 /// `working_tree` signal resolves empty (no worktree to diff) and the
-/// `working_tree` preview tab dims. OSC 8 hyperlinks are stripped to match the
-/// rows the handler builds (skim's pipeline mangles them).
+/// `working_tree` preview tab dims.
 fn build_morph_branch_row(
     layout: &crate::commands::list::layout::LayoutConfig,
     worktree_item: &ListItem,
@@ -843,11 +840,9 @@ fn build_morph_branch_row(
     branch_item.kind = ItemKind::Branch(BranchScope::Local);
     branch_item.status_symbols = Default::default();
     branch_item.refresh_status_symbols(default_branch);
-    let line = strip_osc8_hyperlinks(
-        &layout
-            .render_list_item_line(&branch_item, PLACEHOLDER)
-            .render(),
-    );
+    let line = layout
+        .render_list_item_line(&branch_item, PLACEHOLDER)
+        .render();
     (line, LocalContent::from_item(&branch_item))
 }
 
@@ -3170,7 +3165,10 @@ pub mod tests {
             Some(crate::commands::list::layout::calculate_layout_with_width(
                 std::slice::from_ref(&*item_arc),
                 &crate::commands::list::columns::all_tasks(),
-                80,
+                crate::commands::list::layout::Destination {
+                    width: 80,
+                    link_style: crate::commands::list::layout::LinkStyle::Expanded,
+                },
                 Path::new("/test"),
                 None,
                 None,
@@ -4141,7 +4139,10 @@ pub mod tests {
         let layout = crate::commands::list::layout::calculate_layout_with_width(
             std::slice::from_ref(&worktree_item),
             &crate::commands::list::columns::all_tasks(),
-            80,
+            crate::commands::list::layout::Destination {
+                width: 80,
+                link_style: crate::commands::list::layout::LinkStyle::Expanded,
+            },
             Path::new("/test"),
             None,
             None,

--- a/src/commands/picker/progressive_handler.rs
+++ b/src/commands/picker/progressive_handler.rs
@@ -41,7 +41,7 @@ use std::time::{Duration, Instant};
 use color_print::cformat;
 use skim::prelude::*;
 use worktrunk::git::Repository;
-use worktrunk::styling::{HINT_SYMBOL, StyledLine, strip_osc8_hyperlinks};
+use worktrunk::styling::{HINT_SYMBOL, StyledLine};
 
 use super::super::list::ci_status::PrStatus;
 
@@ -404,9 +404,7 @@ impl PickerProgressHandler for PickerHandler {
                 search_base.push_str(&path_str);
             }
 
-            // Strip OSC 8 hyperlinks — skim's pipeline mangles them into
-            // garbage like `^[8;;…`. Colors (SGR codes) are preserved.
-            let rendered_arc = Arc::new(Mutex::new(strip_osc8_hyperlinks(&rendered_line)));
+            let rendered_arc = Arc::new(Mutex::new(rendered_line));
             slots.push(Arc::clone(&rendered_arc));
 
             let item_arc = Arc::new(item);
@@ -567,7 +565,7 @@ impl PickerProgressHandler for PickerHandler {
         if let Some(slots) = self.rendered_slots.get()
             && let Some(slot) = slots.get(idx)
         {
-            *slot.lock().unwrap() = strip_osc8_hyperlinks(&rendered);
+            *slot.lock().unwrap() = rendered;
         }
         // Mirror the row's current CI status into its live slot so the `pr` /
         // `comments` tabs reflect the fetch as it lands. Track change at the
@@ -635,7 +633,7 @@ impl PickerProgressHandler for PickerHandler {
             return;
         };
         for (slot, line) in slots.iter().zip(rendered) {
-            *slot.lock().unwrap() = strip_osc8_hyperlinks(&line);
+            *slot.lock().unwrap() = line;
         }
         self.request_render(false);
     }

--- a/src/commands/picker/prs.rs
+++ b/src/commands/picker/prs.rs
@@ -1275,7 +1275,7 @@ fn render_grid_row(entry: &PrEntry, grid: &ColumnGrid, list_width: usize) -> Str
     match grid.column(ColumnKind::CiStatus).zip(entry.status.as_ref()) {
         Some((col, status)) => {
             let mut cell = StyledLine::new();
-            cell.push_raw(status.format_cell(col.width, false));
+            cell.push_raw(status.format_cell(col.width, grid.link_style));
             segments.push((col.start, cell));
         }
         None => {
@@ -1327,6 +1327,7 @@ fn render_freeform_row(entry: &PrEntry, list_width: usize) -> String {
 // cached the same way via `spawn_pr_previews`.
 #[cfg(test)]
 mod tests {
+    use super::super::super::list::layout::LinkStyle;
     use super::super::items::PreviewCache;
     use super::super::preview_notify::PreviewNotifier;
     use super::*;
@@ -1418,6 +1419,7 @@ mod tests {
     /// longer skipped). Gutter 0–2, Branch 2–22, Status 24–32, CI 34–40.
     fn grid_with_ci() -> ColumnGrid {
         ColumnGrid {
+            link_style: LinkStyle::Unlinked,
             columns: vec![
                 grid_col(ColumnKind::Gutter, 0, 2),
                 grid_col(ColumnKind::Branch, 2, 20),
@@ -1557,6 +1559,7 @@ mod tests {
     /// the shape `calculate_layout_with_width` produces for the picker.
     fn grid() -> ColumnGrid {
         ColumnGrid {
+            link_style: LinkStyle::Unlinked,
             columns: vec![
                 grid_col(ColumnKind::Gutter, 0, 2),
                 grid_col(ColumnKind::Branch, 2, 20),
@@ -1662,6 +1665,7 @@ mod tests {
         // Even with a long branch the row stays inside the pane: the branch
         // truncates to its column and nothing flexible follows.
         let no_flexible = ColumnGrid {
+            link_style: LinkStyle::Unlinked,
             columns: vec![
                 grid_col(ColumnKind::Gutter, 0, 2),
                 grid_col(ColumnKind::Branch, 2, 20),
@@ -1698,6 +1702,7 @@ mod tests {
         // Message column (where worktree rows show their commit subject) is
         // present, only the gutter, branch, and CI number land.
         let grid = ColumnGrid {
+            link_style: LinkStyle::Unlinked,
             columns: vec![
                 grid_col(ColumnKind::Gutter, 0, 2),
                 grid_col(ColumnKind::Branch, 2, 20),

--- a/src/commands/statusline.rs
+++ b/src/commands/statusline.rs
@@ -1206,7 +1206,7 @@ mod tests {
     #[test]
     fn test_statusline_fitting_never_splits_a_hyperlink() {
         use super::super::list::columns::ColumnKind;
-        use super::super::list::layout::format_url_cell;
+        use super::super::list::layout::{LinkStyle, format_url_cell};
 
         let ci = StatuslineSegment::from_column(
             format!(
@@ -1217,7 +1217,7 @@ mod tests {
             ColumnKind::CiStatus,
         );
         let url = StatuslineSegment::from_column(
-            format_url_cell("http://127.0.0.1:17913", true),
+            format_url_cell("http://127.0.0.1:17913", LinkStyle::Linked),
             ColumnKind::Url,
         );
         let segments = vec![


### PR DESCRIPTION
The picker rendered its rows with hyperlinks enabled and then stripped the OSC 8 escapes afterwards, keeping the underline. A row showed an underlined `#3604` and `:11486` with nothing behind either. This is the follow-up to #3643, which established the "every link is underlined" policy; the picker was the one place the policy was being asserted about text that wasn't a link.

The cause was one boolean answering two questions. `supports_hyperlinks(Stream::Stdout)` decided both whether the terminal draws OSC 8 (which is what lets a dev-server URL collapse to `:port`, since the URL rides inside the escape) and whether this render's output delivers the escape intact (which the picker answers differently, because skim mangles it). Each cell called the probe independently, so a row's cells could disagree, and the fix for one cell wouldn't reach the other.

`LinkStyle` now answers both once per render: `Linked` (underlined OSC 8 link), `Unlinked` (the same short text, no escape and no underline) and `Expanded` (no OSC 8 in the terminal, so a dev-server URL prints in full and stays copyable). It lives on `LayoutConfig` and rides into `ColumnGrid`, so `--prs` rows rendered off-thread present references exactly as the worktree rows beside them do rather than hardcoding `false`. `Destination` pairs it with the width because one fact decides both: `wt list` writes to the terminal and gets the full width plus intact escapes, while the picker gets a narrower list (skim keeps the rest for the preview pane) and no escapes. The four post-hoc `strip_osc8_hyperlinks` calls in the picker are gone, since nothing emits links there to strip.

Two things fell out. `render_cell` was carrying four `LayoutConfig` fields as separate arguments; it now takes the layout, which is also how it got back under clippy's 7-argument cap without a suppression. And the "collapse to `:port`" decision stayed tied to the terminal probe rather than to link emission, so the picker's URL column keeps its narrow form instead of expanding to the full URL.

## Reviewer notes

`src/commands/list/layout.rs` holds `LinkStyle` and `Destination` with the rationale; `src/commands/list/collect/mod.rs` is where the picker and `wt list` diverge, keyed on the same `progressive_handler.is_some()` the surrounding picker forks already use.

## Testing

`test_link_markup_is_uniform_across_a_row` renders one item under both styles and asserts the CI reference and the dev-server port agree: both underlined links under `Linked`, both plain with no escape and no underline under `Unlinked`. `test_format_cell` additionally pins that `Expanded` and `Unlinked` read the same for a PR reference, which has no URL to fall back on.

Beyond the suite, checked against a scratch repo with a URL template: `wt list` emits the dim-plus-underline-plus-link form closing with `[24m` so the dim survives, and the picker's rows render `:12107` with no escape and no underline. The port still collapses in the picker, which was the regression risk worth confirming.

> _This was written by Claude Code on behalf of max_
