### PR TITLE
Consolidate benchmark fixtures and harness

### DIFF
--- a/benches/CLAUDE.md
+++ b/benches/CLAUDE.md
@@ -47,7 +47,7 @@ it runs on.
 | `RepoConfig::branches(N, M)` | `branches-N[-M]` | `completion_switch` (completion.rs) |
 | `RepoConfig::many_divergent_branches()` | `divergent` | `divergent_branches` (list.rs) |
 | `create_mixed_repo(W, B)` | `mixed-W-B` | `full` (list.rs) |
-| `create_prune_repo_at(M, U)` | `prune-M-U` | `prune_e2e` (prune.rs) |
+| `create_prune_repo(M, U)` | `prune-M-U` | `prune_e2e` (prune.rs) |
 | `ensure_prune_real_repo(M, U)` | `prune-real[-M-U]` | `prune_real_repo` (prune.rs) |
 | rust-lang/rust clone (`clone_rust_repo`) | — | `real_repo`, `real_repo_many_branches` (list.rs) |
 | `lean_worktrees` (local to alias.rs) | — | `dispatch` (alias.rs) |
@@ -57,6 +57,12 @@ Renaming a bench group is not free: `.github/scripts/criterion-to-jsonl.py`
 keys each time-series row by the criterion output path (`<group>/<id>`), and the
 daily `benchmarks` workflow appends those to a gist. A rename orphans that
 series.
+
+Every ephemeral generator returns `FixtureRepo`, the owner of the temporary
+root plus the canonical primary/linked-worktree paths. Repo-bound benchmark
+subprocesses start through `wt_command`, and warm/cold matrices use
+`CacheState::WARM_AND_COLD`; keep lifecycle, environment isolation, and cache
+labels in those shared APIs rather than re-deriving them in a bench target.
 
 ## Rust Repo Caching
 

--- a/benches/alias.rs
+++ b/benches/alias.rs
@@ -33,7 +33,7 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 use std::path::Path;
 use std::process::Command;
 use worktrunk::testing::isolate_subprocess_env;
-use wt_perf::{CacheState, RepoConfig, bench_wt, create_repo, run_and_check};
+use wt_perf::{CacheState, RepoConfig, bench_wt, create_repo, run_and_check, wt_command};
 
 /// Alias body is a shell builtin so the wall-clock is dominated by the
 /// parent's dispatch — not by running a real subcommand.
@@ -44,7 +44,7 @@ const STUB_CONFIG: &str = "[aliases]\nstub = \"echo hello\"\n";
 /// fork), `default_branch` (cold detection), `primary_worktree_path`
 /// (lookup). `branch` and `worktree_path` are nearly free but kept so a
 /// future filter sees them as "referenced". `upstream` is omitted because
-/// the bench repo has no remote — adding `setup_fake_remote` would change
+/// fixture branches have no configured upstream — adding one would change
 /// what the stub variant measures and break label continuity.
 const WITH_VARS_CONFIG: &str = r#"[aliases]
 with_vars = "echo {{ branch }} {{ default_branch }} {{ commit }} {{ short_commit }} {{ primary_worktree_path }} {{ worktree_path }}"
@@ -55,21 +55,15 @@ with_vars = "echo {{ branch }} {{ default_branch }} {{ commit }} {{ short_commit
 /// 10s at 100 worktrees (vs. ~60s for `RepoConfig::typical(100)`).
 const fn lean_worktrees(worktrees: usize) -> RepoConfig {
     RepoConfig {
-        commits_on_main: 1,
-        files: 1,
-        branches: 0,
-        commits_per_branch: 0,
         worktrees,
-        worktree_commits_ahead: 0,
-        worktree_uncommitted_files: 0,
+        ..RepoConfig::branches(0, 0)
     }
 }
 
 /// Build an isolated `wt` invocation pointed at a fixture user config.
 fn wt_cmd(binary: &Path, repo: &Path, user_config: &Path, args: &[&str]) -> Command {
-    let mut cmd = Command::new(binary);
-    cmd.args(args).current_dir(repo);
-    isolate_subprocess_env(&mut cmd, Some(user_config));
+    let mut cmd = wt_command(binary, repo, Some(user_config));
+    cmd.args(args);
     cmd
 }
 
@@ -90,10 +84,9 @@ fn bench_dispatch(c: &mut Criterion) {
     });
 
     for worktrees in [1usize, 100] {
-        let temp = create_repo(&lean_worktrees(worktrees));
-        let repo_path = temp.path().join("repo");
-        let stub_config = temp.path().join("stub-config.toml");
-        let vars_config = temp.path().join("with-vars-config.toml");
+        let fixture = create_repo(&lean_worktrees(worktrees));
+        let stub_config = fixture.root().join("stub-config.toml");
+        let vars_config = fixture.root().join("with-vars-config.toml");
         std::fs::write(&stub_config, STUB_CONFIG).unwrap();
         std::fs::write(&vars_config, WITH_VARS_CONFIG).unwrap();
 
@@ -104,8 +97,8 @@ fn bench_dispatch(c: &mut Criterion) {
             (None, "stub", &stub_config),
             (Some("with_vars"), "with_vars", &vars_config),
         ] {
-            for cold in [false, true] {
-                let cache_label = if cold { "cold" } else { "warm" };
+            for cache in CacheState::WARM_AND_COLD {
+                let cache_label = cache.label();
                 let id = match id_prefix {
                     Some(prefix) => format!("{prefix}/{cache_label}"),
                     None => cache_label.to_string(),
@@ -115,13 +108,8 @@ fn bench_dispatch(c: &mut Criterion) {
                     // Cold matters here: `build_hook_context` resolves the
                     // default branch, which writes `worktrunk.default-branch`
                     // and would otherwise be a cache hit on iters 2-N.
-                    let cache = if cold {
-                        CacheState::Cold
-                    } else {
-                        CacheState::Warm
-                    };
-                    bench_wt(b, &repo_path, cache, || {
-                        wt_cmd(binary, &repo_path, user_config, &[alias_name])
+                    bench_wt(b, fixture.path(), cache, || {
+                        wt_cmd(binary, fixture.path(), user_config, &[alias_name])
                     });
                 });
             }

--- a/benches/completion.rs
+++ b/benches/completion.rs
@@ -1,20 +1,17 @@
 use criterion::{Criterion, criterion_group, criterion_main};
 use std::path::Path;
-use std::process::Command;
-use worktrunk::testing::isolate_subprocess_env;
-use wt_perf::{RepoConfig, create_repo};
+use wt_perf::{RepoConfig, create_repo, run_and_check, wt_command};
 
 fn run_completion(binary: &Path, repo_path: &Path, words: &[&str]) {
     let index = words.len().saturating_sub(1);
-    let mut cmd = Command::new(binary);
-    cmd.arg("--").args(words).current_dir(repo_path);
-    isolate_subprocess_env(&mut cmd, None);
+    let mut cmd = wt_command(binary, repo_path, None);
+    cmd.arg("--").args(words);
     cmd.env("COMPLETE", "bash")
         .env("_CLAP_COMPLETE_INDEX", index.to_string())
         .env("_CLAP_COMPLETE_COMP_TYPE", "9")
         .env("_CLAP_COMPLETE_SPACE", "true")
         .env("_CLAP_IFS", "\n");
-    cmd.output().unwrap();
+    run_and_check(&mut cmd);
 }
 
 fn bench_completion_switch(c: &mut Criterion) {
@@ -24,9 +21,8 @@ fn bench_completion_switch(c: &mut Criterion) {
     // Without worktrees: all branches are candidates
     group.bench_function("branches_only", |b| {
         let config = RepoConfig::branches(50, 0);
-        let temp = create_repo(&config);
-        let repo = temp.path().join("repo");
-        b.iter(|| run_completion(binary, &repo, &["wt", "switch", ""]));
+        let fixture = create_repo(&config);
+        b.iter(|| run_completion(binary, fixture.path(), &["wt", "switch", ""]));
     });
 
     // With worktrees: filters out branches that already have worktrees
@@ -35,9 +31,8 @@ fn bench_completion_switch(c: &mut Criterion) {
             worktrees: 10,
             ..RepoConfig::branches(50, 0)
         };
-        let temp = create_repo(&config);
-        let repo = temp.path().join("repo");
-        b.iter(|| run_completion(binary, &repo, &["wt", "switch", ""]));
+        let fixture = create_repo(&config);
+        b.iter(|| run_completion(binary, fixture.path(), &["wt", "switch", ""]));
     });
 
     group.finish();

--- a/benches/list.rs
+++ b/benches/list.rs
@@ -28,62 +28,27 @@
 //   cargo bench --bench list skeleton/warm           # Skeleton group, warm only
 
 use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
-use std::path::{Path, PathBuf};
-use std::process::Command;
-use worktrunk::testing::isolate_subprocess_env;
+use std::path::Path;
 use wt_perf::{
-    CacheState, RepoConfig, add_history_spread_branches, add_worktrees, bench_wt, clone_rust_repo,
-    create_mixed_repo, create_repo, run_git, setup_fake_remote,
+    CacheState, FixtureRepo, RepoConfig, add_history_spread_branches, add_worktrees, bench_wt,
+    clone_rust_repo, create_mixed_repo, create_repo, run_git, wt_command,
 };
-
-/// Benchmark configuration wrapping RepoConfig with cache state.
-#[derive(Clone)]
-struct BenchConfig {
-    repo: RepoConfig,
-    cold_cache: bool,
-}
-
-impl BenchConfig {
-    const fn typical(worktrees: usize, cold_cache: bool) -> Self {
-        Self {
-            repo: RepoConfig::typical(worktrees),
-            cold_cache,
-        }
-    }
-
-    const fn many_divergent_branches(cold_cache: bool) -> Self {
-        Self {
-            repo: RepoConfig::many_divergent_branches(),
-            cold_cache,
-        }
-    }
-
-    fn label(&self) -> &'static str {
-        if self.cold_cache { "cold" } else { "warm" }
-    }
-}
 
 /// Run `wt` with `args` in `repo_path`, on a warm or cold cache.
 ///
 /// Fixture-agnostic: callers build whatever repo shape they want, then pass
-/// `cold_cache` to pick the iteration strategy (see [`bench_wt`]).
+/// `cache` to pick the iteration strategy (see [`bench_wt`]).
 fn run_benchmark(
     b: &mut criterion::Bencher,
     binary: &Path,
     repo_path: &Path,
-    cold_cache: bool,
+    cache: CacheState,
     args: &[&str],
     env: Option<(&str, &str)>,
 ) {
-    let cache = if cold_cache {
-        CacheState::Cold
-    } else {
-        CacheState::Warm
-    };
     bench_wt(b, repo_path, cache, || {
-        let mut cmd = Command::new(binary);
-        cmd.args(args).current_dir(repo_path);
-        isolate_subprocess_env(&mut cmd, None);
+        let mut cmd = wt_command(binary, repo_path, None);
+        cmd.args(args);
         if let Some((key, value)) = env {
             cmd.env(key, value);
         }
@@ -96,21 +61,17 @@ fn bench_skeleton(c: &mut Criterion) {
     let binary = Path::new(env!("CARGO_BIN_EXE_wt"));
 
     for worktrees in [1, 4, 8] {
-        for cold in [false, true] {
-            let config = BenchConfig::typical(worktrees, cold);
-
+        for cache in CacheState::WARM_AND_COLD {
             group.bench_with_input(
-                BenchmarkId::new(config.label(), worktrees),
-                &config,
-                |b, config| {
-                    let temp = create_repo(&config.repo);
-                    let repo_path = temp.path().join("repo");
-                    setup_fake_remote(&repo_path);
+                BenchmarkId::new(cache.label(), worktrees),
+                &cache,
+                |b, &cache| {
+                    let fixture = create_repo(&RepoConfig::typical(worktrees));
                     run_benchmark(
                         b,
                         binary,
-                        &repo_path,
-                        config.cold_cache,
+                        fixture.path(),
+                        cache,
                         &["list"],
                         Some(("WORKTRUNK_SKELETON_ONLY", "1")),
                     );
@@ -127,17 +88,14 @@ fn bench_worktree_scaling(c: &mut Criterion) {
     let binary = Path::new(env!("CARGO_BIN_EXE_wt"));
 
     for worktrees in [1, 4, 8] {
-        for cold in [false, true] {
-            let config = BenchConfig::typical(worktrees, cold);
-
+        for cache in CacheState::WARM_AND_COLD {
             group.bench_with_input(
-                BenchmarkId::new(config.label(), worktrees),
-                &config,
-                |b, config| {
-                    let temp = create_repo(&config.repo);
-                    let repo_path = temp.path().join("repo");
-                    run_git(&repo_path, &["status"]);
-                    run_benchmark(b, binary, &repo_path, config.cold_cache, &["list"], None);
+                BenchmarkId::new(cache.label(), worktrees),
+                &cache,
+                |b, &cache| {
+                    let fixture = create_repo(&RepoConfig::typical(worktrees));
+                    run_git(fixture.path(), &["status"]);
+                    run_benchmark(b, binary, fixture.path(), cache, &["list"], None);
                 },
             );
         }
@@ -168,28 +126,23 @@ fn bench_real_repo(c: &mut Criterion) {
     let binary = Path::new(env!("CARGO_BIN_EXE_wt"));
     let worktrees = 8;
 
-    for cold in [false, true] {
-        let label = if cold { "cold" } else { "warm" };
+    for cache in CacheState::WARM_AND_COLD {
+        group.bench_with_input(
+            BenchmarkId::new(cache.label(), worktrees),
+            &cache,
+            |b, &cache| {
+                let config = RepoConfig::typical(worktrees);
+                let fixture = clone_rust_repo();
+                add_worktrees(&config, fixture.path());
+                run_git(fixture.path(), &["status"]);
 
-        group.bench_with_input(BenchmarkId::new(label, worktrees), &cold, |b, &cold| {
-            let config = RepoConfig::typical(worktrees);
-            let temp = tempfile::tempdir().unwrap();
-            let workspace_main = clone_rust_repo(&temp);
-            add_worktrees(&config, &workspace_main);
-            run_git(&workspace_main, &["status"]);
-
-            let cache = if cold {
-                CacheState::Cold
-            } else {
-                CacheState::Warm
-            };
-            bench_wt(b, &workspace_main, cache, || {
-                let mut cmd = Command::new(binary);
-                cmd.arg("list").current_dir(&workspace_main);
-                isolate_subprocess_env(&mut cmd, None);
-                cmd
-            });
-        });
+                bench_wt(b, fixture.path(), cache, || {
+                    let mut cmd = wt_command(binary, fixture.path(), None);
+                    cmd.arg("list");
+                    cmd
+                });
+            },
+        );
     }
 
     group.finish();
@@ -202,18 +155,15 @@ fn bench_divergent_branches(c: &mut Criterion) {
 
     let binary = Path::new(env!("CARGO_BIN_EXE_wt"));
 
-    for cold in [false, true] {
-        let config = BenchConfig::many_divergent_branches(cold);
-
-        group.bench_function(config.label(), |b| {
-            let temp = create_repo(&config.repo);
-            let repo_path = temp.path().join("repo");
-            run_git(&repo_path, &["status"]);
+    for cache in CacheState::WARM_AND_COLD {
+        group.bench_function(cache.label(), |b| {
+            let fixture = create_repo(&RepoConfig::many_divergent_branches());
+            run_git(fixture.path(), &["status"]);
             run_benchmark(
                 b,
                 binary,
-                &repo_path,
-                config.cold_cache,
+                fixture.path(),
+                cache,
                 &["list", "--branches", "--progressive"],
                 None,
             );
@@ -224,12 +174,11 @@ fn bench_divergent_branches(c: &mut Criterion) {
 }
 
 /// Set up rust repo workspace with branches at different history depths.
-/// Returns the workspace path (temp dir must outlive usage).
-fn setup_rust_workspace_with_branches(temp: &tempfile::TempDir, num_branches: usize) -> PathBuf {
-    let workspace_main = clone_rust_repo(temp);
-    add_history_spread_branches(&workspace_main, num_branches);
-    run_git(&workspace_main, &["status"]);
-    workspace_main
+fn setup_rust_workspace_with_branches(num_branches: usize) -> FixtureRepo {
+    let fixture = clone_rust_repo();
+    add_history_spread_branches(fixture.path(), num_branches);
+    run_git(fixture.path(), &["status"]);
+    fixture
 }
 
 /// Benchmark GH #461 scenario: large real repo (rust-lang/rust) with branches at different
@@ -261,13 +210,12 @@ fn bench_real_repo_many_branches(c: &mut Criterion) {
     // Setup function - each bench_function creates its own fresh workspace
     // Uses setup_rust_workspace_with_branches plus a worktree for worktrees_only test
     let setup_workspace = || {
-        let temp = tempfile::tempdir().unwrap();
-        let workspace_main = setup_rust_workspace_with_branches(&temp, 50);
+        let fixture = setup_rust_workspace_with_branches(50);
 
         // Add a second worktree (needed for worktrees_only to not auto-show branches)
-        let wt_path = temp.path().join("wt-test");
+        let wt_path = fixture.root().join("wt-test");
         run_git(
-            &workspace_main,
+            fixture.path(),
             &[
                 "worktree",
                 "add",
@@ -278,28 +226,25 @@ fn bench_real_repo_many_branches(c: &mut Criterion) {
             ],
         );
 
-        (temp, workspace_main)
+        fixture
     };
 
     // Baseline: all branches
     group.bench_function("warm", |b| {
-        let (_temp, workspace_main) = setup_workspace();
-        bench_wt(b, &workspace_main, CacheState::Warm, || {
-            let mut cmd = Command::new(binary);
-            cmd.args(["list", "--branches"])
-                .current_dir(&workspace_main);
-            isolate_subprocess_env(&mut cmd, None);
+        let fixture = setup_workspace();
+        bench_wt(b, fixture.path(), CacheState::Warm, || {
+            let mut cmd = wt_command(binary, fixture.path(), None);
+            cmd.args(["list", "--branches"]);
             cmd
         });
     });
 
     // Worktrees only: no branch enumeration, skips expensive %(ahead-behind) batch
     group.bench_function("warm_worktrees_only", |b| {
-        let (_temp, workspace_main) = setup_workspace();
-        bench_wt(b, &workspace_main, CacheState::Warm, || {
-            let mut cmd = Command::new(binary);
-            cmd.arg("list").current_dir(&workspace_main); // no --branches
-            isolate_subprocess_env(&mut cmd, None);
+        let fixture = setup_workspace();
+        bench_wt(b, fixture.path(), CacheState::Warm, || {
+            let mut cmd = wt_command(binary, fixture.path(), None);
+            cmd.arg("list"); // no --branches
             cmd
         });
     });
@@ -350,16 +295,14 @@ fn bench_full(c: &mut Criterion) {
     let binary = Path::new(env!("CARGO_BIN_EXE_wt"));
     let (worktrees, branches) = (24usize, 120usize);
 
-    for cold in [false, true] {
-        let label = if cold { "cold" } else { "warm" };
-        group.bench_function(label, |b| {
-            let temp = create_mixed_repo(worktrees, branches);
-            let repo_path = temp.path().join("repo");
+    for cache in CacheState::WARM_AND_COLD {
+        group.bench_function(cache.label(), |b| {
+            let fixture = create_mixed_repo(worktrees, branches);
             run_benchmark(
                 b,
                 binary,
-                &repo_path,
-                cold,
+                fixture.path(),
+                cache,
                 &["list", "--branches", "--progressive"],
                 None,
             );

--- a/benches/picker_preview.rs
+++ b/benches/picker_preview.rs
@@ -47,11 +47,7 @@ use criterion::{BenchmarkId, Criterion, criterion_group, criterion_main};
 #[cfg(unix)]
 use std::path::Path;
 #[cfg(unix)]
-use std::process::Command;
-#[cfg(unix)]
-use worktrunk::testing::isolate_subprocess_env;
-#[cfg(unix)]
-use wt_perf::{CacheState, RepoConfig, bench_wt, create_repo, setup_fake_remote};
+use wt_perf::{CacheState, RepoConfig, bench_wt, create_repo, wt_command};
 
 #[cfg(unix)]
 fn bench_picker_preview(c: &mut Criterion) {
@@ -66,41 +62,29 @@ fn bench_picker_preview(c: &mut Criterion) {
     group.measurement_time(std::time::Duration::from_secs(35));
 
     let binary = Path::new(env!("CARGO_BIN_EXE_wt"));
+    let worktrees = 8;
 
-    for worktrees in [8] {
-        for cold in [false, true] {
-            let label = if cold { "cold" } else { "warm" };
-            let config = RepoConfig::typical(worktrees);
+    for cache in CacheState::WARM_AND_COLD {
+        group.bench_with_input(
+            BenchmarkId::new(cache.label(), format!("typical-{worktrees}")),
+            &cache,
+            |b, &cache| {
+                let fixture = create_repo(&RepoConfig::typical(worktrees));
 
-            group.bench_with_input(
-                BenchmarkId::new(label, format!("typical-{worktrees}")),
-                &(config, cold),
-                |b, (config, cold)| {
-                    let temp = create_repo(config);
-                    let repo_path = temp.path().join("repo");
-                    setup_fake_remote(&repo_path);
+                let make_cmd = || {
+                    let mut cmd = wt_command(binary, fixture.path(), None);
+                    cmd.args(["switch", "--no-cd"])
+                        .env("WORKTRUNK_PREVIEW_BENCH", "1");
+                    cmd
+                };
 
-                    let make_cmd = || {
-                        let mut cmd = Command::new(binary);
-                        cmd.args(["switch", "--no-cd"]).current_dir(&repo_path);
-                        isolate_subprocess_env(&mut cmd, None);
-                        cmd.env("WORKTRUNK_PREVIEW_BENCH", "1");
-                        cmd
-                    };
-
-                    // Cold matters here: the picker writes to
-                    // `.git/wt/cache/picker-preview/` (Log / BranchDiff /
-                    // UpstreamDiff entries), so without invalidation iter 1
-                    // measures real cost and iter 2+ measure cache hits.
-                    let cache = if *cold {
-                        CacheState::Cold
-                    } else {
-                        CacheState::Warm
-                    };
-                    bench_wt(b, &repo_path, cache, make_cmd);
-                },
-            );
-        }
+                // Cold matters here: the picker writes to
+                // `.git/wt/cache/picker-preview/` (Log / BranchDiff /
+                // UpstreamDiff entries), so without invalidation iter 1
+                // measures real cost and iter 2+ measure cache hits.
+                bench_wt(b, fixture.path(), cache, make_cmd);
+            },
+        );
     }
 
     group.finish();

--- a/benches/prune.rs
+++ b/benches/prune.rs
@@ -11,7 +11,7 @@
 //      delete) serially under the write side of the scan lock, reusing the
 //      removal plan its scan check computed.
 //
-// The fixture is `wt_perf::create_prune_repo_at`: squash-merged candidates
+// The fixture is `wt_perf::create_prune_repo`: squash-merged candidates
 // (integrated by content — the expensive probe path, the post-PR-squash shape
 // prune typically removes) against a two-sided-diverged backdrop of unmerged
 // worktrees and branches (forked deep in history while main advanced) that
@@ -49,10 +49,9 @@ use std::path::Path;
 use std::process::Command;
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use worktrunk::testing::isolate_subprocess_env;
 use wt_perf::{
     CacheState, PRUNE_REAL_MERGED, PRUNE_REAL_UNMERGED, add_squash_merged, bench_wt,
-    create_prune_repo_at, ensure_prune_real_repo, run_and_check,
+    create_prune_repo, ensure_prune_real_repo, run_and_check, wt_command,
 };
 
 /// Squash-merged candidates per population (worktrees and orphan branches) —
@@ -76,9 +75,8 @@ const LIVE_ARGS: &[&str] = &["step", "prune", "--min-age", "0s", "--format", "js
 
 /// Build the `wt <args>` command for `repo`.
 fn wt_cmd(repo: &Path, args: &[&str]) -> Command {
-    let mut cmd = Command::new(Path::new(env!("CARGO_BIN_EXE_wt")));
-    cmd.args(args).current_dir(repo);
-    isolate_subprocess_env(&mut cmd, None);
+    let mut cmd = wt_command(Path::new(env!("CARGO_BIN_EXE_wt")), repo, None);
+    cmd.args(args);
     cmd
 }
 
@@ -92,12 +90,7 @@ fn wt_cmd(repo: &Path, args: &[&str]) -> Command {
 /// re-creation instead — branch names don't carry the round, so
 /// `add_squash_merged` fails loudly on the collision.
 fn verify_candidates(repo: &Path, expected: usize) {
-    let output = wt_cmd(repo, DRY_RUN_ARGS).output().unwrap();
-    assert!(
-        output.status.success(),
-        "fixture-check dry-run failed:\nstderr: {}",
-        String::from_utf8_lossy(&output.stderr)
-    );
+    let output = run_and_check(&mut wt_cmd(repo, DRY_RUN_ARGS));
     let items: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
     let found = items.as_array().unwrap().len();
     assert_eq!(
@@ -111,24 +104,22 @@ fn bench_prune_e2e(c: &mut Criterion) {
 
     // Dry-run repo: candidates present but never removed, so the fixture is
     // reusable across iterations without re-setup.
-    let temp_dry = tempfile::tempdir().unwrap();
-    let repo_dry = temp_dry.path().join("repo");
-    create_prune_repo_at(MERGED, UNMERGED, &repo_dry);
-    verify_candidates(&repo_dry, MERGED * 2);
+    let dry_fixture = create_prune_repo(MERGED, UNMERGED);
+    verify_candidates(dry_fixture.path(), MERGED * 2);
 
     // Probe-cold: every iteration re-pays the integration probes that
     // sha_cache would otherwise absorb — the "first prune after fetching
     // main" cost, with git's own caches staying warm as after a real fetch.
     group.bench_function("dry_run_probe_cold", |b| {
-        bench_wt(b, &repo_dry, CacheState::ProbeCold, || {
-            wt_cmd(&repo_dry, DRY_RUN_ARGS)
+        bench_wt(b, dry_fixture.path(), CacheState::ProbeCold, || {
+            wt_cmd(dry_fixture.path(), DRY_RUN_ARGS)
         });
     });
 
     // Warm: the steady-state re-scan where every probe hits sha_cache.
     group.bench_function("dry_run_warm", |b| {
-        bench_wt(b, &repo_dry, CacheState::Warm, || {
-            wt_cmd(&repo_dry, DRY_RUN_ARGS)
+        bench_wt(b, dry_fixture.path(), CacheState::Warm, || {
+            wt_cmd(dry_fixture.path(), DRY_RUN_ARGS)
         });
     });
 
@@ -146,10 +137,8 @@ fn bench_prune_e2e(c: &mut Criterion) {
     // `benches/remove.rs`, which removes the *current* worktree — that path
     // leaves a placeholder directory plus a background `rmdir` that would
     // race the recreation.)
-    let temp_live = tempfile::tempdir().unwrap();
-    let repo_live = temp_live.path().join("repo");
-    create_prune_repo_at(0, UNMERGED, &repo_live);
-    verify_candidates(&repo_live, 0);
+    let live_fixture = create_prune_repo(0, UNMERGED);
+    verify_candidates(live_fixture.path(), 0);
     let round = Cell::new(0usize);
 
     // Setup here is candidate re-creation, not invalidation, so this arm
@@ -157,10 +146,12 @@ fn bench_prune_e2e(c: &mut Criterion) {
     group.bench_function("live", |b| {
         b.iter_batched(
             || {
-                add_squash_merged(&repo_live, MERGED, round.get());
+                add_squash_merged(live_fixture.path(), MERGED, round.get());
                 round.set(round.get() + 1);
             },
-            |_| run_and_check(&mut wt_cmd(&repo_live, LIVE_ARGS)),
+            |_| {
+                run_and_check(&mut wt_cmd(live_fixture.path(), LIVE_ARGS));
+            },
             criterion::BatchSize::PerIteration,
         );
     });

--- a/benches/remove.rs
+++ b/benches/remove.rs
@@ -13,39 +13,36 @@
 //   cargo bench --bench remove -- no_hooks  # Just no-hooks variant
 
 use criterion::{Criterion, criterion_group, criterion_main};
-use std::path::{Path, PathBuf};
-use std::process::Command;
-use worktrunk::testing::isolate_subprocess_env;
-use wt_perf::{RepoConfig, run_git, run_git_ok, setup_fake_remote};
+use std::path::Path;
+use wt_perf::{
+    FixtureRepo, RepoConfig, create_repo, linked_worktree_path, run_and_check, run_git, run_git_ok,
+    wt_command,
+};
 
-/// Create a benchmark repo at a specific path with optional hooks.
-fn create_bench_repo(base_path: &Path, with_hooks: bool) -> PathBuf {
+/// Create an owned benchmark repo with optional hooks.
+fn create_bench_repo(with_hooks: bool) -> FixtureRepo {
     let config = RepoConfig::typical(2); // main + 1 feature worktree
-    wt_perf::create_repo_at(&config, base_path);
-    setup_fake_remote(base_path);
+    let fixture = create_repo(&config);
 
     if with_hooks {
         // Project config with post-remove hook
-        let config_dir = base_path.join(".config");
+        let config_dir = fixture.path().join(".config");
         std::fs::create_dir_all(&config_dir).unwrap();
         std::fs::write(
             config_dir.join("wt.toml"),
             "[post-remove]\ndocs = \"echo post-remove-done\"\n",
         )
         .unwrap();
-        run_git(base_path, &["add", "."]);
-        run_git(base_path, &["commit", "-m", "Add project config"]);
+        run_git(fixture.path(), &["add", "."]);
+        run_git(fixture.path(), &["commit", "-m", "Add project config"]);
     }
 
-    base_path.to_path_buf()
+    fixture
 }
 
 /// Recreate the feature worktree after it was removed.
 fn recreate_worktree(repo_path: &Path) {
-    let wt_path = repo_path.parent().unwrap().join(format!(
-        "{}.feature-wt-1",
-        repo_path.file_name().unwrap().to_str().unwrap()
-    ));
+    let wt_path = linked_worktree_path(repo_path, "feature-wt-1");
 
     // Wait briefly for background removal to finish (sleep 1 + rm -rf in detached process).
     // Without this, the background rmdir/rm-rf races with worktree recreation.
@@ -84,47 +81,29 @@ fn bench_remove_e2e(c: &mut Criterion) {
     let mut group = c.benchmark_group("remove_e2e");
     let binary = Path::new(env!("CARGO_BIN_EXE_wt"));
 
-    // Persistent temp dirs (kept alive for the benchmark group)
-    let temp_no_hooks = tempfile::tempdir().unwrap();
-    let temp_with_hooks = tempfile::tempdir().unwrap();
-
-    let repo_no_hooks = create_bench_repo(&temp_no_hooks.path().join("repo"), false);
-    let repo_with_hooks = create_bench_repo(&temp_with_hooks.path().join("repo"), true);
+    let repo_no_hooks = create_bench_repo(false);
+    let repo_with_hooks = create_bench_repo(true);
 
     // User config with post-switch hook (written beside repo)
-    let user_config_no_hooks = temp_no_hooks.path().join("config.toml");
+    let user_config_no_hooks = repo_no_hooks.root().join("config.toml");
     std::fs::write(&user_config_no_hooks, "").unwrap();
 
-    let user_config_with_hooks = temp_with_hooks.path().join("config.toml");
+    let user_config_with_hooks = repo_with_hooks.root().join("config.toml");
     std::fs::write(
         &user_config_with_hooks,
         "[hooks.post-switch]\nzellij-tab = \"echo post-switch-done\"\n",
     )
     .unwrap();
 
-    let wt_name = |repo: &Path| -> PathBuf {
-        repo.parent().unwrap().join(format!(
-            "{}.feature-wt-1",
-            repo.file_name().unwrap().to_str().unwrap()
-        ))
-    };
-
     // No hooks: --no-hooks (skip hook loading), run from feature worktree
     group.bench_function("no_hooks", |b| {
         b.iter_batched(
-            || recreate_worktree(&repo_no_hooks),
+            || recreate_worktree(repo_no_hooks.path()),
             |()| {
-                let wt_path = wt_name(&repo_no_hooks);
-                let mut cmd = Command::new(binary);
+                let wt_path = repo_no_hooks.worktree_path("feature-wt-1");
+                let mut cmd = wt_command(binary, &wt_path, Some(&user_config_no_hooks));
                 cmd.args(["remove", "--yes", "--no-hooks", "--force"]);
-                cmd.current_dir(&wt_path);
-                isolate_subprocess_env(&mut cmd, Some(&user_config_no_hooks));
-                let output = cmd.output().unwrap();
-                assert!(
-                    output.status.success(),
-                    "no_hooks failed: {}",
-                    String::from_utf8_lossy(&output.stderr)
-                );
+                run_and_check(&mut cmd);
             },
             criterion::BatchSize::PerIteration,
         );
@@ -133,19 +112,12 @@ fn bench_remove_e2e(c: &mut Criterion) {
     // With hooks: user post-switch + project post-remove
     group.bench_function("with_hooks", |b| {
         b.iter_batched(
-            || recreate_worktree(&repo_with_hooks),
+            || recreate_worktree(repo_with_hooks.path()),
             |()| {
-                let wt_path = wt_name(&repo_with_hooks);
-                let mut cmd = Command::new(binary);
+                let wt_path = repo_with_hooks.worktree_path("feature-wt-1");
+                let mut cmd = wt_command(binary, &wt_path, Some(&user_config_with_hooks));
                 cmd.args(["remove", "--yes", "--force"]);
-                cmd.current_dir(&wt_path);
-                isolate_subprocess_env(&mut cmd, Some(&user_config_with_hooks));
-                let output = cmd.output().unwrap();
-                assert!(
-                    output.status.success(),
-                    "with_hooks failed: {}",
-                    String::from_utf8_lossy(&output.stderr)
-                );
+                run_and_check(&mut cmd);
             },
             criterion::BatchSize::PerIteration,
         );

--- a/benches/time_to_first_output.rs
+++ b/benches/time_to_first_output.rs
@@ -15,23 +15,18 @@
 
 use criterion::{Criterion, criterion_group, criterion_main};
 use std::path::Path;
-use std::process::Command;
-use worktrunk::testing::isolate_subprocess_env;
-use wt_perf::{CacheState, RepoConfig, bench_wt, create_repo, setup_fake_remote};
+use wt_perf::{CacheState, RepoConfig, bench_wt, create_repo, run_and_check, wt_command};
 
 fn bench_first_output(c: &mut Criterion) {
     let mut group = c.benchmark_group("first_output");
     let binary = Path::new(env!("CARGO_BIN_EXE_wt"));
 
     let config = RepoConfig::typical(4);
-    let temp = create_repo(&config);
-    let repo_path = temp.path().join("repo");
-    setup_fake_remote(&repo_path);
+    let fixture = create_repo(&config);
 
     let make_cmd = |args: &[&str]| {
-        let mut cmd = Command::new(binary);
-        cmd.args(args).current_dir(&repo_path);
-        isolate_subprocess_env(&mut cmd, None);
+        let mut cmd = wt_command(binary, fixture.path(), None);
+        cmd.args(args);
         cmd.env("WORKTRUNK_FIRST_OUTPUT", "1");
         cmd
     };
@@ -44,14 +39,14 @@ fn bench_first_output(c: &mut Criterion) {
     // first invocation. Without per-iteration invalidation the reported
     // timing would be warm cache, not the first-invocation TTFO a user sees.
     group.bench_function("remove", |b| {
-        bench_wt(b, &repo_path, CacheState::Cold, || {
+        bench_wt(b, fixture.path(), CacheState::Cold, || {
             make_cmd(&["remove", "--yes", "--no-hooks", "--force", "feature-wt-1"])
         });
     });
 
     // switch: exits after execute_switch, before mismatch computation and output
     group.bench_function("switch", |b| {
-        bench_wt(b, &repo_path, CacheState::Warm, || {
+        bench_wt(b, fixture.path(), CacheState::Warm, || {
             make_cmd(&["switch", "--yes", "--no-hooks", "feature-wt-1"])
         });
     });
@@ -60,12 +55,7 @@ fn bench_first_output(c: &mut Criterion) {
     // line after collection/render preparation, not the progressive skeleton.
     group.bench_function("list", |b| {
         b.iter(|| {
-            let output = make_cmd(&["list"]).output().unwrap();
-            assert!(
-                output.status.success(),
-                "Benchmark command failed:\nstderr: {}",
-                String::from_utf8_lossy(&output.stderr)
-            );
+            let output = run_and_check(&mut make_cmd(&["list"]));
             assert!(
                 !output.stdout.is_empty(),
                 "WORKTRUNK_FIRST_OUTPUT should emit the first stdout line"

--- a/tests/helpers/wt-perf/src/lib.rs
+++ b/tests/helpers/wt-perf/src/lib.rs
@@ -1,13 +1,10 @@
 //! Performance testing and tracing tools for worktrunk.
 //!
 //! This crate provides:
-//! - Benchmark repository setup (used by `benches/list.rs`, `benches/time_to_first_output.rs`)
+//! - Benchmark repository setup (shared by all subprocess benchmarks)
 //! - Cache invalidation for cold benchmark runs
 //! - Trace analysis utilities
-//! - Shared benchmark helpers (`run_git`, `run_git_ok`, …)
-//!
-//! For wt-subprocess isolation, benches use
-//! [`worktrunk::testing::isolate_subprocess_env`] directly.
+//! - Shared benchmark helpers (`bench_wt`, `wt_command`, `run_git`, …)
 //!
 //! # Library Usage
 //!
@@ -15,23 +12,68 @@
 //! use wt_perf::{RepoConfig, create_repo, invalidate_caches_auto};
 //!
 //! // Create a test repo with 8 worktrees
-//! let temp = create_repo(&RepoConfig::typical(8));
-//! let repo_path = temp.path().join("repo");
+//! let fixture = create_repo(&RepoConfig::typical(8));
 //!
 //! // Invalidate caches for cold benchmark
-//! invalidate_caches_auto(&repo_path);
+//! invalidate_caches_auto(fixture.path());
 //! ```
 //!
 //! See `wt-perf --help` for CLI usage.
 
 use std::path::{Path, PathBuf};
-use std::process::Command;
+use std::process::{Command, Output};
 use std::sync::OnceLock;
 use tempfile::TempDir;
-use worktrunk::testing::{allow_network_transports, configure_git_cmd};
+use worktrunk::testing::{allow_network_transports, configure_git_cmd, isolate_subprocess_env};
 
 /// Lazy-initialized rust repo path.
 static RUST_REPO: OnceLock<PathBuf> = OnceLock::new();
+
+/// An owned temporary benchmark fixture.
+///
+/// Every ephemeral fixture has the same layout: the primary worktree is
+/// `<root>/repo`, and linked worktrees are siblings named
+/// `<root>/repo.<branch>`. Keeping the [`TempDir`] and canonical paths in one
+/// value prevents benches from each re-deriving the layout (and accidentally
+/// dropping the tempdir while a path into it is still in use).
+pub struct FixtureRepo {
+    root: TempDir,
+    repo: PathBuf,
+}
+
+impl FixtureRepo {
+    /// Create a fixture with its primary worktree at `<temp>/repo`.
+    fn create(build: impl FnOnce(&Path)) -> Self {
+        let root = tempfile::tempdir().unwrap();
+        let repo = root.path().join("repo");
+        build(&repo);
+        Self { root, repo }
+    }
+
+    /// Path to the fixture's primary worktree.
+    pub fn path(&self) -> &Path {
+        &self.repo
+    }
+
+    /// Root containing the primary and linked worktrees.
+    pub fn root(&self) -> &Path {
+        self.root.path()
+    }
+
+    /// Path to the linked worktree for `branch`.
+    pub fn worktree_path(&self, branch: &str) -> PathBuf {
+        linked_worktree_path(&self.repo, branch)
+    }
+}
+
+/// Derive worktrunk's sibling path for a linked worktree.
+pub fn linked_worktree_path(repo_path: &Path, branch: &str) -> PathBuf {
+    let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
+    repo_path
+        .parent()
+        .unwrap()
+        .join(format!("{repo_name}.{branch}"))
+}
 
 /// Configuration for creating a benchmark repository.
 #[derive(Clone, Debug)]
@@ -177,6 +219,29 @@ pub enum CacheState {
     ProbeCold,
 }
 
+impl CacheState {
+    /// The warm/cold pair used by benchmark groups that cover both states.
+    pub const WARM_AND_COLD: [Self; 2] = [Self::Warm, Self::Cold];
+
+    /// Stable Criterion label for this cache state.
+    pub const fn label(self) -> &'static str {
+        match self {
+            Self::Warm => "warm",
+            Self::Cold => "cold",
+            Self::ProbeCold => "probe_cold",
+        }
+    }
+}
+
+/// Build a `wt` command with the benchmark subprocess environment isolated
+/// from the developer's git, shell, and worktrunk configuration.
+pub fn wt_command(binary: &Path, repo_path: &Path, user_config: Option<&Path>) -> Command {
+    let mut cmd = Command::new(binary);
+    cmd.current_dir(repo_path);
+    isolate_subprocess_env(&mut cmd, user_config);
+    cmd
+}
+
 /// Run a `wt` benchmark iteration function under criterion, warm or cold.
 ///
 /// The one place the warm/cold iteration strategy lives: warm uses plain
@@ -206,7 +271,9 @@ pub fn bench_wt(
     cache: CacheState,
     mut make_cmd: impl FnMut() -> Command,
 ) {
-    let mut run = move || run_and_check(&mut make_cmd());
+    let mut run = move || {
+        run_and_check(&mut make_cmd());
+    };
     let invalidate: fn(&Path) = match cache {
         CacheState::Warm => {
             b.iter(run);
@@ -223,13 +290,17 @@ pub fn bench_wt(
 }
 
 /// Spawn the command, wait, and panic with its stderr if it failed.
-pub fn run_and_check(cmd: &mut Command) {
+///
+/// Returns the captured output so benchmarks with a load-bearing output
+/// contract can validate it once without reimplementing the status check.
+pub fn run_and_check(cmd: &mut Command) -> Output {
     let output = cmd.output().unwrap();
     assert!(
         output.status.success(),
         "benchmark command failed:\nstderr: {}",
         String::from_utf8_lossy(&output.stderr)
     );
+    output
 }
 
 /// Run a git command in the given directory. Panics on failure.
@@ -312,12 +383,10 @@ fn git_stdout(path: &Path, args: &[&str], index_file: &Path) -> String {
 
 /// Create a test repository from config.
 ///
-/// Returns a `TempDir` containing the repo. The main worktree is at `temp.path().join("repo")`.
-/// Additional worktrees are siblings: `temp.path().join("repo.feature-wt-N")`.
-pub fn create_repo(config: &RepoConfig) -> TempDir {
-    let temp_dir = tempfile::tempdir().unwrap();
-    create_repo_at(config, &temp_dir.path().join("repo"));
-    temp_dir
+/// Returns an owned fixture whose primary worktree is available through
+/// [`FixtureRepo::path`].
+pub fn create_repo(config: &RepoConfig) -> FixtureRepo {
+    FixtureRepo::create(|repo| create_repo_at(config, repo))
 }
 
 /// Create a test repository at a specific path.
@@ -411,12 +480,9 @@ pub fn create_repo_at(config: &RepoConfig, base_path: &Path) {
 /// (e.g., `repo.feature-wt-1`), each with diverging commits and uncommitted files
 /// controlled by `config.worktree_commits_ahead` and `config.worktree_uncommitted_files`.
 pub fn add_worktrees(config: &RepoConfig, repo_path: &Path) {
-    let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
-    let parent_dir = repo_path.parent().unwrap();
-
     for wt_num in 1..config.worktrees {
         let branch = format!("feature-wt-{wt_num}");
-        let wt_path = parent_dir.join(format!("{repo_name}.{branch}"));
+        let wt_path = linked_worktree_path(repo_path, &branch);
 
         let head_output = git_command()
             .args(["rev-parse", "HEAD"])
@@ -750,13 +816,9 @@ fn clone_rust_repo_at(dest: &Path) {
     run_git(dest, &["config", "user.email", "bench@test.com"]);
 }
 
-/// Clone rust-lang/rust into `temp/repo` for benchmarking.
-///
-/// Returns the clone path. The `temp` dir must outlive usage.
-pub fn clone_rust_repo(temp: &TempDir) -> PathBuf {
-    let workspace_main = temp.path().join("repo");
-    clone_rust_repo_at(&workspace_main);
-    workspace_main
+/// Clone rust-lang/rust into an owned temporary benchmark fixture.
+pub fn clone_rust_repo() -> FixtureRepo {
+    FixtureRepo::create(clone_rust_repo_at)
 }
 
 /// Sample up to `count` commit SHAs evenly spread across the last 5000
@@ -880,8 +942,6 @@ pub fn add_history_spread_branches(repo_path: &Path, count: usize) {
 /// a linked worktree materializes a full working tree (~1 GiB on
 /// rust-lang/rust) and pays a checkout.
 fn add_diverged_backdrop(repo_path: &Path, worktrees: usize, branches: usize) {
-    let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
-    let parent_dir = repo_path.parent().unwrap();
     let forks = history_spread_shas(repo_path, worktrees.max(branches).max(1));
 
     // Each orphan branch forks at a spread point and carries 3 commits of its
@@ -898,7 +958,7 @@ fn add_diverged_backdrop(repo_path: &Path, worktrees: usize, branches: usize) {
 
     for i in 0..worktrees {
         let wt_branch = format!("feature-wt-{i}");
-        let wt_path = parent_dir.join(format!("{repo_name}.{wt_branch}"));
+        let wt_path = linked_worktree_path(repo_path, &wt_branch);
         run_git(
             repo_path,
             &[
@@ -951,10 +1011,10 @@ fn append_line(path: &Path, rel: &str, line: &str) {
 /// full spread of `wt list` gates and tasks at once — clean vs dirty working
 /// trees, merged vs ahead vs diverged branches, *and* divergence spread across
 /// history depth — the realistic shape of "a huge number of worktrees &
-/// branches, all in various states". Returns the `TempDir`; the main worktree
-/// is at `temp.path().join("repo")`, linked worktrees are siblings
-/// (`repo.wt-NNNN`). Either dimension may be `0` (e.g. `mixed-W-0` for a
-/// worktrees-only repo).
+/// branches, all in various states". Returns an owned fixture; the main
+/// worktree is available through [`FixtureRepo::path`], and linked worktrees
+/// through [`FixtureRepo::worktree_path`]. Either dimension may be `0` (e.g.
+/// `mixed-W-0` for a worktrees-only repo).
 ///
 /// Worktree states cycle by index % 4:
 /// 0. clean, several commits ahead of base
@@ -972,10 +1032,8 @@ fn append_line(path: &Path, rel: &str, line: &str) {
 /// 2. diverged: a short own-commit chain forked from an older checkpoint
 ///    while base advanced (deep two-sided divergence)
 /// 3. identical to the base tip (trees match — squash-merge shape)
-pub fn create_mixed_repo(worktrees: usize, branches: usize) -> TempDir {
-    let temp = tempfile::tempdir().unwrap();
-    create_mixed_repo_at(worktrees, branches, &temp.path().join("repo"));
-    temp
+pub fn create_mixed_repo(worktrees: usize, branches: usize) -> FixtureRepo {
+    FixtureRepo::create(|repo| create_mixed_repo_at(worktrees, branches, repo))
 }
 
 /// [`create_mixed_repo`] at a caller-chosen path (used by `wt-perf setup
@@ -1055,11 +1113,9 @@ fn create_mixed_repo_at(worktrees: usize, branches: usize, repo: &Path) {
     // Linked worktrees are siblings named `<repo-dir>.<branch>` (worktrunk
     // convention), derived from the repo's own directory name so the path is
     // correct whether the repo is the tempdir's `repo` or a custom `setup` path.
-    let parent = repo.parent().unwrap();
-    let repo_name = repo.file_name().unwrap().to_str().unwrap().to_string();
     for j in 0..worktrees {
         let branch = format!("wt-{j:04}");
-        let wt = parent.join(format!("{repo_name}.{branch}"));
+        let wt = linked_worktree_path(&repo, &branch);
         run_git(
             &repo,
             &[
@@ -1129,6 +1185,11 @@ pub fn create_prune_repo_at(merged: usize, unmerged: usize, base_path: &Path) {
     setup_fake_remote(base_path);
 }
 
+/// Create an owned synthetic `wt step prune` fixture.
+pub fn create_prune_repo(merged: usize, unmerged: usize) -> FixtureRepo {
+    FixtureRepo::create(|repo| create_prune_repo_at(merged, unmerged, repo))
+}
+
 /// Add `count` squash-merged worktrees (`merged-wt-N`) and `count`
 /// squash-merged orphan branches (`merged-br-N`) to an existing repo.
 ///
@@ -1146,8 +1207,6 @@ pub fn create_prune_repo_at(merged: usize, unmerged: usize, base_path: &Path) {
 /// and a name collision on re-creation fails loudly — surfacing a prune run
 /// that didn't remove what the benchmark expected.
 pub fn add_squash_merged(repo_path: &Path, count: usize, round: usize) {
-    let repo_name = repo_path.file_name().unwrap().to_str().unwrap();
-    let parent_dir = repo_path.parent().unwrap();
     let default_branch = capture_git(repo_path, &["rev-parse", "--abbrev-ref", "HEAD"]);
 
     // Two commits in `dir`, each adding a round-uniquified file (the branch
@@ -1186,7 +1245,7 @@ pub fn add_squash_merged(repo_path: &Path, count: usize, round: usize) {
 
     for i in 0..count {
         let branch = format!("merged-wt-{i}");
-        let wt_path = parent_dir.join(format!("{repo_name}.{branch}"));
+        let wt_path = linked_worktree_path(repo_path, &branch);
         run_git(
             repo_path,
             &[
@@ -1515,7 +1574,7 @@ mod tests {
     /// refs and breaking the `with_vars` alias bench at `dispatch/with_vars/*`.
     #[test]
     fn invalidate_preserves_refs_after_gc() {
-        let temp = create_repo(&RepoConfig {
+        let fixture = create_repo(&RepoConfig {
             commits_on_main: 1,
             files: 1,
             branches: 0,
@@ -1524,7 +1583,7 @@ mod tests {
             worktree_commits_ahead: 0,
             worktree_uncommitted_files: 0,
         });
-        let repo_path = temp.path().join("repo");
+        let repo_path = fixture.path().to_path_buf();
 
         let rev_parse_main = || {
             git_command()
@@ -1563,8 +1622,8 @@ mod tests {
         // Two full rotations of each 4-state cycle, so a state that collapsed
         // into its neighbour fails on both of its indices rather than one.
         const N: usize = 8;
-        let temp = create_mixed_repo(N, N);
-        let repo = temp.path().join("repo");
+        let fixture = create_mixed_repo(N, N);
+        let repo = fixture.path().to_path_buf();
         let main = capture_git(&repo, &["rev-parse", "main"]);
 
         let refs = capture_git(
@@ -1617,7 +1676,7 @@ mod tests {
         // untracked, 3 clean at the tip.
         for j in 0..N {
             let branch = format!("wt-{j:04}");
-            let wt = temp.path().join(format!("repo.{branch}"));
+            let wt = fixture.worktree_path(&branch);
             let tip = capture_git(&repo, &["rev-parse", &branch]);
             let status = status_lines(&wt);
             match j % 4 {
@@ -1663,7 +1722,7 @@ mod tests {
     /// the property (unique file content per round).
     #[test]
     fn squash_merged_fixture_is_content_integrated() {
-        let temp = create_repo(&RepoConfig {
+        let fixture = create_repo(&RepoConfig {
             commits_on_main: 3,
             files: 2,
             branches: 0,
@@ -1672,7 +1731,7 @@ mod tests {
             worktree_commits_ahead: 0,
             worktree_uncommitted_files: 0,
         });
-        let repo_path = temp.path().join("repo");
+        let repo_path = fixture.path().to_path_buf();
 
         for round in 0..2 {
             add_squash_merged(&repo_path, 1, round);
@@ -1701,7 +1760,7 @@ mod tests {
 
             // Simulate the live benchmark's per-iteration cleanup before the
             // next round re-creates the candidates.
-            let wt_path = temp.path().join("repo.merged-wt-0");
+            let wt_path = fixture.worktree_path("merged-wt-0");
             run_git(
                 &repo_path,
                 &["worktree", "remove", "--force", wt_path.to_str().unwrap()],
@@ -1715,9 +1774,8 @@ mod tests {
     /// Exercised on the synthetic fixture, which shares the exact layout.
     #[test]
     fn prune_fixture_state_classifies_lifecycle() {
-        let temp = tempfile::tempdir().unwrap();
-        let repo_path = temp.path().join("repo");
-        create_prune_repo_at(1, 2, &repo_path);
+        let fixture = create_prune_repo(1, 2);
+        let repo_path = fixture.path().to_path_buf();
 
         assert_eq!(
             prune_fixture_state(&repo_path, 1, 2),
@@ -1731,7 +1789,7 @@ mod tests {
 
         // Partial consumption (worktree candidate gone, branches still there)
         // is Broken — an interrupted live prune needs a rebuild.
-        let wt_path = temp.path().join("repo.merged-wt-0");
+        let wt_path = fixture.worktree_path("merged-wt-0");
         run_git(
             &repo_path,
             &["worktree", "remove", "--force", wt_path.to_str().unwrap()],
@@ -1771,7 +1829,7 @@ mod tests {
     /// `step_by`, both panicked before the `max(1)` guards.
     #[test]
     fn history_spread_handles_degenerate_counts() {
-        let temp = create_repo(&RepoConfig {
+        let fixture = create_repo(&RepoConfig {
             commits_on_main: 3,
             files: 1,
             branches: 0,
@@ -1780,7 +1838,7 @@ mod tests {
             worktree_commits_ahead: 0,
             worktree_uncommitted_files: 0,
         });
-        let repo_path = temp.path().join("repo");
+        let repo_path = fixture.path().to_path_buf();
 
         // count == 0: no branches created, no divide-by-zero.
         add_history_spread_branches(&repo_path, 0);
@@ -1814,14 +1872,14 @@ mod tests {
 
         // The two dimensions share no state, so covering each zero once spans
         // the contract — a both-zero repo just skips both loops.
-        let temp = create_mixed_repo(3, 0);
-        let repo = temp.path().join("repo");
+        let fixture = create_mixed_repo(3, 0);
+        let repo = fixture.path().to_path_buf();
         assert_eq!(refs(&repo, "refs/heads/br-*"), 0, "no branchless branches");
         assert_eq!(refs(&repo, "refs/heads/wt-*"), 3);
         assert_eq!(linked(&repo), 3);
 
-        let temp = create_mixed_repo(0, 3);
-        let repo = temp.path().join("repo");
+        let fixture = create_mixed_repo(0, 3);
+        let repo = fixture.path().to_path_buf();
         assert_eq!(refs(&repo, "refs/heads/br-*"), 3);
         assert_eq!(refs(&repo, "refs/heads/wt-*"), 0, "no worktree branches");
         assert_eq!(linked(&repo), 0);
@@ -1838,7 +1896,7 @@ mod tests {
     /// parameters is invisible there and would be caught only here.
     #[test]
     fn diverged_backdrop_is_unintegrated_and_spread_across_history() {
-        let temp = create_repo(&RepoConfig {
+        let fixture = create_repo(&RepoConfig {
             commits_on_main: 40,
             files: 2,
             branches: 0,
@@ -1847,7 +1905,7 @@ mod tests {
             worktree_commits_ahead: 0,
             worktree_uncommitted_files: 0,
         });
-        let repo = temp.path().join("repo");
+        let repo = fixture.path().to_path_buf();
         add_diverged_backdrop(&repo, 3, 4);
 
         // `<branch>..main` counts what main has that the branch doesn't — the
@@ -1892,7 +1950,7 @@ mod tests {
             let branch = format!("feature-wt-{i}");
             let (_, ahead) = counts(&branch);
             assert_eq!(ahead, 5, "{branch} must carry its own commits");
-            let wt = temp.path().join(format!("repo.{branch}"));
+            let wt = fixture.worktree_path(&branch);
             assert_eq!(
                 status_lines(&wt),
                 ["?? uncommitted_0.txt", "?? uncommitted_1.txt"],
@@ -1900,7 +1958,7 @@ mod tests {
             );
         }
         assert!(
-            !temp.path().join("repo.feature-wt-3").exists(),
+            !fixture.worktree_path("feature-wt-3").exists(),
             "worktree count must not follow the branch count"
         );
     }


### PR DESCRIPTION
Benchmark targets had each reimplemented temporary-repository ownership, linked-worktree paths, subprocess isolation, and warm/cold loops. This adds a shared `FixtureRepo` and canonical command/cache helpers while leaving each scenario-specific workload and destructive lifecycle explicit.

All 41 existing Criterion IDs, fixture dimensions, command arguments, and cache ordering are preserved. The completion benchmark now also fails when its measured subprocess fails instead of silently accepting the result.

Tests: `cargo run -- hook pre-merge --yes`; `cargo test -p wt-perf`; `cargo check --benches -p worktrunk -p wt-perf`; representative Criterion test-mode runs for completion, list, first-output, remove, and prune.

> _This was written by Claude Code on behalf of max_.
