### PR TITLE
docs(release): spell out the merge step instead of naming a personal skill

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -41,8 +41,12 @@ metadata:
     ```bash
     git reset --soft HEAD~1 && git add -A && git commit -m "Release vX.Y.Z"
     ```
-11. **Merge to main**: `/gpk` — opens a PR, waits for CI, merges via PR (preserves worktree). `main` can advance during the CI wait; step 12 catches anything that lands before the tag.
-12. **Verify the changelog covers `main`, then tag and push**: the tag decides what ships — `release.yaml` builds the binaries and the GitHub release notes from the tree at the tag, so everything reachable from it is in the release. `/gpk` squash-merges onto whatever `main` tip exists at merge time, so a commit that lands during the PR's CI wait is already an ancestor of the release commit and ships whether or not the changelog mentions it (the easy miss is a follow-up that reworks a feature this release already documents). List what reached `main` since the cut-from tip (step 1):
+11. **Merge to main**: push the release branch, open a PR, wait for CI, and merge it. Keep the worktree — the remaining steps run from it. Then move the branch onto the merged tip:
+    ```bash
+    git fetch origin && git reset --keep origin/main
+    ```
+    The PR squash-merges, so the branch is no longer an ancestor of `main` and step 1's `--ff-only` can't advance it; `--keep` moves it across and still fails if anything is uncommitted. `main` can advance during the CI wait; step 12 catches anything that lands before the tag.
+12. **Verify the changelog covers `main`, then tag and push**: the tag decides what ships — `release.yaml` builds the binaries and the GitHub release notes from the tree at the tag, so everything reachable from it is in the release. The merge squashes onto whatever `main` tip exists at merge time, so a commit that lands during the PR's CI wait is already an ancestor of the release commit and ships whether or not the changelog mentions it (the easy miss is a follow-up that reworks a feature this release already documents). List what reached `main` since the cut-from tip (step 1):
     ```bash
     git fetch origin
     git log --oneline <cut-from-commit>..origin/main


### PR DESCRIPTION
Step 11 of the release skill pointed at `/gpk`, a user-level skill that isn't in this repo. `.claude/skills/` is checked in, so the one step a contributor can't infer was written as a command they don't have. (Nothing else leaks: the shipped plugin skills reference only their own `/worktrunk` and `/wt-switch-create` plus Claude Code builtins.)

Replaced with the actions it stood for — push, open a PR, wait for CI, merge, keep the worktree — plus the branch re-sync that was riding along in the skill's tail:

```bash
git fetch origin && git reset --keep origin/main
```

That last part fills a real gap rather than just rewording the step. The PR squash-merges, so the release branch stops being an ancestor of `main`, and step 1's `git merge --ff-only origin/main` can't advance it at the next release — step 1 already alludes to this ("it's only reset to `main` after a release lands") without saying where the reset happens. `--keep` moves the branch across and still fails rather than discarding uncommitted work, per the data-safety rule on preferring the failing variant. Doing it in step 11 also means a step 12 changelog follow-up PR starts from the merged `main`.

Doc-only, and no test reads this file. `pre-commit run --files .claude/skills/release/SKILL.md` passes; the Rust hooks skip since no Rust changed.

> _This was written by Claude Code on behalf of @max-sixty_
