### PR TITLE
feat(list): name a detached row by its short hash, not `-`

### DIFF
--- a/docs/content/list.md
+++ b/docs/content/list.md
@@ -74,7 +74,7 @@ Output as JSON for scripting:
 
 | Column | Shows |
 |--------|-------|
-| Branch | Branch name |
+| Branch | Branch name; a detached worktree has none, so it shows its short hash in dim yellow |
 | Status | Compact symbols (see below) |
 | HEAD± | Uncommitted changes: +added -deleted lines |
 | main↕ | Commits ahead/behind default branch |
@@ -173,7 +173,7 @@ An in-progress git operation, a worktree-location attribute, or a branch with no
 | `⊟` | `worktree.state` `"prunable"` | Prunable (worktree directory missing) |
 | `⊞` | `worktree.state` `"locked"` | Locked worktree |
 | `⚑` | `worktree.state` `"duplicate_branch"` | Branch checked out in more than one worktree, so `wt` resolves it to whichever git lists first; every worktree on the branch is flagged |
-| `⚑` | `worktree.state` `"branch_worktree_mismatch"` | Branch name doesn't match the worktree path |
+| `⚑` | `worktree.state` `"branch_worktree_mismatch"` | Worktree isn't at the path its branch implies — including a detached one, which has no branch to imply a path and so is never at home |
 | `/` | `kind` `"branch"` | Branch without a worktree (no `worktree` object) |
 
 ### Default branch

--- a/plugins/worktrunk/skills/worktrunk/reference/list.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/list.md
@@ -63,7 +63,7 @@ $ wt list --format=json
 
 | Column | Shows |
 |--------|-------|
-| Branch | Branch name |
+| Branch | Branch name; a detached worktree has none, so it shows its short hash in dim yellow |
 | Status | Compact symbols (see below) |
 | HEAD± | Uncommitted changes: +added -deleted lines |
 | main↕ | Commits ahead/behind default branch |
@@ -158,7 +158,7 @@ An in-progress git operation, a worktree-location attribute, or a branch with no
 | `⊟` | `worktree.state` `"prunable"` | Prunable (worktree directory missing) |
 | `⊞` | `worktree.state` `"locked"` | Locked worktree |
 | `⚑` | `worktree.state` `"duplicate_branch"` | Branch checked out in more than one worktree, so `wt` resolves it to whichever git lists first; every worktree on the branch is flagged |
-| `⚑` | `worktree.state` `"branch_worktree_mismatch"` | Branch name doesn't match the worktree path |
+| `⚑` | `worktree.state` `"branch_worktree_mismatch"` | Worktree isn't at the path its branch implies — including a detached one, which has no branch to imply a path and so is never at home |
 | `/` | `kind` `"branch"` | Branch without a worktree (no `worktree` object) |
 
 ### Default branch

--- a/skills/worktrunk/reference/list.md
+++ b/skills/worktrunk/reference/list.md
@@ -63,7 +63,7 @@ $ wt list --format=json
 
 | Column | Shows |
 |--------|-------|
-| Branch | Branch name |
+| Branch | Branch name; a detached worktree has none, so it shows its short hash in dim yellow |
 | Status | Compact symbols (see below) |
 | HEAD± | Uncommitted changes: +added -deleted lines |
 | main↕ | Commits ahead/behind default branch |
@@ -158,7 +158,7 @@ An in-progress git operation, a worktree-location attribute, or a branch with no
 | `⊟` | `worktree.state` `"prunable"` | Prunable (worktree directory missing) |
 | `⊞` | `worktree.state` `"locked"` | Locked worktree |
 | `⚑` | `worktree.state` `"duplicate_branch"` | Branch checked out in more than one worktree, so `wt` resolves it to whichever git lists first; every worktree on the branch is flagged |
-| `⚑` | `worktree.state` `"branch_worktree_mismatch"` | Branch name doesn't match the worktree path |
+| `⚑` | `worktree.state` `"branch_worktree_mismatch"` | Worktree isn't at the path its branch implies — including a detached one, which has no branch to imply a path and so is never at home |
 | `/` | `kind` `"branch"` | Branch without a worktree (no `worktree` object) |
 
 ### Default branch

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -825,7 +825,7 @@ $ wt list --format=json
 
 | Column | Shows |
 |--------|-------|
-| Branch | Branch name |
+| Branch | Branch name; a detached worktree has none, so it shows its short hash in dim yellow |
 | Status | Compact symbols (see below) |
 | HEAD± | Uncommitted changes: +added -deleted lines |
 | main↕ | Commits ahead/behind default branch |
@@ -920,7 +920,7 @@ An in-progress git operation, a worktree-location attribute, or a branch with no
 | `⊟` | `worktree.state` `"prunable"` | Prunable (worktree directory missing) |
 | `⊞` | `worktree.state` `"locked"` | Locked worktree |
 | `⚑` | `worktree.state` `"duplicate_branch"` | Branch checked out in more than one worktree, so `wt` resolves it to whichever git lists first; every worktree on the branch is flagged |
-| `⚑` | `worktree.state` `"branch_worktree_mismatch"` | Branch name doesn't match the worktree path |
+| `⚑` | `worktree.state` `"branch_worktree_mismatch"` | Worktree isn't at the path its branch implies — including a detached one, which has no branch to imply a path and so is never at home |
 | `/` | `kind` `"branch"` | Branch without a worktree (no `worktree` object) |
 
 ### Default branch

--- a/src/commands/list/layout.rs
+++ b/src/commands/list/layout.rs
@@ -1186,7 +1186,21 @@ pub fn calculate_layout_with_width(
         .filter_map(|item| item.branch.as_deref())
         .max_by_key(|b| b.width());
 
-    let max_branch = longest_branch.map(|b| b.width()).unwrap_or(0);
+    // A detached row shows its abbreviated HEAD in this column
+    // (`ListItem::display_name`), so the column has to fit a SHA as well as the
+    // branch names — the same `COMMIT_HASH_WIDTH` the Commit column budgets for
+    // the identical string.
+    let detached_width = items
+        .iter()
+        .any(|item| item.branch.is_none())
+        .then_some(COMMIT_HASH_WIDTH);
+
+    let max_branch = longest_branch
+        .map(|b| b.width())
+        .into_iter()
+        .chain(detached_width)
+        .max()
+        .unwrap_or(0);
     let max_branch = fit_header(ColumnKind::Branch.header(), max_branch);
 
     let path_data_width = items
@@ -2081,6 +2095,40 @@ mod tests {
         assert!(
             find_column(&layout, ColumnKind::Custom(0)).is_some(),
             "custom columns append in the default (no-selection) set"
+        );
+    }
+
+    /// A detached row shows its abbreviated HEAD in the Branch column, so the
+    /// column has to fit a SHA even when every branch name is shorter than one.
+    /// Sized off the names alone it would truncate the hash mid-way.
+    #[test]
+    fn test_branch_column_fits_a_detached_rows_sha() {
+        let mut detached = make_test_item("main");
+        detached.branch = None;
+        let items = vec![make_test_item("main"), detached];
+
+        let layout = calculate_layout_with_width(
+            &items,
+            &non_full_run_tasks(),
+            Destination {
+                width: 200,
+                link_style: LinkStyle::Expanded,
+            },
+            Path::new("/test"),
+            None,
+            None,
+            ColumnSelection {
+                custom: &[],
+                selected: None,
+            },
+        );
+
+        let branch = find_column(&layout, ColumnKind::Branch).expect("Branch allocated");
+        assert_eq!(
+            branch.width, COMMIT_HASH_WIDTH,
+            "the Branch column fits the abbreviated HEAD a detached row renders, \
+             not just the branch names ({:?} wide)",
+            branch.width
         );
     }
 

--- a/src/commands/list/model/item.rs
+++ b/src/commands/list/model/item.rs
@@ -409,11 +409,34 @@ impl ListItem {
     }
 
     /// Short display name for this item — the branch if present, otherwise
-    /// the short SHA. Use when reporting which item is pending, stuck, or
+    /// the abbreviated HEAD. Use when reporting which item is pending, stuck, or
     /// missing: `branch_name()`'s `"(detached)"` fallback collapses distinct
     /// detached items into one label.
+    ///
+    /// Also the Branch cell's text: a detached worktree has no name to put
+    /// there, so the column shows this instead (styled `DETACHED`, since a SHA
+    /// is a legal branch name too).
     pub fn display_name(&self) -> &str {
-        self.branch.as_deref().unwrap_or(&self.short_sha)
+        self.branch
+            .as_deref()
+            .unwrap_or_else(|| self.abbreviated_head())
+    }
+
+    /// HEAD abbreviated for the table: a fixed 8-character prefix, empty for a
+    /// null OID (an unborn branch). The Commit cell of every row and the Branch
+    /// cell of a detached one both render this, so the row that shows both
+    /// prints the same commit the same way twice.
+    ///
+    /// Not [`Self::short_sha`] (`%h`, `core.abbrev`-aware, and what the JSON
+    /// output carries): it lands post-skeleton, so sourcing one of those cells
+    /// from each would give a row two lengths of the same SHA, and a detached
+    /// row a Branch cell that fills in late.
+    pub fn abbreviated_head(&self) -> &str {
+        if self.head == worktrunk::git::NULL_OID {
+            ""
+        } else {
+            &self.head[..8.min(self.head.len())]
+        }
     }
 
     pub fn is_main(&self) -> bool {
@@ -504,9 +527,12 @@ impl ListItem {
 
         let mut segments = Vec::new();
 
-        // 1. Branch name (priority 1)
+        // 1. Branch name (priority 1) — `display_name`, so the prompt names a
+        // detached worktree the way its `wt list` row does: the abbreviated
+        // HEAD, which also tells two detached worktrees apart where the
+        // `"(detached)"` label collapses them.
         segments.push(StatuslineSegment::from_column(
-            self.branch_name().to_string(),
+            self.display_name().to_string(),
             ColumnKind::Branch,
         ));
 
@@ -910,6 +936,32 @@ mod tests {
         let mut item = ListItem::new_branch("abc123".to_string(), "feature".to_string());
         item.branch = None; // Simulate detached
         assert_eq!(item.branch_name(), "(detached)");
+    }
+
+    /// The Branch cell of a detached row renders `display_name`, and the Commit
+    /// cell of every row renders `abbreviated_head` — the same string, so the
+    /// row that shows both agrees with itself. Neither waits on the `%h` batch
+    /// that populates `short_sha` post-skeleton.
+    #[test]
+    fn test_list_item_display_name_falls_back_to_abbreviated_head() {
+        let head = "abc123def456abc123def456abc123def456abcd";
+        let mut item = ListItem::new_branch(head.to_string(), "feature".to_string());
+        assert_eq!(item.display_name(), "feature");
+
+        item.branch = None; // Simulate detached
+        assert_eq!(item.display_name(), "abc123de");
+        assert_eq!(item.abbreviated_head(), "abc123de");
+
+        // `short_sha` lands later and is `core.abbrev`-aware; the cells keep
+        // the fixed prefix so the two never print at different lengths.
+        item.short_sha = "abc123d".to_string();
+        assert_eq!(item.display_name(), "abc123de");
+
+        // An unborn branch has no commit to abbreviate — the cell stays empty
+        // rather than rendering a row of zeros.
+        let unborn =
+            ListItem::new_branch(worktrunk::git::NULL_OID.to_string(), "unborn".to_string());
+        assert_eq!(unborn.abbreviated_head(), "");
     }
 
     #[test]

--- a/src/commands/list/render.rs
+++ b/src/commands/list/render.rs
@@ -1,7 +1,7 @@
 use crate::display::{format_relative_time_short, shorten_path, truncate_to_width};
 use anstyle::{Effects, Style};
 use unicode_width::UnicodeWidthStr;
-use worktrunk::styling::StyledLine;
+use worktrunk::styling::{DETACHED, StyledLine};
 
 use super::columns::{ColumnKind, DiffVariant};
 use super::layout::{
@@ -286,7 +286,7 @@ impl LayoutConfig {
     /// Used for both worktrees and branch-only items; branch-only rows render an empty path
     /// and a blank gutter placeholder. See [`Self::render_list_item_line`] for `placeholder` semantics.
     pub fn render_skeleton_row(&self, item: &ListItem, placeholder: &str) -> StyledLine {
-        let branch = item.branch_name();
+        let branch = item.display_name();
         let shortened_path = item
             .worktree_path()
             .map(|p| shorten_path(p, &self.main_worktree_path))
@@ -315,8 +315,15 @@ impl LayoutConfig {
                     }
                 }
                 ColumnKind::Branch => {
-                    // Show actual branch name (no dim - start normal, gray out later if removable)
-                    cell.push_raw(branch.to_string());
+                    // Show actual branch name (no dim - start normal, gray out later if removable).
+                    // A detached row shows its abbreviated HEAD in the settled
+                    // row's `DETACHED` style, so the cell doesn't restyle as
+                    // the row fills in.
+                    if item.branch.is_none() {
+                        cell.push_styled(branch.to_string(), DETACHED);
+                    } else {
+                        cell.push_raw(branch.to_string());
+                    }
                     cell.pad_to(col.width);
                 }
                 ColumnKind::Path => {
@@ -326,9 +333,8 @@ impl LayoutConfig {
                 }
                 ColumnKind::Commit => {
                     // Show actual commit hash (empty for unborn branches with null OID)
-                    let head = item.head();
-                    if head != worktrunk::git::NULL_OID {
-                        let short_head = &head[..8.min(head.len())];
+                    let short_head = item.abbreviated_head();
+                    if !short_head.is_empty() {
                         cell.push_styled(short_head, dim);
                     }
                 }
@@ -458,8 +464,19 @@ impl ColumnLayout {
                 cell
             }
             ColumnKind::Branch => {
-                let text = item.branch.as_deref().unwrap_or("-");
-                self.render_text_cell(text, text_style)
+                // A detached worktree has no name for this cell, so it carries
+                // the abbreviated HEAD — the Commit column's value, repeated
+                // here because the column's question is "which ref is this?"
+                // and a SHA is the answer. `DETACHED` outranks `text_style`:
+                // the removable dim still reaches this row's Path and Message
+                // cells, while yellow keeps the SHA from reading as a branch
+                // that happens to be named like one.
+                let style = if item.branch.is_none() {
+                    Some(DETACHED)
+                } else {
+                    text_style
+                };
+                self.render_text_cell(item.display_name(), style)
             }
             ColumnKind::Status => {
                 // `render_with_mask` emits the placeholder glyph per
@@ -572,13 +589,11 @@ impl ColumnLayout {
                 }
             }
             ColumnKind::Commit => {
-                let head = item.head();
-                if head == worktrunk::git::NULL_OID {
-                    self.render_text_cell("", None)
-                } else {
-                    let short_head = &head[..8.min(head.len())];
-                    self.render_text_cell(short_head, Some(Style::new().dimmed()))
-                }
+                // Style only a real SHA: an empty cell (null OID) styled would
+                // render as bare escape codes around nothing.
+                let short_head = item.abbreviated_head();
+                let style = (!short_head.is_empty()).then(|| Style::new().dimmed());
+                self.render_text_cell(short_head, style)
             }
             ColumnKind::Summary => match &item.summary {
                 None => self.placeholder_cell(placeholder),

--- a/src/commands/picker/items.rs
+++ b/src/commands/picker/items.rs
@@ -445,8 +445,9 @@ pub(super) fn push_pr_search_tokens(
 /// without a re-send; the row may re-rank as that data streams in during the
 /// first frame.
 pub(super) struct PickerRow {
-    /// The stable, skeleton-time head of the matcher text: branch name plus —
-    /// for a worktree row — the distinct worktree path. The PR tokens and
+    /// The stable, skeleton-time head of the matcher text: the Branch column's
+    /// text — branch name, or the abbreviated HEAD for a detached worktree —
+    /// plus, for a worktree row, the distinct worktree path. The PR tokens and
     /// trailing gutter glyph are appended live in `text()`.
     pub search_base: String,
     /// Trailing gutter glyph (`@`/`^`/`+`/`/`/`|`, or `#` for a listed `--prs`

--- a/src/commands/picker/progressive_handler.rs
+++ b/src/commands/picker/progressive_handler.rs
@@ -398,7 +398,11 @@ impl PickerProgressHandler for PickerHandler {
             // filters those (see
             // `folded_pr_reference_filters_under_skims_default_engine`).
             let gutter = item.kind.gutter_glyph();
-            let mut search_base = branch_name.clone();
+            // `display_name`, not `branch_name`: a detached row shows its
+            // abbreviated HEAD in the Branch column, so that's what the user
+            // reads and types. `branch_name`'s `"(detached)"` matches nothing
+            // on screen, and collapses every detached row onto one token.
+            let mut search_base = item.display_name().to_string();
             if !path_str.is_empty() {
                 search_base.push(' ');
                 search_base.push_str(&path_str);

--- a/src/styling/constants.rs
+++ b/src/styling/constants.rs
@@ -41,6 +41,15 @@ pub const ADDITION: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Gr
 /// Deletion style for diffs (red) - used in table rendering
 pub const DELETION: Style = Style::new().fg_color(Some(Color::Ansi(AnsiColor::Red)));
 
+/// Detached-HEAD style (dim yellow) - used in table rendering
+///
+/// Marks the abbreviated HEAD a `wt list` Branch cell shows when the worktree
+/// has no branch. Yellow separates it from a branch literally named like a SHA;
+/// dim keeps a row that isn't on a branch from reading as loudly as one that is.
+pub const DETACHED: Style = Style::new()
+    .fg_color(Some(Color::Ansi(AnsiColor::Yellow)))
+    .dimmed();
+
 /// Gutter style for quoted content (commands, config, error details)
 ///
 /// We wanted the dimmest/most subtle background that works on both dark and light

--- a/tests/integration_tests/statusline.rs
+++ b/tests/integration_tests/statusline.rs
@@ -480,12 +480,16 @@ fn test_statusline_detached_head(mut repo: TestRepo) {
         .run()
         .unwrap();
 
-    // Verify statusline shows the detached marker, not the prior branch name.
+    // Verify the statusline names a detached worktree the way its `wt list`
+    // row does — by the abbreviated HEAD — and not by the prior branch name.
+    // The SHA also tells two detached worktrees apart, which one shared
+    // "(detached)" label cannot.
     let output = run_statusline_from_dir(&repo, &[], None, &feature_path);
-    // In detached state we render "(detached)" in place of a branch name.
+    let head = repo.git_output(&["rev-parse", "HEAD"]);
+    let short_head = &head.trim()[..8];
     assert!(
-        output.contains("(detached)"),
-        "statusline should show '(detached)' for detached HEAD, got: {output}"
+        output.contains(short_head),
+        "statusline should show the abbreviated HEAD ({short_head}) for detached HEAD, got: {output}"
     );
     assert!(
         !output.contains("feature"),

--- a/tests/snapshots/integration__integration_tests__help__help_list_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_long.snap
@@ -9,6 +9,13 @@ info:
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
     GIT_ALLOW_PROTOCOL: file
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
     LANG: C
     LC_ALL: C
     LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
@@ -135,7 +142,7 @@ Output as JSON for scripting:
 
   Column                                                 Shows                                                
  ──────── ─────────────────────────────────────────────────────────────────────────────────────────────────── 
- Branch   Branch name                                                                                         
+ Branch   Branch name; a detached worktree has none, so it shows its short hash in dim yellow                 
  Status   Compact symbols (see below)                                                                         
  HEAD±    Uncommitted changes: +added -deleted lines                                                          
  main↕    Commits ahead/behind default branch                                                                 
@@ -229,7 +236,7 @@ An in-progress git operation, a worktree-location attribute, or a branch with no
  [33m⊟[0m      [2mworktree.state[0m [2m"prunable"[0m                                            Prunable (worktree directory missing)                                                                                                 
  [33m⊞[0m      [2mworktree.state[0m [2m"locked"[0m                                              Locked worktree                                                                                                                       
  [2m[33m⚑[0m      [2mworktree.state[0m [2m"duplicate_branch"[0m                                    Branch checked out in more than one worktree, so [2mwt[0m resolves it to whichever git lists first; every worktree on the branch is flagged 
- [2m[33m⚑[0m      [2mworktree.state[0m [2m"branch_worktree_mismatch"[0m                            Branch name doesn't match the worktree path                                                                                           
+ [2m[33m⚑[0m      [2mworktree.state[0m [2m"branch_worktree_mismatch"[0m                            Worktree isn't at the path its branch implies — including a detached one, which has no branch to imply a path and so is never at home 
  [2m/[0m      [2mkind[0m [2m"branch"[0m                                                        Branch without a worktree (no [2mworktree[0m object)                                                                                        
 
 [32mDefault branch[0m

--- a/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_list_narrow_80.snap
@@ -9,6 +9,13 @@ info:
     CLICOLOR_FORCE: "1"
     COLUMNS: "80"
     GIT_ALLOW_PROTOCOL: file
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
     LANG: C
     LC_ALL: C
     LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
@@ -146,7 +153,8 @@ Output as JSON for scripting:
 
   Column                                  Shows                                 
  ──────── ───────────────────────────────────────────────────────────────────── 
- Branch   Branch name                                                           
+ Branch   Branch name; a detached worktree has none, so it shows its short hash 
+          in dim yellow                                                         
  Status   Compact symbols (see below)                                           
  HEAD±    Uncommitted changes: +added -deleted lines                            
  main↕    Commits ahead/behind default branch                                   
@@ -285,8 +293,10 @@ An in-progress git operation, a worktree-location attribute, or a branch with no
       [2m"duplicate_branch"[0m             worktree, so [2mwt[0m resolves it to whichever   
                                      git lists first; every worktree on the     
                                      branch is flagged                          
- [2m[33m⚑[0m    [2mworktree.state[0m                 Branch name doesn't match the worktree     
-      [2m"branch_worktree_mismatch"[0m     path                                       
+ [2m[33m⚑[0m    [2mworktree.state[0m                 Worktree isn't at the path its branch      
+      [2m"branch_worktree_mismatch"[0m     implies — including a detached one, which  
+                                     has no branch to imply a path and so is    
+                                     never at home                              
  [2m/[0m    [2mkind[0m [2m"branch"[0m                  Branch without a worktree (no [2mworktree[0m     
                                      object)                                    
 

--- a/tests/snapshots/integration__integration_tests__list__list_detached_head.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_detached_head.snap
@@ -9,10 +9,20 @@ info:
     CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
-    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
-    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -35,6 +45,7 @@ info:
     WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -45,7 +56,7 @@ success: true
 exit_code: 0
 ----- stdout -----
   [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ -             [33m[2m⚑[39m[22m[2m^[22m                                             .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+@ [2m[33m05a4a45d[0m      [33m[2m⚑[39m[22m[2m^[22m                                             .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 + feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m

--- a/tests/snapshots/integration__integration_tests__list__list_detached_head_in_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_detached_head_in_worktree.snap
@@ -9,10 +9,20 @@ info:
     CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
-    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
-    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -35,6 +45,7 @@ info:
     WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -46,7 +57,7 @@ exit_code: 0
 ----- stdout -----
   [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
 @ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
-+ [2m-[0m             [33m[2m⚑[39m[22m[2m_[22m                                             [2m../repo.feature[0m    [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
++ [2m[33m05a4a45d[0m      [33m[2m⚑[39m[22m[2m_[22m                                             [2m../repo.feature[0m    [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 + feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m

--- a/tests/snapshots/integration__integration_tests__list__list_task_dag_detached_head.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_task_dag_detached_head.snap
@@ -10,10 +10,20 @@ info:
     CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
-    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
-    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -36,6 +46,7 @@ info:
     WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
@@ -46,7 +57,7 @@ success: true
 exit_code: 0
 ----- stdout -----
   [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
-@ -             [33m[2m⚑[39m[22m[2m^[22m                                             .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
+@ [2m[33m05a4a45d[0m      [33m[2m⚑[39m[22m[2m^[22m                                             .                  [2m05a4a45d[0m  [2m16h[0m   [2mInitial commit[0m
 + feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m16h[0m   [2mAdd feature-a file[0m
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m16h[0m   [2mAdd feature-b file[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m16h[0m   [2mAdd feature-c file[0m

--- a/tests/snapshots/integration__integration_tests__list__list_warns_when_commit_details_batch_fails.snap
+++ b/tests/snapshots/integration__integration_tests__list__list_warns_when_commit_details_batch_fails.snap
@@ -9,10 +9,20 @@ info:
     CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
-    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
-    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -47,7 +57,7 @@ exit_code: 0
 ----- stdout -----
   [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mPath[0m               [1mCommit[0m    [1mAge[0m   [1mMessage[0m
 @ main           [2m^[22m[2m|[22m                                      [2m|[0m     .                  [2m05a4a45d[0m  [2m·[0m     [2m·[0m
-+ -          [2m·[0m  [2m·[0m[2m·[0m             [2m·[0m        [2m·[0m          [2m·[0m           ../repo.feature    [2m00000000[0m  [2m·[0m     [2m·[0m
++ [2m[33m00000000[0m   [2m·[0m  [2m·[0m[2m·[0m             [2m·[0m        [2m·[0m          [2m·[0m           ../repo.feature    [2m00000000[0m  [2m·[0m     [2m·[0m
 + feature-a      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-a  [2m1b87d473[0m  [2m·[0m     [2m·[0m
 + feature-b      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-b  [2mf62940fc[0m  [2m·[0m     [2m·[0m
 + feature-c      [2m↑[22m                 [32m↑1[0m        [32m+1[0m                ../repo.feature-c  [2m345c7c93[0m  [2m·[0m     [2m·[0m


### PR DESCRIPTION
The Branch cell hardcoded `"-"` for a worktree with no branch. It reads as missing data rather than as a state, and it was the odd one out: the skeleton row, the statusline, and `worktree_display_name` all reach for `branch_name()`'s `"(detached)"`, so the same cell changed label as the row settled. Detached worktrees aren't exotic here any more — Codex creates one per session under `~/.codex/worktrees/`, and they sit in `wt list` alongside everything else.

The cell now carries the row's abbreviated HEAD in dim yellow. Yellow keeps it from reading as a branch that happens to be named like a SHA; dim keeps a row that isn't on a branch quieter than one that is. `should_dim`'s removable dim still reaches the row's Path and Message cells, so that signal survives the override.

```
  Branch      Status  Path        Commit          Branch      Status  Path        Commit
@ main            ^|  .           1243e9c0      @ main            ^|  .           1243e9c0
+ -            ! ⚑↓   ../codex/…  bdc5c663  →   + bdc5c663     ! ⚑↓   ../codex/…  bdc5c663
+ 1p              ⊂   ../wt.1p    bdc5c663      + 1p              ⊂   ../wt.1p    bdc5c663
```

### What to look at

`display_name()` gains a HEAD-prefix fallback so it answers before the `%h` batch lands post-skeleton — the skeleton and settled rows now print the same text in the same style, with no restyle as the row fills in. Both the Branch cell of a detached row and the Commit cell of every row render the new `abbreviated_head()`, so one commit gets one spelling: sourcing the Branch cell from `short_sha` (`core.abbrev`-aware) instead put `1b9f1d9` beside the Commit column's `1b9f1d96` on the same row.

The Branch column budgets `COMMIT_HASH_WIDTH` when any row is detached. Sized off branch names alone it truncated the hash — and it already truncated the skeleton's `(detached)` to `(detac` behind a short branch set, so that was a latent bug rather than a new constraint.

The picker's matcher text and the statusline follow the display. A detached row now filters by the hash on screen rather than a `"(detached)"` token that matches nothing visible and collapses every detached row onto one key, and a prompt names the same worktree the same way its `wt list` row does.

`⚑` on a detached row stays as it was. The flag's axis is "not at home", and a worktree with no branch has no home path to be at — but the docs described only "branch name doesn't match the worktree path", which doesn't cover the case that has no branch at all. They now name it.

### Testing

Covered by the existing detached-head list snapshots (all four now show the hash), a new layout test pinning the column width against a short branch set, a unit test for the `display_name` / `abbreviated_head` pair across the skeleton boundary, and the statusline detached test rewritten to assert the hash. Full suite green locally: 4493 tests, clippy and pre-commit clean.

> _This was written by Claude Code on behalf of max-sixty_
