### PR TITLE
fix(picker): abbreviate a PR's commits with git, not a fixed 8

### DIFF
--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -1508,7 +1508,7 @@ fn render_ci_status_section(out: &mut String, repo: &Repository) -> anyhow::Resu
         // same width `wt list`'s Commit cell and the statusline print. One
         // probe covers every row: `short_sha` per entry would be a `git
         // rev-parse` fork apiece, and a repo with a cache entry per branch
-        // turned this dump from 38 ms into 285 ms at 50 entries.
+        // turned this dump from 26 ms into 267 ms at 50 entries.
         let abbrev = repo.abbrev_len();
         let rows: Vec<Vec<String>> = entries
             .iter()

--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -1503,6 +1503,13 @@ fn render_ci_status_section(out: &mut String, repo: &Repository) -> anyhow::Resu
     } else if entries.is_empty() {
         writeln!(out, "{}", format_with_gutter("(no entries)", None))?;
     } else {
+        // The Head column is here to be eyeballed against the branch's current
+        // head, so it abbreviates to the width git uses — `core.abbrev`, the
+        // same width `wt list`'s Commit cell and the statusline print. One
+        // probe covers every row: `short_sha` per entry would be a `git
+        // rev-parse` fork apiece, and a repo with a cache entry per branch
+        // turned this dump from 38 ms into 285 ms at 50 entries.
+        let abbrev = repo.abbrev_len();
         let rows: Vec<Vec<String>> = entries
             .iter()
             .map(|cached| {
@@ -1514,16 +1521,7 @@ fn render_ci_status_section(out: &mut String, repo: &Repository) -> anyhow::Resu
                     None => "none".to_string(),
                 };
                 let age = format_relative_time_short(cached.checked_at as i64);
-                // The Head column is here to be eyeballed against the branch's
-                // current head, so it abbreviates the way every other head `wt`
-                // prints does — git's, honoring `core.abbrev`. A full-length SHA
-                // abbreviates whether or not its object survives, so the
-                // fallback is for a cached value that isn't one at all (a
-                // hand-written entry): printing it verbatim is the more useful
-                // thing for a diagnostic dump to say than slicing it.
-                let head = repo
-                    .short_sha(&cached.head)
-                    .unwrap_or_else(|_| cached.head.clone());
+                let head: String = cached.head.chars().take(abbrev).collect();
                 vec![cached.branch.clone(), status, age, head]
             })
             .collect();

--- a/src/commands/config/state.rs
+++ b/src/commands/config/state.rs
@@ -1514,7 +1514,16 @@ fn render_ci_status_section(out: &mut String, repo: &Repository) -> anyhow::Resu
                     None => "none".to_string(),
                 };
                 let age = format_relative_time_short(cached.checked_at as i64);
-                let head: String = cached.head.chars().take(8).collect();
+                // The Head column is here to be eyeballed against the branch's
+                // current head, so it abbreviates the way every other head `wt`
+                // prints does — git's, honoring `core.abbrev`. A full-length SHA
+                // abbreviates whether or not its object survives, so the
+                // fallback is for a cached value that isn't one at all (a
+                // hand-written entry): printing it verbatim is the more useful
+                // thing for a diagnostic dump to say than slicing it.
+                let head = repo
+                    .short_sha(&cached.head)
+                    .unwrap_or_else(|_| cached.head.clone());
                 vec![cached.branch.clone(), status, age, head]
             })
             .collect();

--- a/src/commands/picker/prs.rs
+++ b/src/commands/picker/prs.rs
@@ -934,9 +934,11 @@ fn fetch_forge_json(
 /// view <n> --json commits` (GitHub) or `glab api
 /// projects/:fullpath/merge_requests/<n>/commits` (GitLab). That path renders a
 /// flat `git log --oneline`-style list — no graph or merge-base coloring, since
-/// the objects aren't present to compute them. `glab`'s `--paginate` follows
-/// every page so a long PR isn't capped at GitLab's default page size, matching
-/// `gh`'s complete `--json` result.
+/// the objects aren't present to compute them. Their SHAs still read at the
+/// local repo's own abbreviation width ([`Repository::abbrev_len`]), so fetching
+/// the PR doesn't change how wide its commits print. `glab`'s `--paginate`
+/// follows every page so a long PR isn't capped at GitLab's default page size,
+/// matching `gh`'s complete `--json` result.
 fn compute_pr_log(
     repo: &Repository,
     kind: RefType,
@@ -960,10 +962,11 @@ fn compute_pr_log(
         &["pr", "view", &number, "--json", "commits"],
         &["api", "--paginate", &endpoint],
     )?;
-    match kind {
-        RefType::Pr => render_github_commits(&stdout, width),
-        RefType::Mr => render_gitlab_commits(&stdout, width),
-    }
+    let commits = match kind {
+        RefType::Pr => parse_github_commits(&stdout)?,
+        RefType::Mr => parse_gitlab_commits(&stdout)?,
+    };
+    Some(render_commit_lines(&commits, repo.abbrev_len(), width))
 }
 
 /// Render the local `git log` for `oid` when it's present in the object store,
@@ -1009,39 +1012,39 @@ struct GhCommit {
     message_headline: String,
 }
 
-/// Map `gh pr view <n> --json commits` to the `log` pane. gh returns commits
-/// oldest-first; the log reads newest-first like `git log`, so reverse.
-fn render_github_commits(stdout: &[u8], width: usize) -> Option<String> {
+/// Parse `gh pr view <n> --json commits` into the `log` pane's `(full SHA,
+/// subject)` pairs. gh returns commits oldest-first; the log reads newest-first
+/// like `git log`, so reverse.
+fn parse_github_commits(stdout: &[u8]) -> Option<Vec<(String, String)>> {
     let parsed: GhCommitsResponse = serde_json::from_slice(stdout).ok()?;
-    let lines: Vec<(String, String)> = parsed
-        .commits
-        .into_iter()
-        .rev()
-        .map(|c| (short_hash(&c.oid), c.message_headline))
-        .collect();
-    Some(render_commit_lines(&lines, width))
+    Some(
+        parsed
+            .commits
+            .into_iter()
+            .rev()
+            .map(|c| (c.oid, c.message_headline))
+            .collect(),
+    )
 }
 
 #[derive(Deserialize)]
 struct GlabCommit {
     #[serde(default)]
-    short_id: String,
+    id: String,
     #[serde(default)]
     title: String,
 }
 
-/// Map `glab api …/merge_requests/<n>/commits` to the `log` pane. GitLab's
-/// commits endpoint returns newest-first already, so keep the order.
-fn render_gitlab_commits(stdout: &[u8], width: usize) -> Option<String> {
+/// Parse `glab api …/merge_requests/<n>/commits` into the `log` pane's `(full
+/// SHA, subject)` pairs. GitLab's commits endpoint returns newest-first already,
+/// so keep the order. Each entry also carries a ready-abbreviated `short_id`,
+/// which this deliberately ignores in favor of `id`: that field is the
+/// *server's* abbreviation, blind to the reader's `core.abbrev`, and taking it
+/// would print a GitLab MR's commits at a different width from a GitHub PR's
+/// and from every other SHA `wt` renders.
+fn parse_gitlab_commits(stdout: &[u8]) -> Option<Vec<(String, String)>> {
     let commits: Vec<GlabCommit> = serde_json::from_slice(stdout).ok()?;
-    let lines: Vec<(String, String)> = commits.into_iter().map(|c| (c.short_id, c.title)).collect();
-    Some(render_commit_lines(&lines, width))
-}
-
-/// Abbreviate a full commit hash to the conventional short form. GitLab already
-/// supplies a `short_id`; GitHub's `oid` is the full SHA.
-fn short_hash(oid: &str) -> String {
-    oid.chars().take(8).collect()
+    Some(commits.into_iter().map(|c| (c.id, c.title)).collect())
 }
 
 /// Render a `git log --oneline`-style list for the `log` pane: a dim short hash,
@@ -1050,13 +1053,22 @@ fn short_hash(oid: &str) -> String {
 /// with no commits the API returned) renders an info line so `spawn_compute`
 /// caches a terminal value rather than leaving the slot empty (an empty string
 /// is skipped, which would keep the loading placeholder).
-fn render_commit_lines(commits: &[(String, String)], width: usize) -> String {
+///
+/// `commits` holds full SHAs — the forge's own — and `abbrev` is the local
+/// repo's abbreviation width from [`Repository::abbrev_len`], so the same commit
+/// reads at the same width here as in the rich local `log` tab this pane stands
+/// in for, in `wt list`, and in the statusline. Truncating is the whole of the
+/// abbreviation: this path runs precisely because the PR's head isn't in the
+/// local object store (see [`compute_pr_log`]), so there are no objects for git
+/// to abbreviate these commits against one by one.
+fn render_commit_lines(commits: &[(String, String)], abbrev: usize, width: usize) -> String {
     let reset = Reset;
     if commits.is_empty() {
         return cformat!("{INFO_SYMBOL}{reset} No commits\n");
     }
     let mut out = String::new();
-    for (short, headline) in commits {
+    for (oid, headline) in commits {
+        let short: String = oid.chars().take(abbrev).collect();
         let budget = width.saturating_sub(short.width() + 2).max(8);
         let headline = crate::display::truncate_to_width(headline, budget);
         out.push_str(&cformat!("<dim>{short}</>{reset}  {headline}\n"));
@@ -2012,51 +2024,82 @@ mod tests {
     }
 
     #[test]
-    fn render_github_commits_oneline_newest_first() {
+    fn parse_github_commits_is_newest_first() {
         // gh returns commits oldest-first; the `log` pane shows them
-        // newest-first like `git log`, with a dim 8-char short hash.
+        // newest-first like `git log`.
         let json = br#"{"commits":[
           {"oid":"aaaaaaaa0000000000000000000000000000aaaa","messageHeadline":"older change"},
           {"oid":"bbbbbbbb1111111111111111111111111111bbbb","messageHeadline":"newer change"}
         ]}"#;
-        let out = plain(&render_github_commits(json, 80).unwrap());
-        assert!(
-            out.find("bbbbbbbb").unwrap() < out.find("aaaaaaaa").unwrap(),
-            "newest-first: {out:?}"
+        let commits = parse_github_commits(json).unwrap();
+        assert_eq!(
+            commits,
+            vec![
+                (
+                    "bbbbbbbb1111111111111111111111111111bbbb".to_string(),
+                    "newer change".to_string()
+                ),
+                (
+                    "aaaaaaaa0000000000000000000000000000aaaa".to_string(),
+                    "older change".to_string()
+                ),
+            ]
         );
-        assert!(out.contains("newer change") && out.contains("older change"));
-        // Hash abbreviated to 8 chars, not the full 40.
-        assert!(!out.contains("bbbbbbbb1"), "short hash only: {out:?}");
     }
 
     #[test]
-    fn render_gitlab_commits_keeps_order_and_uses_short_id() {
-        // GitLab's commits endpoint returns newest-first already, and supplies a
-        // ready `short_id`, so the order is preserved as-is.
+    fn parse_gitlab_commits_keeps_order_and_takes_the_full_id() {
+        // GitLab's commits endpoint returns newest-first already, so the order
+        // is preserved as-is. Its ready-abbreviated `short_id` is the server's
+        // width, not the reader's, so the parse takes `id` — the full SHA — and
+        // leaves abbreviating to `render_commit_lines`.
         let json = br#"[
-          {"short_id":"deadbeef","title":"newer change"},
-          {"short_id":"cafef00d","title":"older change"}
+          {"id":"deadbeef2222222222222222222222222222dead","short_id":"deadbeef","title":"newer change"},
+          {"id":"cafef00d3333333333333333333333333333cafe","short_id":"cafef00d","title":"older change"}
         ]"#;
-        let out = plain(&render_gitlab_commits(json, 80).unwrap());
-        assert!(out.contains("deadbeef") && out.contains("newer change"));
-        assert!(
-            out.find("deadbeef").unwrap() < out.find("cafef00d").unwrap(),
-            "order preserved: {out:?}"
+        let commits = parse_gitlab_commits(json).unwrap();
+        assert_eq!(
+            commits,
+            vec![
+                (
+                    "deadbeef2222222222222222222222222222dead".to_string(),
+                    "newer change".to_string()
+                ),
+                (
+                    "cafef00d3333333333333333333333333333cafe".to_string(),
+                    "older change".to_string()
+                ),
+            ]
         );
+    }
+
+    #[test]
+    fn render_commits_abbreviates_to_the_given_width() {
+        // The pane prints the local repo's abbreviation width — whatever
+        // `Repository::abbrev_len` reported — not a width of its own choosing,
+        // so a fetched PR's commits don't change length under the user.
+        let commits = vec![(
+            "abc12345def67890000000000000000000000000".to_string(),
+            "Wrap the request in a retry".to_string(),
+        )];
+        for abbrev in [7, 12] {
+            let out = plain(&render_commit_lines(&commits, abbrev, 80));
+            let hash = out.split_whitespace().next().unwrap();
+            assert_eq!(hash.chars().count(), abbrev, "abbrev={abbrev}: {out:?}");
+            assert!(commits[0].0.starts_with(hash), "a prefix: {hash:?}");
+        }
     }
 
     #[test]
     fn render_commits_empty_and_truncation() {
         // A PR the API reports with no commits caches an info line (a terminal
         // value) rather than leaving the slot empty.
-        assert!(
-            plain(&render_github_commits(br#"{"commits":[]}"#, 80).unwrap()).contains("No commits")
-        );
+        assert!(plain(&render_commit_lines(&[], 7, 80)).contains("No commits"));
 
         // The preview doesn't wrap, so a long subject truncates to the pane
         // width (after the dim hash + two spaces) rather than clipping mid-escape.
         let commits = vec![("abc12345".to_string(), "subject-".repeat(20))];
-        let line = render_commit_lines(&commits, 40);
+        let line = render_commit_lines(&commits, 8, 40);
         let first = plain(&line);
         let first = first.lines().next().unwrap();
         assert!(first.width() <= 40, "within pane: {first:?}");
@@ -2064,12 +2107,12 @@ mod tests {
     }
 
     #[test]
-    fn render_commits_invalid_json_is_none() {
-        // A forge that returns junk yields `None` from the renderer; the deferred
+    fn parse_commits_invalid_json_is_none() {
+        // A forge that returns junk yields `None` from the parse; the deferred
         // closure maps that to a couldn't-load pane (`pr_unavailable_pane`) rather
         // than caching garbage.
-        assert!(render_github_commits(b"not json", 80).is_none());
-        assert!(render_gitlab_commits(b"not json", 80).is_none());
+        assert!(parse_github_commits(b"not json").is_none());
+        assert!(parse_gitlab_commits(b"not json").is_none());
     }
 
     #[test]

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -1653,8 +1653,8 @@ impl Repository {
     /// For batches (e.g., abbreviating many worktree heads at once), prefer
     /// folding `%h` into an existing `git log --format` call rather than
     /// looping this helper. See [`commit_details_many`](Self::commit_details_many).
-    /// A batch whose objects aren't local can't use `%h` either — abbreviate it
-    /// with [`abbrev_len`](Self::abbrev_len).
+    /// Where that batch doesn't fit — the objects aren't local, or one bad ref
+    /// mustn't cost the rest — abbreviate to [`abbrev_len`](Self::abbrev_len).
     pub fn short_sha(&self, sha: &str) -> anyhow::Result<String> {
         Ok(self
             .run_command(&["rev-parse", "--short", sha])?
@@ -1663,16 +1663,23 @@ impl Repository {
     }
 
     /// How many characters git abbreviates a SHA to in this repo — `core.abbrev`,
-    /// or the width git auto-scales from the object count.
+    /// or the width git auto-scales from the object count. Resolved once per
+    /// repo and shared by every clone, so a caller pays one `git rev-parse` no
+    /// matter how many SHAs it goes on to abbreviate.
     ///
-    /// Prefer [`short_sha`](Self::short_sha), which asks git about one specific
-    /// commit and so extends past this width when the prefix is ambiguous. This
-    /// is the width alone, for the case `short_sha` can't serve: abbreviating
-    /// SHAs whose objects **aren't in the local store** — commits a forge API
-    /// named, which git has nothing to disambiguate against and would therefore
-    /// abbreviate to exactly this many characters apiece. `git rev-parse
-    /// --short` takes a single revision, so a list of them has no batched form;
-    /// this resolves the shared answer once instead.
+    /// This is the width for **a list of SHAs**; [`short_sha`](Self::short_sha)
+    /// is the answer for one. `git rev-parse --short` takes a single revision,
+    /// so a list has no batched form, and looping it is a fork per SHA — the
+    /// trade this exists to avoid. `%h` folded into an existing `git log` is
+    /// better still where it fits ([`commit_details_many`](Self::commit_details_many)),
+    /// but it needs the objects present and refuses the whole batch on one bad
+    /// ref, so it can't serve a list of forge-named commits or a cache of
+    /// historical heads.
+    ///
+    /// What that costs against `short_sha` is disambiguation: git extends a
+    /// prefix that collides with another object, and a plain width can't. Absent
+    /// objects have nothing to collide with, and a live collision at this width
+    /// is rare enough that a display column can wear it.
     ///
     /// Probed with `HEAD` so the length matches the repo's object format (a
     /// SHA-256 repo abbreviates from 64 hex digits, and a literal SHA-1-shaped

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -263,6 +263,11 @@ pub(super) struct RepoCache {
     pub(super) resolved_config: OnceCell<ResolvedConfig>,
     /// Sparse checkout paths (empty if not a sparse checkout)
     pub(super) sparse_checkout_paths: OnceCell<Vec<String>>,
+    /// Width git abbreviates a SHA to here, resolved once via
+    /// [`Repository::abbrev_len`]. Repo-wide and settled for the process:
+    /// `core.abbrev` doesn't change mid-run, and the auto-scaled default only
+    /// moves as the object count crosses a power of two.
+    pub(super) abbrev_len: OnceCell<usize>,
     /// Merge-base cache: (sha1, sha2) -> merge_base_sha (None = no common ancestor).
     /// Keys are commit SHAs by contract — callers must resolve refs through
     /// a [`RefSnapshot`] before consulting. The key order is normalized
@@ -1648,11 +1653,39 @@ impl Repository {
     /// For batches (e.g., abbreviating many worktree heads at once), prefer
     /// folding `%h` into an existing `git log --format` call rather than
     /// looping this helper. See [`commit_details_many`](Self::commit_details_many).
+    /// A batch whose objects aren't local can't use `%h` either — abbreviate it
+    /// with [`abbrev_len`](Self::abbrev_len).
     pub fn short_sha(&self, sha: &str) -> anyhow::Result<String> {
         Ok(self
             .run_command(&["rev-parse", "--short", sha])?
             .trim()
             .to_string())
+    }
+
+    /// How many characters git abbreviates a SHA to in this repo — `core.abbrev`,
+    /// or the width git auto-scales from the object count.
+    ///
+    /// Prefer [`short_sha`](Self::short_sha), which asks git about one specific
+    /// commit and so extends past this width when the prefix is ambiguous. This
+    /// is the width alone, for the case `short_sha` can't serve: abbreviating
+    /// SHAs whose objects **aren't in the local store** — commits a forge API
+    /// named, which git has nothing to disambiguate against and would therefore
+    /// abbreviate to exactly this many characters apiece. `git rev-parse
+    /// --short` takes a single revision, so a list of them has no batched form;
+    /// this resolves the shared answer once instead.
+    ///
+    /// Probed with `HEAD` so the length matches the repo's object format (a
+    /// SHA-256 repo abbreviates from 64 hex digits, and a literal SHA-1-shaped
+    /// probe is not even a valid revision there) — a HEAD whose own prefix is
+    /// ambiguous therefore reports a character or two over the base width, which
+    /// costs a caller nothing but a slightly longer SHA. Falls back to 7 — git's
+    /// `MINIMUM_ABBREV`, and what git itself reports in an objectless repo — for
+    /// the one failure a working repo reaches, an unborn HEAD.
+    pub fn abbrev_len(&self) -> usize {
+        *self.cache.abbrev_len.get_or_init(|| {
+            self.short_sha("HEAD")
+                .map_or(7, |short| short.chars().count())
+        })
     }
 
     /// Delay before showing progress output for slow operations.

--- a/src/git/repository/mod.rs
+++ b/src/git/repository/mod.rs
@@ -1686,8 +1686,8 @@ impl Repository {
     /// probe is not even a valid revision there) — a HEAD whose own prefix is
     /// ambiguous therefore reports a character or two over the base width, which
     /// costs a caller nothing but a slightly longer SHA. Falls back to 7 — git's
-    /// `MINIMUM_ABBREV`, and what git itself reports in an objectless repo — for
-    /// the one failure a working repo reaches, an unborn HEAD.
+    /// default auto-abbreviation length, and what it reports in an objectless
+    /// repo — for the one failure a working repo reaches, an unborn HEAD.
     pub fn abbrev_len(&self) -> usize {
         *self.cache.abbrev_len.get_or_init(|| {
             self.short_sha("HEAD")

--- a/src/git/repository/tests.rs
+++ b/src/git/repository/tests.rs
@@ -716,6 +716,37 @@ fn commit_details_many_returns_subject_with_spaces() {
 }
 
 #[test]
+fn abbrev_len_follows_core_abbrev_and_covers_absent_objects() {
+    use crate::git::Repository;
+    use crate::testing::TestRepo;
+
+    let test = TestRepo::with_initial_commit();
+
+    // The width git actually uses here — the same one `%h` and `short_sha`
+    // produce, which is the whole point of asking git rather than picking a
+    // number.
+    let head_short = test.repo.short_sha("HEAD").unwrap();
+    assert_eq!(test.repo.abbrev_len(), head_short.chars().count());
+
+    // `core.abbrev` reaches it. A fresh `Repository` because the width is
+    // resolved once per repo handle and cached for the process.
+    test.repo
+        .run_command(&["config", "core.abbrev", "12"])
+        .unwrap();
+    let reread = Repository::at(test.path()).unwrap();
+    assert_eq!(reread.abbrev_len(), 12);
+
+    // The case `short_sha` can't serve: a SHA whose object isn't in the store,
+    // as every commit the `--prs` log tab gets from a forge API is. git has
+    // nothing to disambiguate against, so this width is its complete answer.
+    let absent = "0".repeat(head_short.chars().count().max(40));
+    assert_eq!(
+        reread.short_sha(&absent).unwrap().chars().count(),
+        reread.abbrev_len(),
+    );
+}
+
+#[test]
 fn commit_details_many_empty_input_is_noop() {
     use crate::testing::TestRepo;
 

--- a/src/git/repository/tests.rs
+++ b/src/git/repository/tests.rs
@@ -736,9 +736,9 @@ fn abbrev_len_follows_core_abbrev_and_covers_absent_objects() {
     let reread = Repository::at(test.path()).unwrap();
     assert_eq!(reread.abbrev_len(), 12);
 
-    // The case `short_sha` can't serve: a SHA whose object isn't in the store,
-    // as every commit the `--prs` log tab gets from a forge API is. git has
-    // nothing to disambiguate against, so this width is its complete answer.
+    // The case `short_sha` can't serve per-SHA: an object that isn't in the
+    // store, as every commit the `--prs` log tab gets from a forge API is. git
+    // has nothing to disambiguate against, so this width is its whole answer.
     let absent = "0".repeat(head_short.chars().count().max(40));
     assert_eq!(
         reread.short_sha(&absent).unwrap().chars().count(),

--- a/tests/integration_tests/config_state.rs
+++ b/tests/integration_tests/config_state.rs
@@ -1798,10 +1798,9 @@ fn test_state_get_empty(repo: TestRepo) {
 
 #[rstest]
 fn test_state_get_with_ci_entries(repo: TestRepo) {
-    // Add CI cache entries - use TEST_EPOCH for deterministic age=0s in snapshots.
-    // The heads are placeholders that resolve to no object here, so the dump
-    // prints them verbatim and the snapshot stays fixed while the real
-    // abbreviation (git's, and so repo-dependent) is pinned separately by
+    // Add CI cache entries - use TEST_EPOCH for deterministic age=0s in
+    // snapshots. The heads are placeholders, so what the snapshot pins is the
+    // table's shape; that the width is git's own is pinned separately by
     // `test_state_get_ci_head_uses_git_abbreviation`.
     write_ci_cache(
         &repo,

--- a/tests/integration_tests/config_state.rs
+++ b/tests/integration_tests/config_state.rs
@@ -1798,12 +1798,16 @@ fn test_state_get_empty(repo: TestRepo) {
 
 #[rstest]
 fn test_state_get_with_ci_entries(repo: TestRepo) {
-    // Add CI cache entries - use TEST_EPOCH for deterministic age=0s in snapshots
+    // Add CI cache entries - use TEST_EPOCH for deterministic age=0s in snapshots.
+    // The heads are placeholders that resolve to no object here, so the dump
+    // prints them verbatim and the snapshot stays fixed while the real
+    // abbreviation (git's, and so repo-dependent) is pinned separately by
+    // `test_state_get_ci_head_uses_git_abbreviation`.
     write_ci_cache(
         &repo,
         "feature",
         &format!(
-            r#"{{"status":{{"ci_status":"passed","source":"pr","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"abc12345def67890","branch":"feature"}}"#
+            r#"{{"status":{{"ci_status":"passed","source":"pr","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"abc12345","branch":"feature"}}"#
         ),
     );
 
@@ -1811,7 +1815,7 @@ fn test_state_get_with_ci_entries(repo: TestRepo) {
         &repo,
         "bugfix",
         &format!(
-            r#"{{"status":{{"ci_status":"failed","source":"branch","is_stale":true}},"checked_at":{TEST_EPOCH},"head":"111222333444555","branch":"bugfix"}}"#
+            r#"{{"status":{{"ci_status":"failed","source":"branch","is_stale":true}},"checked_at":{TEST_EPOCH},"head":"11122233","branch":"bugfix"}}"#
         ),
     );
 
@@ -1819,7 +1823,7 @@ fn test_state_get_with_ci_entries(repo: TestRepo) {
         &repo,
         "main",
         &format!(
-            r#"{{"status":null,"checked_at":{TEST_EPOCH},"head":"deadbeef12345678","branch":"main"}}"#
+            r#"{{"status":null,"checked_at":{TEST_EPOCH},"head":"deadbeef","branch":"main"}}"#
         ),
     );
 
@@ -1828,6 +1832,48 @@ fn test_state_get_with_ci_entries(repo: TestRepo) {
     state_get_settings().bind(|| {
         assert_snapshot!(String::from_utf8_lossy(&output.stdout));
     });
+}
+
+/// The CI cache's Head column abbreviates through git, so a head reads at the
+/// same width in `wt config state` as it does in `wt list`'s Commit column and
+/// in the statusline — all of them `core.abbrev`, none of them a slice of their
+/// own. Snapshots can't pin this: the width git picks scales with the repo's
+/// object count, and the SHA a test repo commits to isn't fixed.
+#[rstest]
+fn test_state_get_ci_head_uses_git_abbreviation(repo: TestRepo) {
+    let head = repo.head_sha();
+    write_ci_cache(
+        &repo,
+        "main",
+        &format!(r#"{{"status":null,"checked_at":{TEST_EPOCH},"head":"{head}","branch":"main"}}"#),
+    );
+
+    let expected = String::from_utf8_lossy(
+        &repo
+            .git_command()
+            .args(["rev-parse", "--short", &head])
+            .run()
+            .unwrap()
+            .stdout,
+    )
+    .trim()
+    .to_string();
+
+    let output = wt_state_get_cmd(&repo).output().unwrap();
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let row = stdout
+        .lines()
+        .find(|l| l.contains("main") && l.contains("none"))
+        .unwrap_or_else(|| panic!("no CI cache row for main:\n{stdout}"));
+    assert!(
+        row.split_whitespace().any(|cell| cell == expected),
+        "expected the git-abbreviated head {expected:?} in the CI row: {row:?}"
+    );
+    assert!(
+        !stdout.contains(&head),
+        "the full SHA should not reach the table:\n{stdout}"
+    );
 }
 
 #[rstest]
@@ -1877,7 +1923,7 @@ fn test_state_get_comprehensive(repo: TestRepo) {
         &repo,
         "feature",
         &format!(
-            r#"{{"status":{{"ci_status":"passed","source":"pr","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"abc12345def67890","branch":"feature"}}"#
+            r#"{{"status":{{"ci_status":"passed","source":"pr","is_stale":false}},"checked_at":{TEST_EPOCH},"head":"abc12345","branch":"feature"}}"#
         ),
     );
 

--- a/tests/integration_tests/switch.rs
+++ b/tests/integration_tests/switch.rs
@@ -2446,7 +2446,7 @@ fn test_switch_prs_dry_run_github(repo: TestRepo) {
 /// commits` on `COLLECT_POOL`, keyed by the row's `pr:{N}` token. The dry-run
 /// path joins that work and dumps the preview cache, so a `{branch:"pr:42",
 /// mode:2}` (Log) entry with non-empty bytes proves the whole mechanism end to
-/// end: `spawn_compute` → `compute_pr_log` → `render_github_commits` → cache.
+/// end: `spawn_compute` → `compute_pr_log` → `parse_github_commits` → cache.
 ///
 /// `headRefOid` here is a SHA that isn't in the test repo's object store, so
 /// `compute_pr_log`'s local-`git log` fast path misses and falls back to the
@@ -2713,19 +2713,19 @@ fn test_switch_prs_dry_run_gitlab(repo: TestRepo) {
 /// --paginate projects/:fullpath/merge_requests/<n>/commits` / `…/notes?sort=asc`
 /// calls keyed by the row's `mr:{N}` token. Both `mode:2` (Log) and `mode:7`
 /// (Comments) cache entries with non-empty bytes prove `compute_pr_log` /
-/// `compute_pr_comments` → `render_gitlab_commits` / `render_gitlab_notes` →
+/// `compute_pr_comments` → `parse_gitlab_commits` / `render_gitlab_notes` →
 /// cache for the GitLab forge — the half the unit tests (canned JSON straight
 /// into the renderers) can't reach, pinning the endpoint/arg construction.
 ///
 /// Both `glab api …/commits` and `…/notes` match the mock's `api --paginate`
 /// compound key, so one canned response carries all fields each renderer reads
-/// (`short_id`/`title` for commits; `body`/`author`/`created_at`/`system` for
+/// (`id`/`title` for commits; `body`/`author`/`created_at`/`system` for
 /// notes) — serde ignores the rest.
 #[rstest]
 fn test_switch_prs_dry_run_gitlab_deferred_tabs(repo: TestRepo) {
     repo.write_project_config("[forge]\nplatform = \"gitlab\"\n");
     let mr_json = r#"[{"iid":7,"title":"Cache the dependency graph","source_branch":"feat/cache","author":{"username":"alice"},"draft":false,"web_url":"https://gitlab.com/owner/test-repo/-/merge_requests/7"}]"#;
-    let api_json = r#"[{"short_id":"abc12345","title":"Cache deps between jobs","body":"Looks good.","author":{"username":"reviewer"},"created_at":"2024-12-01T00:00:00Z","system":false}]"#;
+    let api_json = r#"[{"id":"abc12345def678900000000000000000000000a","short_id":"abc12345","title":"Cache deps between jobs","body":"Looks good.","author":{"username":"reviewer"},"created_at":"2024-12-01T00:00:00Z","system":false}]"#;
 
     let mock_bin = repo.root_path().join("mock-bin");
     fs::create_dir_all(&mock_bin).unwrap();

--- a/tests/snapshots/integration__integration_tests__config_state__state_get_comprehensive.snap
+++ b/tests/snapshots/integration__integration_tests__config_state__state_get_comprehensive.snap
@@ -21,9 +21,9 @@ expression: "String::from_utf8_lossy(&output.stdout)"
  main    env  staging
 
 [36mCI STATUS CACHE[39m
- Branch  Status Age   Head   
- ─────── ────── ─── ──────── 
- feature passed now abc12345
+ Branch  Status Age  Head   
+ ─────── ────── ─── ─────── 
+ feature passed now abc1234
 
 [36mSUMMARY CACHE[39m
  Branch               Summary               Age 

--- a/tests/snapshots/integration__integration_tests__config_state__state_get_with_ci_entries.snap
+++ b/tests/snapshots/integration__integration_tests__config_state__state_get_with_ci_entries.snap
@@ -15,11 +15,11 @@ expression: "String::from_utf8_lossy(&output.stdout)"
 [107m [0m (none)
 
 [36mCI STATUS CACHE[39m
- Branch  Status Age   Head   
- ─────── ────── ─── ──────── 
- bugfix  failed now 11122233 
- feature passed now abc12345 
- main    none   now deadbeef
+ Branch  Status Age  Head   
+ ─────── ────── ─── ─────── 
+ bugfix  failed now 1112223 
+ feature passed now abc1234 
+ main    none   now deadbee
 
 [36mSUMMARY CACHE[39m
 [107m [0m (none)


### PR DESCRIPTION
Follow-up to #3676, which made `wt list`'s table render git's `%h` instead of `&head[..8]`. The `--prs` `log` tab was the last user-visible fixed-8 abbreviation.

## The defect

`wt switch --prs` renders a row's `log` tab from the local `git log` when the PR head is in the object store, and from `gh pr view <n> --json commits` / `glab api …/commits` when it isn't. The forge path sliced each SHA to 8 characters, so on a repo where git abbreviates to 9 the same commit read `abc1234` at 8 before a fetch and 9 after, and `core.abbrev` never reached the pane at all.

## The fix

`Repository::abbrev_len` asks git how wide it abbreviates in this repo and caches the answer on `RepoCache`, so a picker with 30 PR rows probes once — clones share the `Arc<RepoCache>`, and `once_cell::sync::OnceCell` collapses the concurrent background rows onto one fork.

The pane wants the width rather than `short_sha` because of the branch it sits on: it runs precisely when the head *isn't* local, and `git rev-parse --short` takes a single revision — there is no batched form for a list of absent commits, and looping it would be one subprocess per commit per row. With no objects to disambiguate against, the width is git's whole answer for these SHAs.

Both forge arms now parse the full SHA and share one abbreviation step in `render_commit_lines`. GitLab's ready-made `short_id` goes unused: it's the server's abbreviation, blind to the reader's `core.abbrev`, and taking it printed an MR's commits at a different width from a PR's.

## The audit

#8 claimed the `--prs` tab was the last one; that came from a grep. Sweeping `.take(N)`, `[..N]`, `{:.N}`, `truncate(N)`, `get(..N)`, and `--abbrev`/`--short=` across `src/` turned up one more user-visible case: **`wt config state`'s CI cache table**, which sliced `cached.head` to 8 and now truncates to `abbrev_len`.

One fixed-width slice over a SHA survives deliberately: `collect/tasks.rs` labels a `tracing::debug!` line with `&sha[..8]` as a fallback when a timed-out task has no branch name. It's a trace field rather than rendered output, and the timeout error path is the wrong place to spawn git.

Everything else the sweep found hashes something other than a git object — `config::short_hash`'s base36 branch suffix, `summary.rs`'s content digest — or is a column width rather than a truncation.

## Cost

Both call sites are flat in the number of SHAs: one `git rev-parse --short HEAD` per repo per process.

The first cut of the CI table called `short_sha` per row instead, to keep git's extension of an ambiguous prefix. That's a fork apiece, and it cost more than the whole command was worth — measured on a repo with a cache entry per branch, `wt config state get` at 50 entries:

`wt config state get`, 50 cache entries, release build, hyperfine (warmup 20, 80+ runs, quiet machine):

| | mean ± σ | vs. baseline |
|---|---:|---:|
| before this PR (`.take(8)`) | 22.1 ± 0.8 ms | — |
| `abbrev_len` (this PR) | 26.1 ± 1.3 ms | +4.0 ms, **1.18× ± 0.07** |
| `short_sha` per row | 266.7 ± 3.9 ms | **12×** |

The +18% is one `git rev-parse --short HEAD` against a command whose entire
runtime is ~22 ms. For scale, a trace of the same command shows `gh --version`
at 15.3 ms and `git config --list -z` running three times for ~12 ms, both of
which predate this PR. The probe sits inside the non-empty branch, so a repo
with no CI cache pays nothing.

No Criterion target covers `wt config state` (`time_to_first_output` covers
`remove`/`switch`/`list`; `picker_preview` covers worktree rows, not `--prs`,
which needs a forge CLI), hence the standalone measurement. Worth noting against
the daily suite's own resolution: run-to-run spread on an unchanged bench
(`worktree_scaling/warm/8`, last 10 nightlies) is 18%, so a benchmark would not
have caught the +18% either — though it would have caught the 12×.

So the form here pays one probe and gives up disambiguation. Absent objects have nothing to collide with, and a live collision at 7–9 characters is rare enough for a display column to wear.

On the picker, `abbrev_len` lands on a background pool thread behind a `gh`/`glab` call that costs orders of magnitude more, and never on a first-paint path.

#3676 itself cost nothing at runtime, for the record: `%h` was already in the pre-skeleton `git log --no-walk` batch (`%ct` from the same fork drives row order), and the format string is byte-identical across that commit. It moved where the already-fetched string is copied onto the row and swapped a `COMMIT_HASH_WIDTH = 8` constant for an O(N) width pass over the rendered SHAs. No fork added, no phase reordered — the pre-skeleton budget table in `collect/mod.rs` reads 23 commands on both sides.

## Tests

- `abbrev_len_follows_core_abbrev_and_covers_absent_objects` — the width matches `%h`, `core.abbrev = 12` reaches it, and it equals what git gives for a SHA with no object behind it.
- `render_commits_abbreviates_to_the_given_width` — the pane prints the width it's handed, at 7 and at 12.
- `parse_gitlab_commits_keeps_order_and_takes_the_full_id` — `id` over `short_id`.
- `test_state_get_ci_head_uses_git_abbreviation` — the CI table's Head cell equals `git rev-parse --short`. It can't be a snapshot: the width scales with the repo's object count and a test repo's SHA isn't fixed.

`cargo run -- hook pre-merge --yes`: 4494 passed.

> _This was written by Claude Code on behalf of max-sixty_


