### PR TITLE
docs(tests): describe the stale mock-stub, not only the missing one

### DIFF
--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -12,7 +12,7 @@ cargo test --test integration                                      # integration
 cargo test --test integration --features shell-integration-tests   # + shell tests
 ```
 
-A target-filtered run (`--lib`, `--test integration`, …) on a fresh `target/` panics with "mock-stub binary not found" (a target filter skips the helper-bin build). Fix: `cargo build -p mock-stub`, or use `cargo nextest run` / `cargo llvm-cov nextest`.
+A target filter (`--lib`, `--test integration`, …) never builds `mock-stub`, so the run gets whatever sits in `target/`: a fresh tree has none and panics with "mock-stub binary not found", and a warm one runs the tests against a stale stub, whose failures reflect the code it was built from rather than the change under test. Fix: `cargo build -p mock-stub`, or use `cargo nextest run` / `cargo llvm-cov nextest`.
 
 **Claude Code web:** `task setup-web` installs zsh/fish/nushell, `gh`, and dev tools. Install `task` first if needed: `sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/bin` then `export PATH="$HOME/bin:$PATH"`. The permission tests (`test_permission_error_prevents_save`, `test_approval_prompt_permission_error`) skip automatically when running as root.
 


### PR DESCRIPTION
A target filter (`cargo test --lib`, `--test integration`, …) never builds `mock-stub`, so the binary the tests run against is whatever a previous build left in `target/`. `tests/CLAUDE.md` covered only the empty case — the "not found" panic — and pinned it to a fresh `target/`. On a warm tree the run instead uses a stale stub and fails with messages from the code that stub was built from, which reads as a few hundred failures unrelated to the change under test. That's the case a developer machine actually hits.

Confirmed by touching `tests/helpers/mock-stub/src/main.rs` and running `cargo test --test integration --no-run`: it recompiles `worktrunk` and `wt-perf` and leaves `target/debug/mock-stub` at its old mtime.

No structural fix sits above the doc. `workspace.default-members` covers plain `cargo test` and nextest's `build-bins` setup script covers nextest, but a `--test` filter is scoped to the current package's targets, so cargo has no way to pull in another package's binary. The residual hole is the thing to document.

> _This was written by Claude Code on behalf of max-sixty_
