### PR TITLE
docs: add MiniMax commit generation example

### DIFF
--- a/dev/config.example.toml
+++ b/dev/config.example.toml
@@ -64,6 +64,13 @@
 # [commit.generation]
 # command = "MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --safe-mode --setting-sources='user' --system-prompt=''"
 #
+# ### MiniMax
+#
+# [commit.generation]
+# command = "ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic ANTHROPIC_AUTH_TOKEN=\"$MINIMAX_API_KEY\" ANTHROPIC_MODEL=MiniMax-M3 claude -p --no-session-persistence --tools='' --safe-mode --setting-sources='user' --system-prompt=''"
+#
+# Set MINIMAX_API_KEY in your shell environment. For users in China, replace https://api.minimax.io/anthropic with https://api.minimaxi.com/anthropic.
+#
 # ### Codex
 #
 # [commit.generation]

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -142,6 +142,15 @@ Generate commit messages automatically during merge. Requires an external CLI to
 command = "MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --safe-mode --setting-sources='user' --system-prompt=''"
 ```
 
+### MiniMax
+
+```toml
+[commit.generation]
+command = "ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic ANTHROPIC_AUTH_TOKEN=\"$MINIMAX_API_KEY\" ANTHROPIC_MODEL=MiniMax-M3 claude -p --no-session-persistence --tools='' --safe-mode --setting-sources='user' --system-prompt=''"
+```
+
+Set MINIMAX_API_KEY in your shell environment. For users in China, replace https://api.minimax.io/anthropic with https://api.minimaxi.com/anthropic.
+
 ### Codex
 
 ```toml

--- a/docs/content/llm-commits.md
+++ b/docs/content/llm-commits.md
@@ -29,6 +29,15 @@ command = "MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haik
 
 `--no-session-persistence` prevents the commit conversation from polluting `claude --continue`. `--safe-mode` keeps the run hermetic — no hooks, plugins, MCP, skills, or CLAUDE.md — while leaving authentication working normally, so setups that authenticate via `apiKeyHelper` (not just OAuth or `ANTHROPIC_API_KEY`) still get a key. `--setting-sources='user'` scopes settings to your user config so a project `.claude/settings.json` can't override auth. The remaining flags disable tools, system prompt, and thinking for fast text-only output. `--safe-mode` requires Claude Code ≥ 2.1.169. See [Claude Code docs](https://code.claude.com/docs/en/setup) for installation.
 
+### MiniMax
+
+```toml
+[commit.generation]
+command = "ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic ANTHROPIC_AUTH_TOKEN=\"$MINIMAX_API_KEY\" ANTHROPIC_MODEL=MiniMax-M3 claude -p --no-session-persistence --tools='' --safe-mode --setting-sources='user' --system-prompt=''"
+```
+
+Set `MINIMAX_API_KEY` in your shell environment. For users in China, replace `https://api.minimax.io/anthropic` with `https://api.minimaxi.com/anthropic`. See [MiniMax API docs](https://platform.minimax.io/docs/api-reference/api-overview).
+
 ### Codex
 
 ```toml

--- a/plugins/worktrunk/skills/worktrunk/reference/config.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/config.md
@@ -141,6 +141,15 @@ Generate commit messages automatically during merge. Requires an external CLI to
 command = "MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --safe-mode --setting-sources='user' --system-prompt=''"
 ```
 
+### MiniMax
+
+```toml
+[commit.generation]
+command = "ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic ANTHROPIC_AUTH_TOKEN=\"$MINIMAX_API_KEY\" ANTHROPIC_MODEL=MiniMax-M3 claude -p --no-session-persistence --tools='' --safe-mode --setting-sources='user' --system-prompt=''"
+```
+
+Set MINIMAX_API_KEY in your shell environment. For users in China, replace https://api.minimax.io/anthropic with https://api.minimaxi.com/anthropic.
+
 ### Codex
 
 ```toml

--- a/plugins/worktrunk/skills/worktrunk/reference/llm-commits.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/llm-commits.md
@@ -15,6 +15,15 @@ command = "MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haik
 
 `--no-session-persistence` prevents the commit conversation from polluting `claude --continue`. `--safe-mode` keeps the run hermetic — no hooks, plugins, MCP, skills, or CLAUDE.md — while leaving authentication working normally, so setups that authenticate via `apiKeyHelper` (not just OAuth or `ANTHROPIC_API_KEY`) still get a key. `--setting-sources='user'` scopes settings to your user config so a project `.claude/settings.json` can't override auth. The remaining flags disable tools, system prompt, and thinking for fast text-only output. `--safe-mode` requires Claude Code ≥ 2.1.169. See [Claude Code docs](https://code.claude.com/docs/en/setup) for installation.
 
+### MiniMax
+
+```toml
+[commit.generation]
+command = "ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic ANTHROPIC_AUTH_TOKEN=\"$MINIMAX_API_KEY\" ANTHROPIC_MODEL=MiniMax-M3 claude -p --no-session-persistence --tools='' --safe-mode --setting-sources='user' --system-prompt=''"
+```
+
+Set `MINIMAX_API_KEY` in your shell environment. For users in China, replace `https://api.minimax.io/anthropic` with `https://api.minimaxi.com/anthropic`. See [MiniMax API docs](https://platform.minimax.io/docs/api-reference/api-overview).
+
 ### Codex
 
 ```toml

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -141,6 +141,15 @@ Generate commit messages automatically during merge. Requires an external CLI to
 command = "MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --safe-mode --setting-sources='user' --system-prompt=''"
 ```
 
+### MiniMax
+
+```toml
+[commit.generation]
+command = "ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic ANTHROPIC_AUTH_TOKEN=\"$MINIMAX_API_KEY\" ANTHROPIC_MODEL=MiniMax-M3 claude -p --no-session-persistence --tools='' --safe-mode --setting-sources='user' --system-prompt=''"
+```
+
+Set MINIMAX_API_KEY in your shell environment. For users in China, replace https://api.minimax.io/anthropic with https://api.minimaxi.com/anthropic.
+
 ### Codex
 
 ```toml

--- a/skills/worktrunk/reference/llm-commits.md
+++ b/skills/worktrunk/reference/llm-commits.md
@@ -15,6 +15,15 @@ command = "MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haik
 
 `--no-session-persistence` prevents the commit conversation from polluting `claude --continue`. `--safe-mode` keeps the run hermetic — no hooks, plugins, MCP, skills, or CLAUDE.md — while leaving authentication working normally, so setups that authenticate via `apiKeyHelper` (not just OAuth or `ANTHROPIC_API_KEY`) still get a key. `--setting-sources='user'` scopes settings to your user config so a project `.claude/settings.json` can't override auth. The remaining flags disable tools, system prompt, and thinking for fast text-only output. `--safe-mode` requires Claude Code ≥ 2.1.169. See [Claude Code docs](https://code.claude.com/docs/en/setup) for installation.
 
+### MiniMax
+
+```toml
+[commit.generation]
+command = "ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic ANTHROPIC_AUTH_TOKEN=\"$MINIMAX_API_KEY\" ANTHROPIC_MODEL=MiniMax-M3 claude -p --no-session-persistence --tools='' --safe-mode --setting-sources='user' --system-prompt=''"
+```
+
+Set `MINIMAX_API_KEY` in your shell environment. For users in China, replace `https://api.minimax.io/anthropic` with `https://api.minimaxi.com/anthropic`. See [MiniMax API docs](https://platform.minimax.io/docs/api-reference/api-overview).
+
 ### Codex
 
 ```toml

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -2011,6 +2011,15 @@ Generate commit messages automatically during merge. Requires an external CLI to
 command = "MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --safe-mode --setting-sources='user' --system-prompt=''"
 ```
 
+### MiniMax
+
+```toml
+[commit.generation]
+command = "ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic ANTHROPIC_AUTH_TOKEN=\"$MINIMAX_API_KEY\" ANTHROPIC_MODEL=MiniMax-M3 claude -p --no-session-persistence --tools='' --safe-mode --setting-sources='user' --system-prompt=''"
+```
+
+Set MINIMAX_API_KEY in your shell environment. For users in China, replace https://api.minimax.io/anthropic with https://api.minimaxi.com/anthropic.
+
 ### Codex
 
 ```toml

--- a/tests/snapshots/integration__integration_tests__help__help_config_create.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_create.snap
@@ -139,6 +139,13 @@ Creates [2m~/.config/worktrunk/config.toml[0m with the following content:
 [107m [0m [2m# [commit.generation][0m
 [107m [0m [2m# command = "MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --safe-mode --setting-sources='user' --system-prompt=''"[0m
 [107m [0m [2m#[0m
+[107m [0m [2m# ### MiniMax[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# [commit.generation][0m
+[107m [0m [2m# command = "ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic ANTHROPIC_AUTH_TOKEN=\"$MINIMAX_API_KEY\" ANTHROPIC_MODEL=MiniMax-M3 claude -p --no-session-persistence --tools='' --safe-mode --setting-sources='user' --system-prompt=''"[0m
+[107m [0m [2m#[0m
+[107m [0m [2m# Set MINIMAX_API_KEY in your shell environment. For users in China, replace https://api.minimax.io/anthropic with https://api.minimaxi.com/anthropic.[0m
+[107m [0m [2m#[0m
 [107m [0m [2m# ### Codex[0m
 [107m [0m [2m#[0m
 [107m [0m [2m# [commit.generation][0m

--- a/tests/snapshots/integration__integration_tests__help__help_config_long.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_long.snap
@@ -187,6 +187,13 @@ Generate commit messages automatically during merge. Requires an external CLI to
 [107m [0m [2m[36m[commit.generation][0m
 [107m [0m [2mcommand = [0m[2m[32m"MAX_THINKING_TOKENS=0 claude -p --no-session-persistence --model=haiku --tools='' --safe-mode --setting-sources='user' --system-prompt=''"[0m
 
+[32mMiniMax[0m
+
+[107m [0m [2m[36m[commit.generation][0m
+[107m [0m [2mcommand = [0m[2m[32m"ANTHROPIC_BASE_URL=https://api.minimax.io/anthropic ANTHROPIC_AUTH_TOKEN=\"$MINIMAX_API_KEY\" ANTHROPIC_MODEL=MiniMax-M3 claude -p --no-session-persistence --tools='' --safe-mode --setting-sources='user' --system-prompt=''"[0m
+
+Set MINIMAX_API_KEY in your shell environment. For users in China, replace https://api.minimax.io/anthropic with https://api.minimaxi.com/anthropic.
+
 [32mCodex[0m
 
 [107m [0m [2m[36m[commit.generation][0m


### PR DESCRIPTION
Reason: Add a documented MiniMax option for Worktrunk commit message generation.

## Summary

- Document a MiniMax-M3 command using the supported global endpoint.
- Note the regional endpoint used in China.
- Refresh generated config references, skill mirrors, and help snapshots.

## Checks

- `cargo fmt --check`
- `cargo test --test integration readme_sync`
- `cargo test --test integration 'help::test_help'`
