### PR TITLE
docs(remove): record the dirty-worktree gate as a match-git decision

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,10 @@ Never risk data loss without explicit user consent. A failed command that preser
 - **Time-of-check vs time-of-use** — be conservative when there's a gap between the safety check and the operation. `wt merge` verifies clean before rebasing, but files could appear before cleanup — don't force-remove during cleanup.
 - **Replace files, never truncate them** — `fs::write` truncates before it writes, so a crash mid-write leaves the file empty. Every write to a file worktrunk can't put back (rc files, shell wrappers, `config.toml`, `approvals.toml`, another tool's `settings.json`) goes through `utils::write_atomically`, which renames a sibling temp file over the target; the spec on that function covers symlinks, mode, and what a rename costs. Regenerable content (the cache, the `-vv` diagnostic report) keeps the plain write.
 
-These stop where git's own protections stop: `wt merge` and `wt step push` overwrite an ignored file in the destination worktree whose path the incoming commits track, exactly as a `git merge` run there would. Matching git is deliberate — the spec in `src/commands/worktree/push.rs` says why.
+These stop where git's own protections stop, and matching git is deliberate in each case. The named spec says why:
+
+- `wt merge` and `wt step push` overwrite an ignored file in the destination worktree whose path the incoming commits track, exactly as a `git merge` run there would (`src/commands/worktree/push.rs`).
+- Removal's final dirty-worktree gate is answered by the fsmonitor daemon under `core.fsmonitor`, exactly as `git worktree remove`'s own gate is (`src/git/remove.rs`).
 
 Full inventory: FAQ [What files does Worktrunk create?](docs/content/faq.md#what-files-does-worktrunk-create) and [What can Worktrunk delete?](docs/content/faq.md#what-can-worktrunk-delete). Review new code that changes this surface against those sections.
 

--- a/src/git/remove.rs
+++ b/src/git/remove.rs
@@ -35,6 +35,22 @@
 //!    - [`ForceDelete`](BranchDeletionMode::ForceDelete): run `branch -D`
 //!      without the integration check.
 //!
+//! # The dirty-worktree gate follows git
+//!
+//! Under `core.fsmonitor` the daemon answers step 1's `git status`, so a
+//! daemon returning a stale clean answer would let removal delete uncommitted
+//! work. That is git's own line, not a gap in `wt`: `git worktree remove`
+//! refuses a dirty worktree off the same daemon-served status, and on detected
+//! event loss the builtin daemon forces a client rescan or exits. A stale
+//! clean answer therefore requires an *undetected* loss, which lies to the
+//! user's own `git status` in that worktree just as readily.
+//!
+//! Matching git is the decision. Scoping `-c core.fsmonitor=` to that one call
+//! would make `wt` stricter than the command it replaces, and would restore
+//! the full re-stat the ordering above avoids — the dominant per-removal cost
+//! at rust-lang/rust scale. (`--no-optional-locks` is not that knob: it
+//! governs index-lock acquisition, and git still queries the daemon under it.)
+//!
 //! # Example
 //!
 //! ```no_run


### PR DESCRIPTION
Closes #3646.

**Recommendation: keep the daemon-served gate. No behavior change.** This PR records that as a decision so the next release review doesn't re-litigate it.

`wt remove`'s final dirty-worktree check is answered by the fsmonitor daemon when `core.fsmonitor` is set. #3646 asked whether the default removal path should trust that for the last gate before a destructive rename. Three findings decide it, all verified against git 2.55.0 and the current tree:

**`git worktree remove` gates on the same daemon-served status.** With `core.fsmonitor=true`, it detects a modification through `fsmonitor_refresh_callback` and refuses. So `wt remove`'s gate is exactly as daemon-trusting as the command it replaces; forcing a non-daemon status would make `wt` stricter than git, which is the thing `src/commands/worktree/push.rs` already declines to do for ignored-file overwrites.

**The posited failure mode is guarded in git's builtin daemon.** All three backends meet detected event loss by making clients rescan: `fsm-listen-darwin.c` calls `fsmonitor_force_resync()` on `ef_is_dropped()`, `fsm-listen-win32.c` calls it on the `watch->count == 0` kernel-buffer overflow, and `fsm-listen-linux.c` force-shuts the daemon down on `IN_Q_OVERFLOW`. A stale clean answer therefore needs an *undetected* loss, which lies to the user's own `git status` in that worktree just as readily.

**Only `-c core.fsmonitor=` would close the gap, and it costs exactly what #3617 removed.** Confirmed as @worktrunk-bot reported: `--no-optional-locks` still queries the daemon. A non-fsmonitor status is the full-tree re-stat that #3617 measured as the dominant per-removal cost at rust-lang/rust scale, and it would fall only on repos whose owners enabled fsmonitor to avoid full scans.

<details><summary>git 2.55.0 traces</summary>

`git worktree remove` on a dirty worktree, `core.fsmonitor=true`:

```
fsmonitor.c:534         refresh fsmonitor
fsmonitor.c:443         fsmonitor_refresh_callback 'f1.txt' (pos 0)
fsmonitor.c:202         fsmonitor_refresh_callback INV: 'f1.txt'
fatal: '.../wt-test' contains modified or untracked files, use --force to delete it
```

`--no-optional-locks` vs `-c core.fsmonitor=`:

```
=== git --no-optional-locks status --porcelain ===
fsmonitor.c:534         refresh fsmonitor     # still queries the daemon

=== git -c core.fsmonitor= status --porcelain ===
fsmonitor.c:786         remove fsmonitor      # bypasses the daemon
```

</details>

### Two premises in the issue that don't hold

Neither changes the conclusion, but both should leave the record.

**There is no 24-hour recovery window.** The issue's third "acceptable" reason says a worktree lost this way is recoverable for a day. On the normal path the detached process runs `rm -rf` on the staged directory immediately — `build_remove_command_staged` emits `rm -rf -- <staged>`. The 24-hour sweep (`TRASH_STALE_THRESHOLD_SECS`) collects entries orphaned when a background removal was *interrupted*. So the gate is the last line with nothing behind it, which weakens the acceptance case; the two findings above carry it instead. No user-facing doc claims otherwise — the FAQ and `config state` both describe trash accurately.

**The wedged daemon worktrunk already handles fails safe.** The issue cites `stop_fsmonitor_daemon` force-killing a wedged daemon as evidence that wedged daemons are real. That function's own spec describes the case it handles as "one that has stopped answering its socket — the common failure, which also hangs `git status` in that worktree". A daemon that stops answering makes status hang or full-scan; it doesn't return stale-clean. That's evidence for the safe failure direction, not the dangerous one.

### The change

Comments only. The removal module spec gains a `# The dirty-worktree gate follows git` section stating the decision and why `-c core.fsmonitor=` isn't the fix, and `CLAUDE.md`'s "stop where git's own protections stop" paragraph gains this as its second instance, so a release data-loss review lands on it. Lint, clippy, and rustdoc under `-Dwarnings` pass; no behavior or tests change.

> _This was written by Claude Code on behalf of max-sixty_
