### PR TITLE
test: run the git-hook autostash tests on every platform

### DIFF
--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -24,6 +24,30 @@ use tempfile::TempDir;
 use worktrunk::path::to_posix_path;
 
 // =============================================================================
+// Git hooks
+// =============================================================================
+
+/// Write `script` as a native git hook at `path` and make git willing to run it.
+///
+/// Git runs hooks through a shell it ships on every platform, so the script is
+/// `sh` regardless of host and the hook itself needs no platform gate. Only the
+/// executable bit does, since Windows has none to set. A path interpolated into
+/// the script needs forward slashes (`path_slash::PathExt::to_slash_lossy`), or
+/// a Windows path's separators reach `sh` as escapes.
+pub fn write_git_hook(path: &Path, script: &str) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).unwrap();
+    }
+    std::fs::write(path, script).unwrap();
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt as _;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o755)).unwrap();
+    }
+}
+
+// =============================================================================
 // Signal handling (for PTY tests)
 // =============================================================================
 

--- a/tests/integration_tests/merge.rs
+++ b/tests/integration_tests/merge.rs
@@ -3,7 +3,7 @@ use crate::common::{
     mock_commands::{create_mock_cargo, create_mock_llm_auth},
     repo, repo_with_alternate_primary, repo_with_main_worktree, repo_with_multi_commit_feature,
     repo_with_remote, setup_snapshot_settings, wait_for_file, wait_for_file_content,
-    wait_for_worktree_removed,
+    wait_for_worktree_removed, write_git_hook,
 };
 use insta::assert_snapshot;
 use insta_cmd::assert_cmd_snapshot;
@@ -1941,11 +1941,8 @@ post-merge = "touch {{ repo_path }}/post-merge-race-ran"
     );
 }
 
-#[cfg(unix)]
 #[rstest]
 fn test_merge_target_diverges_during_receive_restores_autostash(mut repo: TestRepo) {
-    use std::os::unix::fs::PermissionsExt as _;
-
     let feature_wt = repo.add_worktree_with_commit(
         "feature-receive-race",
         "feature.txt",
@@ -1956,11 +1953,10 @@ fn test_merge_target_diverges_during_receive_restores_autostash(mut repo: TestRe
 
     let git_common_dir =
         repo.git_output(&["rev-parse", "--path-format=absolute", "--git-common-dir"]);
-    let hooks_dir = PathBuf::from(git_common_dir).join("hooks");
-    fs::create_dir_all(&hooks_dir).unwrap();
-    let hook_path = hooks_dir.join("pre-receive");
-    fs::write(
-        &hook_path,
+    write_git_hook(
+        &PathBuf::from(git_common_dir)
+            .join("hooks")
+            .join("pre-receive"),
         r#"#!/bin/sh
 set -eu
 unset GIT_QUARANTINE_PATH GIT_OBJECT_DIRECTORY GIT_ALTERNATE_OBJECT_DIRECTORIES
@@ -1969,9 +1965,7 @@ tree=$(git rev-parse "${target}^{tree}")
 concurrent=$(printf 'concurrent target\n' | git commit-tree "$tree" -p "$target")
 git update-ref refs/heads/main "$concurrent" "$target"
 "#,
-    )
-    .unwrap();
-    fs::set_permissions(&hook_path, fs::Permissions::from_mode(0o755)).unwrap();
+    );
 
     let target_before = repo.git_output(&["rev-parse", "main"]);
     let source_tip = repo.git_output(&["rev-parse", "feature-receive-race"]);

--- a/tests/integration_tests/push.rs
+++ b/tests/integration_tests/push.rs
@@ -1,9 +1,32 @@
 use crate::common::{
     TestRepo, make_snapshot_cmd, repo, repo_with_feature_worktree, repo_with_remote,
-    setup_snapshot_settings,
+    setup_snapshot_settings, write_git_hook,
 };
 use insta_cmd::assert_cmd_snapshot;
 use rstest::rstest;
+
+/// Install a `post-receive` hook whose body `build_body` composes from the repo
+/// root, passed in forward-slashed form.
+///
+/// The hook fires during `wt`'s own `git push`, which is the window between the
+/// autostash capture and its restore. Git runs hooks through a shell it
+/// provides on every platform, so the script is `sh` either way, and the root
+/// is forward-slashed for the same reason — a Windows path's backslashes would
+/// otherwise reach `sh` as escapes.
+fn install_post_receive_hook(root: &std::path::Path, build_body: impl FnOnce(&str) -> String) {
+    use path_slash::PathExt as _;
+
+    let body = build_body(&root.to_slash_lossy());
+    write_git_hook(
+        &root.join(".git/hooks/post-receive"),
+        &format!(
+            "#!/bin/sh\n\
+             unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_QUARANTINE_PATH\n\
+             {body}\n\
+             exit 0\n"
+        ),
+    );
+}
 
 /// Helper to create snapshot with normalized paths
 fn snapshot_push(test_name: &str, repo: &TestRepo, args: &[&str], cwd: Option<&std::path::Path>) {
@@ -135,33 +158,21 @@ fn test_push_dirty_target_autostash(mut repo: TestRepo) {
 /// A `post-receive` hook is the deterministic stand-in for the concurrent
 /// writer: it fires during `wt`'s own fast-forward `git push`, which is exactly
 /// the window between the autostash capture and its restore.
-#[cfg(unix)]
 #[rstest]
 fn test_push_autostash_survives_concurrent_stash(mut repo: TestRepo) {
-    use std::os::unix::fs::PermissionsExt;
-
     // Uncommitted, non-conflicting work in the target worktree (repo root).
     let notes = repo.root_path().join("notes.txt");
     std::fs::write(&notes, "PRECIOUS-USER-WORK").unwrap();
 
     // A post-receive hook that pushes an unrelated stash during the push,
     // shifting the reflog indices out from under the autostash entry.
-    let root = repo.root_path().to_path_buf();
-    let hook = root.join(".git/hooks/post-receive");
-    std::fs::write(
-        &hook,
+    install_post_receive_hook(repo.root_path(), |root| {
         format!(
-            "#!/bin/sh\n\
-             unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_QUARANTINE_PATH\n\
-             printf 'interloper\\n' > '{root}/interloper.txt'\n\
+            "printf 'interloper\\n' > '{root}/interloper.txt'\n\
              git -C '{root}' -c user.email=i@i -c user.name=I \
-                 stash push --include-untracked -m INTERLOPER >/dev/null 2>&1\n\
-             exit 0\n",
-            root = root.display(),
-        ),
-    )
-    .unwrap();
-    std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755)).unwrap();
+                 stash push --include-untracked -m INTERLOPER >/dev/null 2>&1"
+        )
+    });
 
     let feature_wt = repo.add_feature();
 
@@ -201,31 +212,17 @@ fn test_push_autostash_survives_concurrent_stash(mut repo: TestRepo) {
 /// by the time the push finishes — must warn with a recoverable `git stash
 /// apply <sha>` rather than silently report success. Data-safety guard for
 /// #3683: the stash entry is left intact so the work is recoverable.
-#[cfg(unix)]
 #[rstest]
 fn test_push_autostash_restore_failure_warns(mut repo: TestRepo) {
-    use std::os::unix::fs::PermissionsExt;
-
     // Untracked, non-conflicting work in the target worktree (repo root).
     std::fs::write(repo.root_path().join("notes.txt"), "USER-WORK").unwrap();
 
     // A post-receive hook re-creates the stashed path with different content,
     // so `git stash apply` can't restore the untracked file and the restore
     // fails after the push has already landed.
-    let root = repo.root_path().to_path_buf();
-    let hook = root.join(".git/hooks/post-receive");
-    std::fs::write(
-        &hook,
-        format!(
-            "#!/bin/sh\n\
-             unset GIT_DIR GIT_WORK_TREE GIT_INDEX_FILE GIT_QUARANTINE_PATH\n\
-             printf 'HOOK-CONFLICT\\n' > '{root}/notes.txt'\n\
-             exit 0\n",
-            root = root.display(),
-        ),
-    )
-    .unwrap();
-    std::fs::set_permissions(&hook, std::fs::Permissions::from_mode(0o755)).unwrap();
+    install_post_receive_hook(repo.root_path(), |root| {
+        format!("printf 'HOOK-CONFLICT\\n' > '{root}/notes.txt'")
+    });
 
     let feature_wt = repo.add_feature();
 


### PR DESCRIPTION
Split out of #3693 so it can be reviewed on its own. Follows #3684.

## Problem

The three tests that install a native git hook — `test_push_autostash_survives_concurrent_stash`, `test_push_autostash_restore_failure_warns`, and `test_merge_target_diverges_during_receive_restores_autostash` — were gated `#[cfg(unix)]`, so the autostash regression they guard went unverified on Windows.

Nothing they assert is unix-specific; git runs hooks through a shell it ships on every platform. The gate was carrying two incidental blockers:

- `std::os::unix::fs::PermissionsExt`, for an executable bit Windows has none of.
- A `root.display()` path interpolated into the hook script, whose Windows backslashes would reach `sh` as escapes.

## Solution

`common::write_git_hook` writes the hook and gates only the chmod, so the platform fact lives in one place instead of being re-derived per test. The repo root is interpolated with `path_slash`'s `to_slash_lossy` — the form `step_prune.rs` already uses to embed a path in a hook command that runs on Windows.

## Why un-gating is safe

Each test asserts that its own hook fired: the push tests require `INTERLOPER` in the stash list, and the merge test requires the target ref to have advanced. A hook that silently fails to run on Windows therefore fails the test rather than passing vacuously.

Confirmed rather than assumed — on the stacked branch these tests ran green on `test (windows)`, and pulling that job's junit artifact shows all three present by name, so they executed rather than being filtered out.

## Sweep

The rest of the suite's platform gates were checked and left alone; the remaining ones are gated for real reasons: symlinks, signal delivery, unix permission bits, `lsof`/fsmonitor daemon reaping, shell-script `git` shims on `PATH` (Windows can't exec a shebang script that way), ConPTY output capture, and clap's differing `[experimental]` tag rendering in Windows snapshots (`step_alias.rs`, `help.rs` — already documented in-place). The `#[ignore]`s and elevated-privileges runtime skips are likewise documented and intentional.

> _This was written by Claude Code on behalf of max-sixty_
