### PR TITLE
docs(claude): record the immutable-id-over-list-position rule

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,10 @@ Prefer exit codes / `--porcelain` / `--json` over parsing human-readable message
 
 When no structured alternative exists, document the fragility inline.
 
+### Immutable Ids Over List Positions
+
+`stash@{0}` names a position in a list any process can reorder, so a handle captured before a mutation window and used after it can resolve to a different object — restoring the target worktree's autostash by position after `git push` silently restored a concurrent writer's entry and reported success. Capture the immutable id instead (`git stash list --format=%H`, `git stash create`, `rev-parse`) and act on that; where an operation accepts only a positional selector, re-derive it from something stable immediately beforehand, as `StashData::locate_by_message` does before dropping the entry. An index into a collection `wt` owns is a different thing — this is about namespaces other processes can mutate.
+
 ### Network Access
 
 worktrunk is local-first: the network is touched only when the user asked for it, and only where reaching the wire directly serves that request. **One detection helper is exempt:** the *first* `Repository::default_branch()` per repo may fall through to `git ls-remote`; the result caches in `worktrunk.default-branch` and every later call is local. The query is bounded by `REMOTE_DETECTION_TIMEOUT` — nothing in git bounds it, and an unreachable host costs ~127 s per address on Linux — and a query that hits the bound falls back to local inference *without* caching it, so an outage can't make a guess permanent. No other detection helper may add a similar fallback.


### PR DESCRIPTION
Follows #3693. That PR fixed the autostash restore; this records the rule it was an instance of, so the next one doesn't have to be found the hard way.

## Why

The bug was holding `stash@{0}` — a *position* in a list any process can reorder — across a `git push`, then acting on it. Nothing in the guidance said not to. `CLAUDE.md` already has a rule for picking a robust handle over a fragile one (**Structured Output Over Error-Message Parsing**), so this sits next to it as a sibling.

## Scope of the rule

I swept the codebase for other instances before writing it. There are none, and the three places that *look* like the bug shape are why the rule is worded narrowly:

- `create_safety_backup` (`working_tree.rs`) already does it right — `git stash create` returns a SHA that never enters the stash list, stored under a named `refs/wt-backup/<branch>` ref.
- `orphan_branch_age` (`step/prune.rs`) reads `reflog show` for a named ref and takes the oldest line as a creation timestamp. Single-shot, no mutation window; a pruned reflog makes a branch read younger, which skips it from pruning and so fails safe.
- `relocate.rs` holds `idx` into `pending` across cycle-breaking moves. Not the bug shape: `pending` is built once, only ever read, and owned by `wt`.

So the rule is about namespaces *other processes can mutate*, not about indices generally. Stated loosely it would invite "fixing" `relocate.rs` and making it worse — hence the closing sentence drawing that line explicitly.

The one surviving positional selector, inside `StashData::locate_by_message`, is cited in the rule as the correct pattern: re-derive the selector from something stable immediately before the operation that needs it.

## Testing

Docs-only. `cargo run -- hook pre-merge --yes` green.

> _This was written by Claude Code on behalf of max-sixty_
