### PR TITLE
ci(release): scope SIGNPATH_API_TOKEN to a dedicated signing environment

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -25,8 +25,11 @@ Only the repo owner (`@max-sixty`, admin) can merge to `main`.
 
 ## Environment protection
 
-`AUR_SSH_PRIVATE_KEY` is in a protected GitHub Environment (`release`) requiring
-deployment approval from `@max-sixty`, restricted to `v*` tags.
+The `release` environment holds the credentials only a release build needs —
+`AUR_SSH_PRIVATE_KEY` and `SIGNPATH_API_TOKEN` — so no other workflow the repo
+runs can read them. Its one protection rule restricts deployments to `v*` tags;
+there is no reviewer gate, so adding `environment: release` to a job costs no
+approval step.
 
 crates.io publishing holds no stored token — it uses Trusted Publishing.
 crates.io mints a short-lived one only for an OIDC claim from `release.yaml`

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -25,11 +25,17 @@ Only the repo owner (`@max-sixty`, admin) can merge to `main`.
 
 ## Environment protection
 
-The `release` environment holds the credentials only a release build needs —
-`AUR_SSH_PRIVATE_KEY` and `SIGNPATH_API_TOKEN` — so no other workflow the repo
-runs can read them. Its one protection rule restricts deployments to `v*` tags;
-there is no reviewer gate, so adding `environment: release` to a job costs no
-approval step.
+Release credentials live in GitHub Environments so no other workflow the repo
+runs can read them. Each environment holds what one phase needs, since a job
+that joins an environment can read every secret in it:
+
+| Environment | Secret | Read by |
+|-------------|--------|---------|
+| `release` | `AUR_SSH_PRIVATE_KEY` | `publish-aur` |
+| `signing` | `SIGNPATH_API_TOKEN` | `build-local-artifacts` |
+
+Both restrict deployments to `v*` tags and neither has a reviewer rule, so
+joining a job to one costs no approval step.
 
 crates.io publishing holds no stored token — it uses Trusted Publishing.
 crates.io mints a short-lived one only for an OIDC claim from `release.yaml`

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -117,9 +117,8 @@ jobs:
     container: ${{ matrix.container && matrix.container.image || null }}
     # This job doesn't deploy anything; the environment scopes
     # SIGNPATH_API_TOKEN so it isn't readable by every workflow the repo runs.
-    # `signing` holds that one token rather than `release` holding it alongside
-    # the publish credentials, which this job has no business reading. The
-    # environment restricts deployments to `v*` tags, so setting
+    # It is deliberately not `release`, which also holds the publish
+    # credentials — see .github/CLAUDE.md. The `v*` tag policy means setting
     # `pr-run-mode = "upload"` in dist-workspace.toml would make GitHub reject
     # this job on a PR ref.
     environment: signing

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -115,6 +115,12 @@ jobs:
       matrix: ${{ fromJson(needs.plan.outputs.val).ci.github.artifacts_matrix }}
     runs-on: ${{ matrix.runner }}
     container: ${{ matrix.container && matrix.container.image || null }}
+    # This job doesn't deploy anything; the environment scopes
+    # SIGNPATH_API_TOKEN so it isn't readable by every workflow the repo runs.
+    # The environment restricts deployments to `v*` tags, so setting
+    # `pr-run-mode = "upload"` in dist-workspace.toml would make GitHub reject
+    # this job on a PR ref.
+    environment: release
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -117,10 +117,12 @@ jobs:
     container: ${{ matrix.container && matrix.container.image || null }}
     # This job doesn't deploy anything; the environment scopes
     # SIGNPATH_API_TOKEN so it isn't readable by every workflow the repo runs.
-    # The environment restricts deployments to `v*` tags, so setting
+    # `signing` holds that one token rather than `release` holding it alongside
+    # the publish credentials, which this job has no business reading. The
+    # environment restricts deployments to `v*` tags, so setting
     # `pr-run-mode = "upload"` in dist-workspace.toml would make GitHub reject
     # this job on a PR ref.
-    environment: release
+    environment: signing
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       BUILD_MANIFEST_NAME: target/distrib/${{ join(matrix.targets, '-') }}-dist-manifest.json


### PR DESCRIPTION
`SIGNPATH_API_TOKEN` sits at repo level, where every workflow the repo runs can read it. It is referenced once, by the "Submit SignPath signing request" step in `build-local-artifacts`. This joins that job to a new `signing` environment so the token can be held there instead.

The environment already exists, with a `v*` tag policy and no reviewer rule. It holds no secret yet, and this PR is safe to merge before it does: an environment secret *overrides* a repository one of the same name rather than displacing access to it, so until `signing` holds a token the job keeps reading the repo-level copy and signing behaves exactly as it does today.

Two steps remain, and both need the token value, which is write-only and so has to be set by hand — or re-issued from the SignPath console, which rotates it at the same time:

```
gh secret set SIGNPATH_API_TOKEN --repo max-sixty/worktrunk --env signing
```

```
gh secret delete SIGNPATH_API_TOKEN --repo max-sixty/worktrunk
```

The delete is what clears the drift, and it is the one step with an ordering constraint: run it after the environment secret exists, or the next release signs with an empty token.

## Why a new environment rather than the existing `release`

Reusing `release` looks cheaper, and the usual objection to it turns out to be false: `release` has no reviewer rule, so it would not have pulled an approval gate into the build phase. Its only protection rule is a `v*` tag policy, which is why `publish-cargo` and `publish-aur` deploy to it unattended today.

The real problem is the other direction. A job that joins an environment can read *every* secret in it, and `release` holds `AUR_SSH_PRIVATE_KEY`. Putting `build-local-artifacts` there would give the build phase the AUR deploy key, so the change would trade one over-broad grant for another rather than removing one. `signing` holds the single token its single consumer needs.

Allowlisting the secret in `.config/tend.yaml` was the third option. It records "intentionally repo-wide", which is the wrong posture for a credential that becomes a real code-signing key once the SignPath OSS application clears. It is a self-signed test certificate today, which is the argument for moving it now rather than after.

<details><summary>Verification</summary>

`.github/CLAUDE.md` claimed the `release` environment required "deployment approval from `@max-sixty`". That was the source of the approval-gate objection, and it was wrong:

```
$ gh api repos/max-sixty/worktrunk/environments/release
"protection_rules": [{"id": 48355233, "type": "branch_policy"}]

$ gh api repos/max-sixty/worktrunk/environments/release/deployment-branch-policies
{"branch_policies": [{"name": "v*", "type": "tag"}]}
```

No `required_reviewers` rule. The v0.71.0 deployment confirms it behaviorally — `waiting` to `queued` in one second, with no approval in between:

```
$ gh api repos/max-sixty/worktrunk/deployments/5682057674/statuses
success      2026-07-30T20:46:46Z
in_progress  2026-07-30T20:45:00Z
queued       2026-07-30T20:44:57Z
waiting      2026-07-30T20:44:56Z
```

That doc line is rewritten here, into a table of which environment holds what and which job reads it.

Three other things worth confirming before touching a dist-generated file:

- **Hand edits survive.** `dist-workspace.toml` sets `allow-dirty = ["ci"]`, and no job anywhere runs `dist generate --check`. The custom `publish-cargo`, `publish-winget`, and `publish-aur` jobs already only exist because of this.
- **The environment doesn't serialize the matrix.** `publish-cargo` and `publish-aur` both target `release` and ran concurrently in the v0.71.0 release (started `20:44:58` and `20:44:59`), so the five matrix legs won't queue behind each other.
- **tend only scans repo-level secrets.** `AUR_SSH_PRIVATE_KEY` and `WINGET_TOKEN` sit in the `release` environment and `tend check` passes them without complaint, so moving `SIGNPATH_API_TOKEN` to an environment is what clears the check.

</details>

## Risk

Low. The repo-level token remains readable until it is deleted, so signing is unaffected by the merge. Even with no token reachable at all, the signing step is `continue-on-error: true` while the certificate is a test one, so it would fail without blocking the crates.io, Homebrew, winget, or AUR publishes — the one step that is deliberately not `continue-on-error` just recomputes a checksum over whatever zip is in place.

One coupling is now load-bearing and is noted in the workflow: the `v*` tag policy means setting `pr-run-mode = "upload"` in `dist-workspace.toml` would make GitHub reject this job on a PR ref. Today `pr-run-mode` defaults to `plan`, so `build-local-artifacts` is skipped on pull requests entirely — which also means this PR's own CI does not exercise the change. The first real exercise is the next release tag.

Ref #3572 — the issue closes once the repo-level secret is deleted.

> _This was written by Claude Code on behalf of max-sixty_
