### PR TITLE
docs(ci): widen the TEND_BOT_TOKEN row past the Claude workflows

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -13,7 +13,7 @@ Workflows check `user.login == 'worktrunk-bot'` directly.
 
 | Token | Purpose |
 |-------|---------|
-| `TEND_BOT_TOKEN` | All Claude workflows — consistent bot identity |
+| `TEND_BOT_TOKEN` | Every workflow acting as `worktrunk-bot`, including the winget and Homebrew publish jobs |
 | `CLAUDE_CODE_OAUTH_TOKEN` | Authenticates Claude Code to the Anthropic API |
 
 ## Merge restriction


### PR DESCRIPTION
`WINGET_TOKEN` sat in the `release` environment with no reference anywhere in the repo. Its last use was removed in December 2025; the February 2026 environment migration carried it across anyway. `publish-winget` also declares no `environment:`, so it could not have read a `release`-scoped secret even if the workflow still named it.

What actually publishes to winget is `TEND_BOT_TOKEN`: as `GH_TOKEN` for the fork-sync step, and as the `token:` input to `vedantmgoyal9/winget-releaser`. Submission to `microsoft/winget-pkgs` is a plain fork-and-PR — there is no separate winget publisher credential — and the v0.71.0 PR there was opened by `worktrunk-bot`, the account that token belongs to.

The secret is deleted. This commit closes the documentation gap that made it look load-bearing: the Tokens table described `TEND_BOT_TOKEN` as covering "All Claude workflows", which left winget publishing with no credential named anywhere.

> _This was written by Claude Code on behalf of max-sixty_
