### PR TITLE
fix(gitea): key tea api errors on the HTTP status line, not the response shape

### DIFF
--- a/src/commands/list/ci_status/gitea.rs
+++ b/src/commands/list/ci_status/gitea.rs
@@ -5,7 +5,7 @@
 
 use serde::Deserialize;
 use std::process::Output;
-use worktrunk::git::remote_ref::gitea::api_error_message;
+use worktrunk::git::remote_ref::gitea::{api_error_message, api_status};
 use worktrunk::git::{Repository, parse_owner_repo};
 
 use super::{
@@ -13,7 +13,11 @@ use super::{
     is_retriable_error, non_interactive_cmd, output_error_text, parse_json,
 };
 
-/// Run `tea api <path>` from the worktree root.
+/// Run `tea api --include <path>` from the worktree root.
+///
+/// `--include` puts the HTTP status line on stderr, which is the only place the
+/// status reaches us — see the [`gitea`](worktrunk::git::remote_ref::gitea)
+/// module docs.
 ///
 /// `is_tool_available` has already confirmed `tea` is on PATH, so a spawn
 /// failure here is an OS-level edge case — fall through to `None` (no CI status
@@ -21,7 +25,7 @@ use super::{
 fn tea_api(repo: &Repository, path: &str) -> Option<Output> {
     let repo_root = repo.current_worktree().root().ok()?;
     non_interactive_cmd("tea")
-        .args(["api", path])
+        .args(["api", "--include", path])
         .current_dir(&repo_root)
         .run()
         .ok()
@@ -30,26 +34,30 @@ fn tea_api(repo: &Repository, path: &str) -> Option<Output> {
 /// The error text of a `tea api` call, or `None` when the response carries the
 /// resource.
 ///
-/// Neither failure shape is an exit code. `tea api` never reads the HTTP status
-/// — it copies the response body to stdout and exits 0 — so a non-zero exit
-/// means `tea` itself failed (transport error, no login configured) and its
-/// stderr names which, while every HTTP error arrives as a successful spawn
-/// carrying Gitea's `APIError` body in place of the resource, which
-/// [`api_error_message`] classifies by shape. Branching on the exit code alone
-/// would let that body through as data: every field of [`GiteaCombinedStatus`]
-/// defaults, so a 500 would deserialize as "no statuses" and paint a blank CI
-/// cell.
+/// Neither failure shape is an exit code. `tea api` exits 0 for every HTTP
+/// response, so a non-zero exit means `tea` itself failed (transport error, no
+/// login configured) and its stderr names which, while every HTTP error arrives
+/// as a successful spawn carrying a body in place of the resource — which
+/// [`api_status`] identifies. Branching on the exit code alone would let that
+/// body through as data: every field of [`GiteaCombinedStatus`] defaults, so a
+/// 500 would deserialize as "no statuses" and paint a blank CI cell.
 ///
-/// A 500 whose message Gitea blanked comes back as an empty string — an error
-/// with nothing to sniff, which [`is_retriable_error`] reads as non-retriable,
-/// so the cell stays blank. That is the same cell the body would have produced
-/// as data, but reaching it as an error keeps the PR-list path from warning
-/// about a Gitea API change when the API in fact answered with an error.
+/// The text is Gitea's own message where it sent one. Where it didn't — a
+/// blanked 5xx, or a proxy's HTML error page in front of Gitea — the error is
+/// empty, which [`is_retriable_error`] reads as non-retriable, so the cell
+/// stays blank. That is the same cell the body would have produced as data, but
+/// reaching it as an error keeps the PR-list path from warning about a Gitea API
+/// change when the API in fact answered with one.
 fn tea_api_error(output: &Output) -> Option<String> {
     if !output.status.success() {
         return Some(output_error_text(output));
     }
-    api_error_message(&output.stdout)
+    match api_status(&output.stderr) {
+        // Only a 2xx/3xx carries the resource. A missing status line means the
+        // response never arrived, so it doesn't either.
+        Some(status) if status < 400 => None,
+        _ => Some(api_error_message(&output.stdout).unwrap_or_default()),
+    }
 }
 
 /// Fetch the combined CI status for a commit SHA.
@@ -283,40 +291,59 @@ mod tests {
         assert_eq!(pr(Some(2)).comment_count(), Some(2));
     }
 
-    /// `tea_api_error` reads the response shape, since the exit code carries
-    /// nothing: a PR array and a combined status are data, an `APIError` body
-    /// is the failure. Gitea blanks the message of a 500 for a non-admin token,
-    /// which leaves nothing to sniff but is still the error shape — it comes
-    /// back as an empty message rather than falling through to the data path,
-    /// where the PR-list parse would blame a Gitea API change.
+    /// `tea_api_error` reads the status line, since the exit code carries
+    /// nothing: a 2xx is data whatever it holds, anything from 400 up is the
+    /// failure whatever it holds. The body only supplies the text, and where
+    /// there is none — a 500 Gitea blanked for a non-admin token, a proxy's
+    /// HTML page — the error is empty rather than falling through to the data
+    /// path, where the PR-list parse would blame a Gitea API change.
     #[test]
-    fn test_tea_api_error_reads_the_response_shape() {
+    fn test_tea_api_error_reads_the_http_status() {
         // `ExitStatus::default()` is success on every platform, so these all
         // exercise the exit-0 path — the one the exit code can't classify.
-        let response = |stdout: &str| Output {
+        let response = |status: &str, stdout: &str| Output {
             status: Default::default(),
             stdout: stdout.as_bytes().to_vec(),
-            stderr: Vec::new(),
+            stderr: format!("HTTP/1.1 {status}\r\nContent-Type: application/json\r\n\r\n")
+                .into_bytes(),
         };
 
-        assert_eq!(tea_api_error(&response("[]")), None);
+        assert_eq!(tea_api_error(&response("200 OK", "[]")), None);
         assert_eq!(
-            tea_api_error(&response(r#"{"state":"success","total_count":2}"#)),
+            tea_api_error(&response(
+                "200 OK",
+                r#"{"state":"success","total_count":2}"#
+            )),
             None
         );
         assert_eq!(
-            tea_api_error(&response(r#"{"message":"token does not have scope"}"#)),
+            tea_api_error(&response(
+                "403 Forbidden",
+                r#"{"message":"token does not have scope"}"#
+            )),
             Some("token does not have scope".to_string())
         );
         // A production 500 for a non-admin token: the envelope, no text.
         assert_eq!(
             tea_api_error(&response(
+                "500 Internal Server Error",
                 r#"{"message":"","url":"https://gitea.example.com/api/swagger"}"#
             )),
             Some(String::new())
         );
+        // A body from in front of Gitea, which the shape check used to read as
+        // data and warn about.
         assert_eq!(
-            tea_api_error(&response(r#"{"message":"  "}"#)),
+            tea_api_error(&response("502 Bad Gateway", "<html>Bad Gateway</html>")),
+            Some(String::new())
+        );
+        // No status line from an exit-0 `tea`: a failure, never the resource.
+        assert_eq!(
+            tea_api_error(&Output {
+                status: Default::default(),
+                stdout: b"[]".to_vec(),
+                stderr: Vec::new(),
+            }),
             Some(String::new())
         );
     }

--- a/src/commands/list/ci_status/gitea.rs
+++ b/src/commands/list/ci_status/gitea.rs
@@ -5,7 +5,7 @@
 
 use serde::Deserialize;
 use std::process::Output;
-use worktrunk::git::remote_ref::gitea::{api_error_message, api_status};
+use worktrunk::git::remote_ref::gitea::api_status;
 use worktrunk::git::{Repository, parse_owner_repo};
 
 use super::{
@@ -31,32 +31,42 @@ fn tea_api(repo: &Repository, path: &str) -> Option<Output> {
         .ok()
 }
 
-/// The error text of a `tea api` call, or `None` when the response carries the
+/// Whether a `tea api` call failed, and if so whether a later `wt list` could
+/// get an answer where this one didn't. `None` when the response carries the
 /// resource.
 ///
-/// Neither failure shape is an exit code. `tea api` exits 0 for every HTTP
-/// response, so a non-zero exit means `tea` itself failed (transport error, no
-/// login configured) and its stderr names which, while every HTTP error arrives
-/// as a successful spawn carrying a body in place of the resource — which
+/// Neither failure is an exit code. `tea api` exits 0 for every HTTP response,
+/// so a non-zero exit means `tea` itself failed and every HTTP error arrives as
+/// a successful spawn carrying a body in place of the resource — which
 /// [`api_status`] identifies. Branching on the exit code alone would let that
 /// body through as data: every field of [`GiteaCombinedStatus`] defaults, so a
 /// 500 would deserialize as "no statuses" and paint a blank CI cell.
 ///
-/// The text is Gitea's own message where it sent one. Where it didn't — a
-/// blanked 5xx, or a proxy's HTML error page in front of Gitea — the error is
-/// empty, which [`is_retriable_error`] reads as non-retriable, so the cell
-/// stays blank. That is the same cell the body would have produced as data, but
-/// reaching it as an error keeps the PR-list path from warning about a Gitea API
-/// change when the API in fact answered with one.
-fn tea_api_error(output: &Output) -> Option<String> {
+/// Retriability then comes from whichever channel knows:
+///
+/// - **`tea` itself failed** — no response, so its own stderr is the only
+///   account of why (transport error, no login configured), and
+///   [`is_retriable_error`] reads it as it does for every other backend's CLI.
+/// - **the API answered** — the status settles it outright: 429 and 5xx are the
+///   server saying "later", while every other 4xx is a token or a missing
+///   resource that repeating the call won't change. Gitea is the only backend
+///   that can answer this way; `gh` and `glab` leave the status inside prose,
+///   which is why they still sniff for it.
+/// - **no status line from an exit-0 `tea`** — the response never arrived, and
+///   a call that can't be classified won't classify on a retry either.
+///
+/// Gitea's message is read nowhere here. It reached the user only through this
+/// sniff, and the status answers better than the sniff did: a 500 whose message
+/// Gitea blanked for a non-admin token used to leave nothing to match, so a
+/// server error painted the same blank cell as a healthy branch with no CI.
+fn tea_api_failure_is_retriable(output: &Output) -> Option<bool> {
     if !output.status.success() {
-        return Some(output_error_text(output));
+        return Some(is_retriable_error(&output_error_text(output)));
     }
     match api_status(&output.stderr) {
-        // Only a 2xx/3xx carries the resource. A missing status line means the
-        // response never arrived, so it doesn't either.
         Some(status) if status < 400 => None,
-        _ => Some(api_error_message(&output.stdout).unwrap_or_default()),
+        Some(status) => Some(status == 429 || status >= 500),
+        None => Some(false),
     }
 }
 
@@ -72,10 +82,10 @@ fn fetch_combined_status(
 ) -> Option<CiStatus> {
     let path = format!("repos/{owner}/{repo_name}/commits/{sha}/status");
     let output = tea_api(repo, &path)?;
-    if let Some(error) = tea_api_error(&output) {
+    if let Some(retriable) = tea_api_failure_is_retriable(&output) {
         // The PR-status warning from `retriable_pr_error` is the wrong shape
         // here (this returns just CiStatus).
-        return is_retriable_error(&error).then_some(CiStatus::Error);
+        return retriable.then_some(CiStatus::Error);
     }
     let combined: GiteaCombinedStatus = parse_json(&output.stdout, "tea api commit status", sha)?;
     if combined.total_count == 0 {
@@ -106,8 +116,8 @@ pub(super) fn detect_gitea_pr(
     let path =
         format!("repos/{query_owner}/{query_repo}/pulls?state=open&limit={MAX_PRS_TO_FETCH}");
     let output = tea_api(repo, &path)?;
-    if let Some(error) = tea_api_error(&output) {
-        return is_retriable_error(&error).then(PrStatus::error);
+    if let Some(retriable) = tea_api_failure_is_retriable(&output) {
+        return retriable.then(PrStatus::error);
     }
 
     let prs: Vec<GiteaPr> = parse_json(&output.stdout, "tea api pulls", &branch.full_name)?;
@@ -291,14 +301,12 @@ mod tests {
         assert_eq!(pr(Some(2)).comment_count(), Some(2));
     }
 
-    /// `tea_api_error` reads the status line, since the exit code carries
-    /// nothing: a 2xx is data whatever it holds, anything from 400 up is the
-    /// failure whatever it holds. The body only supplies the text, and where
-    /// there is none — a 500 Gitea blanked for a non-admin token, a proxy's
-    /// HTML page — the error is empty rather than falling through to the data
-    /// path, where the PR-list parse would blame a Gitea API change.
+    /// The status line answers both questions the exit code can't: whether the
+    /// call failed, and whether repeating it could help. The body is not read —
+    /// each case below pairs a status with a body that would have said something
+    /// different, so a sniff surviving anywhere would show up here.
     #[test]
-    fn test_tea_api_error_reads_the_http_status() {
+    fn test_tea_api_failure_is_retriable_reads_the_http_status() {
         // `ExitStatus::default()` is success on every platform, so these all
         // exercise the exit-0 path — the one the exit code can't classify.
         let response = |status: &str, stdout: &str| Output {
@@ -307,44 +315,49 @@ mod tests {
             stderr: format!("HTTP/1.1 {status}\r\nContent-Type: application/json\r\n\r\n")
                 .into_bytes(),
         };
+        let retriable =
+            |status: &str, stdout: &str| tea_api_failure_is_retriable(&response(status, stdout));
 
-        assert_eq!(tea_api_error(&response("200 OK", "[]")), None);
+        // 2xx is the resource, whatever it holds — an `APIError` body served
+        // with a 200 is a Gitea API change, not an API error.
+        assert_eq!(retriable("200 OK", "[]"), None);
+        assert_eq!(retriable("200 OK", r#"{"message":"nope"}"#), None);
+
+        // The server saying "later".
         assert_eq!(
-            tea_api_error(&response(
-                "200 OK",
-                r#"{"state":"success","total_count":2}"#
-            )),
-            None
+            retriable("500 Internal Server Error", r#"{"message":""}"#),
+            Some(true)
         );
         assert_eq!(
-            tea_api_error(&response(
-                "403 Forbidden",
-                r#"{"message":"token does not have scope"}"#
-            )),
-            Some("token does not have scope".to_string())
+            retriable("502 Bad Gateway", "<html>Bad Gateway</html>"),
+            Some(true)
         );
-        // A production 500 for a non-admin token: the envelope, no text.
+        assert_eq!(retriable("429 Too Many Requests", "{}"), Some(true));
+
+        // A token or a missing resource: repeating the call changes nothing,
+        // even when the message reads like a network fault.
         assert_eq!(
-            tea_api_error(&response(
-                "500 Internal Server Error",
-                r#"{"message":"","url":"https://gitea.example.com/api/swagger"}"#
-            )),
-            Some(String::new())
+            retriable("401 Unauthorized", r#"{"message":"token is required"}"#),
+            Some(false)
         );
-        // A body from in front of Gitea, which the shape check used to read as
-        // data and warn about.
         assert_eq!(
-            tea_api_error(&response("502 Bad Gateway", "<html>Bad Gateway</html>")),
-            Some(String::new())
+            retriable("403 Forbidden", r#"{"message":"connection timeout"}"#),
+            Some(false)
         );
-        // No status line from an exit-0 `tea`: a failure, never the resource.
         assert_eq!(
-            tea_api_error(&Output {
+            retriable("404 Not Found", r#"{"message":"does not exist"}"#),
+            Some(false)
+        );
+
+        // No status line from an exit-0 `tea`: a failure, never the resource,
+        // and nothing a retry would classify differently.
+        assert_eq!(
+            tea_api_failure_is_retriable(&Output {
                 status: Default::default(),
                 stdout: b"[]".to_vec(),
                 stderr: Vec::new(),
             }),
-            Some(String::new())
+            Some(false)
         );
     }
 

--- a/src/git/remote_ref/gitea.rs
+++ b/src/git/remote_ref/gitea.rs
@@ -1,10 +1,28 @@
 //! Gitea PR provider.
 //!
 //! Implements `RemoteRefProvider` for Gitea Pull Requests using the `tea` CLI,
-//! and hosts the `tea`-facing helpers other modules share: [`api_error_message`]
-//! (how every caller separates a failed request from a resource),
-//! [`is_authed_for`], and [`has_any_login`] — read by the switch dispatcher and
-//! the CI-status backend, so a change to one of them is not local.
+//! and hosts the `tea`-facing helpers other modules share: [`api_status`] and
+//! [`api_error_message`] (how every caller separates a failed request from a
+//! resource, and what it says about one), [`is_authed_for`], and
+//! [`has_any_login`] — read by the switch dispatcher and the CI-status backend,
+//! so a change to one of them is not local.
+//!
+//! ## Reading the HTTP status
+//!
+//! `tea api` copies the response body to stdout and exits 0 whatever the status,
+//! so the exit code answers only whether `tea` itself ran. `--include` adds the
+//! status line and response headers on stderr, and that line is where every
+//! caller here reads the status from. Both `tea api` call sites pass the flag.
+//!
+//! The flag shipped with the `api` subcommand itself in tea v0.12.0 and is
+//! unchanged since, so every `tea` that can make this call accepts it — a `tea`
+//! old enough to lack `--include` has no `api` subcommand to send it to.
+//!
+//! It writes the whole header block, not just the status line, so the captured
+//! stderr now holds whatever the server sends back — a `Set-Cookie` among it,
+//! on a Gitea that issues one. That reaches disk only under `-vv`, which logs
+//! every subprocess's output to `subprocess.log`; there is no narrower flag to
+//! ask for, and the status is not available any other way.
 //!
 //! ## API path resolution
 //!
@@ -62,29 +80,39 @@ struct TeaApiErrorResponse {
     message: String,
 }
 
-/// The message from Gitea's `APIError` body, or `None` when the response
-/// carries the resource.
+/// The HTTP status of a `tea api --include` response, read from the status
+/// line `tea` writes to stderr (`HTTP/1.1 404 Not Found`).
 ///
-/// `tea api` never reads the HTTP status — it copies the response body to
-/// stdout and exits 0 — so the body's *shape* is the only thing separating a
-/// failed request from a successful one, and the presence of a `message` key
-/// is that shape: none of the resources read here (a PR object, a PR array, a
-/// combined commit status) carries one.
+/// `None` means no such line arrived. From a `tea` that exited 0 that is
+/// structurally impossible — `--include` prints the moment the response does,
+/// before the body — so callers treat it as a failed request rather than
+/// reading stdout as the resource.
 ///
-/// The message's *content* is not part of the key. Gitea blanks a 500's
-/// message in production unless the token belongs to an admin, so that body
-/// arrives as `{"message":"","url":"…/api/swagger"}`; keying on a non-empty
-/// message would read it as the resource — a PR array that fails to parse, or
-/// a combined status whose fields all default to "no statuses".
+/// Scans for the line rather than taking the first, so anything `tea` writes
+/// to stderr ahead of it can't hide it.
+pub fn api_status(stderr: &[u8]) -> Option<u16> {
+    String::from_utf8_lossy(stderr)
+        .lines()
+        .find_map(|line| line.strip_prefix("HTTP/"))
+        .and_then(|rest| rest.split_whitespace().nth(1))
+        .and_then(|code| code.parse().ok())
+}
+
+/// Gitea's own account of a failed request, from the `APIError` body it returns
+/// in place of the resource.
 ///
-/// `url` is not part of the key either, though `APIError` carries one: an error
-/// shape that omits it — Gitea has them, `APIInvalidTopicsError` being `message`
-/// plus `invalidTopics` — would read as the resource, the failure this key
-/// exists to prevent, while requiring it would only guard against a resource
-/// one day growing a `message` field.
+/// Read only after [`api_status`] has said the request failed, so this decides
+/// nothing. It reports three states, and a caller with prose to write needs all
+/// three:
 ///
-/// Callers render the empty message themselves: what to say about an error the
-/// server won't describe depends on what the caller was doing.
+/// - `Some(message)` — Gitea said what went wrong.
+/// - `Some("")` — Gitea's envelope with nothing in it. Production blanks a 5xx
+///   message unless the token belongs to an admin, so the body arrives as
+///   `{"message":"","url":"…/api/swagger"}`. There is no more to report, and
+///   that is worth saying.
+/// - `None` — not an `APIError` at all, so the body didn't come from Gitea's
+///   API layer: a reverse proxy's HTML error page, or a shape Gitea doesn't
+///   send today.
 pub fn api_error_message(stdout: &[u8]) -> Option<String> {
     serde_json::from_slice::<TeaApiErrorResponse>(stdout)
         .ok()
@@ -137,7 +165,7 @@ fn fetch_pr_info(pr_number: u32, repo: &Repository) -> anyhow::Result<RemoteRefI
 
     let output = run_cli_api(CliApiRequest {
         tool: "tea",
-        args: &["api", &api_path],
+        args: &["api", "--include", &api_path],
         repo_root,
         // tea reads no prompt-disable env var; pass a no-op key/value so the
         // shared helper has something to set without inventing a fake var.
@@ -146,10 +174,10 @@ fn fetch_pr_info(pr_number: u32, repo: &Repository) -> anyhow::Result<RemoteRefI
         run_context: "Failed to run tea api",
     })?;
 
-    // `tea api` never reads the HTTP status — it copies the response body to
-    // stdout and exits 0 — so a non-zero exit means `tea` itself failed (no
-    // login configured, unresolvable endpoint, transport error), and its own
-    // stderr names which.
+    // `tea api` exits 0 for every HTTP response, so a non-zero exit means `tea`
+    // itself failed (no login configured, unresolvable endpoint, transport
+    // error) and its own stderr names which. It also means no status line, so
+    // this branch comes first.
     if !output.status.success() {
         return Err(cli_api_error(
             ForgeKind::Gitea.ref_type(),
@@ -158,23 +186,32 @@ fn fetch_pr_info(pr_number: u32, repo: &Repository) -> anyhow::Result<RemoteRefI
         ));
     }
 
-    // A 404, 401, or 403 therefore arrives here, as a successful spawn
-    // carrying Gitea's `APIError` body instead of the PR. The response shape
-    // is what separates them, and it's the only thing that can: the status
-    // code never reaches us, and Gitea's message doesn't spell it either.
-    if let Some(message) = api_error_message(&output.stdout) {
+    // A 404, 401, 403, or 500 therefore arrives here as a successful spawn
+    // carrying Gitea's `APIError` body instead of the PR, and the status line
+    // from `--include` is what says so.
+    let status = api_status(&output.stderr).with_context(|| {
+        format!(
+            "tea api --include wrote no HTTP status line for PR #{pr_number}, \
+             so a PR can't be told from an API error"
+        )
+    })?;
+
+    if status >= 400 {
         let (owner, repo_name) = (parsed.owner(), parsed.repo());
-        if message.is_empty() {
-            bail!(
-                "Gitea API error for PR #{pr_number} on {owner}/{repo_name}, but the response \
-                 carried no message — Gitea hides 500 messages from non-admin tokens"
-            );
+        let context =
+            format!("Gitea API error {status} for PR #{pr_number} on {owner}/{repo_name}");
+        match api_error_message(&output.stdout) {
+            Some(message) if !message.is_empty() => bail!("{context}: {message}"),
+            Some(_) => bail!(
+                "{context}, but the response carried no message — Gitea hides 5xx messages \
+                 from non-admin tokens"
+            ),
+            None => bail!("{context}, and the response body is not one Gitea sends"),
         }
-        bail!("Gitea API error for PR #{pr_number} on {owner}/{repo_name}: {message}");
     }
 
-    // Neither the resource nor an error envelope: report the parse failure,
-    // whose source names where the body diverged.
+    // A 2xx that isn't the resource: report the parse failure, whose source
+    // names where the body diverged.
     let response: TeaApiPrResponse = serde_json::from_slice(&output.stdout).with_context(|| {
         format!(
             "Failed to parse Gitea API response for PR #{}. \
@@ -388,11 +425,39 @@ mod tests {
         assert_eq!(provider.ref_type(), crate::git::RefType::Pr);
     }
 
-    /// The `APIError` envelope is recognized by the presence of a `message`
-    /// key, not by what the message says: a 500 whose message Gitea blanked
-    /// for a non-admin token is still an error, not a PR.
+    /// The status line is the discriminator, and it is the second token of the
+    /// first `HTTP/` line — reachable past whatever `tea` wrote before it, and
+    /// past a status with no reason phrase.
     #[test]
-    fn test_api_error_message_reads_the_response_shape() {
+    fn test_api_status_reads_the_status_line() {
+        let status = |stderr: &str| api_status(stderr.as_bytes());
+
+        assert_eq!(status("HTTP/1.1 200 OK\r\n\r\n"), Some(200));
+        assert_eq!(status("HTTP/2.0 404 Not Found\n\n"), Some(404));
+        assert_eq!(status("HTTP/1.1 500\n"), Some(500));
+        // Headers follow the status line and must not be mistaken for it.
+        assert_eq!(
+            status("HTTP/1.1 403 Forbidden\r\nX-Proto: HTTP/1.1 200 OK\r\n\r\n"),
+            Some(403)
+        );
+        // Anything `tea` says first is stepped over.
+        assert_eq!(
+            status("warning: login token expires soon\nHTTP/1.1 401 Unauthorized\n"),
+            Some(401)
+        );
+
+        // Nothing to read: no `--include` output at all, or a line that
+        // doesn't carry a number where the status belongs.
+        assert_eq!(status(""), None);
+        assert_eq!(status("Error: dial tcp: connection refused\n"), None);
+        assert_eq!(status("HTTP/1.1 OK\n"), None);
+    }
+
+    /// The body supplies the error text, and its three states are three
+    /// different things to say: Gitea's message, Gitea's envelope with the
+    /// message blanked, and a body Gitea didn't write.
+    #[test]
+    fn test_api_error_message_reads_the_body() {
         let error = |body: &str| api_error_message(body.as_bytes());
 
         assert_eq!(
@@ -401,21 +466,21 @@ mod tests {
             ),
             Some("token is required".to_string())
         );
+
+        // Gitea's envelope, blanked for a non-admin token. Whitespace-only is
+        // the same thing — trimmed, so one branch covers both.
         assert_eq!(
             error(r#"{"message":"","url":"https://gitea.example.com/api/swagger"}"#),
             Some(String::new())
         );
         assert_eq!(error(r#"{"message":"   "}"#), Some(String::new()));
 
-        // The resources read through `tea api` carry no `message`, so they
-        // stay data: a single PR, a PR array, a combined commit status.
+        // Not an `APIError` at all: a resource, an unknown shape, a proxy's
+        // error page.
         assert_eq!(error(r#"{"title":"Fix login","state":"open"}"#), None);
         assert_eq!(error("[]"), None);
-        assert_eq!(error(r#"{"state":"success","total_count":2}"#), None);
-
-        // Neither shape — the caller reports a parse failure, not an API error.
         assert_eq!(error(r#"{"unexpected":1}"#), None);
-        assert_eq!(error("not json"), None);
+        assert_eq!(error("<html>Bad Gateway</html>"), None);
     }
 
     #[test]

--- a/src/git/remote_ref/gitea.rs
+++ b/src/git/remote_ref/gitea.rs
@@ -1,11 +1,11 @@
 //! Gitea PR provider.
 //!
 //! Implements `RemoteRefProvider` for Gitea Pull Requests using the `tea` CLI,
-//! and hosts the `tea`-facing helpers other modules share: [`api_status`] and
-//! [`api_error_message`] (how every caller separates a failed request from a
-//! resource, and what it says about one), [`is_authed_for`], and
-//! [`has_any_login`] — read by the switch dispatcher and the CI-status backend,
-//! so a change to one of them is not local.
+//! and hosts the `tea`-facing helpers other modules share: [`api_status`] (how
+//! every caller separates a failed request from a resource, and decides whether
+//! a retry could help), [`is_authed_for`], and [`has_any_login`] — read by the
+//! switch dispatcher and the CI-status backend, so a change to one of them is
+//! not local.
 //!
 //! ## Reading the HTTP status
 //!
@@ -102,8 +102,8 @@ pub fn api_status(stderr: &[u8]) -> Option<u16> {
 /// in place of the resource.
 ///
 /// Read only after [`api_status`] has said the request failed, so this decides
-/// nothing. It reports three states, and a caller with prose to write needs all
-/// three:
+/// nothing. It reports three states, and [`fetch_pr_info`] — which does have
+/// prose to write — says something different for each:
 ///
 /// - `Some(message)` — Gitea said what went wrong.
 /// - `Some("")` — Gitea's envelope with nothing in it. Production blanks a 5xx
@@ -113,7 +113,11 @@ pub fn api_status(stderr: &[u8]) -> Option<u16> {
 /// - `None` — not an `APIError` at all, so the body didn't come from Gitea's
 ///   API layer: a reverse proxy's HTML error page, or a shape Gitea doesn't
 ///   send today.
-pub fn api_error_message(stdout: &[u8]) -> Option<String> {
+///
+/// Local to this module: the CI-status backend reads only [`api_status`], since
+/// a CI cell has no room for the text and the status already decides what the
+/// cell shows.
+fn api_error_message(stdout: &[u8]) -> Option<String> {
     serde_json::from_slice::<TeaApiErrorResponse>(stdout)
         .ok()
         .map(|error| error.message.trim().to_string())

--- a/src/testing/mock_commands.rs
+++ b/src/testing/mock_commands.rs
@@ -265,6 +265,20 @@ pub fn copy_mock_binary(bin_dir: &Path, name: &str) {
 // High-level mock helpers for common test scenarios
 // =============================================================================
 
+/// The stderr `tea api --include` writes ahead of the body: the status line,
+/// then the response headers, then a blank line.
+///
+/// Every mock `tea api` response that stands for an HTTP response carries this
+/// — both Gitea backends read the status from here, and a body arriving with no
+/// status line is a failed request rather than a resource. `status` is the
+/// status line's tail (`200 OK`, `404 Not Found`).
+///
+/// A mock standing for `tea` itself failing (non-zero exit, no response) has no
+/// status line to write, and must not have one.
+pub fn tea_api_include_stderr(status: &str) -> String {
+    format!("HTTP/1.1 {status}\r\nContent-Type: application/json;charset=utf-8\r\n\r\n")
+}
+
 /// Create a mock cargo command for tests.
 pub fn create_mock_cargo(bin_dir: &Path) {
     MockConfig::new("cargo")

--- a/src/testing/mod.rs
+++ b/src/testing/mod.rs
@@ -63,7 +63,7 @@ use crate::git::Repository;
 use crate::shell_exec::{self, Cmd, INHERITED_GIT_PATH_VARS};
 use path_slash::PathExt;
 
-use self::mock_commands::{MockConfig, MockResponse};
+use self::mock_commands::{MockConfig, MockResponse, tea_api_include_stderr};
 
 /// Path to the `wt` binary built by Cargo.
 ///
@@ -2630,48 +2630,69 @@ impl TestRepo {
         self.mock_bin_path = Some(mock_bin);
     }
 
-    /// Setup mock `tea` that returns configurable Gitea PR / commit-status data.
+    /// Setup mock `tea` that returns configurable Gitea PR / commit-status
+    /// responses.
     ///
     /// Use this for testing Gitea CI status parsing. The mock handles:
-    /// - `tea api repos/{owner}/{repo}/pulls?state=open` → `pulls_json`
-    /// - `tea api repos/{owner}/{repo}/commits/{head_sha}/status` → `status_json`
+    /// - `tea api --include repos/{owner}/{repo}/pulls?state=open` → `pulls`
+    /// - `tea api --include repos/{owner}/{repo}/commits/{head_sha}/status` →
+    ///   `status`
     ///
     /// `owner`/`repo_name`/`head_sha` are needed because mock-stub matches the
-    /// invocation's leading arguments verbatim, and `tea api <path>` passes the
-    /// whole API path as a single argument — so the exact path string must be
-    /// registered.
+    /// invocation's leading arguments verbatim, and `tea api --include <path>`
+    /// passes the whole API path as a single argument — so the exact path
+    /// string must be registered.
     ///
     /// # Arguments
     /// * `owner`, `repo_name` - the Gitea repo the test's remote points at.
     /// * `head_sha` - the SHA used for the `commits/{sha}/status` lookup
-    ///   (the feature branch's HEAD; also the PR head SHA in `pulls_json`).
-    /// * `pulls_json` - JSON array for `tea api .../pulls`. Each entry should
-    ///   include `mergeable`, `html_url`, and `head.{ref,sha,repo.owner.login}`.
-    /// * `status_json` - JSON object for `tea api .../commits/{sha}/status`,
-    ///   with `state` and `total_count`.
+    ///   (the feature branch's HEAD; also the PR head SHA in `pulls`).
+    /// * `pulls` - `(HTTP status, body)` for `tea api .../pulls`. On 200 the
+    ///   body is a JSON array whose entries carry `mergeable`, `html_url`, and
+    ///   `head.{ref,sha,repo.owner.login}`; on a 4xx/5xx it is whatever the
+    ///   server sent instead, which the backend reads only for error text.
+    /// * `status` - `(HTTP status, body)` for
+    ///   `tea api .../commits/{sha}/status`, the 200 body carrying `state` and
+    ///   `total_count`.
+    ///
+    /// The status is what the backend classifies on, so it is a parameter
+    /// rather than inferred from the body — an `APIError` served with a 200 is
+    /// a Gitea API change, and the tests say which they mean.
     pub fn setup_mock_tea_with_ci_data(
         &mut self,
         owner: &str,
         repo_name: &str,
         head_sha: &str,
-        pulls_json: &str,
-        status_json: &str,
+        pulls: (&str, &str),
+        status: (&str, &str),
     ) {
         let mock_bin = self.temp_dir.path().join("mock-bin");
         std::fs::create_dir_all(&mock_bin).unwrap();
 
+        let (pulls_status, pulls_json) = pulls;
+        let (status_status, status_json) = status;
         std::fs::write(mock_bin.join("tea_pulls.json"), pulls_json).unwrap();
         std::fs::write(mock_bin.join("tea_status.json"), status_json).unwrap();
 
         // Keep `&limit=20` in sync with `MAX_PRS_TO_FETCH` in
         // `src/commands/list/ci_status/mod.rs`.
-        let pulls_path = format!("api repos/{owner}/{repo_name}/pulls?state=open&limit=20");
-        let status_path = format!("api repos/{owner}/{repo_name}/commits/{head_sha}/status");
+        let pulls_path =
+            format!("api --include repos/{owner}/{repo_name}/pulls?state=open&limit=20");
+        let status_path =
+            format!("api --include repos/{owner}/{repo_name}/commits/{head_sha}/status");
 
         MockConfig::new("tea")
             .version("tea version development (mock)")
-            .command(&pulls_path, MockResponse::file("tea_pulls.json"))
-            .command(&status_path, MockResponse::file("tea_status.json"))
+            .command(
+                &pulls_path,
+                MockResponse::file("tea_pulls.json")
+                    .with_stderr(&tea_api_include_stderr(pulls_status)),
+            )
+            .command(
+                &status_path,
+                MockResponse::file("tea_status.json")
+                    .with_stderr(&tea_api_include_stderr(status_status)),
+            )
             .command("_default", MockResponse::exit(1))
             .write(&mock_bin);
 
@@ -2727,11 +2748,12 @@ impl TestRepo {
             .command(
                 // Keep `&limit=20` in sync with `MAX_PRS_TO_FETCH` in
                 // `src/commands/list/ci_status/mod.rs`.
-                "api repos/owner/test-repo/pulls?state=open&limit=20",
-                MockResponse::file("tea_pulls.json"),
+                "api --include repos/owner/test-repo/pulls?state=open&limit=20",
+                MockResponse::file("tea_pulls.json").with_stderr(&tea_api_include_stderr("200 OK")),
             )
             .command(
-                &format!("api repos/owner/test-repo/commits/{head_sha}/status"),
+                // `tea` itself failing: no response, so no status line.
+                &format!("api --include repos/owner/test-repo/commits/{head_sha}/status"),
                 MockResponse::stderr(stderr).with_exit_code(1),
             )
             .command("_default", MockResponse::exit(1))

--- a/tests/integration_tests/ci_status.rs
+++ b/tests/integration_tests/ci_status.rs
@@ -1150,15 +1150,16 @@ fn setup_gitea_repo_with_feature(repo: &mut TestRepo) -> String {
 }
 
 /// Run a Gitea CI status test with the given `tea api .../pulls` and
-/// `tea api .../commits/{sha}/status` mock responses.
+/// `tea api .../commits/{sha}/status` mock responses, each an
+/// `(HTTP status, body)` pair.
 fn run_gitea_ci_status_test(
     repo: &mut TestRepo,
     snapshot_name: &str,
     head_sha: &str,
-    pulls_json: &str,
-    status_json: &str,
+    pulls: (&str, &str),
+    status: (&str, &str),
 ) {
-    repo.setup_mock_tea_with_ci_data("owner", "test-repo", head_sha, pulls_json, status_json);
+    repo.setup_mock_tea_with_ci_data("owner", "test-repo", head_sha, pulls, status);
 
     let settings = setup_snapshot_settings(repo);
     settings.bind(|| {
@@ -1179,8 +1180,8 @@ const GITEA_API_ERROR_BODY: &str = r#"{
 }"#;
 
 /// The same body a production Gitea sends a non-admin token for that 500:
-/// `APIError` with the message blanked. Only the envelope is left, which is
-/// what `api_error_message` keys on.
+/// `APIError` with the message blanked. Nothing in it says "error", which is
+/// why the status line rather than the body is what the backend reads.
 const GITEA_BLANK_ERROR_BODY: &str = r#"{
     "message": "",
     "url": "https://gitea.example.com/api/swagger"
@@ -1211,8 +1212,8 @@ fn test_list_full_with_gitea_pr_conflicts(mut repo: TestRepo) {
         &mut repo,
         "gitea_pr_conflicts",
         &head_sha,
-        &gitea_feature_pr_json(&head_sha, false),
-        r#"{"state":"","total_count":0}"#,
+        ("200 OK", &gitea_feature_pr_json(&head_sha, false)),
+        ("200 OK", r#"{"state":"","total_count":0}"#),
     );
 }
 
@@ -1225,8 +1226,8 @@ fn test_list_full_with_gitea_commit_status(mut repo: TestRepo) {
         &mut repo,
         "gitea_commit_status",
         &head_sha,
-        "[]",
-        r#"{"state":"failure","total_count":1}"#,
+        ("200 OK", "[]"),
+        ("200 OK", r#"{"state":"failure","total_count":1}"#),
     );
 }
 
@@ -1238,15 +1239,15 @@ fn test_list_full_with_gitea_no_ci(mut repo: TestRepo) {
         &mut repo,
         "gitea_no_ci",
         &head_sha,
-        "[]",
-        r#"{"state":"","total_count":0}"#,
+        ("200 OK", "[]"),
+        ("200 OK", r#"{"state":"","total_count":0}"#),
     );
 }
 
 /// A Gitea 500 whose `APIError` body names a retriable cause surfaces as an
 /// error indicator rather than NoCI. `tea api` exits 0 here — it copies the
-/// response body through without reading the HTTP status — so the body's shape
-/// is what separates this from a PR list.
+/// response body through whatever the status — so the status line `--include`
+/// puts on stderr is what separates this from a PR list.
 #[rstest]
 fn test_list_full_with_gitea_pr_error_body(mut repo: TestRepo) {
     let head_sha = setup_gitea_repo_with_feature(&mut repo);
@@ -1254,15 +1255,15 @@ fn test_list_full_with_gitea_pr_error_body(mut repo: TestRepo) {
         &mut repo,
         "gitea_pr_error_body",
         &head_sha,
-        GITEA_API_ERROR_BODY,
-        r#"{"state":"","total_count":0}"#,
+        ("500 Internal Server Error", GITEA_API_ERROR_BODY),
+        ("200 OK", r#"{"state":"","total_count":0}"#),
     );
 }
 
 /// The same `APIError` body from the commit-status lookup (when no PR exists
-/// for the branch). Without shape discrimination this one is the quieter bug:
-/// every field of `GiteaCombinedStatus` defaults, so the error body would
-/// deserialize as "no statuses" and paint a blank cell.
+/// for the branch). Read as data this one is the quieter bug: every field of
+/// `GiteaCombinedStatus` defaults, so the error body would deserialize as "no
+/// statuses" and paint a blank cell.
 #[rstest]
 fn test_list_full_with_gitea_commit_status_error_body(mut repo: TestRepo) {
     let head_sha = setup_gitea_repo_with_feature(&mut repo);
@@ -1270,24 +1271,24 @@ fn test_list_full_with_gitea_commit_status_error_body(mut repo: TestRepo) {
         &mut repo,
         "gitea_commit_status_error_body",
         &head_sha,
-        "[]",
-        GITEA_API_ERROR_BODY,
+        ("200 OK", "[]"),
+        ("500 Internal Server Error", GITEA_API_ERROR_BODY),
     );
 }
 
-/// Run `wt list --full` against the given `tea api .../pulls` body and return
-/// stderr.
+/// Run `wt list --full` against the given `tea api .../pulls` response — an
+/// `(HTTP status, body)` pair — and return stderr.
 ///
 /// `RUST_LOG=warn` because `parse_json`'s warning is a `tracing` record and the
 /// stderr layer is off at the default verbosity; `-v` would turn it on but bury
 /// it under a template expansion per worktree.
-fn gitea_ci_status_stderr(repo: &mut TestRepo, head_sha: &str, pulls_json: &str) -> String {
+fn gitea_ci_status_stderr(repo: &mut TestRepo, head_sha: &str, pulls: (&str, &str)) -> String {
     repo.setup_mock_tea_with_ci_data(
         "owner",
         "test-repo",
         head_sha,
-        pulls_json,
-        r#"{"state":"","total_count":0}"#,
+        pulls,
+        ("200 OK", r#"{"state":"","total_count":0}"#),
     );
 
     let mut cmd = wt_command();
@@ -1300,34 +1301,38 @@ fn gitea_ci_status_stderr(repo: &mut TestRepo, head_sha: &str, pulls_json: &str)
     stderr
 }
 
-/// "May indicate a Gitea API change" is reserved for a body that is neither the
-/// resource nor the error envelope.
+/// "May indicate a Gitea API change" is reserved for a 2xx whose body isn't the
+/// resource, which is the only response that is one.
 ///
-/// A blanked message is still the envelope, so the PR list never reads it as
-/// data. The CI cell is blank either way — an empty message isn't retriable —
-/// so what the key buys is the diagnosis: requiring a *non-empty* message let
-/// that body through to `parse_json`, which blamed a Gitea API change for a
-/// Gitea API error. The unknown-body case is the control: it pins where the
-/// warning does belong, and keeps the first case from passing merely because
-/// nothing logs at all.
+/// The status decides, so the two bodies that used to be the hard cases are
+/// now read by what accompanied them. A 500 whose message Gitea blanked says
+/// nothing about being an error, and a proxy's HTML page isn't Gitea's shape at
+/// all; both reach the PR list as errors on the strength of the status line
+/// alone, and the CI cell stays blank because neither carries retriable text.
+/// The 200 case is the control: it pins where the warning does belong, and
+/// keeps the others from passing merely because nothing logs at all.
 ///
-/// One case per repo, not two runs in one: `wt list` caches CI status per
+/// One case per repo, not several runs in one: `wt list` caches CI status per
 /// branch for 30s, so a second run against the same HEAD never reaches `tea`.
 #[rstest]
-#[case::blank_message_is_still_an_error(GITEA_BLANK_ERROR_BODY, false)]
-#[case::unknown_body_is_a_parse_failure(r#"{"unexpected":1}"#, true)]
+#[case::blanked_500_is_an_error(
+    ("500 Internal Server Error", GITEA_BLANK_ERROR_BODY),
+    false
+)]
+#[case::proxy_page_is_an_error(("502 Bad Gateway", "<html>Bad Gateway</html>"), false)]
+#[case::unknown_200_body_is_a_parse_failure(("200 OK", r#"{"unexpected":1}"#), true)]
 fn test_list_full_gitea_parse_warning_is_reserved_for_unknown_bodies(
     mut repo: TestRepo,
-    #[case] pulls_json: &str,
+    #[case] pulls: (&str, &str),
     #[case] expect_parse_warning: bool,
 ) {
     let head_sha = setup_gitea_repo_with_feature(&mut repo);
-    let stderr = gitea_ci_status_stderr(&mut repo, &head_sha, pulls_json);
+    let stderr = gitea_ci_status_stderr(&mut repo, &head_sha, pulls);
 
     assert_eq!(
         stderr.contains("Failed to parse tea api pulls JSON"),
         expect_parse_warning,
-        "wrong diagnosis for {pulls_json}: {stderr}"
+        "wrong diagnosis for {pulls:?}: {stderr}"
     );
 }
 
@@ -1409,8 +1414,8 @@ fn test_list_remotes_full_with_gitea_remote_branch(mut repo: TestRepo) {
         "forkowner",
         "test-repo",
         &head_sha,
-        "[]",
-        r#"{"state":"success","total_count":1}"#,
+        ("200 OK", "[]"),
+        ("200 OK", r#"{"state":"success","total_count":1}"#),
     );
 
     let settings = setup_snapshot_settings(&repo);
@@ -1477,8 +1482,8 @@ fn test_list_full_with_gitea_fork_pr(mut repo: TestRepo) {
         "upstream",
         "test-repo",
         &head_sha,
-        &pulls_json,
-        r#"{"state":"success","total_count":1}"#,
+        ("200 OK", &pulls_json),
+        ("200 OK", r#"{"state":"success","total_count":1}"#),
     );
 
     let settings = setup_snapshot_settings(&repo);

--- a/tests/integration_tests/ci_status.rs
+++ b/tests/integration_tests/ci_status.rs
@@ -1276,6 +1276,41 @@ fn test_list_full_with_gitea_commit_status_error_body(mut repo: TestRepo) {
     );
 }
 
+/// A 500 the message of which Gitea blanked still reaches the cell as an error.
+/// The status is the whole basis: the body says nothing, so the text sniff that
+/// used to decide had nothing to match and painted the same blank cell as a
+/// healthy branch with no CI.
+#[rstest]
+fn test_list_full_with_gitea_blanked_500(mut repo: TestRepo) {
+    let head_sha = setup_gitea_repo_with_feature(&mut repo);
+    run_gitea_ci_status_test(
+        &mut repo,
+        "gitea_blanked_500",
+        &head_sha,
+        ("500 Internal Server Error", GITEA_BLANK_ERROR_BODY),
+        ("200 OK", r#"{"state":"","total_count":0}"#),
+    );
+}
+
+/// A 404 is the other half of that: also an error, also carrying no useful
+/// text, but nothing a later `wt list` would answer differently — so the cell
+/// stays blank rather than showing an indicator that never clears. Pairs with
+/// the 500 above; between them the status is doing the deciding, not the body.
+#[rstest]
+fn test_list_full_with_gitea_not_found(mut repo: TestRepo) {
+    let head_sha = setup_gitea_repo_with_feature(&mut repo);
+    run_gitea_ci_status_test(
+        &mut repo,
+        "gitea_not_found",
+        &head_sha,
+        (
+            "404 Not Found",
+            r#"{"message":"user redirect does not exist [name: owner]"}"#,
+        ),
+        ("200 OK", r#"{"state":"","total_count":0}"#),
+    );
+}
+
 /// Run `wt list --full` against the given `tea api .../pulls` response — an
 /// `(HTTP status, body)` pair — and return stderr.
 ///

--- a/tests/integration_tests/switch.rs
+++ b/tests/integration_tests/switch.rs
@@ -2350,7 +2350,9 @@ worktree-path = "{{ repo_path }}/../{{ branch | sanitize }}"
 // PR Syntax Tests (pr:<number>)
 // ============================================================================
 
-use crate::common::mock_commands::{MockConfig, MockResponse, copy_mock_binary};
+use crate::common::mock_commands::{
+    MockConfig, MockResponse, copy_mock_binary, tea_api_include_stderr,
+};
 
 /// Set origin to a GitHub URL so `fetch_pr_info` can parse owner/repo.
 ///
@@ -4724,25 +4726,27 @@ fn test_switch_pr_empty_branch(#[from(repo_with_remote)] repo: TestRepo) {
 // not real `gh`.
 // ============================================================================
 
-/// Helper to set up mock tea for Gitea PR tests with custom response.
+/// Set up mock `tea` answering every `tea api --include` with `status` on
+/// stderr and `body` on stdout — the two streams a real `tea` writes for one
+/// HTTP response.
 ///
-/// Returns the path to the mock bin directory; pass it to
-/// `configure_mock_cli_env`.
-fn setup_mock_tea(repo: &TestRepo, tea_response: Option<&str>) -> std::path::PathBuf {
+/// The status is what the Gitea provider classifies on, so every test states
+/// the one it stands for rather than leaving it implied. Returns the mock bin
+/// directory; pass it to `configure_mock_cli_env`.
+fn setup_mock_tea(repo: &TestRepo, status: &str, body: &str) -> std::path::PathBuf {
     let mock_bin = repo.root_path().join("mock-bin");
     fs::create_dir_all(&mock_bin).unwrap();
-
     copy_mock_binary(&mock_bin, "tea");
+    fs::write(mock_bin.join("tea_pr_response.json"), body).unwrap();
 
-    if let Some(response) = tea_response {
-        fs::write(mock_bin.join("tea_pr_response.json"), response).unwrap();
-
-        MockConfig::new("tea")
-            .version("tea version development (mock)")
-            .command("api", MockResponse::file("tea_pr_response.json"))
-            .command("_default", MockResponse::exit(1))
-            .write(&mock_bin);
-    }
+    MockConfig::new("tea")
+        .version("tea version development (mock)")
+        .command(
+            "api",
+            MockResponse::file("tea_pr_response.json").with_stderr(&tea_api_include_stderr(status)),
+        )
+        .command("_default", MockResponse::exit(1))
+        .write(&mock_bin);
 
     mock_bin
 }
@@ -4774,7 +4778,7 @@ fn test_switch_pr_gitea_create_conflict(#[from(repo_with_remote)] repo: TestRepo
         "html_url": "https://gitea.example.com/owner/test-repo/pulls/101"
     }"#;
 
-    let mock_bin = setup_mock_tea(&repo, Some(tea_response));
+    let mock_bin = setup_mock_tea(&repo, "200 OK", tea_response);
 
     let settings = setup_snapshot_settings(&repo);
     settings.bind(|| {
@@ -4847,7 +4851,7 @@ fn test_switch_pr_gitea_same_repo(#[from(repo_with_remote)] mut repo: TestRepo) 
         "html_url": "https://gitea.example.com/owner/test-repo/pulls/101"
     }"#;
 
-    let mock_bin = setup_mock_tea(&repo, Some(tea_response));
+    let mock_bin = setup_mock_tea(&repo, "200 OK", tea_response);
 
     let settings = setup_snapshot_settings(&repo);
     settings.bind(|| {
@@ -4921,7 +4925,7 @@ fn test_switch_pr_gitea_fork(#[from(repo_with_remote)] repo: TestRepo) {
         "html_url": "https://gitea.example.com/owner/test-repo/pulls/42"
     }"#;
 
-    let mock_bin = setup_mock_tea(&repo, Some(tea_response));
+    let mock_bin = setup_mock_tea(&repo, "200 OK", tea_response);
 
     let settings = setup_snapshot_settings(&repo);
     settings.bind(|| {
@@ -4935,7 +4939,8 @@ fn test_switch_pr_gitea_fork(#[from(repo_with_remote)] repo: TestRepo) {
 ///
 /// `tea api` exits 0 for every HTTP response, so the 404 arrives as a
 /// successful spawn whose stdout carries Gitea's `APIError` body rather than
-/// the PR — the shape, not the exit code, is what says the request failed.
+/// the PR — the status line, not the exit code, is what says the request
+/// failed.
 #[rstest]
 fn test_switch_pr_gitea_not_found(#[from(repo_with_remote)] repo: TestRepo) {
     repo.run_git(&[
@@ -4945,21 +4950,11 @@ fn test_switch_pr_gitea_not_found(#[from(repo_with_remote)] repo: TestRepo) {
         "https://gitea.example.com/owner/test-repo.git",
     ]);
 
-    let mock_bin = repo.root_path().join("mock-bin");
-    fs::create_dir_all(&mock_bin).unwrap();
-
-    copy_mock_binary(&mock_bin, "tea");
-
-    MockConfig::new("tea")
-        .version("tea version development (mock)")
-        .command(
-            "api",
-            MockResponse::output(
-                r#"{"errors":null,"message":"pull request does not exist [index: 9999]","url":"https://gitea.example.com/api/swagger"}"#,
-            ),
-        )
-        .command("_default", MockResponse::exit(1))
-        .write(&mock_bin);
+    let mock_bin = setup_mock_tea(
+        &repo,
+        "404 Not Found",
+        r#"{"errors":null,"message":"pull request does not exist [index: 9999]","url":"https://gitea.example.com/api/swagger"}"#,
+    );
 
     let settings = setup_snapshot_settings(&repo);
     settings.bind(|| {
@@ -5025,7 +5020,7 @@ fn test_switch_pr_gitea_forge_platform(#[from(repo_with_remote)] repo: TestRepo)
         "html_url": "https://git.internal.example.com/owner/test-repo/pulls/101"
     }"#;
 
-    let mock_bin = setup_mock_tea(&repo, Some(tea_response));
+    let mock_bin = setup_mock_tea(&repo, "200 OK", tea_response);
 
     let settings = setup_snapshot_settings(&repo);
     settings.bind(|| {
@@ -5205,7 +5200,7 @@ fn test_switch_pr_self_hosted_tea_authed_dispatches_to_gitea(
         },
         "html_url": "https://forge.selfhosted.test/owner/test-repo/pulls/101"
     }"#;
-    let mock_bin = setup_mock_tea(&repo, Some(tea_response));
+    let mock_bin = setup_mock_tea(&repo, "200 OK", tea_response);
 
     let settings = setup_snapshot_settings(&repo);
     settings.bind(|| {
@@ -5283,7 +5278,7 @@ fn test_switch_pr_gitea_invalid_json(#[from(repo_with_remote)] repo: TestRepo) {
         "https://gitea.example.com/owner/test-repo.git",
     ]);
 
-    let mock_bin = setup_mock_tea(&repo, Some("not json {"));
+    let mock_bin = setup_mock_tea(&repo, "200 OK", "not json {");
 
     let settings = setup_snapshot_settings(&repo);
     settings.bind(|| {
@@ -5357,7 +5352,7 @@ fn test_switch_pr_gitea_no_source_branch(#[from(repo_with_remote)] repo: TestRep
         "html_url": "https://gitea.example.com/owner/test-repo/pulls/101"
     }"#;
 
-    let mock_bin = setup_mock_tea(&repo, Some(tea_response));
+    let mock_bin = setup_mock_tea(&repo, "200 OK", tea_response);
 
     let settings = setup_snapshot_settings(&repo);
     settings.bind(|| {
@@ -5396,7 +5391,7 @@ fn test_switch_pr_gitea_deleted_fork(#[from(repo_with_remote)] repo: TestRepo) {
         "html_url": "https://gitea.example.com/owner/test-repo/pulls/101"
     }"#;
 
-    let mock_bin = setup_mock_tea(&repo, Some(tea_response));
+    let mock_bin = setup_mock_tea(&repo, "200 OK", tea_response);
 
     let settings = setup_snapshot_settings(&repo);
     settings.bind(|| {
@@ -5417,20 +5412,11 @@ fn test_switch_pr_gitea_unauthorized(#[from(repo_with_remote)] repo: TestRepo) {
         "https://gitea.example.com/owner/test-repo.git",
     ]);
 
-    let mock_bin = repo.root_path().join("mock-bin");
-    fs::create_dir_all(&mock_bin).unwrap();
-    copy_mock_binary(&mock_bin, "tea");
-
-    MockConfig::new("tea")
-        .version("tea version development (mock)")
-        .command(
-            "api",
-            MockResponse::output(
-                r#"{"errors":null,"message":"token is required","url":"https://gitea.example.com/api/swagger"}"#,
-            ),
-        )
-        .command("_default", MockResponse::exit(1))
-        .write(&mock_bin);
+    let mock_bin = setup_mock_tea(
+        &repo,
+        "401 Unauthorized",
+        r#"{"errors":null,"message":"token is required","url":"https://gitea.example.com/api/swagger"}"#,
+    );
 
     let settings = setup_snapshot_settings(&repo);
     settings.bind(|| {
@@ -5452,20 +5438,11 @@ fn test_switch_pr_gitea_forbidden(#[from(repo_with_remote)] repo: TestRepo) {
         "https://gitea.example.com/owner/test-repo.git",
     ]);
 
-    let mock_bin = repo.root_path().join("mock-bin");
-    fs::create_dir_all(&mock_bin).unwrap();
-    copy_mock_binary(&mock_bin, "tea");
-
-    MockConfig::new("tea")
-        .version("tea version development (mock)")
-        .command(
-            "api",
-            MockResponse::output(
-                r#"{"errors":null,"message":"user does not have permission to read this repository","url":"https://gitea.example.com/api/swagger"}"#,
-            ),
-        )
-        .command("_default", MockResponse::exit(1))
-        .write(&mock_bin);
+    let mock_bin = setup_mock_tea(
+        &repo,
+        "403 Forbidden",
+        r#"{"errors":null,"message":"user does not have permission to read this repository","url":"https://gitea.example.com/api/swagger"}"#,
+    );
 
     let settings = setup_snapshot_settings(&repo);
     settings.bind(|| {
@@ -5477,11 +5454,40 @@ fn test_switch_pr_gitea_forbidden(#[from(repo_with_remote)] repo: TestRepo) {
 
 /// A 500 reaches the user as an API error, not as a parse failure. Gitea
 /// blanks the message of a 500 in production unless the token belongs to an
-/// admin, so the body arrives as the same `APIError` envelope with nothing in
-/// it — the shape still says the request failed, and the message says why
+/// admin, so the body arrives as the `APIError` envelope with nothing in it —
+/// the status line still says the request failed, and the message says why
 /// there's no more to report.
 #[rstest]
 fn test_switch_pr_gitea_blank_error_message(#[from(repo_with_remote)] repo: TestRepo) {
+    repo.run_git(&[
+        "remote",
+        "set-url",
+        "origin",
+        "https://gitea.example.com/owner/test-repo.git",
+    ]);
+
+    let mock_bin = setup_mock_tea(
+        &repo,
+        "500 Internal Server Error",
+        r#"{"errors":null,"message":"","url":"https://gitea.example.com/api/swagger"}"#,
+    );
+
+    let settings = setup_snapshot_settings(&repo);
+    settings.bind(|| {
+        let mut cmd = make_snapshot_cmd(&repo, "switch", &["pr:101"], None);
+        configure_mock_cli_env(&mut cmd, &mock_bin);
+        assert_cmd_snapshot!("switch_pr_gitea_blank_error_message", cmd);
+    });
+}
+
+/// A `tea` that exits 0 having written no status line never reached the API,
+/// so its stdout is not the PR however well-formed it looks. Real `tea` can't
+/// produce this — `--include` prints the moment the response does — which is
+/// exactly why the backstop is here rather than a fall-through: without it the
+/// body would be read as the resource, the failure the status line exists to
+/// prevent.
+#[rstest]
+fn test_switch_pr_gitea_no_status_line(#[from(repo_with_remote)] repo: TestRepo) {
     repo.run_git(&[
         "remote",
         "set-url",
@@ -5493,12 +5499,22 @@ fn test_switch_pr_gitea_blank_error_message(#[from(repo_with_remote)] repo: Test
     fs::create_dir_all(&mock_bin).unwrap();
     copy_mock_binary(&mock_bin, "tea");
 
+    // A complete PR body, so nothing but the absent status line can reject it.
     MockConfig::new("tea")
         .version("tea version development (mock)")
         .command(
             "api",
             MockResponse::output(
-                r#"{"errors":null,"message":"","url":"https://gitea.example.com/api/swagger"}"#,
+                r#"{
+                "title": "Fix login",
+                "user": {"login": "alice"},
+                "state": "open",
+                "head": {"label": "feature", "ref": "feature",
+                         "repo": {"name": "test-repo", "owner": {"login": "owner"}}},
+                "base": {"label": "main", "ref": "main",
+                         "repo": {"name": "test-repo", "owner": {"login": "owner"}}},
+                "html_url": "https://gitea.example.com/owner/test-repo/pulls/101"
+            }"#,
             ),
         )
         .command("_default", MockResponse::exit(1))
@@ -5508,7 +5524,36 @@ fn test_switch_pr_gitea_blank_error_message(#[from(repo_with_remote)] repo: Test
     settings.bind(|| {
         let mut cmd = make_snapshot_cmd(&repo, "switch", &["pr:101"], None);
         configure_mock_cli_env(&mut cmd, &mock_bin);
-        assert_cmd_snapshot!("switch_pr_gitea_blank_error_message", cmd);
+        assert_cmd_snapshot!("switch_pr_gitea_no_status_line", cmd);
+    });
+}
+
+/// A body written in front of Gitea — a reverse proxy's error page — is an API
+/// error too, on the strength of the status alone. Nothing in the body says so,
+/// which is what separates this from the blanked 500 above: that one at least
+/// arrives in Gitea's own envelope, while this is not JSON at all. Reading the
+/// body for the answer would send it to the resource parse and blame a Gitea
+/// API change for a gateway that never reached Gitea.
+#[rstest]
+fn test_switch_pr_gitea_proxy_error_page(#[from(repo_with_remote)] repo: TestRepo) {
+    repo.run_git(&[
+        "remote",
+        "set-url",
+        "origin",
+        "https://gitea.example.com/owner/test-repo.git",
+    ]);
+
+    let mock_bin = setup_mock_tea(
+        &repo,
+        "502 Bad Gateway",
+        "<html><head><title>502 Bad Gateway</title></head></html>",
+    );
+
+    let settings = setup_snapshot_settings(&repo);
+    settings.bind(|| {
+        let mut cmd = make_snapshot_cmd(&repo, "switch", &["pr:101"], None);
+        configure_mock_cli_env(&mut cmd, &mock_bin);
+        assert_cmd_snapshot!("switch_pr_gitea_proxy_error_page", cmd);
     });
 }
 

--- a/tests/snapshots/integration__integration_tests__ci_status__gitea_blanked_500.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitea_blanked_500.snap
@@ -1,0 +1,68 @@
+---
+source: tests/integration_tests/ci_status.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCI[0m     [1mPath[0m               [1mCommit[0m   [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m     [33m⚠[0m      .                  [2m05a4a45[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [33m⚠[0m      ../repo.feature-a  [2m1b87d47[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [33m⚠[0m      ../repo.feature-b  [2mf62940f[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [33m⚠[0m      ../repo.feature-c  [2m345c7c9[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ feature        [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m     [33m⚠[0m      ../repo.feature    [2m9c1e078[0m  [2m1d[0m    [2mfeat: gitea feature[0m
+
+----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__ci_status__gitea_not_found.snap
+++ b/tests/snapshots/integration__integration_tests__ci_status__gitea_not_found.snap
@@ -1,0 +1,68 @@
+---
+source: tests/integration_tests/ci_status.rs
+info:
+  program: wt
+  args:
+    - list
+    - "--full"
+  env:
+    APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
+    CLICOLOR_FORCE: "1"
+    COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
+    GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
+    GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
+    GIT_TERMINAL_PROMPT: "0"
+    HOME: "[TEST_HOME]"
+    LANG: C
+    LC_ALL: C
+    LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
+    OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
+    PATH: "[PATH]"
+    TERM: alacritty
+    USERPROFILE: "[TEST_HOME]"
+    WORKTRUNK_APPROVALS_PATH: "[TEST_APPROVALS]"
+    WORKTRUNK_CONFIG_PATH: "[TEST_CONFIG]"
+    WORKTRUNK_SYSTEM_CONFIG_PATH: "[TEST_SYSTEM_CONFIG]"
+    WORKTRUNK_TEST_BASH_INSTALLED: "0"
+    WORKTRUNK_TEST_CLAUDE_INSTALLED: "0"
+    WORKTRUNK_TEST_CODEX_INSTALLED: "0"
+    WORKTRUNK_TEST_DELAYED_STREAM_MS: "-1"
+    WORKTRUNK_TEST_EPOCH: "1735776000"
+    WORKTRUNK_TEST_FISH_INSTALLED: "0"
+    WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
+    WORKTRUNK_TEST_NUSHELL_ENV: "0"
+    WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
+    WORKTRUNK_TEST_POWERSHELL_ENV: "0"
+    WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
+    WORKTRUNK_TEST_ZSH_INSTALLED: "0"
+    XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
+---
+success: true
+exit_code: 0
+----- stdout -----
+  [1mBranch[0m     [1mStatus[0m        [1mHEAD±[0m    [1mmain↕[0m     [1mmain…±[0m  [1mRemote⇅[0m  [1mCI[0m     [1mPath[0m               [1mCommit[0m   [1mAge[0m   [1mMessage[0m
+@ main           [2m^[22m[2m|[22m                                      [2m|[0m            .                  [2m05a4a45[0m  [2m16h[0m   [2mInitial commit[0m
++ feature-a      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-a  [2m1b87d47[0m  [2m16h[0m   [2mAdd feature-a file[0m
++ feature-b      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-b  [2mf62940f[0m  [2m16h[0m   [2mAdd feature-b file[0m
++ feature-c      [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature-c  [2m345c7c9[0m  [2m16h[0m   [2mAdd feature-c file[0m
++ feature        [2m↑[22m[2m|[22m                [32m↑1[0m        [32m+1[0m          [2m|[0m            ../repo.feature    [2m9c1e078[0m  [2m1d[0m    [2mfeat: gitea feature[0m
+
+----- stderr -----
+
+[2m○[22m [2mShowing 5 worktrees, 4 ahead[0m

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_blank_error_message.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_blank_error_message.snap
@@ -10,16 +10,25 @@ info:
     CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
-    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
-    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
     LC_ALL: C
     LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
-    MOCK_CONFIG_DIR: "[MOCK_CONFIG_DIR]"
     OPENCODE_CONFIG_DIR: "[TEST_OPENCODE_CONFIG]"
     PATH: "[PATH]"
     TERM: alacritty
@@ -34,6 +43,7 @@ info:
     WORKTRUNK_TEST_EPOCH: "1735776000"
     WORKTRUNK_TEST_FISH_INSTALLED: "0"
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
+    WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
     WORKTRUNK_TEST_PARENT_SHELL: ""
@@ -49,4 +59,4 @@ exit_code: 1
 
 ----- stderr -----
 [36m◎[39m [36mFetching PR #101...[39m
-[31m✗[39m [31mGitea API error for PR #101 on owner/test-repo, but the response carried no message — Gitea hides 500 messages from non-admin tokens[39m
+[31m✗[39m [31mGitea API error 500 for PR #101 on owner/test-repo, but the response carried no message — Gitea hides 5xx messages from non-admin tokens[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_forbidden.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_forbidden.snap
@@ -10,10 +10,20 @@ info:
     CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
-    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
-    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -49,4 +59,4 @@ exit_code: 1
 
 ----- stderr -----
 [36m◎[39m [36mFetching PR #101...[39m
-[31m✗[39m [31mGitea API error for PR #101 on owner/test-repo: user does not have permission to read this repository[39m
+[31m✗[39m [31mGitea API error 403 for PR #101 on owner/test-repo: user does not have permission to read this repository[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_no_status_line.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_no_status_line.snap
@@ -59,4 +59,4 @@ exit_code: 1
 
 ----- stderr -----
 [36m◎[39m [36mFetching PR #101...[39m
-[31m✗[39m [31mGitea API error 401 for PR #101 on owner/test-repo: token is required[39m
+[31m✗[39m [31mtea api --include wrote no HTTP status line for PR #101, so a PR can't be told from an API error[39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_not_found.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_not_found.snap
@@ -10,10 +10,20 @@ info:
     CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
-    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
-    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -49,4 +59,4 @@ exit_code: 1
 
 ----- stderr -----
 [36m◎[39m [36mFetching PR #9999...[39m
-[31m✗[39m [31mGitea API error for PR #9999 on owner/test-repo: pull request does not exist [index: 9999][39m
+[31m✗[39m [31mGitea API error 404 for PR #9999 on owner/test-repo: pull request does not exist [index: 9999][39m

--- a/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_proxy_error_page.snap
+++ b/tests/snapshots/integration__integration_tests__switch__switch_pr_gitea_proxy_error_page.snap
@@ -59,4 +59,4 @@ exit_code: 1
 
 ----- stderr -----
 [36m◎[39m [36mFetching PR #101...[39m
-[31m✗[39m [31mGitea API error 401 for PR #101 on owner/test-repo: token is required[39m
+[31m✗[39m [31mGitea API error 502 for PR #101 on owner/test-repo, and the response body is not one Gitea sends[39m


### PR DESCRIPTION
`tea api` copies the response body to stdout and exits 0 whatever the HTTP status, so both Gitea call sites guessed from the body: a `message` key meant the request had failed, anything else was the resource. `tea api --include` writes the status line and headers to stderr and leaves stdout the bare body, so the status is available after all.

## Availability

`--include` shipped with the `api` subcommand itself in **v0.12.0** — `cmd/api.go` doesn't exist at v0.11.1 — and the implementation is byte-identical through v0.15.1. A `tea` old enough to lack the flag has no `api` to send it to, so nothing that can make this call rejects it. tea's own `api_test.go` passes flags ahead of the endpoint (`{"-d", "@file", "/test"}`), which settles the argument order.

## What the status buys

Two things the shape check couldn't do:

**A body Gitea didn't write is now an error.** A reverse proxy's HTML page has no `message` key, so it used to read as the resource — and `wt list` then logged `Failed to parse tea api pulls JSON`, blaming a Gitea API change for a gateway that never reached Gitea. Verified by restoring the old key and re-running: `proxy_page_is_an_error` fails against it and passes with the status.

**Retriability stops being a text sniff.** `is_retriable_error` was looking for `429` or `connection` somewhere in Gitea's prose, which never carries the code. 429 and 5xx are now the server saying "later"; every other 4xx is a token or a missing resource that repeating the call won't change. `gh` and `glab` still sniff because they bury the status inside prose.

Visible change: a blanked 500 shows the error indicator where it used to paint the same blank cell as a healthy branch with no CI. `gitea_blanked_500` and `gitea_not_found` pin both halves of that contrast.

## The body's three states

The status decides; the body only supplies text, and its three states are three different things to say — so `api_error_message` reports all three rather than flattening them. The switch path prints the code in its headline:

```
✗ Gitea API error 404 for PR #9999 on owner/test-repo: pull request does not exist [index: 9999]
✗ Gitea API error 500 for PR #101 on owner/test-repo, but the response carried no message — Gitea hides 5xx messages from non-admin tokens
✗ Gitea API error 502 for PR #101 on owner/test-repo, and the response body is not one Gitea sends
```

An exit-0 `tea` that writes no status line is a backstop rather than a fall-through: `--include` prints the moment the response does, so its absence means nothing arrived, and reading stdout as the resource there is the failure the status line exists to prevent. `switch_pr_gitea_no_status_line` covers it.

With the CI path no longer reading the message, `api_error_message` drops to module-private.

## Tests

Every mock `tea` response now carries the two streams a real one writes, via `tea_api_include_stderr`. `setup_mock_tea` takes the status explicitly, so each test states the HTTP response it stands for instead of leaving it implied — which also collapses four hand-rolled inline mocks into it.

## Cost

`--include` writes the whole header block, not just the status line, so captured stderr now holds whatever the server returns — a `Set-Cookie` among it, on a Gitea that issues one. That reaches disk only under `-vv`, which logs every subprocess's output to `subprocess.log`. There's no narrower flag, and the status isn't available any other way; it's noted in the module docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> _This was written by Claude Code on behalf of Maximilian_
