### PR TITLE
fix(shell): use command rm in wrapper cleanup to bypass rm aliases

### DIFF
--- a/src/shell/snapshots/worktrunk__shell__tests__init_bash.snap
+++ b/src/shell/snapshots/worktrunk__shell__tests__init_bash.snap
@@ -60,7 +60,7 @@ if command -v wt >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
             fi
         fi
 
-        rm -f "$cd_file" "$exec_file"
+        command rm -f "$cd_file" "$exec_file"
         return "$exit_code"
     }
 

--- a/src/shell/snapshots/worktrunk__shell__tests__init_zsh.snap
+++ b/src/shell/snapshots/worktrunk__shell__tests__init_zsh.snap
@@ -63,7 +63,7 @@ if command -v wt >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
             fi
         fi
 
-        rm -f "$cd_file" "$exec_file"
+        command rm -f "$cd_file" "$exec_file"
         return "$exit_code"
     }
 

--- a/src/shell/snapshots/worktrunk__shell__tests__shell_init_with_custom_prefix.snap
+++ b/src/shell/snapshots/worktrunk__shell__tests__shell_init_with_custom_prefix.snap
@@ -60,7 +60,7 @@ if command -v custom >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
             fi
         fi
 
-        rm -f "$cd_file" "$exec_file"
+        command rm -f "$cd_file" "$exec_file"
         return "$exit_code"
     }
 

--- a/templates/bash.sh
+++ b/templates/bash.sh
@@ -56,7 +56,7 @@ if command -v {{ cmd }} >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
             fi
         fi
 
-        rm -f "$cd_file" "$exec_file"
+        command rm -f "$cd_file" "$exec_file"
         return "$exit_code"
     }
 

--- a/templates/zsh.zsh
+++ b/templates/zsh.zsh
@@ -59,7 +59,7 @@ if command -v {{ cmd }} >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
             fi
         fi
 
-        rm -f "$cd_file" "$exec_file"
+        command rm -f "$cd_file" "$exec_file"
         return "$exit_code"
     }
 

--- a/tests/snapshots/integration__integration_tests__init__init_bash.snap
+++ b/tests/snapshots/integration__integration_tests__init__init_bash.snap
@@ -104,7 +104,7 @@ if command -v wt >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
             fi
         fi
 
-        rm -f "$cd_file" "$exec_file"
+        command rm -f "$cd_file" "$exec_file"
         return "$exit_code"
     }
 

--- a/tests/snapshots/integration__integration_tests__init__init_zsh.snap
+++ b/tests/snapshots/integration__integration_tests__init__init_zsh.snap
@@ -107,7 +107,7 @@ if command -v wt >/dev/null 2>&1 || [[ -n "${WORKTRUNK_BIN:-}" ]]; then
             fi
         fi
 
-        rm -f "$cd_file" "$exec_file"
+        command rm -f "$cd_file" "$exec_file"
         return "$exit_code"
     }
 


### PR DESCRIPTION
zsh (and bash with `expand_aliases`) expand aliases at function-**definition** parse time. If a user has `alias rm='rm -v'` defined before `eval "$(wt config shell init zsh)"` in their rc file — a common ordering, since alias blocks usually come first — the wrapper's cleanup bakes in `rm -v -f …`, and every `wt` invocation prints two lines of noise:

```
removed '/tmp/tmp.XXXXXXXXXX'
removed '/tmp/tmp.YYYYYYYYYY'
```

This changes the zsh and bash wrapper cleanup from `rm -f` to `command rm -f`, mirroring:

- the existing `command rm -f` in `templates/fish.fish`
- the `builtin cd` guard added for the same alias-expansion reason in the zsh template (#2643)

nushell and powershell are unaffected (`rm` there resolves to shell builtins with different alias semantics).

Insta snapshots regenerated; `cargo test --lib shell` passes (236 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)