### PR TITLE
fix(shell): don't panic on a multibyte shell name

### DIFF
--- a/src/path.rs
+++ b/src/path.rs
@@ -276,14 +276,18 @@ pub fn executable_name(path: &Path) -> Option<String> {
 
 /// Strip `suffix` from the end of `name`, matching it case-insensitively.
 ///
-/// The suffix is a parameter rather than [`std::env::consts::EXE_SUFFIX`] read
-/// in place so that a test on any platform can exercise the Windows answer: the
-/// constant is empty on Unix, where this can only ever be a no-op, and the
-/// merge gate runs one platform.
+/// The suffix is a parameter because the two callers strip different ones:
+/// [`executable_name`] strips the running platform's
+/// [`std::env::consts::EXE_SUFFIX`], while
+/// [`shell::extract_filename_from_path`](crate::shell::extract_filename_from_path)
+/// strips `.exe` on every platform. It also lets a test on any platform exercise
+/// the Windows answer, which `EXE_SUFFIX` — empty on Unix — cannot.
 ///
 /// `str::get` rather than a byte slice, so a name whose trailing bytes fall
-/// mid-character yields the name unchanged instead of panicking.
-fn strip_suffix_ignoring_case<'a>(name: &'a str, suffix: &str) -> &'a str {
+/// mid-character yields the name unchanged instead of panicking. The macOS `ps`
+/// snapshot feeds every process name on the machine through here, so a name
+/// like `日本語` is ordinary input rather than a hypothetical.
+pub(crate) fn strip_suffix_ignoring_case<'a>(name: &'a str, suffix: &str) -> &'a str {
     let stem_len = name.len().saturating_sub(suffix.len());
     match name.get(stem_len..) {
         Some(tail) if tail.eq_ignore_ascii_case(suffix) => &name[..stem_len],

--- a/src/shell/utils.rs
+++ b/src/shell/utils.rs
@@ -5,24 +5,20 @@
 
 use super::Shell;
 
-/// Extract executable name from a path, stripping `.exe` on Windows.
+/// Extract executable name from a path, stripping a trailing `.exe`.
 ///
 /// Uses `std::path::Path` for platform-native path handling:
 /// - Unix: `/usr/bin/bash` -> "bash"
 /// - Windows: `C:\Program Files\Git\usr\bin\bash.exe` -> "bash"
 ///
-/// Only strips `.exe` extension (not other extensions like `.9` in `zsh-5.9`).
+/// Only `.exe`, and on every platform — a version suffix like the `.9` in
+/// `zsh-5.9` stays, which is why this isn't `file_stem`.
+///
+/// `None` when the path names nothing, or names nothing but the suffix.
 pub fn extract_filename_from_path(path: &str) -> Option<&str> {
     let filename = std::path::Path::new(path).file_name()?.to_str()?;
-
-    // Strip .exe extension (case-insensitive for Windows)
-    // Don't use file_stem() because it would strip version numbers like ".9" from "zsh-5.9"
-    // Handle all case variants: .exe, .EXE, .Exe, .eXe, etc.
-    if filename.len() > 4 && filename[filename.len() - 4..].eq_ignore_ascii_case(".exe") {
-        Some(&filename[..filename.len() - 4])
-    } else {
-        Some(filename)
-    }
+    let name = crate::path::strip_suffix_ignoring_case(filename, ".exe");
+    (!name.is_empty()).then_some(name)
 }
 
 /// Determine Shell variant from a shell name (without path or extension).
@@ -417,7 +413,15 @@ mod tests {
     #[case::mixed_case_exe_title("bash.Exe", Some("bash"))]
     #[case::mixed_case_exe_upper("bash.EXE", Some("bash"))]
     #[case::mixed_case_exe_camel("bash.eXe", Some("bash"))]
+    // Multibyte names are ordinary input: `ps_snapshot` feeds every process
+    // name on the machine through here. `日本語`'s last four bytes start
+    // mid-character; `café.exe`'s do not, and still strip.
+    #[case::multibyte("日本語", Some("日本語"))]
+    #[case::multibyte_exe("café.exe", Some("café"))]
     #[case::empty("", None)]
+    // Nothing but the suffix names no command, so callers fall back to their
+    // next detection source rather than reporting an empty shell name.
+    #[case::suffix_only(".exe", None)]
     fn test_extract_filename_from_path_common(#[case] path: &str, #[case] expected: Option<&str>) {
         assert_eq!(extract_filename_from_path(path), expected);
     }


### PR DESCRIPTION
`shell::extract_filename_from_path` compared a file name's last four bytes against `.exe` by slicing at `len() - 4`, with no char-boundary check. Any name whose last four bytes start mid-character panicked.

<details>
<summary>Before and after, at the CLI</summary>

```console
$ SHELL=/bin/日本語 wt config show
thread 'main' panicked at src/shell/utils.rs:21:38:
start byte index 5 is not a char boundary; it is inside '本' (bytes 3..6 of string)
exit=101

$ SHELL=/bin/日本語 wt config show   # with this change
...
▲ Shell integration not active
  $SHELL: /bin/日本語
exit=0
```

</details>

`$SHELL` is the mild case. On macOS `ps_snapshot` feeds every process name on the machine through this function, so a single CJK-named process crashes any command that detects the shell.

The fix reuses `path::strip_suffix_ignoring_case` — the `str::get`-based helper #3719 added for naming wt from `argv[0]` — now `pub(crate)` and called with `.exe`. That leaves one case-insensitive suffix-stripper where there were two, one safe and one not.

One deliberate behavior change beyond the panic: a name that is nothing but the suffix (`.exe`) now yields `None` rather than `Some(".exe")`. All three callers already handle `None` by falling through to their next detection source, and `Some("")` — what a naive swap would produce — would have reported an empty shell name.

I checked for siblings of the same defect class; this was the only one. Every other computed slice index in `src/` derives from `find()`, which returns char boundaries.

> _This was written by Claude Code on behalf of max-sixty_
