### PR TITLE
fix(plugin): resolve WorktreeRemove against the worktree path, not the project dir

### DIFF
--- a/plugins/worktrunk/hooks/hooks.json
+++ b/plugins/worktrunk/hooks/hooks.json
@@ -79,7 +79,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'p=$(jq -er .worktree_path) || exit 1; cd \"${CLAUDE_PROJECT_DIR:-.}\" || exit 1; [ -e \"$p\" ] || exit 0; bash \"$CLAUDE_PLUGIN_ROOT/hooks/wt.sh\" remove --foreground \"$p\"'"
+            "command": "bash -c 'p=$(jq -er .worktree_path) || exit 1; [ -e \"$p\" ] || exit 0; bash \"$CLAUDE_PLUGIN_ROOT/hooks/wt.sh\" -C \"$p\" remove --foreground \"$p\"'"
           }
         ]
       }

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -3882,6 +3882,23 @@ fn test_plugin_layout_is_consolidated() {
          hooks.json:\n{hooks}"
     );
 
+    // The WorktreeRemove hook must resolve against the worktree path Claude
+    // Code hands it, not the session's project dir. The `claude agents` view
+    // spans every repo with a background session and is often launched from a
+    // parent directory that merely contains them, so `CLAUDE_PROJECT_DIR` names
+    // the wrong repo or none at all, `wt remove <path>` dies with `fatal: not a
+    // git repository`, and the session row is left undeletable (#3754, after
+    // the #3489 anchor proved insufficient). `-C "$p"` is layout-independent: a
+    // linked worktree carries a `.git` file pointing at its owning repository.
+    assert!(
+        worktree_remove_cmd.contains("-C \"$p\"")
+            && !worktree_remove_cmd.contains("CLAUDE_PROJECT_DIR"),
+        "WorktreeRemove hook must resolve via -C \"$p\" (the worktree path Claude Code \
+         handed it), never CLAUDE_PROJECT_DIR — the agents view is multi-repo, so no \
+         single project dir is correct for every session (#3754). \
+         command:\n{worktree_remove_cmd}"
+    );
+
     // The WorktreeCreate hook pipes `wt … --format=json | jq -er .path`. Without
     // `set -o pipefail` the pipeline's exit status is jq's, and `jq -er .path`
     // on the empty stdout of a failed `wt` exits 0 on jq 1.6 — so a `wt` failure


### PR DESCRIPTION
Follow-up to #3489. That PR anchored the `WorktreeRemove` hook at `CLAUDE_PROJECT_DIR`, which fixes the case where the variable names the repository. It cannot help when the anchor itself is not inside a repository — which is the normal situation for the `claude agents` view, and the case I still hit after #3489 landed.

### Why the project dir isn't a usable anchor here

The `claude agents` view is a single list spanning every repository you have run a background session in. It is launched from one directory, and for anyone managing several repos that directory is typically a parent that merely *contains* them rather than a repository itself:

```
claude daemon run --origin transient \
  --spawned-by {"label":"claude agents","cwd":"/…/Repositories/github.com/<org>",…}
```

`/…/Repositories/github.com/<org>` holds several clones and is not a git repository. The daemon supervisor's own cwd is `$HOME`, and its environment carries no `CLAUDE_PROJECT_DIR` at all. So both the anchor and the `:-.` fallback land outside any repository, and `wt remove <path>` dies exactly as it did before #3489:

```
✗ Failed to remove worktree
  fatal: not a git repository (or any of the parent directories): .git
# exit 1 → "WorktreeRemove hook failed" → session undeletable
```

The deletion runs in the long-lived daemon, so relaunching `claude agents` from inside a repository does not change the outcome. More generally: `CLAUDE_PROJECT_DIR` can only ever name one directory, but the agents view is inherently multi-repo — no single value is correct for every row in the list.

This is probably why it has stayed quiet: it only bites background sessions driven from the agents view, and only once the anchor directory isn't itself a repository.

### Change

Resolve against the worktree path itself, using the existing global `-C`:

```diff
-bash -c 'p=$(jq -er .worktree_path) || exit 1; cd "${CLAUDE_PROJECT_DIR:-.}" || exit 1; [ -e "$p" ] || exit 0; bash "$CLAUDE_PLUGIN_ROOT/hooks/wt.sh" remove --foreground "$p"'
+bash -c 'p=$(jq -er .worktree_path) || exit 1; [ -e "$p" ] || exit 0; bash "$CLAUDE_PLUGIN_ROOT/hooks/wt.sh" -C "$p" remove --foreground "$p"'
```

`$p` is strictly more specific than any environment variable: a linked worktree carries a `.git` file pointing at `<repo>/.git/worktrees/<name>`, so discovery from inside it resolves the owning repository wherever the worktree lives on disk. That makes the fix layout-independent — it behaves identically for the default out-of-tree layout and for a `worktree-path` pointing inside the repo. The `[ -e "$p" ]` guard from #3493 already runs first, so `-C "$p"` is only reached when the directory exists.

### Reproduction

cwd `$HOME`, `CLAUDE_PROJECT_DIR` unset, worktree clean and pushed. Run against both layouts — an out-of-tree worktree (default `worktree-path`) and one inside the repo:

| hook body | out-of-tree | in-repo |
|---|---|---|
| `cd "${CLAUDE_PROJECT_DIR:-.}"` … `remove` (current) | `fatal: not a git repository`, exit 1 | `fatal: not a git repository`, exit 1 |
| `-C "$p"` … `remove` (this PR) | `✓ Removed … worktree & branch`, exit 0 | `✓ Removed … worktree & branch`, exit 0 |

With `CLAUDE_PROJECT_DIR` set to the repository, both forms succeed — this PR only changes the case where it isn't.

### Knock-on: which `.config/wt.toml` supplies the removal hooks

The anchor also selects the project config that `pre-remove` / `post-remove` are taken from — they come from the invoking worktree, so `-C "$p"` makes that the worktree being removed rather than the project dir. Approvals are keyed on the repo-level project identifier, so a checked-in config the session never touched resolves identically and nothing changes.

The one behavioural delta is a session that edited `.config/wt.toml` inside its own worktree: those commands are then unapproved, and because the hook's stdin isn't a TTY, `prompt_for_batch_approval` returns `NotInteractive` and `wt remove` exits nonzero instead of continuing hookless. That is fail-closed, which seems right for a command the agent itself wrote — but it does mean that particular session stays undeletable from the agents view, so this trades one instance of the symptom for a narrower one rather than removing it outright.

### Tests

Initially none: an anchor regression surfaces loudly rather than silently, unlike #2939 / #3545, and #3453 / #3489 / #3493 each landed as a one-line `hooks.json` change with the test file untouched. On review it's a fair point that this is the fourth change to these two commands and `test_plugin_layout_is_consolidated` is where each prior fix was pinned, so the second commit adds an assertion there: the `WorktreeRemove` command must resolve via `-C "$p"`, and must not depend on `CLAUDE_PROJECT_DIR`. It sits next to the existing `-D` and `pipefail` checks on `worktree_remove_cmd`, and fails against the pre-fix `hooks.json`.

The existing assertions still hold: every hook command references `$CLAUDE_PLUGIN_ROOT` unbraced — unchanged; the WorktreeRemove command contains no ` -D` / `--force-delete` — `-C` is neither. `test_claude_hook_commands_parse_in_all_shells` checks the outer command line under fish/zsh/bash, and the edit stays inside the single-quoted `bash -c` body.

### Alternatives considered

- `cd "$p"` rather than `-C "$p"` — also works, but it moves the shell into the directory that is about to be deleted. `-C` leaves the cwd alone and matches how `wt step prune -C` is already used elsewhere.
- Keeping `CLAUDE_PROJECT_DIR` as a fallback — adds nothing. When it names the right repository, `-C "$p"` resolves to that same repository; when it doesn't, it is the bug being fixed.

### Out of scope

A path that exists on disk but holds no worktree (a skeleton left by an interrupted create/remove) still fails, because `[ -e "$p" ]` passes and `wt remove` then finds nothing to remove. That is orthogonal to the anchor — tracked separately in #3753.