### PR TITLE
fix(plugin): WorktreeRemove hook skips a path holding no worktree

### DIFF
--- a/plugins/worktrunk/hooks/hooks.json
+++ b/plugins/worktrunk/hooks/hooks.json
@@ -79,7 +79,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'p=$(jq -er .worktree_path) || exit 1; [ -e \"$p\" ] || exit 0; bash \"$CLAUDE_PLUGIN_ROOT/hooks/wt.sh\" -C \"$p\" remove --foreground \"$p\"'"
+            "command": "bash -c 'p=$(jq -er .worktree_path) || exit 1; [ -e \"$p/.git\" ] || exit 0; bash \"$CLAUDE_PLUGIN_ROOT/hooks/wt.sh\" -C \"$p\" remove --foreground \"$p\"'"
           }
         ]
       }

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -4003,6 +4003,132 @@ fn test_claude_hook_commands_parse_in_all_shells() {
     }
 }
 
+/// Claude Code fires `WorktreeRemove` with the path it recorded at creation, and
+/// that path can outlive the worktree in more than one way. #3493 covered the
+/// recorded path being gone. The third state is a path that *exists* but holds
+/// no worktree — a skeleton directory left by an interrupted create or remove:
+/// no `.git`, invisible to both `git worktree list` and `wt list`, and never
+/// cleaned up by prune. An existence guard let it through to `wt remove <path>`,
+/// which resolves a path naming no worktree as a branch name and exits 1 (`No
+/// branch named …` in-tree, `fatal: not a git repository` outside the repo).
+/// Claude Code reads that as a failed removal and keeps the session row, so the
+/// finished background session can never be deleted with Ctrl+X (#3753).
+///
+/// The guard therefore tests for git's marker rather than for the directory:
+/// every linked worktree carries a `.git` file, and a dirty / locked / unmerged
+/// one still does, so genuine failures keep surfacing loudly (#2939). All three
+/// directions are pinned below — a skeleton is a no-op, a clean worktree is
+/// still removed, a dirty one still fails — so neither a blanket `exit 0` nor a
+/// swallowed `wt remove` failure can satisfy this test. It runs the real command
+/// out of `hooks.json`, which parses its stdin with `jq`.
+#[cfg(all(unix, feature = "shell-integration-tests"))]
+#[rstest]
+fn test_worktree_remove_hook_skips_path_holding_no_worktree(mut repo: TestRepo) {
+    use std::io::Write;
+    use std::path::Path;
+    use std::process::{Output, Stdio};
+
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let hooks_json: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(root.join("plugins/worktrunk/hooks/hooks.json")).unwrap(),
+    )
+    .unwrap();
+    let command = hooks_json["hooks"]["WorktreeRemove"][0]["hooks"][0]["command"]
+        .as_str()
+        .expect("WorktreeRemove hook must define a command")
+        .to_owned();
+
+    // Branched from `main` at HEAD, so its removal is the unremarkable case:
+    // clean worktree, merged branch, both go. Created before `run_hook` below
+    // takes its shared borrow of `repo`.
+    let live = repo.add_worktree("hook-live");
+
+    // Fire the hook exactly as Claude Code does: the recorded path on stdin, the
+    // plugin root in the environment. No `CLAUDE_PROJECT_DIR` — the hook
+    // resolves the repository from the worktree path via `-C "$p"` and must
+    // never consult a project dir (#3754), so setting one here would be dead
+    // setup.
+    let run_hook = |worktree_path: &Path| -> Output {
+        let mut cmd = std::process::Command::new("bash");
+        repo.configure_wt_cmd(&mut cmd);
+        let mut child = cmd
+            .args(["-c", &command])
+            .env("WORKTRUNK_BIN", crate::common::wt_bin())
+            .env("CLAUDE_PLUGIN_ROOT", root.join("plugins/worktrunk"))
+            .current_dir(repo.root_path())
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::piped())
+            .spawn()
+            .expect("failed to spawn bash");
+        let payload = serde_json::json!({ "worktree_path": worktree_path.to_str().unwrap() });
+        child
+            .stdin
+            .take()
+            .unwrap()
+            .write_all(payload.to_string().as_bytes())
+            .unwrap();
+        child.wait_with_output().unwrap()
+    };
+    let describe = |output: &Output| {
+        format!(
+            "got {}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        )
+    };
+
+    // A skeleton directory: exists, holds no worktree, has no `.git`. Both
+    // shapes the issue reports — nested inside the repository, where git
+    // discovery walks up and answers for the *parent* (which is why
+    // `rev-parse --is-inside-work-tree` is not a usable test), and outside it,
+    // where git has nothing to walk up to.
+    for skeleton in [
+        repo.root_path().join(".claude/worktrees/ghost"),
+        repo.home_path().join("outside/ghost"),
+    ] {
+        fs::create_dir_all(skeleton.join("apps")).unwrap();
+        let output = run_hook(&skeleton);
+        assert!(
+            output.status.success(),
+            "hook must be a no-op for a path holding no worktree ({}); {}",
+            skeleton.display(),
+            describe(&output)
+        );
+        assert!(
+            skeleton.exists(),
+            "hook must leave a directory it doesn't own in place: {}",
+            skeleton.display()
+        );
+    }
+
+    // Leniency is scoped to "no worktree lives here", so a dirty worktree —
+    // which has a `.git` like any other — must still fail loudly rather than be
+    // swallowed alongside the skeletons.
+    assert!(live.join(".git").exists(), "a linked worktree has a .git");
+    fs::write(live.join("file.txt"), "uncommitted\n").unwrap();
+    let output = run_hook(&live);
+    assert!(
+        !output.status.success()
+            && String::from_utf8_lossy(&output.stderr).contains("uncommitted changes"),
+        "hook must still refuse a dirty worktree, and for that reason; {}",
+        describe(&output)
+    );
+    assert!(live.exists(), "a refused removal must leave the worktree");
+
+    // And the same worktree, once clean, is still removed — so a blanket
+    // `exit 0` can't satisfy this test either.
+    repo.run_git_in(&live, &["checkout", "--", "file.txt"]);
+    let output = run_hook(&live);
+    assert!(
+        output.status.success(),
+        "hook must remove a live worktree; {}",
+        describe(&output)
+    );
+    assert!(!live.exists(), "the hook must remove a real worktree");
+}
+
 // ==================== Plugin Install-Statusline Tests ====================
 
 #[rstest]


### PR DESCRIPTION
## Problem

The `WorktreeRemove` hook guards with `[ -e "$p" ]` — #3493's narrowing, which made the hook a no-op when the recorded worktree path is gone. #3753 reports the third state between "gone" and "live": a path that **exists but holds no worktree**. A skeleton directory left by an interrupted create or remove has no `.git`, is invisible to both `git worktree list` and `wt list`, and passes the existence guard, so `wt remove <path>` runs and resolves the path as a *branch* name:

```
✗ No branch named /…/.claude/worktrees/<name>
  ↳ To list branches, run wt list --branches --remotes
# exit 1
```

An out-of-tree skeleton gives `fatal: not a git repository` instead. Claude Code reads a nonzero `WorktreeRemove` as a failed removal and keeps the session row, so the finished background session can never be deleted with Ctrl+X — the same end symptom as #3488, but permanent: prune ignores a directory that was never a worktree, so nothing heals it.

## Solution

Test for git's marker rather than for the directory:

```diff
- [ -e "$p" ] || exit 0
+ [ -e "$p/.git" ] || exit 0
```

Every linked worktree carries a `.git` file, and a dirty, locked, or unmerged one still does, so genuine failures keep surfacing loudly — the #2939 spirit the #3493 guard was written to preserve. Leniency stays scoped to "no worktree lives here" rather than becoming a blanket success, and the change stays inside the single-quoted `bash -c` body, so outer login-shell (fish/zsh/bash) parsing is untouched.

`-e` rather than `-f` is deliberate: the *main* worktree's `.git` is a directory, so `-e` keeps `✗ The main worktree cannot be removed` loud where `-f` would silently no-op it.

This composes with #3754 rather than overlapping it: the guard now runs before `-C "$p"`, so `-C` only ever resolves a path that really is a worktree.

One state changes beyond the reported one, in the same direction: a registered worktree whose `.git` file was deleted by hand already failed the hook (`fatal: not a git repository`), and now exits 0, leaving a prunable registration for `git worktree prune`. Nothing `wt remove` could previously remove is skipped.

## Testing

`test_worktree_remove_hook_skips_path_holding_no_worktree` runs the real command out of `hooks.json` under `bash`, feeding it the recorded path on stdin exactly as Claude Code does. It pins three directions, so neither a blanket `exit 0` nor a swallowed `wt remove` failure can satisfy it: a skeleton is a no-op and is left on disk (both in-tree and out-of-tree), a dirty worktree still fails with `uncommitted changes` and stays put, and that same worktree once clean is still removed.

<details><summary>Mutation evidence and hand-verified states</summary>

Each mutation was applied to `hooks.json` and the test re-run:

| mutation | result |
|---|---|
| `[ -e "$p" ]` (the pre-fix guard) | fails — `hook must be a no-op for a path holding no worktree` |
| whole body replaced with `exit 0` | fails — `hook must still refuse a dirty worktree, and for that reason` |
| `wt remove … \|\| exit 0` (failure swallowed) | fails — same assertion |

Hand-verified against the built binary via `WORKTRUNK_BIN`, firing the hook as Claude Code does:

| state | before | after |
|---|---|---|
| skeleton dir, in-tree | exit 1, `No branch named …` | exit 0, directory untouched |
| skeleton dir, out-of-tree | exit 1, `fatal: not a git repository` | exit 0, directory untouched |
| recorded path gone | exit 0 | exit 0 |
| clean worktree | removed | removed |
| dirty worktree | exit 1, `has uncommitted changes` | unchanged |
| unmerged branch | worktree removed, branch retained + `-D` hint | unchanged |
| main worktree | exit 1, `The main worktree cannot be removed` | unchanged |
| registered worktree, `.git` deleted by hand | exit 1, `fatal: not a git repository` | exit 0, prunable entry left |

The test is gated on `all(unix, feature = "shell-integration-tests")`, which the required `test` jobs and the coverage run both enable; the hook parses its stdin with `jq`.

**Not verified:** Claude Code's own session-row teardown — CI can't drive the agent UI. The evidence here is the hook's exit status, which is what Claude Code branches on per #3488/#3493.

</details>

The full pre-merge gate passes locally (4571 tests, clippy, doctests, docs sync, no pending snapshots).

## Relation to #3755

Supersedes worktrunk-bot's #3755, whose one-line hook edit is byte-identical to this one. The difference is test coverage: #3755's test passes against a hook with `|| exit 0` appended to `wt remove`, which would silently discard the dirty-worktree refusal — verified by running that test file against the mutation. This one also covers the out-of-tree skeleton. #3755's `flake.nix` addition of `jq` is left out: the devShell already omits nushell so it can't run the shell-integration suite regardless, and the nix test derivation runs default features only, where this test isn't compiled.

Closes #3753. Thanks to @judewang for the report, the reproduction, and the fix direction — including the note that `git -C "$p" rev-parse --is-inside-work-tree` is not a usable test, since discovery walks up to the parent for a nested skeleton.

> _This was written by Claude Code on behalf of max-sixty_
