### PR TITLE
fix(nix): give the devShell every tool the test suite shells out to

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,7 +96,7 @@ cli = [
     "dep:tracing-subscriber",
 ]
 syntax-highlighting = ["dep:tree-sitter-bash", "dep:tree-sitter-highlight"]
-# Enable shell/PTY integration tests (requires bash, zsh, fish installed on system)
+# Enable shell/PTY integration tests (needs bash, zsh, fish, nu, pwsh, and jq on PATH)
 # Includes: shell wrapper tests, PTY-based approval prompts, TUI select, progressive rendering
 shell-integration-tests = []
 # Enable benchmarks whose fixture is too large for hosted CI: the

--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -287,7 +287,7 @@ This disables bash syntax highlighting in command output but keeps all core func
 
 ### Full integration tests
 
-Shell integration tests require bash, zsh, fish, and nushell:
+Shell integration tests require bash, zsh, fish, nushell, and pwsh, plus `jq`:
 
 {{ terminal(cmd="cargo test --test integration --features shell-integration-tests") }}
 

--- a/flake.nix
+++ b/flake.nix
@@ -201,12 +201,6 @@
             cargo-release
             cargo-llvm-cov
 
-            # Host tools the suite shells out to; the `worktrunk-tests` check
-            # above names what each one is for.
-            python3
-            procps
-            lsof
-
             # Shells the `shell-integration-tests` feature drives, plus the
             # `jq` its Claude-hook tests pipe the hook payload through. The
             # pre-merge gate runs `--all-features`, so a run here exercises

--- a/flake.nix
+++ b/flake.nix
@@ -150,8 +150,9 @@
           # Wider src than the package build: tests need .snap files and
           # tests/ fixtures (prebuilt _git/ trees, .sh scripts, no-extension
           # git database files). Default features only — shell-integration-
-          # tests requires zsh/fish/nushell + PTY (see CLAUDE.md → "Shell/PTY
-          # Integration Tests").
+          # tests wants a PTY and more shells than this derivation carries;
+          # the devShell below is where that set lives (see tests/CLAUDE.md →
+          # "Feature Flags, Not Runtime Skipping").
           worktrunk-tests = craneLib.cargoTest (
             commonArgs
             // {
@@ -200,10 +201,22 @@
             cargo-release
             cargo-llvm-cov
 
-            # For shell integration tests
+            # Host tools the suite shells out to; the `worktrunk-tests` check
+            # above names what each one is for.
+            python3
+            procps
+            lsof
+
+            # Shells the `shell-integration-tests` feature drives, plus the
+            # `jq` its Claude-hook tests pipe the hook payload through. The
+            # pre-merge gate runs `--all-features`, so a run here exercises
+            # every one.
             bash
             zsh
             fish
+            nushell
+            powershell
+            jq
 
             # Development tools
             git

--- a/plugins/worktrunk/skills/worktrunk/reference/faq.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/faq.md
@@ -284,7 +284,7 @@ cargo test
 
 ### Full integration tests
 
-Shell integration tests require bash, zsh, fish, and nushell:
+Shell integration tests require bash, zsh, fish, nushell, and pwsh, plus `jq`:
 
 ```bash
 cargo test --test integration --features shell-integration-tests

--- a/skills/worktrunk/reference/faq.md
+++ b/skills/worktrunk/reference/faq.md
@@ -284,7 +284,7 @@ cargo test
 
 ### Full integration tests
 
-Shell integration tests require bash, zsh, fish, and nushell:
+Shell integration tests require bash, zsh, fish, nushell, and pwsh, plus `jq`:
 
 ```bash
 cargo test --test integration --features shell-integration-tests

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -427,7 +427,9 @@ fn test_fish_integration() {
 - CI can enable features when dependencies are installed
 
 **Existing feature flags:**
-- `shell-integration-tests` — Tests requiring bash/zsh/fish shells and PTY
+- `shell-integration-tests` — Tests that drive real shells over a PTY: bash,
+  zsh, fish, nushell, and pwsh, plus the `jq` the Claude hook commands in
+  `plugins/worktrunk/hooks/` pipe their payload through
 
 ## PTY Tests and README Examples
 


### PR DESCRIPTION
`devShells.default` listed `bash`, `zsh`, `fish` under a `# For shell integration tests` comment, but that feature drives two more shells and shells out to `jq`. So `nix develop` could not run `--features shell-integration-tests`, which is what the repo's own gate runs (`.config/wt.toml` → `cargo insta test … --all-features`). This adds `nushell`, `powershell` and `jq`.

The same dependency claim was stated, wrongly, in three other places. All four now name the real set:

| Where | Was | Now |
|---|---|---|
| `flake.nix` devShell | bash, zsh, fish | + nushell, powershell, jq |
| `Cargo.toml` feature comment | bash, zsh, fish | + nu, pwsh, jq |
| `tests/CLAUDE.md` | bash/zsh/fish + PTY | + nushell, pwsh, jq |
| `docs/content/faq.md` | bash, zsh, fish, nushell | + pwsh, jq |

`flake.nix` also referenced a `CLAUDE.md → "Shell/PTY Integration Tests"` heading that exists nowhere in the repo; it now points at the section that does.

## Verification

There is no `nix` on the machine this was written on, so the two claims were checked separately rather than by entering the shell.

**Is the list right?** A symlink farm modelling a devShell's `PATH` — nixpkgs stdenv's own tools plus the candidate list, and nothing else — with the full `--all-features` suite run under it. `configure_pty_command` propagates the test process's `PATH` into PTY children, so this reaches the shell tests.

<details>
<summary>Runs (the control is what makes the failures attributable)</summary>

| PATH | Result |
|---|---|
| Full ambient PATH (control) | 4572 passed, 0 failed |
| stdenv + every tool the suite needs | 4572 passed, 0 failed |
| …minus `pwsh` | 3 `shell_powershell` tests fail |
| …minus `jq` | `test_worktree_remove_hook_skips_path_holding_no_worktree` fails |
| …minus `python3` / `lsof` / `ps` | 6 failed: 2 `for_each`/`post_start` (python3), 1 `remove::test_remove_reap_kills_process` (lsof), 3 pgid/process-probe (ps) |

The control run matters: it establishes that every failure above is caused by the withheld tool rather than by a local flake.

The last row is about what the *suite* needs, not what the shell was missing — see the correction below.

</details>

**Does the flake still evaluate?** `nixos/nix` in a container, evaluating `devShells.<system>.default` for all four systems `flake-utils` covers, against unmodified `main` as a control. All four evaluate, and every tool resolves on each.

Not verified: nothing here was *built*, only evaluated, so a package that evaluates but fails to build would not have been caught. The nightly `nix-flake` job runs `nix flake check` on PRs touching `flake.nix`, which covers that on x86_64-linux.

<details>
<summary>A correction: python3/procps/lsof were never missing</summary>

The first version of this PR also added `python3`, `procps` and `lsof`, claiming the shell could not run a plain `cargo test`. That was wrong, and worktrunk-bot caught it.

`craneLib.devShell` sets `inputsFrom = builtins.attrValues checks ++ inputsFrom`, and `mkShell` folds each `inputsFrom` derivation's `nativeBuildInputs` into its own. `checks` includes `worktrunk-tests`, whose `nativeBuildInputs` already carry `git`, `python3`, `procps` and `lsof` — so the devShell inherited all four. Evaluating the unmodified `main` tree confirms it: its `x86_64-linux` devShell derivation already contains `python3`, `procps` and `lsof`, and contains no `nushell`, `powershell` or `jq`.

The symlink farm could not have caught this: it modelled stdenv plus the literal `packages` list, so crane's inherited inputs were invisible to it by construction. The experiment established what the *suite* needs; it said nothing about what the *shell already had*.

Those three lines are dropped. `git` remains listed in both places — pre-existing, and left alone here.

</details>

<details>
<summary>A guard I added and then removed</summary>

`powershell` first went in behind `lib.meta.availableOn`, because nixos-unstable's PowerShell has no `x86_64-darwin` source. Testing that guard against nixpkgs HEAD showed the actual cause: nixpkgs 26.11 dropped Intel macOS wholesale, so the entire flake fails to evaluate there regardless of the guard. On every system nixpkgs still supports, PowerShell has a build — the guard protected against nothing, and its comment justified it with the wrong mechanism. Removed; `powershell` is listed plainly with the other shells.

</details>

## Notes

`task setup-web` checks for `bash zsh fish nu` and not `pwsh`/`jq` — the same gap in a different environment, left alone here since its install mechanics are unrelated.

> _This was written by Claude Code on behalf of max-sixty_
