### PR TITLE
docs(ci): record that the release/signing environments admit any tag

### DIFF
--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -34,8 +34,8 @@ joins an environment can read every secret in it:
 | Environment | Admits | Secret | Read by |
 |-------------|--------|--------|---------|
 | `tend` | `main` | `CLAUDE_CODE_OAUTH_TOKEN`, `TEND_BOT_TOKEN` | every `tend-*.yaml` job except `relay`; `append-gist`; both `create-issue-on-*-failure` jobs |
-| `release` | `v*` tags | `AUR_SSH_PRIVATE_KEY`, `TEND_BOT_TOKEN` | `publish-aur`, `publish-winget`, `publish-homebrew` |
-| `signing` | `v*` tags | `SIGNPATH_API_TOKEN` | `build-local-artifacts` |
+| `release` | any tag | `AUR_SSH_PRIVATE_KEY`, `TEND_BOT_TOKEN` | `publish-aur`, `publish-winget`, `publish-homebrew` |
+| `signing` | any tag | `SIGNPATH_API_TOKEN` | `build-local-artifacts` |
 | `github-pages` | `main` | none — OIDC only | `deploy-docs` |
 
 The deployment branch policy is the gate: a job naming an environment runs
@@ -46,9 +46,16 @@ ruleset, admin-only), which is what makes both admitted sets unreachable to
 it. No environment has a reviewer rule, so joining a job to one costs no
 approval step.
 
+The tag policies admit every tag rather than a `v*` pattern. "Tag operations"
+covers `~ALL` tags, so the pattern carries no part of the gate — it only
+duplicates `release.yaml`'s own tag filter, and the two are easy to drift
+apart. They already had: the workflow fires on `**[0-9]+.[0-9]+.[0-9]+*`,
+which matches an unprefixed `1.2.3` that a `v*` policy would then refuse, so a
+release cut under that name would have failed at the first publish job.
+
 `TEND_BOT_TOKEN` is stored in two environments rather than shared, because a
 policy admits branches or tags but the token is needed under both: the bot's
-own workflows run on `main`, the publish jobs on a `v*` tag. Adding the tag to
+own workflows run on `main`, the publish jobs on a tag. Adding the tag to
 `tend` is not an option — `tend check` pins that policy to exactly the
 protected branches and its `--fix` deletes anything else.
 

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -50,8 +50,10 @@ The tag policies admit every tag rather than a `v*` pattern. "Tag operations"
 covers `~ALL` tags, so the pattern carries no part of the gate — it only
 duplicates `release.yaml`'s own tag filter, and the two are easy to drift
 apart. They already had: the workflow fires on `**[0-9]+.[0-9]+.[0-9]+*`,
-which matches an unprefixed `1.2.3` that a `v*` policy would then refuse, so a
-release cut under that name would have failed at the first publish job.
+which matches an unprefixed `1.2.3` that a `v*` policy would then refuse. A
+release cut under that name would have stopped at `build-local-artifacts`,
+which names `signing` and waits only on `plan` — before an artifact was built,
+let alone published.
 
 `TEND_BOT_TOKEN` is stored in two environments rather than shared, because a
 policy admits branches or tags but the token is needed under both: the bot's

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -118,9 +118,9 @@ jobs:
     # This job doesn't deploy anything; the environment scopes
     # SIGNPATH_API_TOKEN so it isn't readable by every workflow the repo runs.
     # It is deliberately not `release`, which also holds the publish
-    # credentials — see .github/CLAUDE.md. The `v*` tag policy means setting
-    # `pr-run-mode = "upload"` in dist-workspace.toml would make GitHub reject
-    # this job on a PR ref.
+    # credentials — see .github/CLAUDE.md. The policy admits tags only, so
+    # setting `pr-run-mode = "upload"` in dist-workspace.toml would make GitHub
+    # reject this job on a PR ref.
     environment: signing
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The `release` and `signing` deployment branch policies were pinned to `v*` tags; they now admit any tag, and this records that.

The "Tag operations" ruleset covers `~ALL` tags, so the `v*` pattern carried no part of the gate — tend's `_tags_admin_gated` credits a tag entry on that ruleset alone and never reads the pattern. What the pattern did do was duplicate `release.yaml`'s own tag filter, which is broader: `**[0-9]+.[0-9]+.[0-9]+*` matches an unprefixed `1.2.3`, which a `v*` policy would then refuse. A release cut under that name would have stopped at `build-local-artifacts` — it names `signing` and waits only on `plan`, so the refusal lands before an artifact is built, not at a publish job. Dropping the pattern removes the only place the two could drift.

This also brings the repo onto the shape install-tend's §3 recipe documents (`-f name='*' -f type=tag`), which worktrunk had deviated from. `uvx tend check` still reports 8/8.

Also updates a stale `v*` reference in the `signing` job's comment in `release.yaml`.

> _This was written by Claude Code on behalf of max-sixty_
