### PR TITLE
fix(env): drop Intel macOS from the flake, and install pwsh and jq for web setup

### DIFF
--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -58,9 +58,10 @@ tasks:
         echo "Installing shell-integration test dependencies..."
         if command -v apt-get &> /dev/null; then
             export DEBIAN_FRONTEND=noninteractive
-            # An `if` rather than an `&&` chain: with no `.list` files to
-            # match, the glob leaves `$f` as the pattern itself, the chain
-            # ends false, and `set -e` takes the whole task down.
+            # An `if` rather than an `&&` chain: under `set -e` a chain
+            # ending false takes the whole task down, and this one ends
+            # false both on an unmatched glob and on a `.list` file with
+            # no `[` line.
             for f in /etc/apt/sources.list.d/*.list; do
                 if [ -f "$f" ] && grep -q '^\[' "$f" 2>/dev/null; then
                     rm -f "$f"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -53,22 +53,47 @@ tasks:
         fi
         echo "Rust version: $(rustc --version | awk '{print $2}')"
 
-        # Install shells
+        # Install what the `shell-integration-tests` feature drives
         echo ""
-        echo "Installing shells for integration tests..."
+        echo "Installing shell-integration test dependencies..."
         if command -v apt-get &> /dev/null; then
             export DEBIAN_FRONTEND=noninteractive
+            # An `if` rather than an `&&` chain: with no `.list` files to
+            # match, the glob leaves `$f` as the pattern itself, the chain
+            # ends false, and `set -e` takes the whole task down.
             for f in /etc/apt/sources.list.d/*.list; do
-                [ -f "$f" ] && grep -q '^\[' "$f" 2>/dev/null && rm -f "$f"
+                if [ -f "$f" ] && grep -q '^\[' "$f" 2>/dev/null; then
+                    rm -f "$f"
+                fi
             done
-            if ! command -v zsh &> /dev/null || ! command -v fish &> /dev/null; then
+            # A missing pwsh joins the condition so one refresh serves both
+            # installs: apt resolves the PowerShell .deb's dependencies from
+            # these lists too.
+            if ! command -v zsh &> /dev/null || ! command -v fish &> /dev/null \
+                || ! command -v jq &> /dev/null || ! command -v pwsh &> /dev/null; then
                 apt-get update -qq
-                apt-get install -y -qq zsh fish
+                apt-get install -y -qq zsh fish jq
+            fi
+            # PowerShell isn't in Debian's repos. Install the release .deb
+            # rather than the tarball: pwsh aborts at startup without libicu,
+            # and only the .deb declares that dependency for apt to resolve.
+            if ! command -v pwsh &> /dev/null; then
+                PWSH_VERSION="7.6.4"
+                URL="https://github.com/PowerShell/PowerShell/releases/download/v${PWSH_VERSION}/powershell_${PWSH_VERSION}-1.deb_amd64.deb"
+                TEMP=$(mktemp -d)
+                curl -fsSL -o "$TEMP/powershell.deb" "$URL"
+                apt-get install -y -qq "$TEMP/powershell.deb"
+                rm -rf "$TEMP"
+                echo "pwsh installed"
             fi
         fi
-        for shell in bash zsh fish nu; do
-            command -v "$shell" &> /dev/null || { echo "Error: $shell not found"; exit 1; }
-            echo "$shell available"
+        # The shells the feature drives, plus the `jq` its Claude-hook tests
+        # pipe the hook payload through. Run each rather than looking for it
+        # on PATH, because a pwsh missing its libicu is on PATH and aborts at
+        # startup anyway.
+        for tool in bash zsh fish nu pwsh jq; do
+            "$tool" --version > /dev/null 2>&1 || { echo "Error: $tool not usable"; exit 1; }
+            echo "$tool available"
         done
 
         # Install gh CLI

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,11 @@
       rust-overlay,
       crane,
     }:
-    flake-utils.lib.eachDefaultSystem (
+    # `eachDefaultSystem` minus x86_64-darwin: nixpkgs drops Intel macOS in
+    # 26.11, so that system stops evaluating once flake.lock advances past
+    # it. Release binaries still ship for Intel macOS (dist-workspace.toml);
+    # this is the Nix surface only.
+    flake-utils.lib.eachSystem [ "x86_64-linux" "aarch64-linux" "aarch64-darwin" ] (
       system:
       let
         overlays = [ (import rust-overlay) ];
@@ -212,8 +216,8 @@
             powershell
             jq
 
-            # Development tools
-            git
+            # Development tools. `git` comes from the `checks` above: crane
+            # folds each check's `nativeBuildInputs` in via `inputsFrom`.
             gh
             pre-commit
           ];

--- a/tests/CLAUDE.md
+++ b/tests/CLAUDE.md
@@ -14,7 +14,7 @@ cargo test --test integration --features shell-integration-tests   # + shell tes
 
 Every binary the suite spawns is `wt` itself — the mock commands are the same binary linked under other names, dispatching on argv[0] (`testing::mock_stub`) — so no run can spawn missing or stale code: cargo rebuilds a package's own binaries whenever its integration tests build, under every runner and filter, and the `CARGO_BIN_EXE_wt` the harness resolves at runtime names that just-built binary; outside a cargo runner the suite panics ("CARGO_BIN_EXE_wt not set") rather than guessing a path. `cargo build --bin wt` recompiling right after a test run is the bin-only build being a separate cached unit (a different feature graph), not evidence the tests ran stale code.
 
-**Claude Code web:** `task setup-web` installs zsh/fish/nushell, `gh`, and dev tools. Install `task` first if needed: `sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/bin` then `export PATH="$HOME/bin:$PATH"`. The permission tests (`test_permission_error_prevents_save`, `test_approval_prompt_permission_error`) skip automatically when running as root.
+**Claude Code web:** `task setup-web` installs zsh, fish, `jq`, PowerShell, `gh`, and dev tools, and checks that nushell is already there. Install `task` first if needed: `sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/bin` then `export PATH="$HOME/bin:$PATH"`. The permission tests (`test_permission_error_prevents_save`, `test_approval_prompt_permission_error`) skip automatically when running as root.
 
 **Shell/PTY tests** (`shell-integration-tests` feature): approval prompts, picker, progressive rendering, shell wrappers.
 


### PR DESCRIPTION
Three follow-ups from #3768, plus a bug the verification turned up.

**The flake stops declaring outputs for `x86_64-darwin`.** nixpkgs drops Intel macOS in 26.11: evaluating anything for that system against `nixos-unstable` (`26.11pre-git`) throws. The rev `flake.lock` pins is 26.05-era, so it still evaluates today, carrying nixpkgs' own warning that "26.05 will be the last release to support x86_64-darwin". Naming three systems rather than `eachDefaultSystem` drops Nix support for Intel Macs now, ahead of that bump. Release binaries are untouched: `dist-workspace.toml` still ships `x86_64-apple-darwin` and nightly still tests it on `macos-15-intel`.

**`git` leaves the devShell's `packages`.** It arrives with the `checks`, which crane folds in via `inputsFrom`, the same mechanism that already supplied `python3`, `procps` and `lsof`.

**`task setup-web` installs `pwsh` and `jq`.** Without them Claude Code web can't run `--features shell-integration-tests`, which is what the pre-merge gate runs. PowerShell comes from the release `.deb` rather than the tarball, because pwsh aborts at startup without libicu and only the `.deb` declares that dependency for apt to resolve. The verification loop runs each tool instead of looking for it on PATH, since the tarball install left a `pwsh` that was on PATH and still aborted.

**A `set -e` abort found while testing that.** The `sources.list.d` cleanup was an `&&` chain, and under `set -e` a chain ending false takes the whole task down. This one ends false on an unmatched glob and on a `.list` file with no `[` line, so setup was dying before it installed anything on a stock Debian box as well as an empty one. It's an `if` now.

## Verification

No `nix` on the machine this was written on, so the flake was checked in a `nixos/nix` container and the Taskfile block in an amd64 Debian one.

<details>
<summary>flake: three systems evaluate, x86_64-darwin is gone, git survives its deletion</summary>

```
== devShell evaluates per system ==
x86_64-linux     OK   g172vwl0g339zsxx9l6mz5pca6w9jbcx-nix-shell.drv
aarch64-linux    OK   pgvq71zs48bx3naddncms954jyqpl0bl-nix-shell.drv
aarch64-darwin   OK   d17q1772si0x0hj1lgpnin8wiq4zlpr2-nix-shell.drv
x86_64-darwin    FAIL: flake does not provide attribute 'devShells.x86_64-darwin.default'

== systems the flake declares ==
["aarch64-darwin","aarch64-linux","x86_64-linux"]

== tools in the x86_64-linux devShell ==
  git: present        jq: present         nushell: present
  powershell: present python3: present    procps: present
  lsof: present       fish: present       zsh: present
  bash: present       gh: present         pre-commit: present

== nixfmt --check flake.nix ==
  clean (exit 0)
```

The x86_64-darwin claim, checked against nixpkgs directly rather than inferred:

```
== nixos-unstable lib.version ==
"26.11pre-git"
== x86_64-darwin eval on nixos-unstable ==
  error, pointing at release-notes#x86_64-darwin-26.11
== x86_64-darwin eval on the pinned rev (flake.lock) ==
evaluation warning: Nixpkgs 26.05 will be the last release to support x86_64-darwin
"hello-2.12.3"
```

Not verified: nothing was built, only evaluated. The nightly `nix-flake` job runs `nix flake check` on PRs touching `flake.nix`, which covers that on x86_64-linux.

</details>

<details>
<summary>setup-web: the block run under Task's own interpreter, in an amd64 Debian container</summary>

The edited block was extracted into a minimal Taskfile and run by `task` itself, so mvdan/sh parses it rather than bash. `curl` and nushell are container prereqs, not part of what's under test.

```
=== running the extracted block under Task ===
Installing shell-integration test dependencies...
pwsh installed
bash available
zsh available
fish available
nu available
pwsh available
jq available
task exit: 0

=== does the installed pwsh actually run? ===
7.6.4
jq-1.6
/usr/bin/pwsh

=== rerun is idempotent ===
Installing shell-integration test dependencies...
bash available   zsh available   fish available
nu available     pwsh available  jq available
```

Two earlier runs are why the shape changed. The first died at the `sources.list.d` glob. The second installed PowerShell from the release tarball: every tool reported "available" and `pwsh` then aborted with `Couldn't find a valid ICU package installed on the system`, which is what moved the install to the `.deb` and the check from `command -v` to `--version`.

</details>

`cargo run -- hook pre-merge --yes` passes: 4574 tests, 1 skipped.

## Notes

`task setup-web` still requires nushell to be present rather than installing it, unchanged here.

> _This was written by Claude Code on behalf of max-sixty_
