### PR TITLE
docs(tend): bound the data-loss hold to what the deletion can reach

### DIFF
--- a/.claude/skills/running-tend/references/review-pr.md
+++ b/.claude/skills/running-tend/references/review-pr.md
@@ -18,9 +18,12 @@ delete, or edits a file that contains one:
 
 The hold is for what a user can't get back: a worktree, a repository, a branch,
 uncommitted work, or a file worktrunk writes on their behalf (its own config and
-state, an rc file, another tool's settings). A deletion confined to a directory
-the same code just created, or to a throwaway CI or development environment,
-reaches none of that.
+state, an rc file, another tool's settings). A deletion reaches none of that when
+everything under its target can be regenerated, or when it is confined to a
+throwaway CI or development environment. The test is the contents rather than the
+directory's age: `wt step promote` creates its staging directory and removes it
+inside one operation, and in between the directory holds the user's only copy of
+both worktrees' ignored files.
 
 Hold on what the diff can reach, not co-location. In source, a change near the
 force-delete path holds even when the destructive line isn't in the diff. In

--- a/.claude/skills/running-tend/references/review-pr.md
+++ b/.claude/skills/running-tend/references/review-pr.md
@@ -6,8 +6,8 @@ Worktrunk's worst failure is silently destroying a user's work, and the deletion
 surface is where it leaks in. A change that touches it is not an agent's to
 merge: a force-flag bypass can read as harmless and still discard committed work.
 
-Flag a PR when its diff **introduces** any of these, or **edits a file that
-already contains** one:
+Flag a PR when its diff adds one of these, widens what an existing one can
+delete, or edits a file that contains one:
 
 - `wt remove`, especially `-D` / `--force-delete` or `-f` / `--force`
 - `git branch -D` / `-d`, `git worktree remove --force`
@@ -15,6 +15,12 @@ already contains** one:
 - `rm -rf`, `std::fs::remove_dir_all`, `std::fs::remove_file`
 - shipped automation that runs the above: `plugins/*/hooks/hooks.json`,
   `hooks/hooks.json`, `hooks/wt.sh`, and skill or alias examples users copy
+
+The hold is for what a user can't get back: a worktree, a repository, a branch,
+uncommitted work, or a file worktrunk writes on their behalf (its own config and
+state, an rc file, another tool's settings). A deletion confined to a directory
+the same code just created, or to a throwaway CI or development environment,
+reaches none of that.
 
 Hold on what the diff can reach, not co-location. In source, a change near the
 force-delete path holds even when the destructive line isn't in the diff. In


### PR DESCRIPTION
The data-loss hold in the tend review reference was purely lexical: any deletion token appearing in a diff matched, with no bound on what the deletion could reach. On #3776 that meant holding on `rm -rf "$TEMP"` against a `mktemp -d` the same script created three lines earlier, and on `rm -f` against the container's apt lists inside `task setup-web`. Neither can touch a worktree.

The trigger list is unchanged. Two things now bound it:

- The first clause fires on adding a deletion or on widening what an existing one can delete, so restructuring one that keeps firing on the same or fewer paths is no longer a match.
- A new paragraph names the surface the hold protects: a worktree, a repository, a branch, uncommitted work, or a file worktrunk writes on the user's behalf — the inventory in CLAUDE.md § Data Safety. A deletion reaches none of it when everything under its target can be regenerated, or when it is confined to a throwaway CI or development environment.

The carve-out turns on contents, not on how recently the directory was created. `wt step promote` is the in-repo counterexample to the naive version: `stage_ignored` moves both worktrees' ignored files into `.git/wt/staging/promote` and `distribute_staged` removes the directory at the end of the same operation, so a directory the code just created holds the user's only copy in between — which is why `check_leftover_staging` refuses to proceed when it survives.

Checked against cases that must still hold: `remove_dir_all` on a worktree path, `git clean -fdx` in a shipped hook, and a Taskfile step deleting `.git/wt/` state all match, since none of those targets is regenerable or confined to a throwaway environment.

This file lists `rm -rf` and its neighbours as review triggers, so the diff edits a file that contains one. It executes nothing.

`cargo run -- hook pre-merge --yes` passes: 4583 tests, 1 skipped.

> _This was written by Claude Code on behalf of max-sixty_
