### PR TITLE
docs(release): scope the changelog length rule to bullets, on a three-point scale

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -134,13 +134,13 @@ Skip: internal refactors, test additions (unless user-facing like shell completi
 
 **Combine related bullets.** Several PRs that share a theme — e.g. three perf changes that together account for one user-visible speedup — belong in one bullet, not three. The reader cares about the net change, not the PR boundaries. Cite all the PRs in the trailing `([#a](...), [#b](...), [#c](...))` list.
 
-**Be brief — the ceiling is words, not sentences.** A bullet lands at 40 words or under; the two or three headline entries may reach 80; Internal-section bullets get one sentence. The whole release — every section together, which is what the command below measures — stays under ~1,200 words. Drop the "why we did it this way" details unless they change how the user thinks about the change, and leave code examples and `Cmd::stream` / `OnceCell` / `DashMap`-style internals in the PR description, where the reasoning belongs.
+**Be brief — the ceiling is words, not sentences.** A bullet aims at 35 words; a dense one runs to 60, and the two or three headline entries may reach 80; Internal-section bullets get one sentence. Drop the "why we did it this way" details unless they change how the user thinks about the change, and leave code examples and `Cmd::stream` / `OnceCell` / `DashMap`-style internals in the PR description, where the reasoning belongs.
 
 Sentences stretch to fit whatever you want to say; words don't. So measure rather than judge:
 
 ```bash
 awk '/^## /{if (f) exit; f=1} f' CHANGELOG.md \
-  | awk '/^- \*\*/ {n=split($0,_," "); t+=n; c++; printf "%4d  %.58s\n", n, $0} END {printf "\n%d entries, %d words, %d avg\n", c, t, c?t/c:0}'
+  | awk '/^- \*\*/ {n=split($0,_," "); t+=n; c++; if (n>60) o++; printf "%4d  %.58s\n", n, $0} END {printf "\n%d entries, %d avg, %d over 60\n", c, c?t/c:0, o}'
 ```
 
 **Calibrate against the ceiling, not against the last release.** Length ratchets: each release is drafted beside the previous section, and an abstract rule loses to a concrete neighbouring exemplar every time. Entries grew from 49 to 101 words on average across five releases while this skill said "be brief" throughout. Read the previous section for what it drifted to, then ignore it and write to the ceiling.
@@ -251,7 +251,7 @@ For EACH entry:
 2. Read the actual diff, not just the commit message
 3. Confirm the entry accurately describes the user-facing change
 4. Flag if the entry overstates, understates, or misdescribes the change
-5. Flag if the entry runs over 40 words (80 for one of the two or three headline
+5. Flag if the entry runs over 60 words (80 for one of the two or three headline
    entries), restates the PR description, or explains mechanism the reader cannot
    act on — report these as seriously as an inaccuracy, and quote a shorter
    rewrite that keeps every user-facing claim


### PR DESCRIPTION
Two corrections to the changelog length rule [#3774](https://github.com/max-sixty/worktrunk/pull/3774) added, both surfaced by writing 0.72.0's section to it in [#3778](https://github.com/max-sixty/worktrunk/pull/3778).

**The whole-release ~1,200-word ceiling is gone.** It gated a number dominated by things that aren't prose: of that section's 1,314 measured words, 320 are the bold entry titles and 76 are trailing PR links and `thanks @…` credits, leaving 918 words of description. A release-level total also scales with entry count, so a release with more changes reads as more verbose without any single bullet being longer. The per-bullet numbers are the rule; the release total was a second, worse proxy for the same thing.

**One number became a scale: 35 typical, 60 for a dense entry, 80 for the two or three headline entries.** A flat 40 put more than half of a carefully-trimmed section in violation, which makes the rule noise rather than a signal. 60 is roughly 43 words of description once the ~17 words of title, links, and credit are subtracted — two full sentences, which is what an entry combining several PRs actually needs.

The measuring command reported the release total. It now reports the average and the count over 60:

```
30 entries, 43 avg, 3 over 60
```

Worth flagging against this change: on 0.72.0's section those 3 *are* the designated headline entries, so the outer bound flags nothing there. The live signal is the average — 43 against a 35 target. The verification gate flags entries over 60 to match.

> _This was written by Claude Code on behalf of max-sixty_
