### PR TITLE
feat(approvals): let `wt config approvals add --yes` record approvals without a TTY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Improved
 
+- **`wt config approvals add --yes` records approvals without a terminal**: the command refused every non-interactive run, so a container that had just cloned a project could only pre-approve it by hand-writing `approvals.toml` from `wt config approvals list --format=json`. `--yes` now lists what it trusts and writes it. A save it cannot make fails the command rather than warning and exiting 0, since the record is all `add` produces — a change that applies to the interactive run too.
+
 - **`remote_repo` names the repository as the remote spells it**: `repo` is the directory on disk, so a renamed clone reports the new name. `{{ remote_repo }}` takes it from the primary remote's URL, available everywhere `owner` is and unset when no remote parses. ([#3745](https://github.com/max-sixty/worktrunk/pull/3745), thanks @canac)
 
 ## 0.73.0

--- a/docs/content/config.md
+++ b/docs/content/config.md
@@ -816,6 +816,9 @@ List commands and their approval status for current project:
 Pre-approve all hook and alias commands for current project:
 {{ terminal(cmd="wt config approvals add") }}
 
+Pre-approve without prompting, for a container or CI job:
+{{ terminal(cmd="wt config approvals add --yes") }}
+
 Clear approvals for current project:
 {{ terminal(cmd="wt config approvals clear") }}
 
@@ -830,7 +833,9 @@ Check whether an unattended run would stop for approval:
 
 ### How approvals work
 
-Approved commands are saved to `~/.config/worktrunk/approvals.toml`. Re-approval is required when the command template changes or the project moves. Use `--yes` to bypass prompts in CI.
+Approved commands are saved to `~/.config/worktrunk/approvals.toml`. Re-approval is required when the command template changes or the project moves.
+
+`--yes` bypasses the prompt, and what it leaves behind depends on the command it is passed to. On a command that runs project commands it grants consent for that run alone and records nothing, so the next run asks again. On `wt config approvals add` the record is the whole point, so the approvals are written — which is how an unattended environment pre-approves a project it has just cloned.
 
 ### Reading approval state
 

--- a/docs/static/.well-known/agent-skills/index.json
+++ b/docs/static/.well-known/agent-skills/index.json
@@ -6,7 +6,7 @@
       "type": "skill-md",
       "description": "Guidance for Worktrunk (the `wt` CLI) — git worktree management, hooks, and config. Load when editing .config/wt.toml or ~/.config/worktrunk/config.toml; adding, modifying, or debugging hooks (post-merge, post-start, pre-commit, pre-merge, post-switch, etc.); configuring commit message generation or command aliases; or troubleshooting wt behavior. Also answers general worktrunk/wt questions.",
       "url": "./worktrunk/SKILL.md",
-      "digest": "sha256:0a217b6b0a30588569bf97d5ad828d07aaf8241c67e2855ef461233098ec8c53"
+      "digest": "sha256:3fc6de776a7db9b9f1f65e8312cf85baa8f9008c1c00144aa319cb8ac0d04af7"
     }
   ]
 }

--- a/plugins/worktrunk/skills/worktrunk/SKILL.md
+++ b/plugins/worktrunk/skills/worktrunk/SKILL.md
@@ -118,14 +118,14 @@ Agents running `wt merge`, `wt switch`, or other commands that trigger hooks wil
 ○ post-merge install:
   cargo install --path .
 ✗ Cannot prompt for approval in non-interactive environment
-↳ To skip prompts in CI/CD, add --yes; to pre-approve commands, run wt config approvals add
+↳ To skip prompts in CI/CD, add --yes; to pre-approve commands, run wt config approvals add --yes
 ```
 
 The resolution is for the user to make the trust decision themselves:
 
 - **`wt config approvals add`** — interactive prompt where the user reviews each command before it is stored to `~/.config/worktrunk/approvals.toml`. Run once per project; the approval persists across invocations until the command template changes or the project moves. This is the path to recommend — the user reviews and consents to exactly the commands that will run.
 
-**When invoked as an agent, stop and escalate to the user.** Approving a project's hooks is a security decision about whether this repository should be trusted to run arbitrary commands on the user's machine — that decision belongs to the user, not the agent. Tell the user to run `wt config approvals add` and let them review the commands. Do not run `--yes` on the user's behalf: it skips the approval gate for that invocation, so reaching for it to unblock a command defeats the protection. `--yes` exists for CI/CD pipelines that already control their own hook contents; it is not a shortcut for an interactive agent to silence an approval prompt.
+**When invoked as an agent, stop and escalate to the user.** Approving a project's hooks is a security decision about whether this repository should be trusted to run arbitrary commands on the user's machine — that decision belongs to the user, not the agent. Tell the user to run `wt config approvals add` and let them review the commands. Do not reach for either `--yes` on the user's behalf: on the blocked command it skips the gate for that invocation, and `wt config approvals add --yes` records every command the project declares with nobody reading them. Both exist for CI/CD pipelines and containers that already control their own hook contents; neither is a shortcut for an interactive agent to silence an approval prompt.
 
 ## Advanced: agent handoffs
 

--- a/plugins/worktrunk/skills/worktrunk/reference/config.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/config.md
@@ -824,6 +824,11 @@ Pre-approve all hook and alias commands for current project:
 $ wt config approvals add
 ```
 
+Pre-approve without prompting, for a container or CI job:
+```bash
+$ wt config approvals add --yes
+```
+
 Clear approvals for current project:
 ```bash
 $ wt config approvals clear
@@ -846,7 +851,9 @@ $ wt config approvals list --format=json | jq -r .state
 
 ### How approvals work
 
-Approved commands are saved to `~/.config/worktrunk/approvals.toml`. Re-approval is required when the command template changes or the project moves. Use `--yes` to bypass prompts in CI.
+Approved commands are saved to `~/.config/worktrunk/approvals.toml`. Re-approval is required when the command template changes or the project moves.
+
+`--yes` bypasses the prompt, and what it leaves behind depends on the command it is passed to. On a command that runs project commands it grants consent for that run alone and records nothing, so the next run asks again. On `wt config approvals add` the record is the whole point, so the approvals are written — which is how an unattended environment pre-approves a project it has just cloned.
 
 ### Reading approval state
 

--- a/skills/worktrunk/SKILL.md
+++ b/skills/worktrunk/SKILL.md
@@ -118,14 +118,14 @@ Agents running `wt merge`, `wt switch`, or other commands that trigger hooks wil
 ○ post-merge install:
   cargo install --path .
 ✗ Cannot prompt for approval in non-interactive environment
-↳ To skip prompts in CI/CD, add --yes; to pre-approve commands, run wt config approvals add
+↳ To skip prompts in CI/CD, add --yes; to pre-approve commands, run wt config approvals add --yes
 ```
 
 The resolution is for the user to make the trust decision themselves:
 
 - **`wt config approvals add`** — interactive prompt where the user reviews each command before it is stored to `~/.config/worktrunk/approvals.toml`. Run once per project; the approval persists across invocations until the command template changes or the project moves. This is the path to recommend — the user reviews and consents to exactly the commands that will run.
 
-**When invoked as an agent, stop and escalate to the user.** Approving a project's hooks is a security decision about whether this repository should be trusted to run arbitrary commands on the user's machine — that decision belongs to the user, not the agent. Tell the user to run `wt config approvals add` and let them review the commands. Do not run `--yes` on the user's behalf: it skips the approval gate for that invocation, so reaching for it to unblock a command defeats the protection. `--yes` exists for CI/CD pipelines that already control their own hook contents; it is not a shortcut for an interactive agent to silence an approval prompt.
+**When invoked as an agent, stop and escalate to the user.** Approving a project's hooks is a security decision about whether this repository should be trusted to run arbitrary commands on the user's machine — that decision belongs to the user, not the agent. Tell the user to run `wt config approvals add` and let them review the commands. Do not reach for either `--yes` on the user's behalf: on the blocked command it skips the gate for that invocation, and `wt config approvals add --yes` records every command the project declares with nobody reading them. Both exist for CI/CD pipelines and containers that already control their own hook contents; neither is a shortcut for an interactive agent to silence an approval prompt.
 
 ## Advanced: agent handoffs
 

--- a/skills/worktrunk/reference/config.md
+++ b/skills/worktrunk/reference/config.md
@@ -824,6 +824,11 @@ Pre-approve all hook and alias commands for current project:
 $ wt config approvals add
 ```
 
+Pre-approve without prompting, for a container or CI job:
+```bash
+$ wt config approvals add --yes
+```
+
 Clear approvals for current project:
 ```bash
 $ wt config approvals clear
@@ -846,7 +851,9 @@ $ wt config approvals list --format=json | jq -r .state
 
 ### How approvals work
 
-Approved commands are saved to `~/.config/worktrunk/approvals.toml`. Re-approval is required when the command template changes or the project moves. Use `--yes` to bypass prompts in CI.
+Approved commands are saved to `~/.config/worktrunk/approvals.toml`. Re-approval is required when the command template changes or the project moves.
+
+`--yes` bypasses the prompt, and what it leaves behind depends on the command it is passed to. On a command that runs project commands it grants consent for that run alone and records nothing, so the next run asks again. On `wt config approvals add` the record is the whole point, so the approvals are written — which is how an unattended environment pre-approves a project it has just cloned.
 
 ### Reading approval state
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -263,7 +263,7 @@ $ wt config approvals list --format=json | jq -r .state
 By default, shows only unapproved commands. Use `--all` to review all commands
 including previously approved ones.
 
-`--yes` writes the approvals without prompting, which is how a container or CI job pre-approves a project it has just cloned. It trusts every command the project config declares, including one whose template changed since an earlier approval — [Reading approval state](@/config.md#reading-approval-state) lists those, for a caller that wants to look before granting them.
+`--yes` writes the approvals without prompting, which is how a container or CI job pre-approves a project it has just cloned. It trusts every command the project config declares, including one whose template changed since an earlier approval. A caller that wants to look before granting them can list those first — see [Reading approval state](@/config.md#reading-approval-state).
 
 ## Examples
 

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -261,7 +261,15 @@ $ wt config approvals list --format=json | jq -r .state
         after_long_help = r#"Prompts for approval of all project commands and saves them to approvals.toml.
 
 By default, shows only unapproved commands. Use `--all` to review all commands
-including previously approved ones."#
+including previously approved ones.
+
+`--yes` writes the approvals without prompting, which is how a container or CI job pre-approves a project it has just cloned. It trusts every command the project config declares, including one whose template changed since an earlier approval — [Reading approval state](@/config.md#reading-approval-state) lists those, for a caller that wants to look before granting them.
+
+## Examples
+
+```console
+$ wt config approvals add --yes
+```"#
     )]
     Add {
         /// Show all commands
@@ -571,6 +579,11 @@ Pre-approve all hook and alias commands for current project:
 $ wt config approvals add
 ```
 
+Pre-approve without prompting, for a container or CI job:
+```console
+$ wt config approvals add --yes
+```
+
 Clear approvals for current project:
 ```console
 $ wt config approvals clear
@@ -593,7 +606,9 @@ $ wt config approvals list --format=json | jq -r .state
 
 ## How approvals work
 
-Approved commands are saved to `~/.config/worktrunk/approvals.toml`. Re-approval is required when the command template changes or the project moves. Use `--yes` to bypass prompts in CI.
+Approved commands are saved to `~/.config/worktrunk/approvals.toml`. Re-approval is required when the command template changes or the project moves.
+
+`--yes` bypasses the prompt, and what it leaves behind depends on the command it is passed to. On a command that runs project commands it grants consent for that run alone and records nothing, so the next run asks again. On `wt config approvals add` the record is the whole point, so the approvals are written — which is how an unattended environment pre-approves a project it has just cloned.
 
 ## Reading approval state
 

--- a/src/commands/command_approval.rs
+++ b/src/commands/command_approval.rs
@@ -32,35 +32,17 @@ use worktrunk::styling::{
 use super::hook_filter::{HookSource, ParsedFilter};
 use super::project_config::{ApprovableCommand, Phase, collect_commands_for_hooks};
 
-/// How a batch of project commands gets approved, and what the approval leaves
-/// behind in `approvals.toml`.
-///
-/// `--yes` means different things on either side of the split: on a command
-/// that is about to *run* project commands it grants consent for that run, and
-/// on `wt config approvals add` it grants the record the command exists to
-/// write.
-#[derive(Clone, Copy)]
-pub enum ApprovalMode {
-    /// A command about to run project commands asks for consent, and records a
-    /// `y` so the next run doesn't ask. Without a terminal it errors rather
-    /// than guessing.
-    Prompt,
-    /// `--yes` on such a command: consent is assumed for this invocation and
-    /// nothing is recorded, so the next run asks again.
-    Assume,
-    /// `wt config approvals add`, whose product is the record itself. `yes`
-    /// decides whether it asks first; it writes either way.
-    Record { yes: bool },
-}
-
 /// Batch approval helper used when multiple commands are queued for execution.
 /// Returns `Ok(true)` when execution may continue, `Ok(false)` when the user
-/// declined, and `Err` when the reload fails, when there is no terminal to
-/// prompt on, or when a save that [`ApprovalMode::Record`] exists to make
-/// fails.
+/// declined, and `Err` if config reload/save fails.
 ///
 /// Shows command templates to the user (what gets saved to config), not expanded values.
 /// This ensures users see exactly what they're approving.
+///
+/// `yes` grants consent for this invocation alone: nothing is recorded, so the
+/// next run asks again. Recording without a prompt is `wt config approvals
+/// add --yes`'s job ([`crate::commands::add_approvals`]), which doesn't pass
+/// through this gate.
 ///
 /// # Parameters
 /// - `commands_already_filtered`: If true, commands list is pre-filtered; skip filtering by approval status
@@ -68,7 +50,7 @@ pub fn approve_command_batch(
     commands: &[ApprovableCommand],
     project_id: &str,
     approvals: &Approvals,
-    mode: ApprovalMode,
+    yes: bool,
     commands_already_filtered: bool,
 ) -> anyhow::Result<bool> {
     let needs_approval: Vec<&ApprovableCommand> = commands
@@ -83,34 +65,20 @@ pub fn approve_command_batch(
         return Ok(true);
     }
 
-    let approved = match mode {
-        ApprovalMode::Assume => true,
-        // Nothing is being asked, but the batch still prints: it is the record
-        // of what an unattended run just trusted.
-        ApprovalMode::Record { yes: true } => {
-            let project_name = display_project_name(project_id);
-            let count = needs_approval.len();
-            let plural = if count == 1 { "" } else { "s" };
-            print_command_batch(
-                &cformat!(
-                    "{WARNING_SYMBOL} <yellow>Approving <bold>{count}</> command{plural} for <bold>{project_name}</> (--yes):</>"
-                ),
-                &needs_approval,
-            );
-            true
-        }
-        ApprovalMode::Prompt | ApprovalMode::Record { yes: false } => {
-            prompt_for_batch_approval(&needs_approval, project_id, mode)?
-        }
+    let approved = if yes {
+        true
+    } else {
+        prompt_for_batch_approval(&needs_approval, project_id)?
     };
 
     if !approved {
         return Ok(false);
     }
 
-    // `--yes` on a command that runs project commands consents to that run
-    // alone, so it writes nothing; every other mode records the approval.
-    if !matches!(mode, ApprovalMode::Assume) {
+    // Only save approvals when interactively approved, not when using --yes.
+    // A failed save costs one more prompt next run, not the command the user
+    // actually ran, so it warns rather than errors.
+    if !yes {
         let mut fresh_approvals = Approvals::load().context("Failed to load approvals")?;
         let commands: Vec<String> = needs_approval
             .iter()
@@ -120,15 +88,6 @@ pub fn approve_command_batch(
             fresh_approvals.approve_commands(project_id.to_string(), commands, &path)
         });
         if let Err(e) = save_result {
-            // On a command that runs project commands the record is a
-            // convenience, so a failed write costs one more prompt rather than
-            // the command the user actually ran. `wt config approvals add` has
-            // nothing else to deliver, so its exit status carries the failure —
-            // an orchestrator that pre-approves and reads only the exit code
-            // would otherwise walk into the prompt it just paid to avoid.
-            if matches!(mode, ApprovalMode::Record { .. }) {
-                return Err(e).context("Failed to save command approval");
-            }
             eprintln!(
                 "{}",
                 warning_message(format!("Failed to save command approval: {e}"))
@@ -163,10 +122,25 @@ fn print_command_batch(header: &str, commands: &[&ApprovableCommand]) {
     }
 }
 
-fn prompt_for_batch_approval(
+/// The batch `wt config approvals add --yes` is about to trust. Nothing is
+/// being asked, but the batch still prints: it is the record of what an
+/// unattended run just approved. Lives beside [`prompt_for_batch_approval`]
+/// so the two headers stay parallel.
+pub fn announce_batch_approval(commands: &[&ApprovableCommand], project_id: &str) {
+    let project_name = display_project_name(project_id);
+    let count = commands.len();
+    let plural = if count == 1 { "" } else { "s" };
+    print_command_batch(
+        &cformat!(
+            "{WARNING_SYMBOL} <yellow>Approving <bold>{count}</> command{plural} for <bold>{project_name}</> (--yes):</>"
+        ),
+        commands,
+    );
+}
+
+pub fn prompt_for_batch_approval(
     commands: &[&ApprovableCommand],
     project_id: &str,
-    mode: ApprovalMode,
 ) -> anyhow::Result<bool> {
     let project_name = display_project_name(project_id);
     let count = commands.len();
@@ -183,13 +157,7 @@ fn prompt_for_batch_approval(
     // This happens AFTER showing the commands so they appear in CI/CD logs
     // even when the prompt cannot be displayed (fail-fast principle)
     if !io::stdin().is_terminal() {
-        // `wt config approvals add` is the pre-approval route, so its own
-        // failure must not send the user back to the command they just ran.
-        let suggest_pre_approval = !matches!(mode, ApprovalMode::Record { .. });
-        return Err(GitError::NotInteractive {
-            suggest_pre_approval,
-        }
-        .into());
+        return Err(GitError::NotInteractive.into());
     }
 
     // Blank line before prompt for visual separation
@@ -230,12 +198,7 @@ pub fn approve_alias_commands(
         })
         .collect();
 
-    let mode = if yes {
-        ApprovalMode::Assume
-    } else {
-        ApprovalMode::Prompt
-    };
-    approve_command_batch(&cmds, project_id, &approvals, mode, false)
+    approve_command_batch(&cmds, project_id, &approvals, yes, false)
 }
 
 /// Collect project commands for hooks and request batch approval.
@@ -317,12 +280,7 @@ pub fn approve_hooks_filtered(
 
     let project_id = ctx.repo.project_identifier()?;
     let approvals = Approvals::load().context("Failed to load approvals")?;
-    let mode = if ctx.yes {
-        ApprovalMode::Assume
-    } else {
-        ApprovalMode::Prompt
-    };
-    approve_command_batch(&commands, &project_id, &approvals, mode, false)
+    approve_command_batch(&commands, &project_id, &approvals, ctx.yes, false)
 }
 
 /// Approve `hook_types` and centralize the "decline → continue without hooks" message.
@@ -394,12 +352,7 @@ pub fn approve_commit_template_append(
     }
 
     let batch = vec![ApprovableCommand::commit_template_append(owned.clone())];
-    let mode = if ctx.yes {
-        ApprovalMode::Assume
-    } else {
-        ApprovalMode::Prompt
-    };
-    let approved = approve_command_batch(&batch, &project_id, &approvals, mode, true)?;
+    let approved = approve_command_batch(&batch, &project_id, &approvals, ctx.yes, true)?;
     if !approved {
         worktrunk::styling::eprintln!(
             "{}",

--- a/src/commands/command_approval.rs
+++ b/src/commands/command_approval.rs
@@ -32,9 +32,32 @@ use worktrunk::styling::{
 use super::hook_filter::{HookSource, ParsedFilter};
 use super::project_config::{ApprovableCommand, Phase, collect_commands_for_hooks};
 
+/// How a batch of project commands gets approved, and what the approval leaves
+/// behind in `approvals.toml`.
+///
+/// `--yes` means different things on either side of the split: on a command
+/// that is about to *run* project commands it grants consent for that run, and
+/// on `wt config approvals add` it grants the record the command exists to
+/// write.
+#[derive(Clone, Copy)]
+pub enum ApprovalMode {
+    /// A command about to run project commands asks for consent, and records a
+    /// `y` so the next run doesn't ask. Without a terminal it errors rather
+    /// than guessing.
+    Prompt,
+    /// `--yes` on such a command: consent is assumed for this invocation and
+    /// nothing is recorded, so the next run asks again.
+    Assume,
+    /// `wt config approvals add`, whose product is the record itself. `yes`
+    /// decides whether it asks first; it writes either way.
+    Record { yes: bool },
+}
+
 /// Batch approval helper used when multiple commands are queued for execution.
 /// Returns `Ok(true)` when execution may continue, `Ok(false)` when the user
-/// declined, and `Err` if config reload/save fails.
+/// declined, and `Err` when the reload fails, when there is no terminal to
+/// prompt on, or when a save that [`ApprovalMode::Record`] exists to make
+/// fails.
 ///
 /// Shows command templates to the user (what gets saved to config), not expanded values.
 /// This ensures users see exactly what they're approving.
@@ -45,7 +68,7 @@ pub fn approve_command_batch(
     commands: &[ApprovableCommand],
     project_id: &str,
     approvals: &Approvals,
-    yes: bool,
+    mode: ApprovalMode,
     commands_already_filtered: bool,
 ) -> anyhow::Result<bool> {
     let needs_approval: Vec<&ApprovableCommand> = commands
@@ -60,18 +83,34 @@ pub fn approve_command_batch(
         return Ok(true);
     }
 
-    let approved = if yes {
-        true
-    } else {
-        prompt_for_batch_approval(&needs_approval, project_id)?
+    let approved = match mode {
+        ApprovalMode::Assume => true,
+        // Nothing is being asked, but the batch still prints: it is the record
+        // of what an unattended run just trusted.
+        ApprovalMode::Record { yes: true } => {
+            let project_name = display_project_name(project_id);
+            let count = needs_approval.len();
+            let plural = if count == 1 { "" } else { "s" };
+            print_command_batch(
+                &cformat!(
+                    "{WARNING_SYMBOL} <yellow>Approving <bold>{count}</> command{plural} for <bold>{project_name}</> (--yes):</>"
+                ),
+                &needs_approval,
+            );
+            true
+        }
+        ApprovalMode::Prompt | ApprovalMode::Record { yes: false } => {
+            prompt_for_batch_approval(&needs_approval, project_id, mode)?
+        }
     };
 
     if !approved {
         return Ok(false);
     }
 
-    // Only save approvals when interactively approved, not when using --yes
-    if !yes {
+    // `--yes` on a command that runs project commands consents to that run
+    // alone, so it writes nothing; every other mode records the approval.
+    if !matches!(mode, ApprovalMode::Assume) {
         let mut fresh_approvals = Approvals::load().context("Failed to load approvals")?;
         let commands: Vec<String> = needs_approval
             .iter()
@@ -81,6 +120,15 @@ pub fn approve_command_batch(
             fresh_approvals.approve_commands(project_id.to_string(), commands, &path)
         });
         if let Err(e) = save_result {
+            // On a command that runs project commands the record is a
+            // convenience, so a failed write costs one more prompt rather than
+            // the command the user actually ran. `wt config approvals add` has
+            // nothing else to deliver, so its exit status carries the failure —
+            // an orchestrator that pre-approves and reads only the exit code
+            // would otherwise walk into the prompt it just paid to avoid.
+            if matches!(mode, ApprovalMode::Record { .. }) {
+                return Err(e).context("Failed to save command approval");
+            }
             eprintln!(
                 "{}",
                 warning_message(format!("Failed to save command approval: {e}"))
@@ -95,36 +143,53 @@ pub fn approve_command_batch(
     Ok(true)
 }
 
-fn prompt_for_batch_approval(
-    commands: &[&ApprovableCommand],
-    project_id: &str,
-) -> anyhow::Result<bool> {
-    // Extract just the directory name for display
-    let project_name = Path::new(project_id)
+/// The project's directory name, which is what a user recognizes; the full
+/// identifier is a path or a remote URL.
+fn display_project_name(project_id: &str) -> &str {
+    Path::new(project_id)
         .file_name()
         .and_then(|n| n.to_str())
-        .unwrap_or(project_id);
-    let count = commands.len();
-    let plural = if count == 1 { "" } else { "s" };
+        .unwrap_or(project_id)
+}
 
-    eprintln!(
-        "{}",
-        cformat!(
-            "{WARNING_SYMBOL} <yellow><bold>{project_name}</> needs approval to execute <bold>{count}</> command{plural}:</>"
-        )
-    );
-
+/// The batch as the user sees it: a header, then each command's label and its
+/// template. Shared by the prompt and by `--yes` on `wt config approvals add`.
+fn print_command_batch(header: &str, commands: &[&ApprovableCommand]) {
+    eprintln!("{header}");
     for cmd in commands {
         // Uses INFO_SYMBOL (○) since this is a preview, not active execution
         eprintln!("{} {}", INFO_SYMBOL, cmd.label());
         eprintln!("{}", cmd.format_template());
     }
+}
+
+fn prompt_for_batch_approval(
+    commands: &[&ApprovableCommand],
+    project_id: &str,
+    mode: ApprovalMode,
+) -> anyhow::Result<bool> {
+    let project_name = display_project_name(project_id);
+    let count = commands.len();
+    let plural = if count == 1 { "" } else { "s" };
+
+    print_command_batch(
+        &cformat!(
+            "{WARNING_SYMBOL} <yellow><bold>{project_name}</> needs approval to execute <bold>{count}</> command{plural}:</>"
+        ),
+        commands,
+    );
 
     // Check if stdin is a TTY before attempting to prompt
     // This happens AFTER showing the commands so they appear in CI/CD logs
     // even when the prompt cannot be displayed (fail-fast principle)
     if !io::stdin().is_terminal() {
-        return Err(GitError::NotInteractive.into());
+        // `wt config approvals add` is the pre-approval route, so its own
+        // failure must not send the user back to the command they just ran.
+        let suggest_pre_approval = !matches!(mode, ApprovalMode::Record { .. });
+        return Err(GitError::NotInteractive {
+            suggest_pre_approval,
+        }
+        .into());
     }
 
     // Blank line before prompt for visual separation
@@ -165,7 +230,12 @@ pub fn approve_alias_commands(
         })
         .collect();
 
-    approve_command_batch(&cmds, project_id, &approvals, yes, false)
+    let mode = if yes {
+        ApprovalMode::Assume
+    } else {
+        ApprovalMode::Prompt
+    };
+    approve_command_batch(&cmds, project_id, &approvals, mode, false)
 }
 
 /// Collect project commands for hooks and request batch approval.
@@ -247,7 +317,12 @@ pub fn approve_hooks_filtered(
 
     let project_id = ctx.repo.project_identifier()?;
     let approvals = Approvals::load().context("Failed to load approvals")?;
-    approve_command_batch(&commands, &project_id, &approvals, ctx.yes, false)
+    let mode = if ctx.yes {
+        ApprovalMode::Assume
+    } else {
+        ApprovalMode::Prompt
+    };
+    approve_command_batch(&commands, &project_id, &approvals, mode, false)
 }
 
 /// Approve `hook_types` and centralize the "decline → continue without hooks" message.
@@ -319,7 +394,12 @@ pub fn approve_commit_template_append(
     }
 
     let batch = vec![ApprovableCommand::commit_template_append(owned.clone())];
-    let approved = approve_command_batch(&batch, &project_id, &approvals, ctx.yes, true)?;
+    let mode = if ctx.yes {
+        ApprovalMode::Assume
+    } else {
+        ApprovalMode::Prompt
+    };
+    let approved = approve_command_batch(&batch, &project_id, &approvals, mode, true)?;
     if !approved {
         worktrunk::styling::eprintln!(
             "{}",

--- a/src/commands/config/approvals.rs
+++ b/src/commands/config/approvals.rs
@@ -19,7 +19,7 @@ use worktrunk::styling::{
 };
 
 use crate::cli::SwitchFormat;
-use crate::commands::command_approval::{ApprovalMode, approve_command_batch};
+use crate::commands::command_approval::{announce_batch_approval, prompt_for_batch_approval};
 use crate::commands::project_config::{
     ApprovableCommand, collect_commands_for_aliases, collect_commands_for_hooks,
 };
@@ -199,7 +199,7 @@ pub fn list_approvals(format: SwitchFormat) -> anyhow::Result<()> {
 pub fn add_approvals(show_all: bool, yes: bool) -> anyhow::Result<()> {
     let repo = Repository::current()?;
     let project_id = repo.project_identifier()?;
-    let approvals = Approvals::load().context("Failed to load approvals")?;
+    let mut approvals = Approvals::load().context("Failed to load approvals")?;
 
     let project_config = require_project_config(&repo)?;
     let commands = collect_approvable_commands(&project_config);
@@ -226,24 +226,33 @@ pub fn add_approvals(show_all: bool, yes: bool) -> anyhow::Result<()> {
         commands
     };
 
-    // When show_all=true, we've already included all commands in commands_to_approve
-    // When show_all=false, we've already filtered to unapproved commands
-    // So we pass skip_approval_filter=true to prevent double-filtering
-    let approved = approve_command_batch(
-        &commands_to_approve,
-        &project_id,
-        &approvals,
-        ApprovalMode::Record { yes },
-        true,
-    )?;
-
-    // Show result
-    if approved {
-        eprintln!("{}", success_message("Commands approved & saved to config"));
+    // Unlike the execution gate (`approve_command_batch`), whose `--yes`
+    // consents to one run and records nothing, the record is this command's
+    // product: it saves on either path, and a failed save fails the command —
+    // an orchestrator that pre-approves and reads only the exit code would
+    // otherwise walk into the prompt it just paid to avoid.
+    let batch: Vec<&_> = commands_to_approve.iter().collect();
+    let approved = if yes {
+        announce_batch_approval(&batch, &project_id);
+        true
     } else {
+        prompt_for_batch_approval(&batch, &project_id)?
+    };
+
+    if !approved {
         eprintln!("{}", info_message("Commands declined"));
+        return Ok(());
     }
 
+    let templates: Vec<String> = commands_to_approve
+        .iter()
+        .map(|cmd| cmd.command.template.clone())
+        .collect();
+    approvals
+        .approve_commands(project_id, templates, &require_approvals_path()?)
+        .context("Failed to save command approval")?;
+
+    eprintln!("{}", success_message("Commands approved & saved to config"));
     Ok(())
 }
 

--- a/src/commands/config/approvals.rs
+++ b/src/commands/config/approvals.rs
@@ -19,7 +19,7 @@ use worktrunk::styling::{
 };
 
 use crate::cli::SwitchFormat;
-use crate::commands::command_approval::approve_command_batch;
+use crate::commands::command_approval::{ApprovalMode, approve_command_batch};
 use crate::commands::project_config::{
     ApprovableCommand, collect_commands_for_aliases, collect_commands_for_hooks,
 };
@@ -189,7 +189,14 @@ pub fn list_approvals(format: SwitchFormat) -> anyhow::Result<()> {
 }
 
 /// Handle `wt config approvals add` command - approve all hook and alias commands in the project
-pub fn add_approvals(show_all: bool) -> anyhow::Result<()> {
+///
+/// `yes` skips the review prompt, which is what makes the command usable
+/// unattended: the approvals are still written, so an orchestrator can
+/// pre-approve a project's commands before any `wt` run that would execute
+/// them. Templates edited since an earlier approval are re-approved without
+/// comment — read `wt config approvals list --format=json`'s `stale` first to
+/// see them.
+pub fn add_approvals(show_all: bool, yes: bool) -> anyhow::Result<()> {
     let repo = Repository::current()?;
     let project_id = repo.project_identifier()?;
     let approvals = Approvals::load().context("Failed to load approvals")?;
@@ -219,12 +226,16 @@ pub fn add_approvals(show_all: bool) -> anyhow::Result<()> {
         commands
     };
 
-    // Call the approval prompt (yes=false to require interactive approval and save)
     // When show_all=true, we've already included all commands in commands_to_approve
     // When show_all=false, we've already filtered to unapproved commands
     // So we pass skip_approval_filter=true to prevent double-filtering
-    let approved =
-        approve_command_batch(&commands_to_approve, &project_id, &approvals, false, true)?;
+    let approved = approve_command_batch(
+        &commands_to_approve,
+        &project_id,
+        &approvals,
+        ApprovalMode::Record { yes },
+        true,
+    )?;
 
     // Show result
     if approved {

--- a/src/commands/hook_plan.rs
+++ b/src/commands/hook_plan.rs
@@ -49,7 +49,7 @@ use worktrunk::HookType;
 use worktrunk::config::{Approvals, Command, CommandConfig, ProjectConfig, UserConfig};
 use worktrunk::git::add_hook_skip_hint;
 
-use super::command_approval::{ApprovalMode, approve_command_batch};
+use super::command_approval::approve_command_batch;
 use super::command_executor::{
     CommandContext, FailureStrategy, PipelineKind, execute_pipeline_foreground, prepare_steps,
 };
@@ -214,20 +214,13 @@ impl HookPlan {
         }
         let project_id =
             project_id.context("project identifier is required to approve project commands")?;
-        // `approve_command_batch` in `ApprovalMode::Assume` is an
-        // unconditional `Ok(true)`, so loading `Approvals` here would be dead
-        // work.
+        // `approve_command_batch` with `yes = true` is an unconditional
+        // `Ok(true)`, so loading `Approvals` here would be dead work.
         let approved = if yes {
             true
         } else {
             let approvals = Approvals::load().context("Failed to load approvals")?;
-            approve_command_batch(
-                &approvable,
-                project_id,
-                &approvals,
-                ApprovalMode::Prompt,
-                false,
-            )?
+            approve_command_batch(&approvable, project_id, &approvals, false, false)?
         };
         if !approved {
             return Ok(None);

--- a/src/commands/hook_plan.rs
+++ b/src/commands/hook_plan.rs
@@ -49,7 +49,7 @@ use worktrunk::HookType;
 use worktrunk::config::{Approvals, Command, CommandConfig, ProjectConfig, UserConfig};
 use worktrunk::git::add_hook_skip_hint;
 
-use super::command_approval::approve_command_batch;
+use super::command_approval::{ApprovalMode, approve_command_batch};
 use super::command_executor::{
     CommandContext, FailureStrategy, PipelineKind, execute_pipeline_foreground, prepare_steps,
 };
@@ -214,13 +214,20 @@ impl HookPlan {
         }
         let project_id =
             project_id.context("project identifier is required to approve project commands")?;
-        // `approve_command_batch` with `yes = true` is an unconditional
-        // `Ok(true)`, so loading `Approvals` here would be dead work.
+        // `approve_command_batch` in `ApprovalMode::Assume` is an
+        // unconditional `Ok(true)`, so loading `Approvals` here would be dead
+        // work.
         let approved = if yes {
             true
         } else {
             let approvals = Approvals::load().context("Failed to load approvals")?;
-            approve_command_batch(&approvable, project_id, &approvals, false, false)?
+            approve_command_batch(
+                &approvable,
+                project_id,
+                &approvals,
+                ApprovalMode::Prompt,
+                false,
+            )?
         };
         if !approved {
             return Ok(None);

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -565,7 +565,14 @@ pub enum GitError {
     },
 
     // Validation/other errors
-    NotInteractive,
+    /// A prompt was reached with no terminal to show it on.
+    ///
+    /// `suggest_pre_approval` is false when `wt config approvals add` is itself
+    /// the command that could not prompt — its hint would otherwise send the
+    /// user back to the command they just ran.
+    NotInteractive {
+        suggest_pre_approval: bool,
+    },
     HookCommandNotFound {
         name: String,
         available: Vec<String>,
@@ -865,7 +872,7 @@ impl GitError {
                 "Local <bold>{target_branch}</> has diverged from <bold>{upstream}</> — can't fast-forward to a branch based on <bold>{upstream}</>"
             ),
 
-            GitError::NotInteractive => {
+            GitError::NotInteractive { .. } => {
                 "Cannot prompt for approval in non-interactive environment".to_string()
             }
 
@@ -1383,17 +1390,22 @@ impl GitError {
                 )
             }
 
-            GitError::NotInteractive => {
+            GitError::NotInteractive {
+                suggest_pre_approval,
+            } => {
                 let title = self.title();
-                let approvals_cmd = suggest_command("config", &["approvals", "add"], &[]);
-                write!(
-                    f,
-                    "{}\n{}",
-                    error_message(&title),
-                    hint_message(cformat!(
+                // The pre-approval route is itself unattended, so it carries
+                // `--yes` — a hint reached in CI must name a command that runs
+                // there.
+                let hint = if *suggest_pre_approval {
+                    let approvals_cmd = suggest_command("config approvals add", &[], &["--yes"]);
+                    cformat!(
                         "To skip prompts in CI/CD, add <underline>--yes</>; to pre-approve commands, run <underline>{approvals_cmd}</>"
-                    ))
-                )
+                    )
+                } else {
+                    cformat!("To skip prompts in CI/CD, add <underline>--yes</>")
+                };
+                write!(f, "{}\n{}", error_message(&title), hint_message(hint))
             }
 
             GitError::HookCommandNotFound { .. } => {

--- a/src/git/error.rs
+++ b/src/git/error.rs
@@ -565,14 +565,7 @@ pub enum GitError {
     },
 
     // Validation/other errors
-    /// A prompt was reached with no terminal to show it on.
-    ///
-    /// `suggest_pre_approval` is false when `wt config approvals add` is itself
-    /// the command that could not prompt — its hint would otherwise send the
-    /// user back to the command they just ran.
-    NotInteractive {
-        suggest_pre_approval: bool,
-    },
+    NotInteractive,
     HookCommandNotFound {
         name: String,
         available: Vec<String>,
@@ -872,7 +865,7 @@ impl GitError {
                 "Local <bold>{target_branch}</> has diverged from <bold>{upstream}</> — can't fast-forward to a branch based on <bold>{upstream}</>"
             ),
 
-            GitError::NotInteractive { .. } => {
+            GitError::NotInteractive => {
                 "Cannot prompt for approval in non-interactive environment".to_string()
             }
 
@@ -1390,22 +1383,21 @@ impl GitError {
                 )
             }
 
-            GitError::NotInteractive {
-                suggest_pre_approval,
-            } => {
+            GitError::NotInteractive => {
                 let title = self.title();
                 // The pre-approval route is itself unattended, so it carries
                 // `--yes` — a hint reached in CI must name a command that runs
-                // there.
-                let hint = if *suggest_pre_approval {
-                    let approvals_cmd = suggest_command("config approvals add", &[], &["--yes"]);
-                    cformat!(
+                // there. Raised from `wt config approvals add` itself, that
+                // suggestion is the exact fix: append the flag.
+                let approvals_cmd = suggest_command("config approvals add", &[], &["--yes"]);
+                write!(
+                    f,
+                    "{}\n{}",
+                    error_message(&title),
+                    hint_message(cformat!(
                         "To skip prompts in CI/CD, add <underline>--yes</>; to pre-approve commands, run <underline>{approvals_cmd}</>"
-                    )
-                } else {
-                    cformat!("To skip prompts in CI/CD, add <underline>--yes</>")
-                };
-                write!(f, "{}\n{}", error_message(&title), hint_message(hint))
+                    ))
+                )
             }
 
             GitError::HookCommandNotFound { .. } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -165,7 +165,7 @@ fn handle_hook_command(action: HookCommand, yes: bool) -> anyhow::Result<()> {
             );
             match action {
                 ApprovalsCommand::List { format } => list_approvals(format),
-                ApprovalsCommand::Add { all } => add_approvals(all),
+                ApprovalsCommand::Add { all } => add_approvals(all, yes),
                 ApprovalsCommand::Clear { global, stale } => clear_approvals(global, stale),
             }
         }
@@ -641,7 +641,7 @@ fn handle_config_command(action: ConfigCommand, yes: bool) -> anyhow::Result<()>
         ConfigCommand::Update { print } => handle_config_update(yes, print),
         ConfigCommand::Approvals { action } => match action {
             ApprovalsCommand::List { format } => list_approvals(format),
-            ApprovalsCommand::Add { all } => add_approvals(all),
+            ApprovalsCommand::Add { all } => add_approvals(all, yes),
             ApprovalsCommand::Clear { global, stale } => clear_approvals(global, stale),
         },
         ConfigCommand::Alias { action } => match action {

--- a/src/styling/suggest.rs
+++ b/src/styling/suggest.rs
@@ -47,7 +47,9 @@ use std::path::Path;
 ///
 /// # Arguments
 ///
-/// * `subcommand` - The subcommand name (e.g., "remove", "switch", "merge")
+/// * `subcommand` - The subcommand name (e.g., "remove", "switch", "merge").
+///   A nested subcommand is written out in full here ("config approvals add"),
+///   so that any flags land after it rather than mid-path.
 /// * `args` - Positional arguments (branch names, paths, etc.)
 /// * `flags` - Additional flags to suggest (e.g., "--force", "-D")
 ///

--- a/tests/integration_tests/approval_save.rs
+++ b/tests/integration_tests/approval_save.rs
@@ -509,9 +509,10 @@ fn test_truly_concurrent_approve_with_threads() {
 
 ///
 /// This tests the lower-level `approve_command()` method fails when permissions
-/// are denied. The higher-level `approve_command_batch()` catches this error and
-/// displays a warning (see src/commands/command_approval.rs:82-85), allowing
-/// commands to execute even when the approval can't be saved.
+/// are denied. On an execution path the higher-level `approve_command_batch()`
+/// catches this error and displays a warning, allowing commands to execute even
+/// when the approval can't be saved; `wt config approvals add` instead
+/// propagates it, since the record is all that command produces.
 ///
 /// TODO: Find a way to test permission errors without skipping when running as root.
 /// Currently skips in containerized environments (Claude Code web, Docker) where
@@ -575,14 +576,11 @@ fn test_permission_error_prevents_save() {
         "Expected save to fail due to permissions, but it succeeded"
     );
 
-    // In the actual code (approve_command_batch), when this error occurs:
-    // 1. It's caught with `if let Err(e) = fresh_config.save()`
-    // 2. Warning is printed: "🟡 Failed to save command approval: {error}"
-    // 3. Hint is printed: "💡 Approval will be requested again next time."
-    // 4. Function returns Ok(true) - execution continues!
-    //
-    // The approval succeeds (commands execute) even though saving failed.
-    // This test verifies the save operation correctly fails with permission errors.
+    // This test verifies the save operation correctly fails with permission
+    // errors. What `approve_command_batch` does with that failure is covered by
+    // `test_add_approvals_yes_fails_when_the_approvals_file_cannot_be_written`
+    // (propagates, for `wt config approvals add`) and by the warning path it
+    // takes for a command that merely runs project commands.
 }
 
 #[test]

--- a/tests/integration_tests/approval_save.rs
+++ b/tests/integration_tests/approval_save.rs
@@ -578,7 +578,7 @@ fn test_permission_error_prevents_save() {
 
     // This test verifies the save operation correctly fails with permission
     // errors. What `approve_command_batch` does with that failure is covered by
-    // `test_add_approvals_yes_fails_when_the_approvals_file_cannot_be_written`
+    // `test_add_approvals_yes_fails_when_approvals_cannot_be_saved`
     // (propagates, for `wt config approvals add`) and by the warning path it
     // takes for a command that merely runs project commands.
 }

--- a/tests/integration_tests/approvals.rs
+++ b/tests/integration_tests/approvals.rs
@@ -1,9 +1,9 @@
 //! Integration tests for the `wt config approvals` subcommands
 
 use crate::common::{
-    BareRepoTest, TestRepo, TestRepoBase, make_snapshot_cmd, repo, set_temp_home_env,
-    setup_snapshot_settings, setup_snapshot_settings_with_home, setup_temp_snapshot_settings,
-    temp_home, wt_command,
+    BareRepoTest, TestRepo, TestRepoBase, make_snapshot_cmd, make_snapshot_cmd_with_global_flags,
+    repo, set_temp_home_env, setup_snapshot_settings, setup_snapshot_settings_with_home,
+    setup_temp_snapshot_settings, temp_home, wt_command,
 };
 use insta_cmd::assert_cmd_snapshot;
 use rstest::rstest;
@@ -177,6 +177,73 @@ fn test_hook_approvals_emits_deprecation_warning(
         cmd.arg("approvals").arg(action);
         assert_cmd_snapshot!(snapshot_name, cmd);
     });
+}
+
+/// `--yes` is what makes `add` usable unattended: with no terminal to prompt
+/// on it lists what it trusts and writes the approvals. The flag is global, so
+/// it records the same thing on either side of the subcommand.
+#[rstest]
+fn test_add_approvals_yes_records_without_a_terminal(repo: TestRepo) {
+    repo.run_git(&["remote", "remove", "origin"]);
+    repo.write_project_config(
+        r#"pre-merge = "cargo test"
+
+[aliases]
+deploy = "echo deploying"
+"#,
+    );
+    repo.commit("Add config");
+
+    snapshot_add_approvals("add_approvals_yes", &repo, &["--yes"]);
+
+    let recorded = fs::read_to_string(repo.test_approvals_path()).unwrap();
+    assert!(recorded.contains("cargo test"), "{recorded}");
+    assert!(recorded.contains("echo deploying"), "{recorded}");
+
+    // Same run again from the global flag position, which reaches the command
+    // through clap's global `--yes` rather than the subcommand's own parse.
+    fs::remove_file(repo.test_approvals_path()).unwrap();
+    let output = make_snapshot_cmd_with_global_flags(&repo, "config", &[], None, &["--yes"])
+        .args(["approvals", "add"])
+        .output()
+        .unwrap();
+    assert!(output.status.success(), "{output:?}");
+    assert_eq!(
+        fs::read_to_string(repo.test_approvals_path()).unwrap(),
+        recorded
+    );
+}
+
+/// The record is all `add` produces, so a write it cannot make fails the
+/// command. A warning plus exit 0 would leave an orchestrator that pre-approves
+/// and reads the exit code walking into the prompt it just paid to avoid.
+#[rstest]
+fn test_add_approvals_yes_fails_when_approvals_cannot_be_saved(repo: TestRepo) {
+    repo.write_project_config(r#"pre-merge = "cargo test""#);
+    repo.commit("Add config");
+
+    // A regular file where the approvals directory would go: creating the
+    // parent fails on every platform, with no permission bits involved.
+    let blocker = repo.test_approvals_path().with_file_name("blocker");
+    fs::write(&blocker, "").unwrap();
+
+    let output = repo
+        .wt_command()
+        .args(["config", "approvals", "add", "--yes"])
+        .env("WORKTRUNK_APPROVALS_PATH", blocker.join("approvals.toml"))
+        .output()
+        .unwrap();
+
+    assert!(!output.status.success(), "{output:?}");
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Failed to save command approval"),
+        "{stderr}"
+    );
+    assert!(
+        !stderr.contains("Commands approved"),
+        "a failed write must not report success: {stderr}"
+    );
 }
 
 /// Regression: `wt config approvals add` must walk project aliases as well as

--- a/tests/integration_tests/git_error_display.rs
+++ b/tests/integration_tests/git_error_display.rs
@@ -368,7 +368,20 @@ fn command_errors_render() {
     );
 
     let cases = [
-        ("non-interactive", GitError::NotInteractive.render()),
+        (
+            "non-interactive",
+            GitError::NotInteractive {
+                suggest_pre_approval: true,
+            }
+            .render(),
+        ),
+        (
+            "non-interactive from the approvals command itself",
+            GitError::NotInteractive {
+                suggest_pre_approval: false,
+            }
+            .render(),
+        ),
         (
             "LLM command failed",
             GitError::LlmCommandFailed {

--- a/tests/integration_tests/git_error_display.rs
+++ b/tests/integration_tests/git_error_display.rs
@@ -368,20 +368,7 @@ fn command_errors_render() {
     );
 
     let cases = [
-        (
-            "non-interactive",
-            GitError::NotInteractive {
-                suggest_pre_approval: true,
-            }
-            .render(),
-        ),
-        (
-            "non-interactive from the approvals command itself",
-            GitError::NotInteractive {
-                suggest_pre_approval: false,
-            }
-            .render(),
-        ),
+        ("non-interactive", GitError::NotInteractive.render()),
         (
             "LLM command failed",
             GitError::LlmCommandFailed {

--- a/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__command_errors.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__command_errors.snap
@@ -7,11 +7,6 @@ expression: render_cases(cases)
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
 [2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add --yes[24m[22m
 
-## non-interactive from the approvals command itself
-
-[31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m[22m
-
 ## LLM command failed
 
 [31m✗[39m [31mCommit generation command failed[39m

--- a/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__command_errors.snap
+++ b/tests/integration_tests/snapshots/integration__integration_tests__git_error_display__command_errors.snap
@@ -5,7 +5,12 @@ expression: render_cases(cases)
 ## non-interactive
 
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add --yes[24m[22m
+
+## non-interactive from the approvals command itself
+
+[31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m[22m
 
 ## LLM command failed
 

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_fails_in_non_tty.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_fails_in_non_tty.snap
@@ -8,12 +8,23 @@ info:
     - test-non-tty
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
-    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
-    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -36,8 +47,10 @@ info:
     WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_PROBE_TIMEOUT_MS: "60000"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -51,4 +64,4 @@ exit_code: 1
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add --yes[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_mixed_approved_unapproved.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_mixed_approved_unapproved.snap
@@ -12,4 +12,4 @@ exit_code: 1
 [2m○[22m pre-start [1mthird[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Third command'[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add --yes[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_multiple_commands.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_multiple_commands.snap
@@ -16,4 +16,4 @@ exit_code: 1
 [2m○[22m pre-start [1mpwd[22m:
 [107m [0m [2m[0m[2m[34mcd[0m[2m [0m[2m[32m{{[0m[2m worktree_path [0m[2m[32m}}[0m[2m [0m[2m[36m&&[0m[2m [0m[2m[34mpwd[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add --yes[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_named_commands.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_named_commands.snap
@@ -14,4 +14,4 @@ exit_code: 1
 [2m○[22m pre-start [1mtest[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Running tests...'[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add --yes[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__approval_single_command.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__approval_single_command.snap
@@ -10,4 +10,4 @@ exit_code: 1
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Worktree path: {{ worktree_path }}'[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add --yes[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__decline_approval_skips_only_unapproved.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__decline_approval_skips_only_unapproved.snap
@@ -12,4 +12,4 @@ exit_code: 1
 [2m○[22m pre-start [1mthird[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Third command'[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add --yes[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__project_prefix_all_requires_approval.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__project_prefix_all_requires_approval.snap
@@ -12,4 +12,4 @@ exit_code: 1
 [2m○[22m pre-merge [1mlint[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Running project lint'[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add --yes[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__project_prefix_requires_approval.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__project_prefix_requires_approval.snap
@@ -10,4 +10,4 @@ exit_code: 1
 [2m○[22m pre-merge [1mtest[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Running project test'[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add --yes[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__run_hook_post_merge_requires_approval.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__run_hook_post_merge_requires_approval.snap
@@ -10,4 +10,4 @@ exit_code: 1
 [2m○[22m post-merge:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Post-merge cleanup for {{ branch }}'[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add --yes[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__run_hook_pre_merge_requires_approval.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__run_hook_pre_merge_requires_approval.snap
@@ -10,4 +10,4 @@ exit_code: 1
 [2m○[22m pre-merge:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'Running pre-merge checks on {{ branch }}'[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add --yes[24m[22m

--- a/tests/snapshots/integration__integration_tests__approval_ui__yes_does_not_save_approvals_second_run.snap
+++ b/tests/snapshots/integration__integration_tests__approval_ui__yes_does_not_save_approvals_second_run.snap
@@ -10,4 +10,4 @@ exit_code: 1
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test command'[0m[2m [0m[2m[36m>[0m[2m output.txt[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add --yes[24m[22m

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_none_approved.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_none_approved.snap
@@ -65,4 +65,4 @@ exit_code: 1
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test'[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add --yes[24m[22m

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_none_approved.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_all_none_approved.snap
@@ -9,12 +9,23 @@ info:
     - "--all"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
-    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
-    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -37,8 +48,10 @@ info:
     WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_PROBE_TIMEOUT_MS: "60000"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -52,4 +65,4 @@ exit_code: 1
 [2m○[22m pre-start:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m'test'[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m[22m

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_bare_repo_config_in_primary_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_bare_repo_config_in_primary_worktree.snap
@@ -56,4 +56,4 @@ exit_code: 1
 ○ pre-start:
   echo 'hello'
 ✗ Cannot prompt for approval in non-interactive environment
-↳ To skip prompts in CI/CD, add --yes
+↳ To skip prompts in CI/CD, add --yes; to pre-approve commands, run wt config approvals add --yes

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_bare_repo_config_in_primary_worktree.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_bare_repo_config_in_primary_worktree.snap
@@ -9,10 +9,20 @@ info:
     - "--all"
   env:
     COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
-    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
-    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
     GIT_TERMINAL_PROMPT: "0"
     LANG: C
     LC_ALL: C
@@ -30,8 +40,10 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_PROBE_TIMEOUT_MS: "60000"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     WORKTRUNK_TEST_ZSH_INSTALLED: "0"
 ---
@@ -44,4 +56,4 @@ exit_code: 1
 ○ pre-start:
   echo 'hello'
 ✗ Cannot prompt for approval in non-interactive environment
-↳ To skip prompts in CI/CD, add --yes; to pre-approve commands, run wt config approvals add
+↳ To skip prompts in CI/CD, add --yes

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_includes_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_includes_aliases.snap
@@ -8,12 +8,23 @@ info:
     - add
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
-    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
-    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -36,8 +47,10 @@ info:
     WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_PROBE_TIMEOUT_MS: "60000"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -51,4 +64,4 @@ exit_code: 1
 [2m○[22m alias [1mdeploy[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m deploying [0m[2m[32m{{[0m[2m branch [0m[2m[32m}}[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m[22m

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_includes_aliases.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_includes_aliases.snap
@@ -64,4 +64,4 @@ exit_code: 1
 [2m○[22m alias [1mdeploy[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m deploying [0m[2m[32m{{[0m[2m branch [0m[2m[32m}}[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add --yes[24m[22m

--- a/tests/snapshots/integration__integration_tests__approvals__add_approvals_yes.snap
+++ b/tests/snapshots/integration__integration_tests__approvals__add_approvals_yes.snap
@@ -1,10 +1,12 @@
 ---
-source: tests/integration_tests/step_alias.rs
+source: tests/integration_tests/approvals.rs
 info:
   program: wt
   args:
-    - step
-    - deploy
+    - config
+    - approvals
+    - add
+    - "--yes"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
     CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
@@ -54,13 +56,14 @@ info:
     WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
 ---
-success: false
-exit_code: 1
+success: true
+exit_code: 0
 ----- stdout -----
 
 ----- stderr -----
-[33m▲[39m [33m[1morigin[22m needs approval to execute [1m1[22m command:[39m
+[33m▲[39m [33mApproving [1m2[22m commands for [1mrepo[22m (--yes):[39m
+[2m○[22m pre-merge:
+[107m [0m [2m[0m[2m[34mcargo[0m[2m test[0m
 [2m○[22m alias [1mdeploy[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m deploying[0m
-[31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add --yes[24m[22m
+[32m✓[39m [32mCommands approved & saved to config[39m

--- a/tests/snapshots/integration__integration_tests__help__help_config_approvals.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_approvals.snap
@@ -36,6 +36,7 @@ info:
     WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_PROBE_TIMEOUT_MS: "60000"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     WORKTRUNK_TEST_ZSH_INSTALLED: "0"
 ---
@@ -81,6 +82,9 @@ List commands and their approval status for current project:
 Pre-approve all hook and alias commands for current project:
 [107m [0m [2m[0m[2m[34mwt[0m[2m config approvals add[0m
 
+Pre-approve without prompting, for a container or CI job:
+[107m [0m [2m[0m[2m[34mwt[0m[2m config approvals add [0m[2m[36m--yes[0m
+
 Clear approvals for current project:
 [107m [0m [2m[0m[2m[34mwt[0m[2m config approvals clear[0m
 
@@ -95,7 +99,9 @@ Check whether an unattended run would stop for approval:
 
 [1m[32mHow approvals work[0m
 
-Approved commands are saved to [2m~/.config/worktrunk/approvals.toml[0m. Re-approval is required when the command template changes or the project moves. Use [2m--yes[0m to bypass prompts in CI.
+Approved commands are saved to [2m~/.config/worktrunk/approvals.toml[0m. Re-approval is required when the command template changes or the project moves.
+
+[2m--yes[0m bypasses the prompt, and what it leaves behind depends on the command it is passed to. On a command that runs project commands it grants consent for that run alone and records nothing, so the next run asks again. On [2mwt config approvals add[0m the record is the whole point, so the approvals are written — which is how an unattended environment pre-approves a project it has just cloned.
 
 [1m[32mReading approval state[0m
 

--- a/tests/snapshots/integration__integration_tests__help__help_config_approvals_add.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_approvals_add.snap
@@ -10,6 +10,14 @@ info:
   env:
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
     LANG: C
     LC_ALL: C
     LLVM_PROFILE_FILE: "[LLVM_PROFILE_FILE]"
@@ -26,8 +34,10 @@ info:
     WORKTRUNK_TEST_GEMINI_INSTALLED: "0"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_PROBE_TIMEOUT_MS: "60000"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     WORKTRUNK_TEST_ZSH_INSTALLED: "0"
 ---
@@ -65,5 +75,11 @@ Prompts for approval of all project commands and saves them to approvals.toml.
 
 By default, shows only unapproved commands. Use [2m--all[0m to review all commands
 including previously approved ones.
+
+[2m--yes[0m writes the approvals without prompting, which is how a container or CI job pre-approves a project it has just cloned. It trusts every command the project config declares, including one whose template changed since an earlier approval — Reading approval state lists those, for a caller that wants to look before granting them.
+
+[1m[32mExamples[0m
+
+[107m [0m [2m[0m[2m[34mwt[0m[2m config approvals add [0m[2m[36m--yes[0m
 
 ----- stderr -----

--- a/tests/snapshots/integration__integration_tests__help__help_config_approvals_add.snap
+++ b/tests/snapshots/integration__integration_tests__help__help_config_approvals_add.snap
@@ -76,7 +76,7 @@ Prompts for approval of all project commands and saves them to approvals.toml.
 By default, shows only unapproved commands. Use [2m--all[0m to review all commands
 including previously approved ones.
 
-[2m--yes[0m writes the approvals without prompting, which is how a container or CI job pre-approves a project it has just cloned. It trusts every command the project config declares, including one whose template changed since an earlier approval — Reading approval state lists those, for a caller that wants to look before granting them.
+[2m--yes[0m writes the approvals without prompting, which is how a container or CI job pre-approves a project it has just cloned. It trusts every command the project config declares, including one whose template changed since an earlier approval. A caller that wants to look before granting them can list those first — see Reading approval state.
 
 [1m[32mExamples[0m
 

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_approval_decline.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_approval_decline.snap
@@ -10,4 +10,4 @@ exit_code: 1
 [2m○[22m alias [1mdeploy[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m deploying[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add --yes[24m[22m

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_approval_project_config_prompts.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_approval_project_config_prompts.snap
@@ -7,12 +7,23 @@ info:
     - deploy
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
-    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
-    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -35,8 +46,10 @@ info:
     WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_PROBE_TIMEOUT_MS: "60000"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -50,4 +63,4 @@ exit_code: 1
 [2m○[22m alias [1mdeploy[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m deploying [0m[2m[32m{{[0m[2m branch [0m[2m[32m}}[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add --yes[24m[22m

--- a/tests/snapshots/integration__integration_tests__step_alias__alias_help_flag_after_double_dash_forwards.snap
+++ b/tests/snapshots/integration__integration_tests__step_alias__alias_help_flag_after_double_dash_forwards.snap
@@ -8,12 +8,23 @@ info:
     - "--help"
   env:
     APPDATA: "[TEST_CONFIG_HOME]"
+    CLAUDE_CONFIG_DIR: "[TEST_CLAUDE_CONFIG]"
     CLICOLOR_FORCE: "1"
     COLUMNS: "500"
+    GIT_ALLOW_PROTOCOL: file
     GIT_AUTHOR_DATE: "2025-01-01T00:00:00Z"
+    GIT_AUTHOR_EMAIL: test@example.com
+    GIT_AUTHOR_NAME: Test User
     GIT_COMMITTER_DATE: "2025-01-01T00:00:00Z"
-    GIT_CONFIG_GLOBAL: "[TEST_GIT_CONFIG]"
-    GIT_CONFIG_SYSTEM: /dev/null
+    GIT_COMMITTER_EMAIL: test@example.com
+    GIT_COMMITTER_NAME: Test User
+    GIT_CONFIG_COUNT: "2"
+    GIT_CONFIG_GLOBAL: /nonexistent/wt/gitconfig
+    GIT_CONFIG_KEY_0: user.useConfigOnly
+    GIT_CONFIG_KEY_1: rerere.enabled
+    GIT_CONFIG_SYSTEM: /nonexistent/wt/gitconfig
+    GIT_CONFIG_VALUE_0: "true"
+    GIT_CONFIG_VALUE_1: "false"
     GIT_TERMINAL_PROMPT: "0"
     HOME: "[TEST_HOME]"
     LANG: C
@@ -36,8 +47,10 @@ info:
     WORKTRUNK_TEST_MOCK_CONFIG_DIR: "[TEST_MOCK_CONFIG]"
     WORKTRUNK_TEST_NUSHELL_ENV: "0"
     WORKTRUNK_TEST_OPENCODE_INSTALLED: "0"
+    WORKTRUNK_TEST_PARENT_SHELL: ""
     WORKTRUNK_TEST_POWERSHELL_ENV: "0"
     WORKTRUNK_TEST_POWERSHELL_INSTALLED: "0"
+    WORKTRUNK_TEST_PROBE_TIMEOUT_MS: "60000"
     WORKTRUNK_TEST_SKIP_URL_HEALTH_CHECK: "1"
     WORKTRUNK_TEST_ZSH_INSTALLED: "0"
     XDG_CONFIG_HOME: "[TEST_CONFIG_HOME]"
@@ -51,4 +64,4 @@ exit_code: 1
 [2m○[22m alias [1mdeploy[22m:
 [107m [0m [2m[0m[2m[34mecho[0m[2m [0m[2m[32m{{[0m[2m args [0m[2m[32m}}[0m
 [31m✗[39m [31mCannot prompt for approval in non-interactive environment[39m
-[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add[24m[22m
+[2m↳[22m [2mTo skip prompts in CI/CD, add [4m--yes[24m; to pre-approve commands, run [4mwt config approvals add --yes[24m[22m


### PR DESCRIPTION
`wt config approvals add` refused every non-interactive run — even with `--yes`, whose hint then suggested the flag already passed — so there was no way to pre-approve a project's commands unattended. An orchestrator (tend's Codex Cloud container was the motivating case) had to hand-write `approvals.toml` from `wt config approvals list --format=json` output, a third-party reimplementation of `add` that breaks whenever the schema changes. The `wt config approvals` docs already promised "`--yes` to bypass prompts in CI" and described `stale` entries as "what `--yes` would silently re-approve"; behavior now matches them.

The two `--yes` meanings stay distinct: on a command that runs project commands it grants consent for that run alone and records nothing (unchanged), while on `add` — whose product is the record — it lists what it trusts and writes it. `add` no longer routes through `approve_command_batch` (the execution gate) for this: it prompts or announces, then saves itself, which also makes a failed `approvals.toml` write fail the command instead of warning behind a `✓ saved` line and exit 0 — an orchestrator reading only the exit code would otherwise walk into the prompt it just paid to avoid.

The non-interactive hint's pre-approval suggestion now carries `--yes` (`run wt config approvals add --yes`), since a hint reached in CI must name a command that runs there. Per the existing `list --format=json` docs, `add --yes` re-approves templates edited since an earlier approval without comment; the `add` help now says so and points at the `stale` field for reading them first, and the worktrunk skill's escalation rule tells agents not to reach for it on a user's behalf.

> _This was written by Claude Code on behalf of max-sixty_
