### PR TITLE
docs(shell): state that install owns the wrapper path it writes

### DIFF
--- a/docs/content/faq.md
+++ b/docs/content/faq.md
@@ -137,6 +137,8 @@ Created by `wt config shell install`:
   - `Documents/PowerShell/Microsoft.PowerShell_profile.ps1` (PowerShell 7+)
   - `Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1` (Windows PowerShell 5.1)
 
+Fish and Nushell wrappers live at a path named after the command, so install writes that file whole, replacing an existing `functions/wt.fish`, `completions/wt.fish`, or `wt.nu`. Bash, zsh, and PowerShell rc files hold the rest of a shell's setup, so install only appends a line to those.
+
 **PowerShell detection on Windows:** When running from cmd.exe or PowerShell, both PowerShell profile files are created automatically. When running from Git Bash or MSYS2, PowerShell is skipped (use `wt config shell install powershell` to create the profiles explicitly).
 
 **To remove:** `wt config shell uninstall`.

--- a/plugins/worktrunk/skills/worktrunk/reference/faq.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/faq.md
@@ -130,6 +130,8 @@ Created by `wt config shell install`:
   - `Documents/PowerShell/Microsoft.PowerShell_profile.ps1` (PowerShell 7+)
   - `Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1` (Windows PowerShell 5.1)
 
+Fish and Nushell wrappers live at a path named after the command, so install writes that file whole, replacing an existing `functions/wt.fish`, `completions/wt.fish`, or `wt.nu`. Bash, zsh, and PowerShell rc files hold the rest of a shell's setup, so install only appends a line to those.
+
 **PowerShell detection on Windows:** When running from cmd.exe or PowerShell, both PowerShell profile files are created automatically. When running from Git Bash or MSYS2, PowerShell is skipped (use `wt config shell install powershell` to create the profiles explicitly).
 
 **To remove:** `wt config shell uninstall`.

--- a/skills/worktrunk/reference/faq.md
+++ b/skills/worktrunk/reference/faq.md
@@ -130,6 +130,8 @@ Created by `wt config shell install`:
   - `Documents/PowerShell/Microsoft.PowerShell_profile.ps1` (PowerShell 7+)
   - `Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1` (Windows PowerShell 5.1)
 
+Fish and Nushell wrappers live at a path named after the command, so install writes that file whole, replacing an existing `functions/wt.fish`, `completions/wt.fish`, or `wt.nu`. Bash, zsh, and PowerShell rc files hold the rest of a shell's setup, so install only appends a line to those.
+
 **PowerShell detection on Windows:** When running from cmd.exe or PowerShell, both PowerShell profile files are created automatically. When running from Git Bash or MSYS2, PowerShell is skipped (use `wt config shell install powershell` to create the profiles explicitly).
 
 **To remove:** `wt config shell uninstall`.

--- a/src/commands/configure_shell.rs
+++ b/src/commands/configure_shell.rs
@@ -769,6 +769,13 @@ fn fish_code_lines(source: &str) -> Vec<&str> {
         .collect()
 }
 
+/// Write the autoloaded wrapper: fish's `functions/{cmd}.fish`, nushell's
+/// `vendor/autoload/{cmd}.nu`.
+///
+/// The path is named after the command being installed, so it names the file
+/// worktrunk owns and an existing one there is replaced whole. The read below
+/// only separates "already installed" from "needs writing"; ownership is read
+/// out of a file's contents in one place only, `is_worktrunk_managed_content`.
 fn configure_wrapper_file(
     shell: Shell,
     path: &Path,


### PR DESCRIPTION
`wt config shell install` replaces an existing `functions/{cmd}.fish`, `completions/{cmd}.fish`, or `vendor/autoload/{cmd}.nu` whole. That is the design — the path is named after the command, so it names the file worktrunk owns — but neither the write site nor the FAQ's file inventory said so, which leaves the overwrite reading as a missing ownership check.

`is_worktrunk_managed_content` already carries the rule, for the uninstall side that has to recognize a file without knowing its name. So `configure_wrapper_file` states it in a clause and points there rather than keeping a second copy. The FAQ sentence adds the contrast: rc files hold the rest of a shell's setup, so install only appends to those.

No behavior change, and no ownership check added.

> _This was written by Claude Code on behalf of max-sixty_
