### PR TITLE
docs(readme): restore the broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,6 @@ The `-x` flag runs a command after switching; arguments after `--` are passed to
 
 ### Star history
 
-<a href="https://star-history.com/#max-sixty/worktrunk&Date">
-  <img src="https://api.star-history.com/svg?repos=max-sixty/worktrunk&type=Date" width="500" alt="Star History Chart">
+<a href="https://star-history.dera.page/#max-sixty/worktrunk&Date">
+  <img src="https://star-history.dera.page/svg?repos=max-sixty/worktrunk&type=Date" width="500" alt="Star History Chart">
 </a>

--- a/plugins/worktrunk/skills/worktrunk/reference/README.md
+++ b/plugins/worktrunk/skills/worktrunk/reference/README.md
@@ -245,6 +245,6 @@ The `-x` flag runs a command after switching; arguments after `--` are passed to
 
 ### Star history
 
-<a href="https://star-history.com/#max-sixty/worktrunk&Date">
-  <img src="https://api.star-history.com/svg?repos=max-sixty/worktrunk&type=Date" width="500" alt="Star History Chart">
+<a href="https://star-history.dera.page/#max-sixty/worktrunk&Date">
+  <img src="https://star-history.dera.page/svg?repos=max-sixty/worktrunk&type=Date" width="500" alt="Star History Chart">
 </a>


### PR DESCRIPTION
The star history chart in the README is currently broken. The chart service behind it relies on the GitHub stargazer API, which now restricts that data, so the image fails to render for everyone visiting the project page.

This PR repoints the chart (and the link wrapping it) at a maintained mirror of the same chart that uses a different data source. No API token is required and the chart keeps its current layout and options.

Please consider merging this fix: without it the README shows a broken image to new visitors.