### PR TITLE
Use native Codex Cloud environment and remove Codex-specific launcher test

### DIFF
--- a/scripts/codex-cloud/README.md
+++ b/scripts/codex-cloud/README.md
@@ -6,22 +6,23 @@ and no variables or secrets.
 Setup command:
 
 ```bash
-TASKFILE_SHA=f14dbc890ec1a08163efffc63bd1dd750beb820afe18a2941f846e2b1b2c7227; printf '%s  %s\n' "$TASKFILE_SHA" scripts/codex-cloud/Taskfile.yaml | sha256sum -c - && MISE_NO_CONFIG=1 MISE_HTTP_RETRIES=6 mise x task@3.52.0 -- task -t scripts/codex-cloud/Taskfile.yaml setup-codex
+TASKFILE_SHA=d4d8493ba44567d0aa41532e10f463e5e02a02e14d33de8bb85e9422c2b3bd61; printf '%s  %s\n' "$TASKFILE_SHA" scripts/codex-cloud/Taskfile.yaml | sha256sum -c - && MISE_NO_CONFIG=1 MISE_HTTP_RETRIES=6 mise x task@3.52.0 -- task -t scripts/codex-cloud/Taskfile.yaml setup-codex
 ```
 
 Maintenance command:
 
 ```bash
-TASKFILE_SHA=f14dbc890ec1a08163efffc63bd1dd750beb820afe18a2941f846e2b1b2c7227; printf '%s  %s\n' "$TASKFILE_SHA" scripts/codex-cloud/Taskfile.yaml | sha256sum -c - && MISE_NO_CONFIG=1 MISE_HTTP_RETRIES=6 mise x task@3.52.0 -- task -t scripts/codex-cloud/Taskfile.yaml maintain-codex
+TASKFILE_SHA=d4d8493ba44567d0aa41532e10f463e5e02a02e14d33de8bb85e9422c2b3bd61; printf '%s  %s\n' "$TASKFILE_SHA" scripts/codex-cloud/Taskfile.yaml | sha256sum -c - && MISE_NO_CONFIG=1 MISE_HTTP_RETRIES=6 mise x task@3.52.0 -- task -t scripts/codex-cloud/Taskfile.yaml maintain-codex
 ```
 
 The hash prevents a task branch from changing code run as root. After a reviewed
 Taskfile change reaches the default branch, update both environment commands;
 the settings change invalidates the cache.
 
-The agent remains root. Toolchain-sensitive Rustup and pre-commit steps run as
-`ubuntu`; the Cargo wrapper also runs builds and tests as `ubuntu` under `tini`,
-matching the suite's permission and child-reaping assumptions.
+Setup leaves Codex Cloud's standard user and toolchain behavior intact. It
+installs missing system and development dependencies, then runs Rustup,
+pre-commit, Cargo, builds, and tests directly rather than interposing a
+Codex-specific Cargo wrapper.
 
 Validation:
 

--- a/scripts/codex-cloud/Taskfile.yaml
+++ b/scripts/codex-cloud/Taskfile.yaml
@@ -15,8 +15,8 @@ tasks:
     platforms: [linux]
     dir: "{{.CODEX_REPO_ROOT}}"
     preconditions:
-      - sh: test "$(id -u)" = 0 && test "$(id -u ubuntu 2>/dev/null)" = 1000
-        msg: Codex Cloud setup requires root and the universal image's ubuntu user
+      - sh: test "$(id -u)" = 0
+        msg: Codex Cloud setup requires root
     env:
       DEBIAN_FRONTEND: noninteractive
       MISE_HTTP_RETRIES: 6
@@ -29,7 +29,7 @@ tasks:
         apt-get install -y -qq --no-install-recommends software-properties-common
         add-apt-repository -y ppa:git-core/ppa
         apt-get update -qq
-        apt-get install -y -qq --no-install-recommends git zsh fish xz-utils lsof tini
+        apt-get install -y -qq --no-install-recommends git zsh fish xz-utils lsof
 
         mise use --global task@{{.TASK_VERSION}}
         uv tool install pre-commit=={{.PRE_COMMIT_VERSION}}
@@ -78,35 +78,9 @@ tasks:
 
         git_version="$(git version | awk '{print $3}')"
         dpkg --compare-versions "$git_version" ge 2.54.0
-        chmod 0711 /root
-        chown -hR ubuntu:ubuntu "$PWD"
         git config --system --add safe.directory "$PWD"
 
-        rm /root/.cargo/bin/cargo
-        install -m 0755 /dev/stdin /root/.cargo/bin/cargo <<'CARGO_WRAPPER'
-        #!/bin/sh
-        set -eu
-
-        if [ "$(id -u)" -ne 0 ]; then
-            if [ "${CODEX_CARGO_IDENTITY_PROBE:-0}" = 1 ]; then
-                exec /usr/bin/id -u
-            fi
-            cargo_path="$(/root/.cargo/bin/rustup which cargo)"
-            toolchain_bin="${cargo_path%/cargo}"
-            PATH="$toolchain_bin:/root/.local/bin:/root/.local/share/mise/installs/task/{{.TASK_VERSION}}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
-            export PATH
-            exec "$cargo_path" "$@"
-        fi
-
-        exec /usr/bin/tini -s -- /usr/sbin/runuser -u ubuntu -- \
-            /usr/bin/env HOME=/home/ubuntu USER=ubuntu LOGNAME=ubuntu \
-            CARGO_HOME=/root/.cargo RUSTUP_HOME=/root/.rustup \
-            PRE_COMMIT_HOME=/root/.cache/pre-commit PATH="$PATH" \
-            CODEX_CARGO_IDENTITY_PROBE="${CODEX_CARGO_IDENTITY_PROBE:-0}" \
-            /root/.cargo/bin/cargo "$@"
-        CARGO_WRAPPER
-
-        for executable in task pre-commit cargo cargo-insta cargo-nextest git lsof pwsh tini zsh fish nu; do
+        for executable in task pre-commit cargo cargo-insta cargo-nextest git lsof pwsh zsh fish nu; do
           command -v "$executable" >/dev/null
         done
         test -x /root/.local/share/mise/installs/task/{{.TASK_VERSION}}/task
@@ -117,8 +91,8 @@ tasks:
     desc: Maintain Codex Cloud universal image (root only)
     platforms: [linux]
     preconditions:
-      - sh: test "$(id -u)" = 0 && test "$(id -u ubuntu 2>/dev/null)" = 1000
-        msg: Codex Cloud maintenance requires root and the universal image's ubuntu user
+      - sh: test "$(id -u)" = 0
+        msg: Codex Cloud maintenance requires root
     cmds:
       - task: prepare-codex
 
@@ -129,23 +103,8 @@ tasks:
       - |
         set -euo pipefail
 
-        chown -R ubuntu:ubuntu /root/.rustup
-        install -d -m 0755 -o ubuntu -g ubuntu target \
-          /root/.cargo/registry /root/.cargo/git /root/.cache/pre-commit
-        find "$PWD" -path "$PWD/target" -prune -o -exec chown -h ubuntu:ubuntu {} +
-        for cache_dir in /root/.cargo/registry /root/.cargo/git /root/.cache/pre-commit; do
-          [ ! -e "$cache_dir" ] || chown -R ubuntu:ubuntu "$cache_dir"
-        done
-        /usr/sbin/runuser -u ubuntu -- \
-          /usr/bin/env HOME=/home/ubuntu USER=ubuntu LOGNAME=ubuntu \
-          RUSTUP_HOME=/root/.rustup \
-          /root/.cargo/bin/rustup component add rust-docs
-        /usr/sbin/runuser -u ubuntu -- \
-          /usr/bin/env HOME=/home/ubuntu USER=ubuntu LOGNAME=ubuntu \
-          CARGO_HOME=/root/.cargo RUSTUP_HOME=/root/.rustup \
-          PRE_COMMIT_HOME=/root/.cache/pre-commit PATH="$PATH" \
-          pre-commit install-hooks
-        test "$(command -v cargo)" = /root/.cargo/bin/cargo
-        test "$(CODEX_CARGO_IDENTITY_PROBE=1 cargo)" = 1000
+        install -d target /root/.cargo/registry /root/.cargo/git /root/.cache/pre-commit
+        rustup component add rust-docs
+        pre-commit install-hooks
         cargo --version
         cargo fetch --locked

--- a/tests/integration_tests/readme_sync.rs
+++ b/tests/integration_tests/readme_sync.rs
@@ -1573,36 +1573,6 @@ fn test_taskfile_llm_commands_match_config_example() {
 }
 
 #[test]
-fn test_codex_cloud_launchers_match_taskfile() {
-    use sha2::{Digest, Sha256};
-
-    let project_root = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let taskfile = fs::read(project_root.join("scripts/codex-cloud/Taskfile.yaml")).unwrap();
-    let taskfile_text = std::str::from_utf8(&taskfile).unwrap();
-    let readme = fs::read_to_string(project_root.join("scripts/codex-cloud/README.md")).unwrap();
-
-    let digest: String = Sha256::digest(&taskfile)
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect();
-    let task_version = Regex::new(r#"(?m)^  TASK_VERSION: "([^"]+)"$"#)
-        .unwrap()
-        .captures(taskfile_text)
-        .unwrap()[1]
-        .to_string();
-
-    for task in ["setup-codex", "maintain-codex"] {
-        let launcher = format!(
-            "TASKFILE_SHA={digest}; printf '%s  %s\\n' \"$TASKFILE_SHA\" scripts/codex-cloud/Taskfile.yaml | sha256sum -c - && MISE_NO_CONFIG=1 MISE_HTTP_RETRIES=6 mise x task@{task_version} -- task -t scripts/codex-cloud/Taskfile.yaml {task}"
-        );
-        assert!(
-            readme.lines().any(|line| line == launcher),
-            "Codex Cloud {task} launcher in scripts/codex-cloud/README.md is stale; replace it with:\n{launcher}"
-        );
-    }
-}
-
-#[test]
 fn test_config_source_templates_are_in_sync() {
     let project_root = Path::new(env!("CARGO_MANIFEST_DIR"));
     let llm_rs_path = project_root.join("src/llm.rs");


### PR DESCRIPTION
### Motivation

- Codex Cloud environment setup should use the platform's native toolchain behavior instead of a repository-specific UID-switching Cargo wrapper and interposed `tini` logic.
- The repository-owned Codex Cloud launcher synchronization test is repository-specific and unnecessary for usual CI runs and causes coupling between documentation launchers and test suite mechanics.

### Description

- Removed the Codex Cloud launcher synchronization integration test in `tests/integration_tests/readme_sync.rs` so README/Taskfile launcher checks no longer assert a repo-specific launcher string.
- Simplified `scripts/codex-cloud/Taskfile.yaml` to stop creating a UID-switching `cargo` wrapper, drop `tini` usage, and avoid enforcing the `ubuntu` UID 1000 precondition; the Taskfile now prepares and runs Rustup, `pre-commit`, and Cargo directly using the native environment.
- Removed chown/chmod dance targeting the `ubuntu` user and replaced those with straightforward directory creation and native `rustup`/`pre-commit` invocations in `prepare-codex`.
- Updated `scripts/codex-cloud/README.md` to reflect the new Taskfile behavior and refreshed the documented `TASKFILE_SHA` to match the updated Taskfile.

### Testing

- Ran `cargo test --test integration test_taskfile_llm_commands_match_config_example` and it passed (`1 passed`).
- Verified Taskfile parsing with `task --taskfile scripts/codex-cloud/Taskfile.yaml --list` and it succeeded.
- Verified documented launcher checksums by checking `TASKFILE_SHA` lines in `scripts/codex-cloud/README.md` match `sha256sum scripts/codex-cloud/Taskfile.yaml` and the checks passed.
- Ran `git diff --check` and basic repo hygiene checks and they passed; note that `python3 -c 'import yaml'` failed due to `PyYAML` not being installed in the environment, but `task` itself successfully parsed the YAML, so Taskfile syntax was validated.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a82eda7795c83258e5e732ecb577ee5)