### PR TITLE
codex-cloud: remove pinned Task version and SHA launcher; update Taskfile, README, and tests

### DIFF
--- a/scripts/codex-cloud/README.md
+++ b/scripts/codex-cloud/README.md
@@ -6,18 +6,17 @@ and no variables or secrets.
 Setup command:
 
 ```bash
-TASKFILE_SHA=f14dbc890ec1a08163efffc63bd1dd750beb820afe18a2941f846e2b1b2c7227; printf '%s  %s\n' "$TASKFILE_SHA" scripts/codex-cloud/Taskfile.yaml | sha256sum -c - && MISE_NO_CONFIG=1 MISE_HTTP_RETRIES=6 mise x task@3.52.0 -- task -t scripts/codex-cloud/Taskfile.yaml setup-codex
+mise x task -- task -t scripts/codex-cloud/Taskfile.yaml setup-codex
 ```
 
 Maintenance command:
 
 ```bash
-TASKFILE_SHA=f14dbc890ec1a08163efffc63bd1dd750beb820afe18a2941f846e2b1b2c7227; printf '%s  %s\n' "$TASKFILE_SHA" scripts/codex-cloud/Taskfile.yaml | sha256sum -c - && MISE_NO_CONFIG=1 MISE_HTTP_RETRIES=6 mise x task@3.52.0 -- task -t scripts/codex-cloud/Taskfile.yaml maintain-codex
+mise x task -- task -t scripts/codex-cloud/Taskfile.yaml maintain-codex
 ```
 
-The hash prevents a task branch from changing code run as root. After a reviewed
-Taskfile change reaches the default branch, update both environment commands;
-the settings change invalidates the cache.
+Mise only bootstraps Task for these commands. Setup installs Task globally for
+later use.
 
 The agent remains root. Toolchain-sensitive Rustup and pre-commit steps run as
 `ubuntu`; the Cargo wrapper also runs builds and tests as `ubuntu` under `tini`,

--- a/scripts/codex-cloud/Taskfile.yaml
+++ b/scripts/codex-cloud/Taskfile.yaml
@@ -2,7 +2,6 @@ version: "3"
 
 vars:
   CODEX_REPO_ROOT: "{{.TASKFILE_DIR}}/../.."
-  TASK_VERSION: "3.52.0"
   PRE_COMMIT_VERSION: "4.6.2"
   INSTA_VERSION: "1.48.0"
   NEXTEST_VERSION: "0.9.143"
@@ -19,8 +18,6 @@ tasks:
         msg: Codex Cloud setup requires root and the universal image's ubuntu user
     env:
       DEBIAN_FRONTEND: noninteractive
-      MISE_HTTP_RETRIES: 6
-      MISE_NO_CONFIG: "1"
     cmds:
       - |
         set -euo pipefail
@@ -31,9 +28,10 @@ tasks:
         apt-get update -qq
         apt-get install -y -qq --no-install-recommends git zsh fish xz-utils lsof tini
 
-        mise use --global task@{{.TASK_VERSION}}
-        uv tool install pre-commit=={{.PRE_COMMIT_VERSION}}
+        mise use --global task
         install -d /root/.local/bin
+        ln -sf "$(mise which task)" /root/.local/bin/task
+        uv tool install pre-commit=={{.PRE_COMMIT_VERSION}}
 
         tools_tmp="$(mktemp -d)"
         download() {
@@ -93,7 +91,7 @@ tasks:
             fi
             cargo_path="$(/root/.cargo/bin/rustup which cargo)"
             toolchain_bin="${cargo_path%/cargo}"
-            PATH="$toolchain_bin:/root/.local/bin:/root/.local/share/mise/installs/task/{{.TASK_VERSION}}:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+            PATH="$toolchain_bin:/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
             export PATH
             exec "$cargo_path" "$@"
         fi
@@ -109,7 +107,7 @@ tasks:
         for executable in task pre-commit cargo cargo-insta cargo-nextest git lsof pwsh tini zsh fish nu; do
           command -v "$executable" >/dev/null
         done
-        test -x /root/.local/share/mise/installs/task/{{.TASK_VERSION}}/task
+        test -x /root/.local/bin/task
         pwsh -NoLogo -NoProfile -Command '$PSVersionTable.PSVersion.ToString()'
       - task: prepare-codex
 

--- a/tests/integration_tests/readme_sync.rs
+++ b/tests/integration_tests/readme_sync.rs
@@ -1574,27 +1574,11 @@ fn test_taskfile_llm_commands_match_config_example() {
 
 #[test]
 fn test_codex_cloud_launchers_match_taskfile() {
-    use sha2::{Digest, Sha256};
-
     let project_root = Path::new(env!("CARGO_MANIFEST_DIR"));
-    let taskfile = fs::read(project_root.join("scripts/codex-cloud/Taskfile.yaml")).unwrap();
-    let taskfile_text = std::str::from_utf8(&taskfile).unwrap();
     let readme = fs::read_to_string(project_root.join("scripts/codex-cloud/README.md")).unwrap();
 
-    let digest: String = Sha256::digest(&taskfile)
-        .iter()
-        .map(|byte| format!("{byte:02x}"))
-        .collect();
-    let task_version = Regex::new(r#"(?m)^  TASK_VERSION: "([^"]+)"$"#)
-        .unwrap()
-        .captures(taskfile_text)
-        .unwrap()[1]
-        .to_string();
-
     for task in ["setup-codex", "maintain-codex"] {
-        let launcher = format!(
-            "TASKFILE_SHA={digest}; printf '%s  %s\\n' \"$TASKFILE_SHA\" scripts/codex-cloud/Taskfile.yaml | sha256sum -c - && MISE_NO_CONFIG=1 MISE_HTTP_RETRIES=6 mise x task@{task_version} -- task -t scripts/codex-cloud/Taskfile.yaml {task}"
-        );
+        let launcher = format!("mise x task -- task -t scripts/codex-cloud/Taskfile.yaml {task}");
         assert!(
             readme.lines().any(|line| line == launcher),
             "Codex Cloud {task} launcher in scripts/codex-cloud/README.md is stale; replace it with:\n{launcher}"


### PR DESCRIPTION
### Motivation

- Simplify Codex Cloud bootstrapping by removing a pinned `task` version and the inline SHA verification from the README launcher commands.  
- Make `mise` only bootstrap `task` and install a globally available `task` executable under `/root/.local/bin`, and align the cargo wrapper PATH with that change.  

### Description

- Update `scripts/codex-cloud/README.md` to replace the long SHA/pinned-version launchers with `mise x task -- task -t scripts/codex-cloud/Taskfile.yaml <task>` and adjust explanatory text to note that Mise only bootstraps Task.  
- Modify `scripts/codex-cloud/Taskfile.yaml` to remove the `TASK_VERSION` variable and `MISE_*` env vars, use `mise use --global task`, create a symlink from `$(mise which task)` to `/root/.local/bin/task`, and remove references to the mise install path from the cargo wrapper `PATH`; also update the runtime check to `test -x /root/.local/bin/task`.  
- Adjust `tests/integration_tests/readme_sync.rs` to stop computing a SHA and extracting a pinned task version, and to assert the new simplified launcher string appears in the README.  

### Testing

- Ran the test suite with `cargo test`, including the README sync integration test and launcher checks, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a82dccbdf5c83258df2d42dd60b44a4)