### PR TITLE
fix(shell_exec): stream rather than fail when delayed_stream's timed wait fails

### DIFF
--- a/src/shell_exec.rs
+++ b/src/shell_exec.rs
@@ -65,6 +65,16 @@
 //! wakeup costs at worst a wait that runs to its deadline, which is what a
 //! deadline is for. It also probes the wake fd and falls back to `write()` on a
 //! pipe, so the syscall that sandbox denies is not even on the path.
+//!
+//! **When the timed wait itself fails.** Setting a deadline is fallible — each
+//! call allocates a pipe and registers a handler — so each site decides what a
+//! failed `wait_timeout` means instead of propagating it. Where the deadline
+//! bounds wall-clock (`run_with_timeout_impl`, the pager) the site tears the
+//! child down, because a wait it cannot observe bounds nothing. Where it only
+//! decides when output starts streaming ([`Cmd::delayed_stream`]) the site
+//! streams. No site fails the command: a denied syscall in wt's own machinery
+//! is not the child's fault, and erroring over one repeats #3856 in a quieter
+//! form.
 
 use std::collections::BTreeSet;
 use std::ffi::{OsStr, OsString};
@@ -2215,13 +2225,17 @@ impl Cmd {
                         trace.complete(status.success());
                         return stream_exit_result(status, &buffer, &cmd_str);
                     }
-                    // Threshold exceeded — fall through to streaming.
-                    Ok(None) => {}
-                    Err(e) => {
-                        let _ = stdout_handle.join();
-                        let _ = stderr_handle.join();
-                        trace.fail(&e);
-                        return Err(e).context("Failed to wait for command");
+                    // No status yet: the threshold passed, or the timed wait
+                    // itself failed. Both fall through to streaming. A failed
+                    // wait means the deadline machinery broke — `sigchld`
+                    // allocates a pipe and registers a handler per call, which
+                    // a sandbox or an fd limit can deny — not that the child
+                    // misbehaved, and Phase 2's `wait()` is a bare `waitid`
+                    // with neither, so it still returns the real status.
+                    // Failing here would turn a denied syscall into a failed
+                    // command, which is the shape of #3856.
+                    outcome => {
+                        tracing::debug!(?outcome, "No exit status yet; switching to streaming");
                     }
                 }
             }
@@ -2910,6 +2924,29 @@ mod tests {
         // A fast command under a generous threshold exits during phase 1
         // (wait_timeout returns Some) and stays buffered/quiet.
         Cmd::new("true").delayed_stream(5_000, None).unwrap();
+    }
+
+    #[test]
+    #[cfg(unix)]
+    fn test_cmd_delayed_stream_crosses_the_threshold() {
+        // A command that outlives the threshold leaves phase 1 with no status
+        // (`wait_timeout` returns `Ok(None)`) and switches to streaming. Phase 2
+        // must then wait out the real exit rather than reporting at the
+        // threshold — the elapsed time is what distinguishes the two, since both
+        // return `Ok`.
+        //
+        // The other two thresholds skip this path entirely: `0` streams without
+        // waiting, `-1` disables phase 1.
+        let start = Instant::now();
+        Cmd::new("sleep")
+            .arg("0.3")
+            .delayed_stream(50, None)
+            .unwrap();
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(300),
+            "phase 2 must wait for the child, not return at the threshold: {elapsed:?}"
+        );
     }
 
     #[test]

--- a/src/shell_exec.rs
+++ b/src/shell_exec.rs
@@ -2141,7 +2141,7 @@ impl Cmd {
     /// to never switch to streaming (always buffer); `0` streams immediately.
     ///
     /// `progress_message`, when set, prints to stderr at the moment streaming
-    /// starts (the delay threshold is crossed).
+    /// starts.
     ///
     /// Like [`Cmd::stream`], this does **not** acquire the concurrency
     /// semaphore: a delayed-stream command runs in the foreground and would

--- a/src/shell_exec.rs
+++ b/src/shell_exec.rs
@@ -2930,22 +2930,25 @@ mod tests {
     #[cfg(unix)]
     fn test_cmd_delayed_stream_crosses_the_threshold() {
         // A command that outlives the threshold leaves phase 1 with no status
-        // (`wait_timeout` returns `Ok(None)`) and switches to streaming. Phase 2
-        // must then wait out the real exit rather than reporting at the
-        // threshold — the elapsed time is what distinguishes the two, since both
-        // return `Ok`.
+        // (`wait_timeout` returns `Ok(None)`), which switches the readers to
+        // streaming, and phase 2 then reports the real exit.
         //
-        // The other two thresholds skip this path entirely: `0` streams without
-        // waiting, `-1` disables phase 1.
-        let start = Instant::now();
-        Cmd::new("sleep")
-            .arg("0.3")
+        // What pins the switch is where the late output goes: a streamed line
+        // is written to stderr instead of the buffer, so the error carries
+        // none of it. Had phase 1 returned a status instead, `late` would
+        // still be buffered and would show up here. The other thresholds never
+        // reach this arm — `0` streams without waiting, `-1` skips phase 1.
+        let err = Cmd::new("sh")
+            .args(["-c", "sleep 0.2; echo late 1>&2; exit 3"])
             .delayed_stream(50, None)
-            .unwrap();
-        let elapsed = start.elapsed();
-        assert!(
-            elapsed >= Duration::from_millis(300),
-            "phase 2 must wait for the child, not return at the threshold: {elapsed:?}"
+            .unwrap_err();
+        let stream_err = err
+            .downcast_ref::<StreamCommandError>()
+            .expect("non-zero delayed_stream exit should be a StreamCommandError");
+        assert_eq!(stream_err.exit_info, "exit code 3");
+        assert_eq!(
+            stream_err.output, "",
+            "output written after the switch must stream, not buffer"
         );
     }
 

--- a/src/shell_exec.rs
+++ b/src/shell_exec.rs
@@ -2938,8 +2938,16 @@ mod tests {
         // none of it. Had phase 1 returned a status instead, `late` would
         // still be buffered and would show up here. The other thresholds never
         // reach this arm — `0` streams without waiting, `-1` skips phase 1.
+        //
+        // The child writes 450 ms after the threshold passes. Only the switch
+        // has to land in that window, and it follows the wait immediately, so
+        // the margin covers a deschedule far longer than anything the suite
+        // produces. The threshold stays well above zero for the opposite
+        // reason: were `remaining` to reach it already spent, phase 1 would
+        // skip the wait entirely and the test would pass without reaching the
+        // arm it exists to cover.
         let err = Cmd::new("sh")
-            .args(["-c", "sleep 0.2; echo late 1>&2; exit 3"])
+            .args(["-c", "sleep 0.5; echo late 1>&2; exit 3"])
             .delayed_stream(50, None)
             .unwrap_err();
         let stream_err = err


### PR DESCRIPTION
## Problem

`Cmd::delayed_stream` waits out a delay threshold before it starts streaming a child's output. When that timed wait returned an error rather than a status, the function returned the error to the caller — but only after joining the two reader threads, and those sit in `read_to_end` until the child closes its pipes. So the caller waited out the child's full runtime and then got `Failed to wait for command` for a command that had already finished.

That arm became reachable in #3857. `shared_child` allocates a pipe and registers a `SIGCHLD` handler on every timed wait, where `wait-timeout` set its self-pipe up once per process. A sandbox or an fd limit that used to abort the process (#3856) now surfaces as an `Err`.

## Change

Phase 1's `Err` falls through to streaming, which is what an exceeded threshold already does. Phase 2's blocking `wait()` is a bare `waitid(WNOWAIT)` loop with neither a pipe nor a signal registration, so whatever broke the timed wait cannot reach it and the real exit status still comes back. A command whose deadline machinery fails now streams its output instead of failing.

The two sites where the deadline bounds wall-clock, `run_with_timeout_impl` and the pager, fold `Err` into their teardown arm instead, because a wait they cannot observe bounds nothing. The threshold here only decides when output starts streaming, so it streams. The module docstring records that split.

## Testing

`test_cmd_delayed_stream_crosses_the_threshold` is new, and it covers an arm nothing reached before. Of the thresholds the suite used, `0` streams without ever calling `wait_timeout`, `-1` disables phase 1, and `5_000` against a fast child returns `Ok(Some)` — so `Ok(None)` never happened.

The child writes a line 450 ms after the threshold passes. That line is the discriminator: streaming sends it to stderr, so the error's buffer comes back empty, where a phase 1 that had returned a status would still have it buffered. Checked by raising the threshold above the child's runtime, which fails the assertion with `left: "late"`. Elapsed time would not have distinguished the two, since the child runs the same wall-clock either way.

The `Err` arm itself stays untested: reaching it needs `pipe` or `sigaction` to fail inside the wait, and it shares every line with the fall-through the new test covers.

Also run: `cargo run -- hook pre-merge --yes` (4677 tests, lints, doctests) and both rustdoc variants with `-D warnings`.

> _This was written by Claude Code on behalf of max-sixty_
