### PR TITLE
ci(tend-setup): install Nix so the weekly bot can refresh flake.lock

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -273,21 +273,19 @@ is needed. After updating the toolchain, refresh `flake.lock` so the locked
 with flakes enabled:
 
 ```bash
+# Name the input: a bare `nix flake update` also relocks nixpkgs, an
+# unrelated bump in a toolchain-scoped PR.
 nix flake update rust-overlay
 # Check the bumped channel still evaluates
 nix eval .#devShells.x86_64-linux.default.name
 ```
 
-Name the input. A bare `nix flake update` also relocks nixpkgs, which lands an
-unrelated bump in a PR scoped to the toolchain and hands the `nix-flake` job a
-nixpkgs nobody chose to move.
+If `nix` isn't on the PATH, `tend-setup` regressed. Say so in the PR and leave
+`flake.lock` alone rather than hand-computing an entry.
 
 Commit `flake.lock` alongside the other toolchain changes. After bumping, run
 the full test suite (`cargo run -- hook pre-merge --yes`) and verify
 `cargo msrv verify` passes.
-
-If `nix` isn't on the PATH, `tend-setup` regressed. Say so in the PR and leave
-`flake.lock` alone rather than hand-computing an entry.
 
 ## Weekly Maintenance: CI Pin Bumps
 

--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -273,14 +273,21 @@ is needed. After updating the toolchain, refresh `flake.lock` so the locked
 with flakes enabled:
 
 ```bash
-nix flake update
+nix flake update rust-overlay
 # Check the bumped channel still evaluates
 nix eval .#devShells.x86_64-linux.default.name
 ```
 
+Name the input. A bare `nix flake update` also relocks nixpkgs, which lands an
+unrelated bump in a PR scoped to the toolchain and hands the `nix-flake` job a
+nixpkgs nobody chose to move.
+
 Commit `flake.lock` alongside the other toolchain changes. After bumping, run
 the full test suite (`cargo run -- hook pre-merge --yes`) and verify
 `cargo msrv verify` passes.
+
+If `nix` isn't on the PATH, `tend-setup` regressed. Say so in the PR and leave
+`flake.lock` alone rather than hand-computing an entry.
 
 ## Weekly Maintenance: CI Pin Bumps
 

--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -44,11 +44,9 @@ If codecov fails **locally**, investigate with `task coverage` and
 `task` and `cargo-llvm-cov` are not installed in the `tend-setup` action.
 Don't try to `cargo install` them in the sandbox — past attempts at
 source-compiling installs cascaded into bash-tool interrupts that blocked
-even `pwd` and `echo`. (Pre-built single-script installers like Determinate
-Nix's are fine — see **Weekly Maintenance: MSRV & Toolchain** for the one we
-use. The block is specifically about long-running cargo compiles.) Instead,
-query Codecov directly, following `tests/CLAUDE.md` → **Coverage
-Investigation** for the endpoints and their traps.
+even `pwd` and `echo`. Instead, query Codecov directly, following
+`tests/CLAUDE.md` → **Coverage Investigation** for the endpoints and their
+traps.
 
 If the Codecov API markers aren't enough, download the `code-coverage-report`
 artifact from the PR head's `coverage` workflow run — it contains a
@@ -271,22 +269,13 @@ Files to update:
 
 `flake.nix` reads the channel from `rust-toolchain.toml`, so no separate bump
 is needed. After updating the toolchain, refresh `flake.lock` so the locked
-`rust-overlay` revision knows about the new version. Nix isn't installed in
-the tend sandbox by default — install it with the Determinate Systems
-installer (single script, daemon-mode, no prompts), then update:
+`rust-overlay` revision knows about the new version. `tend-setup` installs Nix
+with flakes enabled:
 
 ```bash
-curl -fsSL https://install.determinate.systems/nix -o /tmp/nix-installer.sh
-sh /tmp/nix-installer.sh install --no-confirm --determinate
-. /nix/var/nix/profiles/default/etc/profile.d/nix-daemon.sh
-nix flake update --extra-experimental-features 'nix-command flakes'
-```
-
-Verify the new lock evaluates with the channel bump before committing:
-
-```bash
-nix eval --extra-experimental-features 'nix-command flakes' \
-  .#devShells.x86_64-linux.default.name
+nix flake update
+# Check the bumped channel still evaluates
+nix eval .#devShells.x86_64-linux.default.name
 ```
 
 Commit `flake.lock` alongside the other toolchain changes. After bumping, run

--- a/.github/actions/tend-setup/action.yaml
+++ b/.github/actions/tend-setup/action.yaml
@@ -78,13 +78,11 @@ runs:
         sudo timeout -k 30 300 apt-get install -y zsh fish
 
     # Nix, for the weekly toolchain bump's `flake.lock` refresh. The sandboxed
-    # agent can't install it itself: that user has no sudo, so it can't create
-    # /nix. Installing here, as `runner`, puts /nix/var/nix/profiles/default/bin
-    # on $GITHUB_PATH, and tend carries system PATH entries into the sandbox
-    # verbatim (only runner-home entries get rewritten to the sandbox's own
-    # home), so the agent inherits `nix` with no `sandbox_path:` entry in
-    # .config/tend.yaml. It costs ~4 s, so every tend workflow pays it rather
-    # than gating on which one is running.
+    # agent can't install it: that user has no sudo, so it can't create /nix.
+    # Installed here as `runner`, /nix/var/nix/profiles/default/bin lands on
+    # $GITHUB_PATH, and tend carries system PATH entries into the sandbox
+    # verbatim (only runner-home entries are rewritten), so the agent gets
+    # `nix`. ~4 s, so it isn't worth gating to the one workflow that needs it.
     - name: Install Nix
       uses: cachix/install-nix-action@v31
       with:
@@ -93,25 +91,20 @@ runs:
 
     - name: Strip the job token from /etc/nix/nix.conf
       shell: bash
-      # Runs while `runner` is still the only unprivileged user on the box.
       # The step above writes `access-tokens = github.com=<job token>` into
-      # /etc/nix/nix.conf whenever it can see one, and its action.yml passes
-      # `GITHUB_TOKEN: ${{ github.token }}` unconditionally, so no input
-      # suppresses it (install-nix.sh falls through to the job token when
-      # `github_access_token` is empty). The installer creates /etc/nix at
-      # mode 0555 and nix.conf at 0644, so the sandboxed agent could read a
-      # token carrying this job's `contents: write` and `pull-requests:
-      # write`. Deleting the line here closes that: the sandbox user isn't
-      # created until the tend action runs, so nothing untrusted can read the
-      # file in between.
+      # world-readable /etc/nix/nix.conf whenever it can see a token, and its
+      # action.yml passes `GITHUB_TOKEN: ${{ github.token }}` unconditionally.
+      # `github_access_token: ""` doesn't suppress it; install-nix.sh falls
+      # through to the job token, which on tend-weekly carries `contents:
+      # write`. Deleting the line here is enough, because the sandbox user
+      # doesn't exist until the tend action runs.
       #
-      # Nix loses nothing by it. tend's proxy overwrites `Authorization` on
-      # every sandbox request to github.com, codeload.github.com, and
-      # api.github.com with the bot's real token, whether or not nix sends
-      # one, so `github:` flake inputs still authenticate.
+      # Nothing is lost: tend's proxy overwrites `Authorization` on every
+      # sandbox request to github.com, codeload.github.com, and api.github.com
+      # with the bot's token, so flake fetches still authenticate.
       run: |
         sudo sed -i '/^access-tokens/d' /etc/nix/nix.conf
-        if sudo grep -q 'access-tokens' /etc/nix/nix.conf; then
+        if grep -q 'access-tokens' /etc/nix/nix.conf; then
           echo "::error::a GitHub token survived in /etc/nix/nix.conf"
           exit 1
         fi

--- a/.github/actions/tend-setup/action.yaml
+++ b/.github/actions/tend-setup/action.yaml
@@ -76,3 +76,24 @@ runs:
       run: |
         sudo timeout -k 30 300 apt-get update
         sudo timeout -k 30 300 apt-get install -y zsh fish
+
+    # Nix, for the weekly toolchain bump's `flake.lock` refresh. The sandboxed
+    # agent can't install it itself: that user has no sudo, so it can't create
+    # /nix. Installing here, as `runner`, puts /nix/var/nix/profiles/default/bin
+    # on $GITHUB_PATH, and tend carries system PATH entries into the sandbox
+    # verbatim (only runner-home entries get rewritten to the sandbox's own
+    # home), so the agent inherits `nix` with no `sandbox_path:` entry in
+    # .config/tend.yaml. It costs ~4 s, so every tend workflow pays it rather
+    # than gating on which one is running.
+    #
+    # No `access-tokens = github.com=…` here, unlike nightly.yaml's `nix-flake`
+    # job: that value lands in world-readable /etc/nix/nix.conf, and tend's
+    # credential proxy exists so the sandboxed agent never holds a real token.
+    # The proxy injects the bot's token into sandbox requests to github.com,
+    # codeload.github.com, and api.github.com, so flake fetches authenticate
+    # without it.
+    - name: Install Nix
+      uses: cachix/install-nix-action@v31
+      with:
+        extra_nix_config: |
+          experimental-features = nix-command flakes

--- a/.github/actions/tend-setup/action.yaml
+++ b/.github/actions/tend-setup/action.yaml
@@ -102,9 +102,15 @@ runs:
       # Nothing is lost: tend's proxy overwrites `Authorization` on every
       # sandbox request to github.com, codeload.github.com, and api.github.com
       # with the bot's token, so flake fetches still authenticate.
+      #
+      # The `grep` runs under sudo like the `sed`, though the file is
+      # world-readable today: `grep` exits 2 when it can't read a file, and an
+      # `if` condition takes that as "no match", so a check that couldn't run
+      # would report success. After `sed -i` succeeds, root can read the file
+      # by construction.
       run: |
         sudo sed -i '/^access-tokens/d' /etc/nix/nix.conf
-        if grep -q 'access-tokens' /etc/nix/nix.conf; then
+        if sudo grep -q 'access-tokens' /etc/nix/nix.conf; then
           echo "::error::a GitHub token survived in /etc/nix/nix.conf"
           exit 1
         fi

--- a/.github/actions/tend-setup/action.yaml
+++ b/.github/actions/tend-setup/action.yaml
@@ -85,15 +85,47 @@ runs:
     # home), so the agent inherits `nix` with no `sandbox_path:` entry in
     # .config/tend.yaml. It costs ~4 s, so every tend workflow pays it rather
     # than gating on which one is running.
-    #
-    # No `access-tokens = github.com=…` here, unlike nightly.yaml's `nix-flake`
-    # job: that value lands in world-readable /etc/nix/nix.conf, and tend's
-    # credential proxy exists so the sandboxed agent never holds a real token.
-    # The proxy injects the bot's token into sandbox requests to github.com,
-    # codeload.github.com, and api.github.com, so flake fetches authenticate
-    # without it.
     - name: Install Nix
       uses: cachix/install-nix-action@v31
       with:
         extra_nix_config: |
           experimental-features = nix-command flakes
+
+    - name: Make the Nix install sandbox-safe
+      shell: bash
+      # Two guards on the step above, both run while `runner` is still the
+      # only unprivileged user on the box.
+      #
+      # 1. It writes `access-tokens = github.com=<job token>` into
+      # /etc/nix/nix.conf whenever it can see one, and its action.yml passes
+      # `GITHUB_TOKEN: ${{ github.token }}` unconditionally, so no input
+      # suppresses it (install-nix.sh falls through to the job token when
+      # `github_access_token` is empty). The installer creates /etc/nix at
+      # mode 0555 and nix.conf at 0644, so the sandboxed agent could read a
+      # token carrying this job's `contents: write` and `pull-requests:
+      # write`. Deleting the line here closes that: the sandbox user isn't
+      # created until the tend action runs, so nothing untrusted can read the
+      # file in between.
+      #
+      # Nix loses nothing by it. tend's proxy overwrites `Authorization` on
+      # every sandbox request to github.com, codeload.github.com, and
+      # api.github.com with the bot's real token, whether or not nix sends
+      # one, so `github:` flake inputs still authenticate.
+      #
+      # 2. Only the multi-user branch puts /nix/var/nix/profiles/default/bin
+      # on $GITHUB_PATH. Without systemd the installer falls back to a
+      # single-user install whose one PATH entry is the runner's
+      # ~/.nix-profile/bin — a runner-home path tend rewrites to a sandbox
+      # path that doesn't exist, then drops. That leaves a green step and no
+      # `nix` in the session, discovered a week later mid-run, so assert the
+      # branch here instead.
+      run: |
+        sudo sed -i '/^access-tokens/d' /etc/nix/nix.conf
+        if sudo grep -q 'access-tokens' /etc/nix/nix.conf; then
+          echo "::error::a GitHub token survived in /etc/nix/nix.conf"
+          exit 1
+        fi
+        if [ ! -x /nix/var/nix/profiles/default/bin/nix ]; then
+          echo "::error::not a multi-user Nix install; the sandbox will have no nix"
+          exit 1
+        fi

--- a/.github/actions/tend-setup/action.yaml
+++ b/.github/actions/tend-setup/action.yaml
@@ -91,12 +91,10 @@ runs:
         extra_nix_config: |
           experimental-features = nix-command flakes
 
-    - name: Make the Nix install sandbox-safe
+    - name: Strip the job token from /etc/nix/nix.conf
       shell: bash
-      # Two guards on the step above, both run while `runner` is still the
-      # only unprivileged user on the box.
-      #
-      # 1. It writes `access-tokens = github.com=<job token>` into
+      # Runs while `runner` is still the only unprivileged user on the box.
+      # The step above writes `access-tokens = github.com=<job token>` into
       # /etc/nix/nix.conf whenever it can see one, and its action.yml passes
       # `GITHUB_TOKEN: ${{ github.token }}` unconditionally, so no input
       # suppresses it (install-nix.sh falls through to the job token when
@@ -111,21 +109,9 @@ runs:
       # every sandbox request to github.com, codeload.github.com, and
       # api.github.com with the bot's real token, whether or not nix sends
       # one, so `github:` flake inputs still authenticate.
-      #
-      # 2. Only the multi-user branch puts /nix/var/nix/profiles/default/bin
-      # on $GITHUB_PATH. Without systemd the installer falls back to a
-      # single-user install whose one PATH entry is the runner's
-      # ~/.nix-profile/bin — a runner-home path tend rewrites to a sandbox
-      # path that doesn't exist, then drops. That leaves a green step and no
-      # `nix` in the session, discovered a week later mid-run, so assert the
-      # branch here instead.
       run: |
         sudo sed -i '/^access-tokens/d' /etc/nix/nix.conf
         if sudo grep -q 'access-tokens' /etc/nix/nix.conf; then
           echo "::error::a GitHub token survived in /etc/nix/nix.conf"
-          exit 1
-        fi
-        if [ ! -x /nix/var/nix/profiles/default/bin/nix ]; then
-          echo "::error::not a multi-user Nix install; the sandbox will have no nix"
           exit 1
         fi


### PR DESCRIPTION
The weekly MSRV/toolchain bump has to refresh `flake.lock` after moving `rust-toolchain.toml`, and `running-tend` told the bot to install Nix inside its own session with the Determinate installer. That could never work: tend runs the agent as a sandbox user created with plain `useradd` and never granted sudo, so an installer that has to create `/nix` fails on every run. The `nix eval` check below it was downstream of the same dead installer.

Nix now gets provisioned in the layer that does have root. `.github/actions/tend-setup` runs as `runner` before the tend action starts, so `cachix/install-nix-action` succeeds there — the same action `nightly.yaml`'s `nix-flake` job already uses. The skill's recipe becomes `nix flake update` plus `nix eval`.

The codecov section also loses its parenthetical blessing "pre-built single-script installers like Determinate Nix's", which pointed at the recipe this removes.

<details>
<summary>Why the sandbox agent sees <code>nix</code> without a <code>sandbox_path:</code> entry</summary>

Installing as `runner` is necessary but not sufficient — the agent runs as a different UID with a `PATH` tend derives from the runner's. Each link was checked against a source or a live run rather than assumed:

| Link | Evidence |
|------|----------|
| The action performs a multi-user install and appends `/nix/var/nix/profiles/default/bin` to `$GITHUB_PATH` | `install-nix.sh` takes the daemon branch when `/run/systemd/system` exists, then `echo "/nix/var/nix/profiles/default/bin" >> "$GITHUB_PATH"`. The nightly `nix-flake` job's log shows `installer options: … --daemon --daemon-user-count 8` |
| tend keeps that entry verbatim | `proxy/setup-sandbox.sh` rewrites only PATH entries under the runner's home to the sandbox's own copy; other entries survive if they exist and `sudo -u <sandbox> test -x` passes |
| …and it does so in practice | A live sandbox `PATH` captured in tend-weekly run `32630901712` keeps `/opt/pipx_bin`, `/opt/hostedtoolcache/uv/0.12.5/x86_64`, `/usr/local/.ghcup/bin` and `/usr/local/bin` verbatim, while rewriting `.cargo/bin` and `.dotnet/tools` to `/home/tend-sandbox/…`. `/nix/var/nix/profiles/default/bin` is the first shape, not the second |
| The sandbox UID can traverse it | Nix's `install-multi-user.sh` creates `/nix`, `/nix/var`, `/nix/var/nix`, `/nix/var/nix/profiles` with `install -dv -m 0755`, and `/nix/store` with `-m 1775` |
| An unprivileged, non-trusted user can drive the daemon | The daemon's listening socket is created with `.socketMode = 0666` |
| Fetching works through tend's MITM proxy | `libfetchers/tarball.cc` fetches in the evaluating client, not the daemon, so it inherits the sandbox's `https_proxy`. `FileTransferSettings::getDefaultSSLCertFile()` honours `SSL_CERT_FILE`, which the sandbox sets to the bundle `update-ca-certificates` put the proxy CA into |

`.config/tend.yaml` is untouched. The first weekly run after this merges is what confirms the chain end to end.

</details>

A second step then strips a credential the install would otherwise leave lying around, while `runner` is still the only unprivileged user on the machine — tend does not create the sandbox user until its own action starts.

`install-nix.sh` writes `access-tokens = github.com=<job token>` into `/etc/nix/nix.conf` whenever it can see one, and the action's `action.yml` passes `GITHUB_TOKEN: ${{ github.token }}` unconditionally, so `github_access_token: ""` does not suppress it — the script falls through to the job token. The installer creates `/etc/nix` at `0555` and `nix.conf` at `0644`, so a sandboxed agent could `cat` a token carrying `contents: write` and `pull-requests: write`.

That matters more than it first appears. The agent already wields the bot's identity on GitHub, because the proxy injects it per-request — but it never *holds* a secret, and nothing blocks egress, so a token in a readable file could be carried to any host through the CONNECT tunnel. The step deletes the line and fails if one survives. Nix loses nothing by it, since the proxy overwrites `Authorization` on every sandbox request to `github.com`, `codeload.github.com`, and `api.github.com` regardless of what nix sends.

`DeterminateSystems/nix-installer-action` would avoid the write instead of undoing it — `github-token: ""` maps to `null` and the `access-tokens` line is then never appended. That was weighed against a second Nix installer in the repo, with its own pin for the weekly bump pass to track, and against `nightly.yaml`'s `nix-flake` job wanting the opposite (it passes `access-tokens` deliberately, for the rate limit). One installer plus an explicit scrub won.

Cost is ~4 s, measured off the `Install Nix` step in nightly run `32592923294`, so every tend workflow pays it rather than gating on which one is running.

The recipe names the input — `nix flake update rust-overlay` — so a toolchain-scoped PR doesn't also relock nixpkgs, and says what to do when `nix` is absent (report that `tend-setup` regressed; don't hand-compute a lock entry, which is how this failed the first time).

### Overlaps [#3880](https://github.com/max-sixty/worktrunk/pull/3880)

That PR arrived at the same fix independently while this branch was in flight, then dropped its own `install-nix-action` step; it no longer touches `.github/actions/tend-setup/action.yaml` at all. Both still edit the same section of `running-tend`, and they merge without conflict (`git merge-tree --write-tree`, zero markers) because the wording converged. #3880 carries the weekly work this unblocks — the MSRV bump, `flake.lock`, and nightly's `rustup` pins — and its recipe now calls a `nix` only this PR installs, so it wants this to land first.

> _This was written by Claude Code on behalf of max-sixty_
