### PR TITLE
docs: scope `FailureStrategy` to the foreground pipeline

### DIFF
--- a/src/commands/command_executor.rs
+++ b/src/commands/command_executor.rs
@@ -153,6 +153,10 @@ pub struct ForegroundStep {
 }
 
 /// Controls how foreground execution responds to command failures.
+///
+/// Only [`execute_pipeline_foreground`] reads this. `post-*` hooks default to
+/// the background pipeline in [`mod@super::run_pipeline`], which takes no
+/// failure strategy. A step that exits non-zero there stops the steps after it.
 #[derive(Clone, Copy)]
 pub enum FailureStrategy {
     /// Stop on first failure and surface the error to the caller.
@@ -162,8 +166,8 @@ pub enum FailureStrategy {
 }
 
 impl FailureStrategy {
-    /// Default strategy for a hook type: `pre-*` block (fail-fast),
-    /// `post-*` warn-and-continue.
+    /// Default strategy for a hook type: `pre-*` blocks (fail-fast), `post-*`
+    /// warns.
     pub fn default_for(hook_type: HookType) -> Self {
         if hook_type.is_pre() {
             Self::FailFast

--- a/src/commands/command_executor.rs
+++ b/src/commands/command_executor.rs
@@ -165,18 +165,6 @@ pub enum FailureStrategy {
     Warn,
 }
 
-impl FailureStrategy {
-    /// Default strategy for a hook type: `pre-*` blocks (fail-fast), `post-*`
-    /// warns.
-    pub fn default_for(hook_type: HookType) -> Self {
-        if hook_type.is_pre() {
-            Self::FailFast
-        } else {
-            Self::Warn
-        }
-    }
-}
-
 #[derive(Clone, Copy, Debug)]
 pub struct CommandContext<'a> {
     /// The repository, rooted at the worktree this operation acts on.

--- a/src/commands/hook_commands.rs
+++ b/src/commands/hook_commands.rs
@@ -326,7 +326,7 @@ pub fn run_hook(
             hook_type,
             &extra_vars,
             name_filters,
-            FailureStrategy::default_for(hook_type),
+            FailureStrategy::FailFast,
         )
     } else {
         run_post_hook(

--- a/src/commands/hooks.rs
+++ b/src/commands/hooks.rs
@@ -694,17 +694,6 @@ mod tests {
     }
 
     #[test]
-    fn test_failure_strategy_copy() {
-        let strategy = FailureStrategy::FailFast;
-        let copied = strategy; // Copy trait
-        assert!(matches!(copied, FailureStrategy::FailFast));
-
-        let warn = FailureStrategy::Warn;
-        let copied_warn = warn;
-        assert!(matches!(copied_warn, FailureStrategy::Warn));
-    }
-
-    #[test]
     fn test_parsed_filter() {
         // No prefix — matches all sources
         let f = ParsedFilter::parse("foo");


### PR DESCRIPTION
`FailureStrategy::Warn` is documented as "Log warnings and continue executing remaining commands". That holds for `execute_pipeline_foreground`, but reads as a claim about hook pipelines generally, and a reader who takes it that way concludes a failing `post-merge` step lets the rest of the pipeline run. It doesn't: `post-*` hooks default to the background runner in `run_pipeline.rs`, which takes no failure strategy and aborts the remaining steps on the first non-zero exit. The enum now says which path it governs.

Two removals fall out of that. `FailureStrategy::default_for`'s sole caller sits inside `if hook_type.is_pre()`, so its `post-*` arm was unreachable and the helper only re-derived what the caller had just established; the mapping it expressed stays as the comment on that branch. `test_failure_strategy_copy` copied a value and matched the copy, asserting the `Copy` derive the compiler already enforces — it could fail to build but never to run, and `handle_command_error`'s tests in `command_executor.rs` cover what each strategy actually does with a failing command.

No behavior change.

> _This was written by Claude Code on behalf of max-sixty_
