### PR TITLE
Load repository skills in Codex

### DIFF
--- a/.agents/skills
+++ b/.agents/skills
@@ -1,0 +1,1 @@
+../.claude/skills

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,7 +30,7 @@ Use consistently in docs, help text, and code comments:
 
 ## Skills
 
-Load relevant skills before starting; reload when scope changes mid-session. Project-local skills in `.claude/skills/`:
+Load relevant skills before starting; reload when scope changes mid-session. Project-local skills live in `.claude/skills/`, with `.agents/skills` linking Codex to the same files:
 
 - `writing-user-outputs` — before editing code that calls `warning_message`, `hint_message`, `error_message`, `info_message`, `eprintln`, `println`, or otherwise produces user-visible strings (CLI help, progress UI, snapshots).
 - `running-tend` — operating in CI or writing tend workflows.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,7 @@ homepage = "https://worktrunk.dev"
 description = "A CLI for Git worktree management, designed for parallel AI agent workflows"
 license = "MIT OR Apache-2.0"
 default-run = "wt"
+exclude = [".agents/skills/**"]
 
 [package.metadata.release]
 # Allow releases from any branch (GitHub Actions uses detached HEAD)

--- a/plugins/worktrunk/CLAUDE.md
+++ b/plugins/worktrunk/CLAUDE.md
@@ -12,7 +12,7 @@ call the canonical `hooks/wt.sh` below.
 worktrunk/                          ← repo root = marketplace root
 ├── .claude-plugin/marketplace.json ← Claude pointer  (source → ./plugins/worktrunk)
 ├── .agents/plugins/marketplace.json← Codex pointer   (source → ./plugins/worktrunk)
-├── .claude/skills/                  ← authored repo-local maintainer skills
+├── .claude/skills/                 ← authored repo-local maintainer skills
 ├── .agents/skills → ../.claude/skills
 │                                     Codex repo-skill pointer
 ├── gemini-extension.json           ← Gemini manifest (extensionPath = repo root)

--- a/plugins/worktrunk/CLAUDE.md
+++ b/plugins/worktrunk/CLAUDE.md
@@ -12,6 +12,9 @@ call the canonical `hooks/wt.sh` below.
 worktrunk/                          ← repo root = marketplace root
 ├── .claude-plugin/marketplace.json ← Claude pointer  (source → ./plugins/worktrunk)
 ├── .agents/plugins/marketplace.json← Codex pointer   (source → ./plugins/worktrunk)
+├── .claude/skills/                  ← authored repo-local maintainer skills
+├── .agents/skills → ../.claude/skills
+│                                     Codex repo-skill pointer
 ├── gemini-extension.json           ← Gemini manifest (extensionPath = repo root)
 ├── hooks/hooks.json                ← Gemini activity hooks (call the wt.sh below)
 ├── skills/                         ← real dir; Gemini reads ${extensionPath}/skills directly
@@ -36,6 +39,13 @@ worktrunk/                          ← repo root = marketplace root
     └── (Codex activity hooks live *inline* in .codex-plugin/plugin.json's
         `hooks` key — see Known Limitations below)
 ```
+
+The repo-local maintainer skills are separate from the distributed plugin
+skills. `.claude/skills/` is their authored home, and the relative
+`.agents/skills` symlink lets Codex discover the same files. On Windows
+checkouts with `core.symlinks=false`, Git materializes the link as a plain file
+and Codex loads none of these repo-local skills. This limitation is accepted;
+installed plugins use the real-file mirror below and are unaffected.
 
 Path resolution differs by tool, all verified end-to-end against the real CLIs:
 

--- a/tests/integration_tests/config_show.rs
+++ b/tests/integration_tests/config_show.rs
@@ -3688,6 +3688,24 @@ fn test_plugin_layout_is_consolidated() {
     let read = |p: &str| fs::read_to_string(root.join(p)).unwrap();
     let json = |p: &str| serde_json::from_str::<serde_json::Value>(&read(p)).unwrap();
 
+    // Repo-local maintainer skills are authored once for Claude and exposed to
+    // Codex through its conventional .agents/skills discovery path. Windows
+    // checkouts with core.symlinks=false materialize the link as a plain file;
+    // that accepted limitation is documented in plugins/worktrunk/CLAUDE.md.
+    #[cfg(unix)]
+    {
+        let codex_skills = root.join(".agents/skills");
+        assert_eq!(
+            fs::read_link(&codex_skills).unwrap(),
+            std::path::Path::new("../.claude/skills"),
+            ".agents/skills must point at the authored Claude maintainer skills"
+        );
+        assert!(
+            codex_skills.join("running-tend/SKILL.md").is_file(),
+            ".agents/skills must resolve to the repo-local maintainer skills"
+        );
+    }
+
     // Repo root keeps ONLY the two loader-mandated marketplace pointers.
     assert!(
         !root.join(".claude-plugin/plugin.json").exists()


### PR DESCRIPTION
Expose the existing Claude maintainer skills through Codex's documented repository skill directory.

The tracked link keeps one authored skill tree. The layout test covers symlink-preserving checkouts, the docs record the Windows `core.symlinks=false` limitation, and Cargo excludes the compatibility path so the skills are packaged once.

Tested with a Codex `$release` discovery probe and targeted layout and package integration tests. CI runs the full lint and platform suite.

> _This was written by Codex on behalf of @max-sixty_
