### PR TITLE
Remove Codex compatibility entry point

### DIFF
--- a/.codex/cloud.sh
+++ b/.codex/cloud.sh
@@ -3,8 +3,7 @@
 #
 # The environment uses the `universal` image, caching, unrestricted internet,
 # and no variables or secrets. Configure its settings fields with these
-# commands. `dev/codex.sh` remains a supported forwarding entry point for
-# settings that still name that path:
+# commands:
 #
 #     bash .codex/cloud.sh setup
 #     bash .codex/cloud.sh maintain

--- a/dev/codex.sh
+++ b/dev/codex.sh
@@ -1,4 +1,0 @@
-#!/usr/bin/env bash
-# Supported forwarding entry point for Codex Cloud settings that use this path.
-
-exec "$(dirname "${BASH_SOURCE[0]}")/../.codex/cloud.sh" "$@"


### PR DESCRIPTION
Removes `dev/codex.sh` so `.codex/cloud.sh` is the only Codex Cloud setup entry point.

Tested with Bash syntax and usage checks, repository-wide reference search, `git diff --check`, and the applicable pre-commit hooks.

> _This was written by Codex on behalf of @max-sixty_
