### PR TITLE
ci(tend): assert `nix` reaches the sandbox alongside the rest of the toolchain

### DIFF
--- a/.claude/skills/running-tend/SKILL.md
+++ b/.claude/skills/running-tend/SKILL.md
@@ -280,12 +280,13 @@ nix flake update rust-overlay
 nix eval .#devShells.x86_64-linux.default.name
 ```
 
-If `nix` isn't on the PATH, `tend-setup` regressed. Say so in the PR and leave
-`flake.lock` alone rather than hand-computing an entry.
+Commit `flake.lock` alongside the other toolchain changes once both commands
+succeed. A failure is reported in the PR, never worked around: leave the file
+alone if the update fails, `git checkout flake.lock` if the eval does, and
+hand-compute an entry in neither case.
 
-Commit `flake.lock` alongside the other toolchain changes. After bumping, run
-the full test suite (`cargo run -- hook pre-merge --yes`) and verify
-`cargo msrv verify` passes.
+After bumping, run the full test suite (`cargo run -- hook pre-merge --yes`)
+and verify `cargo msrv verify` passes.
 
 ## Weekly Maintenance: CI Pin Bumps
 

--- a/.config/tend.yaml
+++ b/.config/tend.yaml
@@ -6,15 +6,16 @@ setup:
 # the sandbox user once its PATH is built, with ~/.local/bin already first on it:
 # pre-commit installs into the sandbox's own home so uv's shim shebang resolves
 # there, and the cargo binaries are copied from where `tend-setup` already built
-# them, at the versions pinned there. The probe is the assertion — sandbox-setup
-# runs the block under `bash -eo pipefail`, so a tool that goes missing again
-# fails the job and files a tend-outage issue naming it.
+# them, at the versions pinned there. `nu` and `nix` take the system-location
+# route instead and need no line. The probe asserts all five: sandbox-setup
+# runs the block under `bash -eo pipefail`, so a tool that goes missing fails
+# the job and files a tend-outage issue naming it.
 sandbox_setup:
 - mkdir -p ~/.local/bin
 - install -m755 /home/runner/.cargo-install/cargo-insta/bin/cargo-insta ~/.local/bin/
 - install -m755 /home/runner/.cargo-install/cargo-nextest/bin/cargo-nextest ~/.local/bin/
 - uv tool install --quiet pre-commit
-- 'for t in cargo-insta cargo-nextest pre-commit nu; do command -v "$t" >/dev/null || { echo "::error::tend sandbox is missing $t; wt hook pre-merge cannot run"; exit 1; }; done'
+- 'for t in cargo-insta cargo-nextest pre-commit nu nix; do command -v "$t" >/dev/null || { echo "::error::tend sandbox is missing $t; see Sandbox toolchain in .github/CLAUDE.md"; exit 1; }; done'
 secrets:
   allowed:
   - CODECOV_TOKEN

--- a/.github/CLAUDE.md
+++ b/.github/CLAUDE.md
@@ -83,14 +83,15 @@ running in that same `release` environment.
 
 The agent runs as `tend-sandbox`, whose PATH tend derives from the runner's by
 rewriting a leading `/home/runner` to `/home/tend-sandbox` and keeping an entry
-only where that directory exists. `useradd -m` seeds the sandbox home from
-`/etc/skel`, so an image-baked toolchain has a sibling there and survives;
-anything `tend-setup` installs at runtime into the runner's home has none and is
-dropped, unlogged. So a tool the agent needs has to land in a system location
-(`/opt/hostedtoolcache/...`, `/usr/local/bin`), which carries across verbatim —
-the route `nu` takes — or be copied in by `.config/tend.yaml`'s
-`sandbox_setup:`, which is what the pre-merge gate's `cargo-insta`,
-`cargo-nextest` and `pre-commit` take. Its closing probe asserts all four.
+only where the rewritten directory exists and the sandbox UID can traverse it.
+`useradd -m` seeds the sandbox home from `/etc/skel`, so an image-baked
+toolchain has a sibling there and survives; anything `tend-setup` installs at
+runtime into the runner's home has none and is dropped, unlogged. So a tool the
+agent needs has to land in a system location (`/opt/hostedtoolcache/...`,
+`/nix/var/nix/profiles/default/bin`), which carries across verbatim — the route
+`nu` and `nix` take — or be copied in by `.config/tend.yaml`'s `sandbox_setup:`,
+which is what the pre-merge gate's `cargo-insta`, `cargo-nextest` and
+`pre-commit` take. Its closing probe asserts every tool on both routes.
 
 ## Build environment
 

--- a/.github/actions/tend-setup/action.yaml
+++ b/.github/actions/tend-setup/action.yaml
@@ -96,10 +96,25 @@ runs:
 
     # Nix, for the weekly toolchain bump's `flake.lock` refresh. The sandboxed
     # agent can't install it: that user has no sudo, so it can't create /nix.
-    # Installed here as `runner`, /nix/var/nix/profiles/default/bin lands on
-    # $GITHUB_PATH — a system path, so the agent inherits `nix` on the same
-    # rule as `nu` above. ~4 s, so it isn't worth gating to the one workflow
-    # that needs it.
+    # `install-nix-action` runs as `runner` and puts
+    # /nix/var/nix/profiles/default/bin on $GITHUB_PATH — a system path, so the
+    # agent inherits `nix` on the same rule as `nu` above.
+    #
+    # Every tend workflow installs it, though only the weekly one runs `nix`.
+    # `.config/tend.yaml`'s probe asserts `nix` from inside the sandbox and
+    # runs everywhere, so gating this step to the weekly workflow would fail
+    # the rest. It costs 4 s of the action's ~50 s.
+    #
+    # The multi-user daemon install is what carries it across, so the ~1 s
+    # `nixbuild/nix-quick-install-action` is no substitute: it hands /nix to
+    # the runner and puts only $HOME/.nix-profile/bin on $GITHUB_PATH, which
+    # the /home/runner rewrite drops. Here root owns /nix and the sandbox user
+    # reaches the store through the daemon.
+    #
+    # Caching doesn't apply. Of the 4 s, the binary tarball is about half; the
+    # rest creates the nixbld users, /etc/nix and the daemon unit, which no
+    # restored /nix reproduces. Caching the store instead would serve only the
+    # weekly job's flake fetches, at the cost of a restore in every workflow.
     - name: Install Nix
       uses: cachix/install-nix-action@v31
       with:

--- a/.github/workflows/tend-ci-fix.yaml
+++ b/.github/workflows/tend-ci-fix.yaml
@@ -46,7 +46,7 @@ jobs:
             install -m755 /home/runner/.cargo-install/cargo-insta/bin/cargo-insta ~/.local/bin/
             install -m755 /home/runner/.cargo-install/cargo-nextest/bin/cargo-nextest ~/.local/bin/
             uv tool install --quiet pre-commit
-            for t in cargo-insta cargo-nextest pre-commit nu; do command -v "$t" >/dev/null || { echo "::error::tend sandbox is missing $t; wt hook pre-merge cannot run"; exit 1; }; done
+            for t in cargo-insta cargo-nextest pre-commit nu nix; do command -v "$t" >/dev/null || { echo "::error::tend sandbox is missing $t; see Sandbox toolchain in .github/CLAUDE.md"; exit 1; }; done
           prompt: |
             /tend-ci-runner:ci-fix ${{ github.event.workflow_run.id }}
             - Run URL: ${{ github.event.workflow_run.html_url }}

--- a/.github/workflows/tend-mention.yaml
+++ b/.github/workflows/tend-mention.yaml
@@ -432,7 +432,7 @@ jobs:
             install -m755 /home/runner/.cargo-install/cargo-insta/bin/cargo-insta ~/.local/bin/
             install -m755 /home/runner/.cargo-install/cargo-nextest/bin/cargo-nextest ~/.local/bin/
             uv tool install --quiet pre-commit
-            for t in cargo-insta cargo-nextest pre-commit nu; do command -v "$t" >/dev/null || { echo "::error::tend sandbox is missing $t; wt hook pre-merge cannot run"; exit 1; }; done
+            for t in cargo-insta cargo-nextest pre-commit nu nix; do command -v "$t" >/dev/null || { echo "::error::tend sandbox is missing $t; see Sandbox toolchain in .github/CLAUDE.md"; exit 1; }; done
           prompt: >-
             ${{ steps.delay.outputs.seconds
             && format('This job started {0}s after the triggering event (over ~40s means it was queued). ',

--- a/.github/workflows/tend-nightly.yaml
+++ b/.github/workflows/tend-nightly.yaml
@@ -46,6 +46,6 @@ jobs:
             install -m755 /home/runner/.cargo-install/cargo-insta/bin/cargo-insta ~/.local/bin/
             install -m755 /home/runner/.cargo-install/cargo-nextest/bin/cargo-nextest ~/.local/bin/
             uv tool install --quiet pre-commit
-            for t in cargo-insta cargo-nextest pre-commit nu; do command -v "$t" >/dev/null || { echo "::error::tend sandbox is missing $t; wt hook pre-merge cannot run"; exit 1; }; done
+            for t in cargo-insta cargo-nextest pre-commit nu nix; do command -v "$t" >/dev/null || { echo "::error::tend sandbox is missing $t; see Sandbox toolchain in .github/CLAUDE.md"; exit 1; }; done
           prompt: |
             /tend-ci-runner:nightly

--- a/.github/workflows/tend-notifications.yaml
+++ b/.github/workflows/tend-notifications.yaml
@@ -161,6 +161,6 @@ jobs:
             install -m755 /home/runner/.cargo-install/cargo-insta/bin/cargo-insta ~/.local/bin/
             install -m755 /home/runner/.cargo-install/cargo-nextest/bin/cargo-nextest ~/.local/bin/
             uv tool install --quiet pre-commit
-            for t in cargo-insta cargo-nextest pre-commit nu; do command -v "$t" >/dev/null || { echo "::error::tend sandbox is missing $t; wt hook pre-merge cannot run"; exit 1; }; done
+            for t in cargo-insta cargo-nextest pre-commit nu nix; do command -v "$t" >/dev/null || { echo "::error::tend sandbox is missing $t; see Sandbox toolchain in .github/CLAUDE.md"; exit 1; }; done
           prompt: |
             /tend-ci-runner:notifications

--- a/.github/workflows/tend-review-runs.yaml
+++ b/.github/workflows/tend-review-runs.yaml
@@ -46,6 +46,6 @@ jobs:
             install -m755 /home/runner/.cargo-install/cargo-insta/bin/cargo-insta ~/.local/bin/
             install -m755 /home/runner/.cargo-install/cargo-nextest/bin/cargo-nextest ~/.local/bin/
             uv tool install --quiet pre-commit
-            for t in cargo-insta cargo-nextest pre-commit nu; do command -v "$t" >/dev/null || { echo "::error::tend sandbox is missing $t; wt hook pre-merge cannot run"; exit 1; }; done
+            for t in cargo-insta cargo-nextest pre-commit nu nix; do command -v "$t" >/dev/null || { echo "::error::tend sandbox is missing $t; see Sandbox toolchain in .github/CLAUDE.md"; exit 1; }; done
           prompt: |
             /tend-ci-runner:review-runs

--- a/.github/workflows/tend-review.yaml
+++ b/.github/workflows/tend-review.yaml
@@ -161,7 +161,7 @@ jobs:
             install -m755 /home/runner/.cargo-install/cargo-insta/bin/cargo-insta ~/.local/bin/
             install -m755 /home/runner/.cargo-install/cargo-nextest/bin/cargo-nextest ~/.local/bin/
             uv tool install --quiet pre-commit
-            for t in cargo-insta cargo-nextest pre-commit nu; do command -v "$t" >/dev/null || { echo "::error::tend sandbox is missing $t; wt hook pre-merge cannot run"; exit 1; }; done
+            for t in cargo-insta cargo-nextest pre-commit nu nix; do command -v "$t" >/dev/null || { echo "::error::tend sandbox is missing $t; see Sandbox toolchain in .github/CLAUDE.md"; exit 1; }; done
           prompt: >-
             ${{ format('/tend-ci-runner:review {0}', github.event.pull_request.number) }}
 

--- a/.github/workflows/tend-triage.yaml
+++ b/.github/workflows/tend-triage.yaml
@@ -58,7 +58,7 @@ jobs:
             install -m755 /home/runner/.cargo-install/cargo-insta/bin/cargo-insta ~/.local/bin/
             install -m755 /home/runner/.cargo-install/cargo-nextest/bin/cargo-nextest ~/.local/bin/
             uv tool install --quiet pre-commit
-            for t in cargo-insta cargo-nextest pre-commit nu; do command -v "$t" >/dev/null || { echo "::error::tend sandbox is missing $t; wt hook pre-merge cannot run"; exit 1; }; done
+            for t in cargo-insta cargo-nextest pre-commit nu nix; do command -v "$t" >/dev/null || { echo "::error::tend sandbox is missing $t; see Sandbox toolchain in .github/CLAUDE.md"; exit 1; }; done
           prompt: |
             /tend-ci-runner:triage ${{ github.event.issue.number }}
 

--- a/.github/workflows/tend-weekly.yaml
+++ b/.github/workflows/tend-weekly.yaml
@@ -46,6 +46,6 @@ jobs:
             install -m755 /home/runner/.cargo-install/cargo-insta/bin/cargo-insta ~/.local/bin/
             install -m755 /home/runner/.cargo-install/cargo-nextest/bin/cargo-nextest ~/.local/bin/
             uv tool install --quiet pre-commit
-            for t in cargo-insta cargo-nextest pre-commit nu; do command -v "$t" >/dev/null || { echo "::error::tend sandbox is missing $t; wt hook pre-merge cannot run"; exit 1; }; done
+            for t in cargo-insta cargo-nextest pre-commit nu nix; do command -v "$t" >/dev/null || { echo "::error::tend sandbox is missing $t; see Sandbox toolchain in .github/CLAUDE.md"; exit 1; }; done
           prompt: |
             /tend-ci-runner:weekly


### PR DESCRIPTION
`.config/tend.yaml`'s sandbox probe asserted four of the five tools the agent needs. `nix` — installed by `tend-setup` for the weekly `flake.lock` refresh — sat outside it, so a regression in that install would have surfaced only once `tend-weekly` reached for `nix flake update` and found nothing. That gap is not hypothetical: PR #3428 (`bump MSRV and toolchain to 1.96`) was the bot, and it updated `Cargo.toml`, `rust-toolchain.toml` and `tests/helpers/wt-perf/Cargo.toml` while leaving `flake.lock` stale, because `nix` wasn't there.

`nix` reaches the sandbox by the route `nu` does: `install-nix-action`'s multi-user daemon install puts `/nix/var/nix/profiles/default/bin` on `$GITHUB_PATH`, a system path the sandbox PATH derivation carries across verbatim. So it needs no `sandbox_setup:` line of its own, only the probe entry. The error message now points at `.github/CLAUDE.md`'s "Sandbox toolchain" section, since the old "wt hook pre-merge cannot run" is false for a weekly-only tool.

The probe entry couples the install to every workflow: only `tend-weekly` runs `nix`, but the probe runs everywhere, so the step can no longer be gated to one. The `Install Nix` comment records that, in place of the cost argument that used to carry the question.

Also here: `.github/CLAUDE.md` stated the sandbox PATH rule as existence-only, where tend additionally requires the sandbox UID to traverse the directory — the test that decides whether a root-owned `/nix` carries across, and so the one a reader of that section will want.

<details>
<summary>Why the install isn't cached, and why it isn't gated to <code>tend-weekly</code></summary>

Measured from `##[end-action … duration_ms]` markers in four real tend run logs. `Install Nix` takes **3.46 / 3.97 / 4.13 / 4.24 s** against **~46–50 s** for the whole `tend-setup` composite, of which the `rust-cache` restore alone is 26.0–28.5 s and apt (zsh, fish) is 10.9–12.9 s.

Within those 4 s, roughly half is downloading and unpacking the 25.8 MiB tarball and the rest is creating the nixbld users, `/etc/nix`, the store, and the `nix-daemon` systemd unit. That second half is root-level system state no restored `/nix` reproduces, so the install itself is not cacheable. Caching the *store* on top would serve only the weekly job's flake fetches while costing a restore in every workflow.

The multi-user daemon install is also what makes `nix` reach the sandbox at all, so the faster single-user installers are not substitutes. `nixbuild/nix-quick-install-action` (~1 s) does `sudo install -d -o "$USER" /nix` and puts only `$HOME/.nix-profile/bin` on `$GITHUB_PATH` — which the `/home/runner` → `/home/tend-sandbox` rewrite drops, so `nix` would leave the sandbox PATH entirely.

Self-installation by the agent was considered and rejected. The sandbox user has no sudo, and the official Nix binary hardcodes its ELF interpreter to `/nix/store/…-glibc-2.42-67/lib/ld-linux-x86-64.so.2`, so it cannot run without a root-created `/nix`. A statically linked `nix` does work for these two commands with no root — verified, using the automatic `~/.local/share/nix/root` chroot store — but no maintained build is published (`NixOS/nix` has no GitHub releases; `releases.nixos.org` serves no static variant; Hydra's `buildStatic` download URL now redirects to the manual), and a chroot store cannot build anything.

Gating the install to `tend-weekly` was also rejected. It saves 4 s of a ~46 s setup on a public repo with free Actions minutes, `tend-ci-fix` watches `nightly` (which hosts the `nix-flake` job) and would lose the ability to reproduce a red nix build, and — because `sandbox_setup:` is top-level only in tend's config and cannot see which workflow it is in — gating would force dropping the probe entry that this PR adds. max-sixty/tend#1057 removes that last constraint for future cases.

</details>

## Testing

The probe loop was exercised both ways locally under `bash -eo pipefail`: exit 0 with all five names resolvable, exit 1 naming the first missing one otherwise. `uvx tend@latest init` (0.1.18, matching the pinned action) regenerates all eight workflows with exactly the one changed line each, and re-running it is a no-op. `pre-commit run --all-files` and `cargo test --test integration test_docs_are_in_sync` pass.

The probe line itself can only run after merge: the `tend` environment admits only `main`, so `workflow_dispatch` from this branch is refused, and `tend-review` here runs under `pull_request_target` against the base ref, so it exercises `main`'s four-tool probe. The premise underneath it is verified, though — this PR's own `tend-review` session runs as `tend-sandbox` with `main`'s `tend-setup` behind it, which already installs Nix, so it checked the route directly: `command -v nix` resolves to `/nix/var/nix/profiles/default/bin/nix` (2.35.2), `nix flake --help` works with `experimental-features = nix-command flakes` inherited from the system-wide `/etc/nix/nix.conf`, and `nix store info` reports `Store URL: daemon`. So the added name cannot turn the eight workflows red, and the weekly recipe's two commands work from the sandbox rather than just its binary being present.

> _This was written by Claude Code on behalf of max-sixty_
