### PR TITLE
fix(trace): exclude the -vv diagnostic collector from the profile

### DIFF
--- a/src/diagnostic.rs
+++ b/src/diagnostic.rs
@@ -353,33 +353,39 @@ pub(crate) fn write_if_verbose(verbose: u8, command_line: &str, error_msg: Optio
     // directory (named at the start of every `-vv` run), and the report body
     // points at them directly (subprocess_log_path in the template above;
     // the performance profile section names `trace.jsonl` as its source).
-    let report = DiagnosticReport::collect(&repo, command_line, context);
+    // Everything below spawns subprocesses for the report itself, into the same
+    // trace as the command being reported on. `diagnostic_scope` records them
+    // under the reserved diagnostic context so the next process to read
+    // `trace.jsonl` back profiles the command rather than its collector.
+    worktrunk::trace::emit::diagnostic_scope(|| {
+        let report = DiagnosticReport::collect(&repo, command_line, context);
 
-    match report.write_diagnostic_file(&repo) {
-        Some(path) => {
-            let path_display = format_path_for_display(&path);
-            eprintln!(
-                "{}",
-                info_message(format!(
-                    "Diagnostics and performance profile saved @ {path_display}"
-                ))
-            );
-
-            // Only show gh command if gh is installed
-            if is_gh_installed() {
-                let issue_url = "https://github.com/max-sixty/worktrunk/issues/new";
+        match report.write_diagnostic_file(&repo) {
+            Some(path) => {
+                let path_display = format_path_for_display(&path);
                 eprintln!(
                     "{}",
-                    hint_message(cformat!(
-                        "To report a bug, open an issue (<underline>{issue_url}</>) and attach a secret gist: <underline>gh gist create --web {path_display}</>"
+                    info_message(format!(
+                        "Diagnostics and performance profile saved @ {path_display}"
                     ))
                 );
+
+                // Only show gh command if gh is installed
+                if is_gh_installed() {
+                    let issue_url = "https://github.com/max-sixty/worktrunk/issues/new";
+                    eprintln!(
+                        "{}",
+                        hint_message(cformat!(
+                            "To report a bug, open an issue (<underline>{issue_url}</>) and attach a secret gist: <underline>gh gist create --web {path_display}</>"
+                        ))
+                    );
+                }
+            }
+            None => {
+                eprintln!("{}", warning_message("Failed to write diagnostic file"));
             }
         }
-        None => {
-            eprintln!("{}", warning_message("Failed to write diagnostic file"));
-        }
-    }
+    })
 }
 
 /// Check if the GitHub CLI (gh) is installed.

--- a/src/trace/emit.rs
+++ b/src/trace/emit.rs
@@ -29,7 +29,10 @@
 //! `trace.jsonl`. `stdin` (command records, [`CommandTrace::reads_stdin`])
 //! marks a command that consumed stdin the `cmd` string doesn't capture, so the
 //! cache analysis in `super::profile` can skip it — `trace.jsonl` carries it;
-//! the human line omits it.
+//! the human line omits it. `context` is normally the worktree a command reads,
+//! but inside [`diagnostic_scope`] it is [`DIAGNOSTIC_CONTEXT`] instead, marking
+//! the `-vv` collector's own subprocesses so a profile read back from the file
+//! measures the command rather than its reporter.
 //!
 //! This split — structured fields at the emission site, rendering at the
 //! layer — means emit sites carry no string-formatting noise.
@@ -79,6 +82,7 @@
 //! so it stays segmentable and joins back to this record via `seq`.
 
 use std::borrow::Cow;
+use std::cell::Cell;
 use std::fmt::Display;
 use std::sync::OnceLock;
 use std::sync::atomic::{AtomicU64, Ordering};
@@ -122,6 +126,50 @@ pub fn thread_id() -> u64 {
 /// construction (outside any verbosity gate) so the sequence is dense
 /// regardless of whether the file layers are active. Starts at 1.
 static CMD_SEQ: AtomicU64 = AtomicU64::new(1);
+
+/// Context recorded for the subprocesses the `-vv` diagnostic collector spawns
+/// for the report itself.
+///
+/// The collector runs *after* the command it reports on and writes into the
+/// same `trace.jsonl`. A profile rendered in-process is unaffected — it is read
+/// before the collector spawns anything — but a profile read back from the file
+/// afterwards (`wt config state logs profile`, and so the statusline
+/// performance recipe) would otherwise count the collector's own `git
+/// --version`, `gh --version` and `git worktree list --porcelain` as the
+/// command's work, and pair them with the command's own calls as same-context
+/// duplicates. Records made inside [`diagnostic_scope`] carry this reserved
+/// context and [`crate::trace::profile`] excludes it, so the numbers keep
+/// meaning the command. The records still appear in `trace.log`,
+/// `subprocess.log` and the timeline, where a bug report wants to see them.
+///
+/// Parenthesized like `profile`'s `(none)` bucket, so it can't be confused with
+/// the worktree names that fill every other context.
+pub const DIAGNOSTIC_CONTEXT: &str = "(diagnostic)";
+
+thread_local! {
+    /// Whether this thread is currently inside [`diagnostic_scope`].
+    static IN_DIAGNOSTIC: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Resets [`IN_DIAGNOSTIC`] when the scope ends, including on unwind.
+struct DiagnosticGuard;
+
+impl Drop for DiagnosticGuard {
+    fn drop(&mut self) {
+        IN_DIAGNOSTIC.set(false);
+    }
+}
+
+/// Run `f` with every subprocess this thread traces recorded under
+/// [`DIAGNOSTIC_CONTEXT`] instead of its own context.
+///
+/// Thread-local rather than process-global: threads still finishing the
+/// command's own work must keep their real context.
+pub fn diagnostic_scope<T>(f: impl FnOnce() -> T) -> T {
+    IN_DIAGNOSTIC.set(true);
+    let _guard = DiagnosticGuard;
+    f()
+}
 
 /// Emit a completed-command record (`ok=true`/`ok=false`).
 ///
@@ -243,8 +291,15 @@ impl CommandTrace {
     /// Begin tracing a command. Call immediately before spawning the child so
     /// the captured start time brackets the subprocess.
     pub fn new(context: Option<&str>, cmd: &str) -> Self {
+        // Inside the diagnostic collector every spawn is the report's own work,
+        // whichever worktree it happens to read — see [`DIAGNOSTIC_CONTEXT`].
+        let context = if IN_DIAGNOSTIC.get() {
+            Some(DIAGNOSTIC_CONTEXT.to_owned())
+        } else {
+            context.map(ToOwned::to_owned)
+        };
         Self {
-            context: context.map(ToOwned::to_owned),
+            context,
             cmd: cmd.to_owned(),
             start_ts_us: now_us(),
             start: Instant::now(),

--- a/src/trace/profile.rs
+++ b/src/trace/profile.rs
@@ -34,6 +34,7 @@ use serde::Serialize;
 
 use crate::styling::format_heading;
 
+use super::emit::DIAGNOSTIC_CONTEXT;
 use super::{TraceEntry, TraceEntryKind, TraceResult};
 
 /// How many individual calls [`Profile::slowest`] retains.
@@ -302,6 +303,14 @@ pub(super) fn command_label(command: &str, context: Option<&str>, result: &Trace
     label
 }
 
+/// Whether this entry records the `-vv` diagnostic collector's own work rather
+/// than the command being profiled. The collector writes into the same trace
+/// after the command finishes, so every count, total and duplicate bucket here
+/// skips it — see [`crate::trace::emit::DIAGNOSTIC_CONTEXT`].
+fn is_diagnostic(entry: &TraceEntry) -> bool {
+    entry.context.as_deref() == Some(DIAGNOSTIC_CONTEXT)
+}
+
 /// Microseconds of an entry's duration (zero for instant events).
 fn entry_dur_us(entry: &TraceEntry) -> u64 {
     match &entry.kind {
@@ -315,9 +324,14 @@ fn entry_dur_us(entry: &TraceEntry) -> u64 {
 impl Profile {
     /// Build a profile from parsed trace entries.
     pub fn from_entries(entries: &[TraceEntry]) -> Self {
-        let min_start = entries.iter().filter_map(|e| e.start_time_us).min();
+        let min_start = entries
+            .iter()
+            .filter(|e| !is_diagnostic(e))
+            .filter_map(|e| e.start_time_us)
+            .min();
         let max_end = entries
             .iter()
+            .filter(|e| !is_diagnostic(e))
             .filter_map(|e| e.start_time_us.map(|s| s + entry_dur_us(e)))
             .max();
         let traced = match (min_start, max_end) {
@@ -336,6 +350,9 @@ impl Profile {
         let mut slowest: Vec<Slow> = Vec::new();
 
         for entry in entries {
+            if is_diagnostic(entry) {
+                continue;
+            }
             match &entry.kind {
                 TraceEntryKind::Command {
                     command,
@@ -677,6 +694,9 @@ impl CacheReport {
         let mut pair_durations: HashMap<(&str, &str), Vec<u64>> = HashMap::new();
 
         for entry in entries {
+            if is_diagnostic(entry) {
+                continue;
+            }
             if let TraceEntryKind::Command {
                 command,
                 duration,
@@ -1056,6 +1076,70 @@ mod tests {
         assert_eq!(cache.same_context_duplicates[0].command, "git status");
         assert_eq!(cache.same_context_extra_calls, 1);
         assert_eq!(cache.same_context_extra, Duration::from_millis(1));
+    }
+
+    #[test]
+    fn profile_excludes_the_diagnostic_collector() {
+        // The `-vv` collector appends its own calls to the same trace after the
+        // command finishes, so a profile read back from `trace.jsonl` must
+        // count the command's two calls and neither of the collector's.
+        let entries = vec![
+            cmd("git status", Some("main"), 0, 5_000, 1, true),
+            cmd("git rev-parse HEAD", Some("main"), 6_000, 1_000, 1, true),
+            cmd(
+                "git --version",
+                Some(DIAGNOSTIC_CONTEXT),
+                8_000,
+                2_000,
+                1,
+                true,
+            ),
+            cmd(
+                "git worktree list --porcelain",
+                Some(DIAGNOSTIC_CONTEXT),
+                11_000,
+                40_000,
+                1,
+                true,
+            ),
+        ];
+        let profile = Profile::from_entries(&entries);
+
+        assert_eq!(profile.command_count, 2);
+        assert_eq!(profile.command_total, Duration::from_millis(6));
+        // The collector's 40ms tail is outside the traced window too.
+        assert_eq!(profile.traced, Duration::from_millis(7));
+        assert!(
+            !profile
+                .by_context
+                .iter()
+                .any(|c| c.context == DIAGNOSTIC_CONTEXT),
+            "collector context leaked into the attribution table: {:?}",
+            profile.by_context
+        );
+    }
+
+    #[test]
+    fn cache_report_excludes_the_diagnostic_collector() {
+        // The collector re-runs `git worktree list --porcelain`, which the
+        // command already ran. Pairing the two would report a cache miss that
+        // no change to the command could fix.
+        let worktree_list = "git worktree list --porcelain";
+        let entries = vec![
+            cmd(worktree_list, Some("main"), 0, 5_000, 1, true),
+            cmd(
+                worktree_list,
+                Some(DIAGNOSTIC_CONTEXT),
+                6_000,
+                4_000,
+                1,
+                true,
+            ),
+        ];
+        let cache = CacheReport::from_entries(&entries);
+
+        assert_eq!(cache.same_context_extra_calls, 0);
+        assert!(cache.same_context_duplicates.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
The statusline performance check in `.claude/skills/running-tend/SKILL.md` runs two processes: `wt -vv list statusline` writes `trace.jsonl`, then a separate `wt config state logs profile` reads it back. The `-vv` diagnostic collector runs *after* the command it reports on and spawns `git --version`, `git worktree list --porcelain` and `gh --version` into that same file, so the second process counts them as the render's work and pairs the collector's `worktree list` with the render's own as a same-context duplicate. That duplicate is unfixable by definition — no change to the render can stop the reporter from running afterwards — and the subprocess count reads three high against its baseline.

The profile rendered in-process was never wrong: `DiagnosticReport::collect` reads `trace.jsonl` before `format_report` spawns anything. Only a later reader of the file sees them, which is exactly what the recipe is.

Records made inside the new `emit::diagnostic_scope` now carry the reserved context `(diagnostic)`, and `Profile::from_entries` and `CacheReport::from_entries` skip it. That sits alongside the existing `reads_stdin` skip, which excludes commands for the same kind of reason: what they actually did isn't in the record.

Two decisions worth flagging. The scope is thread-local rather than a process-global flag, so threads still finishing the command's own work keep their real context. And the records are excluded from the profile rather than suppressed at the emitter, so they stay in `trace.log`, `subprocess.log` and the timeline, where a bug report still wants to see them. The route not taken was threading an explicit context parameter through `Repository::run_command`, which is correct in principle but changes a widely-used signature and every caller for the sake of one reporter.

`(diagnostic)` is parenthesized like `profile`'s existing `(none)` bucket, so it can't be confused with the worktree names that fill every other context.

## Test plan

Two unit tests in `src/trace/profile.rs` cover the count and the duplicate bucketing. Beyond those, the recipe itself was run end to end against both binaries:

<details><summary>Before / after against the statusline recipe</summary>

Built from `main`:

```
{"command_count": 17, "cache": {"extra": 1, "dups": ["git worktree list --porcelain"]}}
```

Built from this branch:

```
{"command_count": 21, "cache": {"extra": 0, "dups": []}}
```

`trace.jsonl` from the second run carries three records under `"context":"(diagnostic)"` — `git --version`, `git worktree list --porcelain`, `gh --version` — as its trailing block, and `(diagnostic)` is absent from `by_context`. The counts differ between runs because the render itself varies with git state and cache warmth; the duplicate is the decisive comparison.

</details>

One coordination note: #3880's branch carries a "Measurement artifact" bullet and a "minus the collector's three calls" clause in `.claude/skills/running-tend/SKILL.md`, written to be deleted when this lands. That prose isn't on `main`, so there's nothing for this branch to remove — whichever of the two merges second should drop that paragraph, the bullet, and the discount clause, keeping the `~29`/`~32` baseline itself.

> _This was written by Claude Code on behalf of max-sixty_
