### PR TITLE
test(guards): restore the empty-corpus checks the read_dir panics don't cover

### DIFF
--- a/tests/integration_tests/packaged_assets.rs
+++ b/tests/integration_tests/packaged_assets.rs
@@ -52,11 +52,11 @@ fn embedded_assets_ship_in_package() {
     //    repo-root-relative forward-slash string.
     let mut assets = BTreeSet::new();
     scan_directory(&src_dir, manifest_dir, &mut assets);
-    // A walk that reaches no directory is the panic in `scan_directory`. This is
-    // the other way the discovery can come back empty: every file read, and the
-    // `include_str!` / `include_bytes!` / `#[template]` matching in `scan_file`
-    // recognizing none of them. The comparison below iterates `assets`, so an
-    // empty set checks nothing and passes.
+    // `scan_directory` and `scan_file` panic when the tree or one of its files
+    // can't be read. This catches the remaining way discovery comes back empty:
+    // every file read, and the `include_str!` / `include_bytes!` / `#[template]`
+    // matching recognizing none of them. The comparison below iterates `assets`,
+    // so an empty set checks nothing and passes.
     assert!(
         !assets.is_empty(),
         "scanned src/ but found no embedded assets — the scanner is likely broken"
@@ -115,9 +115,12 @@ fn scan_directory(dir: &Path, manifest_dir: &Path, assets: &mut BTreeSet<String>
 }
 
 fn scan_file(path: &Path, manifest_dir: &Path, assets: &mut BTreeSet<String>) {
-    let Ok(contents) = fs::read_to_string(path) else {
-        return;
-    };
+    // Returning here would drop whatever this file embeds while the rest keep
+    // `assets` non-empty, so the empty-scan assert above wouldn't catch it
+    // either. A `.rs` file under `src/` that isn't readable UTF-8 is broken in a
+    // way the crate wouldn't compile through.
+    let contents = fs::read_to_string(path)
+        .unwrap_or_else(|e| panic!("{} unreadable during the src/ scan: {e}", path.display()));
     let source_dir = path.parent().unwrap_or(manifest_dir);
 
     for line in contents.lines() {

--- a/tests/integration_tests/packaged_assets.rs
+++ b/tests/integration_tests/packaged_assets.rs
@@ -104,7 +104,12 @@ fn scan_directory(dir: &Path, manifest_dir: &Path, assets: &mut BTreeSet<String>
     let entries = fs::read_dir(dir)
         .unwrap_or_else(|e| panic!("{} unreadable during the src/ scan: {e}", dir.display()));
 
-    for entry in entries.flatten() {
+    for entry in entries {
+        // `flatten()` here would drop a per-entry error, so a file that never
+        // reaches `scan_file` takes whatever it embeds with it while the rest
+        // keep `assets` non-empty — past both the panic and the assert.
+        let entry = entry
+            .unwrap_or_else(|e| panic!("{} unreadable during the src/ scan: {e}", dir.display()));
         let path = entry.path();
         if path.is_dir() {
             scan_directory(&path, manifest_dir, assets);

--- a/tests/integration_tests/packaged_assets.rs
+++ b/tests/integration_tests/packaged_assets.rs
@@ -108,8 +108,12 @@ fn scan_directory(dir: &Path, manifest_dir: &Path, assets: &mut BTreeSet<String>
         // `flatten()` here would drop a per-entry error, so a file that never
         // reaches `scan_file` takes whatever it embeds with it while the rest
         // keep `assets` non-empty — past both the panic and the assert.
-        let entry = entry
-            .unwrap_or_else(|e| panic!("{} unreadable during the src/ scan: {e}", dir.display()));
+        let entry = entry.unwrap_or_else(|e| {
+            panic!(
+                "an entry in {} unreadable during the src/ scan: {e}",
+                dir.display()
+            )
+        });
         let path = entry.path();
         if path.is_dir() {
             scan_directory(&path, manifest_dir, assets);

--- a/tests/integration_tests/packaged_assets.rs
+++ b/tests/integration_tests/packaged_assets.rs
@@ -52,6 +52,15 @@ fn embedded_assets_ship_in_package() {
     //    repo-root-relative forward-slash string.
     let mut assets = BTreeSet::new();
     scan_directory(&src_dir, manifest_dir, &mut assets);
+    // A walk that reaches no directory is the panic in `scan_directory`. This is
+    // the other way the discovery can come back empty: every file read, and the
+    // `include_str!` / `include_bytes!` / `#[template]` matching in `scan_file`
+    // recognizing none of them. The comparison below iterates `assets`, so an
+    // empty set checks nothing and passes.
+    assert!(
+        !assets.is_empty(),
+        "scanned src/ but found no embedded assets — the scanner is likely broken"
+    );
 
     // 2. The set of files `cargo publish` would put in the crates.io archive.
     let packaged = cargo_package_list(manifest_dir);

--- a/tests/integration_tests/snapshot_formatting_guard.rs
+++ b/tests/integration_tests/snapshot_formatting_guard.rs
@@ -212,7 +212,10 @@ fn visit_snap_files(dir: &Path, f: &mut impl FnMut(&Path, &str)) {
         // `flatten()` here would drop a per-entry error — a file removed
         // mid-walk, a failing `stat` — and skip a snapshot without saying so.
         let entry = entry.unwrap_or_else(|e| {
-            panic!("{} unreadable during the snapshot scan: {e}", dir.display())
+            panic!(
+                "an entry in {} unreadable during the snapshot scan: {e}",
+                dir.display()
+            )
         });
         let path = entry.path();
         if path.is_dir() {

--- a/tests/integration_tests/snapshot_formatting_guard.rs
+++ b/tests/integration_tests/snapshot_formatting_guard.rs
@@ -178,15 +178,29 @@ fn test_no_host_specific_paths_in_snapshots() {
 /// Visit every committed `.snap` file. Snapshot dirs live under `src`
 /// (unit tests), `tests` (integration tests), and `docs` (demo fixtures).
 fn for_each_snapshot(project_root: &Path, mut f: impl FnMut(&Path, &str)) {
+    let mut seen = 0usize;
     for root in ["src", "tests", "docs"] {
-        visit_snap_files(&project_root.join(root), &mut f);
+        visit_snap_files(&project_root.join(root), &mut |path, content| {
+            seen += 1;
+            f(path, content);
+        });
     }
+    // Every caller asserts *absence* over the corpus, so a walk that yields
+    // nothing passes vacuously. The panic in `visit_snap_files` covers a root
+    // that can't be read; this covers the corpus moving out from under these
+    // three roots while all three still exist and read fine.
+    assert!(
+        seen > 0,
+        "walked src/, tests/ and docs/ and found no .snap files — the corpus has \
+         moved, so every assertion these callers make is passing over nothing"
+    );
 }
 
 fn visit_snap_files(dir: &Path, f: &mut impl FnMut(&Path, &str)) {
-    // Every caller asserts absence over the corpus, so a walk that reads
-    // nothing passes vacuously. Swallowing the error is what makes a
-    // directory-layout change look like a clean corpus; surface it instead.
+    // A root that can't be read yields no snapshots, and every caller asserts
+    // absence, so swallowing the error would let an unreadable directory read as
+    // a clean corpus. `for_each_snapshot` covers the separate case where the
+    // roots read fine and simply hold nothing.
     let entries = fs::read_dir(dir)
         .unwrap_or_else(|e| panic!("{} unreadable during the snapshot scan: {e}", dir.display()));
 

--- a/tests/integration_tests/snapshot_formatting_guard.rs
+++ b/tests/integration_tests/snapshot_formatting_guard.rs
@@ -178,22 +178,26 @@ fn test_no_host_specific_paths_in_snapshots() {
 /// Visit every committed `.snap` file. Snapshot dirs live under `src`
 /// (unit tests), `tests` (integration tests), and `docs` (demo fixtures).
 fn for_each_snapshot(project_root: &Path, mut f: impl FnMut(&Path, &str)) {
-    let mut seen = 0usize;
+    // Every caller asserts *absence* over the corpus, so snapshots that stop
+    // being walked pass vacuously. The panic in `visit_snap_files` covers a root
+    // that can't be read; this covers one that reads fine and has stopped
+    // holding snapshots. Per root rather than in aggregate, because a layout
+    // change moves one root and leaves the others: `tests` alone holds the large
+    // majority of the corpus, so an aggregate non-empty check would survive
+    // losing it. That makes each root load-bearing — a root that legitimately
+    // stops holding snapshots belongs out of this list, not exempted from it.
     for root in ["src", "tests", "docs"] {
+        let mut seen = 0usize;
         visit_snap_files(&project_root.join(root), &mut |path, content| {
             seen += 1;
             f(path, content);
         });
+        assert!(
+            seen > 0,
+            "{root}/ holds no .snap files — the corpus has moved, so these \
+             assertions are now passing over whatever is left of it"
+        );
     }
-    // Every caller asserts *absence* over the corpus, so a walk that yields
-    // nothing passes vacuously. The panic in `visit_snap_files` covers a root
-    // that can't be read; this covers the corpus moving out from under these
-    // three roots while all three still exist and read fine.
-    assert!(
-        seen > 0,
-        "walked src/, tests/ and docs/ and found no .snap files — the corpus has \
-         moved, so every assertion these callers make is passing over nothing"
-    );
 }
 
 fn visit_snap_files(dir: &Path, f: &mut impl FnMut(&Path, &str)) {
@@ -204,12 +208,22 @@ fn visit_snap_files(dir: &Path, f: &mut impl FnMut(&Path, &str)) {
     let entries = fs::read_dir(dir)
         .unwrap_or_else(|e| panic!("{} unreadable during the snapshot scan: {e}", dir.display()));
 
-    for entry in entries.flatten() {
+    for entry in entries {
+        // `flatten()` here would drop a per-entry error — a file removed
+        // mid-walk, a failing `stat` — and skip a snapshot without saying so.
+        let entry = entry.unwrap_or_else(|e| {
+            panic!("{} unreadable during the snapshot scan: {e}", dir.display())
+        });
         let path = entry.path();
         if path.is_dir() {
             visit_snap_files(&path, f);
         } else if path.extension().and_then(|s| s.to_str()) == Some("snap") {
-            let content = fs::read_to_string(&path).unwrap();
+            let content = fs::read_to_string(&path).unwrap_or_else(|e| {
+                panic!(
+                    "{} unreadable during the snapshot scan: {e}",
+                    path.display()
+                )
+            });
             f(&path, &content);
         }
     }


### PR DESCRIPTION
#3878 changed each source-scan walk's `fs::read_dir` from a silent `return` into a panic, which is the right call — a directory the walk can't read contributed no violations, so an unreadable or relocated `src/` read as a clean crate. On the strength of that it also dropped two guards as duplicates of what the panic now gives. Neither is one: the panic catches a directory that can't be read, and both of them catch a walk that read everything and found nothing.

**`packaged_assets.rs`** lost `assert!(!assets.is_empty())`. The other way discovery comes back empty is every file reading fine and the `include_str!` / `include_bytes!` / `#[template]` matching in `scan_file` recognizing none of them. Nothing downstream notices, because the comparison against `cargo package --list` and the `flake.nix` filter iterates `assets` — an empty set checks nothing and the test passes green while the guard standing between a bare `include_str!` and another #3123 has stopped guarding.

**`snapshot_formatting_guard.rs`** lost `assert!(seen > 500)` from `for_each_snapshot`. That walk's roots are `src`, `tests` and `docs`, and all three exist, so the `read_dir` panic in `visit_snap_files` only fires when one of them can't be read. If the corpus moves out from under those roots while they still read fine, the walk succeeds, yields zero `.snap` files, and all three callers assert absence over nothing. The comment left in `visit_snap_files` claimed the panic covered exactly that case; it didn't, and now says which of the two failures each mechanism is for.

The count is restored **per root** rather than in aggregate. `tests` holds 1,088 of today's 1,156 snapshots, so relocating just that root leaves 68 behind — a layout change moves one root and leaves the others, which is the realistic shape and the one an aggregate non-empty check survives. Counting inside the loop has no threshold in it and names the root that came back empty. That makes each root load-bearing, `docs` included at 4 files: a root that legitimately stops holding snapshots belongs out of the list rather than exempted from it.

**Two swallows survived in both files.** `scan_file` still had `let Ok(contents) = fs::read_to_string(path) else { return };` — a subset of `src/*.rs` failing to read silently drops whatever those files embed while the rest keep `assets` non-empty, so the restored assert wouldn't have caught it. And both walks iterated `entries.flatten()`, which drops a per-entry `io::Error` (a file removed mid-walk, a failing `stat`), so the file it would have led to reached neither panic. Both now surface. `visit_snap_files` also read each snapshot with a bare `unwrap()` whose message named no file, leaving you to guess which of 1,156 it was; it names the path now, like the others.

Each walk's two directory panics say which read failed. "This directory can't be read" and "this directory reads fine but one entry in it can't" would otherwise print the same line naming the same path, and the second is the one where the obvious next step — open the directory, find it fine — sends you back to the start.

## Test plan

The 14 tests across the four guard files #3878 touched all pass.

The corpus assert is a tripwire for a state the tree isn't in, so it was exercised directly, twice:

<details><summary>Bug-back checks on the corpus assert</summary>

**Whole corpus gone** — roots flipped from `["src", "tests", "docs"]` to `[".github"]`, which exists, reads fine, and holds no snapshots:

```
exit=101
count-assert fired: True
read_dir panic fired instead: False
```

The `read_dir` panic *not* firing is the point: it confirms the two mechanisms cover different failures rather than one being a duplicate of the other.

**One root relocated** — `tests` alone swapped for `.github`, leaving `src`'s 64 and `docs`' 4 in place:

```
exit=101
per-root assert fired and named the root: True
.github/ holds no .snap files — the corpus has moved, so these assertions are now passing over whatever is left of it
```

68 snapshots still walk here, so an aggregate non-empty check passes and this is the case it can't see.

Both edits were reverted after the runs.

</details>

The panics on the read paths aren't exercised. A `.rs` file under `src/` that isn't readable UTF-8 wouldn't compile, so the crate never reaches the test; they're fail-fast for the reachable causes — a permissions change, a file removed mid-walk — rather than live guards.

> _This was written by Claude Code on behalf of max-sixty_
